### PR TITLE
Migrate rand op to ProgramDescriptor framework (#42399)

### DIFF
--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -11,6 +11,7 @@
 
 #include <memory>
 #include <optional>
+#include <type_traits>
 #include <concepts>
 #include <variant>
 #include "ttnn/distributed/types.hpp"
@@ -243,6 +244,40 @@ public:
             return buffers;
         }
 
+        // DirectDescriptorFactory always accepts an optional mesh coordinate, but only forwards it when
+        // DeviceOperation defines the 4-argument overload. Custom descriptor factories opt in explicitly.
+        static consteval bool create_descriptor_uses_mesh_dispatch_coordinate() {
+            if constexpr (std::is_same_v<DescriptorFactory, DirectDescriptorFactory>) {
+                return requires(
+                    const operation_attributes_t& attrs,
+                    const tensor_args_t& tensor_args,
+                    tensor_return_value_t& tensor_return_value,
+                    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+                    DeviceOperation::create_descriptor(
+                        attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
+                };
+            } else if constexpr (has_prepare_resources) {
+                return requires(
+                    const operation_attributes_t& attrs,
+                    const tensor_args_t& tensor_args,
+                    tensor_return_value_t& tensor_return_value,
+                    resource_t& resources,
+                    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+                    DescriptorFactory::create_descriptor(
+                        attrs, tensor_args, tensor_return_value, resources, mesh_dispatch_coordinate);
+                };
+            } else {
+                return requires(
+                    const operation_attributes_t& attrs,
+                    const tensor_args_t& tensor_args,
+                    tensor_return_value_t& tensor_return_value,
+                    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+                    DescriptorFactory::create_descriptor(
+                        attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
+                };
+            }
+        }
+
         static tt::tt_metal::ProgramDescriptor invoke_create_descriptor(
             const operation_attributes_t& attrs,
             const tensor_args_t& tensor_args,
@@ -282,22 +317,32 @@ public:
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
 
-            for (const auto& coord : tensor_coords.coords()) {
-                resource_t resources{};
-                if constexpr (has_prepare_resources) {
-                    resources = DescriptorFactory::prepare_resources(attrs, tensor_args, tensor_return_value);
-                }
+            const auto build_and_add_program =
+                [&](const ttnn::MeshCoordinateRange& device_range,
+                    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+                    resource_t resources{};
+                    if constexpr (has_prepare_resources) {
+                        resources = DescriptorFactory::prepare_resources(attrs, tensor_args, tensor_return_value);
+                    }
 
-                const std::optional<ttnn::MeshCoordinate> mesh_dispatch_coordinate(coord);
-                auto desc = invoke_create_descriptor(
-                    attrs, tensor_args, tensor_return_value, resources, mesh_dispatch_coordinate);
-                tt::tt_metal::Program program{desc};
-                auto tensor_buffers = collect_tensor_buffers(tensor_args, tensor_return_value);
-                auto resolved = tt::tt_metal::resolve_bindings(program, desc, tensor_buffers);
-                const auto device_range = ttnn::MeshCoordinateRange(coord);
-                mesh_workload.add_program(device_range, std::move(program));
-                shared_variables[device_range] = shared_variables_t{
-                    .resources = std::move(resources), .resolved_bindings = std::move(resolved)};
+                    auto desc = invoke_create_descriptor(
+                        attrs, tensor_args, tensor_return_value, resources, mesh_dispatch_coordinate);
+                    tt::tt_metal::Program program{desc};
+                    auto tensor_buffers = collect_tensor_buffers(tensor_args, tensor_return_value);
+                    auto resolved = tt::tt_metal::resolve_bindings(program, desc, tensor_buffers);
+                    mesh_workload.add_program(device_range, std::move(program));
+                    shared_variables[device_range] = shared_variables_t{
+                        .resources = std::move(resources), .resolved_bindings = std::move(resolved)};
+                };
+
+            if constexpr (create_descriptor_uses_mesh_dispatch_coordinate()) {
+                for (const auto& coord : tensor_coords.coords()) {
+                    build_and_add_program(ttnn::MeshCoordinateRange(coord), std::optional<ttnn::MeshCoordinate>(coord));
+                }
+            } else {
+                for (const auto& range : tensor_coords.ranges()) {
+                    build_and_add_program(range, std::nullopt);
+                }
             }
             return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
         }

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -47,11 +47,21 @@ struct MeshDeviceOperationAdapter {
 
 private:
     struct DirectDescriptorFactory {
-        static auto create_descriptor(
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& attrs,
             const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value) {
-            return DeviceOperation::create_descriptor(attrs, tensor_args, tensor_return_value);
+            tensor_return_value_t& tensor_return_value,
+            const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt) {
+            if constexpr (requires {
+                              DeviceOperation::create_descriptor(
+                                  attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
+                          }) {
+                return DeviceOperation::create_descriptor(
+                    attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
+            } else {
+                (void)mesh_dispatch_coordinate;
+                return DeviceOperation::create_descriptor(attrs, tensor_args, tensor_return_value);
+            }
         }
     };
 
@@ -237,11 +247,30 @@ public:
             const operation_attributes_t& attrs,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value,
-            resource_t& resources) {
+            resource_t& resources,
+            const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
             if constexpr (has_prepare_resources) {
-                return DescriptorFactory::create_descriptor(attrs, tensor_args, tensor_return_value, resources);
+                if constexpr (requires {
+                                  DescriptorFactory::create_descriptor(
+                                      attrs, tensor_args, tensor_return_value, resources, mesh_dispatch_coordinate);
+                              }) {
+                    return DescriptorFactory::create_descriptor(
+                        attrs, tensor_args, tensor_return_value, resources, mesh_dispatch_coordinate);
+                } else {
+                    (void)mesh_dispatch_coordinate;
+                    return DescriptorFactory::create_descriptor(attrs, tensor_args, tensor_return_value, resources);
+                }
             } else {
-                return DescriptorFactory::create_descriptor(attrs, tensor_args, tensor_return_value);
+                if constexpr (requires {
+                                  DescriptorFactory::create_descriptor(
+                                      attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
+                              }) {
+                    return DescriptorFactory::create_descriptor(
+                        attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
+                } else {
+                    (void)mesh_dispatch_coordinate;
+                    return DescriptorFactory::create_descriptor(attrs, tensor_args, tensor_return_value);
+                }
             }
         }
 
@@ -253,19 +282,22 @@ public:
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
 
-            for (const auto& range : tensor_coords.ranges()) {
+            for (const auto& coord : tensor_coords.coords()) {
                 resource_t resources{};
                 if constexpr (has_prepare_resources) {
                     resources = DescriptorFactory::prepare_resources(attrs, tensor_args, tensor_return_value);
                 }
 
-                auto desc = invoke_create_descriptor(attrs, tensor_args, tensor_return_value, resources);
+                const std::optional<ttnn::MeshCoordinate> mesh_dispatch_coordinate(coord);
+                auto desc = invoke_create_descriptor(
+                    attrs, tensor_args, tensor_return_value, resources, mesh_dispatch_coordinate);
                 tt::tt_metal::Program program{desc};
                 auto tensor_buffers = collect_tensor_buffers(tensor_args, tensor_return_value);
                 auto resolved = tt::tt_metal::resolve_bindings(program, desc, tensor_buffers);
-                mesh_workload.add_program(range, std::move(program));
-                shared_variables[range] =
-                    shared_variables_t{.resources = std::move(resources), .resolved_bindings = std::move(resolved)};
+                const auto device_range = ttnn::MeshCoordinateRange(coord);
+                mesh_workload.add_program(device_range, std::move(program));
+                shared_variables[device_range] = shared_variables_t{
+                    .resources = std::move(resources), .resolved_bindings = std::move(resolved)};
             }
             return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
         }
@@ -285,7 +317,9 @@ public:
                 } else {
                     // Slow path: full descriptor rebuild + bulk copy.
                     // Used by factories that have not yet adopted emplace_runtime_args().
-                    auto desc = invoke_create_descriptor(attrs, tensor_args, tensor_return_value, sv.resources);
+                    const std::optional<ttnn::MeshCoordinate> mesh_dispatch_coordinate(coordinate_range.start_coord());
+                    auto desc = invoke_create_descriptor(
+                        attrs, tensor_args, tensor_return_value, sv.resources, mesh_dispatch_coordinate);
                     tt::tt_metal::apply_descriptor_runtime_args(program, desc);
                 }
             }

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
@@ -4,8 +4,11 @@
 
 #pragma once
 
+#include <optional>
+
 #include "ttnn/device_operation.hpp"
-#include <tt-metalium/mesh_coord.hpp>
+#include "ttnn/distributed/types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::rand {
 
@@ -27,38 +30,12 @@ struct RandDeviceOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
-    struct RandMeshWorkloadFactory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle compute_kernel_id{};
-            tt::tt_metal::KernelHandle writer_kernel_id{};
-            std::vector<CoreCoord> cores;
-        };
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& output,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 
-        using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-        static cached_mesh_workload_t create_mesh_workload(
-            const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinateRangeSet& tensor_coords,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& output);
-
-        static void override_runtime_arguments(
-            cached_mesh_workload_t& cached_workload,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& output);
-
-    private:
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create_at(
-            const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinate& mesh_coordinate,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& output);
-    };
-
-    using program_factory_t = std::variant<RandMeshWorkloadFactory>;
     static void validate_inputs(const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include <bit>
-#include <cstring>
 #include <ctime>
 #include <limits>
 #include <random>
@@ -111,7 +110,10 @@ ProgramDescriptor RandDeviceOperation::create_descriptor(
     switch (output_dtype) {
         case DataType::BFLOAT16: writer_desc.defines.emplace_back("OUTPUT_DTYPE_BFLOAT16", "1"); break;
         case DataType::FLOAT32: writer_desc.defines.emplace_back("OUTPUT_DTYPE_FLOAT32", "1"); break;
-        default: break;
+        default:
+            // The writer kernel only implements float32 and bfloat16 output paths.
+            // Fail fast here so we never instantiate a program that can hang at runtime.
+            TT_THROW("RandDeviceOperation: unsupported output dtype for writer kernel");
     }
     writer_desc.runtime_args.reserve(num_cores_total);
 

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -25,8 +25,8 @@ std::uniform_int_distribution distribution(1, std::numeric_limits<int32_t>::max(
 
 auto get_random_seed() -> uint32_t { return distribution(rng); }
 
-static constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/writer_uniform.cpp";
-static constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/compute_uniform.cpp";
+constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/writer_uniform.cpp";
+constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/compute_uniform.cpp";
 
 }  // namespace
 

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <bit>
 #include <cstring>
+#include <ctime>
+#include <limits>
+#include <random>
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/work_split.hpp>
@@ -15,33 +18,23 @@ namespace ttnn::operations::rand {
 using namespace tt;
 using namespace tt::tt_metal;
 
+namespace {
+
 std::mt19937 rng(std::time(nullptr));
 std::uniform_int_distribution distribution(1, std::numeric_limits<int32_t>::max());
 
 auto get_random_seed() -> uint32_t { return distribution(rng); }
 
-using Factory = RandDeviceOperation::RandMeshWorkloadFactory;
+static constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/writer_uniform.cpp";
+static constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/compute_uniform.cpp";
 
-Factory::cached_mesh_workload_t Factory::create_mesh_workload(
-    const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(operation_attributes, coord, tensor_args, output);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(ttnn::MeshCoordinateRange(coord), std::move(cached_program.shared_variables));
-    }
-    return cached_mesh_workload_t{std::move(workload), std::move(shared_variables)};
-}
+}  // namespace
 
-Factory::cached_program_t Factory::create_at(
+ProgramDescriptor RandDeviceOperation::create_descriptor(
     const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinate& mesh_coordinate,
     const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& output) {
+    tensor_return_value_t& output,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
     IDevice* device = output.device();
     auto grid = device->compute_with_storage_grid_size();
 
@@ -49,11 +42,8 @@ Factory::cached_program_t Factory::create_at(
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(grid, units_to_divide);
 
-    uint32_t num_cores_x = grid.x;
-    uint32_t num_cores_y = grid.y;
-    auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y);
-
-    Program program = Program();
+    auto cores = grid_to_cores(num_cores, grid.x, grid.y);
+    const auto num_cores_total = cores.size();
 
     DataType output_dtype = output.dtype();
     auto out_data_format = datatype_to_dataformat_converter(output_dtype);
@@ -64,51 +54,11 @@ Factory::cached_program_t Factory::create_at(
     constexpr uint32_t intermed_num_tiles = 2;
 
     constexpr uint32_t intermed_cb_id = CBIndex::c_24;
-    CircularBufferConfig cb_intermed_config =
-        CircularBufferConfig(intermed_num_tiles * intermed_tile_size, {{intermed_cb_id, tt::DataFormat::Float32}})
-            .set_page_size(intermed_cb_id, intermed_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed_config);
-
     constexpr uint32_t dst_cb_id = CBIndex::c_0;
-    CircularBufferConfig cb_output_config =
-        CircularBufferConfig(in_out_num_tiles * dtype_tile_size, {{dst_cb_id, out_data_format}})
-            .set_page_size(dst_cb_id, dtype_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
 
-    const std::string kernels_dir_path = "ttnn/cpp/ttnn/operations/rand/device/kernels/";
-    std::vector<uint32_t> writer_compile_time_args{intermed_cb_id, dst_cb_id};
-    tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
-    const std::string writer_file_path = kernels_dir_path + "writer_uniform.cpp";
-    const std::vector<uint32_t> compute_compile_time_args{intermed_cb_id};
-    const std::string compute_file_path = kernels_dir_path + "compute_uniform.cpp";
+    const ttnn::MeshCoordinate mesh_coordinate = mesh_dispatch_coordinate.value_or(
+        ttnn::MeshCoordinate::zero_coordinate(operation_attributes.device->shape().dims()));
 
-    std::map<std::string, std::string> writer_defines;
-    switch (output_dtype) {
-        case DataType::BFLOAT16: writer_defines["OUTPUT_DTYPE_BFLOAT16"] = "1"; break;
-        case DataType::FLOAT32: writer_defines["OUTPUT_DTYPE_FLOAT32"] = "1"; break;
-        default: break;
-    }
-
-    KernelHandle writer_kernel_id = tt_metal::CreateKernel(
-        program, writer_file_path, all_cores, WriterDataMovementConfig(writer_compile_time_args, writer_defines));
-
-    KernelHandle compute_kernel_id = CreateKernel(
-        program,
-        compute_file_path,
-        all_cores,
-        ComputeConfig{
-            .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
-            .fp32_dest_acc_en = true,  // if fp32_dest_acc_en set to false a precision error may occur which makes
-                                       // generated number out of range [from, to)
-            .dst_full_sync_en = false,
-            .math_approx_mode = true,
-            .compile_args = compute_compile_time_args,
-        });
-
-    // Derive a per-device seed offset so that devices holding different shards
-    // generate distinct random sequences, while replicas share the same seed.
-    // Only mesh dimensions marked as sharded contribute to the index; replicate
-    // dimensions are ignored so that all replicas of the same shard are identical.
     uint32_t device_seed_offset = 0;
     const auto& shard_mask = operation_attributes.mesh_dim_is_sharded;
     if (!shard_mask.empty()) {
@@ -124,8 +74,68 @@ Factory::cached_program_t Factory::create_at(
         device_seed_offset = static_cast<uint32_t>(shard_linear_idx) * static_cast<uint32_t>(cores.size());
     }
 
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = intermed_num_tiles * intermed_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = intermed_cb_id,
+            .data_format = tt::DataFormat::Float32,
+            .page_size = intermed_tile_size,
+        }}},
+    });
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in_out_num_tiles * dtype_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = dst_cb_id,
+            .data_format = out_data_format,
+            .page_size = dtype_tile_size,
+        }}},
+    });
+
+    KernelDescriptor::CompileTimeArgs writer_ct_args;
+    writer_ct_args.reserve(8);
+    writer_ct_args.push_back(intermed_cb_id);
+    writer_ct_args.push_back(dst_cb_id);
+    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = WRITER_KERNEL_PATH;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+    switch (output_dtype) {
+        case DataType::BFLOAT16: writer_desc.defines.emplace_back("OUTPUT_DTYPE_BFLOAT16", "1"); break;
+        case DataType::FLOAT32: writer_desc.defines.emplace_back("OUTPUT_DTYPE_FLOAT32", "1"); break;
+        default: break;
+    }
+    writer_desc.runtime_args.reserve(num_cores_total);
+
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = COMPUTE_KERNEL_PATH;
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = {intermed_cb_id};
+    compute_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
+        .fp32_dest_acc_en = true,  // if fp32_dest_acc_en set to false a precision error may occur which makes
+                                   // generated number out of range [from, to)
+        .dst_full_sync_en = false,
+        .math_approx_mode = true,
+    };
+    compute_desc.runtime_args.reserve(num_cores_total);
+
+    const float eps = 1e-6f;
+    const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
+    const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
+    const uint32_t output_addr = output.buffer()->address();
+
     uint32_t tile_offset = 0;
-    for (int i = 0; i < cores.size(); ++i) {
+    for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
         const auto& core = cores[i];
         uint32_t units_per_core;
         if (core_group_1.contains(core)) {
@@ -136,76 +146,22 @@ Factory::cached_program_t Factory::create_at(
             TT_THROW("Core not in specified core ranges");
         }
 
-        const float eps = 1e-6f;
-        const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
-        const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
-
-        // Each core gets its own seed to increase entropy across the output tensor.
-        // With a user-supplied seed (!=0) the value is deterministic; with seed==0
-        // a fresh random seed is drawn from the host RNG for every core invocation.
         uint32_t seed =
             operation_attributes.seed != 0 ? operation_attributes.seed + i + device_seed_offset : get_random_seed();
 
-        std::vector<uint32_t> compute_runtime_args = {seed, from_bits, to_bits, tile_offset, units_per_core};
-        SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
+        compute_desc.runtime_args.emplace_back(
+            core, KernelDescriptor::CoreRuntimeArgs{seed, from_bits, to_bits, tile_offset, units_per_core});
 
-        std::vector<uint32_t> writer_runtime_args = {output.buffer()->address(), tile_offset, units_per_core};
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+        writer_desc.runtime_args.emplace_back(
+            core, KernelDescriptor::CoreRuntimeArgs{output_addr, tile_offset, units_per_core});
 
         tile_offset += units_per_core;
     }
 
-    return {
-        std::move(program),
-        {.compute_kernel_id = compute_kernel_id, .writer_kernel_id = writer_kernel_id, .cores = cores}};
-}
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-void Factory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& output) {
-    const float eps = 1e-6f;
-    const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
-    const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
-
-    const auto& shard_mask = operation_attributes.mesh_dim_is_sharded;
-    const auto& mesh_shape = operation_attributes.device->shape();
-
-    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-        auto& shared_vars = cached_workload.shared_variables.at(coordinate_range);
-        auto& cores = shared_vars.cores;
-
-        const uint32_t output_addr = output.buffer()->address();
-
-        uint32_t device_seed_offset = 0;
-        if (!shard_mask.empty()) {
-            const auto& coord = coordinate_range.start_coord();
-            size_t shard_linear_idx = 0;
-            size_t shard_stride = 1;
-            for (int i = static_cast<int>(shard_mask.size()) - 1; i >= 0; --i) {
-                if (shard_mask[i]) {
-                    shard_linear_idx += coord[i] * shard_stride;
-                    shard_stride *= mesh_shape[i];
-                }
-            }
-            device_seed_offset = static_cast<uint32_t>(shard_linear_idx) * static_cast<uint32_t>(cores.size());
-        }
-
-        for (int i = 0; i < cores.size(); ++i) {
-            {
-                auto& runtime_args = GetRuntimeArgs(program, shared_vars.compute_kernel_id, cores[i]);
-                runtime_args[0] = operation_attributes.seed != 0 ? operation_attributes.seed + i + device_seed_offset
-                                                                 : get_random_seed();
-                runtime_args[1] = from_bits;
-                runtime_args[2] = to_bits;
-            }
-            {
-                auto& runtime_args = GetRuntimeArgs(program, shared_vars.writer_kernel_id, cores[i]);
-                runtime_args[0] = output_addr;
-            }
-        }
-    }
+    return desc;
 }
 
 }  // namespace ttnn::operations::rand


### PR DESCRIPTION
## Summary

Migrate the `randn` operation from the legacy `ProgramFactory` + `override_runtime_arguments` pattern to the declarative `ProgramDescriptor`-based `create_descriptor` approach.

Closes #42399 

## Notes for reviewers

1. ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
Removed RandMeshWorkloadFactory, program_factory_t, and all mesh-workload / create_at / override_runtime_arguments surface from the public op type.
Included program_descriptors.hpp and ttnn/distributed/types.hpp.
Added static tt::tt_metal::ProgramDescriptor create_descriptor(..., const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt) so mesh seed offsets still depend on the dispatch coordinate when the mesh adapter passes it.
2. ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
Replaced imperative Program / CreateKernel / CreateCircularBuffer / SetRuntimeArgs with building a ProgramDescriptor (CBDescriptors + two **KernelDescriptor**s: writer then compute, same order as before).
Preserved seed / from_bits / to_bits / tile_offset / units_per_core, device_seed_offset from mesh_dispatch_coordinate and mesh_dim_is_sharded, writer defines for BF16/F32, and TensorAccessorArgs on the output buffer.
Removed create_mesh_workload, create_at, and override_runtime_arguments (handled by the generic mesh + descriptor path).
3. ttnn/api/ttnn/mesh_device_operation_adapter.hpp (needed for correct Rand behavior)
Rand previously built one program per mesh coordinate while DescriptorMeshWorkloadFactoryAdapter only walked tensor_coords.ranges(), which collapsed a full mesh to one program and never passed a coordinate into create_descriptor.

Changes there:

DescriptorMeshWorkloadFactoryAdapter::create_mesh_workload now iterates tensor_coords.coords() and calls add_program(MeshCoordinateRange(coord), …) for each coordinate (same granularity as Rand’s old loop).
DirectDescriptorFactory::create_descriptor and invoke_create_descriptor take an optional std::optional<ttnn::MeshCoordinate> and forward it when DeviceOperation::create_descriptor(..., mesh) exists; other ops keep the old 3-argument (or resource) calls.
apply_descriptor passes coordinate_range.start_coord() so cache hits refresh runtime args with the right mesh slice.

## Test plan

- [x] All rand tests pass

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-rand-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-rand-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-rand-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-rand-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-rand-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/migrate-rand-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-rand-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/migrate-rand-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-rand-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-rand-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-rand-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/migrate-rand-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-rand-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/migrate-rand-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-rand-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/migrate-rand-to-program-descriptor)
