### PR TITLE
fix(unpack): update zero-src flag on reconfig to uint16

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_deepseek_moe_gate.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_deepseek_moe_gate.py
@@ -151,3 +151,99 @@ def test_deepseek_moe_gate(device, batch_size, enable_sigmoid, seed):
 
     assert torch.equal(sorted_output_indices_torch.to(top8_indices.dtype), top8_indices), "Output indices do not match"
     assert torch.allclose(sorted_output_torch, top8_scores, atol=1e-2, rtol=1e-4), "Output scores do not match"
+
+
+@pytest.mark.parametrize("start_index", [0x8000], ids=["v_0x8000"])
+def test_deepseek_moe_gate_uint16_high_bit(device, start_index):
+    """Regression test for #43149: reconfig from bfloat16 to uint16 must not zero values with bit 15 set.
+
+    compute_kernel_hw_startup initialises the unpacker for bfloat16, leaving the
+    zero-src flag enabled.  That flag maps the bit pattern 0x8000 (= -0.0f in
+    bfloat16) to zero.  When the kernel reconfigures to uint16 without updating
+    the flag, 0x8000 (= 32768 as uint16) is silently zeroed.
+
+    This test feeds 256 uint16 indices starting from start_index (>= 0x8000)
+    through the gate copy path and asserts they all survive intact.
+    """
+    input_shape = (1, 8, 32)
+    reshaped_input_shape = (1, 16, 16)
+    input_shard_shape = (16, 16)
+    input_tile = ttnn.Tile(input_shard_shape)
+    output_shape = (1, 1, 16)
+    output_shard_shape = (1, 16)
+    output_tile = ttnn.Tile(output_shard_shape)
+
+    torch_input = torch.full(input_shape, 0.5, dtype=torch.bfloat16)
+
+    # Rig bias so top-8 picks are columns [1,4,7,11,15,19,23,28]; column 1 maps
+    # to post-transpose position [1, 0] in the indices tile (index = start_index + 1).
+    bias_2d = torch.full(input_shape, -100.0, dtype=torch.bfloat16)
+    for col in (1, 4, 7, 11, 15, 19, 23, 28):
+        bias_2d[0, 0, col] = 100.0
+
+    grid = device.compute_with_storage_grid_size()
+    core_grid = ttnn.num_cores_to_corerangeset(1, ttnn.CoreCoord(grid.x, grid.y), row_wise=True)
+    input_shard_spec = ttnn.ShardSpec(core_grid, input_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    input_mem_cfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+    output_shard_spec = ttnn.ShardSpec(core_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    output_mem_cfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    ttnn_input = ttnn.from_torch(
+        torch.reshape(torch_input, reshaped_input_shape),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=input_mem_cfg,
+        tile=input_tile,
+    )
+    ttnn_bias = ttnn.from_torch(
+        torch.transpose(torch.reshape(bias_2d, reshaped_input_shape), -2, -1),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=input_mem_cfg,
+        tile=input_tile,
+    )
+
+    # Build uint16 indices: start_index, start_index+1, ..., start_index+255,
+    # laid out as (1,16,16) then transposed (same order the kernel expects).
+    raw = torch.arange(start_index, start_index + 256, dtype=torch.int32)
+    torch_indices = torch.transpose(raw.reshape(reshaped_input_shape), -2, -1).to(torch.uint16)
+
+    ttnn_indices = ttnn.from_torch(
+        torch_indices,
+        dtype=ttnn.uint16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=input_mem_cfg,
+        tile=input_tile,
+    )
+
+    ttnn_output = ttnn.from_torch(
+        torch.zeros(output_shape, dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=output_mem_cfg,
+        tile=output_tile,
+    )
+    ttnn_output_indices = ttnn.from_torch(
+        torch.zeros(output_shape, dtype=torch.uint16),
+        dtype=ttnn.uint16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=output_mem_cfg,
+        tile=output_tile,
+    )
+
+    _, result_indices = DeepseekMoeGateSingleCore.op(
+        ttnn_input, ttnn_bias, ttnn_output, ttnn_indices, ttnn_output_indices, 1e-20, 1.0, False
+    )
+
+    # The gate outputs top-8 indices in the first 8 slots; remaining slots are padding.
+    top8 = ttnn.to_torch(result_indices)[:, 0, :8].to(torch.int32)
+    assert top8.numel() == 8, f"Expected 8 top-k indices, got {top8.numel()}"
+    assert (top8 >= start_index).all(), (
+        f"Detected uint16 high-bit truncation: some index < {start_index:#x} in output.\n"
+        f"Got top-8: {top8.flatten().tolist()}"
+    )

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -182,6 +182,8 @@ inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
     llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(srca_new_operand);
     llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(srcb_new_operand);
+    _llk_unpack_reconfig_zero_src_flag_(
+        unpack_dst_format[get_operand_id(srca_new_operand)], unpack_dst_format[get_operand_id(srcb_new_operand)]);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
@@ -198,6 +200,8 @@ inline void llk_unpack_reconfig_data_format(
         srca_old_operand, srca_new_operand);
     llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(
         srcb_old_operand, srcb_new_operand);
+    _llk_unpack_reconfig_zero_src_flag_(
+        unpack_dst_format[get_operand_id(srca_new_operand)], unpack_dst_format[get_operand_id(srcb_new_operand)]);
 }
 
 // TODO NC: Remove as a part of tt-metal#36411

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -193,6 +193,8 @@ inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
     llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(srca_new_operand);
     llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(srcb_new_operand);
+    _llk_unpack_reconfig_zero_src_flag_(
+        unpack_dst_format[get_operand_id(srca_new_operand)], unpack_dst_format[get_operand_id(srcb_new_operand)]);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
@@ -209,6 +211,8 @@ inline void llk_unpack_reconfig_data_format(
         srca_old_operand, srca_new_operand);
     llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(
         srcb_old_operand, srcb_new_operand);
+    _llk_unpack_reconfig_zero_src_flag_(
+        unpack_dst_format[get_operand_id(srca_new_operand)], unpack_dst_format[get_operand_id(srcb_new_operand)]);
 }
 
 // TODO NC: Remove as a part of tt-metal#36411

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -181,13 +181,19 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
 // pattern matches -0.0f in bfloat16 (e.g. 0x8000).  configure_unpack_AB
 // disables the flag whenever either dest format is uint16, because 0x8000 is a
 // valid uint16 value (32768) that must not be zeroed.  The same adjustment is
-// needed every time formats are reconfigured; call this function after
-// reconfiguring both srca and srcb so the OR of the new formats is applied.
+// needed every time formats are reconfigured.
+//
+// Only disable the flag (write 1) when transitioning TO uint16.  Do NOT
+// re-enable it (write 0) for non-uint16 transitions: other LLK operations
+// (e.g. reduce init with enforce_fp32_accumulation) may have disabled it for
+// unrelated hardware reasons (MOVB2D hi16/lo16), and overwriting that state
+// causes incorrect results in float32 accumulation.
 inline void _llk_unpack_reconfig_zero_src_flag_(const std::uint32_t srca_dst_format, const std::uint32_t srcb_dst_format)
 {
-    const bool disable =
-        (srca_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16)) || (srcb_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16));
-    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(disable ? 1 : 0);
+    if ((srca_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16)) || (srcb_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16)))
+    {
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
 }
 
 // TODO NC: Remove as a part of tt-metal#36411

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -175,6 +175,21 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
     }
 }
 
+// Update ALU_ACC_CTRL_Zero_Flag_disabled_src after a data-format reconfig.
+//
+// The zero-src flag causes the hardware to substitute 0 for values whose bit
+// pattern matches -0.0f in bfloat16 (e.g. 0x8000).  configure_unpack_AB
+// disables the flag whenever either dest format is uint16, because 0x8000 is a
+// valid uint16 value (32768) that must not be zeroed.  The same adjustment is
+// needed every time formats are reconfigured; call this function after
+// reconfiguring both srca and srcb so the OR of the new formats is applied.
+inline void _llk_unpack_reconfig_zero_src_flag_(const std::uint32_t srca_dst_format, const std::uint32_t srcb_dst_format)
+{
+    const bool disable =
+        (srca_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16)) || (srcb_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16));
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(disable ? 1 : 0);
+}
+
 // TODO NC: Remove as a part of tt-metal#36411
 inline void _llk_unpack_dbg_feature_disable_()
 {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -170,6 +170,21 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
     }
 }
 
+// Update ALU_ACC_CTRL_Zero_Flag_disabled_src after a data-format reconfig.
+//
+// The zero-src flag causes the hardware to substitute 0 for values whose bit
+// pattern matches -0.0f in bfloat16 (e.g. 0x8000).  configure_unpack_AB
+// disables the flag whenever either dest format is uint16, because 0x8000 is a
+// valid uint16 value (32768) that must not be zeroed.  The same adjustment is
+// needed every time formats are reconfigured; call this function after
+// reconfiguring both srca and srcb so the OR of the new formats is applied.
+inline void _llk_unpack_reconfig_zero_src_flag_(const std::uint32_t srca_dst_format, const std::uint32_t srcb_dst_format)
+{
+    const bool disable =
+        (srca_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16)) || (srcb_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16));
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(disable ? 1 : 0);
+}
+
 // TODO NC: Remove as a part of tt-metal#36411
 inline void _llk_unpack_dbg_feature_disable_()
 {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -176,13 +176,19 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
 // pattern matches -0.0f in bfloat16 (e.g. 0x8000).  configure_unpack_AB
 // disables the flag whenever either dest format is uint16, because 0x8000 is a
 // valid uint16 value (32768) that must not be zeroed.  The same adjustment is
-// needed every time formats are reconfigured; call this function after
-// reconfiguring both srca and srcb so the OR of the new formats is applied.
+// needed every time formats are reconfigured.
+//
+// Only disable the flag (write 1) when transitioning TO uint16.  Do NOT
+// re-enable it (write 0) for non-uint16 transitions: other LLK operations
+// (e.g. reduce init with enforce_fp32_accumulation) may have disabled it for
+// unrelated hardware reasons (MOVB2D hi16/lo16), and overwriting that state
+// causes incorrect results in float32 accumulation.
 inline void _llk_unpack_reconfig_zero_src_flag_(const std::uint32_t srca_dst_format, const std::uint32_t srcb_dst_format)
 {
-    const bool disable =
-        (srca_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16)) || (srcb_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16));
-    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(disable ? 1 : 0);
+    if ((srca_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16)) || (srcb_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16)))
+    {
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
 }
 
 // TODO NC: Remove as a part of tt-metal#36411


### PR DESCRIPTION
## Summary

- **Root cause**: `ALU_ACC_CTRL_Zero_Flag_disabled_src` is set (enabled) when `compute_kernel_hw_startup` initialises the unpacker for bfloat16. The flag causes hardware to substitute 0 for values whose bit pattern matches `-0.0f` in bfloat16 (i.e. `0x8000`). The combined `llk_unpack_reconfig_data_format` path never updated this flag, so after a bfloat16→uint16 reconfig the value `0x8000` (= 32768 as uint16) was silently zeroed on every unpack.
- **Fix**: mirror the OR logic already present in `configure_unpack_AB` — disable the zero-src flag whenever either new srca or srcb operand is uint16. Applied to both the 2-arg and 4-arg combined reconfig overloads in Blackhole and Wormhole B0 LLK API files.
- **Regression test**: `test_deepseek_moe_gate_uint16_high_bit[v_0x8000]` feeds 256 uint16 indices starting from `0x8000` through the gate copy path and asserts all 8 top-k outputs have bit 15 preserved.

Fixes #43149

## Test plan

- [ ] `pytest -x models/demos/deepseek_v3_b1/tests/unit_tests/test_deepseek_moe_gate.py` — all 13 cases pass (12 existing + 1 new regression)
- [ ] No changes to Quasar (bug is BH/WH-only; Quasar unpack path is separate)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/debug_ds_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/debug_ds_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/debug_ds_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/debug_ds_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ncvetkovic/debug_ds_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ncvetkovic/debug_ds_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/debug_ds_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/debug_ds_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/debug_ds_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/debug_ds_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/debug_ds_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/debug_ds_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/debug_ds_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/debug_ds_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/debug_ds_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/debug_ds_copy)