### PR TITLE
Fix scaler handling for ttnn.min and ttnn.max ops

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
@@ -203,9 +203,6 @@ def test_generic_ops(device, tensor_shape, dim, keepdim, dtype, layout, correcti
     if op not in ("var", "std") and correction:
         pytest.skip("PyTorch supports the correction argument only for var and std")
 
-    if op == "min" and tensor_shape == (3, 6, 40, 63, 20) and dim in ((-2, -1), (0, 2, 4), (0, 2)):
-        pytest.xfail("Issue #40854: ttnn.min produces incorrect results for certain tensor shapes and dimensions")
-
     torch.manual_seed(0)
     torch_tensor = torch.randn(tensor_shape, dtype=dtype)
     pad_value = 1.0 if op == "prod" else None
@@ -561,12 +558,6 @@ def test_generic_ops_w_scalar(device, op, scalar, correction, dim, shape):
 
     if op not in ("var", "std") and correction:
         pytest.skip("PyTorch supports the correction argument only for var and std")
-
-    if op in ("min", "max") and (scalar in (-2.0, -2.43, 2.43) or (scalar == 2.0 and dim in ((-2, -1), None))):
-        pytest.xfail("Issue #40498: ttnn.max/min ignore sign and mantissa of the scalar parameter")
-
-    if op == "min" and shape == (3, 4, 8, 56, 33) and dim in ((-2, -1), (0, -2, -1), -2):
-        pytest.xfail("Issue #40854: ttnn.min produces incorrect results for certain tensor shapes and dimensions")
 
     torch.manual_seed(0)
     torch_input = torch.randn(shape, dtype=torch.bfloat16)

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
@@ -282,7 +282,7 @@ struct NoOp {
  * - post_reduce_op callback receives dst_idx parameter indicating which DEST register to operate on
  * - REDUCE_ROW: Called once per row with dst_idx=0 (single output in DST[0])
  * - REDUCE_COL: Called once per column in current chunk with dst_idx in [0, current_chunk)
- * - REDUCE_SCALAR: Not called (single reduction to DST[0])
+ * - REDUCE_SCALAR: Called once per batch with dst_idx pointing at the single accumulated DST register
  *
  * @tparam reduce_type The type of reduce operation (SUM, AVG, MAX) - required explicit parameter
  * @tparam reduce_dim The dimension to reduce (REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR) - required explicit parameter

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -296,6 +296,11 @@ ALWI void reduce(
                     }
                 }
             }
+
+            // Call post-reduce operation on the single accumulated DST register.
+            // No-op when PostReduceOp is the default NoOp.
+            post_reduce_op(dst_idx);
+
             // Pop modes: reserve per-batch
             if constexpr (should_pop(input_policy)) {
                 output_cb.reserve_back(onetile);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
@@ -5,6 +5,10 @@
 #include <cstdint>
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 
+#ifdef REDUCE_POST_MUL
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
+#endif
+
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);
@@ -20,5 +24,20 @@ void kernel_main() {
         tt::CBIndex::c_0,
         tt::CBIndex::c_2,
         tt::CBIndex::c_3,
-        compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt, NC));
+        compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt, NC),
+        compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+        compute_kernel_lib::NoAccumulation{},
+#ifdef REDUCE_POST_MUL
+        // GMPOOL only respects the scaler's exponent for MAX/MIN, so the host requests reduction
+        // with scaler=1.0 and then applies the user scalar via mul_unary_tile (SFPU) on each
+        // output DEST register.
+        [](uint32_t dst_idx) {
+            constexpr uint32_t post_mul_scaler_bits = get_compile_time_arg_val(3);
+            binop_with_scalar_tile_init();
+            mul_unary_tile(dst_idx, post_mul_scaler_bits);
+        }
+#else
+        compute_kernel_lib::NoOp{}
+#endif
+    );
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
@@ -12,10 +12,18 @@
 #include "experimental/circular_buffer.h"
 #include "ttnn/cpp/ttnn/kernel_lib/dest_helpers.hpp"
 
+#ifdef REDUCE_POST_MUL
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
+#endif
+
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);
     uint32_t NC = get_compile_time_arg_val(2);
+#ifdef REDUCE_POST_MUL
+    // Packed fp32 user scalar applied via mul_unary_tile after the reduce+negate finishes.
+    constexpr uint32_t post_mul_scaler_bits = get_compile_time_arg_val(3);
+#endif
     constexpr uint32_t row_chunk = compute_kernel_lib::DEST_AUTO_LIMIT;
 
     // Circular buffers:
@@ -130,6 +138,16 @@ void kernel_main() {
             for (uint32_t i = 0; i < ntiles; ++i) {
                 negative_tile(i);
             }
+
+#ifdef REDUCE_POST_MUL
+            // GMPOOL only respects the scaler's exponent for MAX/MIN, so the host requests reduction
+            // with scaler=1.0 and then applies the user scalar via mul_unary_tile (SFPU) on each
+            // output DEST register.
+            binop_with_scalar_tile_init();
+            for (uint32_t i = 0; i < ntiles; ++i) {
+                mul_unary_tile(i, post_mul_scaler_bits);
+            }
+#endif
 
             tile_regs_commit();
             cb_acc_obj.pop_front(ntiles);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw_neg.cpp
@@ -11,10 +11,18 @@
 #include "api/compute/tile_move_copy.h"
 #include "experimental/circular_buffer.h"
 
+#ifdef REDUCE_POST_MUL
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
+#endif
+
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);
     uint32_t NC = get_compile_time_arg_val(2);
+#ifdef REDUCE_POST_MUL
+    // Packed fp32 user scalar applied via mul_unary_tile after the reduce+negate finishes.
+    constexpr uint32_t post_mul_scaler_bits = get_compile_time_arg_val(3);
+#endif
 
     constexpr uint32_t cb_input = tt::CBIndex::c_0;
     constexpr uint32_t cb_scaler = tt::CBIndex::c_2;
@@ -78,6 +86,13 @@ void kernel_main() {
         copy_tile(cb_acc, 0, reduce_dst_idx);
         negative_tile_init();
         negative_tile(reduce_dst_idx);
+#ifdef REDUCE_POST_MUL
+        // GMPOOL only respects the scaler's exponent for MAX/MIN, so the host requests reduction
+        // with scaler=1.0 and then applies the user scalar via mul_unary_tile (SFPU) on each
+        // output DEST register.
+        binop_with_scalar_tile_init();
+        mul_unary_tile(reduce_dst_idx, post_mul_scaler_bits);
+#endif
         cb_acc_obj.pop_front(onetile);
         cb_output_obj.reserve_back(onetile);
         pack_tile(reduce_dst_idx, cb_output);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
@@ -14,10 +14,18 @@
 
 #include "llk_math_eltwise_binary.h"
 
+#ifdef REDUCE_POST_MUL
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
+#endif
+
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);
     uint32_t NC = get_compile_time_arg_val(2);
+#ifdef REDUCE_POST_MUL
+    // Packed fp32 user scalar applied via mul_unary_tile after the reduce+negate finishes.
+    constexpr uint32_t post_mul_scaler_bits = get_compile_time_arg_val(3);
+#endif
 
     // Circular buffers:
     constexpr uint32_t cb_input = tt::CBIndex::c_0;
@@ -86,6 +94,13 @@ void kernel_main() {
             copy_tile(cb_acc, 0, dst_idx);
             negative_tile_init();
             negative_tile(dst_idx);
+#ifdef REDUCE_POST_MUL
+            // GMPOOL only respects the scaler's exponent for MAX/MIN, so the host requests reduction
+            // with scaler=1.0 and then applies the user scalar via mul_unary_tile (SFPU) on each
+            // output DEST register.
+            binop_with_scalar_tile_init();
+            mul_unary_tile(dst_idx, post_mul_scaler_bits);
+#endif
             tile_regs_wait();
             cb_acc_obj.pop_front(onetile);
             cb_output_obj.reserve_back(onetile);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -113,12 +113,21 @@ Tensor reduce(
     auto tilized_input = ttnn::tilize_with_val_padding(
         input_tensor, padded_shape, pad_value, input_tensor.memory_config(), std::nullopt, true, sub_core_grids);
 
+    // GMPOOL applies exp2(floor(log2(|s|))) of the scalar (only the exponent), so for
+    // MAX/MIN with non-unity scalar we instead reduce with scaler=1.0 and apply the user
+    // scalar after reduction via post-multiplication. See issue #40498. The flag also
+    // covers reduce_min (math_op=MAX with negate=true) since high-level dispatch lowers
+    // min through reduce_min before reaching here.
+    const bool use_post_mul = (reduce_math == tt::tt_metal::ReduceOpMath::MAX) && (scaler != 1.0f);
+    const float reduce_scaler = use_post_mul ? 1.0f : scaler;
+    const float post_mul = use_post_mul ? scaler : 1.0f;
+
     // The single-core HW path uses REDUCE_SCALAR mode, which applies the
     // scaler twice internally (once per dimension).  The host compensates with
     // sqrt(scaler) in ReduceSingleCoreHwProgramFactory::create.
     // However, sqrt of a negative number is NaN, so negative scalers
     // must take the two-step W-then-H path where the scaler is applied once.
-    if (is_multicore_hw || (reduce_dim == tt::tt_metal::ReduceOpDim::HW && scaler < 0)) {
+    if (is_multicore_hw || (reduce_dim == tt::tt_metal::ReduceOpDim::HW && reduce_scaler < 0)) {
         // Multi-core HW reduction: first reduce W, then reduce H on the result
         const Tensor output_tensor = ttnn::prim::reduce(
             tilized_input,
@@ -129,29 +138,32 @@ Tensor reduce(
             output_dtype.value_or(input_tensor.dtype()),
             config,
             sub_core_grids,
-            negate);
+            negate,
+            /*post_mul_scaler=*/1.0f);
 
         return ttnn::prim::reduce(
             output_tensor,
             reduce_math,
             tt::tt_metal::ReduceOpDim::H,
-            scaler,
+            reduce_scaler,
             output_mem_config,
             output_dtype.value_or(input_tensor.dtype()),
             config,
             sub_core_grids,
-            negate);
+            negate,
+            /*post_mul_scaler=*/post_mul);
     }
     return ttnn::prim::reduce(
         tilized_input,
         reduce_math,
         reduce_dim,
-        scaler,
+        reduce_scaler,
         output_mem_config,
         output_dtype.value_or(input_tensor.dtype()),
         config,
         sub_core_grids,
-        negate);
+        negate,
+        /*post_mul_scaler=*/post_mul);
 }
 
 }  // namespace ttnn::operations::reduction::generic::detail

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -77,6 +77,7 @@ ttsl::hash::hash_t ReduceDeviceOperation::compute_program_hash(
         operation_attributes.compute_kernel_config,
         operation_attributes.sub_core_grids,
         operation_attributes.negate,
+        operation_attributes.post_mul_scaler,
         program_factory.index(),
         tensor_args.dtype(),
         tensor_args.memory_config(),
@@ -93,7 +94,8 @@ ttnn::Tensor reduce(
     const std::optional<DataType>& output_dtype,
     const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
-    bool negate) {
+    bool negate,
+    float post_mul_scaler) {
     return ttnn::device_operation::launch<ReduceDeviceOperation>(
         ReduceParams{
             reduce_math,
@@ -103,7 +105,8 @@ ttnn::Tensor reduce(
             output_dtype.value_or(input_tensor.dtype()),
             compute_kernel_config,
             sub_core_grids,
-            negate},
+            negate,
+            post_mul_scaler},
         input_tensor);
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp
@@ -50,6 +50,7 @@ ttnn::Tensor reduce(
     const std::optional<DataType>& output_dtype,
     const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
-    bool negate = false);
+    bool negate = false,
+    float post_mul_scaler = 1.0f);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation_types.hpp
@@ -21,6 +21,13 @@ struct ReduceParams {
     ttnn::DeviceComputeKernelConfig compute_kernel_config;
     std::optional<tt::tt_metal::CoreRangeSet> sub_core_grids;
     bool negate{false};
+    // For min/max with a non-unity scalar, the GMPOOL hardware path (reduce_tile LLK) only
+    // respects the exponent of the scaler. To produce numerically correct results for any
+    // scalar, the host instead requests reduction with `scaler=1.0` and applies the user
+    // scalar afterwards via SFPU post-multiplication (mul_unary_tile) inside the compute
+    // kernel, gated by the REDUCE_POST_MUL define. When `post_mul_scaler == 1.0f`, the
+    // post-multiplication path is disabled and the existing reduce-only flow runs unchanged.
+    float post_mul_scaler{1.0f};
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -49,6 +49,11 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
 
     uint32_t chunk_size = use_width_sharding ? 1 : ttnn::get_dest_reg_count(operation_attributes.compute_kernel_config);
 
+    // For min/max with non-unity scalar, the GMPOOL hardware path only respects the scaler's
+    // exponent, so the device reduces with scaler=1.0 and the user scalar is applied after the
+    // reduction via SFPU mul_unary_tile inside the compute kernel.
+    const bool use_post_mul = operation_attributes.post_mul_scaler != 1.0f;
+
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     auto num_cols = NC * Wt;
     uint32_t num_cores;
@@ -128,6 +133,8 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
     tt_metal::Buffer* src0_buffer = a.buffer();
     tt_metal::KernelHandle reader_kernel_id;
     uint32_t scaler_bits = std::bit_cast<uint32_t>(operation_attributes.scaler);
+    // Packed fp32 scalar passed to the compute kernel for mul_unary_tile post-reduction scaling.
+    uint32_t post_mul_scaler_bits = std::bit_cast<uint32_t>(operation_attributes.post_mul_scaler);
 
     if (operation_attributes.negate) {
         // The reduce_h_neg kernel pushes ntiles tiles per inner-loop iteration
@@ -179,6 +186,9 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
 
     std::map<std::string, std::string> reduce_defines =
         reduce_op_utils::get_defines(operation_attributes.math_op, tt::tt_metal::ReduceOpDim::H);
+    if (use_post_mul) {
+        reduce_defines["REDUCE_POST_MUL"] = "1";
+    }
 
     if (use_width_sharding) {
         std::vector<uint32_t> reader_compile_time_args = {src0_cb_index, src1_cb_index, scaler_cb_index, scaler_bits};
@@ -240,9 +250,10 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
     uint32_t compute_Wt = use_width_sharding ? (num_cols_per_core_group_1 / NC) : num_cols_per_core_group_1;
     uint32_t compute_NC = use_width_sharding ? NC : 1;
     std::vector<uint32_t> compute_kernel_args_group_1 = {
-        Ht,          // Ht
-        compute_Wt,  // Wt
-        compute_NC,  // NC
+        Ht,                    // Ht
+        compute_Wt,            // Wt
+        compute_NC,            // NC
+        post_mul_scaler_bits,  // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
     };
 
     const std::string compute_kernel =
@@ -264,9 +275,10 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
         uint32_t compute_Wt_group_2 = use_width_sharding ? (num_cols_per_core_group_2 / NC) : num_cols_per_core_group_2;
         uint32_t compute_NC_group_2 = use_width_sharding ? NC : 1;
         std::vector<uint32_t> compute_kernel_args_group_2 = {
-            Ht,                  // Ht
-            compute_Wt_group_2,  // Wt
-            compute_NC_group_2,  // NC
+            Ht,                    // Ht
+            compute_Wt_group_2,    // Wt
+            compute_NC_group_2,    // NC
+            post_mul_scaler_bits,  // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
         };
 
         tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -76,6 +76,12 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
             .set_page_size(output_cb_index, dst_single_tile_size);
     tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
 
+    // For min/max with non-unity scalar, the GMPOOL hardware path only respects the scaler's
+    // exponent, so the device reduces with scaler=1.0 and the user scalar is applied after the
+    // reduction via SFPU mul_unary_tile inside the compute kernel.
+    const bool use_post_mul = operation_attributes.post_mul_scaler != 1.0f;
+    uint32_t post_mul_scaler_bits = std::bit_cast<uint32_t>(operation_attributes.post_mul_scaler);
+
     tt_metal::Buffer* src_buffer = a.buffer();
     std::vector<uint32_t> reader_compile_time_args = {std::bit_cast<uint32_t>(operation_attributes.scaler)};
     TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
@@ -101,6 +107,9 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
 
     std::map<std::string, std::string> reduce_defines =
         reduce_op_utils::get_defines(operation_attributes.math_op, ReduceOpDim::W);
+    if (use_post_mul) {
+        reduce_defines["REDUCE_POST_MUL"] = "1";
+    }
 
     tt_metal::KernelHandle reader_kernel_id = tt_metal::CreateKernel(
         program,
@@ -119,6 +128,7 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
         num_rows_per_core_group_1,  // Ht
         Wt,                         // Wt
         1,                          // NC
+        post_mul_scaler_bits,       // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
     };
 
     const std::string compute_kernel =
@@ -140,6 +150,7 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
             num_rows_per_core_group_2,  // Ht
             Wt,                         // Wt
             1,                          // NC
+            post_mul_scaler_bits,       // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
         };
 
         tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -83,6 +83,12 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
             .set_page_size(output_cb_index, dst_single_tile_size);
     tt_metal::CreateCircularBuffer(program, core, cb_output_config);
 
+    // For min/max with non-unity scalar, the GMPOOL hardware path only respects the scaler's
+    // exponent, so the device reduces with scaler=1.0 and the user scalar is applied after the
+    // reduction via SFPU mul_unary_tile inside the compute kernel.
+    const bool use_post_mul = operation_attributes.post_mul_scaler != 1.0f;
+    uint32_t post_mul_scaler_bits = std::bit_cast<uint32_t>(operation_attributes.post_mul_scaler);
+
     std::vector<uint32_t> reader_compile_time_args = {std::bit_cast<uint32_t>(scaler)};
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
@@ -107,6 +113,9 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
 
     std::map<std::string, std::string> reduce_defines =
         reduce_op_utils::get_defines(operation_attributes.math_op, tt::tt_metal::ReduceOpDim::HW);
+    if (use_post_mul) {
+        reduce_defines["REDUCE_POST_MUL"] = "1";
+    }
 
     tt_metal::KernelHandle reader_kernel_id = tt_metal::CreateKernel(
         program,
@@ -122,9 +131,10 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
         tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
     std::vector<uint32_t> compute_kernel_args = {
-        Ht,  // Ht
-        Wt,  // Wt
-        NC,  // NC
+        Ht,                    // Ht
+        Wt,                    // Wt
+        NC,                    // NC
+        post_mul_scaler_bits,  // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
     };
 
     const std::string compute_kernel =
@@ -139,7 +149,7 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
             .math_fidelity = math_fidelity,
             .fp32_dest_acc_en = fp32_dest_acc_en,
             .compile_args = compute_kernel_args,
-            .defines = reduce_op_utils::get_defines(operation_attributes.math_op, tt::tt_metal::ReduceOpDim::HW)});
+            .defines = reduce_defines});
 
     tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, {a.buffer()->address(), num_tensor_tiles, 0});
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -20,6 +20,7 @@
 #include "ttnn/operations/data_movement/permute/permute.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <numeric>
 
@@ -138,12 +139,20 @@ static Tensor reduce_impl(
         auto reduce_nd_loop = [&](const bool use_reduce_type, float scalar) -> Tensor {
             Tensor output_tensor = input_tensor_arg;
             bool first = true;
+            const int min_reduce_axis = *std::min_element(dim.begin(), dim.end());
             for (int i_dim = rank - 1; i_dim >= 0; i_dim--) {
                 bool found = std::find(dim.begin(), dim.end(), i_dim) != dim.end();
                 if (found) {
                     // Only apply the scalar once when reducing dim-by-dim,
                     // otherwise the result will be scaled multiple times.
                     float effective_scalar = first ? scalar : 1.0;
+                    if constexpr (
+                        reduce_type == reduction_common::ReduceType::Max ||
+                        reduce_type == reduction_common::ReduceType::Min) {
+                        // Sum/Mean: scale once on the first partial reduction. Min/Max: only on the last
+                        // partial step (min_reduce_axis) so the result is scalar * global op(x).
+                        effective_scalar = (i_dim == min_reduce_axis) ? scalar : 1.0;
+                    }
                     first = false;
 
                     bool transpose = i_dim < rank - 2;
@@ -651,6 +660,19 @@ Tensor max(
     float scalar,
     bool correction,
     const std::optional<CoreRangeSet>& sub_core_grids) {
+    /* Scaling is applied after reduction, so flip the op for negative scalars:
+     * max(s * x) = s * min(x) when s < 0.*/
+    if (scalar < 0.0f) {
+        return operations::reduction::reduce<reduction_common::ReduceType::Min>(
+            input_tensor_arg,
+            dim_arg,
+            keepdim,
+            memory_config_arg,
+            compute_kernel_config,
+            scalar,
+            correction,
+            sub_core_grids);
+    }
     return operations::reduction::reduce<reduction_common::ReduceType::Max>(
         input_tensor_arg,
         dim_arg,
@@ -671,6 +693,19 @@ Tensor min(
     float scalar,
     bool correction,
     const std::optional<CoreRangeSet>& sub_core_grids) {
+    /* Scaling is applied after reduction, so flip the op for negative scalars:
+     * min(s * x) = s * max(x) when s < 0.*/
+    if (scalar < 0.0f) {
+        return operations::reduction::reduce<reduction_common::ReduceType::Max>(
+            input_tensor_arg,
+            dim_arg,
+            keepdim,
+            memory_config_arg,
+            compute_kernel_config,
+            scalar,
+            correction,
+            sub_core_grids);
+    }
     return operations::reduction::reduce<reduction_common::ReduceType::Min>(
         input_tensor_arg,
         dim_arg,


### PR DESCRIPTION
### Summary
- Closes #40498

#### Problem description
The scalar parameter in `ttnn.max/min` reductions is eventually passed to the Tensix GMPOOL hardware instruction as the SrcB scalar. However, per the [GMPOOL ISA documentation](https://github.com/tenstorrent/tt-isa-documentation/blob/main/WormholeB0/TensixTile/TensixCoprocessor/GMPOOL.md), this instruction only uses the exponent of the scalar value (applying exp2 ∘ floor ∘ log2), discarding both the sign bit and the mantissa.

This means:
- Negative scalars are treated as positive (sign is ignored)
- Non-power-of-two scalars are rounded down to the nearest power of two (mantissa is ignored)

For example, scalars -2.43, -2.0, 2.0, and 2.43 all produce the same result: scaling by 2.0. The only scalar values that work correctly are positive powers of two. However, ttnn.max/min are supposed to match PyTorch behavior and thus should accept and correctly apply any scalar.

### What's changed
To ensure `ttnn.max` / `ttnn.min` correctly support arbitrary scalar values and match PyTorch behavior, the min/max reduction path now avoids relying on GMPOOL scalar scaling when `scalar != 1.0`.

Instead, reduction is performed with unity scaling, and the full user scalar is applied after reduction.

To support this flow, a dedicated post-multiply scalar path is introduced when required. Host-side program setup detects **non-unit min/max scalars** through `use_post_mul`, enables the `REDUCE_POST_MUL` kernel define, and passes the original scalar as a packed fp32 immediate in compute compile-time arguments.

Reduction then proceeds with:

- unity scalar (1.0f) during pool/reduce, avoiding GMPOOL scalar limitations
- full user scalar applied after reduction using SFPU mul_unary_tile

---

### **Files changed:**

**1) Updated reduction helper flow for post-multiply support**
**Files:**
`ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp`
`ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl`

* Added `post_reduce_op(...)` support for the `REDUCE_SCALAR` path.
* Full H×W reductions can now run the same post-processing callback used by H/W reductions.
* Enables scalar correction after reduction for min/max flows.

**2) Added post-scale plumbing to device reduction operation**
**Files:**
`ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation_types.hpp`
`ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp`
`ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp`

* Added `post_mul_scaler` to `ReduceParams`.
* Updated interfaces to forward the new parameter through the reduction pipeline.
* Included `post_mul_scaler` in `compute_program_hash` to avoid cache collisions across different scalar values.

**3) Updated reduction program factories**
**Files:**
`ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_*_core_*_program_factory.cpp`

Updated all three reduction program factories to:

* detect post-scale mode for min/max when `scalar != 1.0f`
* run reduction with unity scaling on device
* pass packed user scalar bits as compute compile-time args
* define `REDUCE_POST_MUL` for compute kernels when enabled

**4) Updated compute kernels**
**Files:**
`ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp`
`ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_{h,w,hw}_neg.cpp`

Added support for post-multiply scalar correction.

For min/max scalar reductions:

* reduction runs using unity scaling
* final reduced output is multiplied by the original user scalar after reduction using `mul_unary_tile`

This avoids incorrect GMPOOL scalar handling while preserving existing reduction behavior.

**5) Updated core device reduction logic**
**File:**
`ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp`

* Routes min/max scalar reductions through unity pool scaling.
* Forwards original scalar as `post_mul_scaler`.
* Handles chained reductions so scalar is applied only on the final reduction step where required.

**6) Added min/max operation flipping for negative scalars**
**File:**
`ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp`

For negative scalars, the reduction operation is flipped before execution so results match PyTorch semantics:

* `max(x * -s) = min(x) * (-s)`
* `min(x * -s) = max(x) * (-s)`

This preserves correct ordering when scaling is applied after reduction.


Also, refined multi-dimensional (ND) reductions so min/max scalar scaling is applied on the last reduction step (smallest reduced axis), instead of the first step like other reductions. This preserves correct semantics: `scalar × global min/max(input)`

**7) Updated tests**
**File:**
`tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py`

* Removed `xfail` cases for #40498 and #40498 where behavior is now fixed.
* Existing `test_generic_ops_w_scalar` already covers the original issue repro scenarios and now validates the fix.
* Scalar min/max reduction cases now validate against expected PyTorch results.


### Notes for Reviewers

The post-multiply scalar path is only enabled for `ttnn.min` / `ttnn.max` when the user scalar is not 1.0f. All other reductions continue using the existing reduction-scaler flow unchanged.

Start with `use_post_mul` / `REDUCE_POST_MUL` in the H, W, and single-core HW program factories, then review the compute kernels (reduce*.cpp) where the reduced output is post-scaled via `mul_unary_tile`. After that, review the shared reduce helpers where `REDUCE_SCALAR` now invokes `post_reduce_op`, followed by the host-side wiring in `reduce_op.cpp` / `ReduceParams`.

Documentation in the reduction helpers has also been updated to reflect GMPOOL scalar limitations and the post-reduction scaling behavior for MAX/MIN.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/sudha-scalar-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/sudha-scalar-min-max)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/sudha-scalar-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/sudha-scalar-min-max)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/sudha-scalar-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/sudha-scalar-min-max)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/sudha-scalar-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/sudha-scalar-min-max)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/sudha-scalar-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/sudha-scalar-min-max)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/sudha-scalar-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-scalar-min-max)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/sudha-scalar-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-scalar-min-max)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/sudha-scalar-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-scalar-min-max)