### PR TITLE
#41020: fix up layernorm cb usage

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm_sharded.py
@@ -9,7 +9,6 @@ from loguru import logger
 
 from models.common.utility_functions import (
     skip_for_wormhole_b0,
-    skip_with_llk_assert,
 )
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
@@ -298,7 +297,6 @@ def run_pre_allgather_layernorm(
     ],
 )
 @pytest.mark.parametrize(("fuse_residual", "max_atol_ex2"), [(False, 0.04), (True, 0.09)])
-@skip_with_llk_assert("Hit LLK_ASSERT for unpacker data format conversion. Issue: #41020")
 def test_pre_allgather_layernorm(
     device,
     input_width,
@@ -344,7 +342,6 @@ def test_pre_allgather_layernorm(
 @pytest.mark.parametrize("core_grid", ((1, 4),))
 @pytest.mark.parametrize(("min_pcc_ex", "max_atol_ex"), [(0.9997, 0.01)])
 @pytest.mark.parametrize(("min_pcc_ex2", "max_atol_ex2"), [(0.986, 0.04)])
-@skip_with_llk_assert("Hit LLK_ASSERT for unpacker data format conversion. Issue: #41020")
 def test_pre_allgather_layernorm_1d_reduce(
     device,
     input_width,
@@ -388,7 +385,6 @@ def test_pre_allgather_layernorm_1d_reduce(
 @pytest.mark.parametrize("weights_df", [ttnn.bfloat8_b, ttnn.bfloat16])
 @pytest.mark.parametrize(("mean", "std"), ([0, 1],))
 @pytest.mark.parametrize("core_grid", ((8, 2),))
-@skip_with_llk_assert("Hit LLK_ASSERT for unpacker data format conversion. Issue: #41020")
 def test_post_allgather_layernorm(
     device,
     input_width,
@@ -481,7 +477,6 @@ def test_post_allgather_layernorm(
         ((2, 4), ttnn.CoreCoord(0, 0), (4, 2)),
     ],
 )
-@skip_with_llk_assert("Hit LLK_ASSERT for unpacker data format conversion. Issue: #41020")
 def test_simulated_distributed_layernorm(
     device,
     input_width,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
@@ -91,22 +91,17 @@ void kernel_main() {
     experimental::CircularBuffer cb_ex_sqr_obj(cb_ex_sqr);
 
 #ifdef RMSNORM
-    if (is_allgather_worker) {
-        binary_op_init_common(cb_stats, cb_scaler_global, cb_var);
-    } else {
-        binary_op_init_common(cb_in0, cb_scaler_global, cb_out);
-    }
+    constexpr uint32_t init_in_cb = is_allgather_worker ? cb_stats : cb_in0;
+    constexpr uint32_t init_out_cb = is_allgather_worker ? cb_var : cb_out;
     constexpr uint32_t stats_tiles = 1;
     constexpr uint32_t cb_xmm = cb_in0;  // x
 #else
-    if (is_allgather_worker) {
-        binary_op_init_common(cb_stats, cb_scaler_global, cb_stats_reduced);
-    } else {
-        binary_op_init_common(cb_in0, cb_scaler_global, cb_out);
-    }
+    constexpr uint32_t init_in_cb = is_allgather_worker ? cb_stats : cb_in0;
+    constexpr uint32_t init_out_cb = is_allgather_worker ? cb_stats_reduced : cb_out;
     constexpr uint32_t stats_tiles = 2;
     constexpr uint32_t cb_xmm = tt::CBIndex::c_18;  // x minus mean
 #endif
+    binary_op_init_common(init_in_cb, cb_scaler_global, init_out_cb);
     experimental::CircularBuffer cb_xmm_obj(cb_xmm);
 
     // set block_h to volatile to disable automatically unroll of the loops, avoid code overflow

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
@@ -91,11 +91,19 @@ void kernel_main() {
     experimental::CircularBuffer cb_ex_sqr_obj(cb_ex_sqr);
 
 #ifdef RMSNORM
-    binary_op_init_common(cb_stats, cb_scaler_global, cb_var);
+    if (is_allgather_worker) {
+        binary_op_init_common(cb_stats, cb_scaler_global, cb_var);
+    } else {
+        binary_op_init_common(cb_in0, cb_scaler_global, cb_out);
+    }
     constexpr uint32_t stats_tiles = 1;
     constexpr uint32_t cb_xmm = cb_in0;  // x
 #else
-    binary_op_init_common(cb_stats, cb_scaler_global, cb_stats_reduced);
+    if (is_allgather_worker) {
+        binary_op_init_common(cb_stats, cb_scaler_global, cb_stats_reduced);
+    } else {
+        binary_op_init_common(cb_in0, cb_scaler_global, cb_out);
+    }
     constexpr uint32_t stats_tiles = 2;
     constexpr uint32_t cb_xmm = tt::CBIndex::c_18;  // x minus mean
 #endif

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
@@ -357,7 +357,8 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
         .is_post_all_gather = is_post_all_gather,
         .use_two_stage_reduce = grid.use_two_stage_reduce,
         .use_welford = use_welford,
-        .skip_write_back = skip_write_back};
+        .skip_write_back = skip_write_back,
+        .rms_norm = rms_norm};
     auto cb_sizes = cb_size_params.compute();
 
     // Build ProgramDescriptor

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
@@ -547,6 +547,13 @@ CBSizeParams::Sizes CBSizeParams::compute() const {
     sizes.in6_CB_size = in0_block_tiles * beta_single_tile_size / block_ht;
 
     sizes.x_CB_size = in0_block_tiles * single_tile_size;
+    if (is_post_all_gather && !rms_norm) {
+        // Non-RMSNORM post-allgather reuses cb_x (c_24) as both cb_ex_sqr and cb_im.
+        // The allgather worker writes 1 tile to cb_ex_sqr first, advancing the write
+        // pointer. The CB needs an extra tile so the subsequent cb_im write has enough
+        // contiguous space.
+        sizes.x_CB_size += single_tile_size;
+    }
     sizes.xmm_CB_size = in0_block_tiles * single_tile_size;
 
     sizes.ex_partial_CB_size = in0_block_tiles * single_tile_size / block_wt;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
@@ -164,6 +164,7 @@ struct CBSizeParams {
     bool use_two_stage_reduce = false;
     bool use_welford = false;
     bool skip_write_back = false;
+    bool rms_norm = false;
 
     // Computes all CB sizes and returns them in a struct
     struct Sizes {


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #41020

Fixes two LLK asserts in the layernorm_sharded_post_allgather compute kernel and remove @skip_with_llk_assert decorators (Issue #41020) from the pytests.

Fix 1: Invalid data format on non-sender cores. binary_op_init_common() was called unconditionally with cb_stats (c_7) and cb_var/cb_stats_reduced (c_19/c_21), which are only allocated on sender cores. Non-sender cores saw data format 255 (uninitialized), triggering "Unsupported unpacker to register conversion" and "Unsupported packer to L1 conversion" asserts. Fixed by guarding the call: allgather workers use the stats CBs, while other workers use cb_in0/cb_out which exist on all cores.

Fix 2: CB overflow in non-RMSNORM path. CB 24 (cb_x/cb_ex_sqr) was allocated with exactly in0_block_tiles tiles. In non-RMSNORM post-allgather, the allgather worker first writes 1 tile for E[x]^2, advancing the write pointer. When the CB is later reused as cb_im (needing all in0_block_tiles tiles contiguously), there isn't enough space remaining. Fixed by adding 1 extra tile to the CB allocation for this case.
### Notes for reviewers

<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-41020_ln_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-41020_ln_cbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-41020_ln_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-41020_ln_cbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-41020_ln_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-41020_ln_cbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-41020_ln_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-41020_ln_cbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-41020_ln_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-41020_ln_cbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-41020_ln_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-41020_ln_cbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-41020_ln_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-41020_ln_cbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-41020_ln_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-41020_ln_cbs)