### PR TITLE
Fix ttnn.eq(tensor, scalar) always returning false for uint16 scalar != 0

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -679,7 +679,11 @@ uint32_t pack_scalar_runtime_arg(const unary::ScalarVariant scalar, const DataTy
             if (dtype == DataType::UINT32) {
                 return static_cast<uint32_t>(v);
             }
-            // TODO: #27672: Truncation should be removed once we figure a root cause of regression without it
+            if (dtype == DataType::UINT16) {
+                auto val = static_cast<uint16_t>(static_cast<float>(v));
+                return (static_cast<uint32_t>(val) << 16) | val;
+            }
+            //  TODO: #27672: Truncation should be removed once we figure a root cause of regression without it
             auto scalar_bf16 = bfloat16::truncate(static_cast<float>(v));
             return pack_two_bfloat16_into_uint32({scalar_bf16, scalar_bf16});
         },

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -683,7 +683,7 @@ uint32_t pack_scalar_runtime_arg(const unary::ScalarVariant scalar, const DataTy
                 auto val = static_cast<uint16_t>(static_cast<float>(v));
                 return (static_cast<uint32_t>(val) << 16) | val;
             }
-            //  TODO: #27672: Truncation should be removed once we figure a root cause of regression without it
+            // TODO: #27672: Truncation should be removed once we figure a root cause of regression without it
             auto scalar_bf16 = bfloat16::truncate(static_cast<float>(v));
             return pack_two_bfloat16_into_uint32({scalar_bf16, scalar_bf16});
         },


### PR DESCRIPTION
### Summary

Fixes `ttnn.eq` and `ttnn.ne` producing incorrect results when comparing a `uint16` tensor against a float scalar.

**Example:**
```python
t = ttnn.from_torch(torch.full((32, 32), 1, dtype=torch.int16),
                    layout=ttnn.TILE_LAYOUT, device=device)
ttnn.eq(t, 1.0)  # returned all 0s instead of all 1s
```

When the second operand is a scalar, its value is packed into a `uint32` runtime argument and used to fill the scalar tile. For `uint16` tensors, this packing was incorrectly converting the scalar to `bfloat16` format instead of `uint16`, causing a data mismatch in the comparison.

The fix adds a `uint16` branch to `pack_scalar_runtime_arg` in `binary_ng_utils.cpp` that correctly encodes the scalar as a `uint16` integer value.

### Notes for reviewers

- Single-line change on host in `pack_scalar_runtime_arg`; 
- `ttnn.ne` with `uint16` scalars is also fixed by this change.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmaurice/fix-ttnn-eq-uint16-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmaurice/fix-ttnn-eq-uint16-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmaurice/fix-ttnn-eq-uint16-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmaurice/fix-ttnn-eq-uint16-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmaurice/fix-ttnn-eq-uint16-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmaurice/fix-ttnn-eq-uint16-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmaurice/fix-ttnn-eq-uint16-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmaurice/fix-ttnn-eq-uint16-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmaurice/fix-ttnn-eq-uint16-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmaurice/fix-ttnn-eq-uint16-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmaurice/fix-ttnn-eq-uint16-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmaurice/fix-ttnn-eq-uint16-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmaurice/fix-ttnn-eq-uint16-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmaurice/fix-ttnn-eq-uint16-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmaurice/fix-ttnn-eq-uint16-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmaurice/fix-ttnn-eq-uint16-scalar)