### PR TITLE
Reader Indices CB Sizing Fix for Pool / Conv

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -66,7 +66,8 @@ std::vector<CBInfo> get_cb_info(
     bool enable_bias,
     bool is_1d_depthwise_conv,
     bool skip_act_cb_create,
-    uint32_t input_channels_padded) {
+    uint32_t input_channels_padded,
+    std::optional<uint32_t> reader_indices_actual_page_size) {
     const uint32_t num_cbs = static_cast<uint32_t>(Conv2dCb::COUNT);
     std::vector<CBInfo> cb_info;
     cb_info.reserve(num_cbs);
@@ -293,10 +294,27 @@ std::vector<CBInfo> get_cb_info(
         .data_format = output_df});
 
     // Reader indices CB
+    // Worst case is 1 uint16 index per output row (segment headers and discontinuity markers
+    // empirically stay below this bound for supported configs). When the factory has the real
+    // DRAM config buffer it passes its actual per-core page size so the predicted CB footprint
+    // matches the CB the factory creates; auto-shard estimation passes std::nullopt.
+    const uint32_t reader_indices_worst_case_page_size =
+        pconfig.per_core_out_matrix_height_ntile * tt::constants::TILE_HEIGHT * sizeof(uint16_t);
+    if (reader_indices_actual_page_size.has_value()) {
+        // Sanity: the worst-case formula is also what auto-shard L1 estimation uses, so if it ever
+        // underestimates the real config tensor we want to catch it here rather than silently
+        // running auto-shard with the wrong budget.
+        TT_FATAL(
+            reader_indices_actual_page_size.value() <= reader_indices_worst_case_page_size,
+            "Reader indices buffer page size {} exceeds worst-case CB size {} (config tensor "
+            "layout changed?)",
+            reader_indices_actual_page_size.value(),
+            reader_indices_worst_case_page_size);
+    }
     cb_info.emplace_back(CBInfo{
         .name = Conv2dCb::READER_INDICES,
         .num_pages = 1,
-        .page_size = pconfig.per_core_out_matrix_height_ntile * tt::constants::TILE_HEIGHT * 2,  // 2B per index
+        .page_size = reader_indices_actual_page_size.value_or(reader_indices_worst_case_page_size),
         .is_globally_allocated = !conv_config.config_tensors_in_dram,
         .data_format = tt::DataFormat::UInt16});
 
@@ -674,7 +692,8 @@ void post_conv2d_op_memory_checks(
     tt::tt_metal::Program& program,
     const Conv2dParams& operation_attributes,
     const Conv2dInputs& tensor_args,
-    Tensor& /*output_tensor*/) {
+    Tensor& /*output_tensor*/,
+    std::optional<uint32_t> reader_indices_actual_page_size) {
     const auto& input_tensor_a = tensor_args.a;
     const auto& input_tensor_b = tensor_args.b;
     const auto& input_tensor_bias = tensor_args.bias;
@@ -740,7 +759,8 @@ void post_conv2d_op_memory_checks(
             input_tensor_shape[1],
             has_bias),
         input_channels_padded,
-        skip_mcast.skip_activation_mcast);
+        skip_mcast.skip_activation_mcast,
+        reader_indices_actual_page_size);
 
     TT_FATAL(
         actual_cb_size == l1_usage.CB_allocation_size,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -59,6 +59,9 @@ struct CBInfo {
 // Returns a vector of CBInfo objects for the Conv2d operation.
 // The vector will contain information about all circular buffers used in the Conv2d operation.
 // CBInfo::index and CBInfo::handle won't be valid until allocate_cbs() is called.
+// When the program factory has the real reader indices DRAM buffer, it can pass its actual page
+// size so the predicted READER_INDICES CB footprint matches the CB the factory creates. Auto-shard
+// L1 estimation passes std::nullopt and falls back to the worst case (1 uint16 index per output row).
 std::vector<CBInfo> get_cb_info(
     const DeviceComputeKernelConfig& compute_kernel_config,
     const Conv2dBlockConfig& block_config,
@@ -75,7 +78,8 @@ std::vector<CBInfo> get_cb_info(
     bool enable_bias,
     bool is_1d_depthwise_conv,
     bool skip_act_cb_create,
-    uint32_t input_channels_padded);
+    uint32_t input_channels_padded,
+    std::optional<uint32_t> reader_indices_actual_page_size = std::nullopt);
 
 // Allocates circular buffers for the Conv2d operation.
 // This function will populate index and handle fields of each CBInfo in the cb_info vector,
@@ -110,10 +114,15 @@ bool is_split_reader_viable(
     DataType output_datatype,
     bool act_reuse_enabled);
 
+// reader_indices_actual_page_size lets the factory communicate the in-DRAM config tensor's true
+// per-core page size so the post-build CB-size equality check matches what was allocated. When
+// std::nullopt, the worst-case READER_INDICES CB size is used (matches the factory's previous
+// behaviour for the in-DRAM path).
 void post_conv2d_op_memory_checks(
     tt::tt_metal::Program& program,
     const Conv2dParams& operation_attributes,
     const Conv2dInputs& tensor_args,
-    Tensor& output_tensor);
+    Tensor& output_tensor,
+    std::optional<uint32_t> reader_indices_actual_page_size = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1233,7 +1233,8 @@ conv_op_l1_usage calculate_L1_usage(
     const bool enable_bias,
     bool is_1d_depthwise_conv,
     uint32_t input_channels_padded,
-    bool skip_act_cb_create) {
+    bool skip_act_cb_create,
+    std::optional<uint32_t> reader_indices_actual_page_size) {
     // Input shard doesn't affect L1 usage calculation.
     std::array<uint32_t, 2> dummy_input_shard_shape = {0, 0};
     std::vector<CBInfo> cb_info = get_cb_info(
@@ -1252,7 +1253,8 @@ conv_op_l1_usage calculate_L1_usage(
         enable_bias,
         is_1d_depthwise_conv,
         skip_act_cb_create,
-        input_channels_padded);
+        input_channels_padded,
+        reader_indices_actual_page_size);
     uint32_t total_CB_size = 0;
     uint32_t output_size = 0;
     for (const CBInfo& cb : cb_info) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.hpp
@@ -54,6 +54,9 @@ struct Conv2dDeviceOperation {
 bool determine_packer_l1_acc(bool packer_l1_acc, bool enable_bias, uint32_t in0_num_blocks_w);
 
 // L1 allocation is either for the output tensor or for Circular Buffers.
+// reader_indices_actual_page_size lets the program factory communicate the in-DRAM config tensor's
+// true per-core page size; auto-shard estimation passes std::nullopt and falls back to the worst
+// case (1 uint16 index per output row).
 conv_op_l1_usage calculate_L1_usage(
     const DeviceComputeKernelConfig& compute_kernel_config,
     const Conv2dBlockConfig& block_config,
@@ -68,7 +71,8 @@ conv_op_l1_usage calculate_L1_usage(
     bool enable_bias,
     bool is_1d_depthwise_conv,
     uint32_t input_channels_padded,
-    bool skip_act_cb_create = false);
+    bool skip_act_cb_create = false,
+    std::optional<uint32_t> reader_indices_actual_page_size = std::nullopt);
 
 Tensor conv2d(
     const Tensor& a,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -636,6 +636,11 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         .enable_weights_double_buffer = enable_weights_double_buffer,
         .enable_activation_reuse = enable_activation_reuse,
         .force_split_reader = force_split_reader};
+    // Pass the actual DRAM/L1-small config buffer page size into get_cb_info so the predicted
+    // READER_INDICES CB footprint matches the CB this factory creates. Without this, the in-DRAM
+    // path was sized to the worst case (1 uint16 per output row), holding spare L1 that is never
+    // populated by the reader kernel.
+    const uint32_t reader_indices_actual_page_size = conv_reader_indices_storage.get_buffer()->page_size();
     std::vector<CBInfo> cb_info = get_cb_info(
         compute_kernel_config,
         block_config,
@@ -652,21 +657,9 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         has_bias,
         is_conv_1d_depthwise_conv,
         skip_activation_mcast,
-        input_channels_padded);
+        input_channels_padded,
+        reader_indices_actual_page_size);
 
-    if (config_tensors_in_dram) {
-        // The actual CB reader size is difficult to calculate in calculate_L1_size. So instead keep the CB size as the
-        // maximum possible size.
-        TT_FATAL(
-            access_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).page_size >=
-                conv_reader_indices_storage.get_buffer()->page_size(),
-            "CB page size {} should be greater than the config tensor page size {}",
-            access_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).page_size,
-            conv_reader_indices_storage.get_buffer()->page_size());
-    } else {
-        access_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).page_size =
-            conv_reader_indices_storage.get_buffer()->page_size();
-    }
     // call function to allocate circular buffers
     allocate_cbs(cb_info, program, all_cores, a, output, conv_reader_indices_tensor);
 
@@ -1366,7 +1359,8 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         std::vector<CoreCoord> core_range_vec = grid_to_cores(core_range.start_coord, core_range.end_coord, true);
         mcast_sender_cores_vec.insert(mcast_sender_cores_vec.end(), core_range_vec.begin(), core_range_vec.end());
     }
-    post_conv2d_op_memory_checks(program, operation_attributes, tensor_args, output_tensor);
+    post_conv2d_op_memory_checks(
+        program, operation_attributes, tensor_args, output_tensor, reader_indices_actual_page_size);
     // Capture conv_reader_indices_storage to cache this with the program
     return cached_program_t{
         std::move(program),

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -399,6 +399,25 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         .output_layout = (untilize_out ? Layout::ROW_MAJOR : Layout::TILE),
         .enable_act_double_buffer = enable_act_double_buffer,
         .enable_weights_double_buffer = enable_weights_double_buffer};
+
+    std::vector<std::vector<uint16_t>> conv_sharded_input_top_left_indices =
+        ttnn::operations::sliding_window::generate_sliding_window_op_config(
+            op_trace_metadata, shard_boundaries, stride_w, true, act_block_h_datums, 0);
+
+    // create sharded ttnn config tensors
+    Tensor conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
+        conv_sharded_input_top_left_indices, parallel_config, config_tensors_in_dram);
+    conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
+        conv_reader_indices_tensor, parallel_config, false, a.device(), config_tensors_in_dram);
+
+    log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor);
+    const tt::tt_metal::DeviceStorage& conv_reader_indices_storage = conv_reader_indices_tensor.device_storage();
+
+    // Pass the actual DRAM/L1-small config buffer page size into get_cb_info so the predicted
+    // READER_INDICES CB footprint matches the CB this factory creates. Without this, the in-DRAM
+    // path was sized to the worst case (1 uint16 per output row), holding spare L1 that is never
+    // populated by the reader kernel.
+    const uint32_t reader_indices_actual_page_size = conv_reader_indices_storage.get_buffer()->page_size();
     std::vector<CBInfo> cb_info = get_cb_info(
         compute_kernel_config,
         block_config,
@@ -415,34 +434,8 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         has_bias,
         false,
         skip_activation_mcast,
-        input_channels_padded);
-
-    std::vector<std::vector<uint16_t>> conv_sharded_input_top_left_indices =
-        ttnn::operations::sliding_window::generate_sliding_window_op_config(
-            op_trace_metadata, shard_boundaries, stride_w, true, act_block_h_datums, 0);
-
-    // create sharded ttnn config tensors
-    Tensor conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
-        conv_sharded_input_top_left_indices, parallel_config, config_tensors_in_dram);
-    conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
-        conv_reader_indices_tensor, parallel_config, false, a.device(), config_tensors_in_dram);
-
-    log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor);
-    const tt::tt_metal::DeviceStorage& conv_reader_indices_storage = conv_reader_indices_tensor.device_storage();
-
-    if (config_tensors_in_dram) {
-        // The actual CB reader size is difficult to calculate in calculate_L1_size. So instead keep the CB size as the
-        // maximum possible size.
-        TT_FATAL(
-            access_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).page_size >=
-                conv_reader_indices_storage.get_buffer()->page_size(),
-            "CB page size {} should be greater than the config tensor page size {}",
-            access_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).page_size,
-            conv_reader_indices_storage.get_buffer()->page_size());
-    } else {
-        access_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).page_size =
-            conv_reader_indices_storage.get_buffer()->page_size();
-    }
+        input_channels_padded,
+        reader_indices_actual_page_size);
 
     // call function to allocate circular buffers
     allocate_cbs(cb_info, program, all_reader_cores, a, output, conv_reader_indices_tensor);
@@ -639,7 +632,8 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         }
     }
 
-    post_conv2d_op_memory_checks(program, operation_attributes, tensor_args, output_tensor);
+    post_conv2d_op_memory_checks(
+        program, operation_attributes, tensor_args, output_tensor, reader_indices_actual_page_size);
     return cached_program_t{
         std::move(program),
         shared_variables_t{

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -331,8 +331,17 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     const bool one_scalar_per_core = is_pool_op_one_scalar_per_core(
         pool_type, ceil_mode, ceil_pad_h, ceil_pad_w, count_include_pad, pad_h, pad_w, divisor_override);
 
-    // Compute CB sizes centrally - used for both CB creation and L1 validation
+    // Compute CB sizes centrally - used for both CB creation and L1 validation.
+    // When the DRAM config-tensor path is active, the reader indices tensor is already built on
+    // host so we pass its real per-core page size. Auto-shard evaluation in pool_utils.cpp still
+    // falls back to the worst case because the buffers do not exist yet there. The scalar config
+    // tensor (only created for avg pool without one_scalar_per_core) is not yet known at this
+    // point, so its prediction remains the worst case; that matches how the CB is created below.
     auto output_shard_shape = outputs[0].shard_spec().value().shape;
+    std::optional<uint32_t> reader_indices_actual_page_size;
+    if (config_tensor_in_dram) {
+        reader_indices_actual_page_size = reader_indices_storage.get_buffer()->page_size();
+    }
     PoolCBSizes cb_sizes = calculate_pool_cb_sizes(
         params,
         one_scalar_per_core,
@@ -340,7 +349,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         output_layout,
         outputs[0].dtype(),
         {output_shard_shape[0], output_shard_shape[1]},
-        config_tensor_in_dram);
+        config_tensor_in_dram,
+        reader_indices_actual_page_size);
 
     const auto& input_shape = input.padded_shape();
     const uint32_t shard_width = input.shard_spec()->shape[1];
@@ -403,17 +413,18 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
 
     const uint32_t max_reader_indices_size =
         (max_out_nhw_per_core * 3 * sizeof(uint16_t)) + 2;  // worst case of 3 indices per output element
+    const uint32_t actual_reader_indices_buffer_page_size = reader_indices_storage.get_buffer()->page_size();
     TT_FATAL(
-        reader_indices_storage.get_buffer()->page_size() <= max_reader_indices_size,
+        actual_reader_indices_buffer_page_size <= max_reader_indices_size,
         "Reader indices buffer page size {} exceeds max expected size {}",
-        reader_indices_storage.get_buffer()->page_size(),
+        actual_reader_indices_buffer_page_size,
         max_reader_indices_size);
 
     tt::tt_metal::create_cb(
         in_reader_indices_cb_id,
         program,
         all_cores,
-        config_tensor_in_dram ? max_reader_indices_size : in_reader_indices_cb_pagesize,
+        config_tensor_in_dram ? actual_reader_indices_buffer_page_size : in_reader_indices_cb_pagesize,
         in_reader_indices_cb_npages,
         tt::DataFormat::UInt16,
         config_tensor_in_dram ? nullptr : reader_indices_storage.get_buffer());

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -222,7 +222,9 @@ PoolCBSizes calculate_pool_cb_sizes(
     const Layout& output_layout,
     const DataType& output_dtype,
     const std::array<uint32_t, 2>& output_shard_shape,
-    bool config_tensor_in_dram) {
+    bool config_tensor_in_dram,
+    std::optional<uint32_t> reader_indices_actual_page_size,
+    std::optional<uint32_t> scalar_config_actual_page_size) {
     PoolCBSizes sizes;
     const bool is_output_tiled = output_layout == Layout::TILE;
 
@@ -295,13 +297,16 @@ PoolCBSizes calculate_pool_cb_sizes(
     }
 
     // Config tensor L1 CB (for DRAM-based config tensors)
+    // When the factory has the real DRAM buffers it can pass their actual page sizes so that the
+    // predicted CB footprint matches the CB the factory creates. For auto-shard estimation we fall
+    // back to the worst case (3 uint16 indices per output element + 2-byte segment count).
     sizes.config_tensor_l1_size = 0;
     if (config_tensor_in_dram) {
-        sizes.config_tensor_l1_size =
-            (output_shard_shape[0] * 6) + 2;  // Worst case of 6 Bytes per output elem for reader indices
+        const uint32_t reader_indices_worst_case = (output_shard_shape[0] * 6) + 2;
+        sizes.config_tensor_l1_size += reader_indices_actual_page_size.value_or(reader_indices_worst_case);
         if (!one_scalar_per_core) {
-            sizes.config_tensor_l1_size +=
-                output_shard_shape[0] * 6;  // Additional 6 Bytes per output elem for avg pool scalar config tensor
+            const uint32_t scalar_config_worst_case = output_shard_shape[0] * 6;
+            sizes.config_tensor_l1_size += scalar_config_actual_page_size.value_or(scalar_config_worst_case);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -302,10 +302,10 @@ PoolCBSizes calculate_pool_cb_sizes(
     // back to the worst case (3 uint16 indices per output element + 2-byte segment count).
     sizes.config_tensor_l1_size = 0;
     if (config_tensor_in_dram) {
-        const uint32_t reader_indices_worst_case = (output_shard_shape[0] * 6) + 2;
+        const uint32_t reader_indices_worst_case = (output_shard_shape[0] * 3 * sizeof(uint16_t)) + 2;
         sizes.config_tensor_l1_size += reader_indices_actual_page_size.value_or(reader_indices_worst_case);
         if (!one_scalar_per_core) {
-            const uint32_t scalar_config_worst_case = output_shard_shape[0] * 6;
+            const uint32_t scalar_config_worst_case = output_shard_shape[0] * 3 * sizeof(uint16_t);
             sizes.config_tensor_l1_size += scalar_config_actual_page_size.value_or(scalar_config_worst_case);
         }
     }

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
@@ -111,7 +111,9 @@ PoolCBSizes calculate_pool_cb_sizes(
     const Layout& output_layout,
     const DataType& output_dtype,
     const std::array<uint32_t, 2>& output_shard_shape,
-    bool config_tensor_in_dram);
+    bool config_tensor_in_dram,
+    std::optional<uint32_t> reader_indices_actual_page_size = std::nullopt,
+    std::optional<uint32_t> scalar_config_actual_page_size = std::nullopt);
 
 // Separate L1 usage for local CBs vs globally-allocated tensor buffers.
 // Tracking these separately prevents two errors from cancelling out in validation


### PR DESCRIPTION
### Ticket
N/A

### Problem Description
  After #41021 raised MEM_BRISC_FIRMWARE_SIZE by 2560 B to make room for the perf-counter firmware, the static-CB region shifted up by the same amount. That pushed the pool MPWI case test_mpwi_32_bit_index[BFLOAT16, [3, 32, 300, 300, 7, 7, 1, 1,
   3, 3, 1, 1, False]] (and similar large-kernel N300 configs) past the top of the L1 buffer region by ~2.4 KB, tripping validate_circular_buffer_region.
                                                                                                                                                                                                                                                     
  Root cause: when config_tensors_in_dram is set, both the pool MPWI factory and the conv2d sharded / width-sharded factories were sizing the READER_INDICES CB to the worst-case page size — pool reserved 3 uint16 indices per output element + a  
  2-byte segment count, conv reserved 1 uint16 per output row. The reader kernel only ever loads the actual reader_indices_storage.get_buffer()->page_size() bytes per core (e.g. ~68 B vs. 25316 B worst case for the failing pool test), so the
  headroom was dead L1 that was nonetheless absorbing the post-#41021 squeeze.

### What's Changed
  - Pool MPWI factory (pool_multi_core_program_factory.cpp, pool_utils.{cpp,hpp}): size the in_reader_indices CB to the actual reader-indices buffer page size, and thread the same value into calculate_pool_cb_sizes so the factory's              
  predicted-vs-actual CB-size validation still matches. Auto-shard L1 estimation in calculate_L1_usage keeps the worst-case assumption since it runs before the config tensor is built. Added an unused scalar_config_actual_page_size parameter for
  symmetry — scaffolding for trimming the scalar-config CB later, since that tensor is currently built after CB-size prediction.                                                                                                                     
  - Conv2d common factory (conv2d_op_program_factory_common.{cpp,hpp}, conv2d_utils.cpp, conv2d_device_operation.hpp): add an optional reader_indices_actual_page_size parameter to get_cb_info, calculate_L1_usage, and
  post_conv2d_op_memory_checks. When provided, the READER_INDICES CB is sized to the actual page; when std::nullopt (auto-shard estimation), it falls back to the worst case (1 uint16 per output row). A TT_FATAL inside get_cb_info enforces actual
   <= worst_case so a future config-tensor layout change can't silently exceed the auto-shard budget.
  - Conv2d sharded factory (conv2d_op_sharded_program_factory.cpp): pass conv_reader_indices_storage.get_buffer()->page_size() into get_cb_info and post_conv2d_op_memory_checks, and drop the post-hoc access_cb_info_by_name(...).page_size = ...  
  patch / TT_FATAL that previously reconciled the mismatch.                                                                                                                                                                                          
  - Conv2d width-sharded factory (conv2d_op_width_sharded_program_factory.cpp): move the config-tensor construction (generate_sliding_window_op_config → construct_on_host_config_tensor → move_config_tensor_to_device) above the get_cb_info call
  so its actual page size is available at CB-info time. Same plumbing through get_cb_info and post_conv2d_op_memory_checks; same removal of the post-hoc reconciliation block.                                                                       
  - Pool worst-case formula in calculate_pool_cb_sizes: rewrite the magic * 6 as * 3 * sizeof(uint16_t) so the reader/scalar worst-case sizes are self-documenting (no behavior change).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=wransom/pool-mpwi-cb-right-size-reader-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:wransom/pool-mpwi-cb-right-size-reader-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=wransom/pool-mpwi-cb-right-size-reader-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:wransom/pool-mpwi-cb-right-size-reader-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=wransom/pool-mpwi-cb-right-size-reader-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:wransom/pool-mpwi-cb-right-size-reader-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=wransom/pool-mpwi-cb-right-size-reader-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:wransom/pool-mpwi-cb-right-size-reader-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=wransom/pool-mpwi-cb-right-size-reader-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:wransom/pool-mpwi-cb-right-size-reader-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=wransom/pool-mpwi-cb-right-size-reader-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:wransom/pool-mpwi-cb-right-size-reader-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=wransom/pool-mpwi-cb-right-size-reader-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:wransom/pool-mpwi-cb-right-size-reader-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=wransom/pool-mpwi-cb-right-size-reader-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:wransom/pool-mpwi-cb-right-size-reader-indices)