### PR TITLE
fix(kv_cache): encode NOC addr as (bank_id << 32) | per_bank_offset

### DIFF
--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -123,8 +123,10 @@ def create_kv_chunk_address_table(config, mesh_device, mesh_shape, seq_len, sp_a
             for chunk in range(chunks_per_device_group):
                 location = ttnn.experimental.disaggregation.KvCacheLocation()
 
-                # This needs proper handling in KvCacheLocation(), just add it up atm
-                noc_addr = dram_bank_0_addr + curr_bank_id + curr_bank_offset
+                # Encode as (bank_id << 32) | per_bank_offset.
+                # dram_bank_0_addr is the allocatable base within each bank.
+                # curr_bank_offset grows by chunk_size_bytes each time bank wraps.
+                noc_addr = (curr_bank_id << 32) | (dram_bank_0_addr + curr_bank_offset)
                 location.noc_addr = noc_addr
                 location.size_bytes = chunk_size_bytes
                 location.device_group_index = group_idx

--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -107,7 +107,7 @@ def create_kv_chunk_address_table(config, mesh_device, mesh_shape, seq_len, sp_a
     logger.info("chunks_per_device_group = ", chunks_per_device_group)
 
     logger.info(f"kvpe cache shape is: {tt_kvpe_cache.shape}")
-    dram_bank_0_addr = tt_kvpe_cache.buffer_address()
+    dram_bank_base_addr = tt_kvpe_cache.buffer_address()
     for row in range(len(device_group_idx_per_row)):
         group_idx = device_group_idx_per_row[row]
         curr_bank_id = 0
@@ -123,10 +123,7 @@ def create_kv_chunk_address_table(config, mesh_device, mesh_shape, seq_len, sp_a
             for chunk in range(chunks_per_device_group):
                 location = ttnn.experimental.disaggregation.KvCacheLocation()
 
-                # Encode as (bank_id << 32) | per_bank_offset.
-                # dram_bank_0_addr is the allocatable base within each bank.
-                # curr_bank_offset grows by chunk_size_bytes each time bank wraps.
-                noc_addr = (curr_bank_id << 32) | (dram_bank_0_addr + curr_bank_offset)
+                noc_addr = (curr_bank_id << 32) | (dram_bank_base_addr + curr_bank_offset)
                 location.noc_addr = noc_addr
                 location.size_bytes = chunk_size_bytes
                 location.device_group_index = group_idx


### PR DESCRIPTION
The previous formula `dram_bank_0_addr + curr_bank_id + curr_bank_offset` was incorrect — adding the bank index as a byte offset rather than encoding it in the upper 32 bits. The migration layer interprets the upper 32 bits as the DRAM bank ID and the lower 32 bits as the per-bank byte offset.

Introducing strong typing of the address is future work


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snijjar/kv-chunk-table-addr-encoding)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snijjar/kv-chunk-table-addr-encoding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snijjar/kv-chunk-table-addr-encoding)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snijjar/kv-chunk-table-addr-encoding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/kv-chunk-table-addr-encoding)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/kv-chunk-table-addr-encoding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snijjar/kv-chunk-table-addr-encoding)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snijjar/kv-chunk-table-addr-encoding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snijjar/kv-chunk-table-addr-encoding)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snijjar/kv-chunk-table-addr-encoding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snijjar/kv-chunk-table-addr-encoding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snijjar/kv-chunk-table-addr-encoding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snijjar/kv-chunk-table-addr-encoding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snijjar/kv-chunk-table-addr-encoding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snijjar/kv-chunk-table-addr-encoding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snijjar/kv-chunk-table-addr-encoding)