### PR TITLE
Performance: Improve simple trace allocator placement

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_simple_trace_allocator.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_simple_trace_allocator.cpp
@@ -35,6 +35,16 @@ protected:
 
     RegionAllocator make_allocator(uint32_t ringbuffer_size) { return RegionAllocator(ringbuffer_size, extra_data_); }
 
+    void add_memory_usage(
+        RegionAllocator& alloc,
+        uint32_t addr,
+        uint32_t trace_idx,
+        uint32_t data_type,
+        uint32_t size,
+        uint64_t program_id) {
+        alloc.regions_[addr] = {.trace_idx = trace_idx, .data_type = data_type, .size = size, .program_id = program_id};
+    }
+
     std::vector<ExtraData> extra_data_;
 };
 // NOLINTEND(cppcoreguidelines-virtual-class-destructor)
@@ -269,6 +279,19 @@ TEST_F(SimpleTraceAllocatorFixture, AllocationExactFit) {
     auto [sync, addr] = alloc.allocate_region(100, 0, ExtraData::kNonBinary, 100);
     ASSERT_TRUE(addr.has_value());
     EXPECT_EQ(*addr, 0u);
+}
+
+TEST_F(SimpleTraceAllocatorFixture, TopDownScanIncludesPreviousOverlappingRegion) {
+    extra_data_.resize(2);
+    auto alloc = make_allocator(300);
+    add_memory_usage(alloc, 220, 0, ExtraData::kNonBinary, 40, 20);
+    add_memory_usage(alloc, 260, 1, ExtraData::kNonBinary, 40, 10);
+
+    auto [sync, addr] = alloc.allocate_region(40, 1, ExtraData::kBinary, 30, /*top_down=*/true);
+
+    ASSERT_TRUE(addr.has_value());
+    EXPECT_EQ(*addr, 180u);
+    EXPECT_FALSE(sync.has_value());
 }
 
 TEST_F(SimpleTraceAllocatorFixture, EvictionWhenBufferFull) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_simple_trace_allocator.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_simple_trace_allocator.cpp
@@ -547,8 +547,11 @@ TEST_F(SimpleTraceAllocatorDeviceFixture, SingleProgram) {
         trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs.size(), hal_.get_programmable_core_type_count());
     ASSERT_EQ(
         trace_nodes[0].dispatch_metadata.binary_kernel_config_addrs.size(), hal_.get_programmable_core_type_count());
-    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 0u);
-    EXPECT_EQ(trace_nodes[0].dispatch_metadata.binary_kernel_config_addrs[*core_index].addr, 32u);
+    // Non-binary is short-lived so it is placed at the top of the 256-byte buffer (256 - 32).
+    // The single program's binary has no future use, so it is also packed top-down, just below
+    // the non-binary region (224 - 16 = 208).
+    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 224u);
+    EXPECT_EQ(trace_nodes[0].dispatch_metadata.binary_kernel_config_addrs[*core_index].addr, 208u);
     EXPECT_TRUE(trace_nodes[0].dispatch_metadata.send_binary);
     EXPECT_EQ(trace_nodes[0].dispatch_metadata.sync_count, 0u);
     EXPECT_TRUE(trace_nodes[0].dispatch_metadata.stall_first);
@@ -569,10 +572,13 @@ TEST_F(SimpleTraceAllocatorDeviceFixture, TwoDistinctPrograms) {
     auto allocator = make_allocator(256);
     allocator.allocate_trace_programs(hal_, trace_node_ptrs);
 
-    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 0u);
-    EXPECT_EQ(trace_nodes[0].dispatch_metadata.binary_kernel_config_addrs[*core_index].addr, 32u);
-    EXPECT_EQ(trace_nodes[1].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 48u);
-    EXPECT_EQ(trace_nodes[1].dispatch_metadata.binary_kernel_config_addrs[*core_index].addr, 80u);
+    // Each program's non-binary and (un-reused) binary are packed top-down. The first program
+    // gets non-binary at 256 - 32 = 224 and binary at 224 - 16 = 208. The second program then
+    // packs just below: non-binary at 208 - 32 = 176, binary at 176 - 16 = 160.
+    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 224u);
+    EXPECT_EQ(trace_nodes[0].dispatch_metadata.binary_kernel_config_addrs[*core_index].addr, 208u);
+    EXPECT_EQ(trace_nodes[1].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 176u);
+    EXPECT_EQ(trace_nodes[1].dispatch_metadata.binary_kernel_config_addrs[*core_index].addr, 160u);
     EXPECT_TRUE(trace_nodes[1].dispatch_metadata.send_binary);
 }
 
@@ -597,7 +603,10 @@ TEST_F(SimpleTraceAllocatorDeviceFixture, SameProgramBinaryCached) {
     EXPECT_EQ(
         trace_nodes[0].dispatch_metadata.binary_kernel_config_addrs[*core_index].addr,
         trace_nodes[1].dispatch_metadata.binary_kernel_config_addrs[*core_index].addr);
-    EXPECT_EQ(trace_nodes[1].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 48u);
+    // Binary is reused, so it is allocated bottom-up (and stays cached). Non-binary entries are
+    // short-lived and packed top-down: the first node gets 256 - 32 = 224, the second packs just
+    // below at 224 - 32 = 192.
+    EXPECT_EQ(trace_nodes[1].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 192u);
 }
 
 TEST_F(SimpleTraceAllocatorDeviceFixture, BinaryEvictionRetriesAfterReset) {
@@ -641,7 +650,9 @@ TEST_F(SimpleTraceAllocatorDeviceFixture, NonBinaryEvictionSetsStallFirst) {
     auto allocator = make_allocator(100);
     allocator.allocate_trace_programs(hal_, trace_node_ptrs);
 
-    EXPECT_EQ(trace_nodes[1].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 0u);
+    // Buffer is 100 bytes and each non-binary is 80 bytes. Top-down placement puts node 0's
+    // non-binary at 100 - 80 = 20. Node 1's only viable slot is the same one (evicting node 0).
+    EXPECT_EQ(trace_nodes[1].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 20u);
     EXPECT_EQ(trace_nodes[1].dispatch_metadata.sync_count, 2u);
     EXPECT_TRUE(trace_nodes[1].dispatch_metadata.stall_first);
     EXPECT_FALSE(trace_nodes[1].dispatch_metadata.stall_before_program);
@@ -730,7 +741,8 @@ TEST_F(SimpleTraceAllocatorDeviceFixture, SubDeviceFiltering) {
     auto allocator = make_allocator(256);
     allocate_on_subdevice(allocator, trace_nodes, SubDeviceId{0});
 
-    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 0u);
+    // Top-down placement of the (short-lived) non-binary in a 256-byte buffer: 256 - 32 = 224.
+    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 224u);
     EXPECT_TRUE(trace_nodes[0].dispatch_metadata.send_binary);
     EXPECT_EQ(trace_nodes[0].dispatch_metadata.sync_count, 0u);
     EXPECT_TRUE(trace_nodes[0].dispatch_metadata.stall_first);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_simple_trace_allocator.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_simple_trace_allocator.cpp
@@ -834,10 +834,21 @@ TEST_F(SimpleTraceAllocatorDeviceFixture, NonTensixBinaryInConfigContiguousAlloc
     auto allocator = make_allocator(256);
     allocate_on_subdevice(allocator, trace_nodes, SubDeviceId{0});
 
+    const auto& program_config = program->get_program_config(*core_index);
+    constexpr uint32_t full_config_size = 32 + 16;
+    constexpr uint32_t expected_config_base = 256 - full_config_size;
     // The non-binary allocation covers the full config size (32 + 16 = 48) because
-    // there is no separate binary write offset for non-TENSIX core types.
-    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 0u);
-    // Binary is not separately allocated; binary_addr stays at 0.
+    // there is no separate binary write offset for non-TENSIX core types. Full configs
+    // are short-lived and packed top-down, so the single allocation starts at 256 - 48 = 208.
+    EXPECT_EQ(program->get_program_config_sizes()[*core_index], full_config_size);
+    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, expected_config_base);
+    // Binary is not separately allocated. It remains contiguous with the config base via kernel_text_offset.
+    EXPECT_EQ(program_config.kernel_text_offset, 32u);
+    EXPECT_EQ(
+        trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr +
+            program_config.kernel_text_offset,
+        240u);
+    // The separate binary address is unused for this core type and stays at 0.
     EXPECT_EQ(trace_nodes[0].dispatch_metadata.binary_kernel_config_addrs[*core_index].addr, 0u);
     EXPECT_TRUE(trace_nodes[0].dispatch_metadata.send_binary);
 }
@@ -859,9 +870,15 @@ TEST_F(SimpleTraceAllocatorDeviceFixture, NonTensixBinaryInConfigTwoPrograms) {
     auto allocator = make_allocator(256);
     allocate_on_subdevice(allocator, trace_nodes, SubDeviceId{0});
 
-    // Each program gets a full config allocation (32 + 16 = 48 bytes each).
-    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 0u);
-    EXPECT_EQ(trace_nodes[1].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 48u);
+    constexpr uint32_t full_config_size = 32 + 16;
+    // Each program gets a full config allocation (32 + 16 = 48 bytes each), packed top-down.
+    EXPECT_EQ(trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr, 256u - full_config_size);
+    EXPECT_EQ(
+        trace_nodes[1].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr,
+        256u - 2 * full_config_size);
+    EXPECT_EQ(
+        trace_nodes[1].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr + full_config_size,
+        trace_nodes[0].dispatch_metadata.nonbinary_kernel_config_addrs[*core_index].addr);
     EXPECT_TRUE(trace_nodes[0].dispatch_metadata.send_binary);
     EXPECT_TRUE(trace_nodes[1].dispatch_metadata.send_binary);
 }

--- a/tt_metal/impl/dispatch/simple_trace_allocator.cpp
+++ b/tt_metal/impl/dispatch/simple_trace_allocator.cpp
@@ -103,14 +103,25 @@ std::pair<std::optional<uint32_t>, std::optional<uint32_t>> SimpleTraceAllocator
     // these slots. TODO: sweepline algorithm, so the best position can be calculated in linear
     // time relative to the number of regions.
     if (top_down) {
+        auto first_top_down_scan_begin = [&](std::map<uint32_t, MemoryUsage>::const_reverse_iterator reverse_begin,
+                                             std::map<uint32_t, MemoryUsage>::const_iterator default_begin,
+                                             uint32_t addr) {
+            auto scan_begin = default_begin;
+            for (auto scan = reverse_begin; scan != regions_.crend(); ++scan) {
+                if (scan->first + scan->second.size <= addr) {
+                    break;
+                }
+                scan_begin = std::prev(scan.base());
+            }
+            return scan_begin;
+        };
+
         // Top-down walk: try the slot ending exactly at ringbuffer_size_, then the slots ending
-        // just before each existing region, in descending order of address. The inner scan can
-        // no longer rely on a forward-walking cursor, so we always start from regions_.begin()
-        // and let intersects() filter out non-overlapping regions.
+        // just before each existing region, in descending order of address.
         uint32_t top_addr = ringbuffer_size_ - size;
-        bool stop = evaluate(top_addr, regions_.begin());
+        bool stop = evaluate(top_addr, first_top_down_scan_begin(regions_.crbegin(), regions_.cend(), top_addr));
         if (!stop) {
-            for (auto rit = regions_.rbegin(); rit != regions_.rend(); ++rit) {
+            for (auto rit = regions_.crbegin(); rit != regions_.crend(); ++rit) {
                 if (rit->first < size) {
                     // Slot would extend below the start of the buffer.
                     break;
@@ -119,7 +130,9 @@ std::pair<std::optional<uint32_t>, std::optional<uint32_t>> SimpleTraceAllocator
                 if (addr == top_addr) {
                     continue;
                 }
-                if (evaluate(addr, regions_.begin())) {
+                auto after_candidate = std::prev(rit.base());
+                auto scan_begin = first_top_down_scan_begin(std::next(rit), after_candidate, addr);
+                if (evaluate(addr, scan_begin)) {
                     break;
                 }
             }

--- a/tt_metal/impl/dispatch/simple_trace_allocator.cpp
+++ b/tt_metal/impl/dispatch/simple_trace_allocator.cpp
@@ -103,7 +103,7 @@ std::pair<std::optional<uint32_t>, std::optional<uint32_t>> SimpleTraceAllocator
     // these slots. TODO: sweepline algorithm, so the best position can be calculated in linear
     // time relative to the number of regions.
     if (top_down) {
-        auto first_top_down_scan_begin = [&](std::map<uint32_t, MemoryUsage>::const_reverse_iterator reverse_begin,
+        auto first_top_down_scan_begin = [&](const std::map<uint32_t, MemoryUsage>::const_reverse_iterator& reverse_begin,
                                              std::map<uint32_t, MemoryUsage>::const_iterator default_begin,
                                              uint32_t addr) {
             auto scan_begin = default_begin;

--- a/tt_metal/impl/dispatch/simple_trace_allocator.cpp
+++ b/tt_metal/impl/dispatch/simple_trace_allocator.cpp
@@ -15,14 +15,15 @@
 namespace tt::tt_metal {
 
 std::pair<std::optional<uint32_t>, std::optional<uint32_t>> SimpleTraceAllocator::RegionAllocator::allocate_region(
-    uint32_t size, uint32_t trace_idx, uint32_t data_type, uint64_t program_id) {
+    uint32_t size, uint32_t trace_idx, uint32_t data_type, uint64_t program_id, bool top_down) {
     std::optional<uint32_t> best_addr;
     float best_cost = std::numeric_limits<float>::infinity();
     std::optional<uint32_t> best_region_sync_idx;
-    uint32_t addr = 0;
-    auto outer_it = regions_.begin();
     if (size == 0) {
         return {std::nullopt, 0};
+    }
+    if (top_down && size > ringbuffer_size_) {
+        return {std::nullopt, std::nullopt};
     }
 
     // Set of regions that have no future uses, so they can be evicted to avoid cluttering up regions_.
@@ -31,22 +32,16 @@ std::pair<std::optional<uint32_t>, std::optional<uint32_t>> SimpleTraceAllocator
     // Once we've filled up the entire launch message buffer, we'll sync on that rather than on any older regions.
     constexpr uint32_t max_stall_history_size = dev_msgs::launch_msg_buffer_num_entries;
 
-    // Iterate over possible placements, including the very beginning of the ringbuffer and starting immediately after
-    // every region. One of these placements must be the best, since any other placement would be overlap the same or a
-    // smaller number of allocations by moving it forward to one of those positions.
-    // Then attempt to calculate the placement with the smallest total cost.
-    // TODO: sweepline algorithm, so the best postion can be calculated in linear time relative to the number of
-    // regions.
-    while (true) {
-        if (addr + size > ringbuffer_size_) {
-            break;
-        }
+    // Evaluates a single candidate placement at `addr`, optionally pruning the inner region scan
+    // by a `scan_begin` cursor (used in the bottom-up walk to avoid re-scanning regions that
+    // ended at or before previous placements). Updates best_addr/best_cost/best_region_sync_idx
+    // and marked_for_deletion in place. Returns true when the cost reached zero so the caller
+    // can stop searching.
+    auto evaluate = [&](uint32_t addr, std::map<uint32_t, MemoryUsage>::const_iterator scan_begin) {
         float cost = 0;
         std::optional<uint32_t> region_sync_idx;
         bool now_in_use = false;
-        // outer_it must be the first region that could possibly overlap [addr, addr + size), since in the last
-        // iteration we selected addr as the first address after the old version of outer_it.
-        for (auto it = outer_it; it != regions_.end(); ++it) {
+        for (auto it = scan_begin; it != regions_.end(); ++it) {
             auto region = *it;
             if (region.first >= addr + size) {
                 break;
@@ -77,36 +72,79 @@ std::pair<std::optional<uint32_t>, std::optional<uint32_t>> SimpleTraceAllocator
                 region_sync_idx = merge_syncs(region_sync_idx, region.second.trace_idx);
             }
         }
-        if (!now_in_use) {
-            if (region_sync_idx.has_value()) {
-                // Avoid evicting something that was last used recently, as that can cause a stall that is very bad for
-                // performance. This is critical for avoiding gaps between ops, so it's given a very high cost (the
-                // highest cost for a program is normally around 10,000).
-                constexpr uint32_t desired_write_ahead = std::min(dev_msgs::launch_msg_buffer_num_entries, 7u);
-                constexpr float stall_badness = 100000000;
-                static_assert(
-                    max_stall_history_size > desired_write_ahead,
-                    "max_history_size must be greater than desired_write_ahead");
-                int region_idx_diff = trace_idx - *region_sync_idx;
-                if (region_idx_diff < desired_write_ahead) {
-                    // Stall badness is exponential.
-                    cost += stall_badness * (1 << (desired_write_ahead - region_idx_diff));
+        if (now_in_use) {
+            return false;
+        }
+        if (region_sync_idx.has_value()) {
+            // Avoid evicting something that was last used recently, as that can cause a stall that is very bad for
+            // performance. This is critical for avoiding gaps between ops, so it's given a very high cost (the
+            // highest cost for a program is normally around 10,000).
+            constexpr uint32_t desired_write_ahead = std::min(dev_msgs::launch_msg_buffer_num_entries, 7u);
+            constexpr float stall_badness = 100000000;
+            static_assert(
+                max_stall_history_size > desired_write_ahead,
+                "max_history_size must be greater than desired_write_ahead");
+            int region_idx_diff = trace_idx - *region_sync_idx;
+            if (region_idx_diff < desired_write_ahead) {
+                // Stall badness is exponential.
+                cost += stall_badness * (1 << (desired_write_ahead - region_idx_diff));
+            }
+        }
+        if (cost < best_cost) {
+            best_cost = cost;
+            best_addr = addr;
+            best_region_sync_idx = region_sync_idx;
+        }
+        return cost == 0;
+    };
+
+    // Iterate over possible placements. One of these placements must be the best, since any other
+    // placement would overlap the same or a larger number of allocations by moving it to one of
+    // these slots. TODO: sweepline algorithm, so the best position can be calculated in linear
+    // time relative to the number of regions.
+    if (top_down) {
+        // Top-down walk: try the slot ending exactly at ringbuffer_size_, then the slots ending
+        // just before each existing region, in descending order of address. The inner scan can
+        // no longer rely on a forward-walking cursor, so we always start from regions_.begin()
+        // and let intersects() filter out non-overlapping regions.
+        uint32_t top_addr = ringbuffer_size_ - size;
+        bool stop = evaluate(top_addr, regions_.begin());
+        if (!stop) {
+            for (auto rit = regions_.rbegin(); rit != regions_.rend(); ++rit) {
+                if (rit->first < size) {
+                    // Slot would extend below the start of the buffer.
+                    break;
+                }
+                uint32_t addr = rit->first - size;
+                if (addr == top_addr) {
+                    continue;
+                }
+                if (evaluate(addr, regions_.begin())) {
+                    break;
                 }
             }
-            if (cost < best_cost) {
-                best_cost = cost;
-                best_addr = addr;
-                best_region_sync_idx = region_sync_idx;
-            }
-            if (cost == 0) {
+        }
+    } else {
+        // Bottom-up walk: try the very beginning of the ringbuffer and the slots starting
+        // immediately after each existing region.
+        uint32_t addr = 0;
+        auto outer_it = regions_.begin();
+        while (true) {
+            if (addr + size > ringbuffer_size_) {
                 break;
             }
+            // outer_it must be the first region that could possibly overlap [addr, addr + size),
+            // since in the last iteration we selected addr as the first address after the old
+            // version of outer_it.
+            if (evaluate(addr, outer_it)) {
+                break;
+            }
+            if (outer_it == regions_.end()) {
+                break;
+            }
+            addr = outer_it->first + outer_it->second.size;
+            outer_it++;
         }
-        if (outer_it == regions_.end()) {
-            break;
-        }
-        addr = outer_it->first + outer_it->second.size;
-        outer_it++;
     }
 
     for (const auto& addr : marked_for_deletion) {
@@ -208,7 +246,10 @@ void SimpleTraceAllocator::allocate_trace_programs_on_subdevice(
             auto& allocator = region_allocators_[index];
 
             uint64_t pid = node.program->get_id();
-            auto [rta_sync_idx, rta_addr] = allocator.allocate_region(non_binary_size, i, ExtraData::kNonBinary, pid);
+            // Non-binary entries are never reused, so place them top-down to leave the bottom of
+            // the ringbuffer free for cached binaries.
+            auto [rta_sync_idx, rta_addr] =
+                allocator.allocate_region(non_binary_size, i, ExtraData::kNonBinary, pid, /*top_down=*/true);
 
             nonbinary_sync_idx = merge_syncs(nonbinary_sync_idx, rta_sync_idx);
 
@@ -223,14 +264,18 @@ void SimpleTraceAllocator::allocate_trace_programs_on_subdevice(
                     allocator.update_region_trace_idx(*mem_addr, i);
                 } else {
                     all_binaries_cached = false;
-                    auto res = allocator.allocate_region(binary_size, i, ExtraData::kBinary, pid);
+                    // If this binary won't be used again later in the trace, treat it as
+                    // short-lived and pack it top-down. Otherwise allocate bottom-up so it can
+                    // remain cached for future invocations of the same program.
+                    bool binary_top_down = !extra_data_[i].next_use_idx[ExtraData::kBinary].has_value();
+                    auto res = allocator.allocate_region(binary_size, i, ExtraData::kBinary, pid, binary_top_down);
                     if (!res.second.has_value()) {
                         // Clear the allocator and try again. Should succeed unless the total size
                         // of the program is larger than the config buffer.
                         allocator.reset_allocator();
-                        std::tie(rta_sync_idx, rta_addr) =
-                            allocator.allocate_region(non_binary_size, i, ExtraData::kNonBinary, pid);
-                        res = allocator.allocate_region(binary_size, i, ExtraData::kBinary, pid);
+                        std::tie(rta_sync_idx, rta_addr) = allocator.allocate_region(
+                            non_binary_size, i, ExtraData::kNonBinary, pid, /*top_down=*/true);
+                        res = allocator.allocate_region(binary_size, i, ExtraData::kBinary, pid, binary_top_down);
                         TT_ASSERT(res.second.has_value(), "Failed to allocate binary region");
                         TT_ASSERT(
                             !subdevice_launch_window.empty(),

--- a/tt_metal/impl/dispatch/simple_trace_allocator.hpp
+++ b/tt_metal/impl/dispatch/simple_trace_allocator.hpp
@@ -78,9 +78,13 @@ private:
         RegionAllocator(uint32_t ringbuffer_size, std::vector<ExtraData>& extra_data) :
             ringbuffer_size_(ringbuffer_size), extra_data_(extra_data) {}
 
-        // Returns sync_idx and address.
+        // Returns sync_idx and address. When `top_down` is true the candidate placements are
+        // walked from the top of the ringbuffer downward (one slot ending at the top, plus one
+        // slot ending just before each existing region). This is intended for short-lived data
+        // (non-binary entries and binaries that won't be reused later in the trace) so that
+        // long-lived cached binaries can stay packed at the bottom of the buffer.
         std::pair<std::optional<uint32_t>, std::optional<uint32_t>> allocate_region(
-            uint32_t size, uint32_t trace_idx, uint32_t data_type, uint64_t program_id);
+            uint32_t size, uint32_t trace_idx, uint32_t data_type, uint64_t program_id, bool top_down = false);
 
         void add_region(uint32_t data_type, uint64_t program_id, uint32_t addr) {
             program_ids_memory_map_[data_type][program_id] = addr;


### PR DESCRIPTION
Performance

### Summary
Improve `SimpleTraceAllocator` placement to address the Llama 3.3 70B performance regression tracked in [#42182](https://github.com/tenstorrent/tt-metal/issues/42182).

Short-lived kernel config data is now packed from the top of the ringbuffer, leaving the bottom available for cached binaries that are reused later in the trace.

### Notes for reviewers
The allocator now supports top-down candidate walks for non-binary data and binaries with no future use. The SimpleTraceAllocator C++ tests were updated for the new placement addresses.


Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/simple-trace-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/simple-trace-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/simple-trace-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/simple-trace-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/simple-trace-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/simple-trace-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/simple-trace-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/simple-trace-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/simple-trace-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/simple-trace-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/simple-trace-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/simple-trace-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/simple-trace-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/simple-trace-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/simple-trace-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/simple-trace-allocator)