### PR TITLE
Fix incorrect bias tensor padding in matmul tests

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul2.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul2.py
@@ -60,7 +60,14 @@ def test_matmul_1d_in0_batched(
 
         in0_t = torch2tt_tensor(in0, device, tt_memory_config=interleaved_mem_config, tt_dtype=activations_dtype)
         in1_t = torch2tt_tensor(in1, device, tt_memory_config=interleaved_mem_config, tt_dtype=weights_dtype)
-        bias_t = pad_by_zero(bias, device, tt_memory_config=interleaved_mem_config, tt_dtype=weights_dtype)[0]
+
+        bias_t = ttnn.from_torch(
+            bias,
+            dtype=weights_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=interleaved_mem_config,
+        )
 
         output_mem_config = sharded_mem_config if out_sharded else interleaved_mem_config
 
@@ -902,7 +909,14 @@ def test_sharded_matmul_2d_transposed(
 
     in0_t = torch2tt_tensor(in0, device, tt_memory_config=interleaved_mem_config, tt_dtype=activations_dtype)
     in1_t = torch2tt_tensor(in1, device, tt_memory_config=interleaved_mem_config, tt_dtype=weights_dtype)
-    bias_t = pad_by_zero(bias, device, tt_memory_config=interleaved_mem_config, tt_dtype=weights_dtype)[0]
+
+    bias_t = ttnn.from_torch(
+        bias,
+        dtype=weights_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=interleaved_mem_config,
+    )
 
     output_mem_config = sharded_mem_config if out_sharded else interleaved_mem_config
 
@@ -980,7 +994,14 @@ def test_resharded_binary_to_matmul(device, function_level_defaults):
     in0_t = torch2tt_tensor(in0, device, tt_memory_config=interleaved_mem_config)
     in1_t = torch2tt_tensor(in1, device, tt_memory_config=interleaved_mem_config)
     weight_t = torch2tt_tensor(weight, device, tt_memory_config=interleaved_mem_config)
-    bias_t = pad_by_zero(bias, device, tt_memory_config=interleaved_mem_config)[0]
+
+    bias_t = ttnn.from_torch(
+        bias,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=interleaved_mem_config,
+    )
 
     in0_t = ttnn.interleaved_to_sharded(
         in0_t,

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul2.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul2.py
@@ -1048,7 +1048,7 @@ def test_resharded_binary_to_matmul(device, function_level_defaults):
 
     tt_out = tt2torch_tensor(output_matmul_t)
 
-    pt_out = (in0 + in1) @ weight
+    pt_out = (in0 + in1) @ weight + bias
 
     assert_numeric_metrics(pt_out, tt_out, check_allclose=False, check_frobenius=False, check_ulp=False)
 


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

The test_matmul2.py tests were incorrectly using pad_by_zero for bias tensors with shape [1, 1, 1, N]. This function pads both the second-to-last and last dimensions to multiples of 32, resulting in bias shape [1, 1, 32, N] which is not broadcastable to output shape [1, 1, M, N] when M != 32.

This issue was exposed by commit d964b8e which added proper broadcast validation for bias tensors in matmul operations.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

The fix replaces pad_by_zero with ttnn.from_torch which properly handles the bias tensor without incorrectly padding the broadcasting dimension.

Affected tests:
- test_matmul_1d_in0_batched
- test_sharded_matmul_2d_transposed
- test_resharded_binary_to_matmul

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/bias-shape-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/bias-shape-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/bias-shape-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/bias-shape-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/bias-shape-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/bias-shape-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/bias-shape-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/bias-shape-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/bias-shape-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/bias-shape-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/bias-shape-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/bias-shape-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/bias-shape-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/bias-shape-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/bias-shape-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/bias-shape-fix)