### PR TITLE
Fix offline model loading for Gemma-3 on CI (no refs/main in HF hub cache)

### DIFF
--- a/.github/workflows/models-t2-e2e-tests.yaml
+++ b/.github/workflows/models-t2-e2e-tests.yaml
@@ -17,7 +17,7 @@ on:
           - llama3.1-8b-dp
           - llama3.3-70b
           - llama3.3-70b-dp
-          - llama90b-vl
+          - llama3.2-90b-vision
           - qwen3-32b
           - qwen2.5-32b
           - qwen2.5-coder-32b

--- a/.github/workflows/models-t2-unit-tests.yaml
+++ b/.github/workflows/models-t2-unit-tests.yaml
@@ -15,7 +15,7 @@ on:
           - all
           - llama3.1-8b
           - llama3.3-70b
-          - llama90b-vl
+          - llama3.2-90b-vision
           - qwen3-32b
           - qwen2.5-32b
           - qwen2.5-coder-32b

--- a/models/demos/multimodal/gemma3/tt/model_config.py
+++ b/models/demos/multimodal/gemma3/tt/model_config.py
@@ -57,6 +57,17 @@ class ModelArgs(TTModelArgs):
         optimizations=None,
         cache_hf=False,  # Set to False to reduce memory usage by not caching HF model
     ):
+        # Resolve HF_MODEL to a local snapshot path before super().__init__() so that
+        # all HF calls (AutoConfig, tokenizer, weights) skip the refs/main lookup,
+        # which is absent on some CI machines.  Left in env so sub-tests in the same
+        # pytest session (e.g. siglip/test_attention.py) also get the absolute path.
+        hf_model = os.environ.get("HF_MODEL", "")
+        if hf_model and not os.path.isabs(hf_model):
+            snapshot = ModelArgs._resolve_hf_snapshot(hf_model)
+            if snapshot:
+                logger.info(f"[Gemma3] Resolved HF model '{hf_model}' to snapshot: {snapshot}")
+                os.environ["HF_MODEL"] = str(snapshot)
+
         super().__init__(
             mesh_device,
             instruct=instruct,
@@ -70,6 +81,26 @@ class ModelArgs(TTModelArgs):
         self.use_qk_fused = False  # For Gemma 3, we do not use qk fused ops (rotary embedding + paged cache update)
         self.model_config["LM_HEAD_OUTPUT_MEMCFG"] = ttnn.DRAM_MEMORY_CONFIG
         self.padded_vocab_size = 262400
+
+    @staticmethod
+    def _resolve_hf_snapshot(hf_model_name):
+        hf_cache = os.path.normpath(
+            os.environ.get("HF_HUB_CACHE")
+            or os.path.join(os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface")), "hub")
+        )
+        model_slug = "models--" + hf_model_name.replace("/", "--")
+        snapshots_dir = os.path.normpath(os.path.join(hf_cache, model_slug, "snapshots"))
+        # Prevent path traversal: ensure the resolved path stays within hf_cache.
+        if not snapshots_dir.startswith(hf_cache + os.sep):
+            return None
+        if not os.path.isdir(snapshots_dir):
+            return None
+        snaps = [
+            os.path.join(snapshots_dir, s)
+            for s in os.listdir(snapshots_dir)
+            if os.path.isdir(os.path.join(snapshots_dir, s))
+        ]
+        return max(snaps, key=os.path.getmtime) if snaps else None
 
     def get_warmup_prefill_supported_seq_lens(self):
         DEFAULT_VALUE = self.capped_warmup_seq_len
@@ -263,49 +294,6 @@ class ModelArgs(TTModelArgs):
                 state_dict.pop(k)
 
         return state_dict
-
-    def create_tokenizer(self):
-        from transformers import AutoTokenizer
-
-        # Mapping of base model names to their known tokenizer paths
-        # These are the original models that have proper tokenizers
-        base_model_tokenizer_mapping = {
-            "gemma-3-4b-it": "google/gemma-3-4b-it",
-        }
-
-        logger.info(f"Tokenizer path: {self.TOKENIZER_PATH}")
-        logger.info(f"Model name: {self.model_name}")
-        logger.info(f"Base model name: {self.base_model_name}")
-
-        try:
-            # Try to load tokenizer from the original model path
-            # If there is no Processor, it will return Tokenizer (useful for multimodal models)
-            tokenizer = AutoTokenizer.from_pretrained(self.TOKENIZER_PATH, local_files_only=os.getenv("CI") == "true")
-            logger.info(f"Successfully loaded tokenizer from {self.TOKENIZER_PATH}")
-        except Exception as e:
-            logger.warning(f"Failed to load tokenizer from {self.TOKENIZER_PATH}: {e}")
-
-            # Try to use base model tokenizer as fallback
-            fallback_tokenizer_path = base_model_tokenizer_mapping.get(self.base_model_name)
-
-            if fallback_tokenizer_path:
-                logger.info(f"Attempting to use fallback tokenizer: {fallback_tokenizer_path}")
-                try:
-                    tokenizer = AutoTokenizer.from_pretrained(
-                        fallback_tokenizer_path, local_files_only=os.getenv("CI") == "true"
-                    )
-                    logger.info(f"Successfully loaded fallback tokenizer from {fallback_tokenizer_path}")
-                except Exception as fallback_e:
-                    logger.error(f"Failed to load fallback tokenizer from {fallback_tokenizer_path}: {fallback_e}")
-                    raise fallback_e
-            else:
-                logger.error(f"No fallback tokenizer found for base model: {self.base_model_name}")
-                raise e
-
-        # Add meta-compatible stop token list to the HF tokenizer
-        if not hasattr(tokenizer, "stop_tokens") or tokenizer.stop_tokens is None:
-            tokenizer.stop_tokens = [tokenizer.eos_token_id]
-        return tokenizer
 
     def reference_vision_multi_modal(self):
         model = self.reference_vision_transformer(wrap=False)

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -97,7 +97,7 @@
   cmd: |
     export HF_MODEL=meta-llama/Llama-3.2-90B-Vision-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.2-90B-Vision-Instruct MESH_DEVICE=T3K
     pytest --timeout 1000 models/tt_transformers/demo/simple_vision_demo.py -k "batch1-trace"
-  model: llama90b-vl
+  model: llama3.2-90b-vision
   skus:
     wh_llmbox_perf:
       timeout: 25

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -86,7 +86,7 @@
     pytest --timeout 900 models/tt_transformers/tests/multimodal/test_llama_class_embedding.py
     pytest --timeout 900 models/tt_transformers/tests/multimodal/test_llama_tile_position_embedding.py
     pytest --timeout 900 models/tt_transformers/tests/multimodal/test_llama_positional_embedding.py
-  model: llama90b-vl
+  model: llama3.2-90b-vision
   skus:
     wh_llmbox_perf:
       timeout: 15


### PR DESCRIPTION
## Problem

On some CI machines (`tt-metal-ci-vm-14` and others), the HF hub cache at
`/mnt/MLPerf/huggingface/hub` is missing the `refs/main` pointer file. All
`AutoXxx.from_pretrained("google/gemma-3-Xb-it")` calls — AutoConfig,
AutoTokenizer, model weights — rely on `cached_file()` resolving the model
name through `refs/main` to find the snapshot hash. Without it they return
`None` or raise, causing:
- `TypeError: not a string` (SentencePiece loading `None`)
- `OSError: No file named model.safetensors found in directory google/gemma-3-4b-it`
- `AssertionError: Expected a vision_config field` in `siglip/test_attention.py`

## Fix

Before `super().__init__()` runs, scan the local `snapshots/` directory for
the model and inject the absolute path into `HF_MODEL`. This means every
downstream HF call receives a plain local path instead of a model name that
requires `refs/main`.

`HF_MODEL` is intentionally left pointing at the snapshot for the remainder
of the pytest session so that sub-tests dispatched in the same process
(e.g. `siglip/test_attention.py`) also receive the correct multimodal
`Gemma3Config`.

The previous `create_tokenizer` override (with its `GemmaTokenizerFast`
fallback and `base_model_tokenizer_mapping`) is removed — once
`TOKENIZER_PATH` is an absolute snapshot path the parent's implementation
works as-is.

## Also included

Rename CI label `llama90b-vl` → `llama3.2-90b-vision` to align with the
naming convention used by all other Llama models.

## Test plan
- [x] Gemma-3-4B unit tests on N150 — passing: https://github.com/tenstorrent/tt-metal/actions/runs/25065706904
- [x] Gemma-3-27B unit tests on T3000 — passing: https://github.com/tenstorrent/tt-metal/actions/runs/25104928179

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/gemma_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/gemma_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/gemma_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/gemma_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/gemma_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/gemma_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/gemma_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/gemma_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/gemma_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/gemma_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/gemma_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/gemma_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/gemma_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/gemma_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/gemma_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/gemma_bug)