### PR TITLE
(feature) add pybinds for new distributed sub-context APIs

### DIFF
--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -111,6 +111,14 @@ void py_module_types(nb::module_& mod) {
         .def(nb::self > nb::self)
         .def(nb::self >= nb::self);
 
+    nb::class_<SubcontextId>(mod, "SubcontextId", "Sub-context id in a split MPI job")
+        .def(nb::init<int>())
+        .def("__int__", [](const SubcontextId& s) { return *s; })
+        .def("__repr__", [](const SubcontextId& s) { return nb::str("SubcontextId({})").format(*s); })
+        .def("__str__", [](const SubcontextId& s) { return nb::str("{}").format(*s); })
+        .def(nb::self == nb::self)
+        .def(nb::self != nb::self);
+
     nb::class_<MeshToTensor>(mod, "CppMeshToTensor");
     nb::class_<TensorToMesh>(mod, "CppTensorToMesh");
 
@@ -1019,6 +1027,7 @@ void py_module(nb::module_& mod) {
                 >>> # All processes continue from here
         )doc");
 
+
     // Allgather a single int from every rank; returns list[int] of length num_ranks.
     mod.def(
         "allgather_int",
@@ -1103,7 +1112,120 @@ void py_module(nb::module_& mod) {
             Raises:
                 RuntimeError: If the distributed context has not been initialized.
         )doc");
+    // Sub-context API (split MPI world). See Subcontext.md.
+    mod.def(
+        "subcontext_id",
+        []() -> std::optional<int> {
+            if (!DistributedContext::is_initialized()) {
+                throw std::runtime_error("Distributed context not initialized.");
+            }
+            auto id = DistributedContext::get_current_world()->subcontext_id();
+            if (!id.has_value()) {
+                return std::nullopt;
+            }
+            return *(*id);
+        },
+        R"doc(
+            Return this process's sub-context id, or None if the job is not split.
 
+            Set by tt-run via TT_RUN_SUBCONTEXT_ID when ``--rank-bindings-mapping``
+            composes multiple overlays.  The returned int matches the sub-context
+            order declared in the rank-bindings-mapping YAML.
+
+            Returns:
+                Optional[int]: sub-context id, or None.
+        )doc");
+
+    mod.def(
+        "subcontext_count",
+        []() -> int {
+            if (!DistributedContext::is_initialized()) {
+                throw std::runtime_error("Distributed context not initialized.");
+            }
+            return DistributedContext::get_current_world()->subcontext_count();
+        },
+        R"doc(
+            Number of sub-contexts in this MPI world (1 when not split).
+        )doc");
+
+    mod.def(
+        "subcontext_sizes",
+        []() -> std::vector<int> {
+            if (!DistributedContext::is_initialized()) {
+                throw std::runtime_error("Distributed context not initialized.");
+            }
+            auto span = DistributedContext::get_current_world()->subcontext_sizes();
+            return std::vector<int>(span.begin(), span.end());
+        },
+        R"doc(
+            List of sub-context sizes in ascending sub-context id order.
+        )doc");
+
+    mod.def(
+        "subcontext_size",
+        [](int subcontext_id) -> Size {
+            if (!DistributedContext::is_initialized()) {
+                throw std::runtime_error("Distributed context not initialized.");
+            }
+            return DistributedContext::get_current_world()->subcontext_size(SubcontextId{subcontext_id});
+        },
+        nb::arg("subcontext_id"),
+        R"doc(
+            Number of MPI ranks in the given sub-context.
+
+            Args:
+                subcontext_id (int): sub-context id.
+            Returns:
+                Size: number of ranks.
+        )doc");
+
+    mod.def(
+        "local_to_world_rank",
+        [](int subcontext_id, int local_rank) -> Rank {
+            if (!DistributedContext::is_initialized()) {
+                throw std::runtime_error("Distributed context not initialized.");
+            }
+            return DistributedContext::get_current_world()->local_to_world_rank(
+                SubcontextId{subcontext_id}, Rank{local_rank});
+        },
+        nb::arg("subcontext_id"),
+        nb::arg("local_rank"),
+        R"doc(
+            Translate a (subcontext_id, local_rank) pair to the world Rank.
+
+            Args:
+                subcontext_id (int): sub-context id.
+                local_rank (int): rank within that sub-context (0-based).
+            Returns:
+                Rank: corresponding rank in MPI_COMM_WORLD.
+        )doc");
+
+    mod.def(
+        "world_rank",
+        []() -> Rank {
+            if (!DistributedContext::is_initialized()) {
+                throw std::runtime_error("Distributed context not initialized.");
+            }
+            return DistributedContext::get_world_context()->rank();
+        },
+        R"doc(
+            Global rank in MPI_COMM_WORLD (the un-split world).
+
+            Differs from get_rank() when the job is split into sub-contexts:
+            get_rank() returns the local rank within this process's sub-context.
+        )doc");
+
+    mod.def(
+        "world_size",
+        []() -> Size {
+            if (!DistributedContext::is_initialized()) {
+                throw std::runtime_error("Distributed context not initialized.");
+            }
+            return DistributedContext::get_world_context()->size();
+        },
+        R"doc(
+            Total number of ranks in MPI_COMM_WORLD (the un-split world).
+        )doc");
     auto m_experimental = mod.def_submodule("experimental", "experimental distributed operations");
     m_experimental.def(
         "get_worker_noc_hop_distance",

--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -1027,7 +1027,6 @@ void py_module(nb::module_& mod) {
                 >>> # All processes continue from here
         )doc");
 
-
     // Allgather a single int from every rank; returns list[int] of length num_ranks.
     mod.def(
         "allgather_int",

--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -1168,7 +1168,7 @@ void py_module(nb::module_& mod) {
                 throw std::runtime_error("Distributed context not initialized. Call init_distributed_context() first.");
             }
 
-            auto* world = DistributedContext::get_current_world();
+            const ContextPtr& world = DistributedContext::get_current_world();
             const auto subcontext_count = world->subcontext_count();
             if (subcontext_id < 0 || subcontext_id >= subcontext_count) {
                 throw std::out_of_range(
@@ -1195,7 +1195,7 @@ void py_module(nb::module_& mod) {
                 throw std::runtime_error("Distributed context not initialized. Call init_distributed_context() first.");
             }
 
-            auto* world = DistributedContext::get_current_world();
+            const ContextPtr& world = DistributedContext::get_current_world();
             const auto subcontext_count = world->subcontext_count();
             if (subcontext_id < 0 || subcontext_id >= subcontext_count) {
                 throw std::out_of_range(
@@ -1204,11 +1204,11 @@ void py_module(nb::module_& mod) {
             }
 
             const auto subcontext_sz = world->subcontext_size(SubcontextId{subcontext_id});
-            if (local_rank < 0 || local_rank >= subcontext_sz) {
+            if (local_rank < 0 || local_rank >= subcontext_sz.get()) {
                 throw std::out_of_range(
                     "local_rank out of range for subcontext " + std::to_string(subcontext_id) +
-                    ": expected 0 <= local_rank < " + std::to_string(subcontext_sz) +
-                    ", got " + std::to_string(local_rank));
+                    ": expected 0 <= local_rank < " + std::to_string(subcontext_sz.get()) + ", got " +
+                    std::to_string(local_rank));
             }
 
             return world->local_to_world_rank(SubcontextId{subcontext_id}, Rank{local_rank});

--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -1111,7 +1111,8 @@ void py_module(nb::module_& mod) {
             Raises:
                 RuntimeError: If the distributed context has not been initialized.
         )doc");
-    // Sub-context API (split MPI world). See Subcontext.md.
+    // Sub-context API for split MPI worlds. Returns the sub-context identifier
+    // assigned by tt-run when rank bindings compose multiple overlays.
     mod.def(
         "subcontext_id",
         []() -> std::optional<int> {

--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -1117,7 +1117,7 @@ void py_module(nb::module_& mod) {
         "subcontext_id",
         []() -> std::optional<int> {
             if (!DistributedContext::is_initialized()) {
-                throw std::runtime_error("Distributed context not initialized.");
+                throw std::runtime_error("Distributed context not initialized. Call init_distributed_context() first.");
             }
             auto id = DistributedContext::get_current_world()->subcontext_id();
             if (!id.has_value()) {
@@ -1140,7 +1140,7 @@ void py_module(nb::module_& mod) {
         "subcontext_count",
         []() -> int {
             if (!DistributedContext::is_initialized()) {
-                throw std::runtime_error("Distributed context not initialized.");
+                throw std::runtime_error("Distributed context not initialized. Call init_distributed_context() first.");
             }
             return DistributedContext::get_current_world()->subcontext_count();
         },
@@ -1152,7 +1152,7 @@ void py_module(nb::module_& mod) {
         "subcontext_sizes",
         []() -> std::vector<int> {
             if (!DistributedContext::is_initialized()) {
-                throw std::runtime_error("Distributed context not initialized.");
+                throw std::runtime_error("Distributed context not initialized. Call init_distributed_context() first.");
             }
             auto span = DistributedContext::get_current_world()->subcontext_sizes();
             return std::vector<int>(span.begin(), span.end());
@@ -1165,7 +1165,7 @@ void py_module(nb::module_& mod) {
         "subcontext_size",
         [](int subcontext_id) -> Size {
             if (!DistributedContext::is_initialized()) {
-                throw std::runtime_error("Distributed context not initialized.");
+                throw std::runtime_error("Distributed context not initialized. Call init_distributed_context() first.");
             }
 
             auto* world = DistributedContext::get_current_world();
@@ -1192,10 +1192,26 @@ void py_module(nb::module_& mod) {
         "local_to_world_rank",
         [](int subcontext_id, int local_rank) -> Rank {
             if (!DistributedContext::is_initialized()) {
-                throw std::runtime_error("Distributed context not initialized.");
+                throw std::runtime_error("Distributed context not initialized. Call init_distributed_context() first.");
             }
-            return DistributedContext::get_current_world()->local_to_world_rank(
-                SubcontextId{subcontext_id}, Rank{local_rank});
+
+            auto* world = DistributedContext::get_current_world();
+            const auto subcontext_count = world->subcontext_count();
+            if (subcontext_id < 0 || subcontext_id >= subcontext_count) {
+                throw std::out_of_range(
+                    "subcontext_id out of range: expected 0 <= subcontext_id < " +
+                    std::to_string(subcontext_count) + ", got " + std::to_string(subcontext_id));
+            }
+
+            const auto subcontext_sz = world->subcontext_size(SubcontextId{subcontext_id});
+            if (local_rank < 0 || local_rank >= subcontext_sz) {
+                throw std::out_of_range(
+                    "local_rank out of range for subcontext " + std::to_string(subcontext_id) +
+                    ": expected 0 <= local_rank < " + std::to_string(subcontext_sz) +
+                    ", got " + std::to_string(local_rank));
+            }
+
+            return world->local_to_world_rank(SubcontextId{subcontext_id}, Rank{local_rank});
         },
         nb::arg("subcontext_id"),
         nb::arg("local_rank"),
@@ -1213,7 +1229,7 @@ void py_module(nb::module_& mod) {
         "world_rank",
         []() -> Rank {
             if (!DistributedContext::is_initialized()) {
-                throw std::runtime_error("Distributed context not initialized.");
+                throw std::runtime_error("Distributed context not initialized. Call init_distributed_context() first.");
             }
             return DistributedContext::get_world_context()->rank();
         },
@@ -1228,7 +1244,7 @@ void py_module(nb::module_& mod) {
         "world_size",
         []() -> Size {
             if (!DistributedContext::is_initialized()) {
-                throw std::runtime_error("Distributed context not initialized.");
+                throw std::runtime_error("Distributed context not initialized. Call init_distributed_context() first.");
             }
             return DistributedContext::get_world_context()->size();
         },

--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -1167,7 +1167,16 @@ void py_module(nb::module_& mod) {
             if (!DistributedContext::is_initialized()) {
                 throw std::runtime_error("Distributed context not initialized.");
             }
-            return DistributedContext::get_current_world()->subcontext_size(SubcontextId{subcontext_id});
+
+            auto* world = DistributedContext::get_current_world();
+            const auto subcontext_count = world->subcontext_count();
+            if (subcontext_id < 0 || subcontext_id >= subcontext_count) {
+                throw std::out_of_range(
+                    "subcontext_id out of range: expected 0 <= subcontext_id < " +
+                    std::to_string(subcontext_count) + ", got " + std::to_string(subcontext_id));
+            }
+
+            return world->subcontext_size(SubcontextId{subcontext_id});
         },
         nb::arg("subcontext_id"),
         R"doc(

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -124,12 +124,20 @@ from ttnn._ttnn.multi_device import (
     using_distributed_env,
     Rank,
     Size,
+    SubcontextId,
     init_distributed_context,
     is_initialized as distributed_context_is_initialized,
     get_rank as distributed_context_get_rank,
     get_size as distributed_context_get_size,
     barrier as distributed_context_barrier,
     allgather_int as distributed_context_allgather_int,
+    subcontext_id as distributed_context_subcontext_id,
+    subcontext_count as distributed_context_subcontext_count,
+    subcontext_sizes as distributed_context_subcontext_sizes,
+    subcontext_size as distributed_context_subcontext_size,
+    local_to_world_rank as distributed_context_local_to_world_rank,
+    world_rank as distributed_context_world_rank,
+    world_size as distributed_context_world_size,
 )
 
 from ttnn._ttnn.events import (


### PR DESCRIPTION
This is needed to support disaggregated deployments when models are implemented in python (e.g. deepseek prefill).


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snijjar/distributed-subcontexts-pybinds)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snijjar/distributed-subcontexts-pybinds)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snijjar/distributed-subcontexts-pybinds)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snijjar/distributed-subcontexts-pybinds)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/distributed-subcontexts-pybinds)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/distributed-subcontexts-pybinds)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snijjar/distributed-subcontexts-pybinds)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snijjar/distributed-subcontexts-pybinds)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snijjar/distributed-subcontexts-pybinds)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snijjar/distributed-subcontexts-pybinds)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snijjar/distributed-subcontexts-pybinds)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snijjar/distributed-subcontexts-pybinds)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snijjar/distributed-subcontexts-pybinds)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snijjar/distributed-subcontexts-pybinds)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snijjar/distributed-subcontexts-pybinds)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snijjar/distributed-subcontexts-pybinds)