### PR TITLE
[Test] : Enable SD in test_dispatcher.cpp

### DIFF
--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -164,7 +164,8 @@
 - name: runtime_fd2
   cmd: |
     ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher
-    ./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher
+    ./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher --gtest_filter=-*SlowDispatch*
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher --gtest_filter=*SlowDispatch*
   skus:
     wh_n150_civ2:
       timeout: 5

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -164,8 +164,8 @@
 - name: runtime_fd2
   cmd: |
     ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher
-    ./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher --gtest_filter=-*SlowDispatch*
-    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher --gtest_filter=*SlowDispatch*
+    ./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher --gtest_filter='-*SlowDispatch*'
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher --gtest_filter='*SlowDispatch*'
   skus:
     wh_n150_civ2:
       timeout: 5

--- a/tests/scripts/run_cpp_fd2_tests.sh
+++ b/tests/scripts/run_cpp_fd2_tests.sh
@@ -28,5 +28,12 @@ run_test_with_watcher() {
     #############################################
     echo "Running test_dispatcher with fast dispatch mode..";
 
-    run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher"
+    run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher --gtest_filter=-*SlowDispatch*"
 )
+
+#############################################
+# TEST_DISPATCHER TESTS (SD)                #
+#############################################
+echo "Running test_dispatcher with slow dispatch mode..";
+
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher --gtest_filter="*SlowDispatch*""

--- a/tests/scripts/run_cpp_fd2_tests.sh
+++ b/tests/scripts/run_cpp_fd2_tests.sh
@@ -36,4 +36,4 @@ run_test_with_watcher() {
 #############################################
 echo "Running test_dispatcher with slow dispatch mode..";
 
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher --gtest_filter="*SlowDispatch*""
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher --gtest_filter='*SlowDispatch*'

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <unordered_map>
 #include <random>
 #include <tt-metalium/core_coord.hpp>
@@ -16,6 +17,7 @@
 
 #include "tt_metal.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
+#include "tt_metal/impl/dispatch/command_queue_common.hpp"
 
 #include "llrt.hpp"
 #include <tt-metalium/tt_align.hpp>
@@ -921,6 +923,66 @@ inline uint32_t clamp_to_max_fetch(
 }
 }  // namespace PackedWriteUtils
 
+// SD (slow dispatch) buffer constants — used by SlowDispatchBaseTestFixture
+static constexpr uint32_t SD_LOG_DISPATCH_BUFFER_PAGE_SIZE = 12;
+static constexpr uint32_t SD_DISPATCH_BUFFER_PAGE_SIZE = 1u << SD_LOG_DISPATCH_BUFFER_PAGE_SIZE;
+static constexpr uint32_t SD_DISPATCH_BUFFER_SIZE_BLOCKS = 4;
+static constexpr uint32_t SD_DISPATCH_BUFFER_SIZE_BYTES = 768 * 1024;
+static constexpr uint32_t SD_DISPATCH_BUFFER_BLOCK_SIZE_PAGES =
+    SD_DISPATCH_BUFFER_SIZE_BYTES / SD_DISPATCH_BUFFER_PAGE_SIZE / SD_DISPATCH_BUFFER_SIZE_BLOCKS;
+static constexpr uint32_t SD_PREFETCHER_PAGE_BATCH_SIZE = 1;
+
+// Configures a dispatch kernel variant (IS_D / IS_H) and returns its handle.
+// Returns KernelHandle so the caller can call SetRuntimeArgs.
+template <bool is_dram_variant, bool is_host_variant>
+tt_metal::KernelHandle configure_kernel_variant(
+    tt_metal::Program& program,
+    const std::string& path,
+    const std::map<std::string, std::string>& defines_in,
+    std::vector<uint32_t> compile_args,
+    CoreCoord my_core,
+    CoreCoord phys_my_core,
+    CoreCoord phys_upstream_core,
+    CoreCoord phys_downstream_core,
+    tt_metal::IDevice* device,
+    tt_metal::NOC my_noc_index,
+    tt_metal::NOC upstream_noc_index,
+    tt_metal::NOC downstream_noc_index) {
+    auto my_virtual = device->virtual_noc0_coordinate(my_noc_index, phys_my_core);
+    auto upstream_virtual = device->virtual_noc0_coordinate(upstream_noc_index, phys_upstream_core);
+    auto downstream_virtual = device->virtual_noc0_coordinate(downstream_noc_index, phys_downstream_core);
+
+    std::map<std::string, std::string> defines = {
+        {"DISPATCH_KERNEL", "1"},
+        {"MY_NOC_X", std::to_string(my_virtual.x)},
+        {"MY_NOC_Y", std::to_string(my_virtual.y)},
+        {"UPSTREAM_NOC_INDEX", std::to_string(static_cast<uint32_t>(upstream_noc_index))},
+        {"UPSTREAM_NOC_X", std::to_string(upstream_virtual.x)},
+        {"UPSTREAM_NOC_Y", std::to_string(upstream_virtual.y)},
+        {"DOWNSTREAM_NOC_X", std::to_string(downstream_virtual.x)},
+        {"DOWNSTREAM_NOC_Y", std::to_string(downstream_virtual.y)},
+        {"DOWNSTREAM_SUBORDINATE_NOC_X", "255"},
+        {"DOWNSTREAM_SUBORDINATE_NOC_Y", "255"},
+        {"FD_CORE_TYPE", "0"},
+        {"IS_D_VARIANT", std::to_string(static_cast<uint32_t>(is_dram_variant))},
+        {"IS_H_VARIANT", std::to_string(static_cast<uint32_t>(is_host_variant))},
+    };
+    compile_args.push_back(static_cast<uint32_t>(is_dram_variant));
+    compile_args.push_back(static_cast<uint32_t>(is_host_variant));
+    defines.insert(defines_in.begin(), defines_in.end());
+
+    return tt_metal::CreateKernel(
+        program,
+        path,
+        {my_core},
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = my_noc_index,
+            .compile_args = compile_args,
+            .defines = defines,
+            .opt_level = tt_metal::KernelBuildOptLevel::Os});
+}
+
 // BaseTestFixture forms the basis for prefetch and dispatcher tests.
 // Inherits from GenericMeshDeviceFixture which determines the mesh device type automatically
 class BaseTestFixture : public tt_metal::GenericMeshDeviceFixture {
@@ -1161,4 +1223,279 @@ protected:
         }
     }
 };
+
+// SlowDispatchBaseTestFixture validates the dispatcher kernel in isolation without the FD
+// infrastructure. Uses spoof_prefetch.cpp to page pre-written commands into the dispatcher's
+// ring buffer. Requires TT_METAL_SLOW_DISPATCH_MODE=1.
+class SlowDispatchBaseTestFixture : public ::testing::Test {
+protected:
+    std::unique_ptr<DispatchPayloadGenerator> payload_generator_;
+    static constexpr CoreCoord default_worker_start = {0, 1};
+    static constexpr uint32_t bytes_per_16B_unit = 16;
+
+    tt_metal::IDevice* device_ = nullptr;
+    uint32_t dispatch_buffer_page_size_ = SD_DISPATCH_BUFFER_PAGE_SIZE;
+    uint32_t max_fetch_bytes_ = 0;
+    bool send_to_all_ = true;
+    DispatchTestConfig cfg_;
+
+    static constexpr CoreCoord spoof_prefetch_core_ = {0, 0};
+    static constexpr CoreCoord dispatch_core_ = {4, 0};
+
+    void SetUp() override {
+        if (!validate_dispatch_mode()) {
+            GTEST_SKIP();
+            return;
+        }
+        device_ = tt_metal::CreateDevice(0);
+
+        DispatchPayloadGenerator::Config pgcfg;
+        pgcfg.use_coherent_data = cfg_.use_coherent_data;
+        pgcfg.perf_test = cfg_.perf_test;
+        pgcfg.min_xfer_size_bytes = cfg_.min_xfer_size_bytes;
+        pgcfg.max_xfer_size_bytes = cfg_.max_xfer_size_bytes;
+        std::random_device rd;
+        pgcfg.seed = rd();
+        payload_generator_ = std::make_unique<DispatchPayloadGenerator>(pgcfg);
+        log_info(tt::LogTest, "Random seed set to {}", pgcfg.seed);
+        dispatch_buffer_page_size_ = cfg_.dispatch_buffer_page_size;
+        send_to_all_ = cfg_.send_to_all;
+        max_fetch_bytes_ =
+            tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER).max_prefetch_command_size();
+    }
+
+    void TearDown() override {
+        if (device_) {
+            tt_metal::CloseDevice(device_);
+            device_ = nullptr;
+        }
+    }
+
+    bool validate_dispatch_mode() {
+        if (!getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
+            log_info(tt::LogTest, "SD dispatcher suite requires TT_METAL_SLOW_DISPATCH_MODE");
+            return false;
+        }
+        return true;
+    }
+
+    virtual void execute_generated_commands(
+        const std::vector<HostMemDeviceCommand>& commands_per_iteration,
+        DeviceData& device_data,
+        size_t /*num_cores_to_log*/,
+        uint32_t num_iterations,
+        bool /*wait_for_completion*/ = true,
+        bool /*wait_for_host_writes*/ = false) {
+        // 1. Serialize all iterations to a flat byte vector.
+        // Each command must start at a page boundary: cq_dispatch.cpp calls
+        // round_up_pow2(cmd_ptr, dispatch_cb_page_size) after every command.
+        //
+        // HostMemDeviceCommand always prepends a CQPrefetchCmd relay-inline header before
+        // the dispatch payload and appends a pcie-alignment tail (≤63 B).  In FD the prefetcher
+        // strips both.  In SD we strip both by reading relay_inline.length, which DeviceCommand
+        // sets to the exact dispatch content size (before pcie padding) at command-build time.
+        const uint32_t page_size = SD_DISPATCH_BUFFER_PAGE_SIZE;
+        constexpr size_t prefetch_hdr = sizeof(CQPrefetchCmd);  // bytes to skip at front
+        std::vector<uint8_t> raw;
+        for (uint32_t i = 0; i < num_iterations; ++i) {
+            for (const auto& cmd : commands_per_iteration) {
+                TT_ASSERT(cmd.size_bytes() > prefetch_hdr, "Command too small to contain prefetch header");
+                // relay_inline.length is set by DeviceCommand to the exact dispatch content size,
+                // excluding the pcie alignment tail that follows it in the HostMemDeviceCommand.
+                size_t content = reinterpret_cast<const CQPrefetchCmd*>(cmd.data())->relay_inline.length;
+                const auto* p = reinterpret_cast<const uint8_t*>(cmd.data()) + prefetch_hdr;
+                TT_ASSERT(content <= cmd.size_bytes() - prefetch_hdr, "content exceeds payload");
+                raw.insert(raw.end(), p, p + content);
+                // Pad to the next page boundary so the next command starts page-aligned.
+                uint32_t rem = raw.size() % page_size;
+                if (rem) {
+                    raw.resize(raw.size() + (page_size - rem), 0);
+                }
+            }
+        }
+
+        // 3. Append terminate command as its own page.
+        {
+            DeviceCommandCalculator calc;
+            calc.add_dispatch_terminate();
+            HostMemDeviceCommand term_cmd(calc.write_offset_bytes());
+            term_cmd.add_dispatch_terminate();
+            TT_ASSERT(term_cmd.size_bytes() > prefetch_hdr, "Terminate command too small");
+            size_t content = reinterpret_cast<const CQPrefetchCmd*>(term_cmd.data())->relay_inline.length;
+            const auto* p = reinterpret_cast<const uint8_t*>(term_cmd.data()) + prefetch_hdr;
+            raw.insert(raw.end(), p, p + content);
+            uint32_t rem2 = raw.size() % page_size;
+            if (rem2) {
+                raw.resize(raw.size() + (page_size - rem2), 0);
+            }
+        }
+
+        TT_ASSERT(raw.size() % page_size == 0);
+        const uint32_t cmd_cb_pages = raw.size() / page_size;
+        const uint32_t dispatch_buffer_pages = SD_DISPATCH_BUFFER_SIZE_BYTES / page_size;
+        log_info(
+            tt::LogTest,
+            "SD: cmd_cb_pages={} dispatch_buffer_pages={} raw_bytes={}",
+            cmd_cb_pages,
+            dispatch_buffer_pages,
+            raw.size());
+
+        auto& memmap = tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
+        uint32_t dispatch_l1_unreserved_base =
+            memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::UNRESERVED);
+        uint32_t l1_buf_base = tt::align(dispatch_l1_unreserved_base, page_size);
+        TT_ASSERT((l1_buf_base & (page_size - 1)) == 0);
+
+        const auto& soc_desc = tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_->id());
+        TT_FATAL(raw.size() + l1_buf_base <= soc_desc.worker_l1_size, "SD command buffer too large for L1");
+        TT_FATAL(
+            SD_DISPATCH_BUFFER_SIZE_BYTES + l1_buf_base <= soc_desc.worker_l1_size,
+            "SD dispatch buffer too large for L1");
+
+        // 5. Write commands to spoof core's L1
+        CoreCoord phys_spoof = device_->worker_core_from_logical_core(spoof_prefetch_core_);
+        CoreCoord phys_disp = device_->worker_core_from_logical_core(dispatch_core_);
+
+        std::vector<uint32_t> cmds_words(raw.size() / sizeof(uint32_t));
+        std::memcpy(cmds_words.data(), raw.data(), raw.size());
+        tt_metal::MetalContext::instance().get_cluster().write_core(
+            cmds_words.data(),
+            cmds_words.size() * sizeof(uint32_t),
+            tt_cxy_pair(device_->id(), phys_spoof),
+            l1_buf_base);
+
+        // 6. Build program
+        tt_metal::Program program = tt_metal::CreateProgram();
+
+        const uint32_t spoof_prefetch_core_sem_0_id =
+            tt_metal::CreateSemaphore(program, {spoof_prefetch_core_}, dispatch_buffer_pages);
+        const uint32_t dispatch_core_sem_id = tt_metal::CreateSemaphore(program, {dispatch_core_}, 0);
+        TT_ASSERT(dispatch_core_sem_id == spoof_prefetch_core_sem_0_id, "Semaphore IDs must match across cores");
+        const uint32_t prefetch_sync_sem = tt_metal::CreateSemaphore(program, {spoof_prefetch_core_}, 0);
+        const uint32_t dispatch_cb_sem = spoof_prefetch_core_sem_0_id;
+
+        std::vector<uint32_t> spoof_args = {
+            l1_buf_base,                       // 0: dispatch_cb_base
+            SD_LOG_DISPATCH_BUFFER_PAGE_SIZE,  // 1
+            dispatch_buffer_pages,             // 2
+            dispatch_cb_sem,                   // 3
+            l1_buf_base,                       // 4: cmd_cb_base (same region, pre-loaded)
+            cmd_cb_pages,                      // 5
+            SD_PREFETCHER_PAGE_BATCH_SIZE,     // 6
+            prefetch_sync_sem,                 // 7
+        };
+        std::map<std::string, std::string> prefetch_defines = {
+            {"MY_NOC_X", std::to_string(phys_spoof.x)},
+            {"MY_NOC_Y", std::to_string(phys_spoof.y)},
+            {"DISPATCH_NOC_X", std::to_string(phys_disp.x)},
+            {"DISPATCH_NOC_Y", std::to_string(phys_disp.y)},
+            {"FD_CORE_TYPE", "0"},
+        };
+        auto sp = tt_metal::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/spoof_prefetch.cpp",
+            {spoof_prefetch_core_},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = spoof_args,
+                .defines = prefetch_defines});
+        tt_metal::SetRuntimeArgs(program, sp, spoof_prefetch_core_, {1u});
+
+        uint32_t num_compute_cores =
+            device_->compute_with_storage_grid_size().x * device_->compute_with_storage_grid_size().y;
+
+        std::map<std::string, std::string> dispatch_defines = {
+            {"DISPATCH_CB_BASE", std::to_string(l1_buf_base)},
+            {"DISPATCH_CB_LOG_PAGE_SIZE", std::to_string(SD_LOG_DISPATCH_BUFFER_PAGE_SIZE)},
+            {"DISPATCH_CB_PAGES", std::to_string(dispatch_buffer_pages)},
+            {"MY_DISPATCH_CB_SEM_ID", std::to_string(dispatch_cb_sem)},
+            {"UPSTREAM_DISPATCH_CB_SEM_ID", std::to_string(dispatch_cb_sem)},
+            {"DISPATCH_CB_BLOCKS", std::to_string(SD_DISPATCH_BUFFER_SIZE_BLOCKS)},
+            {"UPSTREAM_SYNC_SEM", std::to_string(prefetch_sync_sem)},
+            {"COMMAND_QUEUE_BASE_ADDR", "0"},
+            {"COMPLETION_QUEUE_BASE_ADDR", "0"},
+            {"COMPLETION_QUEUE_SIZE", "0"},
+            {"DOWNSTREAM_CB_BASE", "0"},
+            {"DOWNSTREAM_CB_SIZE", "0"},
+            {"MY_DOWNSTREAM_CB_SEM_ID", "0"},
+            {"DOWNSTREAM_CB_SEM_ID", "0"},
+            {"SPLIT_PREFETCH", "0"},
+            {"PREFETCH_H_NOC_XY", "0"},
+            {"PREFETCH_H_LOCAL_DOWNSTREAM_SEM_ADDR", "0"},
+            {"PREFETCH_H_MAX_CREDITS", "0"},
+            {"PACKED_WRITE_MAX_UNICAST_SUB_CMDS", std::to_string(num_compute_cores)},
+            {"DISPATCH_S_SYNC_SEM_BASE_ADDR", "0"},
+            {"MAX_NUM_WORKER_SEMS", std::to_string(DispatchSettings::DISPATCH_MESSAGE_ENTRIES)},
+            {"MAX_NUM_GO_SIGNAL_NOC_DATA_ENTRIES",
+             std::to_string(DispatchSettings::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES)},
+            {"MCAST_GO_SIGNAL_ADDR", "0"},
+            {"UNICAST_GO_SIGNAL_ADDR", "0"},
+            {"DISTRIBUTED_DISPATCHER", "0"},
+            {"HOST_COMPLETION_Q_WR_PTR",
+             std::to_string(memmap.get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_WR))},
+            {"DEV_COMPLETION_Q_WR_PTR",
+             std::to_string(memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_WR))},
+            {"DEV_COMPLETION_Q_RD_PTR",
+             std::to_string(memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD))},
+            {"DEV_DISPATCH_PROGRESS_PTR",
+             std::to_string(memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_PROGRESS))},
+            {"FIRST_STREAM_USED", std::to_string(memmap.get_dispatch_stream_index(0))},
+            {"VIRTUALIZE_UNICAST_CORES", "0"},
+            {"NUM_VIRTUAL_UNICAST_CORES", "0"},
+            {"NUM_PHYSICAL_UNICAST_CORES", "0"},
+            {"FABRIC_HEADER_RB_BASE", "0"},
+            {"FABRIC_HEADER_RB_ENTRIES", "0"},
+            {"MY_FABRIC_SYNC_STATUS_ADDR", "0"},
+            {"FABRIC_MUX_X", "0"},
+            {"FABRIC_MUX_Y", "0"},
+            {"FABRIC_MUX_NUM_BUFFERS_PER_CHANNEL", "0"},
+            {"FABRIC_MUX_CHANNEL_BUFFER_SIZE_BYTES", "0"},
+            {"FABRIC_MUX_CHANNEL_BASE_ADDRESS", "0"},
+            {"FABRIC_MUX_CONNECTION_INFO_ADDRESS", "0"},
+            {"FABRIC_MUX_CONNECTION_HANDSHAKE_ADDRESS", "0"},
+            {"FABRIC_MUX_FLOW_CONTROL_ADDRESS", "0"},
+            {"FABRIC_MUX_BUFFER_INDEX_ADDRESS", "0"},
+            {"FABRIC_MUX_STATUS_ADDRESS", "0"},
+            {"FABRIC_MUX_TERMINATION_SIGNAL_ADDRESS", "0"},
+            {"WORKER_CREDITS_STREAM_ID", "0"},
+            {"FABRIC_WORKER_FLOW_CONTROL_SEM", "0"},
+            {"FABRIC_WORKER_TEARDOWN_SEM", "0"},
+            {"FABRIC_WORKER_BUFFER_INDEX_SEM", "0"},
+            {"NUM_HOPS", "0"},
+            {"EW_DIM", "0"},
+            {"TO_MESH_ID", "0"},
+            {"FABRIC_2D", "0"},
+            {"WORKER_MCAST_GRID", "0"},
+            {"NUM_WORKER_CORES_TO_MCAST", "0"},
+            {"OFFSETOF_MY_DEV_ID", "0"},
+            {"OFFSETOF_TO_DEV_ID", "1"},
+            {"OFFSETOF_ROUTER_DIRECTION", "2"},
+        };
+
+        auto dispatch_kernel = configure_kernel_variant<true, true>(
+            program,
+            "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
+            dispatch_defines,
+            {},
+            dispatch_core_,
+            phys_disp,
+            phys_spoof,
+            {0, 0},
+            device_,
+            tt_metal::NOC::NOC_0,
+            tt_metal::NOC::NOC_1,
+            tt_metal::NOC::NOC_0);
+
+        // my_dev_id=0, to_dev_id=0, router_direction=0
+        tt_metal::SetRuntimeArgs(program, dispatch_kernel, dispatch_core_, {0u, 0u, 0u});
+
+        // 7. Launch and validate
+        device_data.overflow_check(device_);
+        tt_metal::detail::LaunchProgram(device_, program);
+        const bool pass = device_data.validate(device_);
+        EXPECT_TRUE(pass) << "SD Dispatcher test failed validation";
+    }
+};
+
 }  // namespace tt::tt_metal::tt_dispatch_tests::Common

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -1203,6 +1203,7 @@ inline std::map<std::string, std::string> make_sd_dispatch_defines(
     const auto downstream_virtual = device_->virtual_noc0_coordinate(tt_metal::NOC::NOC_0, CoreCoord{0, 0});
 
     return {
+        {"IS_CQ_DRAM_BACKED", "0"},
         {"DISPATCH_CB_BASE", std::to_string(l1_buf_base)},
         {"DISPATCH_CB_LOG_PAGE_SIZE", std::to_string(DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE)},
         {"DISPATCH_CB_PAGES", std::to_string(dispatch_buffer_pages)},
@@ -1210,6 +1211,7 @@ inline std::map<std::string, std::string> make_sd_dispatch_defines(
         {"UPSTREAM_DISPATCH_CB_SEM_ID", std::to_string(dispatch_core_sem_id)},
         {"DISPATCH_CB_BLOCKS", std::to_string(DispatchSettings::DISPATCH_BUFFER_SIZE_BLOCKS)},
         {"UPSTREAM_SYNC_SEM", std::to_string(prefetch_sync_sem)},
+        {"DISPATCH_D_SHUTDOWN_SEM_ID", "0"},  // no dispatch_s in SD; disables dispatch_s_enabled path
         {"COMMAND_QUEUE_BASE_ADDR", "0"},
         {"COMPLETION_QUEUE_BASE_ADDR", "0"},
         {"COMPLETION_QUEUE_SIZE", "0"},

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -923,14 +923,15 @@ inline uint32_t clamp_to_max_fetch(
 }  // namespace PackedWriteUtils
 
 // SD (slow dispatch) dispatch-buffer constants — consumed by execute_generated_commands.
+// Page size and block count reuse the canonical DispatchSettings values.
 // pages-per-block is derived inside cq_dispatch.cpp as DISPATCH_CB_PAGES / DISPATCH_CB_BLOCKS.
-static constexpr uint32_t SD_LOG_DISPATCH_BUFFER_PAGE_SIZE = 12;
-static constexpr uint32_t SD_DISPATCH_BUFFER_PAGE_SIZE = 1u << SD_LOG_DISPATCH_BUFFER_PAGE_SIZE;
-static constexpr uint32_t SD_DISPATCH_BUFFER_SIZE_BLOCKS = 4;
+static constexpr uint32_t SD_DISPATCH_BUFFER_PAGE_SIZE = 1u << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
 static constexpr uint32_t SD_DISPATCH_BUFFER_SIZE_BYTES = 768 * 1024;
 static constexpr uint32_t SD_PREFETCHER_PAGE_BATCH_SIZE = 1;
 static_assert(SD_DISPATCH_BUFFER_SIZE_BYTES % SD_DISPATCH_BUFFER_PAGE_SIZE == 0);
-static_assert((SD_DISPATCH_BUFFER_SIZE_BYTES / SD_DISPATCH_BUFFER_PAGE_SIZE) % SD_DISPATCH_BUFFER_SIZE_BLOCKS == 0);
+static_assert(
+    (SD_DISPATCH_BUFFER_SIZE_BYTES / SD_DISPATCH_BUFFER_PAGE_SIZE) % DispatchSettings::DISPATCH_BUFFER_SIZE_BLOCKS ==
+    0);
 // spoof_prefetch loop uses (cmd_cb_pages-1)/page_batch_size with no remainder handling
 static_assert(SD_PREFETCHER_PAGE_BATCH_SIZE == 1);
 
@@ -1179,17 +1180,22 @@ protected:
 inline constexpr CoreCoord sd_spoof_prefetch_core = {0, 0};
 inline constexpr CoreCoord sd_dispatch_core = {4, 0};
 
-// cq_dispatch.cpp requires every define present at compile time; SD passes "0" for fields it
-// does not drive (e.g. fabric-mux)
+// Builds the compile-time defines required by cq_dispatch.cpp for the SD (spoof-prefetch) path.
+// SD drives only the core dispatch fields; all fabric-mux, multi-CQ, go-signal, and downstream
+// fields are zeroed since the spoof path never uses them.
+//
+// KEEP IN SYNC WITH: tt_metal/impl/dispatch/kernel_config/dispatch.cpp (the defines block starting
+// around "Add all the dispatch-specific defines"). If a new define is added or removed there,
+// update this map to match - the failure mode is a kernel compile error.
 inline std::map<std::string, std::string> make_sd_dispatch_defines(
     tt_metal::IDevice* device_,
-    uint32_t l1_buf_base,
     uint32_t dispatch_buffer_pages,
     uint32_t dispatch_core_sem_id,
     uint32_t prefetch_sync_sem,
     const CoreCoord& phys_spoof,
     const CoreCoord& phys_disp,
     const tt_metal::DispatchMemMap& memmap) {
+    const uint32_t l1_buf_base = memmap.dispatch_buffer_base();
     const uint32_t num_compute_cores =
         device_->compute_with_storage_grid_size().x * device_->compute_with_storage_grid_size().y;
     const auto my_virtual = device_->virtual_noc0_coordinate(tt_metal::NOC::NOC_0, phys_disp);
@@ -1198,11 +1204,11 @@ inline std::map<std::string, std::string> make_sd_dispatch_defines(
 
     return {
         {"DISPATCH_CB_BASE", std::to_string(l1_buf_base)},
-        {"DISPATCH_CB_LOG_PAGE_SIZE", std::to_string(SD_LOG_DISPATCH_BUFFER_PAGE_SIZE)},
+        {"DISPATCH_CB_LOG_PAGE_SIZE", std::to_string(DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE)},
         {"DISPATCH_CB_PAGES", std::to_string(dispatch_buffer_pages)},
         {"MY_DISPATCH_CB_SEM_ID", std::to_string(dispatch_core_sem_id)},
         {"UPSTREAM_DISPATCH_CB_SEM_ID", std::to_string(dispatch_core_sem_id)},
-        {"DISPATCH_CB_BLOCKS", std::to_string(SD_DISPATCH_BUFFER_SIZE_BLOCKS)},
+        {"DISPATCH_CB_BLOCKS", std::to_string(DispatchSettings::DISPATCH_BUFFER_SIZE_BLOCKS)},
         {"UPSTREAM_SYNC_SEM", std::to_string(prefetch_sync_sem)},
         {"COMMAND_QUEUE_BASE_ADDR", "0"},
         {"COMPLETION_QUEUE_BASE_ADDR", "0"},
@@ -1277,14 +1283,4 @@ inline std::map<std::string, std::string> make_sd_dispatch_defines(
     };
 }
 
-// Executes pre-built dispatch commands via the spoof_prefetch kernel in SD mode.
-// Serializes commands to a flat L1 buffer, launches spoof_prefetch + cq_dispatch,
-// then validates results against device_data.
-//
-// Layout contract: HostMemDeviceCommand prepends a CQPrefetchCmd relay-inline header and appends
-// pcie padding. FD's prefetcher strips both, so in SD, we must do the same too. We rely on relay_inline.length holding
-// the exact dispatch payload size (set by DeviceCommand, before pcie padding).
-//
-// num_cores_to_log / wait_for_* are accepted to match the FD virtual signature but unused —
-// LaunchProgram is synchronous.
 }  // namespace tt::tt_metal::tt_dispatch_tests::Common

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -929,6 +929,10 @@ static constexpr uint32_t SD_DISPATCH_BUFFER_PAGE_SIZE = 1u << SD_LOG_DISPATCH_B
 static constexpr uint32_t SD_DISPATCH_BUFFER_SIZE_BLOCKS = 4;
 static constexpr uint32_t SD_DISPATCH_BUFFER_SIZE_BYTES = 768 * 1024;
 static constexpr uint32_t SD_PREFETCHER_PAGE_BATCH_SIZE = 1;
+static_assert(SD_DISPATCH_BUFFER_SIZE_BYTES % SD_DISPATCH_BUFFER_PAGE_SIZE == 0);
+static_assert((SD_DISPATCH_BUFFER_SIZE_BYTES / SD_DISPATCH_BUFFER_PAGE_SIZE) % SD_DISPATCH_BUFFER_SIZE_BLOCKS == 0);
+// spoof_prefetch loop uses (cmd_cb_pages-1)/page_batch_size with no remainder handling
+static_assert(SD_PREFETCHER_PAGE_BATCH_SIZE == 1);
 
 // BaseTestFixture forms the basis for prefetch and dispatcher tests.
 // Inherits from GenericMeshDeviceFixture which determines the mesh device type automatically

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <cstring>
 #include <unordered_map>
 #include <random>
 #include <tt-metalium/core_coord.hpp>
@@ -923,65 +922,13 @@ inline uint32_t clamp_to_max_fetch(
 }
 }  // namespace PackedWriteUtils
 
-// SD (slow dispatch) buffer constants — used by SlowDispatchBaseTestFixture
+// SD (slow dispatch) dispatch-buffer constants — consumed by execute_generated_commands.
+// pages-per-block is derived inside cq_dispatch.cpp as DISPATCH_CB_PAGES / DISPATCH_CB_BLOCKS.
 static constexpr uint32_t SD_LOG_DISPATCH_BUFFER_PAGE_SIZE = 12;
 static constexpr uint32_t SD_DISPATCH_BUFFER_PAGE_SIZE = 1u << SD_LOG_DISPATCH_BUFFER_PAGE_SIZE;
 static constexpr uint32_t SD_DISPATCH_BUFFER_SIZE_BLOCKS = 4;
 static constexpr uint32_t SD_DISPATCH_BUFFER_SIZE_BYTES = 768 * 1024;
-static constexpr uint32_t SD_DISPATCH_BUFFER_BLOCK_SIZE_PAGES =
-    SD_DISPATCH_BUFFER_SIZE_BYTES / SD_DISPATCH_BUFFER_PAGE_SIZE / SD_DISPATCH_BUFFER_SIZE_BLOCKS;
 static constexpr uint32_t SD_PREFETCHER_PAGE_BATCH_SIZE = 1;
-
-// Configures a dispatch kernel variant (IS_D / IS_H) and returns its handle.
-// Returns KernelHandle so the caller can call SetRuntimeArgs.
-template <bool is_dram_variant, bool is_host_variant>
-tt_metal::KernelHandle configure_kernel_variant(
-    tt_metal::Program& program,
-    const std::string& path,
-    const std::map<std::string, std::string>& defines_in,
-    std::vector<uint32_t> compile_args,
-    CoreCoord my_core,
-    CoreCoord phys_my_core,
-    CoreCoord phys_upstream_core,
-    CoreCoord phys_downstream_core,
-    tt_metal::IDevice* device,
-    tt_metal::NOC my_noc_index,
-    tt_metal::NOC upstream_noc_index,
-    tt_metal::NOC downstream_noc_index) {
-    auto my_virtual = device->virtual_noc0_coordinate(my_noc_index, phys_my_core);
-    auto upstream_virtual = device->virtual_noc0_coordinate(upstream_noc_index, phys_upstream_core);
-    auto downstream_virtual = device->virtual_noc0_coordinate(downstream_noc_index, phys_downstream_core);
-
-    std::map<std::string, std::string> defines = {
-        {"DISPATCH_KERNEL", "1"},
-        {"MY_NOC_X", std::to_string(my_virtual.x)},
-        {"MY_NOC_Y", std::to_string(my_virtual.y)},
-        {"UPSTREAM_NOC_INDEX", std::to_string(static_cast<uint32_t>(upstream_noc_index))},
-        {"UPSTREAM_NOC_X", std::to_string(upstream_virtual.x)},
-        {"UPSTREAM_NOC_Y", std::to_string(upstream_virtual.y)},
-        {"DOWNSTREAM_NOC_X", std::to_string(downstream_virtual.x)},
-        {"DOWNSTREAM_NOC_Y", std::to_string(downstream_virtual.y)},
-        {"DOWNSTREAM_SUBORDINATE_NOC_X", "255"},
-        {"DOWNSTREAM_SUBORDINATE_NOC_Y", "255"},
-        {"FD_CORE_TYPE", "0"},
-        {"IS_D_VARIANT", std::to_string(static_cast<uint32_t>(is_dram_variant))},
-        {"IS_H_VARIANT", std::to_string(static_cast<uint32_t>(is_host_variant))},
-    };
-    compile_args.push_back(static_cast<uint32_t>(is_dram_variant));
-    compile_args.push_back(static_cast<uint32_t>(is_host_variant));
-    defines.insert(defines_in.begin(), defines_in.end());
-
-    return tt_metal::CreateKernel(
-        program,
-        path,
-        {my_core},
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = my_noc_index,
-            .compile_args = compile_args,
-            .defines = defines,
-            .opt_level = tt_metal::KernelBuildOptLevel::Os});
-}
 
 // BaseTestFixture forms the basis for prefetch and dispatcher tests.
 // Inherits from GenericMeshDeviceFixture which determines the mesh device type automatically
@@ -1224,278 +1171,116 @@ protected:
     }
 };
 
-// SlowDispatchBaseTestFixture validates the dispatcher kernel in isolation without the FD
-// infrastructure. Uses spoof_prefetch.cpp to page pre-written commands into the dispatcher's
-// ring buffer. Requires TT_METAL_SLOW_DISPATCH_MODE=1.
-class SlowDispatchBaseTestFixture : public ::testing::Test {
-protected:
-    std::unique_ptr<DispatchPayloadGenerator> payload_generator_;
-    static constexpr CoreCoord default_worker_start = {0, 1};
-    static constexpr uint32_t bytes_per_16B_unit = 16;
+// Fixed core layout used by the SD spoof-prefetch execution path
+inline constexpr CoreCoord sd_spoof_prefetch_core = {0, 0};
+inline constexpr CoreCoord sd_dispatch_core = {4, 0};
 
-    tt_metal::IDevice* device_ = nullptr;
-    uint32_t dispatch_buffer_page_size_ = SD_DISPATCH_BUFFER_PAGE_SIZE;
-    uint32_t max_fetch_bytes_ = 0;
-    bool send_to_all_ = true;
-    DispatchTestConfig cfg_;
+// cq_dispatch.cpp requires every define present at compile time; SD passes "0" for fields it
+// does not drive (e.g. fabric-mux)
+inline std::map<std::string, std::string> make_sd_dispatch_defines(
+    tt_metal::IDevice* device_,
+    uint32_t l1_buf_base,
+    uint32_t dispatch_buffer_pages,
+    uint32_t dispatch_core_sem_id,
+    uint32_t prefetch_sync_sem,
+    const CoreCoord& phys_spoof,
+    const CoreCoord& phys_disp,
+    const tt_metal::DispatchMemMap& memmap) {
+    const uint32_t num_compute_cores =
+        device_->compute_with_storage_grid_size().x * device_->compute_with_storage_grid_size().y;
+    const auto my_virtual = device_->virtual_noc0_coordinate(tt_metal::NOC::NOC_0, phys_disp);
+    const auto upstream_virtual = device_->virtual_noc0_coordinate(tt_metal::NOC::NOC_1, phys_spoof);
+    const auto downstream_virtual = device_->virtual_noc0_coordinate(tt_metal::NOC::NOC_0, CoreCoord{0, 0});
 
-    static constexpr CoreCoord spoof_prefetch_core_ = {0, 0};
-    static constexpr CoreCoord dispatch_core_ = {4, 0};
+    return {
+        {"DISPATCH_CB_BASE", std::to_string(l1_buf_base)},
+        {"DISPATCH_CB_LOG_PAGE_SIZE", std::to_string(SD_LOG_DISPATCH_BUFFER_PAGE_SIZE)},
+        {"DISPATCH_CB_PAGES", std::to_string(dispatch_buffer_pages)},
+        {"MY_DISPATCH_CB_SEM_ID", std::to_string(dispatch_core_sem_id)},
+        {"UPSTREAM_DISPATCH_CB_SEM_ID", std::to_string(dispatch_core_sem_id)},
+        {"DISPATCH_CB_BLOCKS", std::to_string(SD_DISPATCH_BUFFER_SIZE_BLOCKS)},
+        {"UPSTREAM_SYNC_SEM", std::to_string(prefetch_sync_sem)},
+        {"COMMAND_QUEUE_BASE_ADDR", "0"},
+        {"COMPLETION_QUEUE_BASE_ADDR", "0"},
+        {"COMPLETION_QUEUE_SIZE", "0"},
+        {"DOWNSTREAM_CB_BASE", "0"},
+        {"DOWNSTREAM_CB_SIZE", "0"},
+        {"MY_DOWNSTREAM_CB_SEM_ID", "0"},
+        {"DOWNSTREAM_CB_SEM_ID", "0"},
+        {"SPLIT_PREFETCH", "0"},
+        {"PREFETCH_H_NOC_XY", "0"},
+        {"PREFETCH_H_LOCAL_DOWNSTREAM_SEM_ADDR", "0"},
+        {"PREFETCH_H_MAX_CREDITS", "0"},
+        {"PACKED_WRITE_MAX_UNICAST_SUB_CMDS", std::to_string(num_compute_cores)},
+        {"DISPATCH_S_SYNC_SEM_BASE_ADDR", "0"},
+        {"MAX_NUM_WORKER_SEMS", std::to_string(DispatchSettings::DISPATCH_MESSAGE_ENTRIES)},
+        {"MAX_NUM_GO_SIGNAL_NOC_DATA_ENTRIES", std::to_string(DispatchSettings::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES)},
+        {"MCAST_GO_SIGNAL_ADDR", "0"},
+        {"UNICAST_GO_SIGNAL_ADDR", "0"},
+        {"DISTRIBUTED_DISPATCHER", "0"},
+        {"HOST_COMPLETION_Q_WR_PTR",
+         std::to_string(memmap.get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_WR))},
+        {"DEV_COMPLETION_Q_WR_PTR",
+         std::to_string(memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_WR))},
+        {"DEV_COMPLETION_Q_RD_PTR",
+         std::to_string(memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD))},
+        {"DEV_DISPATCH_PROGRESS_PTR",
+         std::to_string(memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_PROGRESS))},
+        {"FIRST_STREAM_USED", std::to_string(memmap.get_dispatch_stream_index(0))},
+        {"VIRTUALIZE_UNICAST_CORES", "0"},
+        {"NUM_VIRTUAL_UNICAST_CORES", "0"},
+        {"NUM_PHYSICAL_UNICAST_CORES", "0"},
+        {"FABRIC_HEADER_RB_BASE", "0"},
+        {"FABRIC_HEADER_RB_ENTRIES", "0"},
+        {"MY_FABRIC_SYNC_STATUS_ADDR", "0"},
+        {"FABRIC_MUX_X", "0"},
+        {"FABRIC_MUX_Y", "0"},
+        {"FABRIC_MUX_NUM_BUFFERS_PER_CHANNEL", "0"},
+        {"FABRIC_MUX_CHANNEL_BUFFER_SIZE_BYTES", "0"},
+        {"FABRIC_MUX_CHANNEL_BASE_ADDRESS", "0"},
+        {"FABRIC_MUX_CONNECTION_INFO_ADDRESS", "0"},
+        {"FABRIC_MUX_CONNECTION_HANDSHAKE_ADDRESS", "0"},
+        {"FABRIC_MUX_FLOW_CONTROL_ADDRESS", "0"},
+        {"FABRIC_MUX_BUFFER_INDEX_ADDRESS", "0"},
+        {"FABRIC_MUX_STATUS_ADDRESS", "0"},
+        {"FABRIC_MUX_TERMINATION_SIGNAL_ADDRESS", "0"},
+        {"WORKER_CREDITS_STREAM_ID", "0"},
+        {"FABRIC_WORKER_FLOW_CONTROL_SEM", "0"},
+        {"FABRIC_WORKER_TEARDOWN_SEM", "0"},
+        {"FABRIC_WORKER_BUFFER_INDEX_SEM", "0"},
+        {"NUM_HOPS", "0"},
+        {"EW_DIM", "0"},
+        {"TO_MESH_ID", "0"},
+        {"FABRIC_2D", "0"},
+        {"WORKER_MCAST_GRID", "0"},
+        {"NUM_WORKER_CORES_TO_MCAST", "0"},
+        {"OFFSETOF_MY_DEV_ID", "0"},
+        {"OFFSETOF_TO_DEV_ID", "1"},
+        {"OFFSETOF_ROUTER_DIRECTION", "2"},
+        {"DISPATCH_KERNEL", "1"},
+        {"MY_NOC_X", std::to_string(my_virtual.x)},
+        {"MY_NOC_Y", std::to_string(my_virtual.y)},
+        {"UPSTREAM_NOC_INDEX", std::to_string(static_cast<uint32_t>(tt_metal::NOC::NOC_1))},
+        {"UPSTREAM_NOC_X", std::to_string(upstream_virtual.x)},
+        {"UPSTREAM_NOC_Y", std::to_string(upstream_virtual.y)},
+        {"DOWNSTREAM_NOC_X", std::to_string(downstream_virtual.x)},
+        {"DOWNSTREAM_NOC_Y", std::to_string(downstream_virtual.y)},
+        {"DOWNSTREAM_SUBORDINATE_NOC_X", "255"},
+        {"DOWNSTREAM_SUBORDINATE_NOC_Y", "255"},
+        {"FD_CORE_TYPE", "0"},
+        {"IS_D_VARIANT", "1"},
+        {"IS_H_VARIANT", "1"},
+    };
+}
 
-    void SetUp() override {
-        if (!validate_dispatch_mode()) {
-            GTEST_SKIP();
-            return;
-        }
-        device_ = tt_metal::CreateDevice(0);
-
-        DispatchPayloadGenerator::Config pgcfg;
-        pgcfg.use_coherent_data = cfg_.use_coherent_data;
-        pgcfg.perf_test = cfg_.perf_test;
-        pgcfg.min_xfer_size_bytes = cfg_.min_xfer_size_bytes;
-        pgcfg.max_xfer_size_bytes = cfg_.max_xfer_size_bytes;
-        std::random_device rd;
-        pgcfg.seed = rd();
-        payload_generator_ = std::make_unique<DispatchPayloadGenerator>(pgcfg);
-        log_info(tt::LogTest, "Random seed set to {}", pgcfg.seed);
-        dispatch_buffer_page_size_ = cfg_.dispatch_buffer_page_size;
-        send_to_all_ = cfg_.send_to_all;
-        max_fetch_bytes_ =
-            tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER).max_prefetch_command_size();
-    }
-
-    void TearDown() override {
-        if (device_) {
-            tt_metal::CloseDevice(device_);
-            device_ = nullptr;
-        }
-    }
-
-    bool validate_dispatch_mode() {
-        if (!getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
-            log_info(tt::LogTest, "SD dispatcher suite requires TT_METAL_SLOW_DISPATCH_MODE");
-            return false;
-        }
-        return true;
-    }
-
-    virtual void execute_generated_commands(
-        const std::vector<HostMemDeviceCommand>& commands_per_iteration,
-        DeviceData& device_data,
-        size_t /*num_cores_to_log*/,
-        uint32_t num_iterations,
-        bool /*wait_for_completion*/ = true,
-        bool /*wait_for_host_writes*/ = false) {
-        // 1. Serialize all iterations to a flat byte vector.
-        // Each command must start at a page boundary: cq_dispatch.cpp calls
-        // round_up_pow2(cmd_ptr, dispatch_cb_page_size) after every command.
-        //
-        // HostMemDeviceCommand always prepends a CQPrefetchCmd relay-inline header before
-        // the dispatch payload and appends a pcie-alignment tail (≤63 B).  In FD the prefetcher
-        // strips both.  In SD we strip both by reading relay_inline.length, which DeviceCommand
-        // sets to the exact dispatch content size (before pcie padding) at command-build time.
-        const uint32_t page_size = SD_DISPATCH_BUFFER_PAGE_SIZE;
-        constexpr size_t prefetch_hdr = sizeof(CQPrefetchCmd);  // bytes to skip at front
-        std::vector<uint8_t> raw;
-        for (uint32_t i = 0; i < num_iterations; ++i) {
-            for (const auto& cmd : commands_per_iteration) {
-                TT_ASSERT(cmd.size_bytes() > prefetch_hdr, "Command too small to contain prefetch header");
-                // relay_inline.length is set by DeviceCommand to the exact dispatch content size,
-                // excluding the pcie alignment tail that follows it in the HostMemDeviceCommand.
-                size_t content = reinterpret_cast<const CQPrefetchCmd*>(cmd.data())->relay_inline.length;
-                const auto* p = reinterpret_cast<const uint8_t*>(cmd.data()) + prefetch_hdr;
-                TT_ASSERT(content <= cmd.size_bytes() - prefetch_hdr, "content exceeds payload");
-                raw.insert(raw.end(), p, p + content);
-                // Pad to the next page boundary so the next command starts page-aligned.
-                uint32_t rem = raw.size() % page_size;
-                if (rem) {
-                    raw.resize(raw.size() + (page_size - rem), 0);
-                }
-            }
-        }
-
-        // 3. Append terminate command as its own page.
-        {
-            DeviceCommandCalculator calc;
-            calc.add_dispatch_terminate();
-            HostMemDeviceCommand term_cmd(calc.write_offset_bytes());
-            term_cmd.add_dispatch_terminate();
-            TT_ASSERT(term_cmd.size_bytes() > prefetch_hdr, "Terminate command too small");
-            size_t content = reinterpret_cast<const CQPrefetchCmd*>(term_cmd.data())->relay_inline.length;
-            const auto* p = reinterpret_cast<const uint8_t*>(term_cmd.data()) + prefetch_hdr;
-            raw.insert(raw.end(), p, p + content);
-            uint32_t rem2 = raw.size() % page_size;
-            if (rem2) {
-                raw.resize(raw.size() + (page_size - rem2), 0);
-            }
-        }
-
-        TT_ASSERT(raw.size() % page_size == 0);
-        const uint32_t cmd_cb_pages = raw.size() / page_size;
-        const uint32_t dispatch_buffer_pages = SD_DISPATCH_BUFFER_SIZE_BYTES / page_size;
-        log_info(
-            tt::LogTest,
-            "SD: cmd_cb_pages={} dispatch_buffer_pages={} raw_bytes={}",
-            cmd_cb_pages,
-            dispatch_buffer_pages,
-            raw.size());
-
-        auto& memmap = tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
-        uint32_t dispatch_l1_unreserved_base =
-            memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::UNRESERVED);
-        uint32_t l1_buf_base = tt::align(dispatch_l1_unreserved_base, page_size);
-        TT_ASSERT((l1_buf_base & (page_size - 1)) == 0);
-
-        const auto& soc_desc = tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_->id());
-        TT_FATAL(raw.size() + l1_buf_base <= soc_desc.worker_l1_size, "SD command buffer too large for L1");
-        TT_FATAL(
-            SD_DISPATCH_BUFFER_SIZE_BYTES + l1_buf_base <= soc_desc.worker_l1_size,
-            "SD dispatch buffer too large for L1");
-
-        // 5. Write commands to spoof core's L1
-        CoreCoord phys_spoof = device_->worker_core_from_logical_core(spoof_prefetch_core_);
-        CoreCoord phys_disp = device_->worker_core_from_logical_core(dispatch_core_);
-
-        std::vector<uint32_t> cmds_words(raw.size() / sizeof(uint32_t));
-        std::memcpy(cmds_words.data(), raw.data(), raw.size());
-        tt_metal::MetalContext::instance().get_cluster().write_core(
-            cmds_words.data(),
-            cmds_words.size() * sizeof(uint32_t),
-            tt_cxy_pair(device_->id(), phys_spoof),
-            l1_buf_base);
-
-        // 6. Build program
-        tt_metal::Program program = tt_metal::CreateProgram();
-
-        const uint32_t spoof_prefetch_core_sem_0_id =
-            tt_metal::CreateSemaphore(program, {spoof_prefetch_core_}, dispatch_buffer_pages);
-        const uint32_t dispatch_core_sem_id = tt_metal::CreateSemaphore(program, {dispatch_core_}, 0);
-        TT_ASSERT(dispatch_core_sem_id == spoof_prefetch_core_sem_0_id, "Semaphore IDs must match across cores");
-        const uint32_t prefetch_sync_sem = tt_metal::CreateSemaphore(program, {spoof_prefetch_core_}, 0);
-        const uint32_t dispatch_cb_sem = spoof_prefetch_core_sem_0_id;
-
-        std::vector<uint32_t> spoof_args = {
-            l1_buf_base,                       // 0: dispatch_cb_base
-            SD_LOG_DISPATCH_BUFFER_PAGE_SIZE,  // 1
-            dispatch_buffer_pages,             // 2
-            dispatch_cb_sem,                   // 3
-            l1_buf_base,                       // 4: cmd_cb_base (same region, pre-loaded)
-            cmd_cb_pages,                      // 5
-            SD_PREFETCHER_PAGE_BATCH_SIZE,     // 6
-            prefetch_sync_sem,                 // 7
-        };
-        std::map<std::string, std::string> prefetch_defines = {
-            {"MY_NOC_X", std::to_string(phys_spoof.x)},
-            {"MY_NOC_Y", std::to_string(phys_spoof.y)},
-            {"DISPATCH_NOC_X", std::to_string(phys_disp.x)},
-            {"DISPATCH_NOC_Y", std::to_string(phys_disp.y)},
-            {"FD_CORE_TYPE", "0"},
-        };
-        auto sp = tt_metal::CreateKernel(
-            program,
-            "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/spoof_prefetch.cpp",
-            {spoof_prefetch_core_},
-            tt_metal::DataMovementConfig{
-                .processor = tt_metal::DataMovementProcessor::RISCV_1,
-                .noc = tt_metal::NOC::RISCV_0_default,
-                .compile_args = spoof_args,
-                .defines = prefetch_defines});
-        tt_metal::SetRuntimeArgs(program, sp, spoof_prefetch_core_, {1u});
-
-        uint32_t num_compute_cores =
-            device_->compute_with_storage_grid_size().x * device_->compute_with_storage_grid_size().y;
-
-        std::map<std::string, std::string> dispatch_defines = {
-            {"DISPATCH_CB_BASE", std::to_string(l1_buf_base)},
-            {"DISPATCH_CB_LOG_PAGE_SIZE", std::to_string(SD_LOG_DISPATCH_BUFFER_PAGE_SIZE)},
-            {"DISPATCH_CB_PAGES", std::to_string(dispatch_buffer_pages)},
-            {"MY_DISPATCH_CB_SEM_ID", std::to_string(dispatch_cb_sem)},
-            {"UPSTREAM_DISPATCH_CB_SEM_ID", std::to_string(dispatch_cb_sem)},
-            {"DISPATCH_CB_BLOCKS", std::to_string(SD_DISPATCH_BUFFER_SIZE_BLOCKS)},
-            {"UPSTREAM_SYNC_SEM", std::to_string(prefetch_sync_sem)},
-            {"COMMAND_QUEUE_BASE_ADDR", "0"},
-            {"COMPLETION_QUEUE_BASE_ADDR", "0"},
-            {"COMPLETION_QUEUE_SIZE", "0"},
-            {"DOWNSTREAM_CB_BASE", "0"},
-            {"DOWNSTREAM_CB_SIZE", "0"},
-            {"MY_DOWNSTREAM_CB_SEM_ID", "0"},
-            {"DOWNSTREAM_CB_SEM_ID", "0"},
-            {"SPLIT_PREFETCH", "0"},
-            {"PREFETCH_H_NOC_XY", "0"},
-            {"PREFETCH_H_LOCAL_DOWNSTREAM_SEM_ADDR", "0"},
-            {"PREFETCH_H_MAX_CREDITS", "0"},
-            {"PACKED_WRITE_MAX_UNICAST_SUB_CMDS", std::to_string(num_compute_cores)},
-            {"DISPATCH_S_SYNC_SEM_BASE_ADDR", "0"},
-            {"MAX_NUM_WORKER_SEMS", std::to_string(DispatchSettings::DISPATCH_MESSAGE_ENTRIES)},
-            {"MAX_NUM_GO_SIGNAL_NOC_DATA_ENTRIES",
-             std::to_string(DispatchSettings::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES)},
-            {"MCAST_GO_SIGNAL_ADDR", "0"},
-            {"UNICAST_GO_SIGNAL_ADDR", "0"},
-            {"DISTRIBUTED_DISPATCHER", "0"},
-            {"HOST_COMPLETION_Q_WR_PTR",
-             std::to_string(memmap.get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_WR))},
-            {"DEV_COMPLETION_Q_WR_PTR",
-             std::to_string(memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_WR))},
-            {"DEV_COMPLETION_Q_RD_PTR",
-             std::to_string(memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD))},
-            {"DEV_DISPATCH_PROGRESS_PTR",
-             std::to_string(memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_PROGRESS))},
-            {"FIRST_STREAM_USED", std::to_string(memmap.get_dispatch_stream_index(0))},
-            {"VIRTUALIZE_UNICAST_CORES", "0"},
-            {"NUM_VIRTUAL_UNICAST_CORES", "0"},
-            {"NUM_PHYSICAL_UNICAST_CORES", "0"},
-            {"FABRIC_HEADER_RB_BASE", "0"},
-            {"FABRIC_HEADER_RB_ENTRIES", "0"},
-            {"MY_FABRIC_SYNC_STATUS_ADDR", "0"},
-            {"FABRIC_MUX_X", "0"},
-            {"FABRIC_MUX_Y", "0"},
-            {"FABRIC_MUX_NUM_BUFFERS_PER_CHANNEL", "0"},
-            {"FABRIC_MUX_CHANNEL_BUFFER_SIZE_BYTES", "0"},
-            {"FABRIC_MUX_CHANNEL_BASE_ADDRESS", "0"},
-            {"FABRIC_MUX_CONNECTION_INFO_ADDRESS", "0"},
-            {"FABRIC_MUX_CONNECTION_HANDSHAKE_ADDRESS", "0"},
-            {"FABRIC_MUX_FLOW_CONTROL_ADDRESS", "0"},
-            {"FABRIC_MUX_BUFFER_INDEX_ADDRESS", "0"},
-            {"FABRIC_MUX_STATUS_ADDRESS", "0"},
-            {"FABRIC_MUX_TERMINATION_SIGNAL_ADDRESS", "0"},
-            {"WORKER_CREDITS_STREAM_ID", "0"},
-            {"FABRIC_WORKER_FLOW_CONTROL_SEM", "0"},
-            {"FABRIC_WORKER_TEARDOWN_SEM", "0"},
-            {"FABRIC_WORKER_BUFFER_INDEX_SEM", "0"},
-            {"NUM_HOPS", "0"},
-            {"EW_DIM", "0"},
-            {"TO_MESH_ID", "0"},
-            {"FABRIC_2D", "0"},
-            {"WORKER_MCAST_GRID", "0"},
-            {"NUM_WORKER_CORES_TO_MCAST", "0"},
-            {"OFFSETOF_MY_DEV_ID", "0"},
-            {"OFFSETOF_TO_DEV_ID", "1"},
-            {"OFFSETOF_ROUTER_DIRECTION", "2"},
-        };
-
-        auto dispatch_kernel = configure_kernel_variant<true, true>(
-            program,
-            "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
-            dispatch_defines,
-            {},
-            dispatch_core_,
-            phys_disp,
-            phys_spoof,
-            {0, 0},
-            device_,
-            tt_metal::NOC::NOC_0,
-            tt_metal::NOC::NOC_1,
-            tt_metal::NOC::NOC_0);
-
-        // my_dev_id=0, to_dev_id=0, router_direction=0
-        tt_metal::SetRuntimeArgs(program, dispatch_kernel, dispatch_core_, {0u, 0u, 0u});
-
-        // 7. Launch and validate
-        device_data.overflow_check(device_);
-        tt_metal::detail::LaunchProgram(device_, program);
-        const bool pass = device_data.validate(device_);
-        EXPECT_TRUE(pass) << "SD Dispatcher test failed validation";
-    }
-};
-
+// Executes pre-built dispatch commands via the spoof_prefetch kernel in SD mode.
+// Serializes commands to a flat L1 buffer, launches spoof_prefetch + cq_dispatch,
+// then validates results against device_data.
+//
+// Layout contract: HostMemDeviceCommand prepends a CQPrefetchCmd relay-inline header and appends
+// pcie padding. FD's prefetcher strips both, so in SD, we must do the same too. We rely on relay_inline.length holding
+// the exact dispatch payload size (set by DeviceCommand, before pcie padding).
+//
+// num_cores_to_log / wait_for_* are accepted to match the FD virtual signature but unused —
+// LaunchProgram is synchronous.
 }  // namespace tt::tt_metal::tt_dispatch_tests::Common

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/spoof_prefetch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/spoof_prefetch.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Spoofed prefetch kernel
+//  - spoofs out the fast dispatch prefetcher to test the dispatcher
+//  - data (dispatch commands) magically appears in a buffer and gets sent to dispatcher
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt_metal/impl/dispatch/kernels/cq_common.hpp"
+
+constexpr uint32_t dispatch_cb_base = get_compile_time_arg_val(0);
+constexpr uint32_t dispatch_cb_log_page_size = get_compile_time_arg_val(1);
+constexpr uint32_t dispatch_cb_pages = get_compile_time_arg_val(2);
+constexpr uint32_t dispatch_cb_sem = get_compile_time_arg_val(3);
+constexpr uint32_t cmd_cb_base = get_compile_time_arg_val(4);
+constexpr uint32_t cmd_cb_pages = get_compile_time_arg_val(5);
+constexpr uint32_t page_batch_size = get_compile_time_arg_val(6);
+
+constexpr uint8_t my_noc_index = NOC_INDEX;
+constexpr uint32_t dispatch_noc_xy = uint32_t(NOC_XY_ENCODING(DISPATCH_NOC_X, DISPATCH_NOC_Y));
+constexpr uint32_t dispatch_cb_page_size = 1 << dispatch_cb_log_page_size;
+constexpr uint32_t dispatch_cb_end = dispatch_cb_base + dispatch_cb_page_size * dispatch_cb_pages;
+
+void kernel_main() {
+    int iterations = get_arg_val<int>(0);
+
+    uint32_t cmd_ptr;
+    uint32_t dispatch_data_ptr = dispatch_cb_base;
+    CBWriter<dispatch_cb_sem, my_noc_index, dispatch_noc_xy, dispatch_cb_sem> writer;
+    for (int i = 0; i < iterations; i++) {
+        cmd_ptr = cmd_cb_base;
+        for (uint32_t j = 0; j < (cmd_cb_pages - 1) / page_batch_size; j++) {
+            writer.acquire_pages(page_batch_size);
+            for (uint32_t k = 0; k < page_batch_size; k++) {
+                noc_async_write(
+                    cmd_ptr, get_noc_addr_helper(dispatch_noc_xy, dispatch_data_ptr), dispatch_cb_page_size);
+                cmd_ptr += dispatch_cb_page_size;
+                dispatch_data_ptr += dispatch_cb_page_size;
+                if (dispatch_data_ptr == dispatch_cb_end) {
+                    dispatch_data_ptr = dispatch_cb_base;
+                }
+            }
+            writer.release_pages(page_batch_size);
+        }
+    }
+
+    // Send finish, last cmd in the chain
+    writer.acquire_pages(1);
+    noc_async_write(cmd_ptr, get_noc_addr_helper(dispatch_noc_xy, dispatch_data_ptr), dispatch_cb_page_size);
+    writer.release_pages(1);
+    noc_async_write_barrier();
+    noc_async_atomic_barrier();
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -1496,11 +1496,6 @@ public:
         device_data.relevel(tt::CoreType::WORKER);
         constexpr uint32_t payload_unit = sizeof(uint32_t);
 
-        // SD ring buffer page budget: dispatch_buffer_pages - 1 (terminate page)
-        const uint32_t page_size = Common::SD_DISPATCH_BUFFER_PAGE_SIZE;
-        const uint32_t dispatch_buffer_pages = Common::SD_DISPATCH_BUFFER_SIZE_BYTES / page_size;
-        uint32_t pages_used = 0;
-
         while (remaining_bytes > payload_unit) {
             uint32_t xfer_size_bytes = payload_generator_->get_random_size(
                 dispatch_buffer_page_size_ / payload_unit, payload_unit, remaining_bytes);
@@ -1518,17 +1513,6 @@ public:
             xfer_size_bytes = clamp_to_max_fetch(
                 xfer_size_bytes, num_sub_cmds, packed_write_max_unicast_sub_cmds, no_stride, l1_alignment);
 
-            // Conservative page budget check: stop before total command bytes exceed the
-            // dispatch ring buffer size (768 KB). Spoof core L1 can hold more, but this
-            // bounds the single-iteration command set to a predictable size.
-            uint32_t num_data_copies = no_stride ? 1u : num_sub_cmds;
-            uint32_t cmd_advance =
-                sizeof(CQDispatchCmd) + sub_cmds_bytes + num_data_copies * tt::align(xfer_size_bytes, l1_alignment);
-            uint32_t cmd_pages = (cmd_advance + page_size - 1) / page_size;
-            if (pages_used + cmd_pages + 1 > dispatch_buffer_pages) {
-                break;  // no room for this command plus the terminate page
-            }
-
             const CoreCoord& fw = worker_cores[0];
             uint32_t common_addr = device_data.get_result_data_addr(fw);
 
@@ -1545,7 +1529,6 @@ public:
                 payload, sub_cmds, common_addr, l1_alignment, packed_write_max_unicast_sub_cmds, no_stride);
 
             commands_per_iteration.push_back(std::move(cmd));
-            pages_used += cmd_pages;
             remaining_bytes -= xfer_size_bytes;
         }
 
@@ -1609,9 +1592,11 @@ TEST_P(DispatchPackedWriteSDTestFixture, WritePackedUnicast) {
 INSTANTIATE_TEST_SUITE_P(
     SlowDispatch,
     DispatchPackedWriteSDTestFixture,
+    // SD sizes are smaller than FD (786432/819200): packed write with 4 worker cores writes
+    // ~4x payload bytes into L1, so max safe payload is ~L1_size/5 (~300KB).
     ::testing::Values(
-        PackedWriteParams{786432, DEFAULT_ITERATIONS_PACKED_WRITE, Common::DRAM_DATA_SIZE_WORDS},
-        PackedWriteParams{819200, DEFAULT_ITERATIONS_PACKED_WRITE, Common::DRAM_DATA_SIZE_WORDS}),
+        PackedWriteParams{131072, DEFAULT_ITERATIONS_PACKED_WRITE, Common::DRAM_DATA_SIZE_WORDS},
+        PackedWriteParams{262144, DEFAULT_ITERATIONS_PACKED_WRITE, Common::DRAM_DATA_SIZE_WORDS}),
     [](const testing::TestParamInfo<PackedWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
                "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
@@ -1682,11 +1667,6 @@ public:
 
         device_data.relevel(worker_range);
 
-        // SD page budget: dispatch_buffer_pages minus one page reserved for terminate
-        const uint32_t page_size = Common::SD_DISPATCH_BUFFER_PAGE_SIZE;
-        const uint32_t dispatch_buffer_pages = Common::SD_DISPATCH_BUFFER_SIZE_BYTES / page_size;
-        uint32_t pages_used = 0;
-
         while (remaining_bytes > 0) {
             const int max_transactions =
                 payload_generator_->get_rand<int>(1, CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS);
@@ -1694,18 +1674,6 @@ public:
             TransactionBatch batch =
                 generate_packed_large_transactions(remaining_bytes, max_transactions, l1_alignment);
             if (batch.sizes.empty()) {
-                break;
-            }
-
-            // Estimate ring buffer pages this command will consume
-            size_t sub_cmds_bytes = batch.sizes.size() * sizeof(CQDispatchWritePackedLargeSubCmd);
-            size_t data_start = tt::align(sizeof(CQDispatchCmd) + sub_cmds_bytes, l1_alignment);
-            size_t data_bytes = 0;
-            for (uint32_t sz : batch.sizes) {
-                data_bytes += tt::align(sz, l1_alignment);
-            }
-            uint32_t cmd_pages = (uint32_t)((data_start + data_bytes + page_size - 1) / page_size);
-            if (pages_used + cmd_pages + 1 > dispatch_buffer_pages) {
                 break;
             }
 
@@ -1737,16 +1705,15 @@ public:
 
             log_info(
                 tt::LogTest,
-                "SD: generated packed-large command {} with {} transactions, {} bytes",
+                "Generated packed-large command {} with {} transactions, {} bytes",
                 commands_per_iteration.size(),
                 sub_cmds.size(),
                 batch.total_payload_bytes);
 
             commands_per_iteration.push_back(std::move(cmd));
-            pages_used += cmd_pages;
         }
 
-        log_info(tt::LogTest, "SD: generated {} packed-large commands total", commands_per_iteration.size());
+        log_info(tt::LogTest, "Generated {} packed-large commands total", commands_per_iteration.size());
         return commands_per_iteration;
     }
 
@@ -1787,7 +1754,7 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchPackedWriteLargeSDTestFixture,
     ::testing::Values(
         PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS},
-        // Generator has page budget tracking; stops early if spoof core L1 would overflow.
+
         PackedWriteParams{409600, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS}),
     [](const testing::TestParamInfo<PackedWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
@@ -1851,11 +1818,6 @@ public:
         std::vector<HostMemDeviceCommand> commands_per_iteration;
         uint32_t remaining_bytes = transfer_size_bytes_;
 
-        // SD page budget: dispatch_buffer_pages minus one page reserved for terminate
-        const uint32_t page_size = Common::SD_DISPATCH_BUFFER_PAGE_SIZE;
-        const uint32_t dispatch_buffer_pages = Common::SD_DISPATCH_BUFFER_SIZE_BYTES / page_size;
-        uint32_t pages_used = 0;
-
         while (remaining_bytes > 0) {
             const int max_transactions =
                 payload_generator_->get_rand<int>(1, CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS);
@@ -1863,18 +1825,6 @@ public:
             TransactionBatch batch =
                 generate_packed_large_unicast_transactions(remaining_bytes, max_transactions, l1_alignment);
             if (batch.sizes.empty()) {
-                break;
-            }
-
-            // Estimate ring buffer pages this command will consume
-            size_t sub_cmds_bytes = batch.sizes.size() * sizeof(CQDispatchWritePackedLargeUnicastSubCmd);
-            size_t data_start = tt::align(sizeof(CQDispatchCmd) + sub_cmds_bytes, l1_alignment);
-            size_t data_bytes = 0;
-            for (uint32_t sz : batch.sizes) {
-                data_bytes += tt::align(sz, l1_alignment);
-            }
-            uint32_t cmd_pages = (uint32_t)((data_start + data_bytes + page_size - 1) / page_size);
-            if (pages_used + cmd_pages + 1 > dispatch_buffer_pages) {
                 break;
             }
 
@@ -1915,16 +1865,15 @@ public:
 
             log_info(
                 tt::LogTest,
-                "SD: generated packed-large unicast command {} with {} transactions, {} bytes",
+                "Generated packed-large unicast command {} with {} transactions, {} bytes",
                 commands_per_iteration.size(),
                 sub_cmds.size(),
                 batch.total_payload_bytes);
 
             commands_per_iteration.push_back(std::move(cmd));
-            pages_used += cmd_pages;
         }
 
-        log_info(tt::LogTest, "SD: generated {} packed-large unicast commands total", commands_per_iteration.size());
+        log_info(tt::LogTest, "Generated {} packed-large unicast commands total", commands_per_iteration.size());
         return commands_per_iteration;
     }
 
@@ -1973,7 +1922,7 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchPackedWriteLargeUnicastSDTestFixture,
     ::testing::Values(
         PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS},
-        // Generator has page budget tracking; stops early if spoof core L1 would overflow.
+
         PackedWriteParams{409600, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS}),
     [](const testing::TestParamInfo<PackedWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -1146,4 +1146,838 @@ INSTANTIATE_TEST_SUITE_P(
                "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
     });
 
+// --- Slow Dispatch (SD) linear write test ---
+// Validates the dispatcher kernel in isolation using spoof_prefetch.cpp.
+// Requires TT_METAL_SLOW_DISPATCH_MODE=1.
+class DispatchLinearWriteSDTestFixture : public Common::SlowDispatchBaseTestFixture,
+                                         public ::testing::WithParamInterface<LinearWriteParams> {
+    uint32_t transfer_size_bytes_{};
+    uint32_t num_iterations_{};
+    uint32_t dram_data_size_words_{};
+    bool is_mcast_{};
+
+protected:
+    static constexpr bool inline_data_ = true;
+    static constexpr bool flush_prefetch_ = true;
+
+public:
+    void SetUp() override {
+        Common::SlowDispatchBaseTestFixture::SetUp();
+        if (IsSkipped()) {
+            return;
+        }
+        const auto params = GetParam();
+        transfer_size_bytes_ = params.transfer_size_bytes;
+        num_iterations_ = params.num_iterations;
+        dram_data_size_words_ = params.dram_data_size_words;
+        is_mcast_ = params.is_mcast;
+    }
+
+    std::vector<HostMemDeviceCommand> generate_linear_write_commands(
+        const CoreRange& worker_range,
+        uint32_t noc_xy,
+        uint32_t max_payload_per_cmd_bytes,
+        Common::DeviceData& device_data) {
+        std::vector<HostMemDeviceCommand> commands_per_iteration;
+        uint32_t remaining_bytes = get_transfer_size_bytes();
+        const CoreCoord first_worker = worker_range.start_coord;
+
+        if (is_mcast_) {
+            device_data.relevel(tt::CoreType::WORKER);
+        }
+
+        while (remaining_bytes > 0) {
+            uint32_t xfer_size_bytes =
+                payload_generator_->get_random_size(MAX_XFER_SIZE_16B, bytes_per_16B_unit, remaining_bytes);
+            xfer_size_bytes = std::min(xfer_size_bytes, max_payload_per_cmd_bytes);
+
+            uint32_t addr = device_data.get_result_data_addr(first_worker, 0);
+            std::vector<uint32_t> payload = payload_generator_->generate_payload(xfer_size_bytes);
+
+            Common::DeviceDataUpdater::update_linear_write(payload, device_data, worker_range, is_mcast_);
+
+            HostMemDeviceCommand cmd =
+                Common::CommandBuilder::build_linear_write_command<flush_prefetch_, inline_data_>(
+                    payload, worker_range, is_mcast_, noc_xy, addr, xfer_size_bytes);
+
+            commands_per_iteration.push_back(std::move(cmd));
+            remaining_bytes -= xfer_size_bytes;
+        }
+
+        return commands_per_iteration;
+    }
+
+    uint32_t get_transfer_size_bytes() const { return transfer_size_bytes_; }
+    uint32_t get_num_iterations() const { return num_iterations_; }
+    uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
+    bool get_is_mcast() const { return is_mcast_; }
+
+private:
+    static constexpr uint32_t MAX_XFER_SIZE_16B = 4 * 1024;
+};
+
+TEST_P(DispatchLinearWriteSDTestFixture, LinearWrite) {
+    log_info(tt::LogTest, "DispatchLinearWriteSDTestFixture - LinearWrite (Slow Dispatch) - Test Start");
+
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+    const uint32_t total_target_bytes = get_transfer_size_bytes();
+    const bool is_mcast = get_is_mcast();
+
+    ASSERT_EQ(total_target_bytes % 16, 0) << "Require 16B alignment for write payload";
+
+    log_info(
+        tt::LogTest,
+        "Target total: {} bytes, Iterations: {}, Multicast: {}",
+        total_target_bytes,
+        num_iterations,
+        is_mcast);
+
+    const CoreCoord first_worker = default_worker_start;
+    CoreCoord last_worker = first_worker;
+    if (is_mcast) {
+        last_worker = {first_worker.x + 1, first_worker.y + 1};
+    }
+    const CoreRange worker_range = {first_worker, last_worker};
+
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
+
+    Common::DeviceData device_data(
+        device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
+
+    DeviceCommandCalculator cmd_calc;
+    cmd_calc.add_dispatch_write_linear<flush_prefetch_, inline_data_>(0);
+    const uint32_t overhead_bytes = cmd_calc.write_offset_bytes();
+    const uint32_t max_payload_per_cmd_bytes = max_fetch_bytes_ - overhead_bytes;
+
+    const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
+    uint32_t noc_xy;
+    if (is_mcast) {
+        const CoreCoord last_virt_worker = device_->virtual_core_from_logical_core(last_worker, CoreType::WORKER);
+        noc_xy = device_->get_noc_multicast_encoding(
+            k_dispatch_downstream_noc, CoreRange(first_virt_worker, last_virt_worker));
+    } else {
+        noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+    }
+
+    auto commands_per_iteration =
+        generate_linear_write_commands(worker_range, noc_xy, max_payload_per_cmd_bytes, device_data);
+
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    DispatchLinearWriteSDTestFixture,
+    ::testing::Values(
+        // Testcase: 49152 bytes (Unicast)
+        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        // Testcase: 196608 bytes (Unicast)
+        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        // Testcase: 49152 bytes (Multicast)
+        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        // Testcase: 196608 bytes (Multicast)
+        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<LinearWriteParams>& info) {
+        return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
+               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_" +
+               (info.param.is_mcast ? "mcast" : "unicast");
+    });
+
+// --- Slow Dispatch (SD) paged write test ---
+class DispatchPagedWriteSDTestFixture : public Common::SlowDispatchBaseTestFixture,
+                                        public ::testing::WithParamInterface<PagedWriteParams> {
+    uint32_t page_size_{};
+    uint32_t num_pages_{};
+    uint32_t num_iterations_{};
+    uint32_t dram_data_size_words_{};
+    bool is_dram_{};
+
+    CoreCoord get_bank_core(uint32_t bank_id) const {
+        if (is_dram_) {
+            const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
+            return device_->logical_core_from_dram_channel(dram_channel);
+        }
+        return device_->allocator_impl()->get_logical_core_from_bank_id(bank_id);
+    }
+
+protected:
+    static constexpr bool inline_data_ = true;
+    static constexpr uint32_t MAX_XFER_SIZE_16B = 4 * 1024;
+
+public:
+    void SetUp() override {
+        Common::SlowDispatchBaseTestFixture::SetUp();
+        if (IsSkipped()) {
+            return;
+        }
+        const auto params = GetParam();
+        page_size_ = params.page_size;
+        num_pages_ = params.num_pages;
+        num_iterations_ = params.num_iterations;
+        dram_data_size_words_ = params.dram_data_size_words;
+        is_dram_ = params.is_dram;
+    }
+
+    std::vector<HostMemDeviceCommand> generate_paged_write_commands(
+        uint32_t page_size_bytes,
+        uint32_t page_size_alignment_bytes,
+        uint32_t num_banks,
+        uint32_t max_payload_per_cmd_bytes,
+        tt::CoreType core_type,
+        Common::DeviceData& device_data) {
+        std::vector<HostMemDeviceCommand> commands_per_iteration;
+        const uint32_t page_size_words = page_size_bytes / sizeof(uint32_t);
+
+        uint32_t remaining_pages = num_pages_;
+        uint32_t absolute_start_page = 0;
+
+        while (remaining_pages > 0) {
+            const uint32_t max_pages_in_chunk = max_payload_per_cmd_bytes / page_size_bytes;
+            const uint32_t pages_in_chunk = std::min(remaining_pages, max_pages_in_chunk);
+
+            std::vector<uint32_t> chunk_payload;
+            chunk_payload.reserve(pages_in_chunk * page_size_words);
+
+            for (uint32_t page = 0; page < pages_in_chunk; ++page) {
+                const uint32_t page_id = absolute_start_page + page;
+                const uint32_t bank_id = page_id % num_banks;
+                CoreCoord bank_core = get_bank_core(bank_id);
+                std::vector<uint32_t> page_payload =
+                    payload_generator_->generate_payload_with_page_id(page_size_words, page_id);
+                Common::DeviceDataUpdater::update_paged_write(
+                    page_payload, device_data, bank_core, bank_id, page_size_alignment_bytes);
+                chunk_payload.insert(chunk_payload.end(), page_payload.begin(), page_payload.end());
+            }
+
+            const uint32_t bank_offset =
+                tt::align(page_size_bytes, page_size_alignment_bytes) * (absolute_start_page / num_banks);
+            const uint32_t base_addr = device_data.get_base_result_addr(core_type) + bank_offset;
+            const uint16_t start_page_cmd = absolute_start_page % num_banks;
+
+            HostMemDeviceCommand cmd = Common::CommandBuilder::build_paged_write_command<inline_data_>(
+                chunk_payload, base_addr, page_size_bytes, pages_in_chunk, start_page_cmd, is_dram_);
+            commands_per_iteration.push_back(std::move(cmd));
+
+            remaining_pages -= pages_in_chunk;
+            absolute_start_page += pages_in_chunk;
+        }
+
+        log_info(
+            tt::LogTest,
+            "Generated {} paged write command chunks for {} total pages",
+            commands_per_iteration.size(),
+            num_pages_);
+
+        return commands_per_iteration;
+    }
+
+    uint32_t get_page_size() const { return page_size_; }
+    uint32_t get_num_pages() const { return num_pages_; }
+    uint32_t get_num_iterations() const { return num_iterations_; }
+    uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
+    bool get_is_dram() const { return is_dram_; }
+};
+
+TEST_P(DispatchPagedWriteSDTestFixture, PagedWrite) {
+    log_info(tt::LogTest, "DispatchPagedWriteSDTestFixture - PagedWrite (Slow Dispatch) - Test Start");
+
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+    const uint32_t num_pages_per_cmd = get_num_pages();
+    const uint32_t page_size_bytes_param = get_page_size();
+    const bool is_dram = get_is_dram();
+
+    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+    const CoreRange worker_range = {first_worker, last_worker};
+
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
+
+    Common::DeviceData device_data(
+        device_, worker_range, l1_base, dram_base, nullptr, true, dram_data_size_words, cfg_);
+
+    const auto buf_type = is_dram ? BufferType::DRAM : BufferType::L1;
+    const uint32_t page_size_alignment_bytes = device_->allocator_impl()->get_alignment(buf_type);
+    const uint32_t num_banks = device_->allocator_impl()->get_num_banks(buf_type);
+    const tt::CoreType core_type = is_dram ? tt::CoreType::DRAM : tt::CoreType::WORKER;
+
+    uint32_t max_allowed = MAX_XFER_SIZE_16B - 1;
+    uint32_t page_size_bytes =
+        payload_generator_->get_random_size(max_allowed, bytes_per_16B_unit, page_size_bytes_param);
+
+    DeviceCommandCalculator cmd_calc;
+    cmd_calc.add_dispatch_write_paged<inline_data_>(page_size_bytes, 0);
+    const uint32_t overhead_bytes = cmd_calc.write_offset_bytes();
+    const uint32_t max_payload_per_cmd_bytes = max_fetch_bytes_ - overhead_bytes;
+
+    log_info(
+        tt::LogTest,
+        "Paged Write test to {} - random page_size: {} bytes, num_pages_per_cmd: {}, iterations: {}",
+        is_dram ? "DRAM" : "L1",
+        page_size_bytes,
+        num_pages_per_cmd,
+        num_iterations);
+
+    auto commands_per_iteration = generate_paged_write_commands(
+        page_size_bytes, page_size_alignment_bytes, num_banks, max_payload_per_cmd_bytes, core_type, device_data);
+
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    DispatchPagedWriteSDTestFixture,
+    // L1 paged writes (is_dram=false) are excluded from SD mode: process_write_paged<false> requires
+    // L1 bank coordinate setup via CRTA that the SD spoof-prefetch fixture does not provide.
+    ::testing::Values(
+        PagedWriteParams{16, 512, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedWriteParams{4128, 10, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedWriteParams{8192, 100, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedWriteParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + (info.param.is_dram ? "dram" : "l1");
+    });
+
+// --- Slow Dispatch (SD) packed write test ---
+class DispatchPackedWriteSDTestFixture : public Common::SlowDispatchBaseTestFixture,
+                                         public ::testing::WithParamInterface<PackedWriteParams> {
+    uint32_t transfer_size_bytes_{};
+    uint32_t num_iterations_{};
+    uint32_t dram_data_size_words_{};
+
+    uint32_t clamp_to_max_fetch(
+        uint32_t xfer_size_bytes,
+        uint32_t num_sub_cmds,
+        uint32_t packed_write_max_unicast_sub_cmds,
+        bool no_stride,
+        uint32_t l1_alignment) {
+        return Common::PackedWriteUtils::clamp_to_max_fetch(
+            max_fetch_bytes_,
+            xfer_size_bytes,
+            num_sub_cmds,
+            packed_write_max_unicast_sub_cmds,
+            no_stride,
+            l1_alignment);
+    }
+
+public:
+    void SetUp() override {
+        Common::SlowDispatchBaseTestFixture::SetUp();
+        if (IsSkipped()) {
+            return;
+        }
+        const auto params = GetParam();
+        transfer_size_bytes_ = params.transfer_size_bytes;
+        num_iterations_ = params.num_iterations;
+        dram_data_size_words_ = params.dram_data_size_words;
+    }
+
+    std::vector<HostMemDeviceCommand> generate_packed_write_commands(
+        const std::vector<CoreCoord>& worker_cores,
+        uint32_t l1_alignment,
+        uint32_t packed_write_max_unicast_sub_cmds,
+        Common::DeviceData& device_data) {
+        std::vector<HostMemDeviceCommand> commands_per_iteration;
+
+        uint32_t remaining_bytes = get_transfer_size_bytes();
+
+        const uint32_t num_sub_cmds = static_cast<uint32_t>(worker_cores.size());
+        const uint32_t sub_cmds_bytes =
+            tt::align(num_sub_cmds * sizeof(CQDispatchWritePackedUnicastSubCmd), l1_alignment);
+
+        std::vector<CQDispatchWritePackedUnicastSubCmd> sub_cmds =
+            Common::PackedWriteUtils::build_sub_cmds(device_, worker_cores, k_dispatch_downstream_noc);
+
+        device_data.relevel(tt::CoreType::WORKER);
+        constexpr uint32_t payload_unit = sizeof(uint32_t);
+
+        // SD ring buffer page budget: dispatch_buffer_pages - 1 (terminate page)
+        const uint32_t page_size = Common::SD_DISPATCH_BUFFER_PAGE_SIZE;
+        const uint32_t dispatch_buffer_pages = Common::SD_DISPATCH_BUFFER_SIZE_BYTES / page_size;
+        uint32_t pages_used = 0;
+
+        while (remaining_bytes > payload_unit) {
+            uint32_t xfer_size_bytes = payload_generator_->get_random_size(
+                dispatch_buffer_page_size_ / payload_unit, payload_unit, remaining_bytes);
+
+            bool no_stride = payload_generator_->get_rand_bool();
+
+            if (no_stride) {
+                const uint32_t max_allowed = dispatch_buffer_page_size_ - sizeof(CQDispatchCmd) - sub_cmds_bytes;
+                if (xfer_size_bytes > max_allowed) {
+                    xfer_size_bytes = max_allowed;
+                }
+            }
+            uint32_t prev_xfer_size_bytes = xfer_size_bytes;
+
+            xfer_size_bytes = clamp_to_max_fetch(
+                xfer_size_bytes, num_sub_cmds, packed_write_max_unicast_sub_cmds, no_stride, l1_alignment);
+
+            // Conservative page budget check: stop before total command bytes exceed the
+            // dispatch ring buffer size (768 KB). Spoof core L1 can hold more, but this
+            // bounds the single-iteration command set to a predictable size.
+            uint32_t num_data_copies = no_stride ? 1u : num_sub_cmds;
+            uint32_t cmd_advance =
+                sizeof(CQDispatchCmd) + sub_cmds_bytes + num_data_copies * tt::align(xfer_size_bytes, l1_alignment);
+            uint32_t cmd_pages = (cmd_advance + page_size - 1) / page_size;
+            if (pages_used + cmd_pages + 1 > dispatch_buffer_pages) {
+                break;  // no room for this command plus the terminate page
+            }
+
+            const CoreCoord& fw = worker_cores[0];
+            uint32_t common_addr = device_data.get_result_data_addr(fw);
+
+            std::vector<uint32_t> payload = payload_generator_->generate_payload_with_core(fw, xfer_size_bytes);
+            TT_FATAL(
+                !payload.empty(),
+                "Generated payload size is 0, xfer_size_bytes: {}, prev_xfer_size_bytes: {}",
+                xfer_size_bytes,
+                prev_xfer_size_bytes);
+
+            Common::DeviceDataUpdater::update_packed_write(payload, device_data, worker_cores, l1_alignment);
+
+            HostMemDeviceCommand cmd = Common::CommandBuilder::build_packed_write_command(
+                payload, sub_cmds, common_addr, l1_alignment, packed_write_max_unicast_sub_cmds, no_stride);
+
+            commands_per_iteration.push_back(std::move(cmd));
+            pages_used += cmd_pages;
+            remaining_bytes -= xfer_size_bytes;
+        }
+
+        log_info(
+            tt::LogTest,
+            "Generated {} packed write commands totaling {} bytes",
+            commands_per_iteration.size(),
+            transfer_size_bytes_ - remaining_bytes);
+
+        return commands_per_iteration;
+    }
+
+    uint32_t get_transfer_size_bytes() const { return transfer_size_bytes_; }
+    uint32_t get_num_iterations() const { return num_iterations_; }
+    uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
+};
+
+TEST_P(DispatchPackedWriteSDTestFixture, WritePackedUnicast) {
+    log_info(tt::LogTest, "DispatchPackedWriteSDTestFixture - WritePackedUnicast (Slow Dispatch) - Test Start");
+
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+    const uint32_t total_target_bytes = get_transfer_size_bytes();
+
+    log_info(tt::LogTest, "Target total: {} bytes, Iterations: {}", total_target_bytes, num_iterations);
+
+    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+    const CoreRange worker_range = {first_worker, last_worker};
+
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
+
+    Common::DeviceData device_data(
+        device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
+
+    const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    const uint32_t packed_write_max_unicast_sub_cmds =
+        device_->compute_with_storage_grid_size().x * device_->compute_with_storage_grid_size().y;
+
+    std::vector<CoreCoord> worker_cores;
+    for (uint32_t y = worker_range.start_coord.y; y <= worker_range.end_coord.y; ++y) {
+        for (uint32_t x = worker_range.start_coord.x; x <= worker_range.end_coord.x; ++x) {
+            if (send_to_all_ || payload_generator_->get_rand_bool()) {
+                worker_cores.push_back({x, y});
+            }
+        }
+    }
+    if (worker_cores.empty()) {
+        worker_cores.push_back(default_worker_start);
+    }
+
+    ASSERT_LE(worker_cores.size(), packed_write_max_unicast_sub_cmds);
+
+    auto commands_per_iteration =
+        generate_packed_write_commands(worker_cores, l1_alignment, packed_write_max_unicast_sub_cmds, device_data);
+
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    DispatchPackedWriteSDTestFixture,
+    ::testing::Values(
+        PackedWriteParams{786432, DEFAULT_ITERATIONS_PACKED_WRITE, Common::DRAM_DATA_SIZE_WORDS},
+        PackedWriteParams{819200, DEFAULT_ITERATIONS_PACKED_WRITE, Common::DRAM_DATA_SIZE_WORDS}),
+    [](const testing::TestParamInfo<PackedWriteParams>& info) {
+        return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
+               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
+    });
+
+// --- Slow Dispatch (SD) packed-large multicast write test ---
+class DispatchPackedWriteLargeSDTestFixture : public Common::SlowDispatchBaseTestFixture,
+                                              public ::testing::WithParamInterface<PackedWriteParams> {
+    static constexpr uint32_t max_pages_per_transaction = 4;
+
+    uint32_t transfer_size_bytes_{};
+    uint32_t num_iterations_{};
+    uint32_t dram_data_size_words_{};
+
+    struct TransactionBatch {
+        std::vector<uint32_t> sizes;
+        uint32_t total_payload_bytes;
+    };
+
+    TransactionBatch generate_packed_large_transactions(
+        uint32_t& remaining_bytes, uint32_t max_transactions, uint32_t l1_alignment) {
+        std::vector<uint32_t> transaction_sizes;
+        transaction_sizes.reserve(max_transactions);
+        uint32_t cumulative_payload_bytes = 0;
+
+        for (int i = 0; i < (int)max_transactions && remaining_bytes > 0; i++) {
+            uint32_t max_allowed = dispatch_buffer_page_size_ * max_pages_per_transaction / l1_alignment;
+            uint32_t xfer_size_bytes =
+                payload_generator_->get_random_size(max_allowed, bytes_per_16B_unit, remaining_bytes);
+
+            DeviceCommandCalculator cmd_calc;
+            cmd_calc.add_dispatch_write_packed_large(
+                transaction_sizes.size() + 1, cumulative_payload_bytes + xfer_size_bytes);
+            if (cmd_calc.write_offset_bytes() > max_fetch_bytes_) {
+                break;
+            }
+
+            transaction_sizes.push_back(xfer_size_bytes);
+            cumulative_payload_bytes += xfer_size_bytes;
+            remaining_bytes -= xfer_size_bytes;
+        }
+
+        return TransactionBatch{transaction_sizes, cumulative_payload_bytes};
+    }
+
+public:
+    void SetUp() override {
+        Common::SlowDispatchBaseTestFixture::SetUp();
+        if (IsSkipped()) {
+            return;
+        }
+        const auto params = GetParam();
+        transfer_size_bytes_ = params.transfer_size_bytes;
+        num_iterations_ = params.num_iterations;
+        dram_data_size_words_ = params.dram_data_size_words;
+    }
+
+    std::vector<HostMemDeviceCommand> generate_packed_large_write_commands(
+        const CoreRange& worker_range, uint32_t l1_alignment, Common::DeviceData& device_data) {
+        std::vector<HostMemDeviceCommand> commands_per_iteration;
+        uint32_t remaining_bytes = transfer_size_bytes_;
+
+        const CoreCoord virtual_start =
+            device_->virtual_core_from_logical_core(worker_range.start_coord, CoreType::WORKER);
+        const CoreCoord virtual_end = device_->virtual_core_from_logical_core(worker_range.end_coord, CoreType::WORKER);
+        const uint32_t num_mcast_dests = (worker_range.end_coord.x - worker_range.start_coord.x + 1) *
+                                         (worker_range.end_coord.y - worker_range.start_coord.y + 1);
+
+        device_data.relevel(worker_range);
+
+        // SD page budget: dispatch_buffer_pages minus one page reserved for terminate
+        const uint32_t page_size = Common::SD_DISPATCH_BUFFER_PAGE_SIZE;
+        const uint32_t dispatch_buffer_pages = Common::SD_DISPATCH_BUFFER_SIZE_BYTES / page_size;
+        uint32_t pages_used = 0;
+
+        while (remaining_bytes > 0) {
+            const int max_transactions =
+                payload_generator_->get_rand<int>(1, CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS);
+
+            TransactionBatch batch =
+                generate_packed_large_transactions(remaining_bytes, max_transactions, l1_alignment);
+            if (batch.sizes.empty()) {
+                break;
+            }
+
+            // Estimate ring buffer pages this command will consume
+            size_t sub_cmds_bytes = batch.sizes.size() * sizeof(CQDispatchWritePackedLargeSubCmd);
+            size_t data_start = tt::align(sizeof(CQDispatchCmd) + sub_cmds_bytes, l1_alignment);
+            size_t data_bytes = 0;
+            for (uint32_t sz : batch.sizes) {
+                data_bytes += tt::align(sz, l1_alignment);
+            }
+            uint32_t cmd_pages = (uint32_t)((data_start + data_bytes + page_size - 1) / page_size);
+            if (pages_used + cmd_pages + 1 > dispatch_buffer_pages) {
+                break;
+            }
+
+            std::vector<CQDispatchWritePackedLargeSubCmd> sub_cmds;
+            std::vector<std::vector<uint32_t>> payloads;
+            sub_cmds.reserve(batch.sizes.size());
+            payloads.reserve(batch.sizes.size());
+
+            for (const uint32_t xfer_size_bytes : batch.sizes) {
+                const CoreCoord& fw = worker_range.start_coord;
+                uint32_t addr = device_data.get_result_data_addr(fw);
+
+                CQDispatchWritePackedLargeSubCmd sub_cmd{};
+                sub_cmd.noc_xy_addr = device_->get_noc_multicast_encoding(
+                    k_dispatch_downstream_noc, CoreRange(virtual_start, virtual_end));
+                sub_cmd.addr = addr;
+                sub_cmd.length_minus1 = static_cast<uint16_t>(xfer_size_bytes) - 1;
+                sub_cmd.num_mcast_dests = num_mcast_dests;
+                sub_cmd.flags = CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK;
+                sub_cmds.push_back(sub_cmd);
+
+                std::vector<uint32_t> payload = payload_generator_->generate_payload_with_core(fw, xfer_size_bytes);
+                DeviceDataUpdater::update_packed_large_write(payload, device_data, worker_range, l1_alignment);
+                payloads.push_back(std::move(payload));
+            }
+
+            HostMemDeviceCommand cmd = CommandBuilder::build_packed_large_write_command(
+                sub_cmds, payloads, batch.total_payload_bytes, l1_alignment);
+
+            log_info(
+                tt::LogTest,
+                "SD: generated packed-large command {} with {} transactions, {} bytes",
+                commands_per_iteration.size(),
+                sub_cmds.size(),
+                batch.total_payload_bytes);
+
+            commands_per_iteration.push_back(std::move(cmd));
+            pages_used += cmd_pages;
+        }
+
+        log_info(tt::LogTest, "SD: generated {} packed-large commands total", commands_per_iteration.size());
+        return commands_per_iteration;
+    }
+
+    uint32_t get_transfer_size_bytes() const { return transfer_size_bytes_; }
+    uint32_t get_num_iterations() const { return num_iterations_; }
+    uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
+};
+
+TEST_P(DispatchPackedWriteLargeSDTestFixture, WriteLargePackedMulticast) {
+    log_info(
+        tt::LogTest, "DispatchPackedWriteLargeSDTestFixture - WriteLargePackedMulticast (Slow Dispatch) - Test Start");
+
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+    const uint32_t total_target_bytes = get_transfer_size_bytes();
+
+    log_info(tt::LogTest, "Max transfer: {} bytes, Iterations: {}", total_target_bytes, num_iterations);
+
+    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+    const CoreRange worker_range = {first_worker, last_worker};
+
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
+
+    Common::DeviceData device_data(
+        device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
+
+    const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
+
+    auto commands_per_iteration = generate_packed_large_write_commands(worker_range, l1_alignment, device_data);
+
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    DispatchPackedWriteLargeSDTestFixture,
+    ::testing::Values(
+        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS},
+        // Generator has page budget tracking; stops early if spoof core L1 would overflow.
+        PackedWriteParams{409600, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS}),
+    [](const testing::TestParamInfo<PackedWriteParams>& info) {
+        return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
+               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
+    });
+
+// --- Slow Dispatch (SD) packed-large unicast write test ---
+class DispatchPackedWriteLargeUnicastSDTestFixture : public Common::SlowDispatchBaseTestFixture,
+                                                     public ::testing::WithParamInterface<PackedWriteParams> {
+    static constexpr uint32_t max_pages_per_transaction = 4;
+
+    uint32_t transfer_size_bytes_{};
+    uint32_t num_iterations_{};
+    uint32_t dram_data_size_words_{};
+
+    struct TransactionBatch {
+        std::vector<uint32_t> sizes;
+        uint32_t total_payload_bytes;
+    };
+
+    TransactionBatch generate_packed_large_unicast_transactions(
+        uint32_t& remaining_bytes, uint32_t max_transactions, uint32_t l1_alignment) {
+        std::vector<uint32_t> transaction_sizes;
+        transaction_sizes.reserve(max_transactions);
+        uint32_t cumulative_payload_bytes = 0;
+
+        for (int i = 0; i < (int)max_transactions && remaining_bytes > 0; i++) {
+            uint32_t max_allowed = dispatch_buffer_page_size_ * max_pages_per_transaction / l1_alignment;
+            uint32_t xfer_size_bytes =
+                payload_generator_->get_random_size(max_allowed, bytes_per_16B_unit, remaining_bytes);
+
+            DeviceCommandCalculator cmd_calc;
+            cmd_calc.add_dispatch_write_packed_large_unicast(
+                transaction_sizes.size() + 1, cumulative_payload_bytes + xfer_size_bytes);
+            if (cmd_calc.write_offset_bytes() > max_fetch_bytes_) {
+                break;
+            }
+
+            transaction_sizes.push_back(xfer_size_bytes);
+            cumulative_payload_bytes += xfer_size_bytes;
+            remaining_bytes -= xfer_size_bytes;
+        }
+
+        return TransactionBatch{transaction_sizes, cumulative_payload_bytes};
+    }
+
+public:
+    void SetUp() override {
+        Common::SlowDispatchBaseTestFixture::SetUp();
+        if (IsSkipped()) {
+            return;
+        }
+        const auto params = GetParam();
+        transfer_size_bytes_ = params.transfer_size_bytes;
+        num_iterations_ = params.num_iterations;
+        dram_data_size_words_ = params.dram_data_size_words;
+    }
+
+    std::vector<HostMemDeviceCommand> generate_packed_large_unicast_write_commands(
+        const std::vector<CoreCoord>& worker_cores, uint32_t l1_alignment, Common::DeviceData& device_data) {
+        std::vector<HostMemDeviceCommand> commands_per_iteration;
+        uint32_t remaining_bytes = transfer_size_bytes_;
+
+        // SD page budget: dispatch_buffer_pages minus one page reserved for terminate
+        const uint32_t page_size = Common::SD_DISPATCH_BUFFER_PAGE_SIZE;
+        const uint32_t dispatch_buffer_pages = Common::SD_DISPATCH_BUFFER_SIZE_BYTES / page_size;
+        uint32_t pages_used = 0;
+
+        while (remaining_bytes > 0) {
+            const int max_transactions =
+                payload_generator_->get_rand<int>(1, CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS);
+
+            TransactionBatch batch =
+                generate_packed_large_unicast_transactions(remaining_bytes, max_transactions, l1_alignment);
+            if (batch.sizes.empty()) {
+                break;
+            }
+
+            // Estimate ring buffer pages this command will consume
+            size_t sub_cmds_bytes = batch.sizes.size() * sizeof(CQDispatchWritePackedLargeUnicastSubCmd);
+            size_t data_start = tt::align(sizeof(CQDispatchCmd) + sub_cmds_bytes, l1_alignment);
+            size_t data_bytes = 0;
+            for (uint32_t sz : batch.sizes) {
+                data_bytes += tt::align(sz, l1_alignment);
+            }
+            uint32_t cmd_pages = (uint32_t)((data_start + data_bytes + page_size - 1) / page_size);
+            if (pages_used + cmd_pages + 1 > dispatch_buffer_pages) {
+                break;
+            }
+
+            std::vector<CQDispatchWritePackedLargeUnicastSubCmd> sub_cmds;
+            std::vector<std::vector<uint32_t>> payloads;
+            sub_cmds.reserve(batch.sizes.size());
+            payloads.reserve(batch.sizes.size());
+
+            for (const uint32_t xfer_size_bytes : batch.sizes) {
+                const CoreCoord& worker_core =
+                    worker_cores[payload_generator_->get_rand<size_t>(0, worker_cores.size() - 1)];
+                bool is_discard = payload_generator_->get_rand<int>(0, 4) == 0;
+
+                CQDispatchWritePackedLargeUnicastSubCmd sub_cmd{};
+                if (is_discard) {
+                    sub_cmd.noc_xy_addr = 0;
+                    sub_cmd.addr = CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_ADDR_DISCARD;
+                } else {
+                    const CoreCoord virtual_coord =
+                        device_->virtual_core_from_logical_core(worker_core, CoreType::WORKER);
+                    sub_cmd.noc_xy_addr = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, virtual_coord);
+                    sub_cmd.addr = device_data.get_result_data_addr(worker_core);
+                }
+                sub_cmd.length = xfer_size_bytes;
+                sub_cmds.push_back(sub_cmd);
+
+                std::vector<uint32_t> payload =
+                    payload_generator_->generate_payload_with_core(worker_core, xfer_size_bytes);
+                if (!is_discard) {
+                    DeviceDataUpdater::update_packed_large_unicast_write(
+                        payload, device_data, worker_core, l1_alignment);
+                }
+                payloads.push_back(std::move(payload));
+            }
+
+            HostMemDeviceCommand cmd = CommandBuilder::build_packed_large_unicast_write_command(
+                sub_cmds, payloads, batch.total_payload_bytes, l1_alignment);
+
+            log_info(
+                tt::LogTest,
+                "SD: generated packed-large unicast command {} with {} transactions, {} bytes",
+                commands_per_iteration.size(),
+                sub_cmds.size(),
+                batch.total_payload_bytes);
+
+            commands_per_iteration.push_back(std::move(cmd));
+            pages_used += cmd_pages;
+        }
+
+        log_info(tt::LogTest, "SD: generated {} packed-large unicast commands total", commands_per_iteration.size());
+        return commands_per_iteration;
+    }
+
+    uint32_t get_transfer_size_bytes() const { return transfer_size_bytes_; }
+    uint32_t get_num_iterations() const { return num_iterations_; }
+    uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
+};
+
+TEST_P(DispatchPackedWriteLargeUnicastSDTestFixture, WriteLargePackedUnicast) {
+    log_info(
+        tt::LogTest,
+        "DispatchPackedWriteLargeUnicastSDTestFixture - WriteLargePackedUnicast (Slow Dispatch) - Test Start");
+
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+    const uint32_t total_target_bytes = get_transfer_size_bytes();
+
+    log_info(tt::LogTest, "Max transfer: {} bytes, Iterations: {}", total_target_bytes, num_iterations);
+
+    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+    const CoreRange worker_range = {first_worker, last_worker};
+
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
+
+    Common::DeviceData device_data(
+        device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
+
+    const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
+
+    std::vector<CoreCoord> worker_cores;
+    for (uint32_t y = worker_range.start_coord.y; y <= worker_range.end_coord.y; ++y) {
+        for (uint32_t x = worker_range.start_coord.x; x <= worker_range.end_coord.x; ++x) {
+            worker_cores.push_back({x, y});
+        }
+    }
+
+    auto commands_per_iteration = generate_packed_large_unicast_write_commands(worker_cores, l1_alignment, device_data);
+
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    DispatchPackedWriteLargeUnicastSDTestFixture,
+    ::testing::Values(
+        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS},
+        // Generator has page budget tracking; stops early if spoof core L1 would overflow.
+        PackedWriteParams{409600, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS}),
+    [](const testing::TestParamInfo<PackedWriteParams>& info) {
+        return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
+               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
+    });
+
 }  // namespace tt::tt_metal::tt_dispatch_tests::dispatcher_tests

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -20,25 +20,31 @@
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h"
 
 /*
- * FAST DISPATCHER MICROBENCHMARK SUITE
+ * DISPATCHER MICROBENCHMARK SUITE (Fast Dispatch + Slow Dispatch)
  *
  * Architecture Overview:
- * This test suite validates the Fast Dispatcher (FD) kernel mechanisms by bypassing the
- * standard high-level Enqueue APIs and directly constructing low-level command sequences.
+ * This test suite validates the Dispatcher kernel in both Fast Dispatch (FD) and Slow Dispatch (SD)
+ * modes by bypassing the standard high-level Enqueue APIs and directly constructing low-level command sequences.
  *
  * The test flow follows a "Shadow Model" pattern:
  * 1. Plan: Determine transfer sizes, destinations, and command types.
  * 2. Shadow: Update `Common::DeviceData` (the expectation model) to reflect what should happen.
  * 3. Build: Use `DeviceCommand` and `DeviceCommandCalculator` to construct binary
  *    command packets (HostMemDeviceCommand) exactly as the runtime would.
- * 4. Execute and Validate: Push these raw commands directly into the Issue Queue and notify the hardware.
- *    Read back device memory and compare against `Common::DeviceData` to validate the correctness of the command
- * execution.
+ * 4. Execute and Validate: Push commands to the hardware and validate device memory against
+ *    `Common::DeviceData`.
+ *
+ * Execution backends:
+ * - FD: Commands are pushed into the Issue Queue via FDMeshCommandQueue; the Prefetcher relays
+ *   them to the Dispatcher.
+ * - SD: Commands are serialized into a flat L1 buffer; spoof_prefetch.cpp replaces the real
+ *   Prefetcher and drives cq_dispatch.cpp directly. Useful for bringup on new hardware where
+ *   the FD host stack is not yet stable.
  *
  * Key Concepts:
- * - Issue Queue: Host-resident ring buffer where commands are written.
+ * - Issue Queue: Host-resident ring buffer where FD commands are written.
  * - Fetch Queue: Device-resident ring buffer (pointers) telling the Prefetcher where to look.
- * - Prefetcher: Kernel that pulls commands from Host/DRAM and relays them.
+ * - Prefetcher: Kernel that pulls commands from Host/DRAM and relays them to the Dispatcher.
  * - Dispatcher: Kernel that parses commands and issues writes/signals to Worker cores.
  */
 
@@ -204,15 +210,17 @@ protected:
     static constexpr bool inline_data_ = true;
     static constexpr bool flush_prefetch_ = true;
 
+    void init_params(const LinearWriteParams& p) {
+        transfer_size_bytes_ = p.transfer_size_bytes;
+        num_iterations_ = p.num_iterations;
+        dram_data_size_words_ = p.dram_data_size_words;
+        is_mcast_ = p.is_mcast;
+    }
+
 public:
     void SetUp() override {
         BaseDispatchTestFixture::SetUp();
-
-        const auto params = GetParam();
-        transfer_size_bytes_ = params.transfer_size_bytes;
-        num_iterations_ = params.num_iterations;
-        dram_data_size_words_ = params.dram_data_size_words;
-        is_mcast_ = params.is_mcast;
+        init_params(GetParam());
     }
 
     // Splits the requested transfer into randomly sized chunks that
@@ -279,6 +287,57 @@ public:
     uint32_t get_num_iterations() const { return num_iterations_; }
     uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
     bool get_is_mcast() const { return is_mcast_; }
+
+    void run_linear_write_test() {
+        const uint32_t num_iterations = get_num_iterations();
+        const uint32_t dram_data_size_words = get_dram_data_size_words();
+        const uint32_t total_target_bytes = get_transfer_size_bytes();
+        const bool is_mcast = get_is_mcast();
+
+        ASSERT_EQ(total_target_bytes % 16, 0) << "Require 16B alignment for write payload";
+
+        log_info(
+            tt::LogTest,
+            "Target total: {} bytes, Iterations: {}, Multicast: {}",
+            total_target_bytes,
+            num_iterations,
+            is_mcast);
+
+        const CoreCoord first_worker = default_worker_start;
+        CoreCoord last_worker = first_worker;
+        if (is_mcast) {
+            last_worker = {first_worker.x + 1, first_worker.y + 1};
+        }
+        const CoreRange worker_range = {first_worker, last_worker};
+
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
+
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
+
+        DeviceCommandCalculator cmd_calc;
+        cmd_calc.add_dispatch_write_linear<flush_prefetch_, inline_data_>(0);
+        const uint32_t overhead_bytes = cmd_calc.write_offset_bytes();
+        const uint32_t max_payload_per_cmd_bytes = max_fetch_bytes_ - overhead_bytes;
+
+        const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
+        uint32_t noc_xy;
+        if (is_mcast) {
+            const CoreCoord last_virt_worker = device_->virtual_core_from_logical_core(last_worker, CoreType::WORKER);
+            noc_xy = device_->get_noc_multicast_encoding(
+                k_dispatch_downstream_noc, CoreRange(first_virt_worker, last_virt_worker));
+        } else {
+            noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+        }
+
+        // PHASE 1: Generate random-sized linear write commands metadata
+        auto commands_per_iteration =
+            generate_linear_write_commands(worker_range, noc_xy, max_payload_per_cmd_bytes, device_data);
+
+        // PHASE 2, 3, 4: Execute and Validate
+        execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    }
 };
 
 // Paged Writes to L1/DRAM
@@ -305,16 +364,18 @@ class DispatchPagedWriteTestFixture : public BaseDispatchTestFixture,
 protected:
     static constexpr bool inline_data_ = true;
 
+    void init_params(const PagedWriteParams& p) {
+        page_size_ = p.page_size;
+        num_pages_ = p.num_pages;
+        num_iterations_ = p.num_iterations;
+        dram_data_size_words_ = p.dram_data_size_words;
+        is_dram_ = p.is_dram;
+    }
+
 public:
     void SetUp() override {
         BaseDispatchTestFixture::SetUp();
-
-        const auto params = GetParam();
-        page_size_ = params.page_size;
-        num_pages_ = params.num_pages;
-        num_iterations_ = params.num_iterations;
-        dram_data_size_words_ = params.dram_data_size_words;
-        is_dram_ = params.is_dram;
+        init_params(GetParam());
     }
 
     // Tiles the requested page count into fetch-sized chunks,
@@ -396,6 +457,53 @@ public:
     uint32_t get_num_iterations() const { return num_iterations_; }
     uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
     bool get_is_dram() const { return is_dram_; }
+
+    void run_paged_write_test() {
+        const uint32_t num_iterations = get_num_iterations();
+        const uint32_t dram_data_size_words = get_dram_data_size_words();
+        const uint32_t num_pages_per_cmd = get_num_pages();
+        const uint32_t page_size_bytes_param = get_page_size();
+        const bool is_dram = get_is_dram();
+
+        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+        const CoreRange worker_range = {first_worker, last_worker};
+
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
+
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base, nullptr, true, dram_data_size_words, cfg_);
+
+        const auto buf_type = is_dram ? BufferType::DRAM : BufferType::L1;
+        const uint32_t page_size_alignment_bytes = device_->allocator_impl()->get_alignment(buf_type);
+        const uint32_t num_banks = device_->allocator_impl()->get_num_banks(buf_type);
+        const tt::CoreType core_type = is_dram ? tt::CoreType::DRAM : tt::CoreType::WORKER;
+
+        uint32_t max_allowed = MAX_XFER_SIZE_16B - 1;
+        uint32_t page_size_bytes =
+            payload_generator_->get_random_size(max_allowed, bytes_per_16B_unit, page_size_bytes_param);
+
+        DeviceCommandCalculator cmd_calc;
+        cmd_calc.add_dispatch_write_paged<inline_data_>(page_size_bytes, 0);
+        const uint32_t overhead_bytes = cmd_calc.write_offset_bytes();
+        const uint32_t max_payload_per_cmd_bytes = max_fetch_bytes_ - overhead_bytes;
+
+        log_info(
+            tt::LogTest,
+            "Paged Write test to {} - random page_size: {} bytes, num_pages_per_cmd: {}, iterations: {}",
+            is_dram ? "DRAM" : "L1",
+            page_size_bytes,
+            num_pages_per_cmd,
+            num_iterations);
+
+        // PHASE 1: Generate paged write command metadata
+        auto commands_per_iteration = generate_paged_write_commands(
+            page_size_bytes, page_size_alignment_bytes, num_banks, max_payload_per_cmd_bytes, core_type, device_data);
+
+        // PHASE 2, 3, 4: Execute and Validate
+        execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    }
 };
 
 class DispatchPackedWriteTestFixture : public BaseDispatchTestFixture,
@@ -420,14 +528,17 @@ class DispatchPackedWriteTestFixture : public BaseDispatchTestFixture,
             l1_alignment);
     };
 
+protected:
+    void init_params(const PackedWriteParams& p) {
+        transfer_size_bytes_ = p.transfer_size_bytes;
+        num_iterations_ = p.num_iterations;
+        dram_data_size_words_ = p.dram_data_size_words;
+    }
+
 public:
     void SetUp() override {
         BaseDispatchTestFixture::SetUp();
-
-        const auto params = GetParam();
-        transfer_size_bytes_ = params.transfer_size_bytes;
-        num_iterations_ = params.num_iterations;
-        dram_data_size_words_ = params.dram_data_size_words;
+        init_params(GetParam());
     }
 
     // Picks a random subset of workers, then emits packed-unicast
@@ -478,8 +589,8 @@ public:
                         "xfer_size_bytes: {}",
                         max_allowed,
                         xfer_size_bytes);
-                    xfer_size_bytes = max_allowed;
                 }
+                xfer_size_bytes = std::min(xfer_size_bytes, max_allowed);
             }
             uint32_t prev_xfer_size_bytes = xfer_size_bytes;
 
@@ -522,6 +633,50 @@ public:
     uint32_t get_transfer_size_bytes() const { return transfer_size_bytes_; }
     uint32_t get_num_iterations() const { return num_iterations_; }
     uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
+
+    void run_packed_write_test() {
+        const uint32_t num_iterations = get_num_iterations();
+        const uint32_t dram_data_size_words = get_dram_data_size_words();
+        const uint32_t total_target_bytes = get_transfer_size_bytes();
+
+        log_info(tt::LogTest, "Target total: {} bytes, Iterations: {}", total_target_bytes, num_iterations);
+
+        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+        const CoreRange worker_range = {first_worker, last_worker};
+
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
+
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
+
+        const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
+        const uint32_t packed_write_max_unicast_sub_cmds =
+            device_->compute_with_storage_grid_size().x * device_->compute_with_storage_grid_size().y;
+
+        std::vector<CoreCoord> worker_cores;
+        for (uint32_t y = worker_range.start_coord.y; y <= worker_range.end_coord.y; ++y) {
+            for (uint32_t x = worker_range.start_coord.x; x <= worker_range.end_coord.x; ++x) {
+                if (send_to_all_ || payload_generator_->get_rand_bool()) {
+                    worker_cores.push_back({x, y});
+                }
+            }
+        }
+
+        if (worker_cores.empty()) {
+            worker_cores.push_back(default_worker_start);
+        }
+
+        ASSERT_LE(worker_cores.size(), packed_write_max_unicast_sub_cmds);
+
+        // PHASE 1: Generate random-sized packed write commands metadata
+        auto commands_per_iteration =
+            generate_packed_write_commands(worker_cores, l1_alignment, packed_write_max_unicast_sub_cmds, device_data);
+
+        // PHASE 2, 3, 4: Execute and Validate
+        execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    }
 };
 
 class DispatchPackedWriteLargeTestFixture : public DispatchPackedWriteTestFixture {
@@ -672,6 +827,33 @@ protected:
 
         return commands_per_iteration;
     }
+
+public:
+    void run_packed_large_write_test() {
+        const uint32_t num_iterations = get_num_iterations();
+        const uint32_t dram_data_size_words = get_dram_data_size_words();
+        const uint32_t total_target_bytes = get_transfer_size_bytes();
+
+        log_info(tt::LogTest, "Max transfer: {} bytes, Iterations: {}", total_target_bytes, num_iterations);
+
+        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+        const CoreRange worker_range = {first_worker, last_worker};
+
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
+
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
+
+        const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
+
+        // PHASE 1: Generate packed-large write commands metadata
+        auto commands_per_iteration = generate_packed_large_write_commands(worker_range, l1_alignment, device_data);
+
+        // PHASE 2, 3, 4: Execute and Validate
+        execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    }
 };
 
 class DispatchPackedWriteLargeUnicastTestFixture : public DispatchPackedWriteTestFixture {
@@ -815,207 +997,243 @@ protected:
 
         return commands_per_iteration;
     }
+
+public:
+    void run_packed_large_unicast_write_test() {
+        const uint32_t num_iterations = get_num_iterations();
+        const uint32_t dram_data_size_words = get_dram_data_size_words();
+        const uint32_t total_target_bytes = get_transfer_size_bytes();
+
+        log_info(tt::LogTest, "Max transfer: {} bytes, Iterations: {}", total_target_bytes, num_iterations);
+
+        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+        const CoreRange worker_range = {first_worker, last_worker};
+
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
+
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
+
+        const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
+
+        std::vector<CoreCoord> worker_cores;
+        for (uint32_t y = worker_range.start_coord.y; y <= worker_range.end_coord.y; ++y) {
+            for (uint32_t x = worker_range.start_coord.x; x <= worker_range.end_coord.x; ++x) {
+                worker_cores.push_back({x, y});
+            }
+        }
+
+        // PHASE 1: Generate packed-large unicast write commands metadata
+        auto commands_per_iteration =
+            generate_packed_large_unicast_write_commands(worker_cores, l1_alignment, device_data);
+
+        // PHASE 2, 3, 4: Execute and Validate
+        execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    }
 };
+
+// Shared SD infrastructure: device lifecycle, execute_generated_commands override, SetUp.
+// FDFixture must expose: device_, cfg_, payload_generator_, dispatch_buffer_page_size_,
+// send_to_all_, max_fetch_bytes_, init_params(GetParam()), and gtest's GetParam().
+template <typename FDFixture>
+class SDDispatchTestBase : public FDFixture {
+public:
+    void SetUp() override {
+        if (!getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
+            GTEST_SKIP() << "Requires TT_METAL_SLOW_DISPATCH_MODE";
+        }
+        this->device_ = tt_metal::CreateDevice(0);
+        Common::DispatchPayloadGenerator::Config pgcfg;
+        pgcfg.use_coherent_data = this->cfg_.use_coherent_data;
+        pgcfg.perf_test = this->cfg_.perf_test;
+        pgcfg.min_xfer_size_bytes = this->cfg_.min_xfer_size_bytes;
+        pgcfg.max_xfer_size_bytes = this->cfg_.max_xfer_size_bytes;
+        std::random_device rd;
+        pgcfg.seed = rd();
+        this->payload_generator_ = std::make_unique<Common::DispatchPayloadGenerator>(pgcfg);
+        log_info(tt::LogTest, "Random seed set to {}", pgcfg.seed);
+        this->dispatch_buffer_page_size_ = this->cfg_.dispatch_buffer_page_size;
+        this->send_to_all_ = this->cfg_.send_to_all;
+        this->max_fetch_bytes_ = tt_metal::MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
+        this->init_params(this->GetParam());
+    }
+
+    void TearDown() override {
+        if (this->device_) {
+            tt_metal::CloseDevice(this->device_);
+            this->device_ = nullptr;
+        }
+    }
+
+    // Executes pre-built dispatch commands via the spoof_prefetch kernel in SD mode.
+    // Serializes commands to a flat L1 buffer, launches spoof_prefetch + cq_dispatch,
+    // then validates results against device_data.
+    //
+    // Layout contract: HostMemDeviceCommand prepends a CQPrefetchCmd relay-inline header and appends
+    // pcie padding. FD's prefetcher strips both, so in SD, we must do the same too. We rely on
+    // relay_inline.length holding the exact dispatch payload size (set by DeviceCommand, before pcie padding).
+    //
+    // num_cores_to_log / wait_for_* are accepted to match the FD virtual signature but unused -
+    // LaunchProgram is synchronous.
+    void execute_generated_commands(
+        const std::vector<HostMemDeviceCommand>& commands_per_iteration,
+        Common::DeviceData& device_data,
+        size_t num_cores_to_log,
+        uint32_t num_iterations,
+        bool wait_for_completion = true,
+        bool wait_for_host_writes = false) override {
+        const uint32_t page_size = Common::SD_DISPATCH_BUFFER_PAGE_SIZE;
+        constexpr size_t prefetch_hdr = sizeof(CQPrefetchCmd);
+
+        // cq_dispatch.cpp page aligns cmd_ptr after every command, so each command starts on its own page
+        auto append_dispatch_payload = [&](std::vector<uint8_t>& v, const HostMemDeviceCommand& cmd) {
+            const size_t content = reinterpret_cast<const CQPrefetchCmd*>(cmd.data())->relay_inline.length;
+            const auto* p = reinterpret_cast<const uint8_t*>(cmd.data()) + prefetch_hdr;
+            v.insert(v.end(), p, p + content);
+            if (uint32_t r = v.size() % page_size) {
+                v.resize(v.size() + (page_size - r), 0);
+            }
+        };
+
+        std::vector<uint8_t> raw;
+        raw.reserve(static_cast<size_t>(num_iterations) * commands_per_iteration.size() * page_size);
+        for (uint32_t i = 0; i < num_iterations; ++i) {
+            for (const auto& cmd : commands_per_iteration) {
+                append_dispatch_payload(raw, cmd);
+            }
+        }
+
+        // Append terminate command as its own page
+        {
+            DeviceCommandCalculator calc;
+            calc.add_dispatch_terminate();
+            HostMemDeviceCommand term_cmd(calc.write_offset_bytes());
+            term_cmd.add_dispatch_terminate();
+            append_dispatch_payload(raw, term_cmd);
+        }
+
+        const uint32_t cmd_cb_pages = raw.size() / page_size;
+        const uint32_t dispatch_buffer_pages = Common::SD_DISPATCH_BUFFER_SIZE_BYTES / page_size;
+        log_info(
+            tt::LogTest,
+            "SD: cmd_cb_pages={} dispatch_buffer_pages={} raw_bytes={}",
+            cmd_cb_pages,
+            dispatch_buffer_pages,
+            raw.size());
+
+        const auto& memmap = tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
+        const uint32_t dispatch_l1_unreserved_base =
+            memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::UNRESERVED);
+        const uint32_t l1_buf_base = tt::align(dispatch_l1_unreserved_base, page_size);
+
+        const auto& soc_desc = tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->device_->id());
+        TT_FATAL(raw.size() + l1_buf_base <= soc_desc.worker_l1_size, "SD command buffer too large for L1");
+        TT_FATAL(
+            Common::SD_DISPATCH_BUFFER_SIZE_BYTES + l1_buf_base <= soc_desc.worker_l1_size,
+            "SD dispatch buffer too large for L1");
+
+        const CoreCoord phys_spoof = this->device_->worker_core_from_logical_core(Common::sd_spoof_prefetch_core);
+        const CoreCoord phys_disp = this->device_->worker_core_from_logical_core(Common::sd_dispatch_core);
+
+        tt_metal::MetalContext::instance().get_cluster().write_core(
+            raw.data(), raw.size(), tt_cxy_pair(this->device_->id(), phys_spoof), l1_buf_base);
+
+        tt_metal::Program program = tt_metal::CreateProgram();
+
+        const uint32_t spoof_prefetch_core_sem_0_id =
+            tt_metal::CreateSemaphore(program, {Common::sd_spoof_prefetch_core}, dispatch_buffer_pages);
+        const uint32_t dispatch_core_sem_id = tt_metal::CreateSemaphore(program, {Common::sd_dispatch_core}, 0);
+        TT_FATAL(
+            dispatch_core_sem_id == spoof_prefetch_core_sem_0_id,
+            "Semaphore IDs must match across spoof and dispatch cores");
+        const uint32_t prefetch_sync_sem = tt_metal::CreateSemaphore(program, {Common::sd_spoof_prefetch_core}, 0);
+
+        const std::vector<uint32_t> spoof_args = {
+            l1_buf_base,                               // 0: dispatch_cb_base
+            Common::SD_LOG_DISPATCH_BUFFER_PAGE_SIZE,  // 1
+            dispatch_buffer_pages,                     // 2
+            dispatch_core_sem_id,                      // 3
+            l1_buf_base,                               // 4: cmd_cb_base (same region, pre-loaded)
+            cmd_cb_pages,                              // 5
+            Common::SD_PREFETCHER_PAGE_BATCH_SIZE,     // 6
+        };
+        const std::map<std::string, std::string> prefetch_defines = {
+            {"DISPATCH_NOC_X", std::to_string(phys_disp.x)},
+            {"DISPATCH_NOC_Y", std::to_string(phys_disp.y)},
+            {"FD_CORE_TYPE", "0"},
+        };
+        auto sp = tt_metal::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/spoof_prefetch.cpp",
+            {Common::sd_spoof_prefetch_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = spoof_args,
+                .defines = prefetch_defines});
+        tt_metal::SetRuntimeArgs(program, sp, Common::sd_spoof_prefetch_core, {1u});
+
+        auto dispatch_defines = Common::make_sd_dispatch_defines(
+            this->device_,
+            l1_buf_base,
+            dispatch_buffer_pages,
+            dispatch_core_sem_id,
+            prefetch_sync_sem,
+            phys_spoof,
+            phys_disp,
+            memmap);
+        auto dispatch_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
+            {Common::sd_dispatch_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::NOC_0,
+                .defines = dispatch_defines});
+        tt_metal::SetRuntimeArgs(program, dispatch_kernel, Common::sd_dispatch_core, {0u, 0u, 0u});
+
+        device_data.overflow_check(this->device_);
+        tt_metal::detail::LaunchProgram(this->device_, program);
+        const bool pass = device_data.validate(this->device_);
+        EXPECT_TRUE(pass) << "SD Dispatcher test failed validation";
+    }
+};
+
+// SD test fixtures: validate the dispatcher kernel in isolation via spoof_prefetch.cpp.
+// Each one only adds SD execution; command generation is inherited unchanged from the FD fixture.
+class DispatchLinearWriteSDTestFixture : public SDDispatchTestBase<DispatchLinearWriteTestFixture> {};
+class DispatchPagedWriteSDTestFixture : public SDDispatchTestBase<DispatchPagedWriteTestFixture> {};
+class DispatchPackedWriteSDTestFixture : public SDDispatchTestBase<DispatchPackedWriteTestFixture> {};
+class DispatchPackedWriteLargeSDTestFixture : public SDDispatchTestBase<DispatchPackedWriteLargeTestFixture> {};
+class DispatchPackedWriteLargeUnicastSDTestFixture
+    : public SDDispatchTestBase<DispatchPackedWriteLargeUnicastTestFixture> {};
 
 // Linear Write Unicast/Multicast
 TEST_P(DispatchLinearWriteTestFixture, LinearWrite) {
     log_info(tt::LogTest, "DispatchLinearWriteTestFixture - LinearWrite (Fast Dispatch) - Test Start");
-
-    // Test parameters
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-    const uint32_t total_target_bytes = get_transfer_size_bytes();  // Total bytes to transfer per iteration
-    const bool is_mcast = get_is_mcast();
-
-    ASSERT_EQ(total_target_bytes % 16, 0) << "Require 16B alignment for write payload";
-
-    log_info(
-        tt::LogTest,
-        "Target total: {} bytes, Iterations: {}, Multicast: {}",
-        total_target_bytes,
-        num_iterations,
-        is_mcast);
-
-    // Setup target worker cores
-    const CoreCoord first_worker = default_worker_start;
-    CoreCoord last_worker = first_worker;
-    if (is_mcast) {
-        last_worker = {first_worker.x + 1, first_worker.y + 1};
-    }
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
-
-    // Calculate the overhead for a linear write command using DeviceCommandCalculator
-    // Substracting the overhead from max_fetch_bytes_ gives the max allowed payload size per command
-    DeviceCommandCalculator cmd_calc;
-    cmd_calc.add_dispatch_write_linear<flush_prefetch_, inline_data_>(0);
-    const uint32_t overhead_bytes = cmd_calc.write_offset_bytes();
-    const uint32_t max_payload_per_cmd_bytes = max_fetch_bytes_ - overhead_bytes;
-
-    // Compute NOC encoding once
-    const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
-    uint32_t noc_xy;
-    if (is_mcast) {
-        const CoreCoord last_virt_worker = device_->virtual_core_from_logical_core(last_worker, CoreType::WORKER);
-        noc_xy = device_->get_noc_multicast_encoding(
-            k_dispatch_downstream_noc, CoreRange(first_virt_worker, last_virt_worker));
-    } else {
-        noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
-    }
-
-    // PHASE 1: Generate random-sized linear write commands metadata
-    auto commands_per_iteration =
-        generate_linear_write_commands(worker_range, noc_xy, max_payload_per_cmd_bytes, device_data);
-
-    // PHASE 2, 3, 4: Execute and Validate
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    run_linear_write_test();
 }
 
 // Paged Write CMD to DRAM/L1
 TEST_P(DispatchPagedWriteTestFixture, PagedWrite) {
     log_info(tt::LogTest, "DispatchPagedWriteTestFixture - PagedWrite (Fast Dispatch) - Test Start");
-
-    // Test parameters
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-    const uint32_t num_pages_per_cmd = get_num_pages();
-    const uint32_t page_size_bytes_param = get_page_size();
-    const bool is_dram = get_is_dram();
-
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base, nullptr, true, dram_data_size_words, cfg_);
-
-    const auto buf_type = is_dram ? BufferType::DRAM : BufferType::L1;
-    const uint32_t page_size_alignment_bytes = device_->allocator_impl()->get_alignment(buf_type);
-    const uint32_t num_banks = device_->allocator_impl()->get_num_banks(buf_type);
-    const tt::CoreType core_type = is_dram ? tt::CoreType::DRAM : tt::CoreType::WORKER;
-
-    // Generate random page size
-    uint32_t max_allowed = MAX_XFER_SIZE_16B - 1;
-    uint32_t page_size_bytes =
-        payload_generator_->get_random_size(max_allowed, bytes_per_16B_unit, page_size_bytes_param);
-
-    // Calculate overhead using DeviceCommandCalculator in CommandSizeHelper
-    // 0 pages for overhead only
-    // Substracting the overhead from max_fetch_bytes_ gives the max allowed payload size per command
-    DeviceCommandCalculator cmd_calc;
-    cmd_calc.add_dispatch_write_paged<inline_data_>(page_size_bytes, 0);
-    const uint32_t overhead_bytes = cmd_calc.write_offset_bytes();
-    const uint32_t max_payload_per_cmd_bytes = max_fetch_bytes_ - overhead_bytes;
-
-    log_info(
-        tt::LogTest,
-        "Paged Write test to {} - random page_size: {} bytes, num_pages_per_cmd: {}, iterations: {}",
-        is_dram ? "DRAM" : "L1",
-        page_size_bytes,
-        num_pages_per_cmd,
-        num_iterations);
-
-    // PHASE 1: Generate paged write command metadata
-    auto commands_per_iteration = generate_paged_write_commands(
-        page_size_bytes, page_size_alignment_bytes, num_banks, max_payload_per_cmd_bytes, core_type, device_data);
-
-    // PHASE 2, 3, 4: Execute and Validate
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    run_paged_write_test();
 }
 
 // Packed Write Unicast
 // TODO: Add multicast support
 TEST_P(DispatchPackedWriteTestFixture, WritePackedUnicast) {
     log_info(tt::LogTest, "DispatchPackedWriteTestFixture - WritePackedUnicast (Fast Dispatch) - Test Start");
-
-    // Test parameters
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-    const uint32_t total_target_bytes = get_transfer_size_bytes();
-
-    log_info(tt::LogTest, "Target total: {} bytes, Iterations: {}", total_target_bytes, num_iterations);
-
-    // Setup target worker cores
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
-
-    const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
-    const uint32_t packed_write_max_unicast_sub_cmds =
-        device_->compute_with_storage_grid_size().x * device_->compute_with_storage_grid_size().y;
-
-    // Randomly pick worker cores once for all commands
-    std::vector<CoreCoord> worker_cores;
-
-    for (uint32_t y = worker_range.start_coord.y; y <= worker_range.end_coord.y; ++y) {
-        for (uint32_t x = worker_range.start_coord.x; x <= worker_range.end_coord.x; ++x) {
-            if (send_to_all_ || payload_generator_->get_rand_bool()) {
-                worker_cores.push_back({x, y});
-            }
-        }
-    }
-
-    if (worker_cores.empty()) {
-        worker_cores.push_back(default_worker_start);
-    }
-
-    ASSERT_LE(worker_cores.size(), packed_write_max_unicast_sub_cmds);
-
-    // PHASE 1: Generate random-sized packed write commands metadata
-    auto commands_per_iteration =
-        generate_packed_write_commands(worker_cores, l1_alignment, packed_write_max_unicast_sub_cmds, device_data);
-
-    // PHASE 2, 3, 4: Execute and Validate
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    run_packed_write_test();
 }
 
 // Large Packed Write - Multiple Commands with Random Transactions
 TEST_P(DispatchPackedWriteLargeTestFixture, WriteLargePackedMulticast) {
     log_info(
         tt::LogTest, "DispatchPackedWriteLargeTestFixture - WriteLargePackedMulticast (Fast Dispatch) - Test Start");
-
-    // Test parameters
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-    const uint32_t total_target_bytes = get_transfer_size_bytes();
-
-    log_info(tt::LogTest, "Max transfer: {} bytes, Iterations: {}", total_target_bytes, num_iterations);
-
-    // Setup worker core range (fixed - no variation)
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    // Get memory base addresses
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
-
-    // Setup Common::DeviceData for validation
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
-
-    // Get alignment requirements
-    const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
-
-    // PHASE 1: Generate packed-large write commands metadata
-    auto commands_per_iteration = generate_packed_large_write_commands(worker_range, l1_alignment, device_data);
-
-    // PHASE 2, 3, 4: Execute and Validate
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    run_packed_large_write_test();
 }
 
 // Large Packed Write Unicast - Multiple Commands with Random Transactions
@@ -1023,43 +1241,41 @@ TEST_P(DispatchPackedWriteLargeUnicastTestFixture, WriteLargePackedUnicast) {
     log_info(
         tt::LogTest,
         "DispatchPackedWriteLargeUnicastTestFixture - WriteLargePackedUnicast (Fast Dispatch) - Test Start");
+    run_packed_large_unicast_write_test();
+}
 
-    // Test parameters
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-    const uint32_t total_target_bytes = get_transfer_size_bytes();
+// Linear Write Unicast/Multicast (SD)
+TEST_P(DispatchLinearWriteSDTestFixture, LinearWrite) {
+    log_info(tt::LogTest, "DispatchLinearWriteSDTestFixture - LinearWrite (Slow Dispatch) - Test Start");
+    run_linear_write_test();
+}
 
-    log_info(tt::LogTest, "Max transfer: {} bytes, Iterations: {}", total_target_bytes, num_iterations);
+// Paged Write CMD to DRAM/L1 (SD)
+TEST_P(DispatchPagedWriteSDTestFixture, PagedWrite) {
+    log_info(tt::LogTest, "DispatchPagedWriteSDTestFixture - PagedWrite (Slow Dispatch) - Test Start");
+    run_paged_write_test();
+}
 
-    // Setup worker cores - pick multiple cores for unicast
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
+// Packed Write Unicast (SD)
+// TODO: Add multicast support
+TEST_P(DispatchPackedWriteSDTestFixture, WritePackedUnicast) {
+    log_info(tt::LogTest, "DispatchPackedWriteSDTestFixture - WritePackedUnicast (Slow Dispatch) - Test Start");
+    run_packed_write_test();
+}
 
-    // Get memory base addresses
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
+// Large Packed Write - Multiple Commands with Random Transactions (SD)
+TEST_P(DispatchPackedWriteLargeSDTestFixture, WriteLargePackedMulticast) {
+    log_info(
+        tt::LogTest, "DispatchPackedWriteLargeSDTestFixture - WriteLargePackedMulticast (Slow Dispatch) - Test Start");
+    run_packed_large_write_test();
+}
 
-    // Setup Common::DeviceData for validation
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
-
-    // Get alignment requirements
-    const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
-
-    // Build list of worker cores
-    std::vector<CoreCoord> worker_cores;
-    for (uint32_t y = worker_range.start_coord.y; y <= worker_range.end_coord.y; ++y) {
-        for (uint32_t x = worker_range.start_coord.x; x <= worker_range.end_coord.x; ++x) {
-            worker_cores.push_back({x, y});
-        }
-    }
-
-    // PHASE 1: Generate packed-large unicast write commands metadata
-    auto commands_per_iteration = generate_packed_large_unicast_write_commands(worker_cores, l1_alignment, device_data);
-
-    // PHASE 2, 3, 4: Execute and Validate
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+// Large Packed Write Unicast - Multiple Commands with Random Transactions (SD)
+TEST_P(DispatchPackedWriteLargeUnicastSDTestFixture, WriteLargePackedUnicast) {
+    log_info(
+        tt::LogTest,
+        "DispatchPackedWriteLargeUnicastSDTestFixture - WriteLargePackedUnicast (Slow Dispatch) - Test Start");
+    run_packed_large_unicast_write_test();
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1146,127 +1362,6 @@ INSTANTIATE_TEST_SUITE_P(
                "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
     });
 
-// --- Slow Dispatch (SD) linear write test ---
-// Validates the dispatcher kernel in isolation using spoof_prefetch.cpp.
-// Requires TT_METAL_SLOW_DISPATCH_MODE=1.
-class DispatchLinearWriteSDTestFixture : public Common::SlowDispatchBaseTestFixture,
-                                         public ::testing::WithParamInterface<LinearWriteParams> {
-    uint32_t transfer_size_bytes_{};
-    uint32_t num_iterations_{};
-    uint32_t dram_data_size_words_{};
-    bool is_mcast_{};
-
-protected:
-    static constexpr bool inline_data_ = true;
-    static constexpr bool flush_prefetch_ = true;
-
-public:
-    void SetUp() override {
-        Common::SlowDispatchBaseTestFixture::SetUp();
-        if (IsSkipped()) {
-            return;
-        }
-        const auto params = GetParam();
-        transfer_size_bytes_ = params.transfer_size_bytes;
-        num_iterations_ = params.num_iterations;
-        dram_data_size_words_ = params.dram_data_size_words;
-        is_mcast_ = params.is_mcast;
-    }
-
-    std::vector<HostMemDeviceCommand> generate_linear_write_commands(
-        const CoreRange& worker_range,
-        uint32_t noc_xy,
-        uint32_t max_payload_per_cmd_bytes,
-        Common::DeviceData& device_data) {
-        std::vector<HostMemDeviceCommand> commands_per_iteration;
-        uint32_t remaining_bytes = get_transfer_size_bytes();
-        const CoreCoord first_worker = worker_range.start_coord;
-
-        if (is_mcast_) {
-            device_data.relevel(tt::CoreType::WORKER);
-        }
-
-        while (remaining_bytes > 0) {
-            uint32_t xfer_size_bytes =
-                payload_generator_->get_random_size(MAX_XFER_SIZE_16B, bytes_per_16B_unit, remaining_bytes);
-            xfer_size_bytes = std::min(xfer_size_bytes, max_payload_per_cmd_bytes);
-
-            uint32_t addr = device_data.get_result_data_addr(first_worker, 0);
-            std::vector<uint32_t> payload = payload_generator_->generate_payload(xfer_size_bytes);
-
-            Common::DeviceDataUpdater::update_linear_write(payload, device_data, worker_range, is_mcast_);
-
-            HostMemDeviceCommand cmd =
-                Common::CommandBuilder::build_linear_write_command<flush_prefetch_, inline_data_>(
-                    payload, worker_range, is_mcast_, noc_xy, addr, xfer_size_bytes);
-
-            commands_per_iteration.push_back(std::move(cmd));
-            remaining_bytes -= xfer_size_bytes;
-        }
-
-        return commands_per_iteration;
-    }
-
-    uint32_t get_transfer_size_bytes() const { return transfer_size_bytes_; }
-    uint32_t get_num_iterations() const { return num_iterations_; }
-    uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
-    bool get_is_mcast() const { return is_mcast_; }
-
-private:
-    static constexpr uint32_t MAX_XFER_SIZE_16B = 4 * 1024;
-};
-
-TEST_P(DispatchLinearWriteSDTestFixture, LinearWrite) {
-    log_info(tt::LogTest, "DispatchLinearWriteSDTestFixture - LinearWrite (Slow Dispatch) - Test Start");
-
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-    const uint32_t total_target_bytes = get_transfer_size_bytes();
-    const bool is_mcast = get_is_mcast();
-
-    ASSERT_EQ(total_target_bytes % 16, 0) << "Require 16B alignment for write payload";
-
-    log_info(
-        tt::LogTest,
-        "Target total: {} bytes, Iterations: {}, Multicast: {}",
-        total_target_bytes,
-        num_iterations,
-        is_mcast);
-
-    const CoreCoord first_worker = default_worker_start;
-    CoreCoord last_worker = first_worker;
-    if (is_mcast) {
-        last_worker = {first_worker.x + 1, first_worker.y + 1};
-    }
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
-
-    DeviceCommandCalculator cmd_calc;
-    cmd_calc.add_dispatch_write_linear<flush_prefetch_, inline_data_>(0);
-    const uint32_t overhead_bytes = cmd_calc.write_offset_bytes();
-    const uint32_t max_payload_per_cmd_bytes = max_fetch_bytes_ - overhead_bytes;
-
-    const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
-    uint32_t noc_xy;
-    if (is_mcast) {
-        const CoreCoord last_virt_worker = device_->virtual_core_from_logical_core(last_worker, CoreType::WORKER);
-        noc_xy = device_->get_noc_multicast_encoding(
-            k_dispatch_downstream_noc, CoreRange(first_virt_worker, last_virt_worker));
-    } else {
-        noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
-    }
-
-    auto commands_per_iteration =
-        generate_linear_write_commands(worker_range, noc_xy, max_payload_per_cmd_bytes, device_data);
-
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
-}
-
 INSTANTIATE_TEST_SUITE_P(
     SlowDispatch,
     DispatchLinearWriteSDTestFixture,
@@ -1285,148 +1380,6 @@ INSTANTIATE_TEST_SUITE_P(
                (info.param.is_mcast ? "mcast" : "unicast");
     });
 
-// --- Slow Dispatch (SD) paged write test ---
-class DispatchPagedWriteSDTestFixture : public Common::SlowDispatchBaseTestFixture,
-                                        public ::testing::WithParamInterface<PagedWriteParams> {
-    uint32_t page_size_{};
-    uint32_t num_pages_{};
-    uint32_t num_iterations_{};
-    uint32_t dram_data_size_words_{};
-    bool is_dram_{};
-
-    CoreCoord get_bank_core(uint32_t bank_id) const {
-        if (is_dram_) {
-            const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
-            return device_->logical_core_from_dram_channel(dram_channel);
-        }
-        return device_->allocator_impl()->get_logical_core_from_bank_id(bank_id);
-    }
-
-protected:
-    static constexpr bool inline_data_ = true;
-    static constexpr uint32_t MAX_XFER_SIZE_16B = 4 * 1024;
-
-public:
-    void SetUp() override {
-        Common::SlowDispatchBaseTestFixture::SetUp();
-        if (IsSkipped()) {
-            return;
-        }
-        const auto params = GetParam();
-        page_size_ = params.page_size;
-        num_pages_ = params.num_pages;
-        num_iterations_ = params.num_iterations;
-        dram_data_size_words_ = params.dram_data_size_words;
-        is_dram_ = params.is_dram;
-    }
-
-    std::vector<HostMemDeviceCommand> generate_paged_write_commands(
-        uint32_t page_size_bytes,
-        uint32_t page_size_alignment_bytes,
-        uint32_t num_banks,
-        uint32_t max_payload_per_cmd_bytes,
-        tt::CoreType core_type,
-        Common::DeviceData& device_data) {
-        std::vector<HostMemDeviceCommand> commands_per_iteration;
-        const uint32_t page_size_words = page_size_bytes / sizeof(uint32_t);
-
-        uint32_t remaining_pages = num_pages_;
-        uint32_t absolute_start_page = 0;
-
-        while (remaining_pages > 0) {
-            const uint32_t max_pages_in_chunk = max_payload_per_cmd_bytes / page_size_bytes;
-            const uint32_t pages_in_chunk = std::min(remaining_pages, max_pages_in_chunk);
-
-            std::vector<uint32_t> chunk_payload;
-            chunk_payload.reserve(pages_in_chunk * page_size_words);
-
-            for (uint32_t page = 0; page < pages_in_chunk; ++page) {
-                const uint32_t page_id = absolute_start_page + page;
-                const uint32_t bank_id = page_id % num_banks;
-                CoreCoord bank_core = get_bank_core(bank_id);
-                std::vector<uint32_t> page_payload =
-                    payload_generator_->generate_payload_with_page_id(page_size_words, page_id);
-                Common::DeviceDataUpdater::update_paged_write(
-                    page_payload, device_data, bank_core, bank_id, page_size_alignment_bytes);
-                chunk_payload.insert(chunk_payload.end(), page_payload.begin(), page_payload.end());
-            }
-
-            const uint32_t bank_offset =
-                tt::align(page_size_bytes, page_size_alignment_bytes) * (absolute_start_page / num_banks);
-            const uint32_t base_addr = device_data.get_base_result_addr(core_type) + bank_offset;
-            const uint16_t start_page_cmd = absolute_start_page % num_banks;
-
-            HostMemDeviceCommand cmd = Common::CommandBuilder::build_paged_write_command<inline_data_>(
-                chunk_payload, base_addr, page_size_bytes, pages_in_chunk, start_page_cmd, is_dram_);
-            commands_per_iteration.push_back(std::move(cmd));
-
-            remaining_pages -= pages_in_chunk;
-            absolute_start_page += pages_in_chunk;
-        }
-
-        log_info(
-            tt::LogTest,
-            "Generated {} paged write command chunks for {} total pages",
-            commands_per_iteration.size(),
-            num_pages_);
-
-        return commands_per_iteration;
-    }
-
-    uint32_t get_page_size() const { return page_size_; }
-    uint32_t get_num_pages() const { return num_pages_; }
-    uint32_t get_num_iterations() const { return num_iterations_; }
-    uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
-    bool get_is_dram() const { return is_dram_; }
-};
-
-TEST_P(DispatchPagedWriteSDTestFixture, PagedWrite) {
-    log_info(tt::LogTest, "DispatchPagedWriteSDTestFixture - PagedWrite (Slow Dispatch) - Test Start");
-
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-    const uint32_t num_pages_per_cmd = get_num_pages();
-    const uint32_t page_size_bytes_param = get_page_size();
-    const bool is_dram = get_is_dram();
-
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base, nullptr, true, dram_data_size_words, cfg_);
-
-    const auto buf_type = is_dram ? BufferType::DRAM : BufferType::L1;
-    const uint32_t page_size_alignment_bytes = device_->allocator_impl()->get_alignment(buf_type);
-    const uint32_t num_banks = device_->allocator_impl()->get_num_banks(buf_type);
-    const tt::CoreType core_type = is_dram ? tt::CoreType::DRAM : tt::CoreType::WORKER;
-
-    uint32_t max_allowed = MAX_XFER_SIZE_16B - 1;
-    uint32_t page_size_bytes =
-        payload_generator_->get_random_size(max_allowed, bytes_per_16B_unit, page_size_bytes_param);
-
-    DeviceCommandCalculator cmd_calc;
-    cmd_calc.add_dispatch_write_paged<inline_data_>(page_size_bytes, 0);
-    const uint32_t overhead_bytes = cmd_calc.write_offset_bytes();
-    const uint32_t max_payload_per_cmd_bytes = max_fetch_bytes_ - overhead_bytes;
-
-    log_info(
-        tt::LogTest,
-        "Paged Write test to {} - random page_size: {} bytes, num_pages_per_cmd: {}, iterations: {}",
-        is_dram ? "DRAM" : "L1",
-        page_size_bytes,
-        num_pages_per_cmd,
-        num_iterations);
-
-    auto commands_per_iteration = generate_paged_write_commands(
-        page_size_bytes, page_size_alignment_bytes, num_banks, max_payload_per_cmd_bytes, core_type, device_data);
-
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
-}
-
 INSTANTIATE_TEST_SUITE_P(
     SlowDispatch,
     DispatchPagedWriteSDTestFixture,
@@ -1443,157 +1396,10 @@ INSTANTIATE_TEST_SUITE_P(
                std::to_string(info.param.num_iterations) + "iter_" + (info.param.is_dram ? "dram" : "l1");
     });
 
-// --- Slow Dispatch (SD) packed write test ---
-class DispatchPackedWriteSDTestFixture : public Common::SlowDispatchBaseTestFixture,
-                                         public ::testing::WithParamInterface<PackedWriteParams> {
-    uint32_t transfer_size_bytes_{};
-    uint32_t num_iterations_{};
-    uint32_t dram_data_size_words_{};
-
-    uint32_t clamp_to_max_fetch(
-        uint32_t xfer_size_bytes,
-        uint32_t num_sub_cmds,
-        uint32_t packed_write_max_unicast_sub_cmds,
-        bool no_stride,
-        uint32_t l1_alignment) {
-        return Common::PackedWriteUtils::clamp_to_max_fetch(
-            max_fetch_bytes_,
-            xfer_size_bytes,
-            num_sub_cmds,
-            packed_write_max_unicast_sub_cmds,
-            no_stride,
-            l1_alignment);
-    }
-
-public:
-    void SetUp() override {
-        Common::SlowDispatchBaseTestFixture::SetUp();
-        if (IsSkipped()) {
-            return;
-        }
-        const auto params = GetParam();
-        transfer_size_bytes_ = params.transfer_size_bytes;
-        num_iterations_ = params.num_iterations;
-        dram_data_size_words_ = params.dram_data_size_words;
-    }
-
-    std::vector<HostMemDeviceCommand> generate_packed_write_commands(
-        const std::vector<CoreCoord>& worker_cores,
-        uint32_t l1_alignment,
-        uint32_t packed_write_max_unicast_sub_cmds,
-        Common::DeviceData& device_data) {
-        std::vector<HostMemDeviceCommand> commands_per_iteration;
-
-        uint32_t remaining_bytes = get_transfer_size_bytes();
-
-        const uint32_t num_sub_cmds = static_cast<uint32_t>(worker_cores.size());
-        const uint32_t sub_cmds_bytes =
-            tt::align(num_sub_cmds * sizeof(CQDispatchWritePackedUnicastSubCmd), l1_alignment);
-
-        std::vector<CQDispatchWritePackedUnicastSubCmd> sub_cmds =
-            Common::PackedWriteUtils::build_sub_cmds(device_, worker_cores, k_dispatch_downstream_noc);
-
-        device_data.relevel(tt::CoreType::WORKER);
-        constexpr uint32_t payload_unit = sizeof(uint32_t);
-
-        while (remaining_bytes > payload_unit) {
-            uint32_t xfer_size_bytes = payload_generator_->get_random_size(
-                dispatch_buffer_page_size_ / payload_unit, payload_unit, remaining_bytes);
-
-            bool no_stride = payload_generator_->get_rand_bool();
-
-            if (no_stride) {
-                const uint32_t max_allowed = dispatch_buffer_page_size_ - sizeof(CQDispatchCmd) - sub_cmds_bytes;
-                if (xfer_size_bytes > max_allowed) {
-                    xfer_size_bytes = max_allowed;
-                }
-            }
-            uint32_t prev_xfer_size_bytes = xfer_size_bytes;
-
-            xfer_size_bytes = clamp_to_max_fetch(
-                xfer_size_bytes, num_sub_cmds, packed_write_max_unicast_sub_cmds, no_stride, l1_alignment);
-
-            const CoreCoord& fw = worker_cores[0];
-            uint32_t common_addr = device_data.get_result_data_addr(fw);
-
-            std::vector<uint32_t> payload = payload_generator_->generate_payload_with_core(fw, xfer_size_bytes);
-            TT_FATAL(
-                !payload.empty(),
-                "Generated payload size is 0, xfer_size_bytes: {}, prev_xfer_size_bytes: {}",
-                xfer_size_bytes,
-                prev_xfer_size_bytes);
-
-            Common::DeviceDataUpdater::update_packed_write(payload, device_data, worker_cores, l1_alignment);
-
-            HostMemDeviceCommand cmd = Common::CommandBuilder::build_packed_write_command(
-                payload, sub_cmds, common_addr, l1_alignment, packed_write_max_unicast_sub_cmds, no_stride);
-
-            commands_per_iteration.push_back(std::move(cmd));
-            remaining_bytes -= xfer_size_bytes;
-        }
-
-        log_info(
-            tt::LogTest,
-            "Generated {} packed write commands totaling {} bytes",
-            commands_per_iteration.size(),
-            transfer_size_bytes_ - remaining_bytes);
-
-        return commands_per_iteration;
-    }
-
-    uint32_t get_transfer_size_bytes() const { return transfer_size_bytes_; }
-    uint32_t get_num_iterations() const { return num_iterations_; }
-    uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
-};
-
-TEST_P(DispatchPackedWriteSDTestFixture, WritePackedUnicast) {
-    log_info(tt::LogTest, "DispatchPackedWriteSDTestFixture - WritePackedUnicast (Slow Dispatch) - Test Start");
-
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-    const uint32_t total_target_bytes = get_transfer_size_bytes();
-
-    log_info(tt::LogTest, "Target total: {} bytes, Iterations: {}", total_target_bytes, num_iterations);
-
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
-
-    const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
-    const uint32_t packed_write_max_unicast_sub_cmds =
-        device_->compute_with_storage_grid_size().x * device_->compute_with_storage_grid_size().y;
-
-    std::vector<CoreCoord> worker_cores;
-    for (uint32_t y = worker_range.start_coord.y; y <= worker_range.end_coord.y; ++y) {
-        for (uint32_t x = worker_range.start_coord.x; x <= worker_range.end_coord.x; ++x) {
-            if (send_to_all_ || payload_generator_->get_rand_bool()) {
-                worker_cores.push_back({x, y});
-            }
-        }
-    }
-    if (worker_cores.empty()) {
-        worker_cores.push_back(default_worker_start);
-    }
-
-    ASSERT_LE(worker_cores.size(), packed_write_max_unicast_sub_cmds);
-
-    auto commands_per_iteration =
-        generate_packed_write_commands(worker_cores, l1_alignment, packed_write_max_unicast_sub_cmds, device_data);
-
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
-}
-
 INSTANTIATE_TEST_SUITE_P(
     SlowDispatch,
     DispatchPackedWriteSDTestFixture,
-    // SD sizes are smaller than FD (786432/819200): packed write with 4 worker cores writes
-    // ~4x payload bytes into L1, so max safe payload is ~L1_size/5 (~300KB).
+    // SD sizes < FD: spoof prefetcher serves commands from worker L1, not a host huge page.
     ::testing::Values(
         PackedWriteParams{131072, DEFAULT_ITERATIONS_PACKED_WRITE, Common::DRAM_DATA_SIZE_WORDS},
         PackedWriteParams{262144, DEFAULT_ITERATIONS_PACKED_WRITE, Common::DRAM_DATA_SIZE_WORDS}),
@@ -1602,327 +1408,24 @@ INSTANTIATE_TEST_SUITE_P(
                "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
     });
 
-// --- Slow Dispatch (SD) packed-large multicast write test ---
-class DispatchPackedWriteLargeSDTestFixture : public Common::SlowDispatchBaseTestFixture,
-                                              public ::testing::WithParamInterface<PackedWriteParams> {
-    static constexpr uint32_t max_pages_per_transaction = 4;
-
-    uint32_t transfer_size_bytes_{};
-    uint32_t num_iterations_{};
-    uint32_t dram_data_size_words_{};
-
-    struct TransactionBatch {
-        std::vector<uint32_t> sizes;
-        uint32_t total_payload_bytes;
-    };
-
-    TransactionBatch generate_packed_large_transactions(
-        uint32_t& remaining_bytes, uint32_t max_transactions, uint32_t l1_alignment) {
-        std::vector<uint32_t> transaction_sizes;
-        transaction_sizes.reserve(max_transactions);
-        uint32_t cumulative_payload_bytes = 0;
-
-        for (int i = 0; i < (int)max_transactions && remaining_bytes > 0; i++) {
-            uint32_t max_allowed = dispatch_buffer_page_size_ * max_pages_per_transaction / l1_alignment;
-            uint32_t xfer_size_bytes =
-                payload_generator_->get_random_size(max_allowed, bytes_per_16B_unit, remaining_bytes);
-
-            DeviceCommandCalculator cmd_calc;
-            cmd_calc.add_dispatch_write_packed_large(
-                transaction_sizes.size() + 1, cumulative_payload_bytes + xfer_size_bytes);
-            if (cmd_calc.write_offset_bytes() > max_fetch_bytes_) {
-                break;
-            }
-
-            transaction_sizes.push_back(xfer_size_bytes);
-            cumulative_payload_bytes += xfer_size_bytes;
-            remaining_bytes -= xfer_size_bytes;
-        }
-
-        return TransactionBatch{transaction_sizes, cumulative_payload_bytes};
-    }
-
-public:
-    void SetUp() override {
-        Common::SlowDispatchBaseTestFixture::SetUp();
-        if (IsSkipped()) {
-            return;
-        }
-        const auto params = GetParam();
-        transfer_size_bytes_ = params.transfer_size_bytes;
-        num_iterations_ = params.num_iterations;
-        dram_data_size_words_ = params.dram_data_size_words;
-    }
-
-    std::vector<HostMemDeviceCommand> generate_packed_large_write_commands(
-        const CoreRange& worker_range, uint32_t l1_alignment, Common::DeviceData& device_data) {
-        std::vector<HostMemDeviceCommand> commands_per_iteration;
-        uint32_t remaining_bytes = transfer_size_bytes_;
-
-        const CoreCoord virtual_start =
-            device_->virtual_core_from_logical_core(worker_range.start_coord, CoreType::WORKER);
-        const CoreCoord virtual_end = device_->virtual_core_from_logical_core(worker_range.end_coord, CoreType::WORKER);
-        const uint32_t num_mcast_dests = (worker_range.end_coord.x - worker_range.start_coord.x + 1) *
-                                         (worker_range.end_coord.y - worker_range.start_coord.y + 1);
-
-        device_data.relevel(worker_range);
-
-        while (remaining_bytes > 0) {
-            const int max_transactions =
-                payload_generator_->get_rand<int>(1, CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS);
-
-            TransactionBatch batch =
-                generate_packed_large_transactions(remaining_bytes, max_transactions, l1_alignment);
-            if (batch.sizes.empty()) {
-                break;
-            }
-
-            std::vector<CQDispatchWritePackedLargeSubCmd> sub_cmds;
-            std::vector<std::vector<uint32_t>> payloads;
-            sub_cmds.reserve(batch.sizes.size());
-            payloads.reserve(batch.sizes.size());
-
-            for (const uint32_t xfer_size_bytes : batch.sizes) {
-                const CoreCoord& fw = worker_range.start_coord;
-                uint32_t addr = device_data.get_result_data_addr(fw);
-
-                CQDispatchWritePackedLargeSubCmd sub_cmd{};
-                sub_cmd.noc_xy_addr = device_->get_noc_multicast_encoding(
-                    k_dispatch_downstream_noc, CoreRange(virtual_start, virtual_end));
-                sub_cmd.addr = addr;
-                sub_cmd.length_minus1 = static_cast<uint16_t>(xfer_size_bytes) - 1;
-                sub_cmd.num_mcast_dests = num_mcast_dests;
-                sub_cmd.flags = CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK;
-                sub_cmds.push_back(sub_cmd);
-
-                std::vector<uint32_t> payload = payload_generator_->generate_payload_with_core(fw, xfer_size_bytes);
-                DeviceDataUpdater::update_packed_large_write(payload, device_data, worker_range, l1_alignment);
-                payloads.push_back(std::move(payload));
-            }
-
-            HostMemDeviceCommand cmd = CommandBuilder::build_packed_large_write_command(
-                sub_cmds, payloads, batch.total_payload_bytes, l1_alignment);
-
-            log_info(
-                tt::LogTest,
-                "Generated packed-large command {} with {} transactions, {} bytes",
-                commands_per_iteration.size(),
-                sub_cmds.size(),
-                batch.total_payload_bytes);
-
-            commands_per_iteration.push_back(std::move(cmd));
-        }
-
-        log_info(tt::LogTest, "Generated {} packed-large commands total", commands_per_iteration.size());
-        return commands_per_iteration;
-    }
-
-    uint32_t get_transfer_size_bytes() const { return transfer_size_bytes_; }
-    uint32_t get_num_iterations() const { return num_iterations_; }
-    uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
-};
-
-TEST_P(DispatchPackedWriteLargeSDTestFixture, WriteLargePackedMulticast) {
-    log_info(
-        tt::LogTest, "DispatchPackedWriteLargeSDTestFixture - WriteLargePackedMulticast (Slow Dispatch) - Test Start");
-
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-    const uint32_t total_target_bytes = get_transfer_size_bytes();
-
-    log_info(tt::LogTest, "Max transfer: {} bytes, Iterations: {}", total_target_bytes, num_iterations);
-
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
-
-    const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
-
-    auto commands_per_iteration = generate_packed_large_write_commands(worker_range, l1_alignment, device_data);
-
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
-}
-
 INSTANTIATE_TEST_SUITE_P(
     SlowDispatch,
     DispatchPackedWriteLargeSDTestFixture,
+    // SD sizes < FD: bounded by spoof L1 (see DispatchPackedWriteSDTestFixture).
     ::testing::Values(
         PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS},
-
         PackedWriteParams{409600, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS}),
     [](const testing::TestParamInfo<PackedWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
                "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
     });
 
-// --- Slow Dispatch (SD) packed-large unicast write test ---
-class DispatchPackedWriteLargeUnicastSDTestFixture : public Common::SlowDispatchBaseTestFixture,
-                                                     public ::testing::WithParamInterface<PackedWriteParams> {
-    static constexpr uint32_t max_pages_per_transaction = 4;
-
-    uint32_t transfer_size_bytes_{};
-    uint32_t num_iterations_{};
-    uint32_t dram_data_size_words_{};
-
-    struct TransactionBatch {
-        std::vector<uint32_t> sizes;
-        uint32_t total_payload_bytes;
-    };
-
-    TransactionBatch generate_packed_large_unicast_transactions(
-        uint32_t& remaining_bytes, uint32_t max_transactions, uint32_t l1_alignment) {
-        std::vector<uint32_t> transaction_sizes;
-        transaction_sizes.reserve(max_transactions);
-        uint32_t cumulative_payload_bytes = 0;
-
-        for (int i = 0; i < (int)max_transactions && remaining_bytes > 0; i++) {
-            uint32_t max_allowed = dispatch_buffer_page_size_ * max_pages_per_transaction / l1_alignment;
-            uint32_t xfer_size_bytes =
-                payload_generator_->get_random_size(max_allowed, bytes_per_16B_unit, remaining_bytes);
-
-            DeviceCommandCalculator cmd_calc;
-            cmd_calc.add_dispatch_write_packed_large_unicast(
-                transaction_sizes.size() + 1, cumulative_payload_bytes + xfer_size_bytes);
-            if (cmd_calc.write_offset_bytes() > max_fetch_bytes_) {
-                break;
-            }
-
-            transaction_sizes.push_back(xfer_size_bytes);
-            cumulative_payload_bytes += xfer_size_bytes;
-            remaining_bytes -= xfer_size_bytes;
-        }
-
-        return TransactionBatch{transaction_sizes, cumulative_payload_bytes};
-    }
-
-public:
-    void SetUp() override {
-        Common::SlowDispatchBaseTestFixture::SetUp();
-        if (IsSkipped()) {
-            return;
-        }
-        const auto params = GetParam();
-        transfer_size_bytes_ = params.transfer_size_bytes;
-        num_iterations_ = params.num_iterations;
-        dram_data_size_words_ = params.dram_data_size_words;
-    }
-
-    std::vector<HostMemDeviceCommand> generate_packed_large_unicast_write_commands(
-        const std::vector<CoreCoord>& worker_cores, uint32_t l1_alignment, Common::DeviceData& device_data) {
-        std::vector<HostMemDeviceCommand> commands_per_iteration;
-        uint32_t remaining_bytes = transfer_size_bytes_;
-
-        while (remaining_bytes > 0) {
-            const int max_transactions =
-                payload_generator_->get_rand<int>(1, CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS);
-
-            TransactionBatch batch =
-                generate_packed_large_unicast_transactions(remaining_bytes, max_transactions, l1_alignment);
-            if (batch.sizes.empty()) {
-                break;
-            }
-
-            std::vector<CQDispatchWritePackedLargeUnicastSubCmd> sub_cmds;
-            std::vector<std::vector<uint32_t>> payloads;
-            sub_cmds.reserve(batch.sizes.size());
-            payloads.reserve(batch.sizes.size());
-
-            for (const uint32_t xfer_size_bytes : batch.sizes) {
-                const CoreCoord& worker_core =
-                    worker_cores[payload_generator_->get_rand<size_t>(0, worker_cores.size() - 1)];
-                bool is_discard = payload_generator_->get_rand<int>(0, 4) == 0;
-
-                CQDispatchWritePackedLargeUnicastSubCmd sub_cmd{};
-                if (is_discard) {
-                    sub_cmd.noc_xy_addr = 0;
-                    sub_cmd.addr = CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_ADDR_DISCARD;
-                } else {
-                    const CoreCoord virtual_coord =
-                        device_->virtual_core_from_logical_core(worker_core, CoreType::WORKER);
-                    sub_cmd.noc_xy_addr = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, virtual_coord);
-                    sub_cmd.addr = device_data.get_result_data_addr(worker_core);
-                }
-                sub_cmd.length = xfer_size_bytes;
-                sub_cmds.push_back(sub_cmd);
-
-                std::vector<uint32_t> payload =
-                    payload_generator_->generate_payload_with_core(worker_core, xfer_size_bytes);
-                if (!is_discard) {
-                    DeviceDataUpdater::update_packed_large_unicast_write(
-                        payload, device_data, worker_core, l1_alignment);
-                }
-                payloads.push_back(std::move(payload));
-            }
-
-            HostMemDeviceCommand cmd = CommandBuilder::build_packed_large_unicast_write_command(
-                sub_cmds, payloads, batch.total_payload_bytes, l1_alignment);
-
-            log_info(
-                tt::LogTest,
-                "Generated packed-large unicast command {} with {} transactions, {} bytes",
-                commands_per_iteration.size(),
-                sub_cmds.size(),
-                batch.total_payload_bytes);
-
-            commands_per_iteration.push_back(std::move(cmd));
-        }
-
-        log_info(tt::LogTest, "Generated {} packed-large unicast commands total", commands_per_iteration.size());
-        return commands_per_iteration;
-    }
-
-    uint32_t get_transfer_size_bytes() const { return transfer_size_bytes_; }
-    uint32_t get_num_iterations() const { return num_iterations_; }
-    uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
-};
-
-TEST_P(DispatchPackedWriteLargeUnicastSDTestFixture, WriteLargePackedUnicast) {
-    log_info(
-        tt::LogTest,
-        "DispatchPackedWriteLargeUnicastSDTestFixture - WriteLargePackedUnicast (Slow Dispatch) - Test Start");
-
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-    const uint32_t total_target_bytes = get_transfer_size_bytes();
-
-    log_info(tt::LogTest, "Max transfer: {} bytes, Iterations: {}", total_target_bytes, num_iterations);
-
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
-
-    const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
-
-    std::vector<CoreCoord> worker_cores;
-    for (uint32_t y = worker_range.start_coord.y; y <= worker_range.end_coord.y; ++y) {
-        for (uint32_t x = worker_range.start_coord.x; x <= worker_range.end_coord.x; ++x) {
-            worker_cores.push_back({x, y});
-        }
-    }
-
-    auto commands_per_iteration = generate_packed_large_unicast_write_commands(worker_cores, l1_alignment, device_data);
-
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
-}
-
 INSTANTIATE_TEST_SUITE_P(
     SlowDispatch,
     DispatchPackedWriteLargeUnicastSDTestFixture,
+    // SD sizes < FD: bounded by spoof L1 (see DispatchPackedWriteSDTestFixture).
     ::testing::Values(
         PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS},
-
         PackedWriteParams{409600, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS}),
     [](const testing::TestParamInfo<PackedWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -1080,10 +1080,10 @@ public:
     void execute_generated_commands(
         const std::vector<HostMemDeviceCommand>& commands_per_iteration,
         Common::DeviceData& device_data,
-        size_t num_cores_to_log,
+        size_t /*num_cores_to_log*/,
         uint32_t num_iterations,
-        bool wait_for_completion = true,
-        bool wait_for_host_writes = false) override {
+        bool /*wait_for_completion*/ = true,
+        bool /*wait_for_host_writes*/ = false) override {
         const uint32_t page_size = Common::SD_DISPATCH_BUFFER_PAGE_SIZE;
         constexpr size_t prefetch_hdr = sizeof(CQPrefetchCmd);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -1124,9 +1124,7 @@ public:
             raw.size());
 
         const auto& memmap = tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
-        const uint32_t dispatch_l1_unreserved_base =
-            memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::UNRESERVED);
-        const uint32_t l1_buf_base = tt::align(dispatch_l1_unreserved_base, page_size);
+        const uint32_t l1_buf_base = memmap.dispatch_buffer_base();
 
         const auto& soc_desc = tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->device_->id());
         TT_FATAL(raw.size() + l1_buf_base <= soc_desc.worker_l1_size, "SD command buffer too large for L1");
@@ -1151,13 +1149,13 @@ public:
         const uint32_t prefetch_sync_sem = tt_metal::CreateSemaphore(program, {Common::sd_spoof_prefetch_core}, 0);
 
         const std::vector<uint32_t> spoof_args = {
-            l1_buf_base,                               // 0: dispatch_cb_base
-            Common::SD_LOG_DISPATCH_BUFFER_PAGE_SIZE,  // 1
-            dispatch_buffer_pages,                     // 2
-            dispatch_core_sem_id,                      // 3
-            l1_buf_base,                               // 4: cmd_cb_base (same region, pre-loaded)
-            cmd_cb_pages,                              // 5
-            Common::SD_PREFETCHER_PAGE_BATCH_SIZE,     // 6
+            l1_buf_base,                                                    // 0: dispatch_cb_base
+            tt::tt_metal::DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE,  // 1
+            dispatch_buffer_pages,                                          // 2
+            dispatch_core_sem_id,                                           // 3
+            l1_buf_base,                                                    // 4: cmd_cb_base (same region, pre-loaded)
+            cmd_cb_pages,                                                   // 5
+            Common::SD_PREFETCHER_PAGE_BATCH_SIZE,                          // 6
         };
         const std::map<std::string, std::string> prefetch_defines = {
             {"DISPATCH_NOC_X", std::to_string(phys_disp.x)},
@@ -1177,7 +1175,6 @@ public:
 
         auto dispatch_defines = Common::make_sd_dispatch_defines(
             this->device_,
-            l1_buf_base,
             dispatch_buffer_pages,
             dispatch_core_sem_id,
             prefetch_sync_sem,


### PR DESCRIPTION
### Summary
PR https://github.com/tenstorrent/tt-metal/pull/31556 refactored `test_dispatcher.cpp` to a unified command generation + FD test + gtest TEST_P architecture but dropped the slow dispatch (SD) validation path. This PR restores it: command generation is shared with the FD path via a `SDDispatchTestBase<FDFixture>` template that overrides only the execution backend (launching kernels `spoof_prefetch.cpp` + `cq_dispatch.cpp` directly, vs FDMeshCommandQueue for FD). Useful during bringup of dispatcher/prefetcher on new hardware in SD mode.

### Notes for reviewers

- `SDDispatchTestBase<FDFixture>`: overrides `execute_generated_commands` to drive `spoof_prefetch` + `cq_dispatch` directly. Each SD fixture is an empty subclass; all setup and init_params dispatch live in the template. No FD fixture code touched.
- Header stripping (`execute_generated_commands` in `common.h`): `HostMemDeviceCommand` prepends a `CQPrefetchCmd` relay-inline header + pcie padding. SD strips both using `relay_inline.length`. 
- `make_sd_dispatch_defines()`: supplies compile-time defines `cq_dispatch.cpp` requires; fields not driven by SD are zeroed. 
- SD test sizes: `spoof_prefetch.cpp` serves from worker L1, not a host huge page. This bounds per-iteration payload to spoof L1 capacity. L1-targeted paged writes (is_dram=false) are excluded from SD, as in the old test (they require L1 bank coordinate setup via CRTA that the spoof path doesn't provide)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/sd_mode_test_dispatcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/sd_mode_test_dispatcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/sd_mode_test_dispatcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/sd_mode_test_dispatcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/sd_mode_test_dispatcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/sd_mode_test_dispatcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/sd_mode_test_dispatcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/sd_mode_test_dispatcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/sd_mode_test_dispatcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/sd_mode_test_dispatcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/sd_mode_test_dispatcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/sd_mode_test_dispatcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/sd_mode_test_dispatcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/sd_mode_test_dispatcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/sd_mode_test_dispatcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/sd_mode_test_dispatcher)