### PR TITLE
Default alignment when there is no over-padding for tile layout.

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_layout.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_layout.cpp
@@ -288,6 +288,7 @@ struct TilePaddedAlignmentTestParams {
     Shape shape;
     Shape padded_shape;
     DataType dtype;
+    tt::tt_metal::Alignment expected_alignment;
     tt::tt_metal::Shape2D expected_physical_shape;
 };
 
@@ -297,6 +298,8 @@ TEST_P(TensorLayoutTilePaddedAlignmentTests, Tensor_TilePaddedAlignmentRegressio
     const auto& params = GetParam();
     TensorLayout layout = TensorLayout::fromPaddedShape(
         params.dtype, Layout::TILE, DefaultMemoryConfig, params.shape, params.padded_shape);
+
+    EXPECT_EQ(layout.get_alignment(), params.expected_alignment);
 
     // The physical shape must match the expected value: it reflects the outer
     // dimension cumulative alignment correctly carrying the original padded
@@ -328,28 +331,32 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         // Minimal reproducer: outer dim N padded from 1 -> 2, padded[-2]=64 > tile_h=32.
         TilePaddedAlignmentTestParams{
-            .shape = Shape{1, 2, 64, 32},
+            .shape = Shape{1, 2, 60, 30},
             .padded_shape = Shape{2, 2, 64, 32},
             .dtype = DataType::BFLOAT16,
+            .expected_alignment = tt::tt_metal::Alignment({256, 128, 32, 32}),
             .expected_physical_shape = tt::tt_metal::Shape2D{256, 32}},
         // Overpadding on H/W.
         TilePaddedAlignmentTestParams{
-            .shape = Shape{1, 2, 16, 16},
+            .shape = Shape{1, 2, 18, 15},
             .padded_shape = Shape{2, 2, 64, 32},
             .dtype = DataType::BFLOAT16,
+            .expected_alignment = tt::tt_metal::Alignment({256, 128, 64, 32}),
             .expected_physical_shape = tt::tt_metal::Shape2D{256, 32}},
         // Padding on C (dim -3) while N stays equal; padded[-2]=64 > 32.
         TilePaddedAlignmentTestParams{
-            .shape = Shape{3, 1, 64, 32},
+            .shape = Shape{3, 1, 60, 30},
             .padded_shape = Shape{3, 2, 64, 32},
             .dtype = DataType::BFLOAT16,
+            .expected_alignment = tt::tt_metal::Alignment({384, 128, 32, 32}),
             .expected_physical_shape = tt::tt_metal::Shape2D{384, 32}},
 
         // padded[-2]=96 > 32 and outer-dim padding on N.
         TilePaddedAlignmentTestParams{
-            .shape = Shape{1, 3, 96, 32},
+            .shape = Shape{1, 3, 90, 30},
             .padded_shape = Shape{2, 3, 96, 32},
             .dtype = DataType::BFLOAT16,
+            .expected_alignment = tt::tt_metal::Alignment({576, 288, 32, 32}),
             .expected_physical_shape = tt::tt_metal::Shape2D{576, 32}}));
 
 // `alignment_can_be_2D` branch for TILE: when legacy H/W padding is no larger than the minimum required for

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_layout.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_layout.cpp
@@ -404,7 +404,7 @@ INSTANTIATE_TEST_SUITE_P(
 struct Tile2DInterleavedAlignmentTestParams {
     Shape shape;
     Shape padded_shape;
-    Tile tile = Tile();
+    Tile tile;
     tt::tt_metal::Alignment expected_alignment;
 };
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_layout.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_layout.cpp
@@ -352,6 +352,57 @@ INSTANTIATE_TEST_SUITE_P(
             .dtype = DataType::BFLOAT16,
             .expected_physical_shape = tt::tt_metal::Shape2D{576, 32}}));
 
+// `alignment_can_be_2D` branch for TILE: when legacy H/W padding is no larger than the minimum required for
+// tile layout on each of the last two dimensions, legacyShapeToAlignment uses tile height/width (not the
+// padded H/W) so the layout matches default TILE alignment. If a dimension is overpadded, that edge is kept.
+struct Tile2DInterleavedAlignmentTestParams {
+    Shape shape;
+    Shape padded_shape;
+    tt::tt_metal::Alignment expected_alignment;
+};
+
+class TensorLayoutTile2DInterleavedAlignmentTests
+    : public ::testing::TestWithParam<Tile2DInterleavedAlignmentTestParams> {};
+
+TEST_P(TensorLayoutTile2DInterleavedAlignmentTests, FromPaddedShape_TileAlignmentUsesTileUnlessOverpadded) {
+    const auto& params = GetParam();
+    TensorLayout layout = TensorLayout::fromPaddedShape(
+        DataType::BFLOAT16, Layout::TILE, DefaultMemoryConfig, params.shape, params.padded_shape);
+
+    EXPECT_EQ(layout.get_alignment(), params.expected_alignment);
+    // Padded shape roundtrip: alignment must still recover the supplied legacy padded shape.
+    EXPECT_EQ(layout.compute_padded_shape(params.shape), params.padded_shape);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TensorLayoutTests,
+    TensorLayoutTile2DInterleavedAlignmentTests,
+    ::testing::Values(
+        // 2D: minimum tile padding only -> alignment is tile 32x32, not 32x64 from padded H/W.
+        Tile2DInterleavedAlignmentTestParams{
+            .shape = Shape{30, 60},
+            .padded_shape = Shape{32, 64},
+            .expected_alignment = tt::tt_metal::Alignment({32, 32}),
+        },
+        // Rank-3: only H/W differ from logical; same rule.
+        Tile2DInterleavedAlignmentTestParams{
+            .shape = Shape{1, 30, 60},
+            .padded_shape = Shape{1, 32, 64},
+            .expected_alignment = tt::tt_metal::Alignment({32, 32}),
+        },
+        // Width overpadded beyond minimum for logical width -> keep legacy padded width in alignment.
+        Tile2DInterleavedAlignmentTestParams{
+            .shape = Shape{30, 60},
+            .padded_shape = Shape{32, 96},
+            .expected_alignment = tt::tt_metal::Alignment({32, 96}),
+        },
+        // Height overpadded (e.g. 30 -> 64) -> keep that edge; width still uses tile when not overpadded.
+        Tile2DInterleavedAlignmentTestParams{
+            .shape = Shape{30, 60},
+            .padded_shape = Shape{64, 64},
+            .expected_alignment = tt::tt_metal::Alignment({64, 32}),
+        }));
+
 struct ConsumedMemoryBytesPerBankTestParams {
     Shape shape;
     TensorLayout tensor_layout;

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_layout.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_layout.cpp
@@ -268,6 +268,45 @@ INSTANTIATE_TEST_SUITE_P(
             .padded_shape = Shape{5, 4, 3, 16, 16},
         }));
 
+struct RowMajorPaddedShapeAlignmentTestParams {
+    Shape shape;
+    Shape padded_shape;
+    tt::tt_metal::Alignment expected_alignment;
+    tt::tt_metal::Shape2D expected_physical_shape;
+    tt::tt_metal::Strides expected_strides;
+};
+
+class TensorLayoutRowMajorPaddedShapeAlignmentTests
+    : public ::testing::TestWithParam<RowMajorPaddedShapeAlignmentTestParams> {};
+
+TEST_P(TensorLayoutRowMajorPaddedShapeAlignmentTests, FromPaddedShape_ComputesFullAlignment) {
+    const auto& params = GetParam();
+    TensorLayout layout = TensorLayout::fromPaddedShape(
+        DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), DefaultMemoryConfig, params.shape, params.padded_shape);
+
+    EXPECT_EQ(layout.get_alignment(), params.expected_alignment);
+    EXPECT_EQ(layout.compute_physical_shape(params.shape), params.expected_physical_shape);
+    EXPECT_EQ(layout.compute_strides(params.shape), params.expected_strides);
+    EXPECT_EQ(layout.compute_padded_shape(params.shape), params.padded_shape);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TensorLayoutTests,
+    TensorLayoutRowMajorPaddedShapeAlignmentTests,
+    ::testing::Values(
+        RowMajorPaddedShapeAlignmentTestParams{
+            .shape = Shape{30, 20, 10},
+            .padded_shape = Shape{32, 32, 32},
+            .expected_alignment = tt::tt_metal::Alignment({1024, 32, 32}),
+            .expected_physical_shape = tt::tt_metal::Shape2D{1024, 32},
+            .expected_strides = tt::tt_metal::Strides({640, 32, 1})},
+        RowMajorPaddedShapeAlignmentTestParams{
+            .shape = Shape{2, 3, 16, 16},
+            .padded_shape = Shape{2, 16, 32, 32},
+            .expected_alignment = tt::tt_metal::Alignment({1024, 512, 32, 32}),
+            .expected_physical_shape = tt::tt_metal::Shape2D{1024, 32},
+            .expected_strides = tt::tt_metal::Strides({1536, 512, 32, 1})}));
+
 // Regression tests for `legacyShapeToAlignment` on TILE-layout tensors that
 // take the "INTERLEAVED with (deprecated) non-height/width padding" branch
 // (i.e. logical and padded shapes differ on outer dimensions).
@@ -365,6 +404,7 @@ INSTANTIATE_TEST_SUITE_P(
 struct Tile2DInterleavedAlignmentTestParams {
     Shape shape;
     Shape padded_shape;
+    Tile tile = Tile();
     tt::tt_metal::Alignment expected_alignment;
 };
 
@@ -374,7 +414,11 @@ class TensorLayoutTile2DInterleavedAlignmentTests
 TEST_P(TensorLayoutTile2DInterleavedAlignmentTests, FromPaddedShape_TileAlignmentUsesTileUnlessOverpadded) {
     const auto& params = GetParam();
     TensorLayout layout = TensorLayout::fromPaddedShape(
-        DataType::BFLOAT16, Layout::TILE, DefaultMemoryConfig, params.shape, params.padded_shape);
+        DataType::BFLOAT16,
+        PageConfig(Layout::TILE, params.tile),
+        DefaultMemoryConfig,
+        params.shape,
+        params.padded_shape);
 
     EXPECT_EQ(layout.get_alignment(), params.expected_alignment);
     // Padded shape roundtrip: alignment must still recover the supplied legacy padded shape.
@@ -408,6 +452,26 @@ INSTANTIATE_TEST_SUITE_P(
             .shape = Shape{30, 60},
             .padded_shape = Shape{64, 64},
             .expected_alignment = tt::tt_metal::Alignment({64, 32}),
+        },
+        // Both H/W overpadded beyond minimum tile padding -> keep both legacy padded edges.
+        Tile2DInterleavedAlignmentTestParams{
+            .shape = Shape{30, 60},
+            .padded_shape = Shape{64, 96},
+            .expected_alignment = tt::tt_metal::Alignment({64, 96}),
+        },
+        // Custom tile: minimum tile padding should use the custom tile H/W, not the legacy padded H/W.
+        Tile2DInterleavedAlignmentTestParams{
+            .shape = Shape{15, 60},
+            .padded_shape = Shape{16, 64},
+            .tile = Tile({16, 32}),
+            .expected_alignment = tt::tt_metal::Alignment({16, 32}),
+        },
+        // Custom tile with both H/W overpadded -> preserve overpadded dimensions.
+        Tile2DInterleavedAlignmentTestParams{
+            .shape = Shape{15, 60},
+            .padded_shape = Shape{32, 96},
+            .tile = Tile({16, 32}),
+            .expected_alignment = tt::tt_metal::Alignment({32, 96}),
         }));
 
 struct ConsumedMemoryBytesPerBankTestParams {

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -24,6 +24,20 @@ size_t round_up(size_t value, size_t multiple) {
     return ((value + multiple - 1) / multiple) * multiple;
 };
 
+std::tuple<bool, bool> get_inner_hw_overpadded(
+    const tt::tt_metal::Shape& logical_shape,
+    const tt::tt_metal::Shape& legacy_padded_shape,
+    const PageConfig& page_config) {
+    if (page_config.get_layout() == Layout::TILE) {
+        const auto& tile = page_config.get_tile();
+        const uint32_t min_padded_h = round_up(logical_shape[-2], tile.get_height());
+        const uint32_t min_padded_w = round_up(logical_shape[-1], tile.get_width());
+        return {legacy_padded_shape[-2] > min_padded_h, legacy_padded_shape[-1] > min_padded_w};
+    }
+    // Always true for non-tile layouts; alignment is the standard padding mechanism for row-major tensors
+    return {true, true};
+}
+
 Alignment legacyShapeToAlignment(
     const tt::tt_metal::Shape& logical_shape,
     const tt::tt_metal::Shape& legacy_padded_shape,
@@ -53,6 +67,8 @@ Alignment legacyShapeToAlignment(
         return Alignment{};
     }
 
+    const auto [height_overpadded, width_overpadded] =
+        get_inner_hw_overpadded(logical_shape, legacy_padded_shape, page_config);
     // INTERLEAVED with only height/width padding
     if (alignment_can_be_2D) {
         ttsl::SmallVector<uint32_t> values(std::min((int)padded_rank, 2));
@@ -60,10 +76,6 @@ Alignment legacyShapeToAlignment(
         if (page_config.get_layout() == Layout::TILE) {
             // When the inner dimensions are not over-padded beyond the logical H/W, use the tile width and height
             const auto& tile = page_config.get_tile();
-            const uint32_t min_padded_h = round_up(logical_shape[-2], tile.get_height());
-            const uint32_t min_padded_w = round_up(logical_shape[-1], tile.get_width());
-            const bool height_overpadded = legacy_padded_shape[-2] > min_padded_h;
-            const bool width_overpadded = legacy_padded_shape[-1] > min_padded_w;
             if (alignment_size == 1) {
                 values[0] = width_overpadded ? legacy_padded_shape[-1] : tile.get_width();
             } else {
@@ -86,15 +98,12 @@ Alignment legacyShapeToAlignment(
     // NOTE: Rank > 2 is guaranteed in this case
     ttsl::SmallVector<uint32_t> values(padded_rank);
 
-    if (page_config.get_layout() == Layout::TILE && logical_shape[-1] == legacy_padded_shape[-1] &&
-        logical_shape[-2] == legacy_padded_shape[-2]) {
+    if (page_config.get_layout() == Layout::TILE) {
         // When the inner dimensions are not over-padded beyond the logical H/W, use the tile width and height
         // for the innermost alignment; otherwise use the legacy padded H/W.
-        values[padded_rank - 1] = page_config.get_tile().get_width();
-        values[padded_rank - 2] = page_config.get_tile().get_height();
-    } else {
-        values[padded_rank - 1] = legacy_padded_shape[-1];
-        values[padded_rank - 2] = legacy_padded_shape[-2];
+        const auto& tile = page_config.get_tile();
+        values[padded_rank - 1] = width_overpadded ? legacy_padded_shape[-1] : tile.get_width();
+        values[padded_rank - 2] = height_overpadded ? legacy_padded_shape[-2] : tile.get_height();
     }
 
     uint32_t cumulative_padded_volume = legacy_padded_shape[-2];

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -57,11 +57,26 @@ Alignment legacyShapeToAlignment(
     if (alignment_can_be_2D) {
         ttsl::SmallVector<uint32_t> values(std::min((int)padded_rank, 2));
         const auto alignment_size = values.size();
-        if (alignment_size >= 1) {
-            values[alignment_size - 1] = legacy_padded_shape[-1];
-        }
-        if (alignment_size == 2) {
-            values[alignment_size - 2] = legacy_padded_shape[-2];
+        if (page_config.get_layout() == Layout::TILE) {
+            // When the inner dimensions are not over-padded beyond the logical H/W, use the tile width and height
+            const auto& tile = page_config.get_tile();
+            const uint32_t min_padded_h = round_up(logical_shape[-2], tile.get_height());
+            const uint32_t min_padded_w = round_up(logical_shape[-1], tile.get_width());
+            const bool height_overpadded = legacy_padded_shape[-2] > min_padded_h;
+            const bool width_overpadded = legacy_padded_shape[-1] > min_padded_w;
+            if (alignment_size == 1) {
+                values[0] = width_overpadded ? legacy_padded_shape[-1] : tile.get_width();
+            } else {
+                values[alignment_size - 2] = height_overpadded ? legacy_padded_shape[-2] : tile.get_height();
+                values[alignment_size - 1] = width_overpadded ? legacy_padded_shape[-1] : tile.get_width();
+            }
+        } else {
+            if (alignment_size >= 1) {
+                values[alignment_size - 1] = legacy_padded_shape[-1];
+            }
+            if (alignment_size == 2) {
+                values[alignment_size - 2] = legacy_padded_shape[-2];
+            }
         }
         Alignment result(std::move(values));
         return result;

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -73,22 +73,13 @@ Alignment legacyShapeToAlignment(
     if (alignment_can_be_2D) {
         ttsl::SmallVector<uint32_t> values(std::min((int)padded_rank, 2));
         const auto alignment_size = values.size();
-        if (page_config.get_layout() == Layout::TILE) {
-            // When the inner dimensions are not over-padded beyond the logical H/W, use the tile width and height
-            const auto& tile = page_config.get_tile();
-            if (alignment_size == 1) {
-                values[0] = width_overpadded ? legacy_padded_shape[-1] : tile.get_width();
-            } else {
-                values[alignment_size - 2] = height_overpadded ? legacy_padded_shape[-2] : tile.get_height();
-                values[alignment_size - 1] = width_overpadded ? legacy_padded_shape[-1] : tile.get_width();
-            }
-        } else {
-            if (alignment_size >= 1) {
-                values[alignment_size - 1] = legacy_padded_shape[-1];
-            }
-            if (alignment_size == 2) {
-                values[alignment_size - 2] = legacy_padded_shape[-2];
-            }
+        if (alignment_size >= 1) {
+            values[alignment_size - 1] =
+                width_overpadded ? legacy_padded_shape[-1] : page_config.get_tile().get_width();
+        }
+        if (alignment_size == 2) {
+            values[alignment_size - 2] =
+                height_overpadded ? legacy_padded_shape[-2] : page_config.get_tile().get_height();
         }
         Alignment result(std::move(values));
         return result;
@@ -98,13 +89,10 @@ Alignment legacyShapeToAlignment(
     // NOTE: Rank > 2 is guaranteed in this case
     ttsl::SmallVector<uint32_t> values(padded_rank);
 
-    if (page_config.get_layout() == Layout::TILE) {
-        // When the inner dimensions are not over-padded beyond the logical H/W, use the tile width and height
-        // for the innermost alignment; otherwise use the legacy padded H/W.
-        const auto& tile = page_config.get_tile();
-        values[padded_rank - 1] = width_overpadded ? legacy_padded_shape[-1] : tile.get_width();
-        values[padded_rank - 2] = height_overpadded ? legacy_padded_shape[-2] : tile.get_height();
-    }
+    // When the inner dimensions are not over-padded beyond the logical H/W, use the tile width and height
+    // for the innermost alignment; otherwise use the legacy padded H/W.
+    values[padded_rank - 1] = width_overpadded ? legacy_padded_shape[-1] : page_config.get_tile().get_width();
+    values[padded_rank - 2] = height_overpadded ? legacy_padded_shape[-2] : page_config.get_tile().get_height();
 
     uint32_t cumulative_padded_volume = legacy_padded_shape[-2];
     for (int dim = padded_rank - 3; dim >= 0; dim--) {


### PR DESCRIPTION
### Summary

[Link to github issue](https://github.com/tenstorrent/tt-metal/issues/42885)

There are two ways to compute a tensor spec: using the constructor, or using `fromPaddedShape`, which applies a custom alignment via `legacyShapeToAlignment`.

This results in different alignment values for the same tensors, leading to issues such as TTNN operation failures (due to spec mismatches) or cache misses in the program factory. These cache misses can cause failures during ttnn.trace execution, where H2D operations are not allowed.

Ensuring that the two innermost dimensions match the tile size in tile layout would unify alignment calculation and help prevent these issues.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=asala/default-tile-no-overpading)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:asala/default-tile-no-overpading)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=asala/default-tile-no-overpading)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:asala/default-tile-no-overpading)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asala/default-tile-no-overpading)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asala/default-tile-no-overpading)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asala/default-tile-no-overpading)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asala/default-tile-no-overpading)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=asala/default-tile-no-overpading)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:asala/default-tile-no-overpading)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asala/default-tile-no-overpading)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asala/default-tile-no-overpading)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asala/default-tile-no-overpading)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asala/default-tile-no-overpading)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asala/default-tile-no-overpading)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asala/default-tile-no-overpading)