### PR TITLE
Fix early-break bug in  loopback pairs

### DIFF
--- a/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
+++ b/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
@@ -109,6 +109,7 @@ std::vector<BlitzDecodePipelineStage> build_pipeline_from_topology(bool initiali
     // Stage 0 entry and loopback exit are intra-mesh on mesh_0 (not from inter-mesh cables).
     // Pick two unclaimed chips with a direct intra-mesh ethernet link (loopback_exit -> stage_0_entry).
     // Prefer a non-Z link when available so the loopback hop matches typical NESW mesh wiring.
+    // Collect ALL unclaimed nodes; the directly-connected pair may not be the first ones found.
     auto mesh_0_coord_range = mesh_graph.get_coord_range(mesh_ids[0]);
     std::vector<tt::tt_fabric::FabricNodeId> unclaimed_mesh_0_nodes;
     for (const auto& coord : mesh_0_coord_range) {
@@ -116,9 +117,6 @@ std::vector<BlitzDecodePipelineStage> build_pipeline_from_topology(bool initiali
         tt::tt_fabric::FabricNodeId fn(mesh_ids[0], chip_id);
         if (!used_nodes.contains(fn)) {
             unclaimed_mesh_0_nodes.push_back(fn);
-            if (unclaimed_mesh_0_nodes.size() >= unclaimed_needed) {
-                break;
-            }
         }
     }
     TT_FATAL(


### PR DESCRIPTION
## Summary

Removes a stale early-`break` in `build_pipeline_from_topology` (`tt_metal/distributed/experimental/blitz_decode_pipeline.cpp`) that I accidentally left behind during a rebase. The break caused the loopback exit → stage 0 entry pair search to fail on topologies where the directly-connected pair wasn't among the first chips in coord-enumeration order.

## Background

When constructing the blitz decode pipeline, the builder needs to pick two unclaimed chips on `mesh_0` that are **physically wired together by an intra-mesh ethernet link** — one becomes the loopback exit, the other becomes stage 0's entry.

The flow is:

1. Walk `mesh_0`'s chips in coord order.
2. Collect unclaimed ones (chips not already claimed by the inter-mesh ring) into a candidate list.
3. Search the list for a directly-connected pair.

## The bug

Step 2 had a leftover early-`break` that stopped collecting once the list reached `unclaimed_needed` (2) entries:

```cpp
unclaimed_mesh_0_nodes.push_back(fn);
if (unclaimed_mesh_0_nodes.size() >= unclaimed_needed) {
    break;
}
```

This is wrong: the first two unclaimed chips in coord-enumeration order are **not guaranteed to be ethernet neighbors**. Coord order is a logical iteration over the (x, y) grid — it has no relationship to which chips have a direct cable between them. So step 3 would search a candidate set of size 2, fail to find a directly-connected pair, and trip the `TT_FATAL`:

```
loopback_exit_fn.has_value() && stage_0_entry_fn.has_value()
"Could not find a directly-connected unclaimed pair on mesh 0 for loopback exit -> stage 0 entry"
```

## Why it was missed
Rebase onto main re-introduced code that should have been deleted

## Fix

Remove the 3-line early-break block so we collect all unclaimed `mesh_0` chips before searching for the directly-connected pair. This brings the production code back in line with the gtest reference. The extra cost is iterating at most ~6 more chips on `mesh_0`, which is negligible.

## Test plan

- [x] `./build_metal.sh`
- [x] Re-run the failing pytest:
  ```bash
  TT_METAL_SLOW_DISPATCH_MODE=1 tt-run \
    --tcp-interface ens5f0np0 \
    --mpi-args "--tag-output --rankfile=blitz_decode_pipeline_rank_file_single_pod --host $HOSTSP" \
    --rank-binding blitz_decode_pipeline_rank_binding_single_pod.yaml \
    pytest -svv models/demos/deepseek_v3_b1/tests/unit_tests/test_multi_host_pipeline.py::test_passthrough_pipeline_block
  ```
- [x] Confirm `ControlPlaneFixture.SP5_TestBlitzDecodePipelineBuilder` still passes.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ridvan/socket-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ridvan/socket-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ridvan/socket-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ridvan/socket-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ridvan/socket-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ridvan/socket-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ridvan/socket-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ridvan/socket-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ridvan/socket-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ridvan/socket-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ridvan/socket-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ridvan/socket-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ridvan/socket-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ridvan/socket-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ridvan/socket-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ridvan/socket-fix)