### PR TITLE
tt-triage: add --json-path for machine-parseable hang diagnosis

### DIFF
--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -5,7 +5,7 @@
 
 """
 Usage:
-    triage [--initialize-with-noc1] [--remote-exalens] [--remote-server=<remote-server>] [--remote-port=<remote-port>] [--verbosity=<verbosity>] [--run=<script>]... [--skip-version-check] [--print-script-times] [-v ...] [--disable-colors] [--disable-progress] [--disable-elf-cache] [--triage-summary-path=<path>]
+    triage [--initialize-with-noc1] [--remote-exalens] [--remote-server=<remote-server>] [--remote-port=<remote-port>] [--verbosity=<verbosity>] [--run=<script>]... [--skip-version-check] [--print-script-times] [-v ...] [--disable-colors] [--disable-progress] [--disable-elf-cache] [--triage-summary-path=<path>] [--json-path=<path>]
 
 Options:
     --remote-exalens                 Connect to remote exalens server.
@@ -25,6 +25,7 @@ Options:
     --disable-progress               Disable progress bars. [default: False]
     --disable-elf-cache              Re-parse ELF files on every access instead of caching. [default: False]
     --triage-summary-path=<path>     Write a triage summary file to the given path (used by CI for hang reports).
+    --json-path=<path>               Write a structured JSON dump of all script results to this file (for agent/tool consumption). Console output is unchanged.
 
 Description:
     Diagnoses Tenstorrent AI hardware by performing comprehensive health checks on ARC processors, NOC connectivity, L1 memory, and RISC-V cores.
@@ -42,6 +43,7 @@ Owner:
 # Check if tt-exalens is installed
 from collections import defaultdict
 from enum import Enum
+import json
 import heapq
 import inspect
 import os
@@ -71,12 +73,13 @@ except ImportError as e:
 
 # Import necessary libraries
 from copy import deepcopy
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields, is_dataclass
 import importlib
 import importlib.metadata as importlib_metadata
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn, TimeRemainingColumn, BarColumn, TextColumn
 from rich.table import Table
+from rich.text import Text
 import sys
 from ttexalens.context import Context
 from ttexalens.device import Device
@@ -690,6 +693,84 @@ def serialize_result(script: TriageScript | None, result, execution_time: str = 
         console.print(table)
 
 
+def _strip_rich_markup(text: str) -> str:
+    """Remove Rich console markup tags from a string using Rich's own parser."""
+    return Text.from_markup(text).plain
+
+
+def iter_serialized_fields(obj, flds):
+    """Yield (serialized_name, justify, str_value) for each leaf field of a triage dataclass.
+
+    Mirrors the field-walking rules used by serialize_result's table builder, but
+    produces structured tuples instead of Rich columns/rows. Used to build JSON entries.
+    """
+    for f in flds:
+        metadata = f.metadata
+        if metadata.get("verbose", 0) > _verbose_level:
+            continue
+        if metadata.get("dont_serialize"):
+            continue
+        if metadata.get("recurse"):
+            value = getattr(obj, f.name)
+            assert is_dataclass(value)
+            yield from iter_serialized_fields(value, fields(value))
+        elif metadata.get("additional_fields"):
+            assert "serializer" in metadata, "Serializer must be provided for combined field."
+            all_values = [getattr(obj, f.name)]
+            all_values.extend(getattr(obj, af) for af in metadata["additional_fields"])
+            yield (
+                metadata.get("serialized_name") or f.name,
+                metadata.get("justify", "left"),
+                metadata["serializer"](all_values),
+            )
+        elif metadata.get("serializer"):
+            yield (
+                metadata.get("serialized_name") or f.name,
+                metadata.get("justify", "left"),
+                metadata["serializer"](getattr(obj, f.name)),
+            )
+
+
+def serialize_result_json(script: "TriageScript | None", result, failures: list[str], warnings: list[str]) -> dict:
+    """Serialize a single script's result to a JSON-compatible dict."""
+    entry: dict[str, Any] = {}
+    if script is not None:
+        entry["script"] = script.name
+
+    if failures:
+        entry["failures"] = [_strip_rich_markup(f) for f in failures]
+    if warnings:
+        entry["warnings"] = [_strip_rich_markup(w) for w in warnings]
+
+    if result is None:
+        if script and script.failed:
+            entry["status"] = "fail"
+            if script.failure_message:
+                entry["error"] = _strip_rich_markup(script.failure_message)
+        elif failures:
+            entry["status"] = "fail"
+        else:
+            entry["status"] = "pass"
+        return entry
+
+    entry["status"] = "ok"
+
+    if isinstance(result, list) and len(result) == 0:
+        entry["data"] = []
+        return entry
+
+    if not (is_dataclass(result) or (isinstance(result, list) and all(is_dataclass(item) for item in result))):
+        entry["data"] = str(result)
+        return entry
+
+    items = result if isinstance(result, list) else [result]
+    entry["data"] = [
+        {name: _strip_rich_markup(value) for name, _, value in iter_serialized_fields(item, fields(item))}
+        for item in items
+    ]
+    return entry
+
+
 def _enforce_dependencies(args: ScriptArguments) -> None:
     """Enforce approved `ttexalens` version unless skipped.
 
@@ -950,6 +1031,9 @@ def main():
     _enforce_dependencies(args)
     context = _init_ttexalens(args)
 
+    json_path = args["--json-path"]
+    json_results: list[dict] = []
+
     with create_progress() as progress:
         scripts_task = progress.add_task("Script execution", total=len(script_queue))
 
@@ -975,6 +1059,8 @@ def main():
                     utils.WARN(f"  Cannot run script due to failed dependencies.")
                     script.failed = True
                     script.failure_message = "Cannot run script due to failed dependencies."
+                    if json_path and not script.config.data_provider:
+                        json_results.append(serialize_result_json(script, None, [], []))
                 else:
                     start_time = time()
                     result = script.run(args=args, context=context)
@@ -994,6 +1080,14 @@ def main():
                             utils.INFO(f"{script.name}{execution_time}:")
                             utils.INFO("  pass")
                     else:
+                        if json_path:
+                            # Peek (don't drain) so serialize_result still drains
+                            # the same per-script logs into the Rich console.
+                            with FAILURE_CHECKS_LOCK:
+                                failures = list(FAILURE_CHECKS)
+                            with WARNING_CHECKS_LOCK:
+                                warnings = list(WARNING_CHECKS)
+                            json_results.append(serialize_result_json(script, result, failures, warnings))
                         start_time = time()
                         serialize_result(script, result, execution_time)
                         end_time = time()
@@ -1005,6 +1099,15 @@ def main():
                 utils.INFO(f"Total serialization time: {serialization_time:.2f}s")
                 utils.INFO(f"Total execution time: {total_time:.2f}s")
         progress.remove_task(scripts_task)
+
+    if json_path:
+        try:
+            os.makedirs(os.path.dirname(os.path.abspath(json_path)), exist_ok=True)
+            with open(json_path, "w") as f:
+                json.dump({"scripts": json_results}, f, indent=2)
+            utils.INFO(f"JSON triage written to {json_path}")
+        except Exception as e:
+            utils.WARN(f"Failed to write JSON triage: {e}")
 
     triage_summary_path = args["--triage-summary-path"]
     if triage_summary_path:


### PR DESCRIPTION
Adding a --json-path argument for tt-triage. 

The motivation behind this change is to enable agents, and some other automatic workflows, to consume JSON files instead of a Rich table. This changes allows agents to grep through the file more easily, as well as creating quick scripts for deeper hang diagnosis (for example, it is easy for an agent / human to write a script that consumes a JSON, loads it as a dict, and then takes some statistics from it).

The main complication was that FAILURE_CHECKS and WARNING_CHECKS were drained by the Rich table serializer, so copies needed to be created.

The rest of the PR description is AI generated.

## Summary
- Adds `--json-path=<path>` to `tools/triage/triage.py`. When set, writes a structured JSON dump of all script results to the given path so agents and scripts can consume hang reports without parsing 20k+ lines of Rich tables and ANSI escapes.
- Console output is unchanged — the JSON file is purely a sidecar artifact, complementary to the existing `--triage-summary-path` (which only records pass/fail per script).
- The JSON serializer walks the same triage dataclass field metadata as the table path (verbose level, recurse, serializer, additional_fields), and strips Rich markup tags via Rich's own parser.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mstaletovic/triage-json-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mstaletovic/triage-json-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mstaletovic/triage-json-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mstaletovic/triage-json-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mstaletovic/triage-json-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mstaletovic/triage-json-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mstaletovic/triage-json-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mstaletovic/triage-json-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mstaletovic/triage-json-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mstaletovic/triage-json-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mstaletovic/triage-json-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mstaletovic/triage-json-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mstaletovic/triage-json-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mstaletovic/triage-json-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mstaletovic/triage-json-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mstaletovic/triage-json-output)