### PR TITLE
Replace assert_with_pcc with assert_equal for DM tests

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -253,7 +253,7 @@ def test_reshape_cw_div2_rm(device, n, c, h, w):
     output_tensor = ttnn.reshape_on_device(input_tensor, n, c * 2, h, w // 2, memory_config=ttnn.L1_MEMORY_CONFIG)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert_equal(torch_output_tensor, output_tensor)
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
@@ -271,7 +271,7 @@ def test_reshape_cw_mul2_rm(device, n, c, h, w):
     output_tensor = ttnn.reshape_on_device(input_tensor, n, c // 2, h, w * 2, memory_config=ttnn.L1_MEMORY_CONFIG)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert_equal(torch_output_tensor, output_tensor)
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
@@ -289,7 +289,7 @@ def test_reshape_hw_div2_rm(device, n, c, h, w):
     output_tensor = ttnn.reshape_on_device(input_tensor, n, c, h * 2, w // 2, memory_config=ttnn.L1_MEMORY_CONFIG)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert_equal(torch_output_tensor, output_tensor)
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
@@ -307,7 +307,7 @@ def test_reshape_hw_mul2_rm(device, n, c, h, w):
     output_tensor = ttnn.reshape_on_device(input_tensor, n, c, h // 2, w * 2, memory_config=ttnn.L1_MEMORY_CONFIG)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert_equal(torch_output_tensor, output_tensor)
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
@@ -322,7 +322,7 @@ def run_reshape_hw_rm_with_program_cache(device, n, c, h, w):
         output_tensor = ttnn.reshape_on_device(input_tensor, n, c, h // 2, w * 2, memory_config=ttnn.L1_MEMORY_CONFIG)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert_equal(torch_output_tensor, output_tensor)
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
@@ -356,7 +356,7 @@ def test_reshape(h, w):
     output_tensor = ttnn.reshape(input_tensor, (w, h))
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert_equal(torch_output_tensor, output_tensor)
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
@@ -370,7 +370,7 @@ def test_reshape_negative_1(h, w):
     output_tensor = ttnn.reshape(input_tensor, (-1,))
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert_equal(torch_output_tensor, output_tensor)
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
@@ -386,7 +386,7 @@ def test_reshape_in_4D(n, c, h, w):
     output_tensor = ttnn.reshape(input_tensor, (h, w, n, c))
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert_equal(torch_output_tensor, output_tensor)
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
@@ -404,7 +404,7 @@ def test_reshape_in_4D_on_device(device, n, c, h, w):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert_equal(torch_output_tensor, output_tensor)
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
@@ -424,7 +424,7 @@ def test_permute_reshape(device):
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 def test_reshape_with_negative_dim(device):
@@ -443,7 +443,7 @@ def test_reshape_with_negative_dim(device):
 
     assert list(expected_output_shape) == list(torch_output.shape)
     assert list(expected_output_shape) == list(tt_output.shape)
-    assert_with_pcc(torch_output, tt_output, 0.9999)
+    assert_equal(torch_output, tt_output)
 
 
 def test_reshape_tile_layout_mamba(device):
@@ -456,7 +456,7 @@ def test_reshape_tile_layout_mamba(device):
 
     output = ttnn.to_torch(ttnn_output)
 
-    assert_with_pcc(torch_result, output, 0.9999)
+    assert_equal(torch_result, output)
 
 
 def test_reshape_tile_layout_only_change_shape(device):
@@ -469,7 +469,7 @@ def test_reshape_tile_layout_only_change_shape(device):
 
     output = ttnn.to_torch(ttnn_output)
 
-    assert_with_pcc(torch_result, output, 0.9999)
+    assert_equal(torch_result, output)
 
 
 @pytest.mark.parametrize(
@@ -521,7 +521,7 @@ def test_reshape_tile(device, input_shape, output_shape, layout, memory_config, 
     )
     ttnn_output = ttnn.reshape(input_tensor, output_shape)
     output = ttnn.to_torch(ttnn_output)
-    assert_with_pcc(torch_result, output, 0.9999)
+    assert_equal(torch_result, output)
 
 
 @pytest.mark.parametrize(
@@ -569,7 +569,7 @@ def test_reshape_subgrid(device, input_shape, output_shape, layout, memory_confi
     )
     ttnn_output = ttnn.reshape(input_tensor, output_shape, sub_core_grids=sub_core_grids)
     output = ttnn.to_torch(ttnn_output)
-    assert_with_pcc(torch_result, output, 0.9999)
+    assert_equal(torch_result, output)
 
 
 @pytest.mark.parametrize("recreate_mapping_tensor", (ttnn.TileReshapeMapMode.CACHE, ttnn.TileReshapeMapMode.RECREATE))
@@ -585,7 +585,7 @@ def test_reshape_tile_program_cache(device, recreate_mapping_tensor):
             ttnn_output = ttnn.reshape(input_tensor, output_shape, recreate_mapping_tensor=recreate_mapping_tensor)
 
             output = ttnn.to_torch(ttnn_output)
-            assert_with_pcc(torch_result, output, 0.9999)
+            assert_equal(torch_result, output)
 
 
 # issue 15048
@@ -606,7 +606,7 @@ def test_previously_failing_test(device):
     ttnn_output = ttnn.reshape(input_tensor, target_shape)
     output = ttnn.to_torch(ttnn_output)
 
-    assert_with_pcc(torch_result, output, 0.9999)
+    assert_equal(torch_result, output)
 
 
 # Since Inner dim is 1 of bfloat16, can't do on device, testing fallback on host
@@ -627,7 +627,7 @@ def test_reshape_host(input_shape, output_shape, device):
 
     output = ttnn.to_torch(ttnn_output)
 
-    assert_with_pcc(torch_result, output, 0.9999)
+    assert_equal(torch_result, output)
 
 
 # required for Embedding
@@ -653,7 +653,7 @@ def test_reshape_int(input_shape, output_shape, device):
 
     output = ttnn.to_torch(ttnn_output)
 
-    assert_with_pcc(torch_result, output, 0.9999)
+    assert_equal(torch_result, output)
 
 
 @pytest.mark.parametrize(
@@ -684,7 +684,7 @@ def test_fp32_support(input_shape, output_shape, device):
 
     output = ttnn.to_torch(ttnn_output)
 
-    assert_with_pcc(torch_result, output, 0.9999)
+    assert_equal(torch_result, output)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -254,7 +254,6 @@ def test_reshape_cw_div2_rm(device, n, c, h, w):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_equal(torch_output_tensor, output_tensor)
-    assert torch.allclose(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("n", [16])
@@ -272,7 +271,6 @@ def test_reshape_cw_mul2_rm(device, n, c, h, w):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_equal(torch_output_tensor, output_tensor)
-    assert torch.allclose(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("n", [16])
@@ -290,7 +288,6 @@ def test_reshape_hw_div2_rm(device, n, c, h, w):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_equal(torch_output_tensor, output_tensor)
-    assert torch.allclose(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("n", [16])
@@ -308,7 +305,6 @@ def test_reshape_hw_mul2_rm(device, n, c, h, w):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_equal(torch_output_tensor, output_tensor)
-    assert torch.allclose(torch_output_tensor, output_tensor)
 
 
 def run_reshape_hw_rm_with_program_cache(device, n, c, h, w):
@@ -323,7 +319,6 @@ def run_reshape_hw_rm_with_program_cache(device, n, c, h, w):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_equal(torch_output_tensor, output_tensor)
-    assert torch.allclose(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("n", [16])
@@ -357,7 +352,6 @@ def test_reshape(h, w):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_equal(torch_output_tensor, output_tensor)
-    assert torch.allclose(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("h", [32])
@@ -371,7 +365,6 @@ def test_reshape_negative_1(h, w):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_equal(torch_output_tensor, output_tensor)
-    assert torch.allclose(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("n", [32, 32])
@@ -387,7 +380,6 @@ def test_reshape_in_4D(n, c, h, w):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_equal(torch_output_tensor, output_tensor)
-    assert torch.allclose(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("n", [32, 64])
@@ -405,7 +397,6 @@ def test_reshape_in_4D_on_device(device, n, c, h, w):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_equal(torch_output_tensor, output_tensor)
-    assert torch.allclose(torch_output_tensor, output_tensor)
 
 
 def test_permute_reshape(device):

--- a/tests/ttnn/unit_tests/base_functionality/test_reshape_transpose.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape_transpose.py
@@ -4,7 +4,7 @@
 
 import torch
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_equal
 
 
 def test_transpose_with_reshape(device):
@@ -30,4 +30,4 @@ def test_transpose_with_reshape(device):
     torch_ref = torch_ref.transpose(1, 2)
 
     # Compare results
-    assert_with_pcc(torch_ref, tt_result, 0.9999)
+    assert_equal(torch_ref, tt_result)

--- a/tests/ttnn/unit_tests/base_functionality/test_roll.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_roll.py
@@ -5,7 +5,7 @@
 import pytest
 import torch
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
 
 
 @pytest.mark.parametrize(
@@ -73,8 +73,7 @@ def test_roll(device, input_tensor, shifts, dim, layout, dtype, memory_config):
     ttnn_out = ttnn.roll(ttnn_tensor, shifts, dim)
     ttnn_result_torch = ttnn.to_torch(ttnn_out)
 
-    assert_with_pcc(pytorch_out, ttnn_result_torch)
-    assert torch.allclose(pytorch_out, ttnn_result_torch)
+    assert_equal(pytorch_out, ttnn_result_torch)
 
 
 @pytest.mark.parametrize(
@@ -115,8 +114,7 @@ def test_roll_without_dim(device, input_tensor, shifts):
     pytorch_out = torch.roll(tensor, shifts)
     ttnn_out = ttnn.roll(ttnn_tensor, shifts)
     ttnn_result_torch = ttnn.to_torch(ttnn_out)
-    assert_with_pcc(pytorch_out, ttnn_result_torch)
-    assert torch.allclose(pytorch_out, ttnn_result_torch)
+    assert_equal(pytorch_out, ttnn_result_torch)
 
 
 @pytest.mark.parametrize(
@@ -191,8 +189,7 @@ def test_roll_tile_padding(device, input_tensor, shifts, dim, layout, dtype):
     ttnn_out = ttnn.roll(ttnn_tensor, shifts, dim)
     ttnn_result_torch = ttnn.to_torch(ttnn_out)
 
-    assert_with_pcc(pytorch_out, ttnn_result_torch)
-    assert torch.allclose(pytorch_out, ttnn_result_torch)
+    assert_equal(pytorch_out, ttnn_result_torch)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/base_functionality/test_view.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_view.py
@@ -7,8 +7,7 @@ import pytest
 import torch
 
 import ttnn
-
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_equal
 
 
 # Reshape in Tile layout with shapes that are not divisible by 32
@@ -34,7 +33,7 @@ def test_view(input_shape, output_shape, layout, device):
     ttnn_output = ttnn.view(input_tensor, output_shape)
     assert layout == ttnn_output.layout
     output = ttnn.to_torch(ttnn_output)
-    assert_with_pcc(torch_result, output, 0.9999)
+    assert_equal(torch_result, output)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
@@ -446,4 +446,4 @@ def test_concat_sub_core_grids(device, layout, dim, input_shapes, sub_core_grids
     output = ttnn.concat([in1, in2], dim=dim, memory_config=memory_config, sub_core_grids=sub_core_grids)
     output = ttnn.to_torch(output)
 
-    assert_with_pcc(torch_output_tensor, output, 0.99)
+    assert_equal(torch_output_tensor, output)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
@@ -452,7 +452,7 @@ def test_tg_llama_sharded_embedding(
         ttnn.Shape((batch_size, 32, hidden_embedding_dim)),
     )
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_equal(output_tensor, torch_output_tensor[:, 0, :].unsqueeze(1))
+    assert_equal(torch_output_tensor[:, 0, :].unsqueeze(1), output_tensor)
 
 
 @run_for_wormhole_b0()
@@ -510,7 +510,7 @@ def test_tg_llama_sharded_rm_embedding(device):
             input_tensor, weights, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=output_mem_config
         )
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_equal(output_tensor, torch_output_tensor)
+    assert_equal(torch_output_tensor, output_tensor)
     assert device.num_program_cache_entries() == 1
 
 

--- a/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
@@ -5,8 +5,8 @@
 import pytest
 import torch
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random, run_for_wormhole_b0, skip_for_blackhole
+from tests.ttnn.utils_for_testing import assert_equal
 
 
 def test_base_case(device):
@@ -19,7 +19,7 @@ def test_base_case(device):
     embeddings = ttnn.embedding(indices, embedding_matrix)
     assert tuple(expected_embeddings.shape) == tuple(embeddings.shape)
     embeddings = ttnn.to_torch(ttnn.from_device(embeddings))
-    assert_with_pcc(expected_embeddings, embeddings)
+    assert_equal(expected_embeddings, embeddings)
 
 
 @pytest.mark.parametrize("batch_size", [1, 8, 9])
@@ -55,7 +55,7 @@ def test_embedding(
     output_tensor = ttnn.embedding(input_tensor, weights, memory_config=output_mem_config, layout=layout)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("batch_size", [55, 100, 200])
@@ -91,7 +91,7 @@ def test_embedding_unaligned_RM_pages(
     output_tensor = ttnn.embedding(input_tensor, weights, memory_config=output_mem_config, layout=layout)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("batch_size", [8])
@@ -123,7 +123,7 @@ def test_bloom_embedding(
     output_tensor = ttnn.embedding(input_tensor, weights, memory_config=output_mem_config, layout=ttnn.TILE_LAYOUT)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("batch_size", [32])
@@ -156,7 +156,7 @@ def test_moe_embedding(
     output_tensor = ttnn.embedding(input_tensor, weights, memory_config=output_mem_config, layout=ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("batch_size", [1, 8, 9])
@@ -212,7 +212,7 @@ def test_embedding_tiled_input(
     )
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 def reverse_embedding_output(output_tensor, weights_tensor):
@@ -316,7 +316,7 @@ def test_tiled(
     )
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("batch_size, sentence_size, hidden_embedding_dim, vocabulary_size", [(10, 96, 2048, 128256)])
@@ -389,7 +389,7 @@ def test_embedding_tiled_sharded_output(
     )
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 @run_for_wormhole_b0()
@@ -452,7 +452,7 @@ def test_tg_llama_sharded_embedding(
         ttnn.Shape((batch_size, 32, hidden_embedding_dim)),
     )
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(output_tensor, torch_output_tensor[:, 0, :].unsqueeze(1))
+    assert_equal(output_tensor, torch_output_tensor[:, 0, :].unsqueeze(1))
 
 
 @run_for_wormhole_b0()
@@ -510,7 +510,7 @@ def test_tg_llama_sharded_rm_embedding(device):
             input_tensor, weights, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=output_mem_config
         )
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(output_tensor, torch_output_tensor)
+    assert_equal(output_tensor, torch_output_tensor)
     assert device.num_program_cache_entries() == 1
 
 
@@ -540,4 +540,4 @@ def test_embedding_oom(
     output_tensor = ttnn.embedding(input_tensor, weights, memory_config=output_mem_config, layout=ttnn.TILE_LAYOUT)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    assert_equal(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_fill_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_fill_pad.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 import ttnn
 import math
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
 from models.common.utility_functions import torch_random, run_for_wormhole_b0
 
 
@@ -189,7 +189,7 @@ def test_fill_pad_int(
     output_tensor = ttnn.fill_implicit_tile_padding(input_tensor, fill_value, memory_config=output_mem_config)
     padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch_with_padded_shape()
 
-    assert_with_pcc(padded_torch_tensor, padded_torch_output_tensor)
+    assert_equal(padded_torch_tensor, padded_torch_output_tensor)
 
 
 @pytest.mark.parametrize("fill_value", [1])

--- a/tests/ttnn/unit_tests/operations/data_movement/test_pad_subcoregrids.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_pad_subcoregrids.py
@@ -5,7 +5,7 @@
 import pytest
 import torch
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_equal
 
 torch.manual_seed(0)
 
@@ -82,7 +82,7 @@ def test_pad_tile_subcoregrids(device, shape, padding, torch_padding, sub_core_g
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert output_tensor.shape == torch_output_tensor.shape
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 # ────────────────────────────────────────────────────────────────────────────────
@@ -141,7 +141,7 @@ def test_pad_rm_subcoregrids(device, shape, padding, torch_padding, sub_core_gri
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert output_tensor.shape == torch_output_tensor.shape
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 # ────────────────────────────────────────────────────────────────────────────────
@@ -193,7 +193,7 @@ def test_pad_tile_subcoregrids_legacy_api(device, shape, padded_shape, sub_core_
     assert output_tensor.shape == torch.Size(padded_shape)
     # Verify original data is preserved in the non-padded region
     output_slice = output_tensor[: shape[0], : shape[1], : shape[2], : shape[3]]
-    assert torch.equal(torch_input_tensor, output_slice)
+    assert_equal(torch_input_tensor, output_slice)
 
 
 # ────────────────────────────────────────────────────────────────────────────────
@@ -233,7 +233,7 @@ def test_pad_tile_subcoregrids_dtypes(device, dtype):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert output_tensor.shape == torch_output_tensor.shape
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 # ────────────────────────────────────────────────────────────────────────────────
@@ -376,6 +376,6 @@ def test_pad_subcoregrids_none_matches_default(device, layout):
     )
     output_default = ttnn.to_torch(output_default)
 
-    assert torch.equal(output_none, output_default)
+    assert_equal(output_none, output_default)
     assert output_none.shape == torch_output.shape
-    assert_with_pcc(torch_output, output_none, 0.9999)
+    assert_equal(torch_output, output_none)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_reallocate.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_reallocate.py
@@ -6,10 +6,8 @@ import pytest
 import torch
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc
-
-
 from models.common.utility_functions import is_wormhole_b0, is_blackhole
+from tests.ttnn.utils_for_testing import assert_equal
 
 
 @pytest.mark.parametrize("mem_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
@@ -57,7 +55,7 @@ def test_reallocate_interleaved(device, mem_config, num_allocs):
     else:
         assert new_address >= initial_address
 
-    assert_with_pcc(torch_tensors[-1], ttnn.to_torch(tensors[-1]), 0.9999)
+    assert_equal(torch_tensors[-1], ttnn.to_torch(tensors[-1]))
 
 
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
@@ -92,4 +90,4 @@ def test_reallocate_sharded(device, input_shape, core_grid, strategy, layout):
     output_tensor = ttnn.reallocate(input_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_input_tensor, output_tensor, 1.0)
+    assert_equal(torch_input_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_reallocate.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_reallocate.py
@@ -6,7 +6,6 @@ import pytest
 import torch
 import ttnn
 
-from models.common.utility_functions import is_wormhole_b0, is_blackhole
 from tests.ttnn.utils_for_testing import assert_equal
 
 

--- a/tests/ttnn/unit_tests/operations/data_movement/test_repeat_interleave.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_repeat_interleave.py
@@ -7,7 +7,6 @@ import pytest
 import torch
 
 import ttnn
-from loguru import logger
 from tests.ttnn.utils_for_testing import assert_equal
 
 

--- a/tests/ttnn/unit_tests/operations/data_movement/test_repeat_interleave.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_repeat_interleave.py
@@ -8,8 +8,7 @@ import torch
 
 import ttnn
 from loguru import logger
-
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_equal
 
 
 @pytest.mark.parametrize("repeats", [1, 2, 3, 58])
@@ -27,7 +26,7 @@ def test_repeat_interleave(device, repeats, dim, dtype):
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, dtype=dtype, device=device)
     output = ttnn.repeat_interleave(input_tensor, repeats, dim=dim)
     output = ttnn.to_torch(output)
-    assert_with_pcc(torch_result, output, 0.9999)
+    assert_equal(torch_result, output)
 
 
 @pytest.mark.skip(reason="ttnn.repeat_interleave only supports `repeats` as int")
@@ -40,4 +39,4 @@ def test_repeat_interleave_with_repeat_tensor(device):
     output = ttnn.repeat_interleave(input_tensor, repeats, dim=1)
     output = ttnn.to_torch(output)
 
-    assert_with_pcc(torch_result, output, 0.9999)
+    assert_equal(torch_result, output)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_sharded_to_interleaved_oob.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sharded_to_interleaved_oob.py
@@ -6,7 +6,7 @@ import pytest
 import ttnn
 import torch
 
-from tests.ttnn.utils_for_testing import assert_equal, assert_with_pcc, comp_pcc
+from tests.ttnn.utils_for_testing import assert_equal
 
 
 def test_s2i_dram_height_sharded(device):
@@ -39,9 +39,5 @@ def test_s2i_dram_height_sharded(device):
     ttnn.deallocate(output_tensor)
     output_tensor = ttnn.sharded_to_interleaved(input_tensor, ttnn.DRAM_MEMORY_CONFIG)
 
-    output_passed, output_message = comp_pcc(torch_input_tensor, ttnn.to_torch(output_tensor), 1.0)
-    weight_passed, weight_message = comp_pcc(torch_weight_tensor, ttnn.to_torch(weight_tensor), 1.0)
-
-    assert (
-        output_passed and weight_passed
-    ), f"Output result: (passed?={output_passed}, pcc={round(output_message, 4)}) - Weight result: (passed?={weight_passed}, pcc={round(weight_message, 4)})"
+    assert_equal(torch_input_tensor, ttnn.to_torch(output_tensor))
+    assert_equal(torch_weight_tensor, ttnn.to_torch(weight_tensor))

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
 from tests.ttnn.unit_tests.operations.test_utils import round_up
 import math
 
@@ -75,7 +75,7 @@ def run_slice_rm_sharded(device, n, c, h, w):
         tt_output_tensor = ttnn.to_memory_config(tt_output_tensor, ttnn.L1_MEMORY_CONFIG)
     tt_output_tensor = ttnn.from_device(tt_output_tensor)
     tt_output_tensor = ttnn.to_torch(tt_output_tensor)
-    assert_with_pcc(torch_output_tensor, tt_output_tensor, 0.9999)
+    assert_equal(torch_output_tensor, tt_output_tensor)
 
 
 @pytest.mark.parametrize(
@@ -186,7 +186,7 @@ def test_slice_rm(device, n, c, h, w):
     activation_pyt_padded_out = ttnn.to_memory_config(activation_pyt_padded, ttnn.L1_MEMORY_CONFIG)
     activation_pyt_padded_out = ttnn.from_device(activation_pyt_padded_out)
     activation_pyt_padded_out = ttnn.to_torch(activation_pyt_padded_out)
-    assert_with_pcc(torch_output_tensor, activation_pyt_padded_out, 0.9999)
+    assert_equal(torch_output_tensor, activation_pyt_padded_out)
 
 
 def slice_test(
@@ -1309,7 +1309,7 @@ def test_slice_sharded_auto_shard_spec_recomputation(
     tt_output_torch = ttnn.to_torch(tt_output_cpu)
     torch_expected = torch_input[begins[0] : ends[0], begins[1] : ends[1], begins[2] : ends[2], begins[3] : ends[3]]
 
-    assert_with_pcc(torch_expected, tt_output_torch, 0.9999)
+    assert_equal(torch_expected, tt_output_torch)
 
 
 @pytest.mark.parametrize(
@@ -1371,7 +1371,7 @@ def test_slice_within_tile_vs_across_tiles(input_shape, begins, ends, layout, us
         tt_output = ttnn.to_memory_config(tt_output, ttnn.DRAM_MEMORY_CONFIG)
     tt_output_torch = ttnn.to_torch(tt_output)
 
-    assert_with_pcc(torch_expected, tt_output_torch, 0.9999)
+    assert_equal(torch_expected, tt_output_torch)
 
 
 @pytest.mark.parametrize(
@@ -1433,7 +1433,7 @@ def test_slice_sharding_independence(input_shape, begins, ends, use_sharding, de
         tt_output = ttnn.to_memory_config(tt_output, ttnn.DRAM_MEMORY_CONFIG)
     tt_output_torch = ttnn.to_torch(tt_output)
 
-    assert_with_pcc(torch_expected, tt_output_torch, 0.9999)
+    assert_equal(torch_expected, tt_output_torch)
 
 
 def test_issue_38841_regression(device):
@@ -1467,7 +1467,7 @@ def test_issue_38841_regression(device):
     torch_expected = torch_input[0:1, 0:1, 0:128, 0:32]
     tt_output_torch = ttnn.to_torch(tt_output)
 
-    assert_with_pcc(torch_expected, tt_output_torch, 0.9999)
+    assert_equal(torch_expected, tt_output_torch)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py
@@ -7,9 +7,9 @@ import pytest
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
 from tests.ttnn.unit_tests.operations.test_utils import round_up
 from models.common.utility_functions import skip_for_blackhole
+from tests.ttnn.utils_for_testing import assert_equal
 import math
 import random
 
@@ -126,5 +126,5 @@ def test_slice_write_nd(rank, layout, device):
     out_host = ttnn.to_torch(tt_out)
     written_region = out_host[slices]
 
-    assert_with_pcc(written_region, torch_src, 0.9999)
-    assert_with_pcc(out_host, torch_out_ref, 0.9999)
+    assert_equal(written_region, torch_src)
+    assert_equal(out_host, torch_out_ref)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py
@@ -6,12 +6,10 @@ import pytest
 
 import torch
 
-import ttnn
-from tests.ttnn.unit_tests.operations.test_utils import round_up
-from models.common.utility_functions import skip_for_blackhole
-from tests.ttnn.utils_for_testing import assert_equal
-import math
 import random
+
+import ttnn
+from tests.ttnn.utils_for_testing import assert_equal
 
 
 def random_torch_tensor(dtype, shape):
@@ -126,5 +124,5 @@ def test_slice_write_nd(rank, layout, device):
     out_host = ttnn.to_torch(tt_out)
     written_region = out_host[slices]
 
-    assert_equal(written_region, torch_src)
-    assert_equal(out_host, torch_out_ref)
+    assert_equal(torch_src, written_region)
+    assert_equal(torch_out_ref, out_host)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_stack.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_stack.py
@@ -5,7 +5,7 @@
 import pytest
 import torch
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_equal
 
 
 @pytest.mark.parametrize(
@@ -32,6 +32,6 @@ def test_stack(device, input_shapes, dim, layout):
     ttnn_result = ttnn.stack(ttnn_tensors, dim=dim)
 
     ttnn_result_torch = ttnn.to_torch(ttnn_result)
-    assert_with_pcc(torch_result, ttnn_result_torch)
+    assert_equal(torch_result, ttnn_result_torch)
 
     assert torch_result.shape == ttnn_result_torch.shape

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tosa_gather.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tosa_gather.py
@@ -5,7 +5,7 @@
 import pytest
 import torch
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_equal
 
 
 @pytest.mark.parametrize(
@@ -39,4 +39,4 @@ def test_tosa_gather_general(N, K, C, W, device):
     ttnn_gather = ttnn.tosa_gather(ttnn_input, ttnn_index)
 
     assert ttnn_gather.shape == torch_gather.shape
-    assert_with_pcc(torch_gather, ttnn.to_torch(ttnn_gather))
+    assert_equal(torch_gather, ttnn.to_torch(ttnn_gather))

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
@@ -519,8 +519,8 @@ def test_untilize_multi_core_interleaved_to_interleaved(device, dtype, tensor_sh
     input_ttnn_tensor = ttnn.from_torch(input_torch_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT)
     input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=input_memory_config)
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, memory_config=output_memory_config, use_multicore=True)
-    ttnn_output = ttnn.to_torch(ttnn_output_tensor)
-    assert_equal(input_torch_tensor, ttnn_output)
+
+    assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
@@ -121,7 +121,7 @@ def test_untilize_single_core_interleaved_to_sharded(
     input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=input_memory_config)
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, memory_config=output_memory_config, use_multicore=False)
 
-    assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+    assert_equal(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor))
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
@@ -325,7 +325,7 @@ def test_untilize_single_core_sharded_to_interleaved(
     input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=input_memory_config)
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, memory_config=output_memory_config, use_multicore=False)
 
-    assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+    assert_equal(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor))
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
@@ -442,7 +442,7 @@ def test_untilize_single_core_sharded_to_sharded(
     input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=input_memory_config)
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, memory_config=output_memory_config, use_multicore=False)
 
-    assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+    assert_equal(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor))
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
@@ -496,7 +496,7 @@ def test_untilize_single_core_buffer_type_variations(
     input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=input_memory_config)
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, memory_config=output_memory_config, use_multicore=False)
 
-    assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+    assert_equal(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor))
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
@@ -519,8 +519,8 @@ def test_untilize_multi_core_interleaved_to_interleaved(device, dtype, tensor_sh
     input_ttnn_tensor = ttnn.from_torch(input_torch_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT)
     input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=input_memory_config)
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, memory_config=output_memory_config, use_multicore=True)
-
-    assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+    ttnn_output = ttnn.to_torch(ttnn_output_tensor)
+    assert_equal(input_torch_tensor, ttnn_output)
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
@@ -636,7 +636,7 @@ def test_untilize_multi_core_interleaved_to_sharded(
     input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=input_memory_config)
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, memory_config=output_memory_config, use_multicore=True)
 
-    assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+    assert_equal(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor))
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
@@ -851,7 +851,7 @@ def test_untilize_multi_core_sharded_to_interleaved(
     input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=input_memory_config)
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, memory_config=output_memory_config, use_multicore=True)
 
-    assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+    assert_equal(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor))
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
@@ -905,7 +905,7 @@ def test_untilize_multi_core_sharded_to_interleaved_uneven_input_shard_spec(
     input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=input_memory_config)
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, memory_config=output_memory_config, use_multicore=True)
 
-    assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+    assert_equal(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor))
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
@@ -1005,7 +1005,7 @@ def test_untilize_multi_core_sharded_to_sharded_different_shard_types(
     input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=input_memory_config)
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, memory_config=output_memory_config, use_multicore=True)
 
-    assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+    assert_equal(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor))
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
@@ -1164,7 +1164,7 @@ def test_untilize_multi_core_sharded_to_sharded_different_shard_types_uneven_inp
     input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=input_memory_config)
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, memory_config=output_memory_config, use_multicore=True)
 
-    assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+    assert_equal(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor))
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
@@ -1307,7 +1307,7 @@ def test_untilize_multi_core_sharded_to_sharded_same_shard_type_different_shard_
     input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=input_memory_config)
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, memory_config=output_memory_config, use_multicore=True)
 
-    assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+    assert_equal(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor))
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
@@ -1366,7 +1366,7 @@ def test_untilize_multi_core_sharded_to_sharded_same_shard_type_different_shard_
     input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=input_memory_config)
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, memory_config=output_memory_config, use_multicore=True)
 
-    assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+    assert_equal(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor))
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
@@ -1456,7 +1456,7 @@ def test_untilize_multi_core_sharded_to_sharded_same_shard_type_and_shard_spec(
     input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=memory_config)
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, memory_config=memory_config, use_multicore=True)
 
-    assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+    assert_equal(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor))
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
@@ -1504,7 +1504,7 @@ def test_untilize_multi_core_sharded_to_sharded_same_shard_type_and_shard_spec_u
     input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=memory_config)
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, memory_config=memory_config, use_multicore=True)
 
-    assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+    assert_equal(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor))
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
@@ -1561,7 +1561,7 @@ def test_untilize_multi_core_buffer_type_variations(
     input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=input_memory_config)
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, memory_config=output_memory_config, use_multicore=True)
 
-    assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+    assert_equal(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor))
 
 
 @pytest.mark.parametrize(
@@ -1635,7 +1635,7 @@ def test_untilize_same_volume_different_shapes(device, dtype, use_multicore, sha
             input_ttnn_tensor, memory_config=output_memory_config, use_multicore=use_multicore
         )
 
-        assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+        assert_equal(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor))
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/43163

### Summary of Work done
Data movement operations (copy, reshape, permute, slice, etc.) are expected to produce bit-exact results — they move data without any arithmetic transformation, so PCC-based assertions (assert_with_pcc) are unnecessarily lenient for these ops.                                                 
  
  This PR replaces assert_with_pcc with assert_equal from tests.ttnn.utils_for_testing for data movement tests where exact equality is guaranteed. assert_equal is preferred over bare torch.equal because it normalizes uint32 → int64 and uint16 → int32 before comparison, avoiding false failures from signed/unsigned dtype mismatches when converting TTNN tensors back to PyTorch.                                                                             
   
  A small set of tests could not be migrated in this PR due to observed non-exact outputs; those will be investigated and addressed in a follow-up   
  PR.     

### Pipeline Checklist

- [x] Sanity tests - Passed
- [x] (Runtime) Sanity Tests - Passed
- [x] BHPC - Passed
- [x] Nightly L2 - Passed

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/dm_equal_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/dm_equal_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/dm_equal_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/dm_equal_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/dm_equal_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchani/dm_equal_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/dm_equal_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/dm_equal_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/dm_equal_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/dm_equal_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/dm_equal_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/dm_equal_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/dm_equal_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/dm_equal_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/dm_equal_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/dm_equal_check)