### PR TITLE
Enabling BFLOAT8_B for Combine operator TILE_LAYOUT input

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -464,7 +464,7 @@ class TtMoe(LightweightModule):
             metadata,
             tt_expert_token_counts,
         )
-        logger.debug(f"[TtMoe.forward] combined_output shape: {combined_output.shape}")
+        logger.debug(f"[TtMoe.forward] combined_output shape: {combined_output.shape} {combined_output.dtype=}")
 
         # ========================================
         # Step 5: Reduce (fused weighted sum over topk + reduce-scatter for TP sharding)

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -456,12 +456,11 @@ class TtMoe(LightweightModule):
         # ========================================
         # Step 4: Combine (enabled)
         # ========================================
-        # Combine expects ROW_MAJOR or TILE_LAYOUT input
-        expert_outputs_rm = ttnn.to_layout(expert_outputs, ttnn.ROW_MAJOR_LAYOUT)
-        logger.debug(f"[TtMoe.forward] expert_outputs_rm shape: {expert_outputs_rm.shape} {expert_outputs_rm.dtype=}")
+        # Combine expects TILE_LAYOUT input
+        logger.debug(f"[TtMoe.forward] expert_outputs shape: {expert_outputs.shape} {expert_outputs.dtype=}")
 
         combined_output = self.combine_module(
-            expert_outputs_rm,
+            expert_outputs,
             metadata,
             tt_expert_token_counts,
         )

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.cpp
@@ -28,8 +28,9 @@ void CombineDeviceOperation::validate_on_program_cache_miss(
 
     // Validate dtypes
     TT_FATAL(
-        tensor_args.dispatched_buffer.dtype() == DataType::BFLOAT16,
-        "Dispatched buffer must be BFLOAT16, got {}",
+        tensor_args.dispatched_buffer.dtype() == DataType::BFLOAT16 ||
+            tensor_args.dispatched_buffer.dtype() == DataType::BFLOAT8_B,
+        "Dispatched buffer must be BFLOAT16 or BFLOAT8_B, got {}",
         tensor_args.dispatched_buffer.dtype());
     TT_FATAL(
         tensor_args.dispatched_metadata.dtype() == DataType::INT32,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.cpp
@@ -29,8 +29,9 @@ void CombineDeviceOperation::validate_on_program_cache_miss(
     // Validate dtypes
     TT_FATAL(
         tensor_args.dispatched_buffer.dtype() == DataType::BFLOAT16 ||
-            tensor_args.dispatched_buffer.dtype() == DataType::BFLOAT8_B,
-        "Dispatched buffer must be BFLOAT16 or BFLOAT8_B, got {}",
+            (tensor_args.dispatched_buffer.dtype() == DataType::BFLOAT8_B &&
+             tensor_args.dispatched_buffer.layout() == tt::tt_metal::Layout::TILE),
+        "Dispatched buffer must be BFLOAT16 or BFLOAT8_B with TILE layout, got {}",
         tensor_args.dispatched_buffer.dtype());
     TT_FATAL(
         tensor_args.dispatched_metadata.dtype() == DataType::INT32,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -1041,9 +1041,8 @@ void CombineProgramFactory::override_runtime_arguments(
             for (size_t i = 0; i < shared_variables.idle_cores.size(); i++) {
                 auto& idle_rt_args = tt::tt_metal::GetRuntimeArgs(
                     program, shared_variables.reader_untilize_kernel_ids[i], shared_variables.idle_cores[i]);
-                // RT layout: [0:counter_ready_sem, 1:data_ready_sem, 2:noc_x, 3:noc_y, 4:start_sem,
-                //             5:dispatched_buffer_addr, 6:expert_start, 7:expert_end]
-                idle_rt_args.at(5) = tensor_args.dispatched_buffer.buffer()->address();
+                // RT layout: [0:counter_ready_sem, 1:dispatched_buffer_addr, 2:expert_start, 3:expert_end]
+                idle_rt_args.at(1) = tensor_args.dispatched_buffer.buffer()->address();
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -267,23 +267,20 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         /*buffering_factor=*/read_batch_size,
         /*cb_id=*/tt::CBIndex::c_1,
         "dispatched_metadata_scratch");
+
     // c_2: expert_token_counts scratch on sender.
     // Sized one extra page larger than the raw counter data so reader_combine can append
     // its receive_buf_addr (get_write_ptr(c_18)) immediately after the counter pages before the
     // multicast, giving idle cores a host-side-free way to discover the sender's receive buffer.
-    // Extra space is one full counter_page_size (not l1_alignment) to keep cb_size divisible by page_size.
-    {
-        uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
-        uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
-        auto data_format = tt::tt_metal::datatype_to_dataformat_converter(expert_token_counts.dtype());
-        // One extra page holds the single receive_buf_addr (uint32) appended after counter data.
-        uint32_t extra_pages = 1;
-        uint32_t cb_size = (counter_pages + extra_pages) * counter_page_size;
-        tt::tt_metal::CircularBufferConfig c2_config =
-            tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CBIndex::c_2, data_format}})
-                .set_page_size(tt::CBIndex::c_2, counter_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, c2_config);
-    }
+    uint32_t extra_pages = is_tile_layout ? 1 : 0;
+    // c_2: expert_token_counts (reader-only, full tensor)
+    detail::create_tensor_cb(
+        program,
+        sender_core_grid,
+        expert_token_counts,
+        /*buffering_factor=*/detail::get_num_pages(expert_token_counts) + extra_pages,
+        /*cb_id=*/tt::CBIndex::c_2,
+        "expert_token_counts");
 
     if (is_tile_layout) {
         // c_18: receive buffer for idle-core untilized data written back via NOC (TILE_LAYOUT only)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39674

### Problem description
Combine operator previously worked only with **BFLOAT16 TILE_LAYOUT** `dispatched_buffer` input in order to make it work E2E inside of **MoE** it needs to work with **BFLOAT8_B TILE_LAYOUT** `dispatched_buffer` input.

### What's changed
- Removed **untilize** from `tt_moe.py`, because **combine operator** can use its fused implementation of **untilize**.
- Fixed bug with **TILE_LAYOUT** `override_runtime_arguments` method.
- Reduce size of `CB_2` for `expert_token_counts` for ROW_MAJOR to be 1 less page, because it is used only for TILE_LAYOUT input so there is no use of it inside ROW_MAJOR input.



### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilojevic/combine-bfloat8)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilojevic/combine-bfloat8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pmilojevic/combine-bfloat8)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pmilojevic/combine-bfloat8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/combine-bfloat8)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/combine-bfloat8)
- [x] [![(T3K) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pmilojevic/combine-bfloat8)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pmilojevic/combine-bfloat8)
- [x] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pmilojevic/combine-bfloat8)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pmilojevic/combine-bfloat8)
- [x] [![Demo SP
Release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=pmilojevic/combine-bfloat8)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:pmilojevic/combine-bfloat8)
- [x] [![(Galaxy) DeepSeek Prefill
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=pmilojevic/combine-bfloat8)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:pmilojevic/combine-bfloat8)