### PR TITLE
Generalize DeepSeekV3 B1 weight loading into two-phase fast/slow dispatch steps

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/weight_provider.py
+++ b/models/demos/deepseek_v3_b1/demo/weight_provider.py
@@ -11,7 +11,7 @@ StateDictWeightProvider loads HuggingFace safetensors and runs the same prepare_
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Protocol, TypeVar
+from typing import Protocol
 
 import torch
 
@@ -35,14 +35,7 @@ from models.demos.deepseek_v3_b1.weights.prepare import (
     prepare_mtp_weights,
     prepare_spec_weights,
 )
-from models.demos.deepseek_v3_b1.weights.upload import (
-    extract_backing_tensors,
-    rebuild_with_device_tensors,
-    tensor_identity_key,
-    two_phase_upload,
-)
-
-TWeights = TypeVar("TWeights")
+from models.demos.deepseek_v3_b1.weights.upload import Uploadable, two_phase_upload
 
 
 class WeightProvider(Protocol):
@@ -245,11 +238,8 @@ class CacheWeightProvider:
         )
         return CacheConfig(cache=self._cache, context=context)
 
-    def _upload_prepared_weights(self, device: ttnn.MeshDevice, host_weights: TWeights) -> TWeights:
-        host_tensors = extract_backing_tensors(host_weights)
-        device_tensors = two_phase_upload(device, host_tensors)
-        host_to_device = {tensor_identity_key(host): dev for host, dev in zip(host_tensors, device_tensors)}
-        return rebuild_with_device_tensors(host_weights, host_to_device)
+    def _upload_prepared_weights(self, device: ttnn.MeshDevice, host_weights: Uploadable):
+        return two_phase_upload(device, host_weights)
 
     def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
         host_weights = prepare_embedding_weights(

--- a/models/demos/deepseek_v3_b1/demo/weight_provider.py
+++ b/models/demos/deepseek_v3_b1/demo/weight_provider.py
@@ -242,22 +242,22 @@ class CacheWeightProvider:
         return two_phase_upload(device, host_weights)
 
     def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
-        host_weights = prepare_embedding_weights(
+        # TODO: Re-enable two-phase upload here after fast-dispatch lifecycle is managed globally.
+        return prepare_embedding_weights(
             self._state_dict,
             device,
-            move_to_device=False,
+            move_to_device=True,
             cache_config=self._cache_config(device),
         )
-        return self._upload_prepared_weights(device, host_weights)
 
     def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
-        host_weights = prepare_lm_head_weights(
+        # TODO: Re-enable two-phase upload here after fast-dispatch lifecycle is managed globally.
+        return prepare_lm_head_weights(
             self._state_dict,
             device,
-            move_to_device=False,
+            move_to_device=True,
             cache_config=self._cache_config(device),
         )
-        return self._upload_prepared_weights(device, host_weights)
 
     def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
         host_weights = prepare_moe_layer_weights(
@@ -281,22 +281,22 @@ class CacheWeightProvider:
         return self._upload_prepared_weights(device, host_weights)
 
     def load_mtp(self, device: ttnn.MeshDevice) -> DeepSeekV3MTPWeights:
-        host_weights = prepare_mtp_weights(
+        # TODO: Re-enable two-phase upload here after fast-dispatch lifecycle is managed globally.
+        return prepare_mtp_weights(
             self._state_dict,
             device,
-            move_to_device=False,
+            move_to_device=True,
             cache_config=self._cache_config(device),
         )
-        return self._upload_prepared_weights(device, host_weights)
 
     def load_spec(self, device: ttnn.MeshDevice) -> DeepSeekV3SpecWeights:
-        host_weights = prepare_spec_weights(
+        # TODO: Re-enable two-phase upload here after fast-dispatch lifecycle is managed globally.
+        return prepare_spec_weights(
             self._state_dict,
             device,
-            move_to_device=False,
+            move_to_device=True,
             cache_config=self._cache_config(device),
         )
-        return self._upload_prepared_weights(device, host_weights)
 
 
 class SyntheticWeightProvider:

--- a/models/demos/deepseek_v3_b1/demo/weight_provider.py
+++ b/models/demos/deepseek_v3_b1/demo/weight_provider.py
@@ -10,12 +10,10 @@ StateDictWeightProvider loads HuggingFace safetensors and runs the same prepare_
 
 from __future__ import annotations
 
-import time
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, TypeVar
 
 import torch
-from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
@@ -30,18 +28,21 @@ from models.demos.deepseek_v3_b1.weights.prepare import (
     DeepSeekV3MoELayerWeights,
     DeepSeekV3MTPWeights,
     DeepSeekV3SpecWeights,
-    MoERoutedExpertWeights,
-    OverlappedTensor,
-    prepare_attention_weights,
     prepare_dense_layer_weights,
     prepare_embedding_weights,
     prepare_lm_head_weights,
     prepare_moe_layer_weights,
     prepare_mtp_weights,
-    prepare_routed_expert_weights,
-    prepare_shared_expert_weights,
     prepare_spec_weights,
 )
+from models.demos.deepseek_v3_b1.weights.upload import (
+    extract_backing_tensors,
+    rebuild_with_device_tensors,
+    tensor_identity_key,
+    two_phase_upload,
+)
+
+TWeights = TypeVar("TWeights")
 
 
 class WeightProvider(Protocol):
@@ -244,110 +245,68 @@ class CacheWeightProvider:
         )
         return CacheConfig(cache=self._cache, context=context)
 
+    def _upload_prepared_weights(self, device: ttnn.MeshDevice, host_weights: TWeights) -> TWeights:
+        host_tensors = extract_backing_tensors(host_weights)
+        device_tensors = two_phase_upload(device, host_tensors)
+        host_to_device = {tensor_identity_key(host): dev for host, dev in zip(host_tensors, device_tensors)}
+        return rebuild_with_device_tensors(host_weights, host_to_device)
+
     def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
-        return prepare_embedding_weights(self._state_dict, device, cache_config=self._cache_config(device))
-
-    def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
-        return prepare_lm_head_weights(self._state_dict, device, cache_config=self._cache_config(device))
-
-    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
-        """Load MoE layer from tensor cache; routed experts use fast dispatch, rest uses slow dispatch."""
-        t_load = time.perf_counter()
-        cache_config = self._cache_config(device)
-        setup_s = time.perf_counter() - t_load
-
-        t_before_with = time.perf_counter()
-        with ttnn.device.setup_fast_dispatch(device):
-            t_after_fd_init = time.perf_counter()
-            fd_init_s = t_after_fd_init - t_before_with
-            t0 = time.perf_counter()
-            routed = prepare_routed_expert_weights(
-                device,
-                self._state_dict,
-                layer_id,
-                is_moe=True,
-                num_routed_experts=NUM_ROUTED_EXPERTS,
-                move_to_device=True,
-                cache_config=cache_config,
-            )
-            routed_prepare_s = time.perf_counter() - t0
-            t_before_teardown = time.perf_counter()
-        t_after_with = time.perf_counter()
-        fd_teardown_s = t_after_with - t_before_teardown
-
-        logger.info(f"CacheWeightProvider MoE layer {layer_id}: setup (cache_config) {setup_s:.3f}s")
-        logger.info(f"CacheWeightProvider MoE layer {layer_id}: fast_dispatch initialize {fd_init_s:.3f}s")
-        logger.info(f"CacheWeightProvider MoE layer {layer_id}: prepare_routed_expert_weights {routed_prepare_s:.3f}s")
-        logger.info(f"CacheWeightProvider MoE layer {layer_id}: fast_dispatch terminate {fd_teardown_s:.3f}s")
-
-        t0 = time.perf_counter()
-        attn = prepare_attention_weights(
-            device,
+        host_weights = prepare_embedding_weights(
             self._state_dict,
-            layer_id,
-            is_moe=True,
-            move_to_device=True,
-            cache_config=cache_config,
-        )
-        attn_s = time.perf_counter() - t0
-        logger.info(f"CacheWeightProvider MoE layer {layer_id}: prepare_attention_weights {attn_s:.3f}s")
-        t0 = time.perf_counter()
-        shared = prepare_shared_expert_weights(
             device,
-            self._state_dict,
-            layer_id,
-            is_moe=True,
-            move_to_device=True,
-            cache_config=cache_config,
-        )
-        shared_s = time.perf_counter() - t0
-        logger.info(f"CacheWeightProvider MoE layer {layer_id}: prepare_shared_expert_weights {shared_s:.3f}s")
-
-        total_s = time.perf_counter() - t_load
-        sum_parts = setup_s + fd_init_s + routed_prepare_s + fd_teardown_s + attn_s + shared_s
-        overhead_s = total_s - sum_parts
-        logger.info(
-            f"CacheWeightProvider MoE layer {layer_id}: load_moe_layer total {total_s:.3f}s "
-            f"(sum of parts {sum_parts:.3f}s; unaccounted {overhead_s:+.3f}s — logging / small gaps)"
-        )
-        assert isinstance(attn.gate_mm, OverlappedTensor)
-        assert attn.gate_bias is not None
-        assert isinstance(routed, MoERoutedExpertWeights)
-        return DeepSeekV3MoELayerWeights(
-            q_a_proj=attn.q_a_proj,
-            q_b_proj=attn.q_b_proj,
-            kv_a_proj=attn.kv_a_proj,
-            o_proj=attn.o_proj,
-            gate_mm=attn.gate_mm,
-            attn_norm=attn.attn_norm,
-            q_norm=attn.q_norm,
-            kv_norm=attn.kv_norm,
-            ffn_norm=attn.ffn_norm,
-            gate_bias=attn.gate_bias,
-            kv_b1_proj=attn.kv_b1_proj,
-            kv_b2_proj=attn.kv_b2_proj,
-            shared_gate_proj=shared.shared_gate_proj,
-            shared_up_proj=shared.shared_up_proj,
-            shared_down_proj=shared.shared_down_proj,
-            routed_gate_proj=routed.routed_gate_proj,
-            routed_up_proj=routed.routed_up_proj,
-            routed_down_proj=routed.routed_down_proj,
-        )
-
-    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
-        return prepare_dense_layer_weights(
-            device,
-            self._state_dict,
-            layer_id,
-            move_to_device=True,
+            move_to_device=False,
             cache_config=self._cache_config(device),
         )
+        return self._upload_prepared_weights(device, host_weights)
+
+    def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
+        host_weights = prepare_lm_head_weights(
+            self._state_dict,
+            device,
+            move_to_device=False,
+            cache_config=self._cache_config(device),
+        )
+        return self._upload_prepared_weights(device, host_weights)
+
+    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+        host_weights = prepare_moe_layer_weights(
+            device,
+            self._state_dict,
+            layer_id,
+            num_routed_experts=NUM_ROUTED_EXPERTS,
+            move_to_device=False,
+            cache_config=self._cache_config(device),
+        )
+        return self._upload_prepared_weights(device, host_weights)
+
+    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
+        host_weights = prepare_dense_layer_weights(
+            device,
+            self._state_dict,
+            layer_id,
+            move_to_device=False,
+            cache_config=self._cache_config(device),
+        )
+        return self._upload_prepared_weights(device, host_weights)
 
     def load_mtp(self, device: ttnn.MeshDevice) -> DeepSeekV3MTPWeights:
-        return prepare_mtp_weights(self._state_dict, device, cache_config=self._cache_config(device))
+        host_weights = prepare_mtp_weights(
+            self._state_dict,
+            device,
+            move_to_device=False,
+            cache_config=self._cache_config(device),
+        )
+        return self._upload_prepared_weights(device, host_weights)
 
     def load_spec(self, device: ttnn.MeshDevice) -> DeepSeekV3SpecWeights:
-        return prepare_spec_weights(self._state_dict, device, cache_config=self._cache_config(device))
+        host_weights = prepare_spec_weights(
+            self._state_dict,
+            device,
+            move_to_device=False,
+            cache_config=self._cache_config(device),
+        )
+        return self._upload_prepared_weights(device, host_weights)
 
 
 class SyntheticWeightProvider:

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_upload.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_upload.py
@@ -115,7 +115,7 @@ def test_split_core_ranges_partitions_tensor_grid_into_fd_and_sd():
     assert union == tensor_grid
 
 
-def test_extract_backing_tensors_deduplicates_fused_and_direct_tensors(monkeypatch):
+def test_uploadable_mixin_backing_tensors_deduplicates_fused_and_direct_tensors(monkeypatch):
     _patch_upload_tensor_types(monkeypatch)
     fused = _FakeTensor("fused")
     direct = _FakeTensor("direct")
@@ -141,66 +141,70 @@ def test_extract_backing_tensors_deduplicates_fused_and_direct_tensors(monkeypat
         byte_offset=128,
         total_size=2048,
     )
-    fixture = _OuterFixture(
-        direct=direct,
-        inner=_InnerFixture(fused=ot_a, tensors=[direct, extra]),
-        extra=(ot_b, None, "ignored"),
-    )
 
-    got = upload.extract_backing_tensors(fixture)
+    @dataclass
+    class _UploadFixture(upload.UploadableMixin):
+        direct: upload.ttnn.Tensor
+        fused_a: upload.OverlappedTensor
+        fused_b: upload.OverlappedTensor
+        tensor_list: list[upload.ttnn.Tensor]
+        maybe_tensor: upload.ttnn.Tensor | None
+        maybe_overlapped: upload.OverlappedTensor | None
+
+    fixture = _UploadFixture(
+        direct=direct,
+        fused_a=ot_a,
+        fused_b=ot_b,
+        tensor_list=[direct, extra],
+        maybe_tensor=None,
+        maybe_overlapped=None,
+    )
+    got = fixture.backing_tensors()
     assert got == [direct, fused, extra]
 
 
-def test_extract_backing_tensors_ignores_non_tensor_fields(monkeypatch):
+def test_uploadable_mixin_raises_on_unknown_field_type(monkeypatch):
     _patch_upload_tensor_types(monkeypatch)
     direct = _FakeTensor("direct")
-    fixture = _OuterFixture(
-        direct=direct,
-        inner=_InnerFixture(
-            fused=upload.OverlappedTensor(
-                fused_tensor=direct,
-                tensor_shape=(32, 32),
-                shard_shape=(32, 32),
-                core_range_set=_crs(0, 0, 0, 0),
-                dtype=object(),
-                tile_shape=(32, 32),
-                byte_offset=0,
-                total_size=2048,
-            ),
-            tensors=[],
-        ),
-        extra=(123, "abc", None),
-    )
-    got = upload.extract_backing_tensors(fixture)
-    assert got == [direct]
+
+    @dataclass
+    class _BadFixture(upload.UploadableMixin):
+        direct: upload.ttnn.Tensor
+        unsupported: str
+
+    fixture = _BadFixture(direct=direct, unsupported="bad")
+    with pytest.raises(TypeError):
+        fixture.backing_tensors()
 
 
-def test_extract_backing_tensors_deduplicates_by_tensor_id(monkeypatch):
+def test_uploadable_mixin_backing_tensors_deduplicates_by_tensor_id(monkeypatch):
     _patch_upload_tensor_types(monkeypatch)
     a = _TensorWithStableId("a", tensor_id=123)
     b = _TensorWithStableId("b", tensor_id=123)
-    fixture = _OuterFixture(
+
+    @dataclass
+    class _IdFixture(upload.UploadableMixin):
+        direct: upload.ttnn.Tensor
+        fused: upload.OverlappedTensor
+
+    fixture = _IdFixture(
         direct=a,
-        inner=_InnerFixture(
-            fused=_FakeOverlappedTensor(
-                fused_tensor=b,
-                tensor_shape=(32, 32),
-                shard_shape=(32, 32),
-                core_range_set=_crs(0, 0, 0, 0),
-                dtype=object(),
-                tile_shape=(32, 32),
-                byte_offset=0,
-                total_size=2048,
-            ),
-            tensors=[],
+        fused=_FakeOverlappedTensor(
+            fused_tensor=b,
+            tensor_shape=(32, 32),
+            shard_shape=(32, 32),
+            core_range_set=_crs(0, 0, 0, 0),
+            dtype=object(),
+            tile_shape=(32, 32),
+            byte_offset=0,
+            total_size=2048,
         ),
-        extra=(),
     )
-    got = upload.extract_backing_tensors(fixture)
+    got = fixture.backing_tensors()
     assert got == [a]
 
 
-def test_rebuild_with_device_tensors_replaces_nested_tensors_and_overlapped_views(monkeypatch):
+def test_uploadable_mixin_with_device_tensors_replaces_nested_tensors_and_overlapped_views(monkeypatch):
     _patch_upload_tensor_types(monkeypatch)
     fused_h = _FakeTensor("fused_h")
     direct_h = _FakeTensor("direct_h")
@@ -219,10 +223,19 @@ def test_rebuild_with_device_tensors_replaces_nested_tensors_and_overlapped_view
         byte_offset=64,
         total_size=2048,
     )
-    fixture = _OuterFixture(
+
+    @dataclass
+    class _RebuildFixture(upload.UploadableMixin):
+        direct: upload.ttnn.Tensor
+        fused: upload.OverlappedTensor
+        tensor_list: list[upload.ttnn.Tensor]
+        maybe_tensor: upload.ttnn.Tensor | None
+
+    fixture = _RebuildFixture(
         direct=direct_h,
-        inner=_InnerFixture(fused=overlapped, tensors=[list_h]),
-        extra=("x",),
+        fused=overlapped,
+        tensor_list=[list_h],
+        maybe_tensor=None,
     )
     mapping = {
         upload.tensor_identity_key(fused_h): fused_d,
@@ -230,40 +243,42 @@ def test_rebuild_with_device_tensors_replaces_nested_tensors_and_overlapped_view
         upload.tensor_identity_key(list_h): list_d,
     }
 
-    rebuilt = upload.rebuild_with_device_tensors(fixture, mapping)
+    rebuilt = fixture.with_device_tensors(mapping)
     assert rebuilt.direct is direct_d
-    assert rebuilt.inner.tensors == [list_d]
-    assert rebuilt.inner.fused.fused_tensor is fused_d
-    assert rebuilt.inner.fused.tensor_shape == overlapped.tensor_shape
-    assert rebuilt.inner.fused.shard_shape == overlapped.shard_shape
-    assert rebuilt.inner.fused.dtype == overlapped.dtype
-    assert rebuilt.inner.fused.tile_shape == overlapped.tile_shape
-    assert rebuilt.inner.fused.byte_offset == overlapped.byte_offset
-    assert rebuilt.inner.fused.total_size == overlapped.total_size
+    assert rebuilt.tensor_list == [list_d]
+    assert rebuilt.fused.fused_tensor is fused_d
+    assert rebuilt.fused.tensor_shape == overlapped.tensor_shape
+    assert rebuilt.fused.shard_shape == overlapped.shard_shape
+    assert rebuilt.fused.dtype == overlapped.dtype
+    assert rebuilt.fused.tile_shape == overlapped.tile_shape
+    assert rebuilt.fused.byte_offset == overlapped.byte_offset
+    assert rebuilt.fused.total_size == overlapped.total_size
 
 
-def test_rebuild_with_device_tensors_raises_on_missing_mapping(monkeypatch):
+def test_uploadable_mixin_with_device_tensors_raises_on_missing_mapping(monkeypatch):
     _patch_upload_tensor_types(monkeypatch)
     host = _FakeTensor("host")
-    fixture = _OuterFixture(
+
+    @dataclass
+    class _MissingMapFixture(upload.UploadableMixin):
+        direct: upload.ttnn.Tensor
+        fused: upload.OverlappedTensor
+
+    fixture = _MissingMapFixture(
         direct=host,
-        inner=_InnerFixture(
-            fused=upload.OverlappedTensor(
-                fused_tensor=host,
-                tensor_shape=(32, 32),
-                shard_shape=(32, 32),
-                core_range_set=_crs(0, 0, 0, 0),
-                dtype=object(),
-                tile_shape=(32, 32),
-                byte_offset=0,
-                total_size=2048,
-            ),
-            tensors=[],
+        fused=upload.OverlappedTensor(
+            fused_tensor=host,
+            tensor_shape=(32, 32),
+            shard_shape=(32, 32),
+            core_range_set=_crs(0, 0, 0, 0),
+            dtype=object(),
+            tile_shape=(32, 32),
+            byte_offset=0,
+            total_size=2048,
         ),
-        extra=(),
     )
     with pytest.raises(KeyError):
-        upload.rebuild_with_device_tensors(fixture, {})
+        fixture.with_device_tensors({})
 
 
 def test_two_phase_upload_non_sharded_goes_full_fd_copy(monkeypatch):
@@ -291,10 +306,24 @@ def test_two_phase_upload_non_sharded_goes_full_fd_copy(monkeypatch):
     monkeypatch.setattr(upload.ttnn.device, "setup_fast_dispatch", lambda _device: _FDContext())
     monkeypatch.setattr(upload, "get_fd_grid", lambda _device: _crs(0, 0, 11, 9))
 
-    host = _FakeHostTensor("a", sharded=False)
-    uploaded = upload.two_phase_upload(object(), [host])
+    class _Uploadable:
+        def __init__(self, tensors):
+            self._tensors = tensors
+            self.received_map = None
 
-    assert uploaded == ["dev-spec-a"]
+        def backing_tensors(self):
+            return self._tensors
+
+        def with_device_tensors(self, tensor_map):
+            self.received_map = tensor_map
+            return self
+
+    host = _FakeHostTensor("a", sharded=False)
+    weights = _Uploadable([host])
+    uploaded = upload.two_phase_upload(object(), weights)
+
+    assert uploaded is weights
+    assert weights.received_map == {upload.tensor_identity_key(host): "dev-spec-a"}
     assert calls == [("fd-enter",), ("full", "a", "dev-spec-a"), ("fd-exit",)]
 
 
@@ -325,8 +354,19 @@ def test_two_phase_upload_sharded_with_both_filters_calls_fd_then_sd_partial(mon
     monkeypatch.setattr(upload.ttnn.device, "setup_fast_dispatch", lambda _device: _FDContext())
     monkeypatch.setattr(upload, "get_fd_grid", lambda _device: _crs(0, 0, 11, 9))
 
+    class _Uploadable:
+        def __init__(self, tensors):
+            self._tensors = tensors
+
+        def backing_tensors(self):
+            return self._tensors
+
+        def with_device_tensors(self, tensor_map):
+            return tensor_map
+
     host = _FakeHostTensor("b", sharded=True, grid=_crs(0, 0, 12, 9))
-    upload.two_phase_upload(object(), [host])
+    result = upload.two_phase_upload(object(), _Uploadable([host]))
+    assert result == {upload.tensor_identity_key(host): "dev-spec-b"}
 
     assert calls == [
         ("fd-enter",),
@@ -362,8 +402,18 @@ def test_two_phase_upload_sharded_fd_only_uses_full_fd_copy(monkeypatch):
     monkeypatch.setattr(upload.ttnn.device, "setup_fast_dispatch", lambda _device: _FDContext())
     monkeypatch.setattr(upload, "get_fd_grid", lambda _device: _crs(0, 0, 11, 9))
 
+    class _Uploadable:
+        def __init__(self, tensors):
+            self._tensors = tensors
+
+        def backing_tensors(self):
+            return self._tensors
+
+        def with_device_tensors(self, tensor_map):
+            return tensor_map
+
     host = _FakeHostTensor("c", sharded=True, grid=_crs(0, 0, 11, 9))
-    upload.two_phase_upload(object(), [host])
+    upload.two_phase_upload(object(), _Uploadable([host]))
 
     assert calls == [("fd-enter",), ("full", "c"), ("fd-exit",)]
 
@@ -394,7 +444,17 @@ def test_two_phase_upload_sharded_with_none_shard_spec_falls_back_to_full_fd(mon
     monkeypatch.setattr(upload.ttnn.device, "setup_fast_dispatch", lambda _device: _FDContext())
     monkeypatch.setattr(upload, "get_fd_grid", lambda _device: _crs(0, 0, 11, 9))
 
+    class _Uploadable:
+        def __init__(self, tensors):
+            self._tensors = tensors
+
+        def backing_tensors(self):
+            return self._tensors
+
+        def with_device_tensors(self, tensor_map):
+            return tensor_map
+
     host = _FakeHostTensor("d", sharded=True, grid=None, shard_spec_none=True)
-    upload.two_phase_upload(object(), [host])
+    upload.two_phase_upload(object(), _Uploadable([host]))
 
     assert calls == [("fd-enter",), ("full", "d"), ("fd-exit",)]

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_upload.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_upload.py
@@ -1,0 +1,400 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+import ttnn
+from models.demos.deepseek_v3_b1.weights import upload
+
+
+def _crs(x0: int, y0: int, x1: int, y1: int) -> ttnn.CoreRangeSet:
+    return ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(x0, y0), ttnn.CoreCoord(x1, y1))])
+
+
+def _crs_to_tuples(crs: ttnn.CoreRangeSet) -> list[tuple[tuple[int, int], tuple[int, int]]]:
+    return sorted(((r.start.x, r.start.y), (r.end.x, r.end.y)) for r in crs.ranges())
+
+
+@dataclass
+class _FakeTensor:
+    name: str
+
+
+@dataclass
+class _TensorWithStableId(_FakeTensor):
+    tensor_id: int
+
+
+@dataclass
+class _FakeOverlappedTensor:
+    fused_tensor: _FakeTensor
+    tensor_shape: tuple[int, int]
+    shard_shape: tuple[int, int]
+    core_range_set: ttnn.CoreRangeSet
+    dtype: object
+    tile_shape: tuple[int, int]
+    byte_offset: int
+    total_size: int
+
+
+@dataclass
+class _InnerFixture:
+    fused: object
+    tensors: list[object]
+
+
+@dataclass
+class _OuterFixture:
+    direct: object
+    inner: _InnerFixture
+    extra: tuple[object, ...]
+    note: str = "fixture"
+
+
+def _patch_upload_tensor_types(monkeypatch):
+    monkeypatch.setattr(upload.ttnn, "Tensor", _FakeTensor, raising=False)
+    monkeypatch.setattr(upload, "OverlappedTensor", _FakeOverlappedTensor)
+
+
+class _FakeDevice:
+    def __init__(self, x: int, y: int):
+        self._grid = SimpleNamespace(x=x, y=y)
+
+    def compute_with_storage_grid_size(self):
+        return self._grid
+
+
+class _FakeHostTensor:
+    def __init__(
+        self, name: str, *, sharded: bool, grid: ttnn.CoreRangeSet | None = None, shard_spec_none: bool = False
+    ):
+        self.name = name
+        self.spec = f"spec-{name}"
+        self._sharded = sharded
+        if shard_spec_none:
+            self._mem_config = SimpleNamespace(shard_spec=None)
+        else:
+            self._mem_config = SimpleNamespace(shard_spec=SimpleNamespace(grid=grid))
+
+    def is_sharded(self) -> bool:
+        return self._sharded
+
+    def memory_config(self):
+        return self._mem_config
+
+
+def test_get_fd_grid_uses_compute_grid_minus_one_x_column():
+    fd_grid = upload.get_fd_grid(_FakeDevice(13, 10))
+    assert _crs_to_tuples(fd_grid) == [((0, 0), (11, 9))]
+
+
+def test_get_fd_grid_returns_empty_when_grid_too_small():
+    fd_grid = upload.get_fd_grid(_FakeDevice(1, 10))
+    assert fd_grid.empty()
+
+
+def test_split_core_ranges_partitions_tensor_grid_into_fd_and_sd():
+    tensor_grid = _crs(0, 0, 12, 9)
+    fd_grid = _crs(0, 0, 11, 9)
+    fd_filter, sd_filter = upload.split_core_ranges(tensor_grid, fd_grid)
+
+    assert fd_filter.num_cores() == 120
+    assert sd_filter.num_cores() == 10
+    assert fd_filter.contains(ttnn.CoreCoord(11, 9))
+    assert not fd_filter.contains(ttnn.CoreCoord(12, 0))
+    assert sd_filter.contains(ttnn.CoreCoord(12, 9))
+    assert not sd_filter.contains(ttnn.CoreCoord(11, 9))
+
+    union = fd_filter.merge(sd_filter)
+    assert union == tensor_grid
+
+
+def test_extract_backing_tensors_deduplicates_fused_and_direct_tensors(monkeypatch):
+    _patch_upload_tensor_types(monkeypatch)
+    fused = _FakeTensor("fused")
+    direct = _FakeTensor("direct")
+    extra = _FakeTensor("extra")
+
+    ot_a = upload.OverlappedTensor(
+        fused_tensor=fused,
+        tensor_shape=(32, 32),
+        shard_shape=(32, 32),
+        core_range_set=_crs(0, 0, 0, 0),
+        dtype=object(),
+        tile_shape=(32, 32),
+        byte_offset=0,
+        total_size=2048,
+    )
+    ot_b = upload.OverlappedTensor(
+        fused_tensor=fused,
+        tensor_shape=(32, 32),
+        shard_shape=(32, 32),
+        core_range_set=_crs(0, 0, 0, 0),
+        dtype=object(),
+        tile_shape=(32, 32),
+        byte_offset=128,
+        total_size=2048,
+    )
+    fixture = _OuterFixture(
+        direct=direct,
+        inner=_InnerFixture(fused=ot_a, tensors=[direct, extra]),
+        extra=(ot_b, None, "ignored"),
+    )
+
+    got = upload.extract_backing_tensors(fixture)
+    assert got == [direct, fused, extra]
+
+
+def test_extract_backing_tensors_ignores_non_tensor_fields(monkeypatch):
+    _patch_upload_tensor_types(monkeypatch)
+    direct = _FakeTensor("direct")
+    fixture = _OuterFixture(
+        direct=direct,
+        inner=_InnerFixture(
+            fused=upload.OverlappedTensor(
+                fused_tensor=direct,
+                tensor_shape=(32, 32),
+                shard_shape=(32, 32),
+                core_range_set=_crs(0, 0, 0, 0),
+                dtype=object(),
+                tile_shape=(32, 32),
+                byte_offset=0,
+                total_size=2048,
+            ),
+            tensors=[],
+        ),
+        extra=(123, "abc", None),
+    )
+    got = upload.extract_backing_tensors(fixture)
+    assert got == [direct]
+
+
+def test_extract_backing_tensors_deduplicates_by_tensor_id(monkeypatch):
+    _patch_upload_tensor_types(monkeypatch)
+    a = _TensorWithStableId("a", tensor_id=123)
+    b = _TensorWithStableId("b", tensor_id=123)
+    fixture = _OuterFixture(
+        direct=a,
+        inner=_InnerFixture(
+            fused=_FakeOverlappedTensor(
+                fused_tensor=b,
+                tensor_shape=(32, 32),
+                shard_shape=(32, 32),
+                core_range_set=_crs(0, 0, 0, 0),
+                dtype=object(),
+                tile_shape=(32, 32),
+                byte_offset=0,
+                total_size=2048,
+            ),
+            tensors=[],
+        ),
+        extra=(),
+    )
+    got = upload.extract_backing_tensors(fixture)
+    assert got == [a]
+
+
+def test_rebuild_with_device_tensors_replaces_nested_tensors_and_overlapped_views(monkeypatch):
+    _patch_upload_tensor_types(monkeypatch)
+    fused_h = _FakeTensor("fused_h")
+    direct_h = _FakeTensor("direct_h")
+    list_h = _FakeTensor("list_h")
+    fused_d = _FakeTensor("fused_d")
+    direct_d = _FakeTensor("direct_d")
+    list_d = _FakeTensor("list_d")
+
+    overlapped = upload.OverlappedTensor(
+        fused_tensor=fused_h,
+        tensor_shape=(32, 32),
+        shard_shape=(32, 32),
+        core_range_set=_crs(0, 0, 0, 0),
+        dtype=object(),
+        tile_shape=(32, 32),
+        byte_offset=64,
+        total_size=2048,
+    )
+    fixture = _OuterFixture(
+        direct=direct_h,
+        inner=_InnerFixture(fused=overlapped, tensors=[list_h]),
+        extra=("x",),
+    )
+    mapping = {
+        upload.tensor_identity_key(fused_h): fused_d,
+        upload.tensor_identity_key(direct_h): direct_d,
+        upload.tensor_identity_key(list_h): list_d,
+    }
+
+    rebuilt = upload.rebuild_with_device_tensors(fixture, mapping)
+    assert rebuilt.direct is direct_d
+    assert rebuilt.inner.tensors == [list_d]
+    assert rebuilt.inner.fused.fused_tensor is fused_d
+    assert rebuilt.inner.fused.tensor_shape == overlapped.tensor_shape
+    assert rebuilt.inner.fused.shard_shape == overlapped.shard_shape
+    assert rebuilt.inner.fused.dtype == overlapped.dtype
+    assert rebuilt.inner.fused.tile_shape == overlapped.tile_shape
+    assert rebuilt.inner.fused.byte_offset == overlapped.byte_offset
+    assert rebuilt.inner.fused.total_size == overlapped.total_size
+
+
+def test_rebuild_with_device_tensors_raises_on_missing_mapping(monkeypatch):
+    _patch_upload_tensor_types(monkeypatch)
+    host = _FakeTensor("host")
+    fixture = _OuterFixture(
+        direct=host,
+        inner=_InnerFixture(
+            fused=upload.OverlappedTensor(
+                fused_tensor=host,
+                tensor_shape=(32, 32),
+                shard_shape=(32, 32),
+                core_range_set=_crs(0, 0, 0, 0),
+                dtype=object(),
+                tile_shape=(32, 32),
+                byte_offset=0,
+                total_size=2048,
+            ),
+            tensors=[],
+        ),
+        extra=(),
+    )
+    with pytest.raises(KeyError):
+        upload.rebuild_with_device_tensors(fixture, {})
+
+
+def test_two_phase_upload_non_sharded_goes_full_fd_copy(monkeypatch):
+    calls: list[tuple] = []
+
+    def _alloc(spec, _device):
+        return f"dev-{spec}"
+
+    def _full(host_tensor, device_tensor):
+        calls.append(("full", host_tensor.name, device_tensor))
+
+    def _partial(host_tensor, device_tensor, core_filter):
+        calls.append(("partial", host_tensor.name, device_tensor, core_filter.num_cores()))
+
+    class _FDContext:
+        def __enter__(self):
+            calls.append(("fd-enter",))
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            calls.append(("fd-exit",))
+
+    monkeypatch.setattr(upload.ttnn, "allocate_tensor_on_device", _alloc)
+    monkeypatch.setattr(upload.ttnn, "copy_host_to_device_tensor", _full)
+    monkeypatch.setattr(upload.ttnn, "copy_host_to_device_tensor_partial", _partial)
+    monkeypatch.setattr(upload.ttnn.device, "setup_fast_dispatch", lambda _device: _FDContext())
+    monkeypatch.setattr(upload, "get_fd_grid", lambda _device: _crs(0, 0, 11, 9))
+
+    host = _FakeHostTensor("a", sharded=False)
+    uploaded = upload.two_phase_upload(object(), [host])
+
+    assert uploaded == ["dev-spec-a"]
+    assert calls == [("fd-enter",), ("full", "a", "dev-spec-a"), ("fd-exit",)]
+
+
+def test_two_phase_upload_sharded_with_both_filters_calls_fd_then_sd_partial(monkeypatch):
+    calls: list[tuple] = []
+
+    monkeypatch.setattr(upload.ttnn, "allocate_tensor_on_device", lambda spec, _device: f"dev-{spec}")
+    monkeypatch.setattr(
+        upload.ttnn,
+        "copy_host_to_device_tensor",
+        lambda host_tensor, device_tensor: calls.append(("full", host_tensor.name)),
+    )
+    monkeypatch.setattr(
+        upload.ttnn,
+        "copy_host_to_device_tensor_partial",
+        lambda host_tensor, device_tensor, core_filter: calls.append(
+            ("partial", host_tensor.name, core_filter.num_cores())
+        ),
+    )
+
+    class _FDContext:
+        def __enter__(self):
+            calls.append(("fd-enter",))
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            calls.append(("fd-exit",))
+
+    monkeypatch.setattr(upload.ttnn.device, "setup_fast_dispatch", lambda _device: _FDContext())
+    monkeypatch.setattr(upload, "get_fd_grid", lambda _device: _crs(0, 0, 11, 9))
+
+    host = _FakeHostTensor("b", sharded=True, grid=_crs(0, 0, 12, 9))
+    upload.two_phase_upload(object(), [host])
+
+    assert calls == [
+        ("fd-enter",),
+        ("partial", "b", 120),
+        ("fd-exit",),
+        ("partial", "b", 10),
+    ]
+
+
+def test_two_phase_upload_sharded_fd_only_uses_full_fd_copy(monkeypatch):
+    calls: list[tuple] = []
+    monkeypatch.setattr(upload.ttnn, "allocate_tensor_on_device", lambda spec, _device: f"dev-{spec}")
+    monkeypatch.setattr(
+        upload.ttnn,
+        "copy_host_to_device_tensor",
+        lambda host_tensor, device_tensor: calls.append(("full", host_tensor.name)),
+    )
+    monkeypatch.setattr(
+        upload.ttnn,
+        "copy_host_to_device_tensor_partial",
+        lambda host_tensor, device_tensor, core_filter: calls.append(
+            ("partial", host_tensor.name, core_filter.num_cores())
+        ),
+    )
+
+    class _FDContext:
+        def __enter__(self):
+            calls.append(("fd-enter",))
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            calls.append(("fd-exit",))
+
+    monkeypatch.setattr(upload.ttnn.device, "setup_fast_dispatch", lambda _device: _FDContext())
+    monkeypatch.setattr(upload, "get_fd_grid", lambda _device: _crs(0, 0, 11, 9))
+
+    host = _FakeHostTensor("c", sharded=True, grid=_crs(0, 0, 11, 9))
+    upload.two_phase_upload(object(), [host])
+
+    assert calls == [("fd-enter",), ("full", "c"), ("fd-exit",)]
+
+
+def test_two_phase_upload_sharded_with_none_shard_spec_falls_back_to_full_fd(monkeypatch):
+    calls: list[tuple] = []
+    monkeypatch.setattr(upload.ttnn, "allocate_tensor_on_device", lambda spec, _device: f"dev-{spec}")
+    monkeypatch.setattr(
+        upload.ttnn,
+        "copy_host_to_device_tensor",
+        lambda host_tensor, device_tensor: calls.append(("full", host_tensor.name)),
+    )
+    monkeypatch.setattr(
+        upload.ttnn,
+        "copy_host_to_device_tensor_partial",
+        lambda host_tensor, device_tensor, core_filter: calls.append(
+            ("partial", host_tensor.name, core_filter.num_cores())
+        ),
+    )
+
+    class _FDContext:
+        def __enter__(self):
+            calls.append(("fd-enter",))
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            calls.append(("fd-exit",))
+
+    monkeypatch.setattr(upload.ttnn.device, "setup_fast_dispatch", lambda _device: _FDContext())
+    monkeypatch.setattr(upload, "get_fd_grid", lambda _device: _crs(0, 0, 11, 9))
+
+    host = _FakeHostTensor("d", sharded=True, grid=None, shard_spec_none=True)
+    upload.two_phase_upload(object(), [host])
+
+    assert calls == [("fd-enter",), ("full", "d"), ("fd-exit",)]

--- a/models/demos/deepseek_v3_b1/weights/cache/cache.py
+++ b/models/demos/deepseek_v3_b1/weights/cache/cache.py
@@ -91,6 +91,7 @@ class TensorCacheProtocol(Protocol):
         fingerprint: Fingerprint,
         device,
         *,
+        move_to_device: bool = True,
         preprocess: Callable[[dict[str, torch.Tensor]], dict],
         raw_tensors: Callable[[], dict[str, torch.Tensor]] | dict[str, torch.Tensor],
         reconstruct: Callable[["CompressedTensorBuildInputs", object], "CompressedTensor"] | None = None,
@@ -211,8 +212,8 @@ class TensorCache:
             json.dump(metadata_dict, f, indent=2, sort_keys=True)
         return dest
 
-    def _load(self, paths: ContentAddressedStoragePaths, device) -> ttnn.Tensor:
-        return ttnn.load_tensor(paths.data_path, device=device)
+    def _load(self, paths: ContentAddressedStoragePaths, device, *, move_to_device: bool = True) -> ttnn.Tensor:
+        return ttnn.load_tensor(paths.data_path, device=device if move_to_device else None)
 
     def _store_fused(
         self,
@@ -240,9 +241,10 @@ class TensorCache:
         paths: ContentAddressedStoragePaths,
         device,
         *,
+        move_to_device: bool = True,
         meta: dict | None = None,
     ) -> dict[str, "OverlappedTensor"]:
-        fused = ttnn.load_tensor(paths.data_path, device=device)
+        fused = ttnn.load_tensor(paths.data_path, device=device if move_to_device else None)
         if meta is None:
             with open(paths.object_dir / "metadata.json") as f:
                 meta = json.load(f)
@@ -358,6 +360,7 @@ class TensorCache:
         fingerprint: Fingerprint,
         device,
         *,
+        move_to_device: bool = True,
         preprocess: Callable[[dict[str, torch.Tensor]], dict],
         raw_tensors: Callable[[], dict[str, torch.Tensor]] | dict[str, torch.Tensor],
         reconstruct: Callable[["CompressedTensorBuildInputs", object], "CompressedTensor"] | None = None,
@@ -383,7 +386,7 @@ class TensorCache:
             if isinstance(entry, PresentCacheEntry):
                 logger.debug("Cache hit (compressed) for {} ({})", logical, artifact_id[:12])
                 inputs = self._load_compressed(entry.paths.object_dir, target)
-                return reconstruct(inputs, device)
+                return reconstruct(inputs, device if move_to_device else None)
             if isinstance(entry, CorruptCacheEntry):
                 logger.warning("Corrupt compressed cache entry for {} ({}), rebuilding", logical, artifact_id[:12])
                 shutil.rmtree(entry.paths.object_dir, ignore_errors=True)
@@ -399,20 +402,20 @@ class TensorCache:
                 elapsed,
                 artifact_id[:12],
             )
-            return reconstruct(inputs, device)
+            return reconstruct(inputs, device if move_to_device else None)
 
         # --- TensorTarget / FusionGroupSpec: original path ---
         entry = self._lookup(artifact_id)
 
         if isinstance(entry, PresentCacheEntry):
             if isinstance(target, TensorTarget):
-                return self._load(entry.paths, device)
+                return self._load(entry.paths, device, move_to_device=move_to_device)
             meta_path = entry.paths.object_dir / "metadata.json"
             if meta_path.is_file():
                 with open(meta_path) as f:
                     meta = json.load(f)
                 if meta.get("views"):
-                    return self._load_fused(entry.paths, device, meta=meta)
+                    return self._load_fused(entry.paths, device, move_to_device=move_to_device, meta=meta)
             logger.warning(
                 "Present cache entry for fused {} ({}) missing fusion metadata; rebuilding",
                 logical,
@@ -443,7 +446,7 @@ class TensorCache:
             paths = self._store(artifact_id, fingerprint, tensor_host)
             elapsed = time.perf_counter() - t0
             logger.info("Cache miss for {} resolved in {:.3f}s, stored as {}", logical, elapsed, artifact_id[:12])
-            return self._load(paths, device)
+            return self._load(paths, device, move_to_device=move_to_device)
 
         spec = target
         fused_host, views = _create_overlapped_tensor_fused(
@@ -460,7 +463,12 @@ class TensorCache:
             elapsed,
             artifact_id[:12],
         )
-        return self._load_fused(paths, device, meta={"views": views_dict_from_overlapped(views)})
+        return self._load_fused(
+            paths,
+            device,
+            move_to_device=move_to_device,
+            meta={"views": views_dict_from_overlapped(views)},
+        )
 
 
 class EphemeralTensorCache:
@@ -478,10 +486,12 @@ class EphemeralTensorCache:
         fingerprint: Fingerprint,
         device,
         *,
+        move_to_device: bool | None = None,
         preprocess: Callable[[dict[str, torch.Tensor]], dict],
         raw_tensors: Callable[[], dict[str, torch.Tensor]] | dict[str, torch.Tensor],
         reconstruct: Callable[["CompressedTensorBuildInputs", object], "CompressedTensor"] | None = None,
     ) -> "ttnn.Tensor | dict[str, OverlappedTensor] | CompressedTensor":
+        effective_move_to_device = self._move_to_device if move_to_device is None else move_to_device
         target = fingerprint.target
         if not isinstance(target, (TensorTarget, FusionGroupSpec, CompressedTensorTarget)):
             raise TypeError(
@@ -499,14 +509,14 @@ class EphemeralTensorCache:
                     "use get_or_create_bspm_expert() instead of calling get_or_create() directly."
                 )
             inputs: CompressedTensorBuildInputs = preprocessed[target.name]
-            return reconstruct(inputs, device)
+            return reconstruct(inputs, device if effective_move_to_device else None)
 
         if isinstance(target, TensorTarget):
             torch_tensor = preprocessed[target.name]
             from_torch_kwargs: dict = {
                 "dtype": target.dtype,
                 "layout": target.layout,
-                "device": device if self._move_to_device else None,
+                "device": device if effective_move_to_device else None,
                 "memory_config": target.memory_config,
                 "mesh_mapper": build_mesh_mapper_for_target(target, device),
             }
@@ -518,6 +528,6 @@ class EphemeralTensorCache:
             target,
             preprocessed,
             device,
-            move_to_device=self._move_to_device,
+            move_to_device=effective_move_to_device,
         )
         return views

--- a/models/demos/deepseek_v3_b1/weights/prepare.py
+++ b/models/demos/deepseek_v3_b1/weights/prepare.py
@@ -722,6 +722,7 @@ def prepare_attention_weights(
     kv_views = cache_config.cache.get_or_create(
         kv_fp,
         device,
+        move_to_device=move_to_device,
         preprocess=_preprocess_kv_b12,
         raw_tensors=lambda: {kv_b_key: state_dict[kv_b_key]},
     )
@@ -765,6 +766,7 @@ def prepare_attention_weights(
             merged_views = cache_config.cache.get_or_create(
                 merged_fp,
                 device,
+                move_to_device=move_to_device,
                 preprocess=lambda t: _preprocess_merged(t, include_gate=True),
                 raw_tensors=lambda: {k: state_dict[k] for k in merged_src},
             )
@@ -780,6 +782,7 @@ def prepare_attention_weights(
             gate_bias_tt = cache_config.cache.get_or_create(
                 fingerprint,
                 device,
+                move_to_device=move_to_device,
                 preprocess=lambda t: {target.name: t[_bias_key].reshape(16, 16).T.contiguous().to(torch.bfloat16)},
                 raw_tensors=lambda: {_bias_key: state_dict[_bias_key]},
             )
@@ -815,6 +818,7 @@ def prepare_attention_weights(
         merged_views = cache_config.cache.get_or_create(
             merged_fp_dense,
             device,
+            move_to_device=move_to_device,
             preprocess=lambda t: _preprocess_merged(t, include_gate=False),
             raw_tensors=lambda: {k: state_dict[k] for k in merged_src_dense},
         )
@@ -857,6 +861,7 @@ def prepare_attention_weights(
     q_ab_views = cache_config.cache.get_or_create(
         q_ab_fp,
         device,
+        move_to_device=move_to_device,
         preprocess=_preprocess_q_ab_kv_a,
         raw_tensors=lambda: {k: state_dict[k] for k in (q_a_key, q_b_key, kv_a_key)},
     )
@@ -895,6 +900,7 @@ def prepare_attention_weights(
         o_views = cache_config.cache.get_or_create(
             o_fp,
             device,
+            move_to_device=move_to_device,
             preprocess=_preprocess_o_proj_moe,
             raw_tensors=lambda: {k: state_dict[k] for k in o_src},
         )
@@ -910,6 +916,7 @@ def prepare_attention_weights(
         gate_bias_tt = cache_config.cache.get_or_create(
             fingerprint,
             device,
+            move_to_device=move_to_device,
             preprocess=lambda t: {target.name: t[_bias_key].reshape(16, 16).T.contiguous().to(torch.bfloat16)},
             raw_tensors=lambda: {_bias_key: state_dict[_bias_key]},
         )
@@ -962,6 +969,7 @@ def prepare_attention_weights(
     o_views = cache_config.cache.get_or_create(
         o_fp_dense,
         device,
+        move_to_device=move_to_device,
         preprocess=_preprocess_o_proj_dense,
         raw_tensors=lambda: {k: state_dict[k] for k in o_src_dense},
     )
@@ -1030,6 +1038,7 @@ def prepare_shared_expert_weights(
         gu_views = cache_config.cache.get_or_create(
             gu_fp,
             device,
+            move_to_device=move_to_device,
             preprocess=_preprocess_gate_up_moe,
             raw_tensors=lambda: {gate_k: state_dict[gate_k], up_k: state_dict[up_k]},
         )
@@ -1052,6 +1061,7 @@ def prepare_shared_expert_weights(
         shared_down_proj = cache_config.cache.get_or_create(
             sd_fp,
             device,
+            move_to_device=move_to_device,
             preprocess=_preprocess_shared_down_moe,
             raw_tensors=lambda: {down_k: state_dict[down_k]},
         )
@@ -1077,6 +1087,7 @@ def prepare_shared_expert_weights(
         gu_views = cache_config.cache.get_or_create(
             gu_fp,
             device,
+            move_to_device=move_to_device,
             preprocess=_preprocess_gate_up_dense,
             raw_tensors=lambda: {gate_k: state_dict[gate_k], up_k: state_dict[up_k]},
         )
@@ -1098,6 +1109,7 @@ def prepare_shared_expert_weights(
         shared_down_proj = cache_config.cache.get_or_create(
             sd_fp,
             device,
+            move_to_device=move_to_device,
             preprocess=_preprocess_shared_down_dense,
             raw_tensors=lambda: {down_k: state_dict[down_k]},
         )
@@ -1273,6 +1285,7 @@ def prepare_routed_expert_weights(
             gw = cache_config.cache.get_or_create(
                 fp_g,
                 device,
+                move_to_device=move_to_device,
                 preprocess=lambda t, _gk=gk: {
                     "routed_gate_proj": moe_routed_expert_torch_for_cache(t[_gk].T.contiguous(), num_banks)
                 },
@@ -1290,6 +1303,7 @@ def prepare_routed_expert_weights(
             uw = cache_config.cache.get_or_create(
                 fp_u,
                 device,
+                move_to_device=move_to_device,
                 preprocess=lambda t, _uk=uk: {
                     "routed_up_proj": moe_routed_expert_torch_for_cache(t[_uk].T.contiguous(), num_banks)
                 },
@@ -1307,6 +1321,7 @@ def prepare_routed_expert_weights(
             dw = cache_config.cache.get_or_create(
                 fp_d,
                 device,
+                move_to_device=move_to_device,
                 preprocess=lambda t, _dk=dk: {
                     "routed_down_proj": moe_routed_expert_torch_for_cache(t[_dk].T.contiguous(), num_banks)
                 },
@@ -1368,18 +1383,21 @@ def prepare_routed_expert_weights(
         routed_gate_proj = cache_config.cache.get_or_create(
             fp_g,
             device,
+            move_to_device=move_to_device,
             preprocess=_pre_routed_gate,
             raw_tensors=lambda: {gate_k: state_dict[gate_k]},
         )
         routed_up_proj = cache_config.cache.get_or_create(
             fp_u,
             device,
+            move_to_device=move_to_device,
             preprocess=_pre_routed_up,
             raw_tensors=lambda: {up_k: state_dict[up_k]},
         )
         routed_down_proj = cache_config.cache.get_or_create(
             fp_d,
             device,
+            move_to_device=move_to_device,
             preprocess=_pre_routed_down,
             raw_tensors=lambda: {down_k: state_dict[down_k]},
         )
@@ -1541,6 +1559,7 @@ def prepare_embedding_weights(
     embedding_tt = cache_config.cache.get_or_create(
         fingerprint,
         device,
+        move_to_device=move_to_device,
         preprocess=_preprocess_embedding,
         raw_tensors=lambda: {_src_key: state_dict[_src_key]},
     )
@@ -1580,6 +1599,7 @@ def prepare_lm_head_weights(
     lm_head_tt = cache_config.cache.get_or_create(
         lm_fingerprint,
         device,
+        move_to_device=move_to_device,
         preprocess=_preprocess_lm_head,
         raw_tensors=lambda: {_lm_key: state_dict[_lm_key]},
     )
@@ -1598,6 +1618,7 @@ def prepare_lm_head_weights(
     final_norm_tt = cache_config.cache.get_or_create(
         norm_fingerprint,
         device,
+        move_to_device=move_to_device,
         preprocess=_preprocess_final_norm,
         raw_tensors=lambda: {_norm_key: state_dict[_norm_key]},
     )
@@ -1654,6 +1675,7 @@ def prepare_shared_head_norm(
     shared_norm_tt = cache_config.cache.get_or_create(
         shared_norm_fingerprint,
         device,
+        move_to_device=move_to_device,
         preprocess=lambda t: {shared_norm_target.name: t[_shared_norm_key].unsqueeze(0).contiguous()},
         raw_tensors=lambda: {_shared_norm_key: state_dict[_shared_norm_key]},
     )
@@ -1706,6 +1728,7 @@ def prepare_mtp_weights(
     h_gamma_tt = cache_config.cache.get_or_create(
         h_fingerprint,
         device,
+        move_to_device=move_to_device,
         preprocess=lambda t: {h_target.name: t[_h_key].unsqueeze(0).contiguous()},
         raw_tensors=lambda: {_h_key: state_dict[_h_key]},
     )
@@ -1716,6 +1739,7 @@ def prepare_mtp_weights(
     e_gamma_tt = cache_config.cache.get_or_create(
         e_fingerprint,
         device,
+        move_to_device=move_to_device,
         preprocess=lambda t: {e_target.name: t[_e_key].unsqueeze(0).contiguous()},
         raw_tensors=lambda: {_e_key: state_dict[_e_key]},
     )
@@ -1726,6 +1750,7 @@ def prepare_mtp_weights(
     eh_proj_tt = cache_config.cache.get_or_create(
         eh_fingerprint,
         device,
+        move_to_device=move_to_device,
         preprocess=lambda t: _mtp_eh_proj_preprocess(t, _eh_key, eh_target.name),
         raw_tensors=lambda: {_eh_key: state_dict[_eh_key]},
     )

--- a/models/demos/deepseek_v3_b1/weights/prepare.py
+++ b/models/demos/deepseek_v3_b1/weights/prepare.py
@@ -48,6 +48,7 @@ from models.demos.deepseek_v3_b1.weights.specs.overlap_configs import (
     O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC,
     QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC,
 )
+from models.demos.deepseek_v3_b1.weights.upload import UploadableMixin
 
 Q_AB_KV_A_SPEC = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.fusion_group_spec()
 O_PROJ_GATE_MM_NORMS_SPEC = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC.fusion_group_spec()
@@ -73,7 +74,7 @@ _GATE_BIAS_TILE = ttnn.Tile([16, 16])
 
 
 @dataclass
-class AttentionWeights:
+class AttentionWeights(UploadableMixin):
     """Attention fusion groups: q_ab_kv_a + kv_b12 + o_proj_gate_mm_norms."""
 
     q_a_proj: OverlappedTensor
@@ -91,7 +92,7 @@ class AttentionWeights:
 
 
 @dataclass
-class SharedExpertWeights:
+class SharedExpertWeights(UploadableMixin):
     """Shared expert gate_up fusion group + standalone shared_down_proj."""
 
     shared_gate_proj: OverlappedTensor
@@ -100,7 +101,7 @@ class SharedExpertWeights:
 
 
 @dataclass
-class DenseRoutedExpertWeights:
+class DenseRoutedExpertWeights(UploadableMixin):
     """Routed expert weights for dense layers (single tensor per proj)."""
 
     routed_gate_proj: ttnn.Tensor
@@ -178,7 +179,7 @@ def _assert_moe_routed_expert_list_contiguous(tensors: list[ttnn.Tensor], name: 
 
 
 @dataclass
-class MoERoutedExpertWeights:
+class MoERoutedExpertWeights(UploadableMixin):
     """Routed expert weights for MoE layers (list of tensors, one per expert).
 
     When on device, each of ``routed_gate_proj``, ``routed_up_proj``, and ``routed_down_proj`` must
@@ -197,7 +198,7 @@ class MoERoutedExpertWeights:
 
 
 @dataclass
-class DeepSeekV3DenseLayerWeights:
+class DeepSeekV3DenseLayerWeights(UploadableMixin):
     """Weights for a dense layer (0..first_k_dense_replace-1).
 
     Has the 3 attention fusion groups and o_proj + norms (no gate_mm).
@@ -231,7 +232,7 @@ class DeepSeekV3DenseLayerWeights:
 
 
 @dataclass
-class DeepSeekV3MoELayerWeights:
+class DeepSeekV3MoELayerWeights(UploadableMixin):
     """Weights for an MoE layer (first_k_dense_replace..num_layers-1).
 
     Extends dense with gate_mm and shared expert projections.
@@ -269,14 +270,14 @@ class DeepSeekV3MoELayerWeights:
 
 
 @dataclass
-class DeepSeekV3EmbeddingLayerWeights:
+class DeepSeekV3EmbeddingLayerWeights(UploadableMixin):
     """Weights for the embedding layer."""
 
     embedding: ttnn.Tensor
 
 
 @dataclass
-class DeepSeekV3LMHeadWeights:
+class DeepSeekV3LMHeadWeights(UploadableMixin):
     """Weights for the LM head and final RMSNorm."""
 
     lm_head: ttnn.Tensor
@@ -284,7 +285,7 @@ class DeepSeekV3LMHeadWeights:
 
 
 @dataclass
-class DeepSeekV3MTPWeights:
+class DeepSeekV3MTPWeights(UploadableMixin):
     """Weights for the MTP (Multi-Token Prediction) speculative decode layer.
 
     HF state dict keys live under ``model.layers.{mtp_layer_idx}.*`` (layer 61 for DeepSeek V3).
@@ -297,7 +298,7 @@ class DeepSeekV3MTPWeights:
 
 
 @dataclass
-class DeepSeekV3SpecWeights:
+class DeepSeekV3SpecWeights(UploadableMixin):
     """Weights used only by the speculative verify LM-head stage."""
 
     shared_head_norm: ttnn.Tensor  # model.layers.61.shared_head.norm.weight

--- a/models/demos/deepseek_v3_b1/weights/upload.py
+++ b/models/demos/deepseek_v3_b1/weights/upload.py
@@ -4,11 +4,129 @@
 
 from __future__ import annotations
 
-from dataclasses import fields, is_dataclass
-from typing import Any
+from dataclasses import fields
+from types import UnionType
+from typing import Protocol, Union, get_args, get_origin, get_type_hints
 
 import ttnn
 from models.demos.deepseek_v3_b1.weights.overlap.packing import OverlappedTensor
+
+TensorKey = tuple[str, int]
+TensorMap = dict[TensorKey, ttnn.Tensor]
+WeightTensor = ttnn.Tensor | OverlappedTensor
+
+
+class Uploadable(Protocol):
+    def backing_tensors(self) -> list[ttnn.Tensor]:
+        ...
+
+    def with_device_tensors(self, tensor_map: TensorMap):
+        ...
+
+
+class UploadableMixin:
+    """Typed helper for extracting and rebuilding weight dataclasses."""
+
+    def backing_tensors(self) -> list[ttnn.Tensor]:
+        out: list[ttnn.Tensor] = []
+        seen_ids: set[TensorKey] = set()
+        hints = get_type_hints(type(self))
+        for field in fields(self):
+            annotation = hints[field.name]
+            value = getattr(self, field.name)
+            kind, allows_none = _classify_annotation(annotation)
+            if value is None:
+                if allows_none:
+                    continue
+                raise TypeError(f"Field {type(self).__name__}.{field.name} is None but annotation is non-optional")
+            if kind == "tensor":
+                _append_unique_tensor(out, seen_ids, value, field.name)
+            elif kind == "overlapped":
+                _append_unique_tensor(out, seen_ids, value.fused_tensor, field.name)
+            elif kind == "tensor_list":
+                if not isinstance(value, list):
+                    raise TypeError(
+                        f"Field {type(self).__name__}.{field.name} must be list[ttnn.Tensor], got {type(value)}"
+                    )
+                for tensor in value:
+                    _append_unique_tensor(out, seen_ids, tensor, field.name)
+            else:
+                raise TypeError(f"Unsupported field annotation in {type(self).__name__}.{field.name}: {annotation}")
+        return out
+
+    def with_device_tensors(self, tensor_map: TensorMap):
+        hints = get_type_hints(type(self))
+        rebuilt_fields: dict[str, object] = {}
+        for field in fields(self):
+            annotation = hints[field.name]
+            value = getattr(self, field.name)
+            kind, allows_none = _classify_annotation(annotation)
+            if value is None:
+                if allows_none:
+                    rebuilt_fields[field.name] = None
+                    continue
+                raise TypeError(f"Field {type(self).__name__}.{field.name} is None but annotation is non-optional")
+            if kind == "tensor":
+                rebuilt_fields[field.name] = tensor_map[tensor_identity_key(value)]
+            elif kind == "overlapped":
+                fused_tensor = tensor_map[tensor_identity_key(value.fused_tensor)]
+                rebuilt_fields[field.name] = OverlappedTensor(
+                    fused_tensor=fused_tensor,
+                    tensor_shape=value.tensor_shape,
+                    shard_shape=value.shard_shape,
+                    core_range_set=value.core_range_set,
+                    dtype=value.dtype,
+                    tile_shape=value.tile_shape,
+                    byte_offset=value.byte_offset,
+                    total_size=value.total_size,
+                )
+            elif kind == "tensor_list":
+                if not isinstance(value, list):
+                    raise TypeError(
+                        f"Field {type(self).__name__}.{field.name} must be list[ttnn.Tensor], got {type(value)}"
+                    )
+                rebuilt_fields[field.name] = [tensor_map[tensor_identity_key(tensor)] for tensor in value]
+            else:
+                raise TypeError(f"Unsupported field annotation in {type(self).__name__}.{field.name}: {annotation}")
+        return type(self)(**rebuilt_fields)
+
+
+def _classify_annotation(annotation: object) -> tuple[str, bool]:
+    origin = get_origin(annotation)
+    if origin is None:
+        if annotation is ttnn.Tensor:
+            return "tensor", False
+        if annotation is OverlappedTensor:
+            return "overlapped", False
+        raise TypeError(f"Unsupported field annotation: {annotation}")
+
+    if origin is list:
+        args = get_args(annotation)
+        if len(args) == 1 and args[0] is ttnn.Tensor:
+            return "tensor_list", False
+        raise TypeError(f"Unsupported list field annotation: {annotation}")
+
+    if origin is tuple:
+        raise TypeError(f"tuple fields are not supported in uploadable weight dataclasses: {annotation}")
+
+    if origin in (Union, UnionType):
+        args = [arg for arg in get_args(annotation) if arg is not type(None)]
+        allows_none = len(args) != len(get_args(annotation))
+        if len(args) != 1:
+            raise TypeError(f"Unsupported union field annotation: {annotation}")
+        kind, _ = _classify_annotation(args[0])
+        return kind, allows_none
+
+    raise TypeError(f"Unsupported field annotation: {annotation}")
+
+
+def _append_unique_tensor(out: list[ttnn.Tensor], seen_ids: set[TensorKey], tensor: object, field_name: str) -> None:
+    if not isinstance(tensor, ttnn.Tensor):
+        raise TypeError(f"Field {field_name} expected ttnn.Tensor, got {type(tensor)}")
+    tensor_key = tensor_identity_key(tensor)
+    if tensor_key not in seen_ids:
+        seen_ids.add(tensor_key)
+        out.append(tensor)
 
 
 def tensor_identity_key(tensor: ttnn.Tensor) -> tuple[str, int]:
@@ -44,39 +162,7 @@ def split_core_ranges(
     return fd_filter, sd_filter
 
 
-def extract_backing_tensors(*weight_structs: Any) -> list[ttnn.Tensor]:
-    """Return unique backing tensors from nested weight dataclasses."""
-    out: list[ttnn.Tensor] = []
-    seen_ids: set[tuple[str, int]] = set()
-
-    def _add_tensor(tensor: ttnn.Tensor) -> None:
-        tensor_key = tensor_identity_key(tensor)
-        if tensor_key not in seen_ids:
-            seen_ids.add(tensor_key)
-            out.append(tensor)
-
-    def _walk(value: Any) -> None:
-        if isinstance(value, OverlappedTensor):
-            _add_tensor(value.fused_tensor)
-            return
-        if isinstance(value, ttnn.Tensor):
-            _add_tensor(value)
-            return
-        if is_dataclass(value):
-            for field in fields(value):
-                _walk(getattr(value, field.name))
-            return
-        if isinstance(value, list | tuple):
-            for item in value:
-                _walk(item)
-
-    for struct in weight_structs:
-        _walk(struct)
-
-    return out
-
-
-def two_phase_upload(device, host_tensors: list[ttnn.Tensor]) -> list[ttnn.Tensor]:
+def _upload_tensors(device: ttnn.MeshDevice, host_tensors: list[ttnn.Tensor]) -> list[ttnn.Tensor]:
     """Upload host tensors by writing FD shards first, then SD-only shards."""
     fd_grid = get_fd_grid(device)
     full_fd_jobs: list[tuple[ttnn.Tensor, ttnn.Tensor]] = []
@@ -118,31 +204,9 @@ def two_phase_upload(device, host_tensors: list[ttnn.Tensor]) -> list[ttnn.Tenso
     return uploaded
 
 
-def rebuild_with_device_tensors(host_struct: Any, host_to_device: dict[tuple[str, int], ttnn.Tensor]) -> Any:
-    """Rebuild nested weight dataclasses by replacing host tensors with device tensors."""
-
-    def _replace(value: Any) -> Any:
-        if isinstance(value, OverlappedTensor):
-            fused_tensor = host_to_device[tensor_identity_key(value.fused_tensor)]
-            return OverlappedTensor(
-                fused_tensor=fused_tensor,
-                tensor_shape=value.tensor_shape,
-                shard_shape=value.shard_shape,
-                core_range_set=value.core_range_set,
-                dtype=value.dtype,
-                tile_shape=value.tile_shape,
-                byte_offset=value.byte_offset,
-                total_size=value.total_size,
-            )
-        if isinstance(value, ttnn.Tensor):
-            return host_to_device[tensor_identity_key(value)]
-        if is_dataclass(value):
-            rebuilt_fields = {field.name: _replace(getattr(value, field.name)) for field in fields(value)}
-            return type(value)(**rebuilt_fields)
-        if isinstance(value, list):
-            return [_replace(item) for item in value]
-        if isinstance(value, tuple):
-            return tuple(_replace(item) for item in value)
-        return value
-
-    return _replace(host_struct)
+def two_phase_upload(device: ttnn.MeshDevice, host_weights: Uploadable):
+    """Upload an Uploadable host weight struct and return device-backed copy."""
+    host_tensors = host_weights.backing_tensors()
+    device_tensors = _upload_tensors(device, host_tensors)
+    host_to_device: TensorMap = {tensor_identity_key(host): dev for host, dev in zip(host_tensors, device_tensors)}
+    return host_weights.with_device_tensors(host_to_device)

--- a/models/demos/deepseek_v3_b1/weights/upload.py
+++ b/models/demos/deepseek_v3_b1/weights/upload.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import fields, is_dataclass
+from typing import Any
+
+import ttnn
+from models.demos.deepseek_v3_b1.weights.overlap.packing import OverlappedTensor
+
+
+def tensor_identity_key(tensor: ttnn.Tensor) -> tuple[str, int]:
+    """Return a stable tensor identity key across python wrapper instances."""
+    tensor_id = getattr(tensor, "tensor_id", None)
+    if tensor_id is not None:
+        return ("tensor_id", int(tensor_id))
+    return ("py_id", id(tensor))
+
+
+def get_fd_grid(device) -> ttnn.CoreRangeSet:
+    """Return the FD grid used for fast host-to-device transfers."""
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x <= 1 or compute_grid.y <= 0:
+        return ttnn.CoreRangeSet([])
+    return ttnn.CoreRangeSet(
+        [
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(compute_grid.x - 2, compute_grid.y - 1),
+            )
+        ]
+    )
+
+
+def split_core_ranges(
+    tensor_grid: ttnn.CoreRangeSet,
+    fd_grid: ttnn.CoreRangeSet,
+) -> tuple[ttnn.CoreRangeSet, ttnn.CoreRangeSet]:
+    """Split tensor shard grid into fast-dispatch and slow-dispatch subsets."""
+    sd_filter = tensor_grid.subtract(fd_grid)
+    fd_filter = tensor_grid.subtract(sd_filter)
+    return fd_filter, sd_filter
+
+
+def extract_backing_tensors(*weight_structs: Any) -> list[ttnn.Tensor]:
+    """Return unique backing tensors from nested weight dataclasses."""
+    out: list[ttnn.Tensor] = []
+    seen_ids: set[tuple[str, int]] = set()
+
+    def _add_tensor(tensor: ttnn.Tensor) -> None:
+        tensor_key = tensor_identity_key(tensor)
+        if tensor_key not in seen_ids:
+            seen_ids.add(tensor_key)
+            out.append(tensor)
+
+    def _walk(value: Any) -> None:
+        if isinstance(value, OverlappedTensor):
+            _add_tensor(value.fused_tensor)
+            return
+        if isinstance(value, ttnn.Tensor):
+            _add_tensor(value)
+            return
+        if is_dataclass(value):
+            for field in fields(value):
+                _walk(getattr(value, field.name))
+            return
+        if isinstance(value, list | tuple):
+            for item in value:
+                _walk(item)
+
+    for struct in weight_structs:
+        _walk(struct)
+
+    return out
+
+
+def two_phase_upload(device, host_tensors: list[ttnn.Tensor]) -> list[ttnn.Tensor]:
+    """Upload host tensors by writing FD shards first, then SD-only shards."""
+    fd_grid = get_fd_grid(device)
+    full_fd_jobs: list[tuple[ttnn.Tensor, ttnn.Tensor]] = []
+    fd_partial_jobs: list[tuple[ttnn.Tensor, ttnn.Tensor, ttnn.CoreRangeSet]] = []
+    sd_partial_jobs: list[tuple[ttnn.Tensor, ttnn.Tensor, ttnn.CoreRangeSet]] = []
+    uploaded: list[ttnn.Tensor] = []
+
+    for host_tensor in host_tensors:
+        device_tensor = ttnn.allocate_tensor_on_device(host_tensor.spec, device)
+        uploaded.append(device_tensor)
+
+        if not host_tensor.is_sharded():
+            full_fd_jobs.append((host_tensor, device_tensor))
+            continue
+
+        shard_spec = host_tensor.memory_config().shard_spec
+        if shard_spec is None:
+            full_fd_jobs.append((host_tensor, device_tensor))
+            continue
+
+        fd_filter, sd_filter = split_core_ranges(shard_spec.grid, fd_grid)
+        if not fd_filter.empty():
+            if sd_filter.empty():
+                full_fd_jobs.append((host_tensor, device_tensor))
+            else:
+                fd_partial_jobs.append((host_tensor, device_tensor, fd_filter))
+        if not sd_filter.empty():
+            sd_partial_jobs.append((host_tensor, device_tensor, sd_filter))
+
+    with ttnn.device.setup_fast_dispatch(device):
+        for host_tensor, device_tensor in full_fd_jobs:
+            ttnn.copy_host_to_device_tensor(host_tensor, device_tensor)
+        for host_tensor, device_tensor, core_filter in fd_partial_jobs:
+            ttnn.copy_host_to_device_tensor_partial(host_tensor, device_tensor, core_filter)
+
+    for host_tensor, device_tensor, core_filter in sd_partial_jobs:
+        ttnn.copy_host_to_device_tensor_partial(host_tensor, device_tensor, core_filter)
+
+    return uploaded
+
+
+def rebuild_with_device_tensors(host_struct: Any, host_to_device: dict[tuple[str, int], ttnn.Tensor]) -> Any:
+    """Rebuild nested weight dataclasses by replacing host tensors with device tensors."""
+
+    def _replace(value: Any) -> Any:
+        if isinstance(value, OverlappedTensor):
+            fused_tensor = host_to_device[tensor_identity_key(value.fused_tensor)]
+            return OverlappedTensor(
+                fused_tensor=fused_tensor,
+                tensor_shape=value.tensor_shape,
+                shard_shape=value.shard_shape,
+                core_range_set=value.core_range_set,
+                dtype=value.dtype,
+                tile_shape=value.tile_shape,
+                byte_offset=value.byte_offset,
+                total_size=value.total_size,
+            )
+        if isinstance(value, ttnn.Tensor):
+            return host_to_device[tensor_identity_key(value)]
+        if is_dataclass(value):
+            rebuilt_fields = {field.name: _replace(getattr(value, field.name)) for field in fields(value)}
+            return type(value)(**rebuilt_fields)
+        if isinstance(value, list):
+            return [_replace(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(_replace(item) for item in value)
+        return value
+
+    return _replace(host_struct)


### PR DESCRIPTION
### Summary

This PR changes the DeepSeek V3 B1 cached weight loading to stage tensors on host first and then upload them through a single generic two-phase path that uses fast dDispatch for all FD-grid shards and slow sDispatch for remaining shards by filtering on the tensor's core-range.

This change improves warm load times of the MoE decoder layer (which is the current bottleneck) by over 30%, bringing it down to <4.5 seconds.

### What's Changed

- Optimize DeepSeek V3 B1 cached weight loading by splitting host-to-device uploads into two phases:
   - Fast Dispatch (FD) for shards inside the FD-compatible core subset (12x10).
   - Slow Dispatch (SD) for remaining shards on the full grid.
- Make the flow generic across all prepare.py weight builders by loading cache entries on host first (move_to_device=False) and then uploading through a singl upload path.
- Refactor upload plumbing to a typed API (Uploadable + UploadableMixin) so tensor extraction/rebuild logic is explicit and less brittle than Any-driven traversal.
- Simplify CacheWeightProvider to always prepare host-backed weight structures then call two_phase_upload(...) helper

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=esmal/enqueue-shards-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmal/enqueue-shards-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=esmal/enqueue-shards-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:esmal/enqueue-shards-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmal/enqueue-shards-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/enqueue-shards-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmal/enqueue-shards-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/enqueue-shards-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=esmal/enqueue-shards-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:esmal/enqueue-shards-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=esmal/enqueue-shards-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/enqueue-shards-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=esmal/enqueue-shards-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/enqueue-shards-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=esmal/enqueue-shards-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/enqueue-shards-3)