### PR TITLE
Migrate moreh family to ProgramDescriptor framework

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
@@ -120,13 +120,12 @@ def test_moreh_cumsum_backward(input_shape, dim, device):
     torch_output = torch.cumsum(torch_input, dim)
     torch_output.backward(torch_output_grad)
 
-    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    tt_input_grad_cpu = (
+    # Same fix pattern as #44283 applied to test_moreh_cumsum_dim: the legacy
+    # .cpu().to(ROW_MAJOR).unpad_from_tile(shape).to_torch() chain trips the
+    # hardened unpad_from_tile precondition (#43568) when input_shape's last
+    # two dims aren't tile-aligned — ttnn.to_torch handles padding correctly.
+    tt_input_grad_cpu = ttnn.to_torch(
         ttnn.operations.moreh.cumsum_backward(tt_output_grad, dim, input_grad=tt_input_grad)
-        .cpu()
-        .to(cpu_layout)
-        .unpad_from_tile(input_shape)
-        .to_torch()
     )
 
     # test for equivalance
@@ -225,13 +224,12 @@ def test_moreh_cumsum_backward(input_shape, dim, device):
     torch_output = torch.cumsum(torch_input, dim)
     torch_output.backward(torch_output_grad)
 
-    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    tt_input_grad_cpu = (
+    # Same fix pattern as #44283 applied to test_moreh_cumsum_dim: the legacy
+    # .cpu().to(ROW_MAJOR).unpad_from_tile(shape).to_torch() chain trips the
+    # hardened unpad_from_tile precondition (#43568) when input_shape's last
+    # two dims aren't tile-aligned — ttnn.to_torch handles padding correctly.
+    tt_input_grad_cpu = ttnn.to_torch(
         ttnn.operations.moreh.cumsum_backward(tt_output_grad, dim, input_grad=tt_input_grad)
-        .cpu()
-        .to(cpu_layout)
-        .unpad_from_tile(input_shape)
-        .to_torch()
     )
 
     # test for equivalance

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
@@ -237,14 +237,15 @@ ProgramDescriptor MorehAdamWDeviceOperation::create_descriptor(
     auto* const grad_buf = grad.buffer();
     auto* const exp_avg_in_buf = exp_avg_in.buffer();
     auto* const exp_avg_sq_in_buf = exp_avg_sq_in.buffer();
-    const uint32_t max_exp_avg_sq_in_addr =
-        max_exp_avg_sq_in.has_value() ? max_exp_avg_sq_in.value().buffer()->address() : 0u;
+    // Register max_exp_avg_sq as a BufferBinding so the framework patches its address on
+    // cache hit. A raw Buffer::address() write here would go stale across cache hits because
+    // the program hash zeros out step+lr, so the same cached program is reused with new tensors.
+    auto* const max_exp_avg_sq_in_buf = max_exp_avg_sq_in.has_value() ? max_exp_avg_sq_in.value().buffer() : nullptr;
 
     auto* const param_out_buf = param_out.buffer();
     auto* const exp_avg_out_buf = exp_avg_out.buffer();
     auto* const exp_avg_sq_out_buf = exp_avg_sq_out.buffer();
-    const uint32_t max_exp_avg_sq_out_addr =
-        max_exp_avg_sq_out.has_value() ? max_exp_avg_sq_out.value().buffer()->address() : 0u;
+    auto* const max_exp_avg_sq_out_buf = max_exp_avg_sq_out.has_value() ? max_exp_avg_sq_out.value().buffer() : nullptr;
     float beta1_exponent = std::pow(beta1, step);
     float beta2_exponent = std::pow(beta2, step);
 
@@ -274,7 +275,7 @@ ProgramDescriptor MorehAdamWDeviceOperation::create_descriptor(
              grad_buf,
              exp_avg_in_buf,
              exp_avg_sq_in_buf,
-             max_exp_avg_sq_in_addr,
+             max_exp_avg_sq_in_buf,
              f2u_lr,
              f2u_beta1,
              f2u_beta2,
@@ -292,7 +293,7 @@ ProgramDescriptor MorehAdamWDeviceOperation::create_descriptor(
             {param_out_buf,
              exp_avg_out_buf,
              exp_avg_sq_out_buf,
-             max_exp_avg_sq_out_addr,
+             max_exp_avg_sq_out_buf,
              num_tiles_per_core,
              tile_offset});
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_program_factory.cpp
@@ -202,7 +202,10 @@ ProgramDescriptor MorehClipGradNormStep1Operation::create_descriptor(
     compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_desc.core_ranges = core_group_1;
     compute_desc.compile_time_args = {num_inputs_per_core_group_1};
-    compute_desc.defines = {{"REDUCE_OP", "PoolType::SUM"}, {"REDUCE_DIM", "ReduceDim::REDUCE_SCALAR"}};
+    compute_desc.defines = KernelDescriptor::Defines{
+        {"REDUCE_OP", "PoolType::SUM"},
+        {"REDUCE_DIM", "ReduceDim::REDUCE_SCALAR"},
+    };
     compute_desc.config = ComputeConfigDescriptor{};
     compute_desc.runtime_args.reserve(num_cores_to_be_used);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.hpp
@@ -11,6 +11,7 @@
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_getitem {
 struct MorehGetItemOperation {
@@ -30,51 +31,17 @@ struct MorehGetItemOperation {
     using tensor_return_value_t = Tensor;
 
     struct MorehGetItemRmFactory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-            tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-            std::size_t num_cores{};
-            uint32_t core_h{};
-            ttnn::SmallVector<uint32_t> index_dims;
-            uint32_t input_dim_offset{};
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& output_tensor);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
     };
 
     struct MorehGetItemTilizedFactory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-            tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-            std::size_t num_cores{};
-            uint32_t core_h{};
-            ttnn::SmallVector<uint32_t> index_dims;
-            uint32_t input_dim_offset{};
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& output_tensor);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
     };
 
     using program_factory_t = std::variant<MorehGetItemRmFactory, MorehGetItemTilizedFactory>;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_rm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_rm_factory.cpp
@@ -7,6 +7,7 @@
 #include "ttnn/operations/experimental/reshape/view.hpp"
 
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tilize_utils.hpp>
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
@@ -20,7 +21,8 @@ struct IndexInfo {
 }  // namespace
 
 namespace ttnn::operations::moreh::moreh_getitem {
-MorehGetItemOperation::MorehGetItemRmFactory::cached_program_t MorehGetItemOperation::MorehGetItemRmFactory::create(
+
+tt::tt_metal::ProgramDescriptor MorehGetItemOperation::MorehGetItemRmFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output_tensor) {
@@ -28,12 +30,10 @@ MorehGetItemOperation::MorehGetItemRmFactory::cached_program_t MorehGetItemOpera
     using namespace tt::tt_metal;
     using namespace CMAKE_UNIQUE_NAMESPACE;
 
-    auto input = tensor_args.input;
-    auto index_tensors = tensor_args.index_tensors;
+    const auto& input = tensor_args.input;
+    const auto& index_tensors = tensor_args.index_tensors;
     const auto& output = output_tensor;
     auto index_dims = operation_attributes.index_dims;
-    auto memory_config = operation_attributes.memory_config;
-    // auto core_range = operation_attributes.core_range;
     auto* device = input.device();
     auto grid_coord = device->compute_with_storage_grid_size();
     const CoreRange allCores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
@@ -89,7 +89,7 @@ MorehGetItemOperation::MorehGetItemRmFactory::cached_program_t MorehGetItemOpera
     auto [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
         split_work_to_cores_wt_core_range(core_range, num_units);
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     auto src_cb_data_format = datatype_to_dataformat_converter(input.dtype());
@@ -98,9 +98,15 @@ MorehGetItemOperation::MorehGetItemRmFactory::cached_program_t MorehGetItemOpera
 
     auto src_cb_index = CBIndex::c_0;
     auto rounded_input_page_size = round_up_to_mul32(input_unit_size);
-    auto cb_src0_config = CircularBufferConfig(rounded_input_page_size, {{src_cb_index, src_cb_data_format}})
-                              .set_page_size(src_cb_index, rounded_input_page_size);
-    CreateCircularBuffer(program, all_cores, cb_src0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = rounded_input_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src_cb_index),
+            .data_format = src_cb_data_format,
+            .page_size = rounded_input_page_size,
+        }}},
+    });
 
     for (uint32_t dim = 0; dim < 5; dim++) {
         if (!index_info[dim].is_defined) {
@@ -109,39 +115,58 @@ MorehGetItemOperation::MorehGetItemRmFactory::cached_program_t MorehGetItemOpera
 
         auto src1_cb_index = CBIndex::c_1 + dim;
         auto index_page_size = round_up_to_mul32(index_info[dim].unit_size);
-        auto cb_index_config = CircularBufferConfig(index_page_size, {{src1_cb_index, index_cb_data_format}})
-                                   .set_page_size(src1_cb_index, index_page_size);
-        CreateCircularBuffer(program, all_cores, cb_index_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = index_page_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(src1_cb_index),
+                .data_format = index_cb_data_format,
+                .page_size = index_page_size,
+            }}},
+        });
     }
 
     auto out_cb_index = CBIndex::c_16;
-    auto cb_out0_config = CircularBufferConfig(rounded_input_page_size, {{out_cb_index, output_cb_data_format}})
-                              .set_page_size(out_cb_index, rounded_input_page_size);
-    CreateCircularBuffer(program, all_cores, cb_out0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = rounded_input_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(out_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = rounded_input_page_size,
+        }}},
+    });
 
     // create read/write kernel
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
+    KernelDescriptor::Defines reader_defines;
+    KernelDescriptor::Defines writer_defines;
 
-    std::vector<uint32_t> reader_compile_time_args;
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args;
     tt::tt_metal::TensorAccessorArgs(input_5d.buffer()).append_to(reader_compile_time_args);
     for (auto& dim : index_info) {
         dim.args.append_to(reader_compile_time_args);
     }
-    auto reader_kernel_id = CreateReadKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_kernels/reader_moreh_getitem.cpp",
-        all_cores,
-        reader_compile_time_args,
-        reader_defines);
-    std::vector<uint32_t> writer_compile_time_args;
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_kernels/reader_moreh_getitem.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args;
     tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
-    auto writer_kernel_id = CreateWriteKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_kernels/writer_moreh_getitem.cpp",
-        all_cores,
-        writer_compile_time_args,
-        writer_defines);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_kernels/writer_moreh_getitem.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterConfigDescriptor{};
 
     uint32_t input_stick_idx_stride_h = 1;
     uint32_t input_stick_idx_stride_d = input_stick_idx_stride_h * input_5d_shape[3];
@@ -159,119 +184,78 @@ MorehGetItemOperation::MorehGetItemRmFactory::cached_program_t MorehGetItemOpera
         CoreCoord core = {(i / core_h) + core_x_offset, (i % core_h) + core_y_offset};
         uint32_t num_units_per_core = i < g1_numcores ? num_units_per_core_group_1 : num_units_per_core_group_2;
 
-        std::vector<uint32_t> reader_args = {
-            // buffers
-            input_5d.buffer()->address(),
-            index_info[0].address,
-            index_info[1].address,
-            index_info[2].address,
-            index_info[3].address,
-            index_info[4].address,
+        reader_desc.emplace_runtime_args(
+            core,
+            {
+                // buffers
+                input_5d.buffer(),
+                index_info[0].address,
+                index_info[1].address,
+                index_info[2].address,
+                index_info[3].address,
+                index_info[4].address,
 
-            // input
-            input_stick_idx_stride_n,
-            input_stick_idx_stride_c,
-            input_stick_idx_stride_d,
-            input_stick_idx_stride_h,
+                // input
+                input_stick_idx_stride_n,
+                input_stick_idx_stride_c,
+                input_stick_idx_stride_d,
+                input_stick_idx_stride_h,
 
-            input_5d_shape[0],
-            input_5d_shape[1],
-            input_5d_shape[2],
-            input_5d_shape[3],
-            input_5d_shape[4],
+                input_5d_shape[0],
+                input_5d_shape[1],
+                input_5d_shape[2],
+                input_5d_shape[3],
+                input_5d_shape[4],
 
-            // index
-            index_info[0].is_defined,
-            index_info[1].is_defined,
-            index_info[2].is_defined,
-            index_info[3].is_defined,
-            index_info[4].is_defined,
-            index_info[0].unit_size,
-            index_info[1].unit_size,
-            index_info[2].unit_size,
-            index_info[3].unit_size,
-            index_info[4].unit_size,
-            index_size,
-            index_start_dim,
-            index_end_dim,
+                // index
+                index_info[0].is_defined,
+                index_info[1].is_defined,
+                index_info[2].is_defined,
+                index_info[3].is_defined,
+                index_info[4].is_defined,
+                index_info[0].unit_size,
+                index_info[1].unit_size,
+                index_info[2].unit_size,
+                index_info[3].unit_size,
+                index_info[4].unit_size,
+                index_size,
+                index_start_dim,
+                index_end_dim,
 
-            // output
-            output_5d_shape[0],
-            output_5d_shape[1],
-            output_5d_shape[2],
-            output_5d_shape[3],
-            output_5d_shape[4],
+                // output
+                output_5d_shape[0],
+                output_5d_shape[1],
+                output_5d_shape[2],
+                output_5d_shape[3],
+                output_5d_shape[4],
 
-            // etc
-            start_id,
-            num_units_per_core,
-            input_unit_size,
-        };
+                // etc
+                start_id,
+                num_units_per_core,
+                input_unit_size,
+            });
 
-        std::vector<uint32_t> writer_args = {
-            // buffer
-            output.buffer()->address(),
+        writer_desc.emplace_runtime_args(
+            core,
+            {
+                // buffer
+                output.buffer(),
 
-            // output
-            output_unit_size,
+                // output
+                output_unit_size,
 
-            // etc
-            start_id,
-            num_units_per_core,
-        };
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+                // etc
+                start_id,
+                num_units_per_core,
+            });
 
         start_id += num_units_per_core;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, core_h, index_dims, input_dim_offset}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
 }
 
-void MorehGetItemOperation::MorehGetItemRmFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    using namespace CMAKE_UNIQUE_NAMESPACE;
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto num_cores = cached_program.shared_variables.num_cores;
-    auto core_h = cached_program.shared_variables.core_h;
-    auto index_dims = cached_program.shared_variables.index_dims;
-    auto input_dim_offset = cached_program.shared_variables.input_dim_offset;
-
-    auto* src_buffer = tensor_args.input.buffer();
-    auto* dst_buffer = tensor_return_value.buffer();
-    auto index_tensors = tensor_args.index_tensors;
-    IndexInfo index_info[5] = {{false}};
-
-    for (uint32_t i = 0; i < index_dims.size(); i++) {
-        auto dim = index_dims[i] + input_dim_offset;
-        const auto& index_buffer = index_tensors[i];
-
-        index_info[dim].address = index_buffer.buffer()->address();
-    }
-
-    for (uint32_t icore = 0; icore < num_cores; icore++) {
-        CoreCoord core = {icore / core_h, icore % core_h};
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = src_buffer->address();
-            runtime_args[1] = index_info[0].address;
-            runtime_args[2] = index_info[1].address;
-            runtime_args[3] = index_info[2].address;
-            runtime_args[4] = index_info[3].address;
-            runtime_args[5] = index_info[4].address;
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = dst_buffer->address();
-        }
-    }
-}
 }  // namespace ttnn::operations::moreh::moreh_getitem

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_factory.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tilize_utils.hpp>
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
@@ -21,8 +22,8 @@ struct IndexInfo {
 }  // namespace
 
 namespace ttnn::operations::moreh::moreh_getitem {
-MorehGetItemOperation::MorehGetItemTilizedFactory::cached_program_t
-MorehGetItemOperation::MorehGetItemTilizedFactory::create(
+
+tt::tt_metal::ProgramDescriptor MorehGetItemOperation::MorehGetItemTilizedFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output_tensor) {
@@ -30,14 +31,12 @@ MorehGetItemOperation::MorehGetItemTilizedFactory::create(
     using namespace tt::tt_metal;
     using namespace CMAKE_UNIQUE_NAMESPACE;
 
-    auto input = tensor_args.input;
-    auto index_tensors = tensor_args.index_tensors;
+    const auto& input = tensor_args.input;
+    const auto& index_tensors = tensor_args.index_tensors;
     const auto& output = output_tensor;
     auto index_dims = operation_attributes.index_dims;
-    auto memory_config = operation_attributes.memory_config;
     auto TILE_HEIGHT = constants::TILE_HEIGHT;
     auto TILE_WIDTH = constants::TILE_WIDTH;
-    // auto core_range = operation_attributes.core_range;
     auto* device = input.device();
     auto grid_coord = device->compute_with_storage_grid_size();
     const CoreRange allCores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
@@ -47,7 +46,6 @@ MorehGetItemOperation::MorehGetItemTilizedFactory::create(
     auto input_shape_without_padding = input.logical_shape();
     auto output_shape = output.padded_shape();
     auto output_shape_without_padding = output.logical_shape();
-    ;
 
     std::array<uint32_t, 5> new_input_shape{};
     std::array<uint32_t, 5> new_output_shape{};
@@ -118,7 +116,7 @@ MorehGetItemOperation::MorehGetItemTilizedFactory::create(
             [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
                 split_work_to_cores_wt_core_range(core_range, num_units);
 
-        Program program = Program();
+        ProgramDescriptor desc;
 
         // create circular buffers
         auto src_cb_data_format = datatype_to_dataformat_converter(input.dtype());
@@ -127,9 +125,15 @@ MorehGetItemOperation::MorehGetItemTilizedFactory::create(
 
         auto src_cb_index = CBIndex::c_0;
         auto rounded_input_page_size = round_up_to_mul32(input_unit_size);
-        auto cb_src0_config = CircularBufferConfig(rounded_input_page_size, {{src_cb_index, src_cb_data_format}})
-                                  .set_page_size(src_cb_index, rounded_input_page_size);
-        CreateCircularBuffer(program, all_cores, cb_src0_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = rounded_input_page_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(src_cb_index),
+                .data_format = src_cb_data_format,
+                .page_size = rounded_input_page_size,
+            }}},
+        });
 
         for (uint32_t dim = 0; dim < 5; dim++) {
             if (!index_info[dim].is_defined) {
@@ -138,53 +142,78 @@ MorehGetItemOperation::MorehGetItemTilizedFactory::create(
 
             auto src1_cb_index = CBIndex::c_1 + dim;
             auto index_page_size = 1024 * 4;
-            auto cb_index_config = CircularBufferConfig(index_page_size, {{src1_cb_index, index_cb_data_format}})
-                                       .set_page_size(src1_cb_index, index_page_size);
-            CreateCircularBuffer(program, all_cores, cb_index_config);
+            desc.cbs.push_back(CBDescriptor{
+                .total_size = static_cast<uint32_t>(index_page_size),
+                .core_ranges = all_cores,
+                .format_descriptors = {{CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(src1_cb_index),
+                    .data_format = index_cb_data_format,
+                    .page_size = static_cast<uint32_t>(index_page_size),
+                }}},
+            });
         }
 
         auto out_cb0_index = CBIndex::c_16;
         auto rounded_output_page_size = round_up_to_mul32(output_unit_size);
-        auto cb_out0_config = CircularBufferConfig(rounded_output_page_size, {{out_cb0_index, output_cb_data_format}})
-                                  .set_page_size(out_cb0_index, rounded_output_page_size);
-        CreateCircularBuffer(program, all_cores, cb_out0_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = rounded_output_page_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(out_cb0_index),
+                .data_format = output_cb_data_format,
+                .page_size = rounded_output_page_size,
+            }}},
+        });
 
         auto out_cb1_index = CBIndex::c_17;
-        auto cb_out1_config = CircularBufferConfig(rounded_output_page_size, {{out_cb1_index, output_cb_data_format}})
-                                  .set_page_size(out_cb1_index, rounded_output_page_size);
-        CreateCircularBuffer(program, all_cores, cb_out1_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = rounded_output_page_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(out_cb1_index),
+                .data_format = output_cb_data_format,
+                .page_size = rounded_output_page_size,
+            }}},
+        });
 
         // create read/write kernel
-        std::map<std::string, std::string> reader_defines;
-        std::map<std::string, std::string> writer_defines;
+        KernelDescriptor::Defines reader_defines;
+        KernelDescriptor::Defines writer_defines;
 
         if (is_row_major_index) {
-            reader_defines["ROW_MAJOR_INDEX"] = "1";
+            reader_defines.emplace_back("ROW_MAJOR_INDEX", "1");
         } else {
-            reader_defines["TILIZE_INDEX"] = "1";
+            reader_defines.emplace_back("TILIZE_INDEX", "1");
         }
 
-        std::vector<uint32_t> reader_compile_time_args;
+        KernelDescriptor::CompileTimeArgs reader_compile_time_args;
         tt::tt_metal::TensorAccessorArgs(input.buffer()).append_to(reader_compile_time_args);
         for (const auto& info : index_info) {
             info.args.append_to(reader_compile_time_args);
         }
-        auto reader_kernel_id = CreateReadKernel(
-            program,
+
+        KernelDescriptor reader_desc;
+        reader_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/"
-            "reader_moreh_getitem_tilize_w.cpp",
-            all_cores,
-            reader_compile_time_args,
-            reader_defines);
-        std::vector<uint32_t> writer_compile_time_args;
+            "reader_moreh_getitem_tilize_w.cpp";
+        reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        reader_desc.core_ranges = all_cores;
+        reader_desc.compile_time_args = std::move(reader_compile_time_args);
+        reader_desc.defines = std::move(reader_defines);
+        reader_desc.config = ReaderConfigDescriptor{};
+
+        KernelDescriptor::CompileTimeArgs writer_compile_time_args;
         tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
-        auto writer_kernel_id = CreateWriteKernel(
-            program,
+
+        KernelDescriptor writer_desc;
+        writer_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/"
-            "writer_moreh_getitem_tilize_w.cpp",
-            all_cores,
-            writer_compile_time_args,
-            writer_defines);
+            "writer_moreh_getitem_tilize_w.cpp";
+        writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        writer_desc.core_ranges = all_cores;
+        writer_desc.compile_time_args = std::move(writer_compile_time_args);
+        writer_desc.defines = std::move(writer_defines);
+        writer_desc.config = WriterConfigDescriptor{};
 
         uint32_t face_width = 16;
         uint32_t input_num_stick_width = div_up(input_5d_shape_without_padding[4], face_width);
@@ -227,96 +256,100 @@ MorehGetItemOperation::MorehGetItemTilizedFactory::create(
             CoreCoord core = {(i / core_h) + core_x_offset, (i % core_h) + core_y_offset};
             uint32_t num_units_per_core = i < g1_numcores ? num_units_per_core_group_1 : num_units_per_core_group_2;
 
-            std::vector<uint32_t> reader_args = {
-                // buffers
-                input.buffer()->address(),
-                index_info[0].address,
-                index_info[1].address,
-                index_info[2].address,
-                index_info[3].address,
-                index_info[4].address,
+            reader_desc.emplace_runtime_args(
+                core,
+                {
+                    // buffers
+                    input.buffer(),
+                    index_info[0].address,
+                    index_info[1].address,
+                    index_info[2].address,
+                    index_info[3].address,
+                    index_info[4].address,
 
-                // input
-                input_stick_idx_stride_n,
-                input_stick_idx_stride_c,
-                input_stick_idx_stride_d,
-                input_stick_idx_stride_h,
-                input_stick_idx_stride_w,
-                input_5d_shape_without_padding[1],
-                input_5d_shape_without_padding[2],
-                input_5d_shape_without_padding[3],
-                input_num_stick_width,
-                input_noc_id_stride_n,
-                input_noc_id_stride_c,
-                input_noc_id_stride_d,
-                input_noc_id_stride_h,
+                    // input
+                    input_stick_idx_stride_n,
+                    input_stick_idx_stride_c,
+                    input_stick_idx_stride_d,
+                    input_stick_idx_stride_h,
+                    input_stick_idx_stride_w,
+                    input_5d_shape_without_padding[1],
+                    input_5d_shape_without_padding[2],
+                    input_5d_shape_without_padding[3],
+                    input_num_stick_width,
+                    input_noc_id_stride_n,
+                    input_noc_id_stride_c,
+                    input_noc_id_stride_d,
+                    input_noc_id_stride_h,
 
-                input_5d_shape_without_padding[0],
-                input_5d_shape_without_padding[1],
-                input_5d_shape_without_padding[2],
-                input_5d_shape_without_padding[3],
-                input_5d_shape_without_padding[4],
+                    input_5d_shape_without_padding[0],
+                    input_5d_shape_without_padding[1],
+                    input_5d_shape_without_padding[2],
+                    input_5d_shape_without_padding[3],
+                    input_5d_shape_without_padding[4],
 
-                // index
-                index_info[0].is_defined,
-                index_info[1].is_defined,
-                index_info[2].is_defined,
-                index_info[3].is_defined,
-                index_info[4].is_defined,
-                index_info[0].unit_size,
-                index_info[1].unit_size,
-                index_info[2].unit_size,
-                index_info[3].unit_size,
-                index_info[4].unit_size,
-                index_size,
+                    // index
+                    index_info[0].is_defined,
+                    index_info[1].is_defined,
+                    index_info[2].is_defined,
+                    index_info[3].is_defined,
+                    index_info[4].is_defined,
+                    index_info[0].unit_size,
+                    index_info[1].unit_size,
+                    index_info[2].unit_size,
+                    index_info[3].unit_size,
+                    index_info[4].unit_size,
+                    index_size,
 
-                // output
-                output_5d_shape_without_padding[0],
-                output_5d_shape_without_padding[1],
-                output_5d_shape_without_padding[2],
-                output_5d_shape_without_padding[3],
-                output_5d_shape_without_padding[4],
-                output_num_stick_width,
+                    // output
+                    output_5d_shape_without_padding[0],
+                    output_5d_shape_without_padding[1],
+                    output_5d_shape_without_padding[2],
+                    output_5d_shape_without_padding[3],
+                    output_5d_shape_without_padding[4],
+                    output_num_stick_width,
 
-                // etc
-                start_id,
-                num_units_per_core,
-                input.element_size(),
-                num_elements_per_alignment,
-                num_alignment_width,
-            };
+                    // etc
+                    start_id,
+                    num_units_per_core,
+                    input.element_size(),
+                    num_elements_per_alignment,
+                    num_alignment_width,
+                });
 
-            std::vector<uint32_t> writer_args = {
-                // buffers
-                output.buffer()->address(),
+            writer_desc.emplace_runtime_args(
+                core,
+                {
+                    // buffers
+                    output.buffer(),
 
-                // output
-                output_5d_shape_without_padding[1],
-                output_5d_shape_without_padding[2],
-                output_5d_shape_without_padding[3],
-                output_5d_shape_without_padding[4],
-                output_noc_id_stride_n,
-                output_noc_id_stride_c,
-                output_noc_id_stride_d,
-                output_noc_id_stride_h,
-                output_num_stick_width,
+                    // output
+                    output_5d_shape_without_padding[1],
+                    output_5d_shape_without_padding[2],
+                    output_5d_shape_without_padding[3],
+                    output_5d_shape_without_padding[4],
+                    output_noc_id_stride_n,
+                    output_noc_id_stride_c,
+                    output_noc_id_stride_d,
+                    output_noc_id_stride_h,
+                    output_num_stick_width,
 
-                // etc
-                start_id,
-                num_units_per_core,
-                output_unit_size,
-                output.element_size(),
-                num_elements_per_alignment,
-                num_alignment_width,
-            };
-
-            SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-            SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+                    // etc
+                    start_id,
+                    num_units_per_core,
+                    output_unit_size,
+                    output.element_size(),
+                    num_elements_per_alignment,
+                    num_alignment_width,
+                });
 
             start_id += num_units_per_core;
         }
-        return {
-            std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, core_h, index_dims, input_dim_offset}};
+
+        desc.kernels.push_back(std::move(reader_desc));
+        desc.kernels.push_back(std::move(writer_desc));
+
+        return desc;
 
     }  // compute index info
 
@@ -345,7 +378,7 @@ MorehGetItemOperation::MorehGetItemTilizedFactory::create(
     auto [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
         split_work_to_cores_wt_core_range(core_range, num_units);
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     auto src_cb_data_format = datatype_to_dataformat_converter(input.dtype());
@@ -354,9 +387,15 @@ MorehGetItemOperation::MorehGetItemTilizedFactory::create(
 
     auto src_cb_index = CBIndex::c_0;
     auto rounded_input_page_size = round_up_to_mul32(input_unit_size);
-    auto cb_src0_config = CircularBufferConfig(rounded_input_page_size, {{src_cb_index, src_cb_data_format}})
-                              .set_page_size(src_cb_index, rounded_input_page_size);
-    CreateCircularBuffer(program, all_cores, cb_src0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = rounded_input_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src_cb_index),
+            .data_format = src_cb_data_format,
+            .page_size = rounded_input_page_size,
+        }}},
+    });
 
     for (uint32_t dim = 0; dim < 5; dim++) {
         if (!index_info[dim].is_defined) {
@@ -364,49 +403,67 @@ MorehGetItemOperation::MorehGetItemTilizedFactory::create(
         }
 
         auto src1_cb_index = CBIndex::c_1 + dim;
-        // auto index_page_size = round_up_to_mul32(index_info[dim].unit_size);
         auto index_page_size = 1024 * 4;
-        auto cb_index_config = CircularBufferConfig(index_page_size, {{src1_cb_index, index_cb_data_format}})
-                                   .set_page_size(src1_cb_index, index_page_size);
-        CreateCircularBuffer(program, all_cores, cb_index_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = static_cast<uint32_t>(index_page_size),
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(src1_cb_index),
+                .data_format = index_cb_data_format,
+                .page_size = static_cast<uint32_t>(index_page_size),
+            }}},
+        });
     }
 
     auto out_cb_index = CBIndex::c_16;
-    auto cb_out0_config = CircularBufferConfig(rounded_input_page_size, {{out_cb_index, output_cb_data_format}})
-                              .set_page_size(out_cb_index, rounded_input_page_size);
-    CreateCircularBuffer(program, all_cores, cb_out0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = rounded_input_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(out_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = rounded_input_page_size,
+        }}},
+    });
 
     // create read/write kernel
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
+    KernelDescriptor::Defines reader_defines;
+    KernelDescriptor::Defines writer_defines;
 
     if (is_row_major_index) {
-        reader_defines["ROW_MAJOR_INDEX"] = "1";
+        reader_defines.emplace_back("ROW_MAJOR_INDEX", "1");
     } else {
-        reader_defines["TILIZE_INDEX"] = "1";
+        reader_defines.emplace_back("TILIZE_INDEX", "1");
     }
 
-    std::vector<uint32_t> reader_compile_time_args;
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args;
     tt::tt_metal::TensorAccessorArgs(input.buffer()).append_to(reader_compile_time_args);
     for (const auto& info : index_info) {
         info.args.append_to(reader_compile_time_args);
     }
-    auto reader_kernel_id = CreateReadKernel(
-        program,
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/"
-        "reader_moreh_getitem_tilize.cpp",
-        all_cores,
-        reader_compile_time_args,
-        reader_defines);
-    std::vector<uint32_t> writer_compile_time_args;
+        "reader_moreh_getitem_tilize.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args;
     tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
-    auto writer_kernel_id = CreateWriteKernel(
-        program,
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/"
-        "writer_moreh_getitem_tilize.cpp",
-        all_cores,
-        writer_compile_time_args,
-        writer_defines);
+        "writer_moreh_getitem_tilize.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterConfigDescriptor{};
 
     uint32_t face_width = 16;
     uint32_t input_num_stick_width = div_up(input_5d_shape_without_padding[4], face_width);
@@ -447,136 +504,97 @@ MorehGetItemOperation::MorehGetItemTilizedFactory::create(
         CoreCoord core = {(i / core_h) + core_x_offset, (i % core_h) + core_y_offset};
         uint32_t num_units_per_core = i < g1_numcores ? num_units_per_core_group_1 : num_units_per_core_group_2;
 
-        std::vector<uint32_t> reader_args = {
-            // buffers
-            input.buffer()->address(),
-            index_info[0].address,
-            index_info[1].address,
-            index_info[2].address,
-            index_info[3].address,
-            index_info[4].address,
+        reader_desc.emplace_runtime_args(
+            core,
+            {
+                // buffers
+                input.buffer(),
+                index_info[0].address,
+                index_info[1].address,
+                index_info[2].address,
+                index_info[3].address,
+                index_info[4].address,
 
-            // input
-            input_stick_idx_stride_n,
-            input_stick_idx_stride_c,
-            input_stick_idx_stride_d,
-            input_stick_idx_stride_h,
-            input_stick_idx_stride_w,
-            input_5d_shape_without_padding[1],
-            input_5d_shape_without_padding[2],
-            input_5d_shape_without_padding[3],
-            input_noc_id_stride_n,
-            input_noc_id_stride_c,
-            input_noc_id_stride_d,
-            input_noc_id_stride_h,
-            input_num_stick_width,
+                // input
+                input_stick_idx_stride_n,
+                input_stick_idx_stride_c,
+                input_stick_idx_stride_d,
+                input_stick_idx_stride_h,
+                input_stick_idx_stride_w,
+                input_5d_shape_without_padding[1],
+                input_5d_shape_without_padding[2],
+                input_5d_shape_without_padding[3],
+                input_noc_id_stride_n,
+                input_noc_id_stride_c,
+                input_noc_id_stride_d,
+                input_noc_id_stride_h,
+                input_num_stick_width,
 
-            input_5d_shape_without_padding[0],
-            input_5d_shape_without_padding[1],
-            input_5d_shape_without_padding[2],
-            input_5d_shape_without_padding[3],
-            input_5d_shape_without_padding[4],
+                input_5d_shape_without_padding[0],
+                input_5d_shape_without_padding[1],
+                input_5d_shape_without_padding[2],
+                input_5d_shape_without_padding[3],
+                input_5d_shape_without_padding[4],
 
-            // index
-            index_info[0].is_defined,
-            index_info[1].is_defined,
-            index_info[2].is_defined,
-            index_info[3].is_defined,
-            index_info[4].is_defined,
-            index_info[0].unit_size,
-            index_info[1].unit_size,
-            index_info[2].unit_size,
-            index_info[3].unit_size,
-            index_info[4].unit_size,
-            index_size,
+                // index
+                index_info[0].is_defined,
+                index_info[1].is_defined,
+                index_info[2].is_defined,
+                index_info[3].is_defined,
+                index_info[4].is_defined,
+                index_info[0].unit_size,
+                index_info[1].unit_size,
+                index_info[2].unit_size,
+                index_info[3].unit_size,
+                index_info[4].unit_size,
+                index_size,
 
-            // output
-            output_5d_shape[0],
-            output_5d_shape[1],
-            output_5d_shape[2],
-            output_5d_shape_without_padding[3],
-            output_5d_shape_without_padding[4],
-            output_num_stick_width,
+                // output
+                output_5d_shape[0],
+                output_5d_shape[1],
+                output_5d_shape[2],
+                output_5d_shape_without_padding[3],
+                output_5d_shape_without_padding[4],
+                output_num_stick_width,
 
-            // etc
-            start_id,
-            num_units_per_core,
-            input_unit_size,
-            input.element_size(),
-        };
-        std::vector<uint32_t> writer_args = {
-            // buffers
-            output.buffer()->address(),
+                // etc
+                start_id,
+                num_units_per_core,
+                input_unit_size,
+                input.element_size(),
+            });
 
-            // output
-            output_5d_shape_without_padding[1],
-            output_5d_shape_without_padding[2],
-            output_5d_shape_without_padding[3],
-            output_5d_shape_without_padding[4],
-            output_noc_id_stride_n,
-            output_noc_id_stride_c,
-            output_noc_id_stride_d,
-            output_noc_id_stride_h,
-            output_num_stick_width,
+        writer_desc.emplace_runtime_args(
+            core,
+            {
+                // buffers
+                output.buffer(),
 
-            // etc
-            start_id,
-            num_units_per_core,
-            output_unit_size,
-            output.element_size(),
-        };
+                // output
+                output_5d_shape_without_padding[1],
+                output_5d_shape_without_padding[2],
+                output_5d_shape_without_padding[3],
+                output_5d_shape_without_padding[4],
+                output_noc_id_stride_n,
+                output_noc_id_stride_c,
+                output_noc_id_stride_d,
+                output_noc_id_stride_h,
+                output_num_stick_width,
 
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+                // etc
+                start_id,
+                num_units_per_core,
+                output_unit_size,
+                output.element_size(),
+            });
 
         start_id += num_units_per_core;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, core_h, index_dims, input_dim_offset}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
 }
 
-void MorehGetItemOperation::MorehGetItemTilizedFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    using namespace CMAKE_UNIQUE_NAMESPACE;
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto num_cores = cached_program.shared_variables.num_cores;
-    auto core_h = cached_program.shared_variables.core_h;
-    auto index_dims = cached_program.shared_variables.index_dims;
-    auto input_dim_offset = cached_program.shared_variables.input_dim_offset;
-
-    auto* src_buffer = tensor_args.input.buffer();
-    auto* dst_buffer = tensor_return_value.buffer();
-    auto index_tensors = tensor_args.index_tensors;
-    IndexInfo index_info[5] = {{false}};
-    for (uint32_t i = 0; i < index_dims.size(); i++) {
-        auto dim = index_dims[i] + input_dim_offset;
-        const auto& index_buffer = index_tensors[i];
-
-        index_info[dim].address = index_buffer.buffer()->address();
-    }
-
-    for (uint32_t icore = 0; icore < num_cores; icore++) {
-        CoreCoord core = {icore / core_h, icore % core_h};
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = src_buffer->address();
-            runtime_args[1] = index_info[0].address;
-            runtime_args[2] = index_info[1].address;
-            runtime_args[3] = index_info[2].address;
-            runtime_args[4] = index_info[3].address;
-            runtime_args[5] = index_info[4].address;
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = dst_buffer->address();
-        }
-    }
-}
 }  // namespace ttnn::operations::moreh::moreh_getitem

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_device_operation.hpp
@@ -12,6 +12,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/tensor/types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_group_norm_backward {
 struct MorehGroupNormBackwardGammaBetaGradOperation {
@@ -35,22 +36,7 @@ struct MorehGroupNormBackwardGammaBetaGradOperation {
     using tensor_return_value_t = std::vector<std::optional<Tensor>>;
 
     struct MorehGroupNormBackwardGammaBetaGradFactory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle reader_kernels_id;
-            tt::tt_metal::KernelHandle writer_kernels_id;
-            uint32_t num_cores_to_be_used;
-            std::size_t num_cores_y;
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& outputs);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& outputs);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_factory.cpp
@@ -8,13 +8,15 @@
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_group_norm_backward {
-MorehGroupNormBackwardGammaBetaGradOperation::MorehGroupNormBackwardGammaBetaGradFactory::cached_program_t
-MorehGroupNormBackwardGammaBetaGradOperation::MorehGroupNormBackwardGammaBetaGradFactory::create(
+
+tt::tt_metal::ProgramDescriptor
+MorehGroupNormBackwardGammaBetaGradOperation::MorehGroupNormBackwardGammaBetaGradFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& outputs) {
     using namespace tt;
     using namespace tt::constants;
+    using namespace tt::tt_metal;
 
     const auto& output_grad = tensor_args.output_grad;
     const auto& input = tensor_args.input;
@@ -29,7 +31,6 @@ MorehGroupNormBackwardGammaBetaGradOperation::MorehGroupNormBackwardGammaBetaGra
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
     auto* device = output_grad.device();
-    auto program = CreateProgram();
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
@@ -104,28 +105,40 @@ MorehGroupNormBackwardGammaBetaGradOperation::MorehGroupNormBackwardGammaBetaGra
     const uint32_t im5_t = 1;  // dycopy
 
     const auto cb_data_format = tt_metal::datatype_to_dataformat_converter(output_grad.dtype());
+    const auto single_tile_size = tt::tile_size(cb_data_format);
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        cb_data_format,
-        {
-            {CBIndex::c_0, in0_t},    // output_grad(==dy)
-            {CBIndex::c_1, in1_t},    // input(==x)
-            {CBIndex::c_2, in2_t},    // mean
-            {CBIndex::c_3, in3_t},    // rstd
-            {CBIndex::c_4, in4_t},    // one
-            {CBIndex::c_5, in5_t},    // mask_h
-            {CBIndex::c_6, in6_t},    // mask_w
-            {CBIndex::c_16, out0_t},  // gamma_grad(==dgamma)
-            {CBIndex::c_17, out1_t},  // beta_grad(==dbeta)
-            {CBIndex::c_24, im0_t},   // output(==y)
-            {CBIndex::c_25, im1_t},   // y * dy
-            {CBIndex::c_26, im2_t},   // Add[dy]
-            {CBIndex::c_27, im3_t},   // Add[y * dy]
-            {CBIndex::c_28, im4_t},   // x - mean
-            {CBIndex::c_29, im5_t},   // dycopy
+    ProgramDescriptor desc;
+
+    auto add_cb = [&](CBIndex cb_index, uint32_t num_tiles) {
+        if (num_tiles == 0) {
+            return;
+        }
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_tiles * single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_index),
+                .data_format = cb_data_format,
+                .page_size = single_tile_size,
+            }}},
         });
+    };
+
+    add_cb(CBIndex::c_0, in0_t);    // output_grad(==dy)
+    add_cb(CBIndex::c_1, in1_t);    // input(==x)
+    add_cb(CBIndex::c_2, in2_t);    // mean
+    add_cb(CBIndex::c_3, in3_t);    // rstd
+    add_cb(CBIndex::c_4, in4_t);    // one
+    add_cb(CBIndex::c_5, in5_t);    // mask_h
+    add_cb(CBIndex::c_6, in6_t);    // mask_w
+    add_cb(CBIndex::c_16, out0_t);  // gamma_grad(==dgamma)
+    add_cb(CBIndex::c_17, out1_t);  // beta_grad(==dbeta)
+    add_cb(CBIndex::c_24, im0_t);   // output(==y)
+    add_cb(CBIndex::c_25, im1_t);   // y * dy
+    add_cb(CBIndex::c_26, im2_t);   // Add[dy]
+    add_cb(CBIndex::c_27, im3_t);   // Add[y * dy]
+    add_cb(CBIndex::c_28, im4_t);   // x - mean
+    add_cb(CBIndex::c_29, im5_t);   // dycopy
 
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
@@ -137,52 +150,47 @@ MorehGroupNormBackwardGammaBetaGradOperation::MorehGroupNormBackwardGammaBetaGra
         "ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/kernels/dataflow/"
         "writer_moreh_group_norm_backward_gamma_beta_grad.cpp");
 
-    std::vector<uint32_t> reader_compile_time_args{static_cast<uint32_t>(gamma_grad_has_value)};
-    TensorAccessorArgs(output_grad.buffer()).append_to(reader_compile_time_args);
-    TensorAccessorArgs(input.buffer()).append_to(reader_compile_time_args);
-    TensorAccessorArgs(mean.buffer()).append_to(reader_compile_time_args);
-    TensorAccessorArgs(rstd.buffer()).append_to(reader_compile_time_args);
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args{static_cast<uint32_t>(gamma_grad_has_value)};
+    TensorAccessorArgs(*output_grad.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*mean.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*rstd.buffer()).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args{
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args{
         static_cast<uint32_t>(gamma_grad_has_value), static_cast<uint32_t>(beta_grad_has_value)};
     TensorAccessorArgs(gamma_grad_has_value ? gamma_grad.value().buffer() : nullptr)
         .append_to(writer_compile_time_args);
     TensorAccessorArgs(beta_grad_has_value ? beta_grad.value().buffer() : nullptr).append_to(writer_compile_time_args);
 
-    const auto reader_kernels_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args);
-    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_file;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_file;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    std::map<std::string, std::string> compute_defines{};
-    compute_defines["REDUCE_OP"] = "PoolType::SUM";
-    compute_defines["REDUCE_DIM"] = "ReduceDim::REDUCE_SCALAR";
+    KernelDescriptor::Defines compute_defines{
+        {"REDUCE_OP", "PoolType::SUM"},
+        {"REDUCE_DIM", "ReduceDim::REDUCE_SCALAR"},
+    };
 
     const std::string compute_kernel_file(
         "ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/"
         "moreh_layer_norm_backward_gamma_beta_grad_kernel.cpp");
 
-    const std::vector<uint32_t> compute_args_group_1{
-        num_channels_per_core_group_1,
-        origin_h,
-        origin_w,
-        num_inner_tiles,
-        Wt,
-        static_cast<uint32_t>(gamma_grad_has_value),
-        static_cast<uint32_t>(beta_grad_has_value),
-        static_cast<uint32_t>(is_lastdim_layernorm),
-        static_cast<uint32_t>(is_groupnorm)};
-
-    CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {core_group_1, num_channels_per_core_group_1, compute_args_group_1},
-        compute_defines);
-
-    if (!core_group_2.ranges().empty()) {
-        const std::vector<uint32_t> compute_args_group_2{
-            num_channels_per_core_group_2,
+    auto make_compute_args = [&](uint32_t num_channels_per_core) -> KernelDescriptor::CompileTimeArgs {
+        return {
+            num_channels_per_core,
             origin_h,
             origin_w,
             num_inner_tiles,
@@ -191,24 +199,37 @@ MorehGroupNormBackwardGammaBetaGradOperation::MorehGroupNormBackwardGammaBetaGra
             static_cast<uint32_t>(beta_grad_has_value),
             static_cast<uint32_t>(is_lastdim_layernorm),
             static_cast<uint32_t>(is_groupnorm)};
+    };
 
-        CreateComputeKernel(
-            program,
-            compute_kernel_file,
-            {core_group_2, num_channels_per_core_group_2, compute_args_group_2},
-            compute_defines);
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = make_compute_args(num_channels_per_core_group_1);
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{};
+
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    KernelDescriptor compute_desc_2;
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = make_compute_args(num_channels_per_core_group_2);
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{};
     }
 
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const auto output_grad_addr = output_grad.buffer()->address();
-    const auto input_addr = input.buffer()->address();
-    const auto mean_addr = mean.buffer()->address();
-    const auto rstd_addr = rstd.buffer()->address();
+    auto* const output_grad_buf = output_grad.buffer();
+    auto* const input_buf = input.buffer();
+    auto* const mean_buf = mean.buffer();
+    auto* const rstd_buf = rstd.buffer();
 
-    const auto gamma_grad_addr = gamma_grad_has_value ? gamma_grad.value().buffer()->address() : 0;
-    const auto beta_grad_addr = beta_grad_has_value ? beta_grad.value().buffer()->address() : 0;
+    const auto gamma_grad_addr = gamma_grad_has_value ? gamma_grad.value().buffer()->address() : 0u;
+    const auto beta_grad_addr = beta_grad_has_value ? beta_grad.value().buffer()->address() : 0u;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -222,78 +243,48 @@ MorehGroupNormBackwardGammaBetaGradOperation::MorehGroupNormBackwardGammaBetaGra
             TT_THROW("Core not in specified core ranges.");
         }
 
-        // reader
-        const std::vector<uint32_t> reader_runtime_args{
-            output_grad_addr,
-            input_addr,
-            mean_addr,
-            rstd_addr,
-            tile_offset,
-            num_channels_per_core,
-            num_inner_tiles,
-            num_channels,
-            num_groups,
-            origin_h,
-            origin_w,
-        };
-        SetRuntimeArgs(program, reader_kernels_id, core, reader_runtime_args);
+        // NOTE: do not pass Buffer* here. tile_offset/num_channels_per_core/etc are
+        // per-core shape-derived; using BufferBinding would skip create_descriptor()
+        // on cache hits and leave those scalars stale.
+        reader_desc.runtime_args.emplace_back(
+            core,
+            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
+                output_grad_buf->address(),
+                input_buf->address(),
+                mean_buf->address(),
+                rstd_buf->address(),
+                tile_offset,
+                num_channels_per_core,
+                num_inner_tiles,
+                num_channels,
+                num_groups,
+                origin_h,
+                origin_w,
+            });
 
-        // writer
-        const std::vector<uint32_t> writer_runtime_args{
-            gamma_grad_addr,
-            beta_grad_addr,
-            tile_offset,
-            num_channels_per_core,
-            num_inner_tiles,
-            batch,
-        };
-        SetRuntimeArgs(program, writer_kernels_id, core, writer_runtime_args);
+        // writer (already address-only, no BufferBinding)
+        writer_desc.runtime_args.emplace_back(
+            core,
+            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
+                gamma_grad_addr,
+                beta_grad_addr,
+                tile_offset,
+                num_channels_per_core,
+                num_inner_tiles,
+                batch,
+            });
 
         tile_offset += num_channels_per_core * HtWt;
     }
 
-    return {std::move(program), {reader_kernels_id, writer_kernels_id, num_cores_to_be_used, num_cores_y}};
-}
-
-void MorehGroupNormBackwardGammaBetaGradOperation::MorehGroupNormBackwardGammaBetaGradFactory::
-    override_runtime_arguments(
-        cached_program_t& cached_program,
-        const operation_attributes_t& /*operation_attributes*/,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& outputs) {
-    auto reader_kernels_id = cached_program.shared_variables.reader_kernels_id;
-    auto writer_kernels_id = cached_program.shared_variables.writer_kernels_id;
-    auto num_cores_to_be_used = cached_program.shared_variables.num_cores_to_be_used;
-    auto num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    auto* output_grad_buffer = tensor_args.output_grad.buffer();
-    auto* input_buffer = tensor_args.input.buffer();
-    auto* mean_buffer = tensor_args.mean.buffer();
-    auto* rstd_buffer = tensor_args.rstd.buffer();
-
-    auto* gamma_grad_buffer = outputs[0]->buffer();
-    auto* beta_grad_buffer = outputs[1]->buffer();
-
-    for (uint32_t i = 0; i < num_cores_to_be_used; ++i) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-        {
-            auto& runtime_args = GetRuntimeArgs(cached_program.program, reader_kernels_id, core);
-            runtime_args[0] = output_grad_buffer->address();
-            runtime_args[1] = input_buffer->address();
-            runtime_args[2] = mean_buffer->address();
-            runtime_args[3] = rstd_buffer->address();
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(cached_program.program, writer_kernels_id, core);
-            if (gamma_grad_buffer != nullptr) {
-                runtime_args[0] = gamma_grad_buffer->address();
-            }
-            if (beta_grad_buffer != nullptr) {
-                runtime_args[1] = beta_grad_buffer->address();
-            }
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::operations::moreh::moreh_group_norm_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_device_operation.hpp
@@ -7,6 +7,7 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/types.hpp"
 #include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_group_norm_backward {
 struct MorehGroupNormBackwardInputGradOperation {
@@ -28,22 +29,7 @@ struct MorehGroupNormBackwardInputGradOperation {
     using tensor_return_value_t = Tensor;
 
     struct MorehGroupNormBackwardInputGradFactory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle reader_kernels_id;
-            tt::tt_metal::KernelHandle writer_kernels_id;
-            uint32_t num_cores_to_be_used;
-            std::size_t num_cores_y;
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& outputs);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& outputs);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_factory.cpp
@@ -2,21 +2,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <iostream>
-
 #include "moreh_group_norm_backward_input_grad_device_operation.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_group_norm_backward {
-MorehGroupNormBackwardInputGradOperation::MorehGroupNormBackwardInputGradFactory::cached_program_t
-MorehGroupNormBackwardInputGradOperation::MorehGroupNormBackwardInputGradFactory::create(
+
+tt::tt_metal::ProgramDescriptor
+MorehGroupNormBackwardInputGradOperation::MorehGroupNormBackwardInputGradFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& outputs) {
     using namespace tt;
     using namespace tt::constants;
+    using namespace tt::tt_metal;
 
     const auto& output_grad = tensor_args.output_grad;
     const auto& input = tensor_args.input;
@@ -24,13 +24,13 @@ MorehGroupNormBackwardInputGradOperation::MorehGroupNormBackwardInputGradFactory
     const auto& rstd = tensor_args.rstd;
 
     const auto& input_grad = outputs;
-    auto gamma = tensor_args.gamma;
+    const auto& gamma = tensor_args.gamma;
     auto num_groups = operation_attributes.num_groups;
+
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
     auto* device = output_grad.device();
-    auto program = CreateProgram();
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
@@ -113,37 +113,48 @@ MorehGroupNormBackwardInputGradOperation::MorehGroupNormBackwardInputGradFactory
     const bool use_large_algorithm = cb_usage >= available_L1;
 
     if (use_large_algorithm) {
-        log_info(LogTest, "Large moreh_layer_norm_backward_input_grad algorithm is selected.");
+        log_info(LogTest, "Large moreh_group_norm_backward_input_grad algorithm is selected.");
         im0_t = 1;
         im1_t = 1;
         im7_t = 0;
     } else {
-        log_info(LogTest, "Small moreh_layer_norm_backward_input_grad algorithm is selected.");
+        log_info(LogTest, "Small moreh_group_norm_backward_input_grad algorithm is selected.");
     }
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        cb_data_format,
-        {
-            {CBIndex::c_0, in0_t},  // output_grad
-            {CBIndex::c_1, in1_t},  // input
-            {CBIndex::c_2, in2_t},  // mean
-            {CBIndex::c_3, in3_t},  // rstd
-            {CBIndex::c_4, in4_t},  // one
-            {CBIndex::c_5, in5_t},  // inner_size(==n)
-            {CBIndex::c_6, in6_t},
-            {CBIndex::c_7, in7_t},
-            {CBIndex::c_16, out0_t},  // input_grad
-            {CBIndex::c_24, im0_t},
-            {CBIndex::c_25, im1_t},
-            {CBIndex::c_26, im2_t},
-            {CBIndex::c_27, im3_t},
-            {CBIndex::c_28, im4_t},
-            {CBIndex::c_29, im5_t},
-            {CBIndex::c_30, im6_t},
-            {CBIndex::c_31, im7_t},
+    ProgramDescriptor desc;
+
+    auto add_cb = [&](CBIndex cb_index, uint32_t num_tiles) {
+        if (num_tiles == 0) {
+            return;
+        }
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_tiles * single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_index),
+                .data_format = cb_data_format,
+                .page_size = single_tile_size,
+            }}},
         });
+    };
+
+    add_cb(CBIndex::c_0, in0_t);  // output_grad
+    add_cb(CBIndex::c_1, in1_t);  // input
+    add_cb(CBIndex::c_2, in2_t);  // mean
+    add_cb(CBIndex::c_3, in3_t);  // rstd
+    add_cb(CBIndex::c_4, in4_t);  // one
+    add_cb(CBIndex::c_5, in5_t);  // inner_size(==n)
+    add_cb(CBIndex::c_6, in6_t);
+    add_cb(CBIndex::c_7, in7_t);
+    add_cb(CBIndex::c_16, out0_t);  // input_grad
+    add_cb(CBIndex::c_24, im0_t);
+    add_cb(CBIndex::c_25, im1_t);
+    add_cb(CBIndex::c_26, im2_t);
+    add_cb(CBIndex::c_27, im3_t);
+    add_cb(CBIndex::c_28, im4_t);
+    add_cb(CBIndex::c_29, im5_t);
+    add_cb(CBIndex::c_30, im6_t);
+    add_cb(CBIndex::c_31, im7_t);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
@@ -159,25 +170,37 @@ MorehGroupNormBackwardInputGradOperation::MorehGroupNormBackwardInputGradFactory
         "ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/kernels/dataflow/"
         "writer_moreh_group_norm_backward_input_grad.cpp");
 
-    std::vector<uint32_t> reader_compile_time_args{static_cast<uint32_t>(gamma_has_value)};
-    TensorAccessorArgs(output_grad.buffer()).append_to(reader_compile_time_args);
-    TensorAccessorArgs(input.buffer()).append_to(reader_compile_time_args);
-    TensorAccessorArgs(mean.buffer()).append_to(reader_compile_time_args);
-    TensorAccessorArgs(rstd.buffer()).append_to(reader_compile_time_args);
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args{static_cast<uint32_t>(gamma_has_value)};
+    TensorAccessorArgs(*output_grad.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*mean.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*rstd.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(gamma_has_value ? gamma->buffer() : nullptr).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args{};
-    TensorAccessorArgs(input_grad.buffer()).append_to(writer_compile_time_args);
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args{};
+    TensorAccessorArgs(*input_grad.buffer()).append_to(writer_compile_time_args);
 
-    const auto reader_kernels_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args);
-    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_file;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_file;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    std::map<std::string, std::string> compute_defines{};
-    compute_defines["REDUCE_OP"] = "PoolType::SUM";
-    compute_defines["REDUCE_DIM"] = "ReduceDim::REDUCE_SCALAR";
+    KernelDescriptor::Defines compute_defines{
+        {"REDUCE_OP", "PoolType::SUM"},
+        {"REDUCE_DIM", "ReduceDim::REDUCE_SCALAR"},
+    };
 
     const auto* const compute_kernel_file =
         use_large_algorithm ? "ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/"
@@ -185,46 +208,47 @@ MorehGroupNormBackwardInputGradOperation::MorehGroupNormBackwardInputGradFactory
                             : "ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/"
                               "moreh_layer_norm_backward_input_grad_small_kernel.cpp";
 
-    const std::vector<uint32_t> compute_args_group_1{
-        num_rows_per_core_group_1,
-        origin_h,
-        origin_w,
-        num_inner_tiles,
-        static_cast<uint32_t>(gamma_has_value),
-        static_cast<uint32_t>(is_lastdim_layernorm),
-        static_cast<uint32_t>(is_groupnorm)};
-
-    CreateComputeKernel(
-        program, compute_kernel_file, {core_group_1, num_rows_per_core_group_1, compute_args_group_1}, compute_defines);
-
-    if (!core_group_2.ranges().empty()) {
-        const std::vector<uint32_t> compute_args_group_2{
-            num_rows_per_core_group_2,
+    auto make_compute_args = [&](uint32_t num_rows_per_core) -> KernelDescriptor::CompileTimeArgs {
+        return {
+            num_rows_per_core,
             origin_h,
             origin_w,
             num_inner_tiles,
             static_cast<uint32_t>(gamma_has_value),
             static_cast<uint32_t>(is_lastdim_layernorm),
             static_cast<uint32_t>(is_groupnorm)};
+    };
 
-        CreateComputeKernel(
-            program,
-            compute_kernel_file,
-            {core_group_2, num_rows_per_core_group_2, compute_args_group_2},
-            compute_defines);
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = make_compute_args(num_rows_per_core_group_1);
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{};
+
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    KernelDescriptor compute_desc_2;
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = make_compute_args(num_rows_per_core_group_2);
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{};
     }
 
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const auto output_grad_addr = output_grad.buffer()->address();
-    const auto input_addr = input.buffer()->address();
-    const auto mean_addr = mean.buffer()->address();
-    const auto rstd_addr = rstd.buffer()->address();
+    auto* const output_grad_buf = output_grad.buffer();
+    auto* const input_buf = input.buffer();
+    auto* const mean_buf = mean.buffer();
+    auto* const rstd_buf = rstd.buffer();
 
-    const auto input_grad_addr = input_grad.buffer()->address();
+    auto* const input_grad_buf = input_grad.buffer();
 
-    const auto gamma_addr = gamma_has_value ? gamma.value().buffer()->address() : 0;
+    const auto gamma_addr = gamma_has_value ? gamma.value().buffer()->address() : 0u;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -238,73 +262,47 @@ MorehGroupNormBackwardInputGradOperation::MorehGroupNormBackwardInputGradFactory
             TT_THROW("Core not in specified core ranges.");
         }
 
-        // reader
-        const std::vector<uint32_t> reader_runtime_args{
-            output_grad_addr,
-            input_addr,
-            mean_addr,
-            rstd_addr,
-            gamma_addr,
-            tile_offset,
-            num_rows_per_core,
-            num_inner_tiles,
-            num_channels,
-            num_groups,
-            origin_h,
-            origin_w,
-        };
-        SetRuntimeArgs(program, reader_kernels_id, core, reader_runtime_args);
+        // NOTE: do not pass Buffer* here. gamma_addr is an optional-tensor address
+        // and tile_offset/etc are per-core shape-derived; using BufferBinding would
+        // skip create_descriptor() on cache hits and leave those scalars stale.
+        reader_desc.runtime_args.emplace_back(
+            core,
+            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
+                output_grad_buf->address(),
+                input_buf->address(),
+                mean_buf->address(),
+                rstd_buf->address(),
+                gamma_addr,
+                tile_offset,
+                num_rows_per_core,
+                num_inner_tiles,
+                num_channels,
+                num_groups,
+                origin_h,
+                origin_w,
+            });
 
         // writer
-        const std::vector<uint32_t> writer_runtime_args{
-            input_grad_addr,
-            tile_offset,
-            num_rows_per_core,
-            num_inner_tiles,
-        };
-        SetRuntimeArgs(program, writer_kernels_id, core, writer_runtime_args);
+        writer_desc.runtime_args.emplace_back(
+            core,
+            tt::tt_metal::KernelDescriptor::CoreRuntimeArgs{
+                input_grad_buf->address(),
+                tile_offset,
+                num_rows_per_core,
+                num_inner_tiles,
+            });
 
         tile_offset += num_rows_per_core * num_inner_tiles;
     }
 
-    return {std::move(program), {reader_kernels_id, writer_kernels_id, num_cores_to_be_used, num_cores_y}};
-}
-
-void MorehGroupNormBackwardInputGradOperation::MorehGroupNormBackwardInputGradFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& outputs) {
-    auto reader_kernels_id = cached_program.shared_variables.reader_kernels_id;
-    auto writer_kernels_id = cached_program.shared_variables.writer_kernels_id;
-    auto num_cores_to_be_used = cached_program.shared_variables.num_cores_to_be_used;
-    auto num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    auto* output_grad_buffer = tensor_args.output_grad.buffer();
-    auto* input_buffer = tensor_args.input.buffer();
-    auto* mean_buffer = tensor_args.mean.buffer();
-    auto* rstd_buffer = tensor_args.rstd.buffer();
-    auto* gamma_buffer = tensor_args.gamma.has_value() ? tensor_args.gamma.value().buffer() : nullptr;
-    auto* input_grad_buffer = outputs.buffer();
-
-    for (uint32_t i = 0; i < num_cores_to_be_used; ++i) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-        {
-            auto& runtime_args = GetRuntimeArgs(cached_program.program, reader_kernels_id, core);
-            runtime_args[0] = output_grad_buffer->address();
-            runtime_args[1] = input_buffer->address();
-            runtime_args[2] = mean_buffer->address();
-            runtime_args[3] = rstd_buffer->address();
-            if (gamma_buffer != nullptr) {
-                runtime_args[4] = gamma_buffer->address();
-            }
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(cached_program.program, writer_kernels_id, core);
-            runtime_args[0] = input_grad_buffer->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::operations::moreh::moreh_group_norm_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.hpp
@@ -7,6 +7,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/tensor/types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_layer_norm {
 struct MorehLayerNormOperation {
@@ -32,25 +33,10 @@ struct MorehLayerNormOperation {
     using tensor_return_value_t = std::vector<std::optional<Tensor>>;
 
     struct ProgramFactory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id;
-            tt::tt_metal::KernelHandle unary_writer_kernel_id;
-            std::size_t num_cores;
-            std::size_t num_cores_y;
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& output_tensor);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
     };
 
     using program_factory_t = std::variant<ProgramFactory>;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_program_factory.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <bit>
+#include <string>
 #include <vector>
 
 #include "moreh_layer_norm_device_operation.hpp"
@@ -23,10 +25,13 @@ inline uint32_t find_divisor_with_max_block_size(uint32_t val, uint32_t max_bloc
     return divisor;
 }
 
-MorehLayerNormOperation::ProgramFactory::cached_program_t MorehLayerNormOperation::ProgramFactory::create(
+tt::tt_metal::ProgramDescriptor MorehLayerNormOperation::ProgramFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output_tensor) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
     const auto& input = tensor_args.input;
     const auto& gamma = tensor_args.gamma;
     const auto& beta = tensor_args.beta;
@@ -59,7 +64,6 @@ MorehLayerNormOperation::ProgramFactory::cached_program_t MorehLayerNormOperatio
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
     IDevice* device = input.device();
-    Program program = Program();
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
@@ -168,70 +172,88 @@ MorehLayerNormOperation::ProgramFactory::cached_program_t MorehLayerNormOperatio
         log_info(tt::LogTest, "Small moreh_layer_norm algorithm is selected.");
     }
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        cb_data_format,
-        {
-            {tt::CBIndex::c_0, in0_t},                       // input
-            {tt::CBIndex::c_1, in1_t},                       // scaler
-            {tt::CBIndex::c_2, in2_t},                       // epsilon
-            {tt::CBIndex::c_3, in3_t},                       // gamma
-            {tt::CBIndex::c_4, in4_t},                       // beta
-            {tt::CBIndex::c_5, in5_t},                       // mask_h
-            {tt::CBIndex::c_6, in6_t},                       // mask_w
-            {tt::CBIndex::c_16, out0_t},                     // output
-            {tt::CBIndex::c_17, out1_t},                     // mean
-            {tt::CBIndex::c_18, out2_t},                     // rstd
-            {tt::CBIndex::c_24, im0_t, intermed_cb_format},  // E[x]
-            {tt::CBIndex::c_25, im1_t, intermed_cb_format},  // x - E[x]
-            {tt::CBIndex::c_26, im2_t, intermed_cb_format},  // (x - E[x])^2
-            {tt::CBIndex::c_27, im3_t, intermed_cb_format},  // Sum[(x - E[x])^2]
-            {tt::CBIndex::c_28, im4_t, intermed_cb_format},  // E[(x - E[x])^2] = Var[x]
-            {tt::CBIndex::c_29, im5_t, intermed_cb_format},  // 1.0/(sqrt(Var[x] + eps))
-            {tt::CBIndex::c_30, im6_t, intermed_cb_format},  // y * gamm + beta
-            {tt::CBIndex::c_31, im7_t, intermed_cb_format},  // Sum[x]
+    ProgramDescriptor desc;
+
+    // ---- Circular buffers ----
+    // Helper to push a CB with a given index, num_tiles, and data format.
+    auto push_cb = [&](uint8_t cb_index, uint32_t num_tiles, tt::DataFormat fmt) {
+        if (num_tiles == 0) {
+            // Preserve original behavior: skip zero-size CBs.
+            return;
+        }
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_tiles * tile_size(fmt),
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = cb_index,
+                .data_format = fmt,
+                .page_size = tile_size(fmt),
+            }}},
         });
+    };
+
+    push_cb(static_cast<uint8_t>(CBIndex::c_0), in0_t, cb_data_format);       // input
+    push_cb(static_cast<uint8_t>(CBIndex::c_1), in1_t, cb_data_format);       // scaler
+    push_cb(static_cast<uint8_t>(CBIndex::c_2), in2_t, cb_data_format);       // epsilon
+    push_cb(static_cast<uint8_t>(CBIndex::c_3), in3_t, cb_data_format);       // gamma
+    push_cb(static_cast<uint8_t>(CBIndex::c_4), in4_t, cb_data_format);       // beta
+    push_cb(static_cast<uint8_t>(CBIndex::c_5), in5_t, cb_data_format);       // mask_h
+    push_cb(static_cast<uint8_t>(CBIndex::c_6), in6_t, cb_data_format);       // mask_w
+    push_cb(static_cast<uint8_t>(CBIndex::c_16), out0_t, cb_data_format);     // output
+    push_cb(static_cast<uint8_t>(CBIndex::c_17), out1_t, cb_data_format);     // mean
+    push_cb(static_cast<uint8_t>(CBIndex::c_18), out2_t, cb_data_format);     // rstd
+    push_cb(static_cast<uint8_t>(CBIndex::c_24), im0_t, intermed_cb_format);  // E[x]
+    push_cb(static_cast<uint8_t>(CBIndex::c_25), im1_t, intermed_cb_format);  // x - E[x]
+    push_cb(static_cast<uint8_t>(CBIndex::c_26), im2_t, intermed_cb_format);  // (x - E[x])^2
+    push_cb(static_cast<uint8_t>(CBIndex::c_27), im3_t, intermed_cb_format);  // Sum[(x - E[x])^2]
+    push_cb(static_cast<uint8_t>(CBIndex::c_28), im4_t, intermed_cb_format);  // E[(x - E[x])^2] = Var[x]
+    push_cb(static_cast<uint8_t>(CBIndex::c_29), im5_t, intermed_cb_format);  // 1.0/(sqrt(Var[x] + eps))
+    push_cb(static_cast<uint8_t>(CBIndex::c_30), im6_t, intermed_cb_format);  // y * gamm + beta
+    push_cb(static_cast<uint8_t>(CBIndex::c_31), im7_t, intermed_cb_format);  // Sum[x]
 
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> reader_compile_time_args{block_size};
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args{block_size};
     tt::tt_metal::TensorAccessorArgs(input.buffer()).append_to(reader_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(gamma ? gamma->buffer() : nullptr).append_to(reader_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(beta ? beta->buffer() : nullptr).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args{mean_has_value, rstd_has_value, block_size};
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args{
+        static_cast<uint32_t>(mean_has_value), static_cast<uint32_t>(rstd_has_value), block_size};
     tt::tt_metal::TensorAccessorArgs(output->buffer()).append_to(writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(mean_as_tensor ? mean_as_tensor->buffer() : nullptr)
         .append_to(writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(rstd_as_tensor ? rstd_as_tensor->buffer() : nullptr)
         .append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines{};
-    std::map<std::string, std::string> compute_defines{};
+    std::map<std::string, std::string> reader_defines_map{};
+    std::map<std::string, std::string> compute_defines_map{};
     if (gamma_has_value) {
-        reader_defines["GAMMA_HAS_VALUE"] = "1";
+        reader_defines_map["GAMMA_HAS_VALUE"] = "1";
     }
     if (beta_has_value) {
-        reader_defines["BETA_HAS_VALUE"] = "1";
+        reader_defines_map["BETA_HAS_VALUE"] = "1";
     }
     if (do_mask_h) {
-        reader_defines["DO_MASK_H"] = "1";
+        reader_defines_map["DO_MASK_H"] = "1";
     }
     if (do_mask_w) {
-        reader_defines["DO_MASK_W"] = "1";
+        reader_defines_map["DO_MASK_W"] = "1";
     }
-    compute_defines["REDUCE_OP"] = "PoolType::AVG";
+    compute_defines_map["REDUCE_OP"] = "PoolType::AVG";
     if (is_lastdim_layer_norm) {
-        compute_defines["REDUCE_DIM"] = "ReduceDim::REDUCE_ROW";
+        compute_defines_map["REDUCE_DIM"] = "ReduceDim::REDUCE_ROW";
     } else {
-        compute_defines["REDUCE_DIM"] = "ReduceDim::REDUCE_SCALAR";
+        compute_defines_map["REDUCE_DIM"] = "ReduceDim::REDUCE_SCALAR";
     }
     if (fp32_dest_acc_en) {
-        reader_defines["FP32_DEST_ACC_EN"] = "1";
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        reader_defines_map["FP32_DEST_ACC_EN"] = "1";
+        compute_defines_map["FP32_DEST_ACC_EN"] = "1";
     }
+
+    KernelDescriptor::Defines reader_defines(reader_defines_map.begin(), reader_defines_map.end());
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
 
     const auto* const reader_kernel_file =
         use_large_algorithm
@@ -240,11 +262,31 @@ MorehLayerNormOperation::ProgramFactory::cached_program_t MorehLayerNormOperatio
     const auto* const writer_kernel_file =
         "ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/writer_moreh_layer_norm.cpp";
 
-    const auto reader_kernels_id =
-        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines);
-    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_file;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = reader_defines;
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    const std::vector<uint32_t> compute_args_group_1{
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_file;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    const auto* const compute_kernel_file =
+        use_large_algorithm
+            ? "ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_large_kernel.cpp"
+            : "ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_small_kernel.cpp";
+
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {
         num_rows_per_core_group_1,
         origin_H,
         origin_W,
@@ -256,23 +298,21 @@ MorehLayerNormOperation::ProgramFactory::cached_program_t MorehLayerNormOperatio
         static_cast<uint32_t>(rstd_has_value),
         static_cast<uint32_t>(is_lastdim_layer_norm),
         static_cast<uint32_t>(is_groupnorm)};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .math_approx_mode = math_approx_mode,
+    };
 
-    const auto* const compute_kernel_file =
-        use_large_algorithm
-            ? "ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_large_kernel.cpp"
-            : "ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_small_kernel.cpp";
-
-    CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {core_group_1, num_rows_per_core_group_1, compute_args_group_1},
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
-
-    if (!core_group_2.ranges().empty()) {
-        const std::vector<uint32_t> compute_args_group_2{
+    KernelDescriptor compute_desc_2;
+    const bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {
             num_rows_per_core_group_2,
             origin_H,
             origin_W,
@@ -284,50 +324,41 @@ MorehLayerNormOperation::ProgramFactory::cached_program_t MorehLayerNormOperatio
             static_cast<uint32_t>(rstd_has_value),
             static_cast<uint32_t>(is_lastdim_layer_norm),
             static_cast<uint32_t>(is_groupnorm)};
-
-        CreateComputeKernel(
-            program,
-            compute_kernel_file,
-            {core_group_2, num_rows_per_core_group_2, compute_args_group_2},
-            compute_defines,
-            math_fidelity,
-            fp32_dest_acc_en,
-            math_approx_mode);
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .math_approx_mode = math_approx_mode,
+        };
     }
 
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
-    union {
-        float f;
-        uint32_t u;
-    } scaler{};
-
+    float scaler_f = 0.0f;
     if (normalized_dims == 1) {
-        scaler.f = 1.0f / static_cast<float>(origin_W);
+        scaler_f = 1.0f / static_cast<float>(origin_W);
     } else {
-        auto reduce_size = 1;
+        uint32_t reduce_size = 1;
         for (uint32_t i = input_rank - normalized_dims; i < input_rank; i++) {
             auto size = input_shape_without_padding[i];
             reduce_size *= size;
         }
 
-        scaler.f = 1.0f / static_cast<float>(sqrt(reduce_size));
+        scaler_f = 1.0f / std::sqrt(static_cast<float>(reduce_size));
     }
+    const uint32_t scaler_u = std::bit_cast<uint32_t>(scaler_f);
 
-    union {
-        float f;
-        uint32_t u;
-    } e{};
-    e.f = eps;  // epsilon
+    const uint32_t e_u = std::bit_cast<uint32_t>(eps);  // epsilon
 
-    const auto input_addr = input.buffer()->address();
-    const auto output_addr = output->buffer()->address();
+    auto* const input_buf = input.buffer();
+    auto* const output_buf = output->buffer();
 
-    const auto gamma_addr = gamma_has_value ? gamma.value().buffer()->address() : 0;
-    const auto beta_addr = beta_has_value ? beta.value().buffer()->address() : 0;
-    const auto mean_addr = mean_has_value ? mean.value().buffer()->address() : 0;
-    const auto rstd_addr = rstd_has_value ? rstd.value().buffer()->address() : 0;
+    const auto gamma_addr = gamma_has_value ? gamma.value().buffer()->address() : 0u;
+    const auto beta_addr = beta_has_value ? beta.value().buffer()->address() : 0u;
+    const auto mean_addr = mean_has_value ? mean.value().buffer()->address() : 0u;
+    const auto rstd_addr = rstd_has_value ? rstd.value().buffer()->address() : 0u;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -341,80 +372,42 @@ MorehLayerNormOperation::ProgramFactory::cached_program_t MorehLayerNormOperatio
             TT_THROW("Core not in specified core ranges.");
         }
 
-        const std::vector<uint32_t> reader_runtime_args{
-            input_addr,
-            gamma_addr,
-            beta_addr,
-            num_rows_per_core,
-            num_inner,
-            tile_offset,
-            scaler.u,
-            e.u,
-            mask_h,
-            mask_w};
-        SetRuntimeArgs(program, reader_kernels_id, core, reader_runtime_args);
+        reader_desc.emplace_runtime_args(
+            core,
+            {input_buf,
+             gamma_addr,
+             beta_addr,
+             num_rows_per_core,
+             num_inner,
+             tile_offset,
+             scaler_u,
+             e_u,
+             mask_h,
+             mask_w});
 
-        const std::vector<uint32_t> writer_runtime_args{
-            output_addr,
-            mean_addr,
-            rstd_addr,
-            num_rows_per_core,
-            num_inner,
-            tile_offset,
-            mean_rstd_height,
-            mean_rstd_width,
-            normalized_dims};
-        SetRuntimeArgs(program, writer_kernels_id, core, writer_runtime_args);
+        writer_desc.emplace_runtime_args(
+            core,
+            {output_buf,
+             mean_addr,
+             rstd_addr,
+             num_rows_per_core,
+             num_inner,
+             tile_offset,
+             mean_rstd_height,
+             mean_rstd_width,
+             normalized_dims});
 
         tile_offset += num_rows_per_core * num_inner;
     }
 
-    return {std::move(program), {reader_kernels_id, writer_kernels_id, num_cores, num_cores_y}};
-}
-
-void MorehLayerNormOperation::ProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-
-    auto* input_buffer = tensor_args.input.buffer();
-    auto* gamma_buffer = tensor_args.gamma.has_value() ? tensor_args.gamma->buffer() : nullptr;
-    auto* beta_buffer = tensor_args.beta.has_value() ? tensor_args.beta->buffer() : nullptr;
-    auto* mean_buffer = tensor_args.mean.has_value() ? tensor_args.mean->buffer() : nullptr;
-    auto* rstd_buffer = tensor_args.rstd.has_value() ? tensor_args.rstd->buffer() : nullptr;
-
-    auto* output_buffer = tensor_return_value.at(0)->buffer();
-
-    auto num_cores = cached_program.shared_variables.num_cores;
-    auto num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = input_buffer->address();
-            if (gamma_buffer != nullptr) {
-                runtime_args[1] = gamma_buffer->address();
-            }
-            if (beta_buffer != nullptr) {
-                runtime_args[2] = beta_buffer->address();
-            }
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = output_buffer->address();
-            if (mean_buffer != nullptr) {
-                runtime_args[1] = mean_buffer->address();
-            }
-            if (rstd_buffer != nullptr) {
-                runtime_args[2] = rstd_buffer->address();
-            }
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::operations::moreh::moreh_layer_norm

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.hpp
@@ -7,6 +7,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/tensor/types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_layer_norm_backward_gamma_beta_grad {
 struct MorehLayerNormBackwardGammaBetaGradOperation {
@@ -29,29 +30,14 @@ struct MorehLayerNormBackwardGammaBetaGradOperation {
     using spec_return_value_t = std::vector<std::optional<TensorSpec>>;
     using tensor_return_value_t = std::vector<std::optional<Tensor>>;
 
-    struct ProgramFactory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id;
-            tt::tt_metal::KernelHandle unary_writer_kernel_id;
-            std::size_t num_cores;
-            std::size_t num_cores_y;
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
+    struct MorehLayerNormBackwardGammaBetaGradFactory {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& output_tensor);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
     };
 
-    using program_factory_t = std::variant<ProgramFactory>;
+    using program_factory_t = std::variant<MorehLayerNormBackwardGammaBetaGradFactory>;
 
     static void validate_inputs(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_program_factory.cpp
@@ -13,22 +13,14 @@
 
 namespace ttnn::operations::moreh::moreh_layer_norm_backward_gamma_beta_grad {
 
-inline uint32_t find_divisor_with_max_block_size(uint32_t val, uint32_t max_block_size) {
-    uint32_t divisor{1};
-    for (uint32_t current_divisor = max_block_size; current_divisor >= 1; current_divisor--) {
-        if (val % current_divisor == 0) {
-            divisor = current_divisor;
-            break;
-        }
-    }
-    return divisor;
-}
-
-MorehLayerNormBackwardGammaBetaGradOperation::ProgramFactory::cached_program_t
-MorehLayerNormBackwardGammaBetaGradOperation::ProgramFactory::create(
+tt::tt_metal::ProgramDescriptor
+MorehLayerNormBackwardGammaBetaGradOperation::MorehLayerNormBackwardGammaBetaGradFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output_tensor) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
     const auto& output_grad = tensor_args.output_grad;
     const auto& input = tensor_args.input;
     const auto& mean = tensor_args.mean;
@@ -47,7 +39,6 @@ MorehLayerNormBackwardGammaBetaGradOperation::ProgramFactory::create(
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
     IDevice* device = output_grad.device();
-    Program program = Program();
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
@@ -113,50 +104,65 @@ MorehLayerNormBackwardGammaBetaGradOperation::ProgramFactory::create(
     const auto cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_grad.dtype());
     auto intermed_cb_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : cb_data_format;
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        cb_data_format,
-        {
-            {tt::CBIndex::c_0, in0_t},                       // output_grad(==dy)
-            {tt::CBIndex::c_1, in1_t},                       // input(==x)
-            {tt::CBIndex::c_2, in2_t},                       // mean
-            {tt::CBIndex::c_3, in3_t},                       // rstd
-            {tt::CBIndex::c_4, in4_t},                       // scaler
-            {tt::CBIndex::c_5, in5_t},                       // mask_h
-            {tt::CBIndex::c_16, out0_t},                     // gamma_grad(==dgamma)
-            {tt::CBIndex::c_17, out1_t},                     // beta_grad(==dbeta)
-            {tt::CBIndex::c_24, im0_t, intermed_cb_format},  // output(==y)
-            {tt::CBIndex::c_25, im1_t, intermed_cb_format},  // y * dy
-            {tt::CBIndex::c_26, im2_t, intermed_cb_format},  // Add[dy]
-            {tt::CBIndex::c_27, im3_t, intermed_cb_format},  // Add[y * dy]
-            {tt::CBIndex::c_28, im4_t, intermed_cb_format},  // x - mean
-            {tt::CBIndex::c_29, im5_t, intermed_cb_format},  // dycopy
+    ProgramDescriptor desc;
+
+    auto push_cb = [&](uint8_t cb_index, uint32_t num_tiles, tt::DataFormat fmt) {
+        if (num_tiles == 0) {
+            // Preserve original behavior: skip zero-size CBs.
+            return;
+        }
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_tiles * tile_size(fmt),
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = cb_index,
+                .data_format = fmt,
+                .page_size = tile_size(fmt),
+            }}},
         });
+    };
+
+    push_cb(static_cast<uint8_t>(CBIndex::c_0), in0_t, cb_data_format);       // output_grad(==dy)
+    push_cb(static_cast<uint8_t>(CBIndex::c_1), in1_t, cb_data_format);       // input(==x)
+    push_cb(static_cast<uint8_t>(CBIndex::c_2), in2_t, cb_data_format);       // mean
+    push_cb(static_cast<uint8_t>(CBIndex::c_3), in3_t, cb_data_format);       // rstd
+    push_cb(static_cast<uint8_t>(CBIndex::c_4), in4_t, cb_data_format);       // scaler
+    push_cb(static_cast<uint8_t>(CBIndex::c_5), in5_t, cb_data_format);       // mask_h
+    push_cb(static_cast<uint8_t>(CBIndex::c_16), out0_t, cb_data_format);     // gamma_grad(==dgamma)
+    push_cb(static_cast<uint8_t>(CBIndex::c_17), out1_t, cb_data_format);     // beta_grad(==dbeta)
+    push_cb(static_cast<uint8_t>(CBIndex::c_24), im0_t, intermed_cb_format);  // output(==y)
+    push_cb(static_cast<uint8_t>(CBIndex::c_25), im1_t, intermed_cb_format);  // y * dy
+    push_cb(static_cast<uint8_t>(CBIndex::c_26), im2_t, intermed_cb_format);  // Add[dy]
+    push_cb(static_cast<uint8_t>(CBIndex::c_27), im3_t, intermed_cb_format);  // Add[y * dy]
+    push_cb(static_cast<uint8_t>(CBIndex::c_28), im4_t, intermed_cb_format);  // x - mean
+    push_cb(static_cast<uint8_t>(CBIndex::c_29), im5_t, intermed_cb_format);  // dycopy
 
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> reader_compile_time_args{
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args{
         static_cast<uint32_t>(gamma_grad_has_value), static_cast<uint32_t>(do_mask_h)};
     TensorAccessorArgs(output_grad.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(mean.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(rstd.buffer()).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args{
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args{
         static_cast<uint32_t>(gamma_grad_has_value), static_cast<uint32_t>(beta_grad_has_value)};
     TensorAccessorArgs(gamma_grad.has_value() ? gamma_grad->buffer() : nullptr).append_to(writer_compile_time_args);
     TensorAccessorArgs(beta_grad.has_value() ? beta_grad->buffer() : nullptr).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines{};
-    std::map<std::string, std::string> compute_defines{};
-    compute_defines["REDUCE_OP"] = "PoolType::SUM";
-    compute_defines["REDUCE_DIM"] = "ReduceDim::REDUCE_COL";
+    std::map<std::string, std::string> reader_defines_map{};
+    std::map<std::string, std::string> compute_defines_map{};
+    compute_defines_map["REDUCE_OP"] = "PoolType::SUM";
+    compute_defines_map["REDUCE_DIM"] = "ReduceDim::REDUCE_COL";
     if (fp32_dest_acc_en) {
-        reader_defines["FP32_DEST_ACC_EN"] = "1";
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        reader_defines_map["FP32_DEST_ACC_EN"] = "1";
+        compute_defines_map["FP32_DEST_ACC_EN"] = "1";
     }
+
+    KernelDescriptor::Defines reader_defines(reader_defines_map.begin(), reader_defines_map.end());
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
 
     const auto* const reader_kernel_file =
         "ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/"
@@ -165,11 +171,30 @@ MorehLayerNormBackwardGammaBetaGradOperation::ProgramFactory::create(
         "ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/"
         "writer_moreh_layer_norm_backward_gamma_beta_grad.cpp";
 
-    const auto reader_kernels_id =
-        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines);
-    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_file;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = reader_defines;
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    const std::vector<uint32_t> compute_args_group_1{
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_file;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    const auto* const compute_kernel_file =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/"
+        "moreh_layer_norm_backward_gamma_beta_grad_kernel.cpp";
+
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {
         num_cols_per_core_group_1,
         origin_H,
         origin_W,
@@ -179,22 +204,21 @@ MorehLayerNormBackwardGammaBetaGradOperation::ProgramFactory::create(
         static_cast<uint32_t>(beta_grad_has_value),
         static_cast<uint32_t>(is_lastdim_layer_norm),
         static_cast<uint32_t>(is_groupnorm)};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .math_approx_mode = math_approx_mode,
+    };
 
-    const auto* const compute_kernel_file =
-        "ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/"
-        "moreh_layer_norm_backward_gamma_beta_grad_kernel.cpp";
-
-    CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {core_group_1, num_cols_per_core_group_1, compute_args_group_1},
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
-
-    if (!core_group_2.ranges().empty()) {
-        const std::vector<uint32_t> compute_args_group_2{
+    KernelDescriptor compute_desc_2;
+    const bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {
             num_cols_per_core_group_2,
             origin_H,
             origin_W,
@@ -204,28 +228,25 @@ MorehLayerNormBackwardGammaBetaGradOperation::ProgramFactory::create(
             static_cast<uint32_t>(beta_grad_has_value),
             static_cast<uint32_t>(is_lastdim_layer_norm),
             static_cast<uint32_t>(is_groupnorm)};
-
-        CreateComputeKernel(
-            program,
-            compute_kernel_file,
-            {core_group_2, num_cols_per_core_group_2, compute_args_group_2},
-
-            compute_defines,
-            math_fidelity,
-            fp32_dest_acc_en,
-            math_approx_mode);
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .math_approx_mode = math_approx_mode,
+        };
     }
 
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const auto output_grad_addr = output_grad.buffer()->address();
-    const auto input_addr = input.buffer()->address();
-    const auto mean_addr = mean.buffer()->address();
-    const auto rstd_addr = rstd.buffer()->address();
+    auto* const output_grad_buf = output_grad.buffer();
+    auto* const input_buf = input.buffer();
+    auto* const mean_buf = mean.buffer();
+    auto* const rstd_buf = rstd.buffer();
 
-    const auto gamma_grad_addr = gamma_grad_has_value ? gamma_grad.value().buffer()->address() : 0;
-    const auto beta_grad_addr = beta_grad_has_value ? beta_grad.value().buffer()->address() : 0;
+    const auto gamma_grad_addr = gamma_grad_has_value ? gamma_grad.value().buffer()->address() : 0u;
+    const auto beta_grad_addr = beta_grad_has_value ? beta_grad.value().buffer()->address() : 0u;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -239,70 +260,34 @@ MorehLayerNormBackwardGammaBetaGradOperation::ProgramFactory::create(
             TT_THROW("Core not in specified core ranges.");
         }
 
-        const std::vector<uint32_t> reader_runtime_args{
-            output_grad_addr,
-            input_addr,
-            mean_addr,
-            rstd_addr,
-            num_cols_per_core,
-            num_outer,
-            num_inner,
-            tile_offset,
-            mask_h,
-            normalized_dims,
-            mean_rstd_height,
-            mean_rstd_width};
-        SetRuntimeArgs(program, reader_kernels_id, core, reader_runtime_args);
+        reader_desc.emplace_runtime_args(
+            core,
+            {output_grad_buf,
+             input_buf,
+             mean_buf,
+             rstd_buf,
+             num_cols_per_core,
+             num_outer,
+             num_inner,
+             tile_offset,
+             mask_h,
+             normalized_dims,
+             mean_rstd_height,
+             mean_rstd_width});
 
-        const std::vector<uint32_t> writer_runtime_args{
-            gamma_grad_addr, beta_grad_addr, num_cols_per_core, tile_offset};
-        SetRuntimeArgs(program, writer_kernels_id, core, writer_runtime_args);
+        writer_desc.emplace_runtime_args(core, {gamma_grad_addr, beta_grad_addr, num_cols_per_core, tile_offset});
 
         tile_offset += num_cols_per_core;
     }
 
-    return {std::move(program), {reader_kernels_id, writer_kernels_id, num_cores, num_cores_y}};
-}
-
-void MorehLayerNormBackwardGammaBetaGradOperation::ProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-
-    auto* output_grad_buffer = tensor_args.output_grad.buffer();
-    auto* input_buffer = tensor_args.input.buffer();
-    auto* mean_buffer = tensor_args.mean.buffer();
-    auto* rstd_buffer = tensor_args.rstd.buffer();
-
-    auto* gamma_grad_buffer = tensor_return_value.at(0).has_value() ? tensor_return_value.at(0)->buffer() : nullptr;
-    auto* beta_grad_buffer = tensor_return_value.at(1).has_value() ? tensor_return_value.at(1)->buffer() : nullptr;
-
-    auto num_cores = cached_program.shared_variables.num_cores;
-    auto num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = output_grad_buffer->address();
-            runtime_args[1] = input_buffer->address();
-            runtime_args[2] = mean_buffer->address();
-            runtime_args[3] = rstd_buffer->address();
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            if (gamma_grad_buffer != nullptr) {
-                runtime_args[0] = gamma_grad_buffer->address();
-            }
-            if (gamma_grad_buffer != nullptr) {
-                runtime_args[1] = beta_grad_buffer->address();
-            }
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::operations::moreh::moreh_layer_norm_backward_gamma_beta_grad

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.hpp
@@ -7,6 +7,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/tensor/types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_layer_norm_backward_input_grad {
 struct MorehLayerNormBackwardInputGradOperation {
@@ -28,29 +29,14 @@ struct MorehLayerNormBackwardInputGradOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
-    struct ProgramFactory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id;
-            tt::tt_metal::KernelHandle unary_writer_kernel_id;
-            std::size_t num_cores;
-            std::size_t num_cores_y;
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& input_grad);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+    struct MorehLayerNormBackwardInputGradFactory {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& input_grad);
     };
 
-    using program_factory_t = std::variant<ProgramFactory>;
+    using program_factory_t = std::variant<MorehLayerNormBackwardInputGradFactory>;
 
     static void validate_inputs(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_program_factory.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <bit>
 #include <string>
 
 #include "moreh_layer_norm_backward_input_grad_device_operation.hpp"
@@ -12,11 +13,14 @@
 
 namespace ttnn::operations::moreh::moreh_layer_norm_backward_input_grad {
 
-MorehLayerNormBackwardInputGradOperation::ProgramFactory::cached_program_t
-MorehLayerNormBackwardInputGradOperation::ProgramFactory::create(
+tt::tt_metal::ProgramDescriptor
+MorehLayerNormBackwardInputGradOperation::MorehLayerNormBackwardInputGradFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& input_grad) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
     const auto& output_grad = tensor_args.output_grad;
     const auto& input = tensor_args.input;
     const auto& mean = tensor_args.mean;
@@ -34,7 +38,6 @@ MorehLayerNormBackwardInputGradOperation::ProgramFactory::create(
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
     IDevice* device = output_grad.device();
-    Program program = Program();
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
@@ -133,34 +136,46 @@ MorehLayerNormBackwardInputGradOperation::ProgramFactory::create(
         log_info(tt::LogTest, "Small moreh_layer_norm_backward_input_grad algorithm is selected.");
     }
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        cb_data_format,
-        {
-            {tt::CBIndex::c_0, in0_t},                       // output_grad(==dy)
-            {tt::CBIndex::c_1, in1_t},                       // input(==x)
-            {tt::CBIndex::c_2, in2_t},                       // mean
-            {tt::CBIndex::c_3, in3_t},                       // rstd
-            {tt::CBIndex::c_4, in4_t},                       // scaler
-            {tt::CBIndex::c_5, in5_t},                       // n_recip_n
-            {tt::CBIndex::c_6, in6_t},                       // gamma
-            {tt::CBIndex::c_7, in7_t},                       // mask_h_w
-            {tt::CBIndex::c_16, out0_t},                     // input_grad(==dx)
-            {tt::CBIndex::c_24, im0_t, intermed_cb_format},  // copy output_grad(==dy or dy * gamma)
-            {tt::CBIndex::c_25, im1_t, intermed_cb_format},  // output(==y)
-            {tt::CBIndex::c_26, im2_t, intermed_cb_format},  // Sum[dy]
-            {tt::CBIndex::c_27, im3_t, intermed_cb_format},  // Sum[y * dy]
-            {tt::CBIndex::c_28, im4_t, intermed_cb_format},  // rstd / n
-            {tt::CBIndex::c_29, im5_t, intermed_cb_format},
-            {tt::CBIndex::c_30, im6_t, intermed_cb_format},
-            {tt::CBIndex::c_31, im7_t, intermed_cb_format},
+    ProgramDescriptor desc;
+
+    auto push_cb = [&](uint8_t cb_index, uint32_t num_tiles, tt::DataFormat fmt) {
+        if (num_tiles == 0) {
+            // Preserve original behavior: skip zero-size CBs.
+            return;
+        }
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_tiles * tile_size(fmt),
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = cb_index,
+                .data_format = fmt,
+                .page_size = tile_size(fmt),
+            }}},
         });
+    };
+
+    push_cb(static_cast<uint8_t>(CBIndex::c_0), in0_t, cb_data_format);       // output_grad(==dy)
+    push_cb(static_cast<uint8_t>(CBIndex::c_1), in1_t, cb_data_format);       // input(==x)
+    push_cb(static_cast<uint8_t>(CBIndex::c_2), in2_t, cb_data_format);       // mean
+    push_cb(static_cast<uint8_t>(CBIndex::c_3), in3_t, cb_data_format);       // rstd
+    push_cb(static_cast<uint8_t>(CBIndex::c_4), in4_t, cb_data_format);       // scaler
+    push_cb(static_cast<uint8_t>(CBIndex::c_5), in5_t, cb_data_format);       // n_recip_n
+    push_cb(static_cast<uint8_t>(CBIndex::c_6), in6_t, cb_data_format);       // gamma
+    push_cb(static_cast<uint8_t>(CBIndex::c_7), in7_t, cb_data_format);       // mask_h_w
+    push_cb(static_cast<uint8_t>(CBIndex::c_16), out0_t, cb_data_format);     // input_grad(==dx)
+    push_cb(static_cast<uint8_t>(CBIndex::c_24), im0_t, intermed_cb_format);  // copy output_grad(==dy or dy * gamma)
+    push_cb(static_cast<uint8_t>(CBIndex::c_25), im1_t, intermed_cb_format);  // output(==y)
+    push_cb(static_cast<uint8_t>(CBIndex::c_26), im2_t, intermed_cb_format);  // Sum[dy]
+    push_cb(static_cast<uint8_t>(CBIndex::c_27), im3_t, intermed_cb_format);  // Sum[y * dy]
+    push_cb(static_cast<uint8_t>(CBIndex::c_28), im4_t, intermed_cb_format);  // rstd / n
+    push_cb(static_cast<uint8_t>(CBIndex::c_29), im5_t, intermed_cb_format);
+    push_cb(static_cast<uint8_t>(CBIndex::c_30), im6_t, intermed_cb_format);
+    push_cb(static_cast<uint8_t>(CBIndex::c_31), im7_t, intermed_cb_format);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> reader_compile_time_args{
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args{
         static_cast<uint32_t>(gamma_has_value), static_cast<uint32_t>(do_mask_h), static_cast<uint32_t>(do_mask_w)};
     TensorAccessorArgs(output_grad.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input.buffer()).append_to(reader_compile_time_args);
@@ -168,21 +183,25 @@ MorehLayerNormBackwardInputGradOperation::ProgramFactory::create(
     TensorAccessorArgs(rstd.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(gamma.has_value() ? gamma->buffer() : nullptr).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args{};
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args{};
     TensorAccessorArgs(input_grad.buffer()).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines{};
-    std::map<std::string, std::string> compute_defines{};
-    compute_defines["REDUCE_OP"] = "PoolType::AVG";
+    std::map<std::string, std::string> reader_defines_map{};
+    std::map<std::string, std::string> compute_defines_map{};
+    compute_defines_map["REDUCE_OP"] = "PoolType::AVG";
     if (is_lastdim_layer_norm) {
-        compute_defines["REDUCE_DIM"] = "ReduceDim::REDUCE_ROW";
+        compute_defines_map["REDUCE_DIM"] = "ReduceDim::REDUCE_ROW";
     } else {
-        compute_defines["REDUCE_DIM"] = "ReduceDim::REDUCE_SCALAR";
+        compute_defines_map["REDUCE_DIM"] = "ReduceDim::REDUCE_SCALAR";
     }
     if (fp32_dest_acc_en) {
-        reader_defines["FP32_DEST_ACC_EN"] = "1";
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        reader_defines_map["FP32_DEST_ACC_EN"] = "1";
+        compute_defines_map["FP32_DEST_ACC_EN"] = "1";
     }
+
+    KernelDescriptor::Defines reader_defines(reader_defines_map.begin(), reader_defines_map.end());
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
+
     const auto* const reader_kernel_file =
         use_large_algorithm ? "ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/"
                               "reader_moreh_layer_norm_backward_input_grad_large.cpp"
@@ -193,18 +212,20 @@ MorehLayerNormBackwardInputGradOperation::ProgramFactory::create(
         "ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/"
         "writer_moreh_layer_norm_backward_input_grad.cpp";
 
-    const auto reader_kernels_id =
-        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines);
-    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_file;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = reader_defines;
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    const std::vector<uint32_t> compute_args_group_1{
-        num_rows_per_core_group_1,
-        origin_H,
-        origin_W,
-        num_inner,
-        static_cast<uint32_t>(gamma_has_value),
-        static_cast<uint32_t>(is_lastdim_layer_norm),
-        static_cast<uint32_t>(is_groupnorm)};
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_file;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     const auto* const compute_kernel_file =
         use_large_algorithm ? "ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/"
@@ -212,17 +233,33 @@ MorehLayerNormBackwardInputGradOperation::ProgramFactory::create(
                             : "ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/"
                               "moreh_layer_norm_backward_input_grad_small_kernel.cpp";
 
-    CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {core_group_1, num_rows_per_core_group_1, compute_args_group_1},
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {
+        num_rows_per_core_group_1,
+        origin_H,
+        origin_W,
+        num_inner,
+        static_cast<uint32_t>(gamma_has_value),
+        static_cast<uint32_t>(is_lastdim_layer_norm),
+        static_cast<uint32_t>(is_groupnorm)};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .math_approx_mode = math_approx_mode,
+    };
 
-    if (!core_group_2.ranges().empty()) {
-        const std::vector<uint32_t> compute_args_group_2{
+    KernelDescriptor compute_desc_2;
+    const bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {
             num_rows_per_core_group_2,
             origin_H,
             origin_W,
@@ -230,28 +267,29 @@ MorehLayerNormBackwardInputGradOperation::ProgramFactory::create(
             static_cast<uint32_t>(gamma_has_value),
             static_cast<uint32_t>(is_lastdim_layer_norm),
             static_cast<uint32_t>(is_groupnorm)};
-
-        CreateComputeKernel(
-            program,
-            compute_kernel_file,
-            {core_group_2, num_rows_per_core_group_2, compute_args_group_2},
-            compute_defines,
-            math_fidelity,
-            fp32_dest_acc_en,
-            math_approx_mode);
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .math_approx_mode = math_approx_mode,
+        };
     }
 
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const auto output_grad_addr = output_grad.buffer()->address();
-    const auto input_addr = input.buffer()->address();
-    const auto mean_addr = mean.buffer()->address();
-    const auto rstd_addr = rstd.buffer()->address();
+    auto* const output_grad_buf = output_grad.buffer();
+    auto* const input_buf = input.buffer();
+    auto* const mean_buf = mean.buffer();
+    auto* const rstd_buf = rstd.buffer();
 
-    const auto gamma_addr = gamma_has_value ? gamma.value().buffer()->address() : 0;
+    const auto gamma_addr = gamma_has_value ? gamma.value().buffer()->address() : 0u;
 
-    const auto input_grad_addr = input_grad.buffer()->address();
+    auto* const input_grad_buf = input_grad.buffer();
+
+    const uint32_t n_u = std::bit_cast<uint32_t>(n);
+    const uint32_t recip_n_u = std::bit_cast<uint32_t>(recip_n);
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -265,70 +303,37 @@ MorehLayerNormBackwardInputGradOperation::ProgramFactory::create(
             TT_THROW("Core not in specified core ranges.");
         }
 
-        const std::vector<uint32_t> reader_runtime_args{
-            output_grad_addr,
-            input_addr,
-            mean_addr,
-            rstd_addr,
-            gamma_addr,
-            num_rows_per_core,
-            num_inner,
-            tile_offset,
-            *reinterpret_cast<uint32_t*>(&n),
-            *reinterpret_cast<uint32_t*>(&recip_n),
-            mask_h,
-            mask_w,
-            normalized_dims,
-            mean_rstd_height,
-            mean_rstd_width};
-        SetRuntimeArgs(program, reader_kernels_id, core, reader_runtime_args);
+        reader_desc.emplace_runtime_args(
+            core,
+            {output_grad_buf,
+             input_buf,
+             mean_buf,
+             rstd_buf,
+             gamma_addr,
+             num_rows_per_core,
+             num_inner,
+             tile_offset,
+             n_u,
+             recip_n_u,
+             mask_h,
+             mask_w,
+             normalized_dims,
+             mean_rstd_height,
+             mean_rstd_width});
 
-        const std::vector<uint32_t> writer_runtime_args{input_grad_addr, num_rows_per_core, num_inner, tile_offset};
-        SetRuntimeArgs(program, writer_kernels_id, core, writer_runtime_args);
+        writer_desc.emplace_runtime_args(core, {input_grad_buf, num_rows_per_core, num_inner, tile_offset});
 
         tile_offset += num_rows_per_core * num_inner;
     }
 
-    return {std::move(program), {reader_kernels_id, writer_kernels_id, num_cores, num_cores_y}};
-}
-
-void MorehLayerNormBackwardInputGradOperation::ProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& input_grad) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-
-    auto* output_grad_buffer = tensor_args.output_grad.buffer();
-    auto* input_buffer = tensor_args.input.buffer();
-    auto* mean_buffer = tensor_args.mean.buffer();
-    auto* rstd_buffer = tensor_args.rstd.buffer();
-    auto* gamma_buffer = tensor_args.gamma.has_value() ? tensor_args.gamma.value().buffer() : nullptr;
-
-    auto* input_grad_buffer = input_grad.buffer();
-
-    auto num_cores = cached_program.shared_variables.num_cores;
-    auto num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = output_grad_buffer->address();
-            runtime_args[1] = input_buffer->address();
-            runtime_args[2] = mean_buffer->address();
-            runtime_args[3] = rstd_buffer->address();
-            if (gamma_buffer != nullptr) {
-                runtime_args[4] = gamma_buffer->address();
-            }
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = input_grad_buffer->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::operations::moreh::moreh_layer_norm_backward_input_grad

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_device_operation.hpp
@@ -11,6 +11,7 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_linear_backward {
 struct MorehBiasAddBackwardOperation {
@@ -29,45 +30,17 @@ struct MorehBiasAddBackwardOperation {
     using tensor_return_value_t = Tensor;
 
     struct SingleCoreProgramFactory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id;
-            tt::tt_metal::KernelHandle unary_writer_kernel_id;
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& bias_grad);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
     };
 
     struct MultiCoreProgramFactory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id;
-            tt::tt_metal::KernelHandle unary_writer_kernel_id;
-            std::size_t num_cores_to_be_used;
-            std::size_t num_cores_y;
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& bias_grad);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
     };
 
     using program_factory_t = std::variant<SingleCoreProgramFactory, MultiCoreProgramFactory>;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_multi_core_program_factory.cpp
@@ -13,20 +13,17 @@
 
 namespace ttnn::operations::moreh::moreh_linear_backward {
 
-MorehBiasAddBackwardOperation::MultiCoreProgramFactory::cached_program_t
-MorehBiasAddBackwardOperation::MultiCoreProgramFactory::create(
+tt::tt_metal::ProgramDescriptor MorehBiasAddBackwardOperation::MultiCoreProgramFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& bias_grad) {
     using namespace tt;
     using namespace tt::tt_metal;
 
-    Program program{};
     const auto& output_grad = tensor_args.output_grad;
 
     const auto& output_grad_shape_wo_padding = output_grad.logical_shape();
 
-    auto bias_grad_memory_config = operation_attributes.bias_grad_memory_config;
     auto compute_kernel_config = operation_attributes.compute_kernel_config;
 
     const bool do_mask_h = (output_grad_shape_wo_padding[-2] % constants::TILE_HEIGHT) != 0;
@@ -70,75 +67,140 @@ MorehBiasAddBackwardOperation::MultiCoreProgramFactory::create(
     const uint32_t im0_t = 1;
     const uint32_t im1_t = 1;
     auto cb_data_format = datatype_to_dataformat_converter(output_grad.dtype());
+    auto fp32_dest_acc_en_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : cb_data_format;
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        cb_data_format,
-        {{CBIndex::c_0, in0_t},    // output_grad
-         {CBIndex::c_1, in1_t},    // scaler
-         {CBIndex::c_2, in2_t},    // mask_h_w
-         {CBIndex::c_16, out0_t},  // bias_grad
-         {CBIndex::c_24, im0_t},
-         {CBIndex::c_25, im1_t, (fp32_dest_acc_en) ? tt::DataFormat::Float32 : cb_data_format}});
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in0_t * tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });  // output_grad
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in1_t * tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });  // scaler
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in2_t * tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_2),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });  // mask_h_w
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = out0_t * tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });  // bias_grad
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = im0_t * tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = im1_t * tile_size(fp32_dest_acc_en_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = fp32_dest_acc_en_data_format,
+            .page_size = tile_size(fp32_dest_acc_en_data_format),
+        }}},
+    });
 
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> reader_compile_time_args = TensorAccessorArgs(output_grad.buffer()).get_compile_time_args();
-    std::vector<uint32_t> writer_compile_time_args = TensorAccessorArgs(bias_grad.buffer()).get_compile_time_args();
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args =
+        TensorAccessorArgs(*output_grad.buffer()).get_compile_time_args();
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args =
+        TensorAccessorArgs(*bias_grad.buffer()).get_compile_time_args();
 
-    const auto* const reader_kernel_file =
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/reader_moreh_bias_backward_h.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    const auto* const writer_kernel_file =
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/writer_moreh_bias_backward.cpp";
-
-    const auto reader_kernel_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args);
-    const auto writer_kernel_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const std::vector<uint32_t> compute_args_group_1{num_cols_per_core_group_1};
-    std::map<std::string, std::string> compute_defines;
-    compute_defines["REDUCE_OP"] = "PoolType::SUM";
-    compute_defines["REDUCE_DIM"] = "ReduceDim::REDUCE_COL";
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::map<std::string, std::string> compute_defines_map;
+    compute_defines_map["REDUCE_OP"] = "PoolType::SUM";
+    compute_defines_map["REDUCE_DIM"] = "ReduceDim::REDUCE_COL";
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
-        unpack_to_dest_mode[tt::CBIndex::c_25] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        compute_defines_map["FP32_DEST_ACC_EN"] = "1";
+        unpack_to_dest_mode[CBIndex::c_25] = UnpackToDestMode::UnpackToDestFp32;
     }
-    const auto* const compute_kernel_file =
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
+
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_multi_core_h.cpp";
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {num_cols_per_core_group_1};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
 
-    const auto compute_kernel_1_id = CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {core_group_1, num_cols_per_core_group_1, compute_args_group_1},
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode,
-        unpack_to_dest_mode);
-
-    std::optional<KernelHandle> compute_kernel_2_id = std::nullopt;
-    if (!core_group_2.ranges().empty()) {
-        const std::vector<uint32_t> compute_args_group_2{num_cols_per_core_group_2};
-        compute_kernel_2_id = CreateComputeKernel(
-            program,
-            compute_kernel_file,
-            {core_group_2, num_cols_per_core_group_2, compute_args_group_2},
-            compute_defines,
-            math_fidelity,
-            fp32_dest_acc_en,
-            math_approx_mode,
-            unpack_to_dest_mode);
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source =
+            "ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_multi_core_h.cpp";
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {num_cols_per_core_group_2};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
     }
 
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
+    auto* const output_grad_buf = output_grad.buffer();
+    auto* const bias_grad_buf = bias_grad.buffer();
     for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
@@ -152,11 +214,9 @@ MorehBiasAddBackwardOperation::MultiCoreProgramFactory::create(
         }
 
         bool core_has_last_wt = (tile_offset + num_cols_per_core == Wt) ? (true) : (false);
-        SetRuntimeArgs(
-            program,
-            reader_kernel_id,
+        reader_desc.emplace_runtime_args(
             core,
-            {output_grad.buffer()->address(),
+            {output_grad_buf,
              num_tiles,
              Wt,
              num_cols_per_core,
@@ -166,13 +226,10 @@ MorehBiasAddBackwardOperation::MultiCoreProgramFactory::create(
              static_cast<uint32_t>(do_mask_h),
              static_cast<uint32_t>(do_mask_w && core_has_last_wt)});
 
-        SetRuntimeArgs(
-            program, writer_kernel_id, core, {bias_grad.buffer()->address(), num_cols_per_core, tile_offset});
+        writer_desc.emplace_runtime_args(core, {bias_grad_buf, num_cols_per_core, tile_offset});
 
         if (core_group_1.contains(core)) {
-            SetRuntimeArgs(
-                program,
-                compute_kernel_1_id,
+            compute_desc_1.emplace_runtime_args(
                 core,
                 {batch_num,
                  Ht,
@@ -180,10 +237,8 @@ MorehBiasAddBackwardOperation::MultiCoreProgramFactory::create(
                  static_cast<uint32_t>(do_mask_h),
                  static_cast<uint32_t>(do_mask_w && core_has_last_wt)});
         } else if (core_group_2.contains(core)) {
-            TT_ASSERT(compute_kernel_2_id.has_value());
-            SetRuntimeArgs(
-                program,
-                compute_kernel_2_id.value(),
+            TT_ASSERT(has_core_group_2);
+            compute_desc_2.emplace_runtime_args(
                 core,
                 {batch_num,
                  Ht,
@@ -196,34 +251,14 @@ MorehBiasAddBackwardOperation::MultiCoreProgramFactory::create(
         tile_offset += num_cols_per_core;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores_to_be_used, num_cores_y}};
-}
-
-void MorehBiasAddBackwardOperation::MultiCoreProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto num_cores_to_be_used = cached_program.shared_variables.num_cores_to_be_used;
-    auto num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    auto* output_grad_buffer = tensor_args.output_grad.buffer();
-    auto* bias_grad_buffer = tensor_return_value.buffer();
-
-    for (uint32_t i = 0; i < num_cores_to_be_used; ++i) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = output_grad_buffer->address();
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = bias_grad_buffer->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::operations::moreh::moreh_linear_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_single_core_program_factory.cpp
@@ -12,8 +12,7 @@
 
 namespace ttnn::operations::moreh::moreh_linear_backward {
 
-MorehBiasAddBackwardOperation::SingleCoreProgramFactory::cached_program_t
-MorehBiasAddBackwardOperation::SingleCoreProgramFactory::create(
+tt::tt_metal::ProgramDescriptor MorehBiasAddBackwardOperation::SingleCoreProgramFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& bias_grad) {
@@ -24,7 +23,6 @@ MorehBiasAddBackwardOperation::SingleCoreProgramFactory::create(
 
     const auto& output_grad_shape_wo_padding = output_grad.logical_shape();
 
-    auto bias_grad_memory_config = operation_attributes.bias_grad_memory_config;
     auto compute_kernel_config = operation_attributes.compute_kernel_config;
 
     const bool do_mask_h = (output_grad_shape_wo_padding[-2] % constants::TILE_HEIGHT) != 0;
@@ -51,9 +49,8 @@ MorehBiasAddBackwardOperation::SingleCoreProgramFactory::create(
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
-    Program program{};
     CoreCoord core = {0, 0};
-    const uint32_t core_num = 1;
+    const CoreRangeSet core_set{CoreRange(core, core)};
 
     IDevice* device = output_grad.device();
     auto arch = device->arch();
@@ -64,91 +61,140 @@ MorehBiasAddBackwardOperation::SingleCoreProgramFactory::create(
     //                         CircularBuffer Setup
     ////////////////////////////////////////////////////////////////////////////
     auto cb_data_format = datatype_to_dataformat_converter(output_grad.dtype());
+    auto fp32_dest_acc_en_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : cb_data_format;
 
-    CreateCircularBuffer(
-        program,
-        std::set<CoreRange>{CoreRange(core, core)},
-        cb_data_format,
-        {{CBIndex::c_0, in0_t},    // output_grad
-         {CBIndex::c_1, in1_t},    // scaler
-         {CBIndex::c_2, in2_t},    // mask_h_w
-         {CBIndex::c_16, out0_t},  // bias_grad
-         {CBIndex::c_24, im0_t},
-         {CBIndex::c_25, im1_t, (fp32_dest_acc_en) ? tt::DataFormat::Float32 : cb_data_format}});
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in0_t * tile_size(cb_data_format),
+        .core_ranges = core_set,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });  // output_grad
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in1_t * tile_size(cb_data_format),
+        .core_ranges = core_set,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });  // scaler
+    if (in2_t > 0) {
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = in2_t * tile_size(cb_data_format),
+            .core_ranges = core_set,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(CBIndex::c_2),
+                .data_format = cb_data_format,
+                .page_size = tile_size(cb_data_format),
+            }}},
+        });  // mask_h_w
+    }
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = out0_t * tile_size(cb_data_format),
+        .core_ranges = core_set,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });  // bias_grad
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = im0_t * tile_size(cb_data_format),
+        .core_ranges = core_set,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = im1_t * tile_size(fp32_dest_acc_en_data_format),
+        .core_ranges = core_set,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = fp32_dest_acc_en_data_format,
+            .page_size = tile_size(fp32_dest_acc_en_data_format),
+        }}},
+    });
 
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args =
+        TensorAccessorArgs(*output_grad.buffer()).get_compile_time_args();
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args =
+        TensorAccessorArgs(*bias_grad.buffer()).get_compile_time_args();
 
-    std::vector<uint32_t> reader_compile_time_args = TensorAccessorArgs(output_grad.buffer()).get_compile_time_args();
-    std::vector<uint32_t> writer_compile_time_args = TensorAccessorArgs(bias_grad.buffer()).get_compile_time_args();
-
-    const auto* const reader_kernel_file =
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/reader_moreh_bias_backward_hw.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core_set;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    const auto* const writer_kernel_file =
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/writer_moreh_bias_backward.cpp";
-
-    const auto reader_kernel_id = CreateReadKernel(program, reader_kernel_file, core, reader_compile_time_args);
-    const auto writer_kernel_id = CreateWriteKernel(program, writer_kernel_file, core, writer_compile_time_args);
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = core_set;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> compute_kernel_args = {};
-    std::map<std::string, std::string> compute_defines;
-    compute_defines["REDUCE_OP"] = "PoolType::SUM";
-    compute_defines["REDUCE_DIM"] = "ReduceDim::REDUCE_SCALAR";
+    std::map<std::string, std::string> compute_defines_map;
+    compute_defines_map["REDUCE_OP"] = "PoolType::SUM";
+    compute_defines_map["REDUCE_DIM"] = "ReduceDim::REDUCE_SCALAR";
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines_map["FP32_DEST_ACC_EN"] = "1";
     }
-    const auto* const compute_kernel_file =
-        "ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_single_core_hw.cpp";
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
 
-    const auto compute_kernel_id = CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {core, core_num, compute_kernel_args},
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_single_core_hw.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = core_set;
+    compute_desc.compile_time_args = {};
+    compute_desc.defines = compute_defines;
+    compute_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
 
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
-    SetRuntimeArgs(
-        program,
-        reader_kernel_id,
+    reader_desc.emplace_runtime_args(
         core,
-        {output_grad.buffer()->address(), num_tiles, 0, mask_h, mask_w, do_mask_h, do_mask_w});
-    SetRuntimeArgs(program, writer_kernel_id, core, {bias_grad.buffer()->address(), 1, 0});
-    SetRuntimeArgs(program, compute_kernel_id, core, {batch_num, Ht, Wt, do_mask_h, do_mask_w});
+        {output_grad.buffer(),
+         num_tiles,
+         0u,
+         mask_h,
+         mask_w,
+         static_cast<uint32_t>(do_mask_h),
+         static_cast<uint32_t>(do_mask_w)});
+    writer_desc.emplace_runtime_args(core, {bias_grad.buffer(), 1u, 0u});
+    compute_desc.emplace_runtime_args(
+        core, {batch_num, Ht, Wt, static_cast<uint32_t>(do_mask_h), static_cast<uint32_t>(do_mask_w)});
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
 }
 
-void MorehBiasAddBackwardOperation::SingleCoreProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-
-    auto* output_grad_buffer = tensor_args.output_grad.buffer();
-    auto* bias_grad_buffer = tensor_return_value.buffer();
-    CoreCoord core = {0, 0};
-    {
-        auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-        runtime_args[0] = output_grad_buffer->address();
-    }
-
-    {
-        auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-        runtime_args[0] = bias_grad_buffer->address();
-    }
-}
 }  // namespace ttnn::operations::moreh::moreh_linear_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.hpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_matmul {
 struct MorehMatmulOperation {
@@ -33,22 +34,7 @@ struct MorehMatmulOperation {
     using tensor_return_value_t = Tensor;
 
     struct MultiCoreProgramFactory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle reader_kernel_id;
-            tt::tt_metal::KernelHandle writer_kernel_id;
-            std::size_t num_cores;
-            std::size_t num_cores_y;
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
@@ -107,10 +107,13 @@ void get_not_bcast(
     }
 }
 
-MorehMatmulOperation::MultiCoreProgramFactory::cached_program_t MorehMatmulOperation::MultiCoreProgramFactory::create(
+tt::tt_metal::ProgramDescriptor MorehMatmulOperation::MultiCoreProgramFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
     const Tensor& input = tensor_args.input;
     const Tensor& other = tensor_args.other;
     const Tensor& output = tensor_return_value;
@@ -122,13 +125,11 @@ MorehMatmulOperation::MultiCoreProgramFactory::cached_program_t MorehMatmulOpera
 
     const DeviceComputeKernelConfig& compute_kernel_config = init_device_compute_kernel_config(
         input.device()->arch(), operation_attributes.compute_kernel_config, tt::tt_metal::MathFidelity::HiFi4);
-    ;
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
-    tt::tt_metal::Program program{};
-    tt::tt_metal::IDevice* device{input.device()};
+    IDevice* device{input.device()};
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
@@ -280,28 +281,39 @@ MorehMatmulOperation::MultiCoreProgramFactory::cached_program_t MorehMatmulOpera
     const uint32_t im3_t{1};   // temp for bias add
     const uint32_t out0_t{2};  // output
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        cb_data_format,
-        {
-            {tt::CBIndex::c_0, in0_t},
-            {tt::CBIndex::c_1, in1_t},
-            {tt::CBIndex::c_2, in2_t},
-            {tt::CBIndex::c_3, in3_t},
-            {tt::CBIndex::c_4, in4_t},
-            {tt::CBIndex::c_24, im0_t, (fp32_dest_acc_en) ? tt::DataFormat::Float32 : cb_data_format},
-            {tt::CBIndex::c_25, im1_t},
-            {tt::CBIndex::c_26, im2_t},
-            {tt::CBIndex::c_27, im3_t, (fp32_dest_acc_en) ? tt::DataFormat::Float32 : cb_data_format},
-            {tt::CBIndex::c_16, out0_t},
+    auto im0_data_format = (fp32_dest_acc_en) ? tt::DataFormat::Float32 : cb_data_format;
+    auto im3_data_format = (fp32_dest_acc_en) ? tt::DataFormat::Float32 : cb_data_format;
+
+    ProgramDescriptor desc;
+
+    auto add_cb = [&](CBIndex idx, uint32_t num_tiles, tt::DataFormat fmt) {
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_tiles * tile_size(fmt),
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(idx),
+                .data_format = fmt,
+                .page_size = tile_size(fmt),
+            }}},
         });
+    };
+
+    add_cb(tt::CBIndex::c_0, in0_t, cb_data_format);
+    add_cb(tt::CBIndex::c_1, in1_t, cb_data_format);
+    add_cb(tt::CBIndex::c_2, in2_t, cb_data_format);
+    add_cb(tt::CBIndex::c_3, in3_t, cb_data_format);
+    add_cb(tt::CBIndex::c_4, in4_t, cb_data_format);
+    add_cb(tt::CBIndex::c_24, im0_t, im0_data_format);
+    add_cb(tt::CBIndex::c_25, im1_t, cb_data_format);
+    add_cb(tt::CBIndex::c_26, im2_t, cb_data_format);
+    add_cb(tt::CBIndex::c_27, im3_t, im3_data_format);
+    add_cb(tt::CBIndex::c_16, out0_t, cb_data_format);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    std::map<std::string, std::string> reader_defines;
-    std::vector<uint32_t> reader_compile_time_args = {
+    std::map<std::string, std::string> reader_defines_map;
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args = {
         Kt,
         static_cast<uint32_t>(transpose_input),
         static_cast<uint32_t>(transpose_other),
@@ -314,23 +326,32 @@ MorehMatmulOperation::MultiCoreProgramFactory::cached_program_t MorehMatmulOpera
     TensorAccessorArgs(other.buffer()).append_to(reader_compile_time_args);
 
     if (bias.has_value()) {
-        reader_defines["FUSE_BIAS"] = "1";
+        reader_defines_map["FUSE_BIAS"] = "1";
         reader_compile_time_args.push_back(static_cast<uint32_t>(is_scalar_bias));
         TensorAccessorArgs(bias->buffer()).append_to(reader_compile_time_args);
         log_debug(tt::LogOp, "{}:{} bias tensor. is bias dram {}", __func__, __LINE__, is_dram(bias));
     }
 
-    std::vector<uint32_t> writer_compile_time_args = {};
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args;
     TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
 
-    const auto* const reader_kernel_file =
-        "ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/kernels/reader_moreh_matmul.cpp";
-    const auto* const writer_kernel_file =
-        "ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/kernels/writer_moreh_matmul.cpp";
+    KernelDescriptor::Defines reader_defines(reader_defines_map.begin(), reader_defines_map.end());
 
-    const auto reader_kernel_id =
-        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines);
-    const auto writer_kernel_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/kernels/reader_moreh_matmul.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = "ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/kernels/writer_moreh_matmul.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
     log_debug(
         tt::LogOp,
         "{}:{} DMVK is_dram(input): {}, is_dram(other): {}, is_dram(output): {}",
@@ -343,11 +364,11 @@ MorehMatmulOperation::MultiCoreProgramFactory::cached_program_t MorehMatmulOpera
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    std::map<std::string, std::string> compute_defines;
+    std::map<std::string, std::string> compute_defines_map;
 
     const auto* const compute_kernel_file =
         "ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/kernels/moreh_matmul.cpp";
-    std::vector<uint32_t> compute_args_group_1 = {
+    KernelDescriptor::CompileTimeArgs compute_args_group_1 = {
         num_output_tiles_per_core_group_1,  // num_output_tiles
         Mt,
         Nt,
@@ -360,29 +381,35 @@ MorehMatmulOperation::MultiCoreProgramFactory::cached_program_t MorehMatmulOpera
         other_mask_w};
 
     if (bias.has_value()) {
-        compute_defines["FUSE_BIAS"] = "1";
+        compute_defines_map["FUSE_BIAS"] = "1";
         compute_args_group_1.push_back(static_cast<uint32_t>(is_scalar_bias));
     }
 
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
-        unpack_to_dest_mode[tt::CBIndex::c_24] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        compute_defines_map["FP32_DEST_ACC_EN"] = "1";
+        unpack_to_dest_mode[tt::CBIndex::c_24] = UnpackToDestMode::UnpackToDestFp32;
     }
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
 
-    const auto compute_kernel_1_id = CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {core_group_1, num_output_tiles_per_core_group_1, compute_args_group_1},
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode,
-        unpack_to_dest_mode);
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = std::move(compute_args_group_1);
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
 
-    std::optional<KernelHandle> compute_kernel_2_id = std::nullopt;
-    if (!core_group_2.ranges().empty()) {
-        std::vector<uint32_t> compute_args_group_2 = {
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        KernelDescriptor::CompileTimeArgs compute_args_group_2 = {
             num_output_tiles_per_core_group_2,  // num_output_tiles
             Mt,
             Nt,
@@ -398,15 +425,18 @@ MorehMatmulOperation::MultiCoreProgramFactory::cached_program_t MorehMatmulOpera
             compute_args_group_2.push_back(static_cast<uint32_t>(is_scalar_bias));
         }
 
-        compute_kernel_2_id = CreateComputeKernel(
-            program,
-            compute_kernel_file,
-            {core_group_2, num_output_tiles_per_core_group_2, compute_args_group_2},
-            compute_defines,
-            math_fidelity,
-            fp32_dest_acc_en,
-            math_approx_mode,
-            unpack_to_dest_mode);
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = std::move(compute_args_group_2);
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
     }
     log_debug(
         tt::LogOp,
@@ -419,29 +449,34 @@ MorehMatmulOperation::MultiCoreProgramFactory::cached_program_t MorehMatmulOpera
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
+    const uint32_t input_addr = input.buffer()->address();
+    const uint32_t other_addr = other.buffer()->address();
+    auto* const output_buf = output.buffer();
+    const uint32_t bias_addr = bias.has_value() ? bias.value().buffer()->address() : 0u;
+
     for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_output_tiles_per_core;
+        std::vector<uint32_t> compute_rt_args;
+        compute_rt_args.push_back(num_tiles_written);
+        compute_rt_args.insert(compute_rt_args.end(), output_stride.begin(), output_stride.end());
+
         if (core_group_1.contains(core)) {
             num_output_tiles_per_core = num_output_tiles_per_core_group_1;
-            std::vector<uint32_t> compute_rt_args;
-            compute_rt_args.push_back(num_tiles_written);
-            compute_rt_args.insert(compute_rt_args.end(), output_stride.begin(), output_stride.end());
-            tt::tt_metal::SetRuntimeArgs(program, compute_kernel_1_id, core, compute_rt_args);
+            compute_desc_1.runtime_args.emplace_back(
+                core, KernelDescriptor::CoreRuntimeArgs(compute_rt_args.begin(), compute_rt_args.end()));
         } else if (core_group_2.contains(core)) {
-            TT_FATAL(compute_kernel_2_id.has_value(), "Core not in specified core ranges");
+            TT_FATAL(has_core_group_2, "Core not in specified core ranges");
             num_output_tiles_per_core = num_output_tiles_per_core_group_2;
-            std::vector<uint32_t> compute_rt_args;
-            compute_rt_args.push_back(num_tiles_written);
-            compute_rt_args.insert(compute_rt_args.end(), output_stride.begin(), output_stride.end());
-            tt::tt_metal::SetRuntimeArgs(program, compute_kernel_2_id.value(), core, compute_rt_args);
+            compute_desc_2.runtime_args.emplace_back(
+                core, KernelDescriptor::CoreRuntimeArgs(compute_rt_args.begin(), compute_rt_args.end()));
         } else {
             TT_THROW("Core not in specified core ranges");
         }
 
         std::vector<uint32_t> reader_rt_args;
-        reader_rt_args.push_back(input.buffer()->address());
-        reader_rt_args.push_back(other.buffer()->address());
+        reader_rt_args.push_back(input_addr);
+        reader_rt_args.push_back(other_addr);
         reader_rt_args.push_back(num_tiles_written);
         reader_rt_args.push_back(num_output_tiles_per_core);
 
@@ -453,57 +488,24 @@ MorehMatmulOperation::MultiCoreProgramFactory::cached_program_t MorehMatmulOpera
         reader_rt_args.insert(reader_rt_args.end(), other_not_bcast.begin(), other_not_bcast.end());
 
         if (bias.has_value()) {
-            reader_rt_args.push_back(bias.value().buffer()->address());
+            reader_rt_args.push_back(bias_addr);
         }
 
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_rt_args);
+        reader_desc.runtime_args.emplace_back(
+            core, KernelDescriptor::CoreRuntimeArgs(reader_rt_args.begin(), reader_rt_args.end()));
 
-        tt::tt_metal::SetRuntimeArgs(
-            program,
-            writer_kernel_id,
-            core,
-            {output.buffer()->address(), num_tiles_written, num_output_tiles_per_core});
+        writer_desc.emplace_runtime_args(core, {output_buf, num_tiles_written, num_output_tiles_per_core});
         num_tiles_written += num_output_tiles_per_core;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, num_cores_y}};
-}
-
-void MorehMatmulOperation::MultiCoreProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    auto num_cores = cached_program.shared_variables.num_cores;
-    auto num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    auto bias = tensor_args.bias;
-
-    log_debug(tt::LogOp, "{}:{} args_callback ", __func__, __LINE__);
-    const auto input_address = tensor_args.input.buffer()->address();
-    const auto other_address = tensor_args.other.buffer()->address();
-    const auto output_address = tensor_return_value.buffer()->address();
-
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = input_address;
-            runtime_args[1] = other_address;
-
-            if (bias.has_value()) {
-                const auto bias_address = bias.value().buffer()->address();
-                runtime_args[runtime_args.size() - 1] = bias_address;
-            }
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = output_address;
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::operations::moreh::moreh_matmul

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.hpp
@@ -12,6 +12,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/tensor/types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_mean {
 struct MorehMeanOperation {
@@ -31,69 +32,24 @@ struct MorehMeanOperation {
     using tensor_return_value_t = Tensor;
 
     struct MorehMeanHFactory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id;
-            tt::tt_metal::KernelHandle unary_writer_kernel_id;
-            std::uint32_t num_cores;
-            std::uint32_t core_h;
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& output);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
     };
 
     struct MorehMeanNCFactory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id;
-            tt::tt_metal::KernelHandle unary_writer_kernel_id;
-            std::uint32_t num_cores;
-            std::uint32_t core_h;
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& output);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
     };
 
     struct MorehMeanWFactory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id;
-            tt::tt_metal::KernelHandle unary_writer_kernel_id;
-            std::uint32_t num_cores;
-            std::uint32_t core_h;
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& output);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
     };
 
     using program_factory_t = std::variant<MorehMeanHFactory, MorehMeanNCFactory, MorehMeanWFactory>;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_h_program_factory.cpp
@@ -14,14 +14,15 @@
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 
 namespace ttnn::operations::moreh::moreh_mean {
-MorehMeanOperation::MorehMeanHFactory::cached_program_t MorehMeanOperation::MorehMeanHFactory::create(
+
+tt::tt_metal::ProgramDescriptor MorehMeanOperation::MorehMeanHFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
     using namespace tt;
     using namespace tt::tt_metal;
 
-    auto input = tensor_args.input;
+    const auto& input = tensor_args.input;
     auto compute_kernel_config =
         init_device_compute_kernel_config(input.device()->arch(), operation_attributes.compute_kernel_config);
     const auto& shape = input.padded_shape();
@@ -32,7 +33,6 @@ MorehMeanOperation::MorehMeanHFactory::cached_program_t MorehMeanOperation::More
     const CoreRange core_range({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
     uint32_t W = shape[-1], H = shape[-2];
-
     uint32_t Wt = W / constants::TILE_WIDTH;
     uint32_t Ht = H / constants::TILE_HEIGHT;
     uint32_t HtWt = Ht * Wt;
@@ -43,99 +43,162 @@ MorehMeanOperation::MorehMeanHFactory::cached_program_t MorehMeanOperation::More
     const bool do_mask_h = (origin_H % constants::TILE_HEIGHT) != 0;
     const auto mask_h = do_mask_h ? origin_H % constants::TILE_HEIGHT : constants::TILE_HEIGHT;
 
-    auto program = CreateProgram();
-
     auto units_to_divide = input.physical_volume() / W / H * Wt;
-
     uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores_wt_core_range(core_range, units_to_divide);
 
-    auto arch = input.device()->arch();
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(arch, compute_kernel_config);
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    // create circular buffers
     tt::DataFormat data_format = datatype_to_dataformat_converter(input.dtype());
-
     auto fp32_dest_acc_en_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
-    uint32_t num_input_tiles = 2;
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        data_format,
-        {
-            {CBIndex::c_0, num_input_tiles},                   // input
-            {CBIndex::c_2, 1},                                 // scaler
-            {CBIndex::c_3, 1},                                 // mask
-            {CBIndex::c_24, 1, fp32_dest_acc_en_data_format},  //
-            {CBIndex::c_25, 1},                                //
-            {CBIndex::c_16, 1},                                // output
-        });
 
-    std::vector<uint32_t> reader_compile_time_args = {Ht, Wt, HtWt};
+    ProgramDescriptor desc;
+
+    // ---- Circular buffers ----
+    constexpr uint32_t num_input_tiles = 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * tile_size(data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = data_format,
+            .page_size = tile_size(data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = tile_size(data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_2),
+            .data_format = data_format,
+            .page_size = tile_size(data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = tile_size(data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_3),
+            .data_format = data_format,
+            .page_size = tile_size(data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = tile_size(fp32_dest_acc_en_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = fp32_dest_acc_en_data_format,
+            .page_size = tile_size(fp32_dest_acc_en_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = tile_size(data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = data_format,
+            .page_size = tile_size(data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = tile_size(data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = data_format,
+            .page_size = tile_size(data_format),
+        }}},
+    });
+
+    // ---- Reader kernel ----
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args = {Ht, Wt, HtWt};
     TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
     reader_compile_time_args.push_back(origin_H);
 
-    std::map<std::string, std::string> reader_defines;
-    reader_defines["REDUCE_SCALER"] = "1";
+    KernelDescriptor::Defines reader_defines = {{"REDUCE_SCALER", "1"}};
     if (do_mask_h) {
-        reader_defines["DO_MASK_H"] = "1";
+        reader_defines.emplace_back("DO_MASK_H", "1");
     }
-    const auto reader_kernel_id = CreateReadKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_h.cpp",
-        all_cores,
-        reader_compile_time_args,
-        reader_defines);
 
-    std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(CBIndex::c_16)};
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_h.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    // ---- Writer kernel ----
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args = {static_cast<uint32_t>(CBIndex::c_16)};
     TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
 
-    const auto writer_kernel_id = CreateWriteKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/writer_moreh_mean_unary_interleaved_start_id.cpp",
-        all_cores,
-        writer_compile_time_args);
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/writer_moreh_mean_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                      ComputeKernel SetUp
-    ///////////////////////////////////////////////////////////////////////////
-    std::string compute_kernel_name = "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_h.cpp";
+    // ---- Compute kernels (two groups) ----
     auto reduce_op = ReduceOpMath::AVG;
     auto reduce_dim = ReduceOpDim::H;
-    std::map<std::string, std::string> compute_defines = reduce_op_utils::get_defines(reduce_op, reduce_dim);
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    auto compute_defines_map = reduce_op_utils::get_defines(reduce_op, reduce_dim);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
-        unpack_to_dest_mode[tt::CBIndex::c_24] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        compute_defines_map["FP32_DEST_ACC_EN"] = "1";
+        unpack_to_dest_mode[CBIndex::c_24] = UnpackToDestMode::UnpackToDestFp32;
     }
-    std::vector<uint32_t> compute_kernel_args_group_1 = {
-        Ht,                      // Ht
-        units_per_core_group_1,  // Wt
-        1,                       // NC
-        origin_H};
-    std::vector<uint32_t> compute_kernel_args_group_2 = {
-        Ht,                      // Ht
-        units_per_core_group_2,  // Wt
-        1,                       // NC
-        origin_H};
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
 
-    auto compute_kernel_ids = CreateComputeKernel(
-        program,
-        compute_kernel_name,
-        {
-            {core_group_1, units_per_core_group_1, compute_kernel_args_group_1},
-            {core_group_2, units_per_core_group_2, compute_kernel_args_group_2},
-        },
-        ComputeKernelConfig{
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_h.cpp";
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {
+        Ht,
+        units_per_core_group_1,
+        1,
+        origin_H,
+    };
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_h.cpp";
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {
+            Ht,
+            units_per_core_group_2,
+            1,
+            origin_H,
+        };
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
             .math_fidelity = math_fidelity,
             .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
             .unpack_to_dest_mode = unpack_to_dest_mode,
             .math_approx_mode = math_approx_mode,
-            .defines = compute_defines});
+        };
+    }
 
+    // ---- Runtime args per core ----
+    auto* const input_buf = input.buffer();
+    auto* const output_buf = output.buffer();
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
         uint32_t units_per_core = 0;
@@ -146,55 +209,23 @@ MorehMeanOperation::MorehMeanHFactory::cached_program_t MorehMeanOperation::More
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");
         }
-        SetRuntimeArgs(
-            program,
-            reader_kernel_id,
+        reader_desc.emplace_runtime_args(
             core,
-            {input.buffer()->address(),
-             (tile_offset / Wt * HtWt) + (tile_offset % Wt),
-             tile_offset % Wt,
-             units_per_core,
-             mask_h});
+            {input_buf, (tile_offset / Wt * HtWt) + (tile_offset % Wt), tile_offset % Wt, units_per_core, mask_h});
 
-        SetRuntimeArgs(
-            program,
-            writer_kernel_id,
-            core,
-            {
-                output.buffer()->address(),
-                units_per_core,  // number of tiles to write
-                tile_offset      // output tile start index
-            });
+        writer_desc.emplace_runtime_args(core, {output_buf, units_per_core, tile_offset});
+
         tile_offset += units_per_core;
     }
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, core_h}};
-}
-void MorehMeanOperation::MorehMeanHFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto num_cores = cached_program.shared_variables.num_cores;
-    auto core_h = cached_program.shared_variables.core_h;
 
-    auto src_buffer_address = tensor_args.input.buffer()->address();
-    auto dst_buffer_address = tensor_return_value.buffer()->address();
-
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / core_h, i % core_h};
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = src_buffer_address;
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = dst_buffer_address;
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::operations::moreh::moreh_mean

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_nc_program_factory.cpp
@@ -5,7 +5,6 @@
 #include <string>
 #include <vector>
 
-#include <tt-metalium/bfloat16.hpp>
 #include "moreh_mean_device_operation.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
@@ -15,14 +14,15 @@
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 
 namespace ttnn::operations::moreh::moreh_mean {
-MorehMeanOperation::MorehMeanNCFactory::cached_program_t MorehMeanOperation::MorehMeanNCFactory::create(
+
+tt::tt_metal::ProgramDescriptor MorehMeanOperation::MorehMeanNCFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
     using namespace tt;
     using namespace tt::tt_metal;
 
-    auto input = tensor_args.input;
+    const auto& input = tensor_args.input;
     auto dim = operation_attributes.dim;
 
     auto compute_kernel_config =
@@ -36,7 +36,6 @@ MorehMeanOperation::MorehMeanNCFactory::cached_program_t MorehMeanOperation::Mor
     const auto cb_data_format = datatype_to_dataformat_converter(output.dtype());
 
     const auto& input_shape = input.padded_shape();
-
     const auto Ht = input_shape[-2] / constants::TILE_HEIGHT;
     const auto Wt = input_shape[-1] / constants::TILE_WIDTH;
     const auto HtWt = Ht * Wt;
@@ -55,138 +54,163 @@ MorehMeanOperation::MorehMeanNCFactory::cached_program_t MorehMeanOperation::Mor
 
     const auto units_to_divide = output.physical_volume() / constants::TILE_HW;
 
-    auto program = CreateProgram();
-
-    ////////////////////////////////////////////////////////////////////////////
-    //                         Core Setup
-    ////////////////////////////////////////////////////////////////////////////
     uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores_wt_core_range(core_range, units_to_divide);
 
-    auto arch = input.device()->arch();
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(arch, compute_kernel_config);
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                         CircularBuffer Setup
-    ////////////////////////////////////////////////////////////////////////////
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        cb_data_format,
-        {
-            {CBIndex::c_0, 2},   // input
-            {CBIndex::c_1, 1},   // zero
-            {CBIndex::c_2, 1},   // scaler
-            {CBIndex::c_24, 1},  // accumulated mean
-            {CBIndex::c_16, 2},  // output
-        });
+    ProgramDescriptor desc;
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                      DataMovementKernel SetUp
-    ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> reader_compile_time_args;
-    std::vector<uint32_t> writer_compile_time_args;
+    // ---- Circular buffers ----
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_2),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });
+
+    // ---- Reader kernel ----
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args;
     TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_nc.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    // ---- Writer kernel ----
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args;
     TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
-    const auto* const reader_kernel_file =
-        "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_nc.cpp";
-    const auto* const writer_kernel_file =
-        "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/writer_moreh_mean_nc.cpp";
-    const auto reader_kernel_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args);
-    const auto writer_kernel_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                      ComputeKernel SetUp
-    ////////////////////////////////////////////////////////////////////////////
-    const auto* const compute_kernel_file =
-        "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_nc.cpp";
-    std::map<std::string, std::string> compute_defines;
-    const std::vector<uint32_t> compute_args_group_1{units_per_core_group_1};
-    const std::vector<uint32_t> compute_args_group_2{units_per_core_group_2};
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/writer_moreh_mean_nc.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
+    // ---- Compute kernels (two groups) ----
+    KernelDescriptor::Defines compute_defines;
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines.emplace_back("FP32_DEST_ACC_EN", "1");
     }
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
-    auto compute_kernel_ids = CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {
-            {core_group_1, units_per_core_group_1, compute_args_group_1},
-            {core_group_2, units_per_core_group_2, compute_args_group_2},
-        },
-        ComputeKernelConfig{
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_nc.cpp";
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {units_per_core_group_1};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_nc.cpp";
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {units_per_core_group_2};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
             .math_fidelity = math_fidelity,
             .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
             .unpack_to_dest_mode = unpack_to_dest_mode,
             .math_approx_mode = math_approx_mode,
-            .defines = compute_defines});
+        };
+    }
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                      RuntimeArgs SetUp
-    ////////////////////////////////////////////////////////////////////////////
+    // ---- Runtime args per core ----
+    auto* const input_buf = input.buffer();
+    auto* const output_buf = output.buffer();
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; ++i) {
         CoreCoord core = {i / core_h, i % core_h};
 
         uint32_t units_per_core;
         if (core_group_1.contains(core)) {
             units_per_core = units_per_core_group_1;
-            SetRuntimeArgs(program, compute_kernel_ids[0], core, {num_reduce_input_tile, units_per_core});
+            compute_desc_1.emplace_runtime_args(core, {static_cast<uint32_t>(num_reduce_input_tile), units_per_core});
         } else if (core_group_2.contains(core)) {
             units_per_core = units_per_core_group_2;
-            SetRuntimeArgs(program, compute_kernel_ids[1], core, {num_reduce_input_tile, units_per_core});
+            compute_desc_2.emplace_runtime_args(core, {static_cast<uint32_t>(num_reduce_input_tile), units_per_core});
         } else {
             TT_THROW("Core not in specified core ranges.");
         }
 
-        SetRuntimeArgs(
-            program,
-            reader_kernel_id,
+        reader_desc.emplace_runtime_args(
             core,
-            {input.buffer()->address(),
-             num_reduce_input_tile,
+            {input_buf,
+             static_cast<uint32_t>(num_reduce_input_tile),
              units_per_core,
-             input_tile_stride,
+             static_cast<uint32_t>(input_tile_stride),
              tile_offset,
-             HtWt,
+             static_cast<uint32_t>(HtWt),
              inner_size});
 
-        SetRuntimeArgs(program, writer_kernel_id, core, {output.buffer()->address(), units_per_core, tile_offset});
+        writer_desc.emplace_runtime_args(core, {output_buf, units_per_core, tile_offset});
 
         tile_offset += units_per_core;
     }
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, core_h}};
-}
 
-void MorehMeanOperation::MorehMeanNCFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto num_cores = cached_program.shared_variables.num_cores;
-    auto core_h = cached_program.shared_variables.core_h;
-
-    auto src_buffer_address = tensor_args.input.buffer()->address();
-    auto dst_buffer_address = tensor_return_value.buffer()->address();
-
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / core_h, i % core_h};
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = src_buffer_address;
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = dst_buffer_address;
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::operations::moreh::moreh_mean

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_w_program_factory.cpp
@@ -15,14 +15,15 @@
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 
 namespace ttnn::operations::moreh::moreh_mean {
-MorehMeanOperation::MorehMeanWFactory::cached_program_t MorehMeanOperation::MorehMeanWFactory::create(
+
+tt::tt_metal::ProgramDescriptor MorehMeanOperation::MorehMeanWFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
     using namespace tt;
     using namespace tt::tt_metal;
 
-    auto input = tensor_args.input;
+    const auto& input = tensor_args.input;
     auto compute_kernel_config =
         init_device_compute_kernel_config(input.device()->arch(), operation_attributes.compute_kernel_config);
     const auto& shape = input.padded_shape();
@@ -33,7 +34,6 @@ MorehMeanOperation::MorehMeanWFactory::cached_program_t MorehMeanOperation::More
     const CoreRange core_range({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
     uint32_t W = shape[-1], H = shape[-2];
-
     uint32_t Wt = W / constants::TILE_WIDTH;
     uint32_t Ht = H / constants::TILE_HEIGHT;
 
@@ -43,104 +43,167 @@ MorehMeanOperation::MorehMeanWFactory::cached_program_t MorehMeanOperation::More
     const bool do_mask_w = (origin_W % constants::TILE_WIDTH) != 0;
     const auto mask_w = do_mask_w ? origin_W % constants::TILE_WIDTH : constants::TILE_WIDTH;
 
-    auto program = CreateProgram();
-
     uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto units_to_divide = input.physical_volume() / W / H * Ht;
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores_wt_core_range(core_range, units_to_divide);
 
-    auto arch = input.device()->arch();
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(arch, compute_kernel_config);
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    // create circular buffers
     tt::DataFormat data_format = datatype_to_dataformat_converter(input.dtype());
-
     auto fp32_dest_acc_en_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
 
-    uint32_t num_input_tiles = 2;
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        data_format,
-        {
-            {CBIndex::c_0, num_input_tiles},                   // input
-            {CBIndex::c_2, 1},                                 // scalar
-            {CBIndex::c_3, 1},                                 // mask
-            {CBIndex::c_24, 1, fp32_dest_acc_en_data_format},  //
-            {CBIndex::c_25, 1},                                //
-            {CBIndex::c_16, 1},                                // output
-        });
+    ProgramDescriptor desc;
 
+    // ---- Circular buffers ----
+    constexpr uint32_t num_input_tiles = 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * tile_size(data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = data_format,
+            .page_size = tile_size(data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = tile_size(data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_2),
+            .data_format = data_format,
+            .page_size = tile_size(data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = tile_size(data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_3),
+            .data_format = data_format,
+            .page_size = tile_size(data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = tile_size(fp32_dest_acc_en_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = fp32_dest_acc_en_data_format,
+            .page_size = tile_size(fp32_dest_acc_en_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = tile_size(data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = data_format,
+            .page_size = tile_size(data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = tile_size(data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = data_format,
+            .page_size = tile_size(data_format),
+        }}},
+    });
+
+    // ---- Reader kernel ----
     float scaler = 1.0f / origin_W;
     bfloat16 bfloat_scaler_value(scaler);
     auto packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
 
-    std::vector<uint32_t> reader_compile_time_args = {};
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args;
     TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
     reader_compile_time_args.push_back(packed_scaler_value);
 
-    std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(CBIndex::c_16)};
+    KernelDescriptor::Defines reader_defines;
+    if (do_mask_w) {
+        reader_defines.emplace_back("DO_MASK_W", "1");
+    }
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_w.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    // ---- Writer kernel ----
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args = {static_cast<uint32_t>(CBIndex::c_16)};
     TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines{};
-    if (do_mask_w) {
-        reader_defines["DO_MASK_W"] = "1";
-    }
-    const auto reader_kernel_id = CreateReadKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_w.cpp",
-        all_cores,
-        reader_compile_time_args,
-        reader_defines);
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/writer_moreh_mean_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    const auto writer_kernel_id = CreateWriteKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/writer_moreh_mean_unary_interleaved_start_id.cpp",
-        all_cores,
-        writer_compile_time_args);
-
-    ////////////////////////////////////////////////////////////////////////////
-    //                      ComputeKernel SetUp
-    ///////////////////////////////////////////////////////////////////////////
-    std::string compute_kernel_name = "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_w.cpp";
+    // ---- Compute kernels (two groups) ----
     auto reduce_op = ReduceOpMath::AVG;
     auto reduce_dim = ReduceOpDim::W;
-    std::map<std::string, std::string> compute_defines = reduce_op_utils::get_defines(reduce_op, reduce_dim);
+    auto compute_defines_map = reduce_op_utils::get_defines(reduce_op, reduce_dim);
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines_map["FP32_DEST_ACC_EN"] = "1";
     }
-    std::vector<uint32_t> compute_kernel_args_group_1 = {
-        units_per_core_group_1,  // Ht
-        Wt,                      // Wt
-        1,                       // NC
-        origin_W,
-    };
-    std::vector<uint32_t> compute_kernel_args_group_2 = {
-        units_per_core_group_2,  // Ht
-        Wt,                      // Wt
-        1,                       // NC
-        origin_W,
-    };
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
 
-    auto compute_kernel_ids = CreateComputeKernel(
-        program,
-        compute_kernel_name,
-        {
-            {core_group_1, units_per_core_group_1, compute_kernel_args_group_1},
-            {core_group_2, units_per_core_group_2, compute_kernel_args_group_2},
-        },
-        ComputeKernelConfig{
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_w.cpp";
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {
+        units_per_core_group_1,
+        Wt,
+        1,
+        origin_W,
+    };
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_w.cpp";
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {
+            units_per_core_group_2,
+            Wt,
+            1,
+            origin_W,
+        };
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
             .math_fidelity = math_fidelity,
             .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
             .unpack_to_dest_mode = unpack_to_dest_mode,
             .math_approx_mode = math_approx_mode,
-            .defines = compute_defines});
+        };
+    }
 
+    // ---- Runtime args per core ----
     uint32_t out_dim_divider = Wt;
+    auto* const input_buf = input.buffer();
+    auto* const output_buf = output.buffer();
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
         uint32_t units_per_core = 0;
@@ -152,55 +215,23 @@ MorehMeanOperation::MorehMeanWFactory::cached_program_t MorehMeanOperation::More
             TT_ASSERT(false, "Core not in specified core ranges");
         }
         uint32_t num_tensor_tiles_per_core = units_per_core * Wt;
-        SetRuntimeArgs(
-            program,
-            reader_kernel_id,
-            core,
-            {input.buffer()->address(),
-             num_tensor_tiles_per_core,
-             tile_offset,  // tile index of row to start reading from
-             mask_w});
 
-        SetRuntimeArgs(
-            program,
-            writer_kernel_id,
-            core,
-            {
-                output.buffer()->address(),
-                num_tensor_tiles_per_core / out_dim_divider,  // number of tiles to write
-                tile_offset / out_dim_divider                 // output tile start index
-            });
+        reader_desc.emplace_runtime_args(core, {input_buf, num_tensor_tiles_per_core, tile_offset, mask_w});
+
+        writer_desc.emplace_runtime_args(
+            core, {output_buf, num_tensor_tiles_per_core / out_dim_divider, tile_offset / out_dim_divider});
+
         tile_offset += num_tensor_tiles_per_core;
     }
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, core_h}};
-}
 
-void MorehMeanOperation::MorehMeanWFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto num_cores = cached_program.shared_variables.num_cores;
-    auto core_h = cached_program.shared_variables.core_h;
-
-    auto src_buffer_address = tensor_args.input.buffer()->address();
-    auto dst_buffer_address = tensor_return_value.buffer()->address();
-
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / core_h, i % core_h};
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = src_buffer_address;
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = dst_buffer_address;
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::operations::moreh::moreh_mean

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_device_operation.hpp
@@ -7,6 +7,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_helper.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_nll_loss_step1 {
 
@@ -30,21 +31,7 @@ struct MorehNllLossStep1DeviceOperation {
     using tensor_return_value_t = Tensor;
 
     struct Factory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id;
-            tt::tt_metal::KernelHandle unary_writer_kernel_id;
-            std::size_t num_cores;
-            std::size_t num_cores_y;
-        };
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_program_factory.cpp
@@ -14,7 +14,7 @@ using namespace tt::tt_metal;
 
 namespace ttnn::operations::moreh::moreh_nll_loss_step1 {
 
-MorehNllLossStep1DeviceOperation::Factory::cached_program_t MorehNllLossStep1DeviceOperation::Factory::create(
+tt::tt_metal::ProgramDescriptor MorehNllLossStep1DeviceOperation::Factory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
@@ -48,8 +48,6 @@ MorehNllLossStep1DeviceOperation::Factory::cached_program_t MorehNllLossStep1Dev
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    Program program = Program();
-
     // create circular buffers
     const auto target_data_format = tt_metal::datatype_to_dataformat_converter(target.dtype());
     const auto data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
@@ -71,54 +69,91 @@ MorehNllLossStep1DeviceOperation::Factory::cached_program_t MorehNllLossStep1Dev
 
     const bool use_large_algorithm = cb_usage >= available_L1;
 
-    if (use_large_algorithm) {
-        CreateCircularBuffer(
-            program,
-            all_cores,
-            data_format,
-            {
-                {CBIndex::c_0, 1, tt::DataFormat::Int32},  // target
-                {CBIndex::c_1, 1},                         // weight
-                {CBIndex::c_24, 1, intermed_data_format},  // tmp_weight
-                {CBIndex::c_16, 1},                        // output
+    ProgramDescriptor desc;
+
+    // target CB (always Int32, single tile)
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = target_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = tt::DataFormat::Int32,
+            .page_size = target_tile_size,
+        }}},
+    });
+
+    // weight CB:
+    //   - large algorithm: always allocate 1 tile (single-tile streaming through CB)
+    //   - small algorithm: allocate weight_num_tile tiles (skip CB when weight is absent and weight_num_tile == 0)
+    {
+        const uint32_t weight_cb_tiles = use_large_algorithm ? 1u : weight_num_tile;
+        if (weight_cb_tiles > 0) {
+            desc.cbs.push_back(CBDescriptor{
+                .total_size = weight_cb_tiles * data_tile_size,
+                .core_ranges = all_cores,
+                .format_descriptors = {{CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+                    .data_format = data_format,
+                    .page_size = data_tile_size,
+                }}},
             });
-    } else {
-        CreateCircularBuffer(
-            program,
-            all_cores,
-            data_format,
-            {
-                {CBIndex::c_0, 1, tt::DataFormat::Int32},  // target
-                {CBIndex::c_1, weight_num_tile},           // weight
-                {CBIndex::c_24, 1, intermed_data_format},  // tmp_weight
-                {CBIndex::c_16, 1},                        // output
-            });
+        }
     }
+
+    // tmp_weight (intermed) CB
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = intermed_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = intermed_data_format,
+            .page_size = intermed_tile_size,
+        }}},
+    });
+
+    // output CB
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = data_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = data_format,
+            .page_size = data_tile_size,
+        }}},
+    });
 
     if (weight_has_value) {
         // This CB will be used as scratch storage when reading data from DRAM into L1,
         // since the two have different alignment requirements on some architectures.
         // Need space for only a single tile in scratch CB, because content is read immediately after writing.
-        CreateCircularBuffer(program, all_cores, data_format, {tt::CBIndex::c_7, 1});
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = data_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(CBIndex::c_7),
+                .data_format = data_format,
+                .page_size = data_tile_size,
+            }}},
+        });
     }
 
     // create read/write kernel
-    std::vector<uint32_t> reader_compile_time_args{static_cast<uint32_t>(weight_has_value)};
-    TensorAccessorArgs(target.buffer()).append_to(reader_compile_time_args);
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args{static_cast<uint32_t>(weight_has_value)};
+    TensorAccessorArgs(*target.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(weight.has_value() ? weight.value().buffer() : nullptr).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args{};
-    TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args{};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
+    KernelDescriptor::Defines reader_defines;
+    KernelDescriptor::Defines writer_defines;
 
     if (weight_has_value) {
-        reader_defines["WEIGHT"] = "1";
+        reader_defines.emplace_back("WEIGHT", "1");
     }
 
     if (fp32_dest_acc_en) {
-        reader_defines["FP32_DEST_ACC_EN"] = "1";
+        reader_defines.emplace_back("FP32_DEST_ACC_EN", "1");
     }
     const auto* const reader_kernel_file =
         use_large_algorithm ? "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/"
@@ -129,14 +164,25 @@ MorehNllLossStep1DeviceOperation::Factory::cached_program_t MorehNllLossStep1Dev
         "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/kernels/"
         "writer_moreh_nll_loss_step1.cpp";
 
-    auto reader_kernel_id =
-        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines);
-    auto writer_kernel_id =
-        CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args, writer_defines);
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_file;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    const auto target_addr = target.buffer()->address();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0;
-    const auto output_addr = output.buffer()->address();
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_file;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    auto* const target_buf = target.buffer();
+    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
+    auto* const output_buf = output.buffer();
 
     // Set Runtime Args
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
@@ -151,69 +197,30 @@ MorehNllLossStep1DeviceOperation::Factory::cached_program_t MorehNllLossStep1Dev
         }
 
         uint32_t element_size = weight_has_value ? weight.value().element_size() : 0;
-        std::vector<uint32_t> reader_args = {
-            target_addr,
-            weight_addr,
-            static_cast<uint32_t>(ignore_index),
-            num_units_per_core,
-            tile_offset,
-            channel_size,
-            weight_num_tile,
-            element_size,
-            target.element_size(),
-        };
 
-        std::vector<uint32_t> writer_args = {output_addr, num_units_per_core, tile_offset};
+        reader_desc.emplace_runtime_args(
+            core,
+            {
+                target_buf,
+                weight_addr,
+                static_cast<uint32_t>(ignore_index),
+                num_units_per_core,
+                tile_offset,
+                channel_size,
+                weight_num_tile,
+                element_size,
+                target.element_size(),
+            });
 
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
-
-        // compute
-        const std::vector<uint32_t> compute_runtime_args{num_units_per_core};
+        writer_desc.emplace_runtime_args(core, {output_buf, num_units_per_core, tile_offset});
 
         tile_offset += num_units_per_core;
     }
 
-    return {
-        std::move(program),
-        {.unary_reader_kernel_id = reader_kernel_id,
-         .unary_writer_kernel_id = writer_kernel_id,
-         .num_cores = num_cores,
-         .num_cores_y = core_h}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void MorehNllLossStep1DeviceOperation::Factory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& num_cores = cached_program.shared_variables.num_cores;
-    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    const uint32_t target_addr = tensor_args.target_tensor.buffer()->address();
-    const uint32_t weight_addr =
-        tensor_args.weight_tensor.has_value() ? tensor_args.weight_tensor.value().buffer()->address() : 0;
-    const uint32_t ignore_index = operation_attributes.ignore_index;
-
-    const uint32_t output_addr = tensor_return_value.buffer()->address();
-
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
-            runtime_args[0] = target_addr;
-            runtime_args[1] = weight_addr;
-            runtime_args[2] = ignore_index;
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
-            runtime_args[0] = output_addr;
-        }
-    }
+    return desc;
 }
 
 }  // namespace ttnn::operations::moreh::moreh_nll_loss_step1

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_device_operation.hpp
@@ -7,6 +7,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_helper.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_nll_loss_step2 {
 
@@ -31,21 +32,7 @@ struct MorehNllLossStep2DeviceOperation {
     using tensor_return_value_t = ttnn::Tensor;
 
     struct Factory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id;
-            tt::tt_metal::KernelHandle unary_writer_kernel_id;
-            std::size_t num_cores;
-            std::size_t num_cores_y;
-        };
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_program_factory.cpp
@@ -16,7 +16,33 @@ using namespace tt::tt_metal;
 
 namespace ttnn::operations::moreh::moreh_nll_loss_step2 {
 
-MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2_impl_2d(
+namespace {
+
+// Helper: append a CB with a given tile-count (skips creation when num_tiles == 0).
+void push_cb(
+    ProgramDescriptor& desc,
+    const CoreRangeSet& core_ranges,
+    uint8_t buffer_index,
+    uint32_t num_tiles,
+    tt::DataFormat data_format) {
+    if (num_tiles == 0) {
+        return;
+    }
+    const auto tile_sz = tt::tile_size(data_format);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * tile_sz,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = buffer_index,
+            .data_format = data_format,
+            .page_size = tile_sz,
+        }}},
+    });
+}
+
+}  // namespace
+
+tt::tt_metal::ProgramDescriptor moreh_nll_loss_step2_impl_2d(
     const Tensor& input,
     const Tensor& target,
     const std::optional<Tensor>& weight,
@@ -49,98 +75,123 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     tt::DataFormat data_format = tt_metal::datatype_to_dataformat_converter(input.dtype());
 
     auto fp32_dest_acc_en_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        data_format,
-        {
-            {CBIndex::c_0, 1},                                                 // input
-            {CBIndex::c_1, 1, tt::DataFormat::Int32},                          // target
-            {CBIndex::c_2, static_cast<uint32_t>(weight_has_value ? 1 : 0)},   // weight
-            {CBIndex::c_3, static_cast<uint32_t>(divisor_has_value ? 1 : 0)},  // divisor
-            {CBIndex::c_24, 1, fp32_dest_acc_en_data_format},                  // tmp_weight to reduce
-            {CBIndex::c_25, 1, fp32_dest_acc_en_data_format},                  // tmp_input to reduce
-            {CBIndex::c_26, 1, fp32_dest_acc_en_data_format},                  // tmp1
-            {CBIndex::c_27, 1, fp32_dest_acc_en_data_format},                  // tmp2
-            {CBIndex::c_28, 1, fp32_dest_acc_en_data_format},                  // tmp3
-            {CBIndex::c_16, 1},                                                // output
-        });
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_0), 1, data_format);                          // input
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_1), 1, tt::DataFormat::Int32);                // target
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_2), weight_has_value ? 1 : 0, data_format);   // weight
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_3), divisor_has_value ? 1 : 0, data_format);  // divisor
+    push_cb(
+        desc, all_cores, static_cast<uint8_t>(CBIndex::c_24), 1, fp32_dest_acc_en_data_format);  // tmp_weight to reduce
+    push_cb(
+        desc, all_cores, static_cast<uint8_t>(CBIndex::c_25), 1, fp32_dest_acc_en_data_format);  // tmp_input to reduce
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_26), 1, fp32_dest_acc_en_data_format);  // tmp1
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_27), 1, fp32_dest_acc_en_data_format);  // tmp2
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_28), 1, fp32_dest_acc_en_data_format);  // tmp3
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_16), 1, data_format);                   // output
 
     if (weight_has_value) {
         // This CB will be used as scratch storage when reading data from DRAM into L1,
         // since the two have different alignment requirements on some architectures.
         // Need space for only a single tile in scratch CB, because content is read immediately after writing.
-        CreateCircularBuffer(program, all_cores, data_format, {tt::CBIndex::c_7, 1});
+        push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_7), 1, data_format);
     }
 
     // create read/write kernel
-    std::vector<uint32_t> reader_compile_time_args{};
-    TensorAccessorArgs(input.buffer()).append_to(reader_compile_time_args);
-    TensorAccessorArgs(target.buffer()).append_to(reader_compile_time_args);
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args{};
+    TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*target.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(weight.has_value() ? weight.value().buffer() : nullptr).append_to(reader_compile_time_args);
     TensorAccessorArgs(divisor.has_value() ? divisor.value().buffer() : nullptr).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args{};
-    TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args{};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
-    std::map<std::string, std::string> compute_defines{};
+    KernelDescriptor::Defines reader_defines;
+    KernelDescriptor::Defines writer_defines;
+    KernelDescriptor::Defines compute_defines;
 
     if (weight_has_value) {
-        reader_defines["WEIGHT"] = "1";
-        compute_defines["WEIGHT"] = "1";
+        reader_defines.emplace_back("WEIGHT", "1");
+        compute_defines.emplace_back("WEIGHT", "1");
     }
     if (divisor_has_value) {
-        reader_defines["DIVISOR"] = "1";
-        compute_defines["DIVISOR"] = "1";
+        reader_defines.emplace_back("DIVISOR", "1");
+        compute_defines.emplace_back("DIVISOR", "1");
     }
 
     if (fp32_dest_acc_en) {
-        reader_defines["FP32_DEST_ACC_EN"] = "1";
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        reader_defines.emplace_back("FP32_DEST_ACC_EN", "1");
+        compute_defines.emplace_back("FP32_DEST_ACC_EN", "1");
     }
 
-    auto reader_kernel_id = CreateReadKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/"
-        "reader_moreh_nll_loss_step2_2d.cpp",
-        all_cores,
-        reader_compile_time_args,
-        reader_defines);
-    auto writer_kernel_id = CreateWriteKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/"
-        "writer_moreh_nll_loss_step2_2d.cpp",
-        all_cores,
-        writer_compile_time_args,
-        writer_defines);
+        "reader_moreh_nll_loss_step2_2d.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    const auto compute_kernel_ids = CreateComputeKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/"
-        "moreh_nll_loss_step2_kernel.cpp",
-        {
-            {core_group_1, units_per_core_group_1, {units_per_core_group_1}},
-            {core_group_2, units_per_core_group_2, {units_per_core_group_2}},
-        },
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+        "writer_moreh_nll_loss_step2_2d.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    const auto input_addr = input.buffer()->address();
-    const auto target_addr = target.buffer()->address();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0;
-    const auto divisor_addr = divisor_has_value ? divisor.value().buffer()->address() : 0;
-    const auto output_addr = output.buffer()->address();
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+
+    const auto* const compute_kernel_file =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/"
+        "moreh_nll_loss_step2_kernel.cpp";
+
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {units_per_core_group_1};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {units_per_core_group_2};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
+    }
+
+    auto* const input_buf = input.buffer();
+    auto* const target_buf = target.buffer();
+    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
+    const auto divisor_addr = divisor_has_value ? divisor.value().buffer()->address() : 0u;
+    auto* const output_buf = output.buffer();
 
     // Set Runtime Args
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
@@ -154,36 +205,37 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
             TT_THROW("Core not in specified core ranges");
         }
 
-        std::vector<uint32_t> reader_args = {
-            input_addr,
-            target_addr,
-            weight_addr,
-            divisor_addr,
-            static_cast<uint32_t>(ignore_index),
-            units_per_core,
-            tile_offset,
-            origin_N,
-            origin_C,
-            input.element_size(),
-        };
+        reader_desc.emplace_runtime_args(
+            core,
+            {
+                input_buf,
+                target_buf,
+                weight_addr,
+                divisor_addr,
+                static_cast<uint32_t>(ignore_index),
+                units_per_core,
+                tile_offset,
+                origin_N,
+                origin_C,
+                input.element_size(),
+            });
 
-        std::vector<uint32_t> writer_args = {
-            output_addr,
-            units_per_core,
-            tile_offset,
-            origin_N,
-        };
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(
+            core,
+            {
+                output_buf,
+                units_per_core,
+                tile_offset,
+                origin_N,
+            });
 
         // compute
-        const std::vector<uint32_t> compute_runtime_args{units_per_core};
+        const KernelDescriptor::CoreRuntimeArgs compute_runtime_args{units_per_core};
 
         if (core_group_1.contains(core)) {
-            SetRuntimeArgs(program, compute_kernel_ids[0], core, compute_runtime_args);
+            compute_desc_1.runtime_args.emplace_back(core, compute_runtime_args);
         } else if (core_group_2.contains(core)) {
-            SetRuntimeArgs(program, compute_kernel_ids[1], core, compute_runtime_args);
+            compute_desc_2.runtime_args.emplace_back(core, compute_runtime_args);
         } else {
             TT_FATAL(false, "Core not in specified core ranges.");
         }
@@ -191,15 +243,17 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
         tile_offset += units_per_core;
     }
 
-    return {
-        std::move(program),
-        {.unary_reader_kernel_id = reader_kernel_id,
-         .unary_writer_kernel_id = writer_kernel_id,
-         .num_cores = num_cores,
-         .num_cores_y = core_h}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
+    }
+
+    return desc;
 }
 
-MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2_impl_3d(
+tt::tt_metal::ProgramDescriptor moreh_nll_loss_step2_impl_3d(
     const Tensor& input,
     const Tensor& target,
     const std::optional<Tensor>& weight,
@@ -230,98 +284,123 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     tt::DataFormat data_format = tt_metal::datatype_to_dataformat_converter(input.dtype());
 
     auto fp32_dest_acc_en_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        data_format,
-        {
-            {CBIndex::c_0, 1},                                                 // input
-            {CBIndex::c_1, 1, tt::DataFormat::Int32},                          // target
-            {CBIndex::c_2, static_cast<uint32_t>(weight_has_value ? 1 : 0)},   // weight
-            {CBIndex::c_3, static_cast<uint32_t>(divisor_has_value ? 1 : 0)},  // divisor
-            {CBIndex::c_24, 1, fp32_dest_acc_en_data_format},                  // tmp_weight to reduce
-            {CBIndex::c_25, 1, fp32_dest_acc_en_data_format},                  // tmp_input to reduce
-            {CBIndex::c_26, 1, fp32_dest_acc_en_data_format},                  // tmp1
-            {CBIndex::c_27, 1, fp32_dest_acc_en_data_format},                  // tmp2
-            {CBIndex::c_28, 1, fp32_dest_acc_en_data_format},                  // tmp3
-            {CBIndex::c_16, 1},                                                // output
-        });
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_0), 1, data_format);                          // input
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_1), 1, tt::DataFormat::Int32);                // target
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_2), weight_has_value ? 1 : 0, data_format);   // weight
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_3), divisor_has_value ? 1 : 0, data_format);  // divisor
+    push_cb(
+        desc, all_cores, static_cast<uint8_t>(CBIndex::c_24), 1, fp32_dest_acc_en_data_format);  // tmp_weight to reduce
+    push_cb(
+        desc, all_cores, static_cast<uint8_t>(CBIndex::c_25), 1, fp32_dest_acc_en_data_format);  // tmp_input to reduce
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_26), 1, fp32_dest_acc_en_data_format);  // tmp1
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_27), 1, fp32_dest_acc_en_data_format);  // tmp2
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_28), 1, fp32_dest_acc_en_data_format);  // tmp3
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_16), 1, data_format);                   // output
 
     if (weight_has_value) {
         // This CB will be used as scratch storage when reading data from DRAM into L1,
         // since the two have different alignment requirements on some architectures.
         // Need space for only a single tile in scratch CB, because content is read immediately after writing.
-        CreateCircularBuffer(program, all_cores, data_format, {tt::CBIndex::c_7, 1});
+        push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_7), 1, data_format);
     }
 
     // create read/write kernel
-    std::vector<uint32_t> reader_compile_time_args{};
-    TensorAccessorArgs(input.buffer()).append_to(reader_compile_time_args);
-    TensorAccessorArgs(target.buffer()).append_to(reader_compile_time_args);
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args{};
+    TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*target.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(weight.has_value() ? weight.value().buffer() : nullptr).append_to(reader_compile_time_args);
     TensorAccessorArgs(divisor.has_value() ? divisor.value().buffer() : nullptr).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args{};
-    TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args{};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
-    std::map<std::string, std::string> compute_defines{};
+    KernelDescriptor::Defines reader_defines;
+    KernelDescriptor::Defines writer_defines;
+    KernelDescriptor::Defines compute_defines;
 
     if (weight_has_value) {
-        reader_defines["WEIGHT"] = "1";
-        compute_defines["WEIGHT"] = "1";
+        reader_defines.emplace_back("WEIGHT", "1");
+        compute_defines.emplace_back("WEIGHT", "1");
     }
     if (divisor_has_value) {
-        reader_defines["DIVISOR"] = "1";
-        compute_defines["DIVISOR"] = "1";
+        reader_defines.emplace_back("DIVISOR", "1");
+        compute_defines.emplace_back("DIVISOR", "1");
     }
 
     if (fp32_dest_acc_en) {
-        reader_defines["FP32_DEST_ACC_EN"] = "1";
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        reader_defines.emplace_back("FP32_DEST_ACC_EN", "1");
+        compute_defines.emplace_back("FP32_DEST_ACC_EN", "1");
     }
 
-    auto reader_kernel_id = CreateReadKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/"
-        "reader_moreh_nll_loss_step2_3d.cpp",
-        all_cores,
-        reader_compile_time_args,
-        reader_defines);
-    auto writer_kernel_id = CreateWriteKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/"
-        "writer_moreh_nll_loss_step2_3d.cpp",
-        all_cores,
-        writer_compile_time_args,
-        writer_defines);
+        "reader_moreh_nll_loss_step2_3d.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    const auto compute_kernel_ids = CreateComputeKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/"
-        "moreh_nll_loss_step2_kernel.cpp",
-        {
-            {core_group_1, units_per_core_group_1, {units_per_core_group_1}},
-            {core_group_2, units_per_core_group_2, {units_per_core_group_2}},
-        },
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+        "writer_moreh_nll_loss_step2_3d.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    const auto input_addr = input.buffer()->address();
-    const auto target_addr = target.buffer()->address();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0;
-    const auto divisor_addr = divisor_has_value ? divisor.value().buffer()->address() : 0;
-    const auto output_addr = output.buffer()->address();
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+
+    const auto* const compute_kernel_file =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/"
+        "moreh_nll_loss_step2_kernel.cpp";
+
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {units_per_core_group_1};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {units_per_core_group_2};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
+    }
+
+    auto* const input_buf = input.buffer();
+    auto* const target_buf = target.buffer();
+    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
+    const auto divisor_addr = divisor_has_value ? divisor.value().buffer()->address() : 0u;
+    auto* const output_buf = output.buffer();
 
     // Set Runtime Args
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
@@ -335,38 +414,39 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
             TT_THROW("Core not in specified core ranges");
         }
 
-        std::vector<uint32_t> reader_args = {
-            input_addr,
-            target_addr,
-            weight_addr,
-            divisor_addr,
-            static_cast<uint32_t>(ignore_index),
-            units_per_core,
-            tile_offset,
-            origin_N,
-            origin_C,
-            origin_W,
-            input.element_size(),
-        };
+        reader_desc.emplace_runtime_args(
+            core,
+            {
+                input_buf,
+                target_buf,
+                weight_addr,
+                divisor_addr,
+                static_cast<uint32_t>(ignore_index),
+                units_per_core,
+                tile_offset,
+                origin_N,
+                origin_C,
+                origin_W,
+                input.element_size(),
+            });
 
-        std::vector<uint32_t> writer_args = {
-            output_addr,
-            units_per_core,
-            tile_offset,
-            origin_W,
-            output.element_size(),
-        };
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(
+            core,
+            {
+                output_buf,
+                units_per_core,
+                tile_offset,
+                origin_W,
+                output.element_size(),
+            });
 
         // compute
-        const std::vector<uint32_t> compute_runtime_args{units_per_core};
+        const KernelDescriptor::CoreRuntimeArgs compute_runtime_args{units_per_core};
 
         if (core_group_1.contains(core)) {
-            SetRuntimeArgs(program, compute_kernel_ids[0], core, compute_runtime_args);
+            compute_desc_1.runtime_args.emplace_back(core, compute_runtime_args);
         } else if (core_group_2.contains(core)) {
-            SetRuntimeArgs(program, compute_kernel_ids[1], core, compute_runtime_args);
+            compute_desc_2.runtime_args.emplace_back(core, compute_runtime_args);
         } else {
             TT_FATAL(false, "Core not in specified core ranges.");
         }
@@ -374,15 +454,17 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
         tile_offset += units_per_core;
     }
 
-    return {
-        std::move(program),
-        {.unary_reader_kernel_id = reader_kernel_id,
-         .unary_writer_kernel_id = writer_kernel_id,
-         .num_cores = num_cores,
-         .num_cores_y = core_h}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
+    }
+
+    return desc;
 }
 
-MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2_impl_4d(
+tt::tt_metal::ProgramDescriptor moreh_nll_loss_step2_impl_4d(
     const Tensor& input,
     const Tensor& target,
     const std::optional<Tensor>& weight,
@@ -395,13 +477,13 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
     auto input_shape = input.padded_shape();
     auto target_shape = target.padded_shape();
     auto N = input_shape[0];
-    auto channel_size = input_shape[1];
+    uint32_t channel_size = input_shape[1];
 
     auto H = target_shape[-2];
     auto W = target_shape[-1];
     auto Ht = H / tt::constants::TILE_HEIGHT;
     auto Wt = W / tt::constants::TILE_WIDTH;
-    auto num_inner_tile = target.physical_volume() / N / tt::constants::TILE_HEIGHT / tt::constants::TILE_WIDTH;
+    uint32_t num_inner_tile = target.physical_volume() / N / tt::constants::TILE_HEIGHT / tt::constants::TILE_WIDTH;
 
     const auto& input_shape_without_padding = input.logical_shape();
     const auto origin_N = input_shape_without_padding[0];
@@ -423,7 +505,7 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     tt::DataFormat data_format = tt_metal::datatype_to_dataformat_converter(input.dtype());
@@ -431,91 +513,122 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
     auto fp32_dest_acc_en_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
 
     uint32_t weight_num_tile = div_up(channel_size, tt::constants::TILE_WIDTH);
-    CreateCircularBuffer(
-        program,
+
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_0), 1, data_format);            // input
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_1), 1, tt::DataFormat::Int32);  // target
+    push_cb(
+        desc,
         all_cores,
-        data_format,
-        {
-            {CBIndex::c_0, 1},                                                              // input
-            {CBIndex::c_1, 1, tt::DataFormat::Int32},                                       // target
-            {CBIndex::c_2, static_cast<uint32_t>(weight_has_value ? weight_num_tile : 0)},  // weight
-            {CBIndex::c_3, static_cast<uint32_t>(divisor_has_value ? 1 : 0)},               // divisor
-            {CBIndex::c_24, 1, fp32_dest_acc_en_data_format},                               // tmp_weight to reduce
-            {CBIndex::c_25, 1, fp32_dest_acc_en_data_format},                               // tmp_input to reduce
-            {CBIndex::c_26, 1, fp32_dest_acc_en_data_format},                               // tmp1
-            {CBIndex::c_27, 1, fp32_dest_acc_en_data_format},                               // tmp2
-            {CBIndex::c_28, 1, fp32_dest_acc_en_data_format},                               // tmp3
-            {CBIndex::c_16, 1},                                                             // output
-        });
+        static_cast<uint8_t>(CBIndex::c_2),
+        weight_has_value ? weight_num_tile : 0u,
+        data_format);                                                                                        // weight
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_3), divisor_has_value ? 1u : 0u, data_format);  // divisor
+    push_cb(
+        desc, all_cores, static_cast<uint8_t>(CBIndex::c_24), 1, fp32_dest_acc_en_data_format);  // tmp_weight to reduce
+    push_cb(
+        desc, all_cores, static_cast<uint8_t>(CBIndex::c_25), 1, fp32_dest_acc_en_data_format);  // tmp_input to reduce
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_26), 1, fp32_dest_acc_en_data_format);  // tmp1
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_27), 1, fp32_dest_acc_en_data_format);  // tmp2
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_28), 1, fp32_dest_acc_en_data_format);  // tmp3
+    push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_16), 1, data_format);                   // output
 
     if (weight_has_value) {
         // This CB will be used as scratch storage when reading data from DRAM into L1,
         // since the two have different alignment requirements on some architectures.
         // Need space for only a single tile in scratch CB, because content is read immediately after writing.
-        CreateCircularBuffer(program, all_cores, data_format, {tt::CBIndex::c_7, 1});
+        push_cb(desc, all_cores, static_cast<uint8_t>(CBIndex::c_7), 1, data_format);
     }
 
     // create read/write kernel
-    std::vector<uint32_t> reader_compile_time_args{};
-    TensorAccessorArgs(input.buffer()).append_to(reader_compile_time_args);
-    TensorAccessorArgs(target.buffer()).append_to(reader_compile_time_args);
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args{};
+    TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*target.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(weight.has_value() ? weight.value().buffer() : nullptr).append_to(reader_compile_time_args);
     TensorAccessorArgs(divisor.has_value() ? divisor.value().buffer() : nullptr).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args{};
-    TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args{};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
-    std::map<std::string, std::string> compute_defines{};
+    KernelDescriptor::Defines reader_defines;
+    KernelDescriptor::Defines writer_defines;
+    KernelDescriptor::Defines compute_defines;
 
     if (weight_has_value) {
-        reader_defines["WEIGHT"] = "1";
-        compute_defines["WEIGHT"] = "1";
+        reader_defines.emplace_back("WEIGHT", "1");
+        compute_defines.emplace_back("WEIGHT", "1");
     }
     if (divisor_has_value) {
-        reader_defines["DIVISOR"] = "1";
-        compute_defines["DIVISOR"] = "1";
+        reader_defines.emplace_back("DIVISOR", "1");
+        compute_defines.emplace_back("DIVISOR", "1");
     }
 
     if (fp32_dest_acc_en) {
-        reader_defines["FP32_DEST_ACC_EN"] = "1";
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        reader_defines.emplace_back("FP32_DEST_ACC_EN", "1");
+        compute_defines.emplace_back("FP32_DEST_ACC_EN", "1");
     }
 
-    auto reader_kernel_id = CreateReadKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/"
-        "reader_moreh_nll_loss_step2_4d.cpp",
-        all_cores,
-        reader_compile_time_args,
-        reader_defines);
-    auto writer_kernel_id = CreateWriteKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/"
-        "writer_moreh_nll_loss_step2_4d.cpp",
-        all_cores,
-        writer_compile_time_args,
-        writer_defines);
+        "reader_moreh_nll_loss_step2_4d.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    const auto compute_kernel_ids = CreateComputeKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/"
-        "moreh_nll_loss_step2_kernel.cpp",
-        {
-            {core_group_1, units_per_core_group_1, {units_per_core_group_1}},
-            {core_group_2, units_per_core_group_2, {units_per_core_group_2}},
-        },
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+        "writer_moreh_nll_loss_step2_4d.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    const auto input_addr = input.buffer()->address();
-    const auto target_addr = target.buffer()->address();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0;
-    const auto divisor_addr = divisor_has_value ? divisor.value().buffer()->address() : 0;
-    const auto output_addr = output.buffer()->address();
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+
+    const auto* const compute_kernel_file =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/"
+        "moreh_nll_loss_step2_kernel.cpp";
+
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {units_per_core_group_1};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {units_per_core_group_2};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
+    }
+
+    auto* const input_buf = input.buffer();
+    auto* const target_buf = target.buffer();
+    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
+    const auto divisor_addr = divisor_has_value ? divisor.value().buffer()->address() : 0u;
+    auto* const output_buf = output.buffer();
 
     // Set Runtime Args
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
@@ -529,38 +642,39 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
             TT_THROW("Core not in specified core ranges");
         }
 
-        std::vector<uint32_t> reader_args = {
-            input_addr,
-            target_addr,
-            weight_addr,
-            divisor_addr,
-            static_cast<uint32_t>(ignore_index),
-            units_per_core,
-            tile_offset,
-            origin_N,
-            origin_C,
-            Wt,
-            num_inner_tile,
-            weight_num_tile,
-            input.element_size(),
-        };
+        reader_desc.emplace_runtime_args(
+            core,
+            {
+                input_buf,
+                target_buf,
+                weight_addr,
+                divisor_addr,
+                static_cast<uint32_t>(ignore_index),
+                units_per_core,
+                tile_offset,
+                origin_N,
+                origin_C,
+                Wt,
+                num_inner_tile,
+                weight_num_tile,
+                input.element_size(),
+            });
 
-        std::vector<uint32_t> writer_args = {
-            output_addr,
-            units_per_core,
-            tile_offset,
-        };
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(
+            core,
+            {
+                output_buf,
+                units_per_core,
+                tile_offset,
+            });
 
         // compute
-        const std::vector<uint32_t> compute_runtime_args{units_per_core};
+        const KernelDescriptor::CoreRuntimeArgs compute_runtime_args{units_per_core};
 
         if (core_group_1.contains(core)) {
-            SetRuntimeArgs(program, compute_kernel_ids[0], core, compute_runtime_args);
+            compute_desc_1.runtime_args.emplace_back(core, compute_runtime_args);
         } else if (core_group_2.contains(core)) {
-            SetRuntimeArgs(program, compute_kernel_ids[1], core, compute_runtime_args);
+            compute_desc_2.runtime_args.emplace_back(core, compute_runtime_args);
         } else {
             TT_FATAL(false, "Core not in specified core ranges.");
         }
@@ -568,15 +682,17 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
         tile_offset += units_per_core;
     }
 
-    return {
-        std::move(program),
-        {.unary_reader_kernel_id = reader_kernel_id,
-         .unary_writer_kernel_id = writer_kernel_id,
-         .num_cores = num_cores,
-         .num_cores_y = core_h}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
+    }
+
+    return desc;
 }
 
-MorehNllLossStep2DeviceOperation::Factory::cached_program_t MorehNllLossStep2DeviceOperation::Factory::create(
+tt::tt_metal::ProgramDescriptor MorehNllLossStep2DeviceOperation::Factory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
@@ -607,45 +723,6 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t MorehNllLossStep2Dev
 
     return moreh_nll_loss_step2_impl_4d(
         input, target, weight, divisor, output, reduction, ignore_index, compute_kernel_config);
-}
-
-void MorehNllLossStep2DeviceOperation::Factory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& num_cores = cached_program.shared_variables.num_cores;
-    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    const uint32_t input_addr = tensor_args.input_tensor.buffer()->address();
-    const uint32_t target_addr = tensor_args.target_tensor.buffer()->address();
-    const uint32_t weight_addr =
-        tensor_args.weight_tensor.has_value() ? tensor_args.weight_tensor.value().buffer()->address() : 0;
-    const uint32_t divisor_addr =
-        tensor_args.divisor_tensor.has_value() ? tensor_args.divisor_tensor.value().buffer()->address() : 0;
-    const uint32_t ignore_index = operation_attributes.ignore_index;
-
-    const uint32_t output_addr = tensor_return_value.buffer()->address();
-
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
-            runtime_args[0] = input_addr;
-            runtime_args[1] = target_addr;
-            runtime_args[2] = weight_addr;
-            runtime_args[3] = divisor_addr;
-            runtime_args[4] = ignore_index;
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
-            runtime_args[0] = output_addr;
-        }
-    }
 }
 
 }  // namespace ttnn::operations::moreh::moreh_nll_loss_step2

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_device_operation.hpp
@@ -11,6 +11,7 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_nll_loss_backward {
 
@@ -35,21 +36,7 @@ struct MorehNllLossBackwardDeviceOperation {
     using tensor_return_value_t = ttnn::Tensor;
 
     struct Factory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id;
-            tt::tt_metal::KernelHandle unary_writer_kernel_id;
-            std::size_t num_cores;
-            std::size_t num_cores_y;
-        };
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_program_factory.cpp
@@ -14,7 +14,36 @@
 
 namespace ttnn::operations::moreh::moreh_nll_loss_backward {
 
-MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_backward_impl_2d(
+using namespace tt;
+using namespace tt::tt_metal;
+
+namespace {
+
+// Helper: append a CB with a given tile-count (skips creation when num_tiles == 0).
+void push_cb(
+    ProgramDescriptor& desc,
+    const CoreRangeSet& core_ranges,
+    uint8_t buffer_index,
+    uint32_t num_tiles,
+    tt::DataFormat data_format) {
+    if (num_tiles == 0) {
+        return;
+    }
+    const auto tile_sz = tt::tile_size(data_format);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * tile_sz,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = buffer_index,
+            .data_format = data_format,
+            .page_size = tile_sz,
+        }}},
+    });
+}
+
+}  // namespace
+
+tt::tt_metal::ProgramDescriptor moreh_nll_loss_backward_impl_2d(
     const Tensor& target,
     const std::optional<Tensor>& weight,
     const std::optional<Tensor>& divisor,
@@ -27,7 +56,7 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
 
     // input_grad: (N, C)
     auto input_grad_shape = input_grad.padded_shape();
-    auto channel_size = input_grad_shape[1];
+    uint32_t channel_size = input_grad_shape[1];
 
     const bool weight_has_value = weight.has_value();
     const bool divisor_has_value = divisor.has_value();
@@ -44,7 +73,7 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(input_grad.dtype());
@@ -52,56 +81,57 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
     auto fp32_dest_acc_en_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
 
     uint32_t weight_num_tile = tt::div_up(channel_size, tt::constants::TILE_WIDTH);
-    CreateCircularBuffer(
-        program,
+
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_0), 1, data_format);            // output_grad
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_1), 1, tt::DataFormat::Int32);  // target
+    push_cb(
+        desc,
         all_cores,
-        data_format,
-        {
-            {tt::CBIndex::c_0, 1},                                                              // output_grad
-            {tt::CBIndex::c_1, 1, tt::DataFormat::Int32},                                       // target
-            {tt::CBIndex::c_2, static_cast<uint32_t>(weight_has_value ? weight_num_tile : 0)},  // weight
-            {tt::CBIndex::c_3, static_cast<uint32_t>(divisor_has_value ? 1 : 0)},               // divisor
-            {tt::CBIndex::c_24, 1, fp32_dest_acc_en_data_format},                               // tmp_weight
-            {tt::CBIndex::c_25, 1, fp32_dest_acc_en_data_format},                               // tmp1
-            {tt::CBIndex::c_26, 1, fp32_dest_acc_en_data_format},                               // tmp2
-            {tt::CBIndex::c_16, 1},                                                             // input_grad
-        });
+        static_cast<uint8_t>(tt::CBIndex::c_2),
+        weight_has_value ? weight_num_tile : 0u,
+        data_format);  // weight
+    push_cb(
+        desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_3), divisor_has_value ? 1u : 0u, data_format);  // divisor
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_24), 1, fp32_dest_acc_en_data_format);  // tmp_weight
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_25), 1, fp32_dest_acc_en_data_format);  // tmp1
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_26), 1, fp32_dest_acc_en_data_format);  // tmp2
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_16), 1, data_format);                   // input_grad
 
     if (weight_has_value) {
         // This CB will be used as scratch storage when reading data from DRAM into L1,
         // since the two have different alignment requirements on some architectures.
         // Need space for only a single tile in scratch CB, because content is read immediately after writing.
-        CreateCircularBuffer(program, all_cores, data_format, {tt::CBIndex::c_7, 1});
+        push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_7), 1, data_format);
     }
     // Need another scratch CB for output_grad reading data from DRAM into L1.
-    CreateCircularBuffer(program, all_cores, data_format, {tt::CBIndex::c_8, 1});
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_8), 1, data_format);
 
     // create read/write kernel
-    std::vector<uint32_t> reader_compile_time_args{};
-    TensorAccessorArgs(target.buffer()).append_to(reader_compile_time_args);
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args{};
+    TensorAccessorArgs(*target.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(weight.has_value() ? weight.value().buffer() : nullptr).append_to(reader_compile_time_args);
     TensorAccessorArgs(divisor.has_value() ? divisor.value().buffer() : nullptr).append_to(reader_compile_time_args);
-    TensorAccessorArgs(output_grad.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*output_grad.buffer()).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args{};
-    TensorAccessorArgs(input_grad.buffer()).append_to(writer_compile_time_args);
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args{};
+    TensorAccessorArgs(*input_grad.buffer()).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
-    std::map<std::string, std::string> compute_defines{};
+    KernelDescriptor::Defines reader_defines;
+    KernelDescriptor::Defines writer_defines;
+    KernelDescriptor::Defines compute_defines;
 
     if (weight_has_value) {
-        reader_defines["WEIGHT"] = "1";
-        compute_defines["WEIGHT"] = "1";
+        reader_defines.emplace_back("WEIGHT", "1");
+        compute_defines.emplace_back("WEIGHT", "1");
     }
     if (divisor_has_value) {
-        reader_defines["DIVISOR"] = "1";
-        compute_defines["DIVISOR"] = "1";
+        reader_defines.emplace_back("DIVISOR", "1");
+        compute_defines.emplace_back("DIVISOR", "1");
     }
 
     if (fp32_dest_acc_en) {
-        reader_defines["FP32_DEST_ACC_EN"] = "1";
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        reader_defines.emplace_back("FP32_DEST_ACC_EN", "1");
+        compute_defines.emplace_back("FP32_DEST_ACC_EN", "1");
     }
 
     const auto* const reader_kernel_file =
@@ -114,31 +144,63 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
         "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/"
         "moreh_nll_loss_backward_kernel.cpp";
 
-    auto reader_kernel_id =
-        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines);
-    auto writer_kernel_id =
-        CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args, writer_defines);
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_file;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    const auto compute_kernel_ids = CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {
-            {core_group_1, units_per_core_group_1, {units_per_core_group_1, divisor_has_value}},
-            {core_group_2, units_per_core_group_2, {units_per_core_group_2, divisor_has_value}},
-        },
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_file;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    const auto target_addr = target.buffer()->address();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0;
-    const auto divisor_addr = divisor_has_value ? divisor.value().buffer()->address() : 0;
-    const auto output_grad_addr = output_grad.buffer()->address();
-    const auto input_grad_addr = input_grad.buffer()->address();
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {units_per_core_group_1, static_cast<uint32_t>(divisor_has_value)};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {units_per_core_group_2, static_cast<uint32_t>(divisor_has_value)};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
+    }
+
+    auto* const target_buf = target.buffer();
+    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
+    const auto divisor_addr = divisor_has_value ? divisor.value().buffer()->address() : 0u;
+    auto* const output_grad_buf = output_grad.buffer();
+    auto* const input_grad_buf = input_grad.buffer();
 
     // Set Runtime Args
-    auto element_size = weight_has_value ? weight.value().element_size() : 0;
+    uint32_t element_size = weight_has_value ? weight.value().element_size() : 0;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
@@ -151,31 +213,30 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
             TT_THROW("Core not in specified core ranges");
         }
 
-        std::vector<uint32_t> reader_args = {
-            target_addr,
-            output_grad_addr,
-            weight_addr,
-            divisor_addr,
-            ignore_index,
-            units_per_core,
-            tile_offset,
-            channel_size,
-            weight_num_tile,
-            element_size,
-        };
+        reader_desc.emplace_runtime_args(
+            core,
+            {
+                target_buf,
+                output_grad_buf,
+                weight_addr,
+                divisor_addr,
+                ignore_index,
+                units_per_core,
+                tile_offset,
+                channel_size,
+                weight_num_tile,
+                element_size,
+            });
 
-        std::vector<uint32_t> writer_args = {input_grad_addr, units_per_core, tile_offset};
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(core, {input_grad_buf, units_per_core, tile_offset});
 
         // compute
-        const std::vector<uint32_t> compute_runtime_args{units_per_core, tile_offset};
+        const KernelDescriptor::CoreRuntimeArgs compute_runtime_args{units_per_core, tile_offset};
 
         if (core_group_1.contains(core)) {
-            SetRuntimeArgs(program, compute_kernel_ids[0], core, compute_runtime_args);
+            compute_desc_1.runtime_args.emplace_back(core, compute_runtime_args);
         } else if (core_group_2.contains(core)) {
-            SetRuntimeArgs(program, compute_kernel_ids[1], core, compute_runtime_args);
+            compute_desc_2.runtime_args.emplace_back(core, compute_runtime_args);
         } else {
             TT_FATAL(false, "Core not in specified core ranges.");
         }
@@ -183,15 +244,17 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
         tile_offset += units_per_core;
     }
 
-    return {
-        std::move(program),
-        {.unary_reader_kernel_id = reader_kernel_id,
-         .unary_writer_kernel_id = writer_kernel_id,
-         .num_cores = num_cores,
-         .num_cores_y = core_h}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
+    }
+
+    return desc;
 }
 
-MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_backward_impl_3d(
+tt::tt_metal::ProgramDescriptor moreh_nll_loss_backward_impl_3d(
     const Tensor& target,
     const std::optional<Tensor>& weight,
     const std::optional<Tensor>& divisor,
@@ -204,10 +267,10 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
 
     // input_grad: (N, C, W)
     auto input_grad_shape = input_grad.padded_shape();
-    auto channel_size = input_grad_shape[1];
+    uint32_t channel_size = input_grad_shape[1];
 
     auto target_shape = target.padded_shape();
-    auto num_inner_tile = target_shape[-1] / tt::constants::TILE_WIDTH;
+    uint32_t num_inner_tile = target_shape[-1] / tt::constants::TILE_WIDTH;
 
     const bool weight_has_value = weight.has_value();
     const bool divisor_has_value = divisor.has_value();
@@ -224,7 +287,7 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(input_grad.dtype());
@@ -232,54 +295,55 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
     auto fp32_dest_acc_en_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
 
     uint32_t weight_num_tile = tt::div_up(channel_size, tt::constants::TILE_WIDTH);
-    CreateCircularBuffer(
-        program,
+
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_0), 1, data_format);            // output_grad
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_1), 1, tt::DataFormat::Int32);  // target
+    push_cb(
+        desc,
         all_cores,
-        data_format,
-        {
-            {tt::CBIndex::c_0, 1},                                                              // output_grad
-            {tt::CBIndex::c_1, 1, tt::DataFormat::Int32},                                       // target
-            {tt::CBIndex::c_2, static_cast<uint32_t>(weight_has_value ? weight_num_tile : 0)},  // weight
-            {tt::CBIndex::c_3, static_cast<uint32_t>(divisor_has_value ? 1 : 0)},               // divisor
-            {tt::CBIndex::c_24, 1, fp32_dest_acc_en_data_format},                               // tmp_weight
-            {tt::CBIndex::c_25, 1, fp32_dest_acc_en_data_format},                               // tmp1
-            {tt::CBIndex::c_26, 1, fp32_dest_acc_en_data_format},                               // tmp2
-            {tt::CBIndex::c_16, 1},                                                             // input_grad
-        });
+        static_cast<uint8_t>(tt::CBIndex::c_2),
+        weight_has_value ? weight_num_tile : 0u,
+        data_format);  // weight
+    push_cb(
+        desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_3), divisor_has_value ? 1u : 0u, data_format);  // divisor
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_24), 1, fp32_dest_acc_en_data_format);  // tmp_weight
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_25), 1, fp32_dest_acc_en_data_format);  // tmp1
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_26), 1, fp32_dest_acc_en_data_format);  // tmp2
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_16), 1, data_format);                   // input_grad
 
     if (weight_has_value) {
         // This CB will be used as scratch storage when reading data from DRAM into L1,
         // since the two have different alignment requirements on some architectures.
         // Need space for only a single tile in scratch CB, because content is read immediately after writing.
-        CreateCircularBuffer(program, all_cores, data_format, {tt::CBIndex::c_7, 1});
+        push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_7), 1, data_format);
     }
 
     // create read/write kernel
-    std::vector<uint32_t> reader_compile_time_args{};
-    TensorAccessorArgs(target.buffer()).append_to(reader_compile_time_args);
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args{};
+    TensorAccessorArgs(*target.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(weight.has_value() ? weight.value().buffer() : nullptr).append_to(reader_compile_time_args);
     TensorAccessorArgs(divisor.has_value() ? divisor.value().buffer() : nullptr).append_to(reader_compile_time_args);
-    TensorAccessorArgs(output_grad.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*output_grad.buffer()).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args{};
-    TensorAccessorArgs(input_grad.buffer()).append_to(writer_compile_time_args);
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args{};
+    TensorAccessorArgs(*input_grad.buffer()).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
-    std::map<std::string, std::string> compute_defines{};
+    KernelDescriptor::Defines reader_defines;
+    KernelDescriptor::Defines writer_defines;
+    KernelDescriptor::Defines compute_defines;
 
     if (weight_has_value) {
-        reader_defines["WEIGHT"] = "1";
-        compute_defines["WEIGHT"] = "1";
+        reader_defines.emplace_back("WEIGHT", "1");
+        compute_defines.emplace_back("WEIGHT", "1");
     }
     if (divisor_has_value) {
-        reader_defines["DIVISOR"] = "1";
-        compute_defines["DIVISOR"] = "1";
+        reader_defines.emplace_back("DIVISOR", "1");
+        compute_defines.emplace_back("DIVISOR", "1");
     }
 
     if (fp32_dest_acc_en) {
-        reader_defines["FP32_DEST_ACC_EN"] = "1";
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        reader_defines.emplace_back("FP32_DEST_ACC_EN", "1");
+        compute_defines.emplace_back("FP32_DEST_ACC_EN", "1");
     }
 
     const auto* const reader_kernel_file =
@@ -292,31 +356,63 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
         "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/"
         "moreh_nll_loss_backward_kernel.cpp";
 
-    auto reader_kernel_id =
-        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines);
-    auto writer_kernel_id =
-        CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args, writer_defines);
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_file;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    const auto compute_kernel_ids = CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {
-            {core_group_1, units_per_core_group_1, {units_per_core_group_1, divisor_has_value}},
-            {core_group_2, units_per_core_group_2, {units_per_core_group_2, divisor_has_value}},
-        },
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_file;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    const auto target_addr = target.buffer()->address();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0;
-    const auto divisor_addr = divisor_has_value ? divisor.value().buffer()->address() : 0;
-    const auto output_grad_addr = output_grad.buffer()->address();
-    const auto input_grad_addr = input_grad.buffer()->address();
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {units_per_core_group_1, static_cast<uint32_t>(divisor_has_value)};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {units_per_core_group_2, static_cast<uint32_t>(divisor_has_value)};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
+    }
+
+    auto* const target_buf = target.buffer();
+    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
+    const auto divisor_addr = divisor_has_value ? divisor.value().buffer()->address() : 0u;
+    auto* const output_grad_buf = output_grad.buffer();
+    auto* const input_grad_buf = input_grad.buffer();
 
     // Set Runtime Args
-    auto element_size = weight_has_value ? weight.value().element_size() : 0;
+    uint32_t element_size = weight_has_value ? weight.value().element_size() : 0;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
@@ -329,32 +425,31 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
             TT_THROW("Core not in specified core ranges");
         }
 
-        std::vector<uint32_t> reader_args = {
-            target_addr,
-            output_grad_addr,
-            weight_addr,
-            divisor_addr,
-            ignore_index,
-            units_per_core,
-            tile_offset,
-            channel_size,
-            num_inner_tile,
-            weight_num_tile,
-            element_size,
-        };
+        reader_desc.emplace_runtime_args(
+            core,
+            {
+                target_buf,
+                output_grad_buf,
+                weight_addr,
+                divisor_addr,
+                ignore_index,
+                units_per_core,
+                tile_offset,
+                channel_size,
+                num_inner_tile,
+                weight_num_tile,
+                element_size,
+            });
 
-        std::vector<uint32_t> writer_args = {input_grad_addr, units_per_core, tile_offset};
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(core, {input_grad_buf, units_per_core, tile_offset});
 
         // compute
-        const std::vector<uint32_t> compute_runtime_args{units_per_core, tile_offset};
+        const KernelDescriptor::CoreRuntimeArgs compute_runtime_args{units_per_core, tile_offset};
 
         if (core_group_1.contains(core)) {
-            SetRuntimeArgs(program, compute_kernel_ids[0], core, compute_runtime_args);
+            compute_desc_1.runtime_args.emplace_back(core, compute_runtime_args);
         } else if (core_group_2.contains(core)) {
-            SetRuntimeArgs(program, compute_kernel_ids[1], core, compute_runtime_args);
+            compute_desc_2.runtime_args.emplace_back(core, compute_runtime_args);
         } else {
             TT_ASSERT(false, "Core not in specified core ranges.");
         }
@@ -362,15 +457,17 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
         tile_offset += units_per_core;
     }
 
-    return {
-        std::move(program),
-        {.unary_reader_kernel_id = reader_kernel_id,
-         .unary_writer_kernel_id = writer_kernel_id,
-         .num_cores = num_cores,
-         .num_cores_y = core_h}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
+    }
+
+    return desc;
 }
 
-MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_backward_impl_4d(
+tt::tt_metal::ProgramDescriptor moreh_nll_loss_backward_impl_4d(
     const Tensor& target,
     const std::optional<Tensor>& weight,
     const std::optional<Tensor>& divisor,
@@ -382,13 +479,13 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
     // split work
     auto input_grad_shape = input_grad.padded_shape();
     auto N = input_grad_shape[0];
-    auto channel_size = input_grad_shape[1];
+    uint32_t channel_size = input_grad_shape[1];
 
     auto H = input_grad_shape[-2];
     auto W = input_grad_shape[-1];
     auto Ht = H / tt::constants::TILE_HEIGHT;
     auto Wt = W / tt::constants::TILE_WIDTH;
-    auto num_inner_tile = target.physical_volume() / N / tt::constants::TILE_HEIGHT / tt::constants::TILE_WIDTH;
+    uint32_t num_inner_tile = target.physical_volume() / N / tt::constants::TILE_HEIGHT / tt::constants::TILE_WIDTH;
 
     const bool weight_has_value = weight.has_value();
     const bool divisor_has_value = divisor.has_value();
@@ -405,7 +502,7 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(input_grad.dtype());
@@ -413,54 +510,55 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
     auto fp32_dest_acc_en_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
 
     uint32_t weight_num_tile = tt::div_up(channel_size, tt::constants::TILE_WIDTH);
-    CreateCircularBuffer(
-        program,
+
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_0), 1, data_format);            // output_grad
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_1), 1, tt::DataFormat::Int32);  // target
+    push_cb(
+        desc,
         all_cores,
-        data_format,
-        {
-            {tt::CBIndex::c_0, 1},                                                              // output_grad
-            {tt::CBIndex::c_1, 1, tt::DataFormat::Int32},                                       // target
-            {tt::CBIndex::c_2, static_cast<uint32_t>(weight_has_value ? weight_num_tile : 0)},  // weight
-            {tt::CBIndex::c_3, static_cast<uint32_t>(divisor_has_value ? 1 : 0)},               // divisor
-            {tt::CBIndex::c_24, 1, fp32_dest_acc_en_data_format},                               // tmp_weight
-            {tt::CBIndex::c_25, 1, fp32_dest_acc_en_data_format},                               // tmp1
-            {tt::CBIndex::c_26, 1, fp32_dest_acc_en_data_format},                               // tmp2
-            {tt::CBIndex::c_16, 1},                                                             // input_grad
-        });
+        static_cast<uint8_t>(tt::CBIndex::c_2),
+        weight_has_value ? weight_num_tile : 0u,
+        data_format);  // weight
+    push_cb(
+        desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_3), divisor_has_value ? 1u : 0u, data_format);  // divisor
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_24), 1, fp32_dest_acc_en_data_format);  // tmp_weight
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_25), 1, fp32_dest_acc_en_data_format);  // tmp1
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_26), 1, fp32_dest_acc_en_data_format);  // tmp2
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_16), 1, data_format);                   // input_grad
 
     if (weight_has_value) {
         // This CB will be used as scratch storage when reading data from DRAM into L1,
         // since the two have different alignment requirements on some architectures.
         // Need space for only a single tile in scratch CB, because content is read immediately after writing.
-        CreateCircularBuffer(program, all_cores, data_format, {tt::CBIndex::c_7, 1});
+        push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_7), 1, data_format);
     }
 
     // create read/write kernel
-    std::vector<uint32_t> reader_compile_time_args{};
-    TensorAccessorArgs(target.buffer()).append_to(reader_compile_time_args);
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args{};
+    TensorAccessorArgs(*target.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(weight.has_value() ? weight.value().buffer() : nullptr).append_to(reader_compile_time_args);
     TensorAccessorArgs(divisor.has_value() ? divisor.value().buffer() : nullptr).append_to(reader_compile_time_args);
-    TensorAccessorArgs(output_grad.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*output_grad.buffer()).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args{};
-    TensorAccessorArgs(input_grad.buffer()).append_to(writer_compile_time_args);
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args{};
+    TensorAccessorArgs(*input_grad.buffer()).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
-    std::map<std::string, std::string> compute_defines{};
+    KernelDescriptor::Defines reader_defines;
+    KernelDescriptor::Defines writer_defines;
+    KernelDescriptor::Defines compute_defines;
 
     if (weight_has_value) {
-        reader_defines["WEIGHT"] = "1";
-        compute_defines["WEIGHT"] = "1";
+        reader_defines.emplace_back("WEIGHT", "1");
+        compute_defines.emplace_back("WEIGHT", "1");
     }
     if (divisor_has_value) {
-        reader_defines["DIVISOR"] = "1";
-        compute_defines["DIVISOR"] = "1";
+        reader_defines.emplace_back("DIVISOR", "1");
+        compute_defines.emplace_back("DIVISOR", "1");
     }
 
     if (fp32_dest_acc_en) {
-        reader_defines["FP32_DEST_ACC_EN"] = "1";
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        reader_defines.emplace_back("FP32_DEST_ACC_EN", "1");
+        compute_defines.emplace_back("FP32_DEST_ACC_EN", "1");
     }
 
     const auto* const reader_kernel_file =
@@ -473,31 +571,63 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
         "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/kernels/"
         "moreh_nll_loss_backward_kernel.cpp";
 
-    auto reader_kernel_id =
-        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines);
-    auto writer_kernel_id =
-        CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args, writer_defines);
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_file;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    const auto compute_kernel_ids = CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {
-            {core_group_1, units_per_core_group_1, {units_per_core_group_1, divisor_has_value}},
-            {core_group_2, units_per_core_group_2, {units_per_core_group_2, divisor_has_value}},
-        },
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_file;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    const auto target_addr = target.buffer()->address();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0;
-    const auto divisor_addr = divisor_has_value ? divisor.value().buffer()->address() : 0;
-    const auto output_grad_addr = output_grad.buffer()->address();
-    const auto input_grad_addr = input_grad.buffer()->address();
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {units_per_core_group_1, static_cast<uint32_t>(divisor_has_value)};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {units_per_core_group_2, static_cast<uint32_t>(divisor_has_value)};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
+    }
+
+    auto* const target_buf = target.buffer();
+    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
+    const auto divisor_addr = divisor_has_value ? divisor.value().buffer()->address() : 0u;
+    auto* const output_grad_buf = output_grad.buffer();
+    auto* const input_grad_buf = input_grad.buffer();
 
     // Set Runtime Args
-    auto element_size = weight_has_value ? weight.value().element_size() : 0;
+    uint32_t element_size = weight_has_value ? weight.value().element_size() : 0;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
@@ -510,32 +640,31 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
             TT_THROW("Core not in specified core ranges");
         }
 
-        std::vector<uint32_t> reader_args = {
-            target_addr,
-            output_grad_addr,
-            weight_addr,
-            divisor_addr,
-            ignore_index,
-            units_per_core,
-            tile_offset,
-            channel_size,
-            num_inner_tile,
-            weight_num_tile,
-            element_size,
-        };
+        reader_desc.emplace_runtime_args(
+            core,
+            {
+                target_buf,
+                output_grad_buf,
+                weight_addr,
+                divisor_addr,
+                ignore_index,
+                units_per_core,
+                tile_offset,
+                channel_size,
+                num_inner_tile,
+                weight_num_tile,
+                element_size,
+            });
 
-        std::vector<uint32_t> writer_args = {input_grad_addr, units_per_core, tile_offset};
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(core, {input_grad_buf, units_per_core, tile_offset});
 
         // compute
-        const std::vector<uint32_t> compute_runtime_args{units_per_core, tile_offset};
+        const KernelDescriptor::CoreRuntimeArgs compute_runtime_args{units_per_core, tile_offset};
 
         if (core_group_1.contains(core)) {
-            SetRuntimeArgs(program, compute_kernel_ids[0], core, compute_runtime_args);
+            compute_desc_1.runtime_args.emplace_back(core, compute_runtime_args);
         } else if (core_group_2.contains(core)) {
-            SetRuntimeArgs(program, compute_kernel_ids[1], core, compute_runtime_args);
+            compute_desc_2.runtime_args.emplace_back(core, compute_runtime_args);
         } else {
             TT_ASSERT(false, "Core not in specified core ranges.");
         }
@@ -543,15 +672,17 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
         tile_offset += units_per_core;
     }
 
-    return {
-        std::move(program),
-        {.unary_reader_kernel_id = reader_kernel_id,
-         .unary_writer_kernel_id = writer_kernel_id,
-         .num_cores = num_cores,
-         .num_cores_y = core_h}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
+    }
+
+    return desc;
 }
 
-MorehNllLossBackwardDeviceOperation::Factory::cached_program_t MorehNllLossBackwardDeviceOperation::Factory::create(
+tt::tt_metal::ProgramDescriptor MorehNllLossBackwardDeviceOperation::Factory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
@@ -585,45 +716,6 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t MorehNllLossBackw
 
     return moreh_nll_loss_backward_impl_4d(
         target, weight, divisor, output_grad, input_grad, reduction_mean, ignore_index, compute_kernel_config);
-}
-
-void MorehNllLossBackwardDeviceOperation::Factory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& num_cores = cached_program.shared_variables.num_cores;
-    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    const uint32_t target_addr = tensor_args.target_tensor.buffer()->address();
-    const uint32_t output_grad_addr = tensor_args.output_grad_tensor.buffer()->address();
-    const uint32_t weight_addr =
-        tensor_args.weight_tensor.has_value() ? tensor_args.weight_tensor.value().buffer()->address() : 0;
-    const uint32_t divisor_addr =
-        tensor_args.divisor_tensor.has_value() ? tensor_args.divisor_tensor.value().buffer()->address() : 0;
-    const uint32_t ignore_index = operation_attributes.ignore_index;
-
-    const uint32_t input_grad_addr = tensor_return_value.buffer()->address();
-
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
-            runtime_args[0] = target_addr;
-            runtime_args[1] = output_grad_addr;
-            runtime_args[2] = weight_addr;
-            runtime_args[3] = divisor_addr;
-            runtime_args[4] = ignore_index;
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
-            runtime_args[0] = input_grad_addr;
-        }
-    }
 }
 
 }  // namespace ttnn::operations::moreh::moreh_nll_loss_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_device_operation.hpp
@@ -11,6 +11,7 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_nll_loss_unreduced_backward {
 
@@ -32,21 +33,7 @@ struct MorehNllLossUnreducedBackwardDeviceOperation {
     using tensor_return_value_t = ttnn::Tensor;
 
     struct Factory {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id;
-            tt::tt_metal::KernelHandle unary_writer_kernel_id;
-            std::size_t num_cores;
-            std::size_t num_cores_y;
-        };
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_program_factory.cpp
@@ -14,7 +14,36 @@
 
 namespace ttnn::operations::moreh::moreh_nll_loss_unreduced_backward {
 
-MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_unreduced_backward_impl_2d(
+using namespace tt;
+using namespace tt::tt_metal;
+
+namespace {
+
+// Helper: append a CB with a given tile-count (skips creation when num_tiles == 0).
+void push_cb(
+    ProgramDescriptor& desc,
+    const CoreRangeSet& core_ranges,
+    uint8_t buffer_index,
+    uint32_t num_tiles,
+    tt::DataFormat data_format) {
+    if (num_tiles == 0) {
+        return;
+    }
+    const auto tile_sz = tt::tile_size(data_format);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * tile_sz,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = buffer_index,
+            .data_format = data_format,
+            .page_size = tile_sz,
+        }}},
+    });
+}
+
+}  // namespace
+
+tt::tt_metal::ProgramDescriptor moreh_nll_loss_unreduced_backward_impl_2d(
     const Tensor& target,
     const std::optional<Tensor>& weight,
     const Tensor& output_grad,
@@ -26,7 +55,7 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
     // input_grad: (N, C)
     auto input_grad_shape = input_grad.padded_shape();
     auto N = input_grad_shape[0];
-    auto channel_size = input_grad_shape[1];
+    uint32_t channel_size = input_grad_shape[1];
 
     const bool weight_has_value = weight.has_value();
 
@@ -42,42 +71,38 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(input_grad.dtype());
 
     auto Ct = tt::div_up(channel_size, tt::constants::TILE_WIDTH);
     auto Nt = tt::div_up(N, tt::constants::TILE_WIDTH);
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        data_format,
-        {
-            {tt::CBIndex::c_0, 1, tt::DataFormat::Int32},                          // target
-            {tt::CBIndex::c_1, Nt},                                                // output_grad
-            {tt::CBIndex::c_2, static_cast<uint32_t>(weight_has_value ? Ct : 0)},  // weight
-            {tt::CBIndex::c_16, 1},                                                // input_grad
-        });
+
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_0), 1, tt::DataFormat::Int32);  // target
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_1), Nt, data_format);           // output_grad
+    push_cb(
+        desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_2), weight_has_value ? Ct : 0u, data_format);  // weight
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_16), 1, data_format);  // input_grad
 
     // create read/write kernel
-    std::vector<uint32_t> reader_compile_time_args{};
-    TensorAccessorArgs(target.buffer()).append_to(reader_compile_time_args);
-    TensorAccessorArgs(output_grad.buffer()).append_to(reader_compile_time_args);
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args{};
+    TensorAccessorArgs(*target.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*output_grad.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(weight.has_value() ? weight.value().buffer() : nullptr).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args{};
-    TensorAccessorArgs(input_grad.buffer()).append_to(writer_compile_time_args);
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args{};
+    TensorAccessorArgs(*input_grad.buffer()).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
+    KernelDescriptor::Defines reader_defines;
+    KernelDescriptor::Defines writer_defines;
 
     if (weight_has_value) {
-        reader_defines["WEIGHT"] = "1";
+        reader_defines.emplace_back("WEIGHT", "1");
     }
 
     if (fp32_dest_acc_en) {
-        reader_defines["FP32_DEST_ACC_EN"] = "1";
+        reader_defines.emplace_back("FP32_DEST_ACC_EN", "1");
     }
 
     const auto* const reader_kernel_file =
@@ -87,15 +112,26 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
         "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/"
         "writer_moreh_nll_loss_unreduced_backward.cpp";
 
-    auto reader_kernel_id =
-        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines);
-    auto writer_kernel_id =
-        CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args, writer_defines);
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_file;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    const auto target_addr = target.buffer()->address();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0;
-    const auto output_grad_addr = output_grad.buffer()->address();
-    const auto input_grad_addr = input_grad.buffer()->address();
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_file;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    auto* const target_buf = target.buffer();
+    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
+    auto* const output_grad_buf = output_grad.buffer();
+    auto* const input_grad_buf = input_grad.buffer();
 
     // Set Runtime Args
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
@@ -109,35 +145,32 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
             TT_THROW("Core not in specified core ranges");
         }
 
-        std::vector<uint32_t> reader_args = {
-            target_addr,
-            output_grad_addr,
-            weight_addr,
-            ignore_index,
-            units_per_core,
-            tile_offset,
-            Nt,
-            channel_size,
-            Ct,
-        };
+        reader_desc.emplace_runtime_args(
+            core,
+            {
+                target_buf,
+                output_grad_buf,
+                weight_addr,
+                ignore_index,
+                units_per_core,
+                tile_offset,
+                Nt,
+                channel_size,
+                Ct,
+            });
 
-        std::vector<uint32_t> writer_args = {input_grad_addr, units_per_core, tile_offset};
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(core, {input_grad_buf, units_per_core, tile_offset});
 
         tile_offset += units_per_core;
     }
 
-    return {
-        std::move(program),
-        {.unary_reader_kernel_id = reader_kernel_id,
-         .unary_writer_kernel_id = writer_kernel_id,
-         .num_cores = num_cores,
-         .num_cores_y = core_h}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
 }
 
-MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_unreduced_backward_impl_3d(
+tt::tt_metal::ProgramDescriptor moreh_nll_loss_unreduced_backward_impl_3d(
     const Tensor& target,
     const std::optional<Tensor>& weight,
     const Tensor& output_grad,
@@ -148,7 +181,7 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
 
     // input_grad: (N, C, W)
     auto input_grad_shape = input_grad.padded_shape();
-    auto channel_size = input_grad_shape[1];
+    uint32_t channel_size = input_grad_shape[1];
 
     auto W = input_grad_shape[-1];
     auto Ct = channel_size / tt::constants::TILE_HEIGHT;
@@ -168,40 +201,35 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(input_grad.dtype());
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        data_format,
-        {
-            {tt::CBIndex::c_0, 1, tt::DataFormat::Int32},                          // target
-            {tt::CBIndex::c_1, 1},                                                 // output_grad
-            {tt::CBIndex::c_2, static_cast<uint32_t>(weight_has_value ? Ct : 0)},  // weight
-            {tt::CBIndex::c_16, 1},                                                // input_grad
-        });
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_0), 1, tt::DataFormat::Int32);  // target
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_1), 1, data_format);            // output_grad
+    push_cb(
+        desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_2), weight_has_value ? Ct : 0u, data_format);  // weight
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_16), 1, data_format);  // input_grad
 
     // create read/write kernel
-    std::vector<uint32_t> reader_compile_time_args{};
-    TensorAccessorArgs(target.buffer()).append_to(reader_compile_time_args);
-    TensorAccessorArgs(output_grad.buffer()).append_to(reader_compile_time_args);
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args{};
+    TensorAccessorArgs(*target.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*output_grad.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(weight.has_value() ? weight.value().buffer() : nullptr).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args{};
-    TensorAccessorArgs(input_grad.buffer()).append_to(writer_compile_time_args);
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args{};
+    TensorAccessorArgs(*input_grad.buffer()).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
+    KernelDescriptor::Defines reader_defines;
+    KernelDescriptor::Defines writer_defines;
 
     if (weight_has_value) {
-        reader_defines["WEIGHT"] = "1";
+        reader_defines.emplace_back("WEIGHT", "1");
     }
 
     if (fp32_dest_acc_en) {
-        reader_defines["FP32_DEST_ACC_EN"] = "1";
+        reader_defines.emplace_back("FP32_DEST_ACC_EN", "1");
     }
 
     const auto* const reader_kernel_file =
@@ -211,15 +239,26 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
         "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/"
         "writer_moreh_nll_loss_unreduced_backward.cpp";
 
-    auto reader_kernel_id =
-        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines);
-    auto writer_kernel_id =
-        CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args, writer_defines);
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_file;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    const auto target_addr = target.buffer()->address();
-    const auto output_grad_addr = output_grad.buffer()->address();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0;
-    const auto input_grad_addr = input_grad.buffer()->address();
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_file;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    auto* const target_buf = target.buffer();
+    auto* const output_grad_buf = output_grad.buffer();
+    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
+    auto* const input_grad_buf = input_grad.buffer();
 
     // Set Runtime Args
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
@@ -233,35 +272,32 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
             TT_THROW("Core not in specified core ranges");
         }
 
-        std::vector<uint32_t> reader_args = {
-            target_addr,
-            output_grad_addr,
-            weight_addr,
-            ignore_index,
-            units_per_core,
-            tile_offset,
-            channel_size,
-            Ct,
-            Wt,
-        };
+        reader_desc.emplace_runtime_args(
+            core,
+            {
+                target_buf,
+                output_grad_buf,
+                weight_addr,
+                ignore_index,
+                units_per_core,
+                tile_offset,
+                channel_size,
+                Ct,
+                Wt,
+            });
 
-        std::vector<uint32_t> writer_args = {input_grad_addr, units_per_core, tile_offset};
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(core, {input_grad_buf, units_per_core, tile_offset});
 
         tile_offset += units_per_core;
     }
 
-    return {
-        std::move(program),
-        {.unary_reader_kernel_id = reader_kernel_id,
-         .unary_writer_kernel_id = writer_kernel_id,
-         .num_cores = num_cores,
-         .num_cores_y = core_h}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
 }
 
-MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_unreduced_backward_impl_4d(
+tt::tt_metal::ProgramDescriptor moreh_nll_loss_unreduced_backward_impl_4d(
     const Tensor& target,
     const std::optional<Tensor>& weight,
     const Tensor& output_grad,
@@ -271,7 +307,7 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
     // split work
     auto input_grad_shape = input_grad.padded_shape();
     auto N = input_grad_shape[0];
-    auto channel_size = input_grad_shape[1];
+    uint32_t channel_size = input_grad_shape[1];
 
     auto Ct = tt::div_up(channel_size, tt::constants::TILE_WIDTH);
 
@@ -279,7 +315,7 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
     auto W = input_grad_shape[-1];
     auto Ht = H / tt::constants::TILE_HEIGHT;
     auto Wt = W / tt::constants::TILE_WIDTH;
-    auto num_inner_tile = target.physical_volume() / N / tt::constants::TILE_HEIGHT / tt::constants::TILE_WIDTH;
+    uint32_t num_inner_tile = target.physical_volume() / N / tt::constants::TILE_HEIGHT / tt::constants::TILE_WIDTH;
 
     const bool weight_has_value = weight.has_value();
 
@@ -295,40 +331,35 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(input_grad.dtype());
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        data_format,
-        {
-            {tt::CBIndex::c_0, 1, tt::DataFormat::Int32},                          // target
-            {tt::CBIndex::c_1, 1},                                                 // output_grad
-            {tt::CBIndex::c_2, static_cast<uint32_t>(weight_has_value ? Ct : 0)},  // weight
-            {tt::CBIndex::c_16, 1},                                                // input_grad
-        });
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_0), 1, tt::DataFormat::Int32);  // target
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_1), 1, data_format);            // output_grad
+    push_cb(
+        desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_2), weight_has_value ? Ct : 0u, data_format);  // weight
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_16), 1, data_format);  // input_grad
 
     // create read/write kernel
-    std::vector<uint32_t> reader_compile_time_args{};
-    TensorAccessorArgs(target.buffer()).append_to(reader_compile_time_args);
-    TensorAccessorArgs(output_grad.buffer()).append_to(reader_compile_time_args);
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args{};
+    TensorAccessorArgs(*target.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*output_grad.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(weight.has_value() ? weight.value().buffer() : nullptr).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args{};
-    TensorAccessorArgs(input_grad.buffer()).append_to(writer_compile_time_args);
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args{};
+    TensorAccessorArgs(*input_grad.buffer()).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
+    KernelDescriptor::Defines reader_defines;
+    KernelDescriptor::Defines writer_defines;
 
     if (weight_has_value) {
-        reader_defines["WEIGHT"] = "1";
+        reader_defines.emplace_back("WEIGHT", "1");
     }
 
     if (fp32_dest_acc_en) {
-        reader_defines["FP32_DEST_ACC_EN"] = "1";
+        reader_defines.emplace_back("FP32_DEST_ACC_EN", "1");
     }
 
     const auto* const reader_kernel_file =
@@ -338,15 +369,26 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
         "ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/"
         "writer_moreh_nll_loss_unreduced_backward.cpp";
 
-    auto reader_kernel_id =
-        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines);
-    auto writer_kernel_id =
-        CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args, writer_defines);
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_file;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    const auto target_addr = target.buffer()->address();
-    const auto output_grad_addr = output_grad.buffer()->address();
-    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0;
-    const auto input_grad_addr = input_grad.buffer()->address();
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_file;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    auto* const target_buf = target.buffer();
+    auto* const output_grad_buf = output_grad.buffer();
+    const auto weight_addr = weight_has_value ? weight.value().buffer()->address() : 0u;
+    auto* const input_grad_buf = input_grad.buffer();
 
     // Set Runtime Args
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
@@ -360,36 +402,32 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
             TT_THROW("Core not in specified core ranges");
         }
 
-        std::vector<uint32_t> reader_args = {
-            target_addr,
-            output_grad_addr,
-            weight_addr,
-            ignore_index,
-            units_per_core,
-            tile_offset,
-            num_inner_tile,
-            channel_size,
-            Ct,
-        };
+        reader_desc.emplace_runtime_args(
+            core,
+            {
+                target_buf,
+                output_grad_buf,
+                weight_addr,
+                ignore_index,
+                units_per_core,
+                tile_offset,
+                num_inner_tile,
+                channel_size,
+                Ct,
+            });
 
-        std::vector<uint32_t> writer_args = {input_grad_addr, units_per_core, tile_offset};
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(core, {input_grad_buf, units_per_core, tile_offset});
 
         tile_offset += units_per_core;
     }
 
-    return {
-        std::move(program),
-        {.unary_reader_kernel_id = reader_kernel_id,
-         .unary_writer_kernel_id = writer_kernel_id,
-         .num_cores = num_cores,
-         .num_cores_y = core_h}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
 }
 
-MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t
-MorehNllLossUnreducedBackwardDeviceOperation::Factory::create(
+tt::tt_metal::ProgramDescriptor MorehNllLossUnreducedBackwardDeviceOperation::Factory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
@@ -421,42 +459,6 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::create(
 
     return moreh_nll_loss_unreduced_backward_impl_4d(
         target, weight, output_grad, input_grad, ignore_index, compute_kernel_config);
-}
-
-void MorehNllLossUnreducedBackwardDeviceOperation::Factory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& num_cores = cached_program.shared_variables.num_cores;
-    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    const uint32_t target_addr = tensor_args.target_tensor.buffer()->address();
-    const uint32_t output_grad_addr = tensor_args.output_grad_tensor.buffer()->address();
-    const uint32_t weight_addr =
-        tensor_args.weight_tensor.has_value() ? tensor_args.weight_tensor.value().buffer()->address() : 0;
-    const uint32_t ignore_index = operation_attributes.ignore_index;
-
-    const uint32_t input_grad_addr = tensor_return_value.buffer()->address();
-
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
-            runtime_args[0] = target_addr;
-            runtime_args[1] = output_grad_addr;
-            runtime_args[2] = weight_addr;
-            runtime_args[3] = ignore_index;
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
-            runtime_args[0] = input_grad_addr;
-        }
-    }
 }
 
 }  // namespace ttnn::operations::moreh::moreh_nll_loss_unreduced_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.hpp
@@ -7,26 +7,7 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/types.hpp"
 #include "ttnn/device_operation.hpp"
-
-#define DEFINE_PROGRAM_FACTORY(FactoryName)                                                 \
-    struct FactoryName {                                                                    \
-        struct shared_variables_t {                                                         \
-            tt::tt_metal::KernelHandle reader_kernels_id;                                   \
-            tt::tt_metal::KernelHandle writer_kernels_id;                                   \
-            std::size_t num_cores_to_be_used;                                               \
-            std::size_t num_cores_y;                                                        \
-        };                                                                                  \
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>; \
-        static cached_program_t create(                                                     \
-            const operation_attributes_t& operation_attributes,                             \
-            const tensor_args_t& tensor_args,                                               \
-            tensor_return_value_t& output);                                                 \
-        static void override_runtime_arguments(                                             \
-            cached_program_t& cached_program,                                               \
-            const operation_attributes_t& operation_attributes,                             \
-            const tensor_args_t& tensor_args,                                               \
-            tensor_return_value_t& output);                                                 \
-    };
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_norm {
 
@@ -49,9 +30,26 @@ struct MorehNormOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
-    DEFINE_PROGRAM_FACTORY(ProgramFactoryWOther)
-    DEFINE_PROGRAM_FACTORY(ProgramFactoryHOther)
-    DEFINE_PROGRAM_FACTORY(ProgramFactoryNCOther)
+    struct ProgramFactoryWOther {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
+
+    struct ProgramFactoryHOther {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
+
+    struct ProgramFactoryNCOther {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
 
     using program_factory_t = std::variant<ProgramFactoryWOther, ProgramFactoryHOther, ProgramFactoryNCOther>;
 
@@ -74,5 +72,3 @@ ttnn::operations::moreh::moreh_norm::MorehNormOperation::tensor_return_value_t m
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 }  // namespace ttnn::prim
-
-#undef DEFINE_PROGRAM_FACTORY

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_h_other.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_h_other.cpp
@@ -9,17 +9,19 @@
 
 namespace ttnn::operations::moreh::moreh_norm {
 
-MorehNormOperation::ProgramFactoryHOther::cached_program_t MorehNormOperation::ProgramFactoryHOther::create(
+tt::tt_metal::ProgramDescriptor MorehNormOperation::ProgramFactoryHOther::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
     const auto& input = tensor_args.input;
     const auto p = operation_attributes.p;
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
     auto* device = input.device();
-    auto program = CreateProgram();
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
@@ -70,19 +72,71 @@ MorehNormOperation::ProgramFactoryHOther::cached_program_t MorehNormOperation::P
     const uint32_t im1_t{1};  // calculate f(x) over dimension
     const uint32_t im2_t{1};  // reduce f(x)
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        cb_data_format,
-        {
-            {tt::CBIndex::c_0, in0_t},    // input
-            {tt::CBIndex::c_1, in1_t},    // one
-            {tt::CBIndex::c_2, in2_t},    // mask_h
-            {tt::CBIndex::c_16, out0_t},  // output
-            {tt::CBIndex::c_24, im0_t, intermed_data_format},
-            {tt::CBIndex::c_25, im1_t, intermed_data_format},
-            {tt::CBIndex::c_26, im2_t, intermed_data_format},
-        });
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in0_t * tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in1_t * tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in2_t * tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_2),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = out0_t * tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = im0_t * tile_size(intermed_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = intermed_data_format,
+            .page_size = tile_size(intermed_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = im1_t * tile_size(intermed_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = intermed_data_format,
+            .page_size = tile_size(intermed_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = im2_t * tile_size(intermed_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_26),
+            .data_format = intermed_data_format,
+            .page_size = tile_size(intermed_data_format),
+        }}},
+    });
 
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
@@ -94,120 +148,123 @@ MorehNormOperation::ProgramFactoryHOther::cached_program_t MorehNormOperation::P
         "ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/"
         "writer_moreh_norm_h.cpp";
 
-    std::vector<uint32_t> reader_ct_args = {};
+    KernelDescriptor::CompileTimeArgs reader_ct_args;
     TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
-    const auto reader_kernels_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_ct_args);
-    std::vector<uint32_t> writer_ct_args = {};
+    KernelDescriptor::CompileTimeArgs writer_ct_args;
     TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
-    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_ct_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_file;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_file;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    std::map<std::string, std::string> compute_defines{};
-    compute_defines["REDUCE_DIM"] = "ReduceDim::REDUCE_COL";
-    if (p == 0.0) {
-        compute_defines["REDUCE_OP"] = "PoolType::SUM";
-        compute_defines["IS_ZERO"] = "1";
+    std::map<std::string, std::string> compute_defines_map{};
+    compute_defines_map["REDUCE_DIM"] = "ReduceDim::REDUCE_COL";
+    if (p == 0.0f) {
+        compute_defines_map["REDUCE_OP"] = "PoolType::SUM";
+        compute_defines_map["IS_ZERO"] = "1";
     } else {
-        compute_defines["REDUCE_OP"] = "PoolType::MAX";
+        compute_defines_map["REDUCE_OP"] = "PoolType::MAX";
         if (p == -std::numeric_limits<float>::infinity()) {
-            compute_defines["MINUS_INF"] = "1";
+            compute_defines_map["MINUS_INF"] = "1";
         }
     }
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
 
     const auto* const compute_kernel_file =
         "ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/"
         "moreh_norm_h_kernel.cpp";
 
-    const auto compute_kernels_id_1 = CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {core_group_1, num_units_per_core_group_1},
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
 
-    KernelHandle compute_kernels_id_2{0};
-    if (!core_group_2.ranges().empty()) {
-        compute_kernels_id_2 = CreateComputeKernel(
-            program,
-            compute_kernel_file,
-            {core_group_2, num_units_per_core_group_2},
-            compute_defines,
-            math_fidelity,
-            fp32_dest_acc_en,
-            math_approx_mode);
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
     }
 
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
+    auto* const input_buf = input.buffer();
+    auto* const output_buf = output.buffer();
     for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_cols_per_core;
-        KernelHandle compute_kernel_id;
         if (core_group_1.contains(core)) {
             num_cols_per_core = num_units_per_core_group_1;
-            compute_kernel_id = compute_kernels_id_1;
+            compute_desc_1.emplace_runtime_args(
+                core, {num_cols_per_core, static_cast<uint32_t>(Ht), static_cast<uint32_t>(origin_h)});
         } else if (core_group_2.contains(core)) {
             num_cols_per_core = num_units_per_core_group_2;
-            compute_kernel_id = compute_kernels_id_2;
+            compute_desc_2.emplace_runtime_args(
+                core, {num_cols_per_core, static_cast<uint32_t>(Ht), static_cast<uint32_t>(origin_h)});
         } else {
             TT_THROW("Core not in specified core ranges.");
         }
         // reader
-        const std::vector<uint32_t> reader_runtime_args{
-            input.buffer()->address(),
-            static_cast<uint32_t>(is_dram(input)),
-            num_cols_per_core,
-            tile_offset,
-            Ht,
-            Wt,
-            origin_h};
-        SetRuntimeArgs(program, reader_kernels_id, core, reader_runtime_args);
+        reader_desc.emplace_runtime_args(
+            core,
+            {input_buf,
+             static_cast<uint32_t>(is_dram(input)),
+             num_cols_per_core,
+             tile_offset,
+             static_cast<uint32_t>(Ht),
+             static_cast<uint32_t>(Wt),
+             static_cast<uint32_t>(origin_h)});
 
         // writer
-        const std::vector<uint32_t> writer_runtime_args{
-            output.buffer()->address(), static_cast<uint32_t>(is_dram(output)), num_cols_per_core, tile_offset};
-        SetRuntimeArgs(program, writer_kernels_id, core, writer_runtime_args);
-
-        // compute
-        const std::vector<uint32_t> compute_runtime_args{num_cols_per_core, Ht, origin_h};
-        SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
+        writer_desc.emplace_runtime_args(
+            core, {output_buf, static_cast<uint32_t>(is_dram(output)), num_cols_per_core, tile_offset});
 
         tile_offset += num_cols_per_core;
     }
 
-    return {std::move(program), {reader_kernels_id, writer_kernels_id, num_cores_to_be_used, num_cores_y}};
-}
-
-void MorehNormOperation::ProgramFactoryHOther::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
-    auto& program = cached_program.program;
-    auto& reader_kernels_id = cached_program.shared_variables.reader_kernels_id;
-    auto& writer_kernels_id = cached_program.shared_variables.writer_kernels_id;
-    auto& num_cores_to_be_used = cached_program.shared_variables.num_cores_to_be_used;
-    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    for (uint32_t icore = 0; icore < num_cores_to_be_used; icore++) {
-        CoreCoord core = {icore / num_cores_y, icore % num_cores_y};
-        // readers
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernels_id, core);
-            runtime_args[0] = tensor_args.input.buffer()->address();
-        }
-
-        // writer
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernels_id, core);
-            runtime_args[0] = output.buffer()->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
 }  // namespace ttnn::operations::moreh::moreh_norm

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_nc_other.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_nc_other.cpp
@@ -9,10 +9,13 @@
 
 namespace ttnn::operations::moreh::moreh_norm {
 
-MorehNormOperation::ProgramFactoryNCOther::cached_program_t MorehNormOperation::ProgramFactoryNCOther::create(
+tt::tt_metal::ProgramDescriptor MorehNormOperation::ProgramFactoryNCOther::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
     const auto& input = tensor_args.input;
     const auto dim = operation_attributes.dim;
     const auto p = operation_attributes.p;
@@ -20,7 +23,6 @@ MorehNormOperation::ProgramFactoryNCOther::cached_program_t MorehNormOperation::
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
     auto* device = input.device();
-    auto program = CreateProgram();
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
@@ -75,17 +77,53 @@ MorehNormOperation::ProgramFactoryNCOther::cached_program_t MorehNormOperation::
     const uint32_t im0_t{1};  // f(x)
     const uint32_t im1_t{1};  // calculate f(x) over dimensions
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        cb_data_format,
-        {
-            {tt::CBIndex::c_0, in0_t},    // input
-            {tt::CBIndex::c_1, in1_t},    // one
-            {tt::CBIndex::c_16, out0_t},  // output
-            {tt::CBIndex::c_24, im0_t, intermed_data_format},
-            {tt::CBIndex::c_25, im1_t, intermed_data_format},
-        });
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in0_t * tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in1_t * tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = out0_t * tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = im0_t * tile_size(intermed_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = intermed_data_format,
+            .page_size = tile_size(intermed_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = im1_t * tile_size(intermed_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = intermed_data_format,
+            .page_size = tile_size(intermed_data_format),
+        }}},
+    });
 
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
@@ -97,120 +135,128 @@ MorehNormOperation::ProgramFactoryNCOther::cached_program_t MorehNormOperation::
         "ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/"
         "writer_moreh_norm_nc.cpp";
 
-    std::vector<uint32_t> reader_ct_args = {};
+    KernelDescriptor::CompileTimeArgs reader_ct_args;
     TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
-    const auto reader_kernels_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_ct_args);
-    std::vector<uint32_t> writer_ct_args = {};
+    KernelDescriptor::CompileTimeArgs writer_ct_args;
     TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
-    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_ct_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_file;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_file;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    std::map<std::string, std::string> compute_defines{};
-    if (p == 0.0) {
-        compute_defines["IS_ZERO"] = "1";
+    std::map<std::string, std::string> compute_defines_map{};
+    if (p == 0.0f) {
+        compute_defines_map["IS_ZERO"] = "1";
     } else {
         if (p == -std::numeric_limits<float>::infinity()) {
-            compute_defines["MINUS_INF"] = "1";
+            compute_defines_map["MINUS_INF"] = "1";
         }
     }
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
 
     const auto* const compute_kernel_file =
         "ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/"
         "moreh_norm_nc_kernel.cpp";
 
-    const auto compute_kernels_id_1 = CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {core_group_1, num_units_per_core_group_1},
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
 
-    KernelHandle compute_kernels_id_2{0};
-    if (!core_group_2.ranges().empty()) {
-        compute_kernels_id_2 = CreateComputeKernel(
-            program,
-            compute_kernel_file,
-            {core_group_2, num_units_per_core_group_2},
-            compute_defines,
-            math_fidelity,
-            fp32_dest_acc_en,
-            math_approx_mode);
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
     }
 
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
+    auto* const input_buf = input.buffer();
+    auto* const output_buf = output.buffer();
     for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_output_tiles_per_core;
-        KernelHandle compute_kernel_id;
         if (core_group_1.contains(core)) {
             num_output_tiles_per_core = num_units_per_core_group_1;
-            compute_kernel_id = compute_kernels_id_1;
+            compute_desc_1.emplace_runtime_args(
+                core,
+                {
+                    num_output_tiles_per_core,
+                    static_cast<uint32_t>(num_reduced_tiles_along_dim),
+                });
         } else if (core_group_2.contains(core)) {
             num_output_tiles_per_core = num_units_per_core_group_2;
-            compute_kernel_id = compute_kernels_id_2;
+            compute_desc_2.emplace_runtime_args(
+                core,
+                {
+                    num_output_tiles_per_core,
+                    static_cast<uint32_t>(num_reduced_tiles_along_dim),
+                });
         } else {
             TT_THROW("Core not in specified core ranges.");
         }
         // reader
-        const std::vector<uint32_t> reader_runtime_args{
-            input.buffer()->address(),
-            static_cast<uint32_t>(is_dram(input)),
-            num_output_tiles_per_core,
-            tile_offset,
-            outer_stride,
-            num_inner_tiles,
-            num_reduced_tiles_along_dim};
-        SetRuntimeArgs(program, reader_kernels_id, core, reader_runtime_args);
+        reader_desc.emplace_runtime_args(
+            core,
+            {input_buf,
+             static_cast<uint32_t>(is_dram(input)),
+             num_output_tiles_per_core,
+             tile_offset,
+             outer_stride,
+             num_inner_tiles,
+             static_cast<uint32_t>(num_reduced_tiles_along_dim)});
 
         // writer
-        const std::vector<uint32_t> writer_runtime_args{
-            output.buffer()->address(), static_cast<uint32_t>(is_dram(output)), num_output_tiles_per_core, tile_offset};
-        SetRuntimeArgs(program, writer_kernels_id, core, writer_runtime_args);
-
-        // compute
-        const std::vector<uint32_t> compute_runtime_args{
-            num_output_tiles_per_core,
-            num_reduced_tiles_along_dim,
-        };
-        SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
+        writer_desc.emplace_runtime_args(
+            core, {output_buf, static_cast<uint32_t>(is_dram(output)), num_output_tiles_per_core, tile_offset});
 
         tile_offset += num_output_tiles_per_core;
     }
 
-    return {std::move(program), {reader_kernels_id, writer_kernels_id, num_cores_to_be_used, num_cores_y}};
-}
-
-void MorehNormOperation::ProgramFactoryNCOther::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
-    auto& program = cached_program.program;
-    auto& reader_kernels_id = cached_program.shared_variables.reader_kernels_id;
-    auto& writer_kernels_id = cached_program.shared_variables.writer_kernels_id;
-    auto& num_cores_to_be_used = cached_program.shared_variables.num_cores_to_be_used;
-    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    for (uint32_t icore = 0; icore < num_cores_to_be_used; icore++) {
-        CoreCoord core = {icore / num_cores_y, icore % num_cores_y};
-        // readers
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernels_id, core);
-            runtime_args[0] = tensor_args.input.buffer()->address();
-        }
-
-        // writer
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernels_id, core);
-            runtime_args[0] = output.buffer()->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
 }  // namespace ttnn::operations::moreh::moreh_norm

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_w_other.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_w_other.cpp
@@ -11,17 +11,19 @@
 
 namespace ttnn::operations::moreh::moreh_norm {
 
-MorehNormOperation::ProgramFactoryWOther::cached_program_t MorehNormOperation::ProgramFactoryWOther::create(
+tt::tt_metal::ProgramDescriptor MorehNormOperation::ProgramFactoryWOther::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
     const auto& input = tensor_args.input;
     const auto p = operation_attributes.p;
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
     auto* device = input.device();
-    auto program = CreateProgram();
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
@@ -73,19 +75,71 @@ MorehNormOperation::ProgramFactoryWOther::cached_program_t MorehNormOperation::P
     const uint32_t im1_t{1};  // calculate f(x) over dimension
     const uint32_t im2_t{1};  // reduce f(x)
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        cb_data_format,
-        {
-            {tt::CBIndex::c_0, in0_t},    // input
-            {tt::CBIndex::c_1, in1_t},    // one
-            {tt::CBIndex::c_2, in2_t},    // mask_w
-            {tt::CBIndex::c_16, out0_t},  // output
-            {tt::CBIndex::c_24, im0_t, intermed_data_format},
-            {tt::CBIndex::c_25, im1_t, intermed_data_format},
-            {tt::CBIndex::c_26, im2_t, intermed_data_format},
-        });
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in0_t * tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in1_t * tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in2_t * tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_2),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = out0_t * tile_size(cb_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = cb_data_format,
+            .page_size = tile_size(cb_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = im0_t * tile_size(intermed_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = intermed_data_format,
+            .page_size = tile_size(intermed_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = im1_t * tile_size(intermed_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = intermed_data_format,
+            .page_size = tile_size(intermed_data_format),
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = im2_t * tile_size(intermed_data_format),
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_26),
+            .data_format = intermed_data_format,
+            .page_size = tile_size(intermed_data_format),
+        }}},
+    });
 
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
@@ -97,124 +151,138 @@ MorehNormOperation::ProgramFactoryWOther::cached_program_t MorehNormOperation::P
         "ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/"
         "writer_moreh_norm_w.cpp";
 
-    std::vector<uint32_t> reader_ct_args = {};
+    KernelDescriptor::CompileTimeArgs reader_ct_args;
     TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
-    const auto reader_kernels_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_ct_args);
-    std::vector<uint32_t> writer_ct_args = {};
+    KernelDescriptor::CompileTimeArgs writer_ct_args;
     TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
-    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_ct_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_file;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_file;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    std::map<std::string, std::string> compute_defines{};
+    std::map<std::string, std::string> compute_defines_map{};
 
-    compute_defines["REDUCE_DIM"] = "ReduceDim::REDUCE_ROW";
-    if (p == 0.0) {
-        compute_defines["REDUCE_OP"] = "PoolType::SUM";
-        compute_defines["IS_ZERO"] = "1";
+    compute_defines_map["REDUCE_DIM"] = "ReduceDim::REDUCE_ROW";
+    if (p == 0.0f) {
+        compute_defines_map["REDUCE_OP"] = "PoolType::SUM";
+        compute_defines_map["IS_ZERO"] = "1";
     } else {
-        compute_defines["REDUCE_OP"] = "PoolType::MAX";
+        compute_defines_map["REDUCE_OP"] = "PoolType::MAX";
         if (p == -std::numeric_limits<float>::infinity()) {
-            compute_defines["MINUS_INF"] = "1";
+            compute_defines_map["MINUS_INF"] = "1";
         }
     }
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
 
     const auto* const compute_kernel_file =
         "ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/"
         "moreh_norm_w_kernel.cpp";
 
-    const auto compute_kernels_id_1 = CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {core_group_1, num_units_per_core_group_1},
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
 
-    KernelHandle compute_kernels_id_2{0};
-    if (!core_group_2.ranges().empty()) {
-        compute_kernels_id_2 = CreateComputeKernel(
-            program,
-            compute_kernel_file,
-            {core_group_2, num_units_per_core_group_2},
-            compute_defines,
-            math_fidelity,
-            fp32_dest_acc_en,
-            math_approx_mode);
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
     }
 
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
+    auto* const input_buf = input.buffer();
+    auto* const output_buf = output.buffer();
     for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_units_per_core;
-        KernelHandle compute_kernel_id;
         if (core_group_1.contains(core)) {
             num_units_per_core = num_units_per_core_group_1;
-            compute_kernel_id = compute_kernels_id_1;
+            compute_desc_1.emplace_runtime_args(
+                core,
+                {
+                    num_units_per_core,
+                    static_cast<uint32_t>(Wt),
+                    static_cast<uint32_t>(origin_w),
+                });
         } else if (core_group_2.contains(core)) {
             num_units_per_core = num_units_per_core_group_2;
-            compute_kernel_id = compute_kernels_id_2;
+            compute_desc_2.emplace_runtime_args(
+                core,
+                {
+                    num_units_per_core,
+                    static_cast<uint32_t>(Wt),
+                    static_cast<uint32_t>(origin_w),
+                });
         } else {
             TT_THROW("Core not in specified core ranges.");
         }
         // reader
-        const std::vector<uint32_t> reader_runtime_args{
-            input.buffer()->address(),
-            static_cast<uint32_t>(is_dram(input)),
-            num_units_per_core,
-            Wt,
-            tile_offset,
-            origin_w};
-        SetRuntimeArgs(program, reader_kernels_id, core, reader_runtime_args);
+        reader_desc.emplace_runtime_args(
+            core,
+            {input_buf,
+             static_cast<uint32_t>(is_dram(input)),
+             num_units_per_core,
+             static_cast<uint32_t>(Wt),
+             tile_offset,
+             static_cast<uint32_t>(origin_w)});
 
         // writer
-        const std::vector<uint32_t> writer_runtime_args{
-            output.buffer()->address(), static_cast<uint32_t>(is_dram(output)), num_units_per_core, Wt, tile_offset};
-        SetRuntimeArgs(program, writer_kernels_id, core, writer_runtime_args);
-
-        // compute
-        const std::vector<uint32_t> compute_runtime_args{
-            num_units_per_core,
-            Wt,
-            origin_w,
-        };
-        SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
+        writer_desc.emplace_runtime_args(
+            core,
+            {output_buf,
+             static_cast<uint32_t>(is_dram(output)),
+             num_units_per_core,
+             static_cast<uint32_t>(Wt),
+             tile_offset});
 
         tile_offset += num_units_per_core * Wt;
     }
 
-    return {std::move(program), {reader_kernels_id, writer_kernels_id, num_cores_to_be_used, num_cores_y}};
-}
-
-void MorehNormOperation::ProgramFactoryWOther::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
-    auto& program = cached_program.program;
-    auto& reader_kernels_id = cached_program.shared_variables.reader_kernels_id;
-    auto& writer_kernels_id = cached_program.shared_variables.writer_kernels_id;
-    auto& num_cores_to_be_used = cached_program.shared_variables.num_cores_to_be_used;
-    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    for (uint32_t icore = 0; icore < num_cores_to_be_used; icore++) {
-        CoreCoord core = {icore / num_cores_y, icore % num_cores_y};
-        // readers
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernels_id, core);
-            runtime_args[0] = tensor_args.input.buffer()->address();
-        }
-
-        // writer
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernels_id, core);
-            runtime_args[0] = output.buffer()->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
 }  // namespace ttnn::operations::moreh::moreh_norm

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp
@@ -7,6 +7,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_softmax {
 
@@ -45,26 +46,12 @@ struct MorehSoftmaxOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
-#define DEFINE_SOFTMAX_FACTORY(factory_name)                                                \
-    struct factory_name {                                                                   \
-        struct shared_variables_t {                                                         \
-            tt::tt_metal::KernelHandle unary_reader_kernel_id;                              \
-            tt::tt_metal::KernelHandle unary_writer_kernel_id;                              \
-            std::size_t num_cores;                                                          \
-            std::size_t num_cores_y;                                                        \
-        };                                                                                  \
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>; \
-                                                                                            \
-        static cached_program_t create(                                                     \
-            const operation_attributes_t& operation_attributes,                             \
-            const tensor_args_t& tensor_args,                                               \
-            tensor_return_value_t& output);                                                 \
-                                                                                            \
-        static void override_runtime_arguments(                                             \
-            cached_program_t& cached_program,                                               \
-            const operation_attributes_t& operation_attributes,                             \
-            const tensor_args_t& tensor_args,                                               \
-            tensor_return_value_t& output);                                                 \
+#define DEFINE_SOFTMAX_FACTORY(factory_name)                      \
+    struct factory_name {                                         \
+        static tt::tt_metal::ProgramDescriptor create_descriptor( \
+            const operation_attributes_t& operation_attributes,   \
+            const tensor_args_t& tensor_args,                     \
+            tensor_return_value_t& output);                       \
     };
 
     DEFINE_SOFTMAX_FACTORY(MorehSoftmaxCLargeFactory)

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
@@ -10,11 +10,13 @@
 
 namespace ttnn::operations::moreh::moreh_softmax {
 
-MorehSoftmaxOperation::MorehSoftmaxCLargeFactory::cached_program_t
-MorehSoftmaxOperation::MorehSoftmaxCLargeFactory::create(
+tt::tt_metal::ProgramDescriptor MorehSoftmaxOperation::MorehSoftmaxCLargeFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
     log_info(tt::LogTest, "Large tensor algorithm selected");
     const auto& input = tensor_args.input;
     const auto dim = operation_attributes.dim;
@@ -48,47 +50,107 @@ MorehSoftmaxOperation::MorehSoftmaxCLargeFactory::create(
             "compute kernel configuration.");
     }
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
+    const uint32_t tile_size_data = tile_size(data_format);
+    const uint32_t tile_size_intermed = tile_size(intermed_data_format);
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        data_format,
-        {
-            {tt::CBIndex::c_0, 2},                         // input
-            {tt::CBIndex::c_16, 2},                        // output
-            {tt::CBIndex::c_24, 1, intermed_data_format},  // exp(x)
-            {tt::CBIndex::c_25, 1, intermed_data_format},  // recips
-            {tt::CBIndex::c_26, 2, intermed_data_format},  // add
-            {tt::CBIndex::c_27, 1},                        // max
-            {tt::CBIndex::c_28, 1, intermed_data_format},  // tmp
-        });
+    // input
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // output
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // exp(x)
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // recips
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // add
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_26),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // max
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_27),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // tmp
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_28),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
 
     // create read/write kernel
-
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
-
-    std::vector<uint32_t> reader_ct_args = {};
+    KernelDescriptor::CompileTimeArgs reader_ct_args = {};
     TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
-    auto reader_kernel_id = CreateReadKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_c_large.cpp",
-        all_cores,
-        reader_ct_args,
-        reader_defines);
-    std::vector<uint32_t> writer_ct_args = {};
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_c_large.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor::CompileTimeArgs writer_ct_args = {};
     TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
-    auto writer_kernel_id = CreateWriteKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_c_large.cpp",
-        all_cores,
-        writer_ct_args,
-        writer_defines);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_c_large.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     auto outer_stride = Ht * Wt;
     for (int i = dim; i < shape.rank() - 2; i++) {
@@ -97,32 +159,56 @@ MorehSoftmaxOperation::MorehSoftmaxCLargeFactory::create(
     auto dim_size = shape[dim];
     auto inner_size = outer_stride / dim_size;
 
-    std::map<std::string, std::string> compute_defines;
+    std::map<std::string, std::string> compute_defines_map;
     if (op == MorehSoftmaxOp::SOFTMAX || op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines_map["SOFTMAX"] = "1";
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines_map["SOFTMIN"] = "1";
     }
     if (op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
+        compute_defines_map["LOG"] = "1";
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines_map["FP32_DEST_ACC_EN"] = "1";
     }
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
 
     // create compute kernel
-    CreateComputeKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_c_large.cpp",
-        {
-            {core_group_1, num_tiles_per_core_group_1, {num_tiles_per_core_group_1, dim_size}},
-            {core_group_2, num_tiles_per_core_group_2, {num_tiles_per_core_group_2, dim_size}},
-        },
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_c_large.cpp";
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {num_tiles_per_core_group_1, dim_size};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source =
+            "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_c_large.cpp";
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {num_tiles_per_core_group_2, dim_size};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
+    }
 
     // Set Runtime Args
     auto core_x_offset = core_range.start_coord.x;
@@ -139,41 +225,22 @@ MorehSoftmaxOperation::MorehSoftmaxCLargeFactory::create(
             TT_THROW("Core not in specified core ranges");
         }
 
-        std::vector<uint32_t> reader_args = {
-            input.buffer()->address(), num_tiles_per_core, tile_offset, outer_stride, inner_size, dim_size};
+        reader_desc.emplace_runtime_args(
+            core, {input.buffer(), num_tiles_per_core, tile_offset, outer_stride, inner_size, dim_size});
 
-        std::vector<uint32_t> writer_args = {
-            output.buffer()->address(), num_tiles_per_core, tile_offset, outer_stride, inner_size, dim_size};
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(
+            core, {output.buffer(), num_tiles_per_core, tile_offset, outer_stride, inner_size, dim_size});
 
         tile_offset += num_tiles_per_core;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, core_h}};
-}
-
-void MorehSoftmaxOperation::MorehSoftmaxCLargeFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& num_cores = cached_program.shared_variables.num_cores;
-    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = tensor_args.input.buffer()->address();
-        }
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = output.buffer()->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
 }  // namespace ttnn::operations::moreh::moreh_softmax

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <bit>
 #include <string>
 
 #include "ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp"
@@ -10,11 +11,13 @@
 
 namespace ttnn::operations::moreh::moreh_softmax {
 
-MorehSoftmaxOperation::MorehSoftmaxHLargeFactory::cached_program_t
-MorehSoftmaxOperation::MorehSoftmaxHLargeFactory::create(
+tt::tt_metal::ProgramDescriptor MorehSoftmaxOperation::MorehSoftmaxHLargeFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
     log_info(tt::LogTest, "Large tensor algorithm selected");
     const auto& input = tensor_args.input;
     const auto op = operation_attributes.op;
@@ -47,78 +50,189 @@ MorehSoftmaxOperation::MorehSoftmaxHLargeFactory::create(
             "compute kernel configuration.");
     }
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
+    const uint32_t tile_size_data = tile_size(data_format);
+    const uint32_t tile_size_intermed = tile_size(intermed_data_format);
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        data_format,
-        {
-            {tt::CBIndex::c_0, 2},                         // input
-            {tt::CBIndex::c_1, 1},                         // mask
-            {tt::CBIndex::c_2, 1},                         // max scaler
-            {tt::CBIndex::c_3, 1},                         // sum scaler
-            {tt::CBIndex::c_16, 2},                        // output
-            {tt::CBIndex::c_24, 2, intermed_data_format},  // exp(x)
-            {tt::CBIndex::c_25, 1, intermed_data_format},  // reduce
-            {tt::CBIndex::c_26, 1, intermed_data_format},  // syn
-            {tt::CBIndex::c_27, 1, intermed_data_format},  // max
-            {tt::CBIndex::c_28, 1, intermed_data_format},  // tmp
-        });
+    // input
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // mask
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // max scaler
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_2),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // sum scaler
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_3),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // output
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // exp(x)
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // reduce
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // syn
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_26),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // max
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_27),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // tmp
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_28),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
 
     // create read/write kernel
-
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
-
-    std::vector<uint32_t> reader_ct_args = {static_cast<uint32_t>(input.dtype() == DataType::FLOAT32)};
+    KernelDescriptor::CompileTimeArgs reader_ct_args = {static_cast<uint32_t>(input.dtype() == DataType::FLOAT32)};
     TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
-    auto reader_kernel_id = CreateReadKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h_large.cpp",
-        all_cores,
-        reader_ct_args,
-        reader_defines);
-    std::vector<uint32_t> writer_ct_args = {};
-    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
-    auto writer_kernel_id = CreateWriteKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_h_large.cpp",
-        all_cores,
-        writer_ct_args,
-        writer_defines);
 
-    std::map<std::string, std::string> compute_defines;
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h_large.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor::CompileTimeArgs writer_ct_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_h_large.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    std::map<std::string, std::string> compute_defines_map;
     if (op == MorehSoftmaxOp::SOFTMAX || op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines_map["SOFTMAX"] = "1";
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines_map["SOFTMIN"] = "1";
     }
 
     if (op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
+        compute_defines_map["LOG"] = "1";
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines_map["FP32_DEST_ACC_EN"] = "1";
     }
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
 
     // create compute kernel
-    CreateComputeKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h_large.cpp",
-        {
-            {core_group_1, num_tiles_per_core_group_1, {num_tiles_per_core_group_1, Ht}},
-            {core_group_2, num_tiles_per_core_group_2, {num_tiles_per_core_group_2, Ht}},
-        },
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h_large.cpp";
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {num_tiles_per_core_group_1, Ht};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source =
+            "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h_large.cpp";
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {num_tiles_per_core_group_2, Ht};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
+    }
 
     // Set Runtime Args
     auto core_x_offset = core_range.start_coord.x;
@@ -140,46 +254,21 @@ MorehSoftmaxOperation::MorehSoftmaxHLargeFactory::create(
         if (mask_h == 0) {
             mask_h = tt::constants::TILE_HEIGHT;
         }
-        std::vector<uint32_t> reader_args = {
-            input.buffer()->address(),
-            num_tiles_per_core,
-            tile_offset,
-            Ht,
-            Wt,
-            *reinterpret_cast<uint32_t*>(&scaler),
-            mask_h};
+        reader_desc.emplace_runtime_args(
+            core, {input.buffer(), num_tiles_per_core, tile_offset, Ht, Wt, std::bit_cast<uint32_t>(scaler), mask_h});
 
-        std::vector<uint32_t> writer_args = {output.buffer()->address(), num_tiles_per_core, tile_offset, Ht, Wt};
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(core, {output.buffer(), num_tiles_per_core, tile_offset, Ht, Wt});
 
         tile_offset += num_tiles_per_core;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, core_h}};
-}
-
-void MorehSoftmaxOperation::MorehSoftmaxHLargeFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& num_cores = cached_program.shared_variables.num_cores;
-    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = tensor_args.input.buffer()->address();
-        }
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = output.buffer()->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
 }  // namespace ttnn::operations::moreh::moreh_softmax

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
@@ -6,17 +6,20 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
-#include <string>
+#include <bit>
 #include <cstdint>
+#include <string>
 
 namespace ttnn::operations::moreh::moreh_softmax {
 
-MorehSoftmaxOperation::MorehSoftmaxHSmallFactory::cached_program_t
-MorehSoftmaxOperation::MorehSoftmaxHSmallFactory::create(
+tt::tt_metal::ProgramDescriptor MorehSoftmaxOperation::MorehSoftmaxHSmallFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
-    log_info(tt::LogTest, "Large tensor algorithm selected");
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    log_info(tt::LogTest, "Small tensor algorithm selected");
     const auto& input = tensor_args.input;
     const auto op = operation_attributes.op;
     const auto& compute_kernel_config = operation_attributes.compute_kernel_config;
@@ -49,78 +52,188 @@ MorehSoftmaxOperation::MorehSoftmaxHSmallFactory::create(
             "compute kernel configuration.");
     }
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
+    const uint32_t tile_size_data = tile_size(data_format);
+    const uint32_t tile_size_intermed = tile_size(intermed_data_format);
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        data_format,
-        {
-            {tt::CBIndex::c_0, Ht},                         // input
-            {tt::CBIndex::c_1, 1},                          // mask
-            {tt::CBIndex::c_2, 1},                          // max scaler
-            {tt::CBIndex::c_3, 1},                          // sum scaler
-            {tt::CBIndex::c_16, Ht},                        // output
-            {tt::CBIndex::c_24, Ht, intermed_data_format},  // exp(x)
-            {tt::CBIndex::c_25, 1, intermed_data_format},   // reduce
-            {tt::CBIndex::c_26, 1, intermed_data_format},   // max
-            {tt::CBIndex::c_27, Ht, intermed_data_format},  // x - max
-            {tt::CBIndex::c_28, 1, intermed_data_format}    // tmp
-        });
+    // input
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = Ht * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // mask
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // max scaler
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_2),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // sum scaler
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_3),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // output
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = Ht * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // exp(x)
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = Ht * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // reduce
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // max
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_26),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // x - max
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = Ht * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_27),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // tmp
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_28),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
 
     // create read/write kernel
-
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
-
-    std::vector<uint32_t> reader_ct_args = {static_cast<uint32_t>(input.dtype() == DataType::FLOAT32)};
+    KernelDescriptor::CompileTimeArgs reader_ct_args = {static_cast<uint32_t>(input.dtype() == DataType::FLOAT32)};
     TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
-    auto reader_kernel_id = CreateReadKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h.cpp",
-        all_cores,
-        reader_ct_args,
-        reader_defines);
-    std::vector<uint32_t> writer_ct_args = {};
-    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
-    auto writer_kernel_id = CreateWriteKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_h.cpp",
-        all_cores,
-        writer_ct_args,
-        writer_defines);
 
-    std::map<std::string, std::string> compute_defines;
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor::CompileTimeArgs writer_ct_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_h.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    std::map<std::string, std::string> compute_defines_map;
     if (op == MorehSoftmaxOp::SOFTMAX || op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines_map["SOFTMAX"] = "1";
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines_map["SOFTMIN"] = "1";
     }
 
     if (op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
+        compute_defines_map["LOG"] = "1";
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines_map["FP32_DEST_ACC_EN"] = "1";
     }
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
 
     // create compute kernel
-    CreateComputeKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h.cpp",
-        {
-            {core_group_1, num_tiles_per_core_group_1, {num_tiles_per_core_group_1, Ht}},
-            {core_group_2, num_tiles_per_core_group_2, {num_tiles_per_core_group_2, Ht}},
-        },
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h.cpp";
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {num_tiles_per_core_group_1, Ht};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source =
+            "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h.cpp";
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {num_tiles_per_core_group_2, Ht};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
+    }
 
     // Set Runtime Args
     auto core_x_offset = core_range.start_coord.x;
@@ -142,46 +255,21 @@ MorehSoftmaxOperation::MorehSoftmaxHSmallFactory::create(
         if (mask_h == 0) {
             mask_h = tt::constants::TILE_HEIGHT;
         }
-        std::vector<uint32_t> reader_args = {
-            input.buffer()->address(),
-            num_tiles_per_core,
-            tile_offset,
-            Ht,
-            Wt,
-            *reinterpret_cast<uint32_t*>(&scaler),
-            mask_h};
+        reader_desc.emplace_runtime_args(
+            core, {input.buffer(), num_tiles_per_core, tile_offset, Ht, Wt, std::bit_cast<uint32_t>(scaler), mask_h});
 
-        std::vector<uint32_t> writer_args = {output.buffer()->address(), num_tiles_per_core, tile_offset, Ht, Wt};
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(core, {output.buffer(), num_tiles_per_core, tile_offset, Ht, Wt});
 
         tile_offset += num_tiles_per_core;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, core_h}};
-}
-
-void MorehSoftmaxOperation::MorehSoftmaxHSmallFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& num_cores = cached_program.shared_variables.num_cores;
-    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = tensor_args.input.buffer()->address();
-        }
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = output.buffer()->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
 }  // namespace ttnn::operations::moreh::moreh_softmax

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
@@ -6,16 +6,19 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
+#include <bit>
 #include <cstdint>
 #include <string>
 
 namespace ttnn::operations::moreh::moreh_softmax {
 
-MorehSoftmaxOperation::MorehSoftmaxWLargeFactory::cached_program_t
-MorehSoftmaxOperation::MorehSoftmaxWLargeFactory::create(
+tt::tt_metal::ProgramDescriptor MorehSoftmaxOperation::MorehSoftmaxWLargeFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
     log_info(tt::LogTest, "Large tensor algorithm selected");
     const auto& input = tensor_args.input;
     const auto op = operation_attributes.op;
@@ -49,78 +52,189 @@ MorehSoftmaxOperation::MorehSoftmaxWLargeFactory::create(
             "compute kernel configuration.");
     }
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
+    const uint32_t tile_size_data = tile_size(data_format);
+    const uint32_t tile_size_intermed = tile_size(intermed_data_format);
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        data_format,
-        {
-            {tt::CBIndex::c_0, 2},                         // input
-            {tt::CBIndex::c_1, 1},                         // mask
-            {tt::CBIndex::c_2, 1},                         // max scaler
-            {tt::CBIndex::c_3, 1},                         // sum scaler
-            {tt::CBIndex::c_16, 2},                        // output
-            {tt::CBIndex::c_24, 2, intermed_data_format},  // exp(x)
-            {tt::CBIndex::c_25, 1, intermed_data_format},  // reduce
-            {tt::CBIndex::c_26, 1, intermed_data_format},  // syn
-            {tt::CBIndex::c_27, 1, intermed_data_format},  // max
-            {tt::CBIndex::c_28, 1, intermed_data_format},  // tmp
-        });
+    // input
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // mask
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // max scaler
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_2),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // sum scaler
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_3),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // output
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // exp(x)
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // reduce
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // syn
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_26),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // max
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_27),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // tmp
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_28),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
 
     // create read/write kernel
-
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
-
-    std::vector<uint32_t> reader_ct_args = {static_cast<uint32_t>(input.dtype() == DataType::FLOAT32)};
+    KernelDescriptor::CompileTimeArgs reader_ct_args = {static_cast<uint32_t>(input.dtype() == DataType::FLOAT32)};
     TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
-    auto reader_kernel_id = CreateReadKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w_large.cpp",
-        all_cores,
-        reader_ct_args,
-        reader_defines);
-    std::vector<uint32_t> writer_ct_args = {};
-    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
-    auto writer_kernel_id = CreateWriteKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_w_large.cpp",
-        all_cores,
-        writer_ct_args,
-        writer_defines);
 
-    std::map<std::string, std::string> compute_defines;
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w_large.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor::CompileTimeArgs writer_ct_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_w_large.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    std::map<std::string, std::string> compute_defines_map;
     if (op == MorehSoftmaxOp::SOFTMAX || op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines_map["SOFTMAX"] = "1";
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines_map["SOFTMIN"] = "1";
     }
 
     if (op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
+        compute_defines_map["LOG"] = "1";
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines_map["FP32_DEST_ACC_EN"] = "1";
     }
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
 
     // create compute kernel
-    CreateComputeKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp",
-        {
-            {core_group_1, num_tiles_per_core_group_1, {num_tiles_per_core_group_1, Wt}},
-            {core_group_2, num_tiles_per_core_group_2, {num_tiles_per_core_group_2, Wt}},
-        },
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp";
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {num_tiles_per_core_group_1, Wt};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source =
+            "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp";
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {num_tiles_per_core_group_2, Wt};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
+    }
 
     // Set Runtime Args
     auto core_x_offset = core_range.start_coord.x;
@@ -142,45 +256,21 @@ MorehSoftmaxOperation::MorehSoftmaxWLargeFactory::create(
         if (mask_w == 0) {
             mask_w = tt::constants::TILE_WIDTH;
         }
-        std::vector<uint32_t> reader_args = {
-            input.buffer()->address(),
-            num_tiles_per_core,
-            tile_offset,
-            Wt,
-            *reinterpret_cast<uint32_t*>(&scaler),
-            mask_w};
+        reader_desc.emplace_runtime_args(
+            core, {input.buffer(), num_tiles_per_core, tile_offset, Wt, std::bit_cast<uint32_t>(scaler), mask_w});
 
-        std::vector<uint32_t> writer_args = {output.buffer()->address(), num_tiles_per_core, tile_offset, Wt};
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(core, {output.buffer(), num_tiles_per_core, tile_offset, Wt});
 
         tile_offset += num_tiles_per_core * Wt;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, core_h}};
-}
-
-void MorehSoftmaxOperation::MorehSoftmaxWLargeFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& num_cores = cached_program.shared_variables.num_cores;
-    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = tensor_args.input.buffer()->address();
-        }
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = output.buffer()->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
 }  // namespace ttnn::operations::moreh::moreh_softmax

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <bit>
 #include <string>
 
 #include <tt_stl/assert.hpp>
@@ -11,12 +12,14 @@
 
 namespace ttnn::operations::moreh::moreh_softmax {
 
-MorehSoftmaxOperation::MorehSoftmaxWSmallFactory::cached_program_t
-MorehSoftmaxOperation::MorehSoftmaxWSmallFactory::create(
+tt::tt_metal::ProgramDescriptor MorehSoftmaxOperation::MorehSoftmaxWSmallFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
-    log_info(tt::LogTest, "Large tensor algorithm selected");
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    log_info(tt::LogTest, "Small tensor algorithm selected");
     const auto& input = tensor_args.input;
     const auto op = operation_attributes.op;
     const auto& compute_kernel_config = operation_attributes.compute_kernel_config;
@@ -49,76 +52,187 @@ MorehSoftmaxOperation::MorehSoftmaxWSmallFactory::create(
             "compute kernel configuration.");
     }
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
+    const uint32_t tile_size_data = tile_size(data_format);
+    const uint32_t tile_size_intermed = tile_size(intermed_data_format);
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        data_format,
-        {
-            {tt::CBIndex::c_0, Wt},                         // input
-            {tt::CBIndex::c_1, 1},                          // mask
-            {tt::CBIndex::c_2, 1},                          // max scaler
-            {tt::CBIndex::c_3, 1},                          // sum scaler
-            {tt::CBIndex::c_16, Wt},                        // output
-            {tt::CBIndex::c_24, Wt, intermed_data_format},  // exp(x)
-            {tt::CBIndex::c_25, 1, intermed_data_format},   // reduce
-            {tt::CBIndex::c_26, 1, intermed_data_format},   // max
-            {tt::CBIndex::c_27, Wt, intermed_data_format},  // x - max
-            {tt::CBIndex::c_28, 1, intermed_data_format}    // tmp
-        });
+    // input
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = Wt * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // mask
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // max scaler
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_2),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // sum scaler
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_3),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // output
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = Wt * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // exp(x)
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = Wt * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // reduce
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // max
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_26),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // x - max
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = Wt * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_27),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // tmp
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_28),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
 
     // create read/write kernel
-
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
-    std::vector<uint32_t> reader_ct_args = {static_cast<uint32_t>(input.dtype() == DataType::FLOAT32)};
+    KernelDescriptor::CompileTimeArgs reader_ct_args = {static_cast<uint32_t>(input.dtype() == DataType::FLOAT32)};
     TensorAccessorArgs(*input.buffer()).append_to(reader_ct_args);
-    auto reader_kernel_id = CreateReadKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w.cpp",
-        all_cores,
-        reader_ct_args,
-        reader_defines);
-    std::vector<uint32_t> writer_ct_args = {};
-    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
-    auto writer_kernel_id = CreateWriteKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_w.cpp",
-        all_cores,
-        writer_ct_args,
-        writer_defines);
 
-    std::map<std::string, std::string> compute_defines;
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor::CompileTimeArgs writer_ct_args = {};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/writer_moreh_softmax_w.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    std::map<std::string, std::string> compute_defines_map;
     if (op == MorehSoftmaxOp::SOFTMAX || op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines_map["SOFTMAX"] = "1";
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines_map["SOFTMIN"] = "1";
     }
     if (op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
+        compute_defines_map["LOG"] = "1";
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines_map["FP32_DEST_ACC_EN"] = "1";
     }
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
 
     // create compute kernel
-    CreateComputeKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp",
-        {
-            {core_group_1, num_tiles_per_core_group_1, {num_tiles_per_core_group_1, Wt}},
-            {core_group_2, num_tiles_per_core_group_2, {num_tiles_per_core_group_2, Wt}},
-        },
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp";
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {num_tiles_per_core_group_1, Wt};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source =
+            "ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp";
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {num_tiles_per_core_group_2, Wt};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
+    }
 
     // Set Runtime Args
     auto core_x_offset = core_range.start_coord.x;
@@ -140,45 +254,21 @@ MorehSoftmaxOperation::MorehSoftmaxWSmallFactory::create(
         if (mask_w == 0) {
             mask_w = tt::constants::TILE_WIDTH;
         }
-        std::vector<uint32_t> reader_args = {
-            input.buffer()->address(),
-            num_tiles_per_core,
-            tile_offset,
-            Wt,
-            *reinterpret_cast<uint32_t*>(&scaler),
-            mask_w};
+        reader_desc.emplace_runtime_args(
+            core, {input.buffer(), num_tiles_per_core, tile_offset, Wt, std::bit_cast<uint32_t>(scaler), mask_w});
 
-        std::vector<uint32_t> writer_args = {output.buffer()->address(), num_tiles_per_core, tile_offset, Wt};
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(core, {output.buffer(), num_tiles_per_core, tile_offset, Wt});
 
         tile_offset += num_tiles_per_core * Wt;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, core_h}};
-}
-
-void MorehSoftmaxOperation::MorehSoftmaxWSmallFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& num_cores = cached_program.shared_variables.num_cores;
-    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = tensor_args.input.buffer()->address();
-        }
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = output.buffer()->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
 }  // namespace ttnn::operations::moreh::moreh_softmax

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp
@@ -7,6 +7,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_softmax_backward {
 
@@ -46,26 +47,12 @@ struct MorehSoftmaxBackwardOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
-#define DEFINE_SOFTMAX_BACKWARD_FACTORY(factory_name)                                       \
-    struct factory_name {                                                                   \
-        struct shared_variables_t {                                                         \
-            tt::tt_metal::KernelHandle unary_reader_kernel_id;                              \
-            tt::tt_metal::KernelHandle unary_writer_kernel_id;                              \
-            std::size_t num_cores;                                                          \
-            std::size_t num_cores_y;                                                        \
-        };                                                                                  \
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>; \
-                                                                                            \
-        static cached_program_t create(                                                     \
-            const operation_attributes_t& operation_attributes,                             \
-            const tensor_args_t& tensor_args,                                               \
-            tensor_return_value_t& output);                                                 \
-                                                                                            \
-        static void override_runtime_arguments(                                             \
-            cached_program_t& cached_program,                                               \
-            const operation_attributes_t& operation_attributes,                             \
-            const tensor_args_t& tensor_args,                                               \
-            tensor_return_value_t& output);                                                 \
+#define DEFINE_SOFTMAX_BACKWARD_FACTORY(factory_name)             \
+    struct factory_name {                                         \
+        static tt::tt_metal::ProgramDescriptor create_descriptor( \
+            const operation_attributes_t& operation_attributes,   \
+            const tensor_args_t& tensor_args,                     \
+            tensor_return_value_t& output);                       \
     };
 
     DEFINE_SOFTMAX_BACKWARD_FACTORY(MorehSoftmaxBackwardCLargeFactory)

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_c_large/softmax_backward_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_c_large/softmax_backward_c_large.cpp
@@ -10,11 +10,13 @@
 
 namespace ttnn::operations::moreh::moreh_softmax_backward {
 
-MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::cached_program_t
-MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::create(
+tt::tt_metal::ProgramDescriptor MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& input_grad) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
     log_info(tt::LogTest, "Large tensor algorithm selected");
     const auto& output = tensor_args.output_tensor;
     const auto& output_grad = tensor_args.output_grad_tensor;
@@ -43,62 +45,118 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::create(
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(input_grad.dtype());
+    tt::DataFormat intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
+    const uint32_t tile_size_data = tile_size(data_format);
+    const uint32_t tile_size_intermed = tile_size(intermed_data_format);
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        data_format,
-        {
-            {tt::CBIndex::c_0, 2},                                                             // y
-            {tt::CBIndex::c_1, 2},                                                             // dy
-            {tt::CBIndex::c_16, 2},                                                            // dx
-            {tt::CBIndex::c_24, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // y * dy
-            {tt::CBIndex::c_25, 2, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // sum(y * dy)
-            {tt::CBIndex::c_26, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // dy - sum
-        });
+    // y
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // dy
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // dx
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // y * dy
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // sum(y * dy)
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // dy - sum
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_26),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
 
     // create read/write kernel
-
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
-
-    std::map<std::string, std::string> compute_defines;
+    std::map<std::string, std::string> reader_defines_map;
+    std::map<std::string, std::string> compute_defines_map;
     if (op == MorehSoftmaxBackwardOp::SOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines_map["SOFTMAX"] = "1";
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines_map["SOFTMIN"] = "1";
     }
 
     if (op == MorehSoftmaxBackwardOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
-        reader_defines["LOG"] = "1";
+        compute_defines_map["LOG"] = "1";
+        reader_defines_map["LOG"] = "1";
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines_map["FP32_DEST_ACC_EN"] = "1";
     }
+    KernelDescriptor::Defines reader_defines(reader_defines_map.begin(), reader_defines_map.end());
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
 
-    std::vector<uint32_t> reader_ct_args = {};
+    KernelDescriptor::CompileTimeArgs reader_ct_args = {};
     TensorAccessorArgs(*output.buffer()).append_to(reader_ct_args);
     TensorAccessorArgs(*output_grad.buffer()).append_to(reader_ct_args);
-    auto reader_kernel_id = CreateReadKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_c.cpp",
-        all_cores,
-        reader_ct_args,
-        reader_defines);
-    std::vector<uint32_t> writer_ct_args = {};
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_c.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor::CompileTimeArgs writer_ct_args = {};
     TensorAccessorArgs(*input_grad.buffer()).append_to(writer_ct_args);
-    auto writer_kernel_id = CreateWriteKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_backward_c.cpp",
-        all_cores,
-        writer_ct_args,
-        writer_defines);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_backward_c.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     auto outer_stride = Ht * Wt;
     for (int i = dim; i < shape.rank() - 2; i++) {
@@ -107,18 +165,41 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::create(
     auto dim_size = shape[dim];
     auto inner_size = outer_stride / dim_size;
 
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+
     // create compute kernel
-    CreateComputeKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_c_large.cpp",
-        {
-            {core_group_1, num_tiles_per_core_group_1, {num_tiles_per_core_group_1, dim_size}},
-            {core_group_2, num_tiles_per_core_group_2, {num_tiles_per_core_group_2, dim_size}},
-        },
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_c_large.cpp";
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {num_tiles_per_core_group_1, dim_size};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source =
+            "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_c_large.cpp";
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {num_tiles_per_core_group_2, dim_size};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
+    }
 
     // Set Runtime Args
     auto core_x_offset = core_range.start_coord.x;
@@ -135,49 +216,30 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::create(
             TT_THROW("Core not in specified core ranges");
         }
 
-        std::vector<uint32_t> reader_args = {
-            output.buffer()->address(),
-            output_grad.buffer()->address(),
-            num_tiles_per_core,
-            tile_offset,
-            outer_stride,
-            inner_size,
-            dim_size};
+        reader_desc.emplace_runtime_args(
+            core,
+            {output.buffer(),
+             output_grad.buffer(),
+             num_tiles_per_core,
+             tile_offset,
+             outer_stride,
+             inner_size,
+             dim_size});
 
-        std::vector<uint32_t> writer_args = {
-            input_grad.buffer()->address(), num_tiles_per_core, tile_offset, outer_stride, inner_size, dim_size};
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(
+            core, {input_grad.buffer(), num_tiles_per_core, tile_offset, outer_stride, inner_size, dim_size});
 
         tile_offset += num_tiles_per_core;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, core_h}};
-}
-
-void MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& input_grad) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& num_cores = cached_program.shared_variables.num_cores;
-    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = tensor_args.output_tensor.buffer()->address();
-            runtime_args[1] = tensor_args.output_grad_tensor.buffer()->address();
-        }
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = input_grad.buffer()->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
 
 }  // namespace ttnn::operations::moreh::moreh_softmax_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_large/softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_large/softmax_backward_h_large.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <bit>
 #include <string>
 
 #include "ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp"
@@ -10,11 +11,13 @@
 
 namespace ttnn::operations::moreh::moreh_softmax_backward {
 
-MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHLargeFactory::cached_program_t
-MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHLargeFactory::create(
+tt::tt_metal::ProgramDescriptor MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHLargeFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& input_grad) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
     log_info(tt::LogTest, "Large tensor algorithm selected");
     const auto& output = tensor_args.output_tensor;
     const auto& output_grad = tensor_args.output_grad_tensor;
@@ -43,80 +46,185 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHLargeFactory::create(
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(input_grad.dtype());
+    tt::DataFormat intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
+    const uint32_t tile_size_data = tile_size(data_format);
+    const uint32_t tile_size_intermed = tile_size(intermed_data_format);
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        data_format,
-        {
-            {tt::CBIndex::c_0, 2},                                                             // output
-            {tt::CBIndex::c_1, 2},                                                             // output_grad
-            {tt::CBIndex::c_2, 1},                                                             // scaler
-            {tt::CBIndex::c_3, 1},                                                             // mask
-            {tt::CBIndex::c_16, 2},                                                            // input_grad
-            {tt::CBIndex::c_24, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // output * output_grad
-            {tt::CBIndex::c_25, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // reduce
-            {tt::CBIndex::c_26, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // dy - sum
-            {tt::CBIndex::c_27,
-             2,
-             fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // add(output * output_grad)
-        });
+    // output
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // output_grad
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // scaler
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_2),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // mask
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_3),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // input_grad
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // output * output_grad
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // reduce
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // dy - sum
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_26),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // add(output * output_grad)
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_27),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
 
     // create read/write kernel
-
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
-    std::map<std::string, std::string> compute_defines;
+    std::map<std::string, std::string> reader_defines_map;
+    std::map<std::string, std::string> compute_defines_map;
     if (op == MorehSoftmaxBackwardOp::SOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines_map["SOFTMAX"] = "1";
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines_map["SOFTMIN"] = "1";
     }
 
     if (op == MorehSoftmaxBackwardOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
-        reader_defines["LOG"] = "1";
+        compute_defines_map["LOG"] = "1";
+        reader_defines_map["LOG"] = "1";
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines_map["FP32_DEST_ACC_EN"] = "1";
     }
+    KernelDescriptor::Defines reader_defines(reader_defines_map.begin(), reader_defines_map.end());
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
 
-    std::vector<uint32_t> reader_ct_args = {};
+    KernelDescriptor::CompileTimeArgs reader_ct_args = {};
     TensorAccessorArgs(*output.buffer()).append_to(reader_ct_args);
     TensorAccessorArgs(*output_grad.buffer()).append_to(reader_ct_args);
-    auto reader_kernel_id = CreateReadKernel(
-        program,
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/"
-        "reader_moreh_softmax_backward_h_large.cpp",
-        all_cores,
-        reader_ct_args,
-        reader_defines);
-    std::vector<uint32_t> writer_ct_args = {};
+        "reader_moreh_softmax_backward_h_large.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor::CompileTimeArgs writer_ct_args = {};
     TensorAccessorArgs(*input_grad.buffer()).append_to(writer_ct_args);
-    auto writer_kernel_id = CreateWriteKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_h.cpp",
-        all_cores,
-        writer_ct_args,
-        writer_defines);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_h.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
 
     // create compute kernel
-    CreateComputeKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h_large.cpp",
-        {
-            {core_group_1, num_tiles_per_core_group_1, {num_tiles_per_core_group_1, Ht}},
-            {core_group_2, num_tiles_per_core_group_2, {num_tiles_per_core_group_2, Ht}},
-        },
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h_large.cpp";
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {num_tiles_per_core_group_1, Ht};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source =
+            "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h_large.cpp";
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {num_tiles_per_core_group_2, Ht};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
+    }
 
     // Set Runtime Args
     auto core_x_offset = core_range.start_coord.x;
@@ -138,49 +246,30 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHLargeFactory::create(
         if (mask_h == 0) {
             mask_h = tt::constants::TILE_HEIGHT;
         }
-        std::vector<uint32_t> reader_args = {
-            output.buffer()->address(),
-            output_grad.buffer()->address(),
-            num_tiles_per_core,
-            tile_offset,
-            Ht,
-            Wt,
-            *reinterpret_cast<uint32_t*>(&scaler),
-            mask_h};
+        reader_desc.emplace_runtime_args(
+            core,
+            {output.buffer(),
+             output_grad.buffer(),
+             num_tiles_per_core,
+             tile_offset,
+             Ht,
+             Wt,
+             std::bit_cast<uint32_t>(scaler),
+             mask_h});
 
-        std::vector<uint32_t> writer_args = {input_grad.buffer()->address(), num_tiles_per_core, tile_offset, Ht, Wt};
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(core, {input_grad.buffer(), num_tiles_per_core, tile_offset, Ht, Wt});
 
         tile_offset += num_tiles_per_core;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, core_h}};
-}
-
-void MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHLargeFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& input_grad) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& num_cores = cached_program.shared_variables.num_cores;
-    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = tensor_args.output_tensor.buffer()->address();
-            runtime_args[1] = tensor_args.output_grad_tensor.buffer()->address();
-        }
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = input_grad.buffer()->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
 
 }  // namespace ttnn::operations::moreh::moreh_softmax_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_small/softmax_backward_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_small/softmax_backward_h_small.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <bit>
 #include <string>
 
 #include "ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp"
@@ -10,11 +11,13 @@
 
 namespace ttnn::operations::moreh::moreh_softmax_backward {
 
-MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHSmallFactory::cached_program_t
-MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHSmallFactory::create(
+tt::tt_metal::ProgramDescriptor MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHSmallFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& input_grad) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
     log_info(tt::LogTest, "Small tensor algorithm selected");
     const auto& output = tensor_args.output_tensor;
     const auto& output_grad = tensor_args.output_grad_tensor;
@@ -43,76 +46,170 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHSmallFactory::create(
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(input_grad.dtype());
+    tt::DataFormat intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
+    const uint32_t tile_size_data = tile_size(data_format);
+    const uint32_t tile_size_intermed = tile_size(intermed_data_format);
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        data_format,
-        {
-            {tt::CBIndex::c_0, Ht},                                                             // output
-            {tt::CBIndex::c_1, Ht},                                                             // output_grad
-            {tt::CBIndex::c_2, 1},                                                              // scaler
-            {tt::CBIndex::c_3, 1},                                                              // mask
-            {tt::CBIndex::c_16, 2},                                                             // input_grad
-            {tt::CBIndex::c_24, Ht, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // output * output_grad
-            {tt::CBIndex::c_25, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},   // reduce
-            {tt::CBIndex::c_26, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},   // dy - sum
-        });
+    // output
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = Ht * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // output_grad
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = Ht * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // scaler
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_2),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // mask
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_3),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // input_grad
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // output * output_grad
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = Ht * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // reduce
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // dy - sum
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_26),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
 
     // create read/write kernel
-
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
-
-    std::vector<uint32_t> reader_ct_args = {};
+    KernelDescriptor::CompileTimeArgs reader_ct_args = {};
     TensorAccessorArgs(*output.buffer()).append_to(reader_ct_args);
     TensorAccessorArgs(*output_grad.buffer()).append_to(reader_ct_args);
-    auto reader_kernel_id = CreateReadKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_h.cpp",
-        all_cores,
-        reader_ct_args,
-        reader_defines);
-    std::vector<uint32_t> writer_ct_args = {};
-    TensorAccessorArgs(*input_grad.buffer()).append_to(writer_ct_args);
-    auto writer_kernel_id = CreateWriteKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_h.cpp",
-        all_cores,
-        writer_ct_args,
-        writer_defines);
 
-    std::map<std::string, std::string> compute_defines;
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_h.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor::CompileTimeArgs writer_ct_args = {};
+    TensorAccessorArgs(*input_grad.buffer()).append_to(writer_ct_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_h.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    std::map<std::string, std::string> compute_defines_map;
     if (op == MorehSoftmaxBackwardOp::SOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines_map["SOFTMAX"] = "1";
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines_map["SOFTMIN"] = "1";
     }
 
     if (op == MorehSoftmaxBackwardOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
+        compute_defines_map["LOG"] = "1";
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines_map["FP32_DEST_ACC_EN"] = "1";
     }
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
 
     // create compute kernel
-    CreateComputeKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h.cpp",
-        {
-            {core_group_1, num_tiles_per_core_group_1, {num_tiles_per_core_group_1, Ht}},
-            {core_group_2, num_tiles_per_core_group_2, {num_tiles_per_core_group_2, Ht}},
-        },
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h.cpp";
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {num_tiles_per_core_group_1, Ht};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source =
+            "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h.cpp";
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {num_tiles_per_core_group_2, Ht};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
+    }
 
     // Set Runtime Args
     auto core_x_offset = core_range.start_coord.x;
@@ -134,49 +231,30 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHSmallFactory::create(
         if (mask_h == 0) {
             mask_h = tt::constants::TILE_HEIGHT;
         }
-        std::vector<uint32_t> reader_args = {
-            output.buffer()->address(),
-            output_grad.buffer()->address(),
-            num_tiles_per_core,
-            tile_offset,
-            Ht,
-            Wt,
-            *reinterpret_cast<uint32_t*>(&scaler),
-            mask_h};
+        reader_desc.emplace_runtime_args(
+            core,
+            {output.buffer(),
+             output_grad.buffer(),
+             num_tiles_per_core,
+             tile_offset,
+             Ht,
+             Wt,
+             std::bit_cast<uint32_t>(scaler),
+             mask_h});
 
-        std::vector<uint32_t> writer_args = {input_grad.buffer()->address(), num_tiles_per_core, tile_offset, Ht, Wt};
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(core, {input_grad.buffer(), num_tiles_per_core, tile_offset, Ht, Wt});
 
         tile_offset += num_tiles_per_core;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, core_h}};
-}
-
-void MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHSmallFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& input_grad) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& num_cores = cached_program.shared_variables.num_cores;
-    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = tensor_args.output_tensor.buffer()->address();
-            runtime_args[1] = tensor_args.output_grad_tensor.buffer()->address();
-        }
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = input_grad.buffer()->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
 
 }  // namespace ttnn::operations::moreh::moreh_softmax_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_large/softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_large/softmax_backward_w_large.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <bit>
 #include <string>
 
 #include "ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp"
@@ -10,11 +11,13 @@
 
 namespace ttnn::operations::moreh::moreh_softmax_backward {
 
-MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWLargeFactory::cached_program_t
-MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWLargeFactory::create(
+tt::tt_metal::ProgramDescriptor MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWLargeFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& input_grad) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
     log_info(tt::LogTest, "Large tensor algorithm selected");
     const auto& output = tensor_args.output_tensor;
     const auto& output_grad = tensor_args.output_grad_tensor;
@@ -43,80 +46,185 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWLargeFactory::create(
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(input_grad.dtype());
+    tt::DataFormat intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
+    const uint32_t tile_size_data = tile_size(data_format);
+    const uint32_t tile_size_intermed = tile_size(intermed_data_format);
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        data_format,
-        {
-            {tt::CBIndex::c_0, 2},                                                             // output
-            {tt::CBIndex::c_1, 2},                                                             // output_grad
-            {tt::CBIndex::c_2, 1},                                                             // scaler
-            {tt::CBIndex::c_3, 1},                                                             // mask
-            {tt::CBIndex::c_16, 2},                                                            // input_grad
-            {tt::CBIndex::c_24, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // output * output_grad
-            {tt::CBIndex::c_25, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // reduce
-            {tt::CBIndex::c_26, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // dy - sum
-            {tt::CBIndex::c_27,
-             2,
-             fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // add(output * output_grad)
-        });
+    // output
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // output_grad
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // scaler
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_2),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // mask
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_3),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // input_grad
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // output * output_grad
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // reduce
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // dy - sum
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_26),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // add(output * output_grad)
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_27),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
 
     // create read/write kernel
-
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
-    std::map<std::string, std::string> compute_defines;
+    std::map<std::string, std::string> reader_defines_map;
+    std::map<std::string, std::string> compute_defines_map;
     if (op == MorehSoftmaxBackwardOp::SOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines_map["SOFTMAX"] = "1";
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines_map["SOFTMIN"] = "1";
     }
 
     if (op == MorehSoftmaxBackwardOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
-        reader_defines["LOG"] = "1";
+        compute_defines_map["LOG"] = "1";
+        reader_defines_map["LOG"] = "1";
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines_map["FP32_DEST_ACC_EN"] = "1";
     }
+    KernelDescriptor::Defines reader_defines(reader_defines_map.begin(), reader_defines_map.end());
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
 
-    std::vector<uint32_t> reader_ct_args = {};
+    KernelDescriptor::CompileTimeArgs reader_ct_args = {};
     TensorAccessorArgs(*output.buffer()).append_to(reader_ct_args);
     TensorAccessorArgs(*output_grad.buffer()).append_to(reader_ct_args);
-    auto reader_kernel_id = CreateReadKernel(
-        program,
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/"
-        "reader_moreh_softmax_backward_w_large.cpp",
-        all_cores,
-        reader_ct_args,
-        reader_defines);
-    std::vector<uint32_t> writer_ct_args = {};
+        "reader_moreh_softmax_backward_w_large.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor::CompileTimeArgs writer_ct_args = {};
     TensorAccessorArgs(*input_grad.buffer()).append_to(writer_ct_args);
-    auto writer_kernel_id = CreateWriteKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_w.cpp",
-        all_cores,
-        writer_ct_args,
-        writer_defines);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_w.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
 
     // create compute kernel
-    CreateComputeKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w_large.cpp",
-        {
-            {core_group_1, num_tiles_per_core_group_1, {num_tiles_per_core_group_1, Wt}},
-            {core_group_2, num_tiles_per_core_group_2, {num_tiles_per_core_group_2, Wt}},
-        },
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w_large.cpp";
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {num_tiles_per_core_group_1, Wt};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source =
+            "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w_large.cpp";
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {num_tiles_per_core_group_2, Wt};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
+    }
 
     // Set Runtime Args
     auto core_x_offset = core_range.start_coord.x;
@@ -138,48 +246,29 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWLargeFactory::create(
         if (mask_w == 0) {
             mask_w = tt::constants::TILE_WIDTH;
         }
-        std::vector<uint32_t> reader_args = {
-            output.buffer()->address(),
-            output_grad.buffer()->address(),
-            num_tiles_per_core,
-            tile_offset,
-            Wt,
-            *reinterpret_cast<uint32_t*>(&scaler),
-            mask_w};
+        reader_desc.emplace_runtime_args(
+            core,
+            {output.buffer(),
+             output_grad.buffer(),
+             num_tiles_per_core,
+             tile_offset,
+             Wt,
+             std::bit_cast<uint32_t>(scaler),
+             mask_w});
 
-        std::vector<uint32_t> writer_args = {input_grad.buffer()->address(), num_tiles_per_core, tile_offset, Wt};
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(core, {input_grad.buffer(), num_tiles_per_core, tile_offset, Wt});
 
         tile_offset += num_tiles_per_core * Wt;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, core_h}};
-}
-
-void MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWLargeFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& input_grad) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& num_cores = cached_program.shared_variables.num_cores;
-    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = tensor_args.output_tensor.buffer()->address();
-            runtime_args[1] = tensor_args.output_grad_tensor.buffer()->address();
-        }
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = input_grad.buffer()->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
 
 }  // namespace ttnn::operations::moreh::moreh_softmax_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_small/softmax_backward_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_small/softmax_backward_w_small.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <bit>
 #include <string>
 
 #include "ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp"
@@ -10,11 +11,13 @@
 
 namespace ttnn::operations::moreh::moreh_softmax_backward {
 
-MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWSmallFactory::cached_program_t
-MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWSmallFactory::create(
+tt::tt_metal::ProgramDescriptor MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWSmallFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& input_grad) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
     log_info(tt::LogTest, "Small tensor algorithm selected");
     const auto& output = tensor_args.output_tensor;
     const auto& output_grad = tensor_args.output_grad_tensor;
@@ -43,74 +46,170 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWSmallFactory::create(
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     // create circular buffers
     tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(input_grad.dtype());
+    tt::DataFormat intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
+    const uint32_t tile_size_data = tile_size(data_format);
+    const uint32_t tile_size_intermed = tile_size(intermed_data_format);
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        data_format,
-        {
-            {tt::CBIndex::c_0, Wt},                                                             // output
-            {tt::CBIndex::c_1, Wt},                                                             // output_grad
-            {tt::CBIndex::c_2, 1},                                                              // scaler
-            {tt::CBIndex::c_3, 1},                                                              // mask
-            {tt::CBIndex::c_16, 2},                                                             // input_grad
-            {tt::CBIndex::c_24, Wt, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // output * output_grad
-            {tt::CBIndex::c_25, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},   // reduce
-            {tt::CBIndex::c_26, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},   // dy - sum
-        });
+    // output
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = Wt * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // output_grad
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = Wt * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // scaler
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_2),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // mask
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_3),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // input_grad
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * tile_size_data,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = data_format,
+            .page_size = tile_size_data,
+        }}},
+    });
+    // output * output_grad
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = Wt * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // reduce
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+    // dy - sum
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 1 * tile_size_intermed,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_26),
+            .data_format = intermed_data_format,
+            .page_size = tile_size_intermed,
+        }}},
+    });
+
     // create read/write kernel
-
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
-
-    std::vector<uint32_t> reader_ct_args = {};
+    KernelDescriptor::CompileTimeArgs reader_ct_args = {};
     TensorAccessorArgs(*output.buffer()).append_to(reader_ct_args);
     TensorAccessorArgs(*output_grad.buffer()).append_to(reader_ct_args);
-    auto reader_kernel_id = CreateReadKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_w.cpp",
-        all_cores,
-        reader_ct_args,
-        reader_defines);
-    std::vector<uint32_t> writer_ct_args = {};
-    TensorAccessorArgs(*input_grad.buffer()).append_to(writer_ct_args);
-    auto writer_kernel_id = CreateWriteKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_w.cpp",
-        all_cores,
-        writer_ct_args,
-        writer_defines);
 
-    std::map<std::string, std::string> compute_defines;
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/reader_moreh_softmax_backward_w.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor::CompileTimeArgs writer_ct_args = {};
+    TensorAccessorArgs(*input_grad.buffer()).append_to(writer_ct_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/writer_moreh_softmax_w.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    std::map<std::string, std::string> compute_defines_map;
     if (op == MorehSoftmaxBackwardOp::SOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines_map["SOFTMAX"] = "1";
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines_map["SOFTMIN"] = "1";
     }
 
     if (op == MorehSoftmaxBackwardOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
+        compute_defines_map["LOG"] = "1";
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines_map["FP32_DEST_ACC_EN"] = "1";
     }
+    KernelDescriptor::Defines compute_defines(compute_defines_map.begin(), compute_defines_map.end());
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+
     // create compute kernel
-    CreateComputeKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w.cpp",
-        {
-            {core_group_1, num_tiles_per_core_group_1, {num_tiles_per_core_group_1, Wt}},
-            {core_group_2, num_tiles_per_core_group_2, {num_tiles_per_core_group_2, Wt}},
-        },
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w.cpp";
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {num_tiles_per_core_group_1, Wt};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source =
+            "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w.cpp";
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {num_tiles_per_core_group_2, Wt};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
+    }
 
     // Set Runtime Args
     auto core_x_offset = core_range.start_coord.x;
@@ -131,48 +230,29 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWSmallFactory::create(
         if (mask_w == 0) {
             mask_w = tt::constants::TILE_WIDTH;
         }
-        std::vector<uint32_t> reader_args = {
-            output.buffer()->address(),
-            output_grad.buffer()->address(),
-            num_tiles_per_core,
-            tile_offset,
-            Wt,
-            *reinterpret_cast<uint32_t*>(&scaler),
-            mask_w};
+        reader_desc.emplace_runtime_args(
+            core,
+            {output.buffer(),
+             output_grad.buffer(),
+             num_tiles_per_core,
+             tile_offset,
+             Wt,
+             std::bit_cast<uint32_t>(scaler),
+             mask_w});
 
-        std::vector<uint32_t> writer_args = {input_grad.buffer()->address(), num_tiles_per_core, tile_offset, Wt};
-
-        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
-        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        writer_desc.emplace_runtime_args(core, {input_grad.buffer(), num_tiles_per_core, tile_offset, Wt});
 
         tile_offset += num_tiles_per_core * Wt;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, core_h}};
-}
-
-void MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWSmallFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& input_grad) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& num_cores = cached_program.shared_variables.num_cores;
-    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = tensor_args.output_tensor.buffer()->address();
-            runtime_args[1] = tensor_args.output_grad_tensor.buffer()->address();
-        }
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = input_grad.buffer()->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
 
 }  // namespace ttnn::operations::moreh::moreh_softmax_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_h_program_factory.cpp
@@ -12,34 +12,34 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 namespace ttnn::operations::moreh::moreh_sum {
-MorehSumOperation::MorehSumHIntFactory::cached_program_t MorehSumOperation::MorehSumHIntFactory::create(
+
+tt::tt_metal::ProgramDescriptor MorehSumOperation::MorehSumHIntFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
-    auto input = tensor_args.input;
-    const auto& output = output_tensor;
+    tensor_return_value_t& output) {
+    using namespace tt;
+    using namespace tt::tt_metal;
 
-    auto memory_config = operation_attributes.memory_config;
+    const auto& input = tensor_args.input;
     const DeviceComputeKernelConfig& compute_kernel_config = operation_attributes.compute_kernel_config;
 
-    tt::tt_metal::IDevice* device{input.device()};
-    tt::tt_metal::Program program{tt::tt_metal::CreateProgram()};
+    IDevice* device{input.device()};
 
     const auto cb_data_format{datatype_to_dataformat_converter(output.dtype())};
     const auto& shape{input.padded_shape()};
 
     const auto [W, H, other_dims_product] = extract_spatial_dims(shape);
-    uint32_t Wt{W / tt::constants::TILE_WIDTH};
-    uint32_t Ht{H / tt::constants::TILE_HEIGHT};
+    uint32_t Wt{W / constants::TILE_WIDTH};
+    uint32_t Ht{H / constants::TILE_HEIGHT};
     uint32_t HtWt{Ht * Wt};
-    [[maybe_unused]] uint32_t num_tiles = input.physical_volume() / tt::constants::TILE_HW;
+    [[maybe_unused]] uint32_t num_tiles = input.physical_volume() / constants::TILE_HW;
     auto num_cols{other_dims_product * Wt};
 
     // check mask for h-dim
     const auto& input_shape_without_padding{input.logical_shape()};
     const auto origin_H{input_shape_without_padding[-2]};
-    const bool do_mask_h{(origin_H % tt::constants::TILE_HEIGHT) != 0};
-    const auto mask_h{do_mask_h ? origin_H % tt::constants::TILE_HEIGHT : tt::constants::TILE_HEIGHT};
+    const bool do_mask_h{(origin_H % constants::TILE_HEIGHT) != 0};
+    const auto mask_h{do_mask_h ? origin_H % constants::TILE_HEIGHT : constants::TILE_HEIGHT};
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
@@ -69,7 +69,7 @@ MorehSumOperation::MorehSumHIntFactory::cached_program_t MorehSumOperation::More
     const uint32_t out0_t{2};       // output
     const auto
         [num_cores, all_cores, core_group_1, core_group_2, num_cols_per_core_group_1, num_cols_per_core_group_2] =
-            tt::tt_metal::split_work_to_cores(grid, num_cols);
+            split_work_to_cores(grid, num_cols);
 
     log_debug(
         tt::LogOp,
@@ -79,77 +79,136 @@ MorehSumOperation::MorehSumHIntFactory::cached_program_t MorehSumOperation::More
         num_cols_per_core_group_1,
         num_cols_per_core_group_2);
 
+    uint32_t cb_tile_size = tile_size(cb_data_format);
+
+    ProgramDescriptor desc;
+
     ////////////////////////////////////////////////////////////////////////////
     //                         CircularBuffer Setup
     ////////////////////////////////////////////////////////////////////////////
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        cb_data_format,
-        {
-            {tt::CBIndex::c_0, in0_t},         // input
-            {tt::CBIndex::c_1, in1_t},         // mask
-            {tt::CBIndex::c_24, intermed0_t},  // accumulated sum
-            {tt::CBIndex::c_16, out0_t},       // output
-        });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in0_t * cb_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = cb_data_format,
+            .page_size = cb_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in1_t * cb_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+            .data_format = cb_data_format,
+            .page_size = cb_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = intermed0_t * cb_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = cb_data_format,
+            .page_size = cb_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = out0_t * cb_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = cb_data_format,
+            .page_size = cb_tile_size,
+        }}},
+    });
+
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> reader_compile_time_args = {Ht, Wt};
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args = {Ht, Wt};
     TensorAccessorArgs(input.buffer()).append_to(reader_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines{};
+    KernelDescriptor::Defines reader_defines;
     if (do_mask_h) {
-        reader_defines["DO_MASK_H"] = "1";
+        reader_defines.emplace_back("DO_MASK_H", "1");
     }
-    std::vector<uint32_t> writer_compile_time_args = {};
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_int_sum_h.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args;
     TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
-    const auto* const reader_kernel_file{
-        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_int_sum_h.cpp"};
-    const auto* const writer_kernel_file{
-        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/writer_moreh_int_sum_h.cpp"};
-    const auto reader_kernel_id{
-        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines)};
-    const auto writer_kernel_id{CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args)};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/writer_moreh_int_sum_h.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const std::vector<uint32_t> compute_args_group_1{
+    KernelDescriptor::Defines compute_defines;
+    if (fp32_dest_acc_en) {
+        compute_defines.emplace_back("FP32_DEST_ACC_EN", "1");
+    }
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+
+    const auto* const compute_kernel_file{
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_int_sum_h.cpp"};
+
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {
         num_cols_per_core_group_1,  // num_cols
         Ht,                         // Ht
         origin_H};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
 
-    std::map<std::string, std::string> compute_defines;
-    if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
-    }
-    const auto* const compute_kernel_file{
-        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_int_sum_h.cpp"};
-    CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {core_group_1, num_cols_per_core_group_1, compute_args_group_1},
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
-
-    std::optional<KernelHandle> compute_kernel_2_id{std::nullopt};
-    if (!core_group_2.ranges().empty()) {
-        const std::vector<uint32_t> compute_args_group_2{
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {
             num_cols_per_core_group_2,  // num_cols
             Ht,                         // Ht
             origin_H};
-        compute_kernel_2_id = CreateComputeKernel(
-            program,
-            compute_kernel_file,
-            {core_group_2, num_cols_per_core_group_2, compute_args_group_2},
-            compute_defines,
-            math_fidelity,
-            fp32_dest_acc_en,
-            math_approx_mode);
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
     }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      RuntimeArgs SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    auto* const input_buf = input.buffer();
+    auto* const output_buf = output.buffer();
     for (uint32_t i = 0, num_cols_read = 0; i < num_cores; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
@@ -162,22 +221,18 @@ MorehSumOperation::MorehSumHIntFactory::cached_program_t MorehSumOperation::More
             TT_THROW("Core not in specified core ranges.");
         }
 
-        SetRuntimeArgs(
-            program,
-            reader_kernel_id,
+        reader_desc.emplace_runtime_args(
             core,
-            {input.buffer()->address(),
+            {input_buf,
              (num_cols_read / Wt * HtWt) + (num_cols_read % Wt),
              num_cols_read % Wt,
              num_cols_per_core,
              mask_h});
 
-        SetRuntimeArgs(
-            program,
-            writer_kernel_id,
+        writer_desc.emplace_runtime_args(
             core,
             {
-                output.buffer()->address(),
+                output_buf,
                 num_cols_per_core,  // number of tiles to write
                 num_cols_read       // output tile start index
             });
@@ -185,36 +240,14 @@ MorehSumOperation::MorehSumHIntFactory::cached_program_t MorehSumOperation::More
         num_cols_read += num_cols_per_core;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, num_cores_y}};
-}
-
-void MorehSumOperation::MorehSumHIntFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto num_cores = cached_program.shared_variables.num_cores;
-    auto num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    log_debug(tt::LogOp, "{}:{} args_callback ", __func__, __LINE__);
-    auto* src_dram_buffer = tensor_args.input.buffer();
-    auto* dst_dram_buffer = tensor_return_value.buffer();
-
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = src_dram_buffer->address();
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = dst_dram_buffer->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::operations::moreh::moreh_sum

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_nc_program_factory.cpp
@@ -12,19 +12,20 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 namespace ttnn::operations::moreh::moreh_sum {
-MorehSumOperation::MorehSumNCIntFactory::cached_program_t MorehSumOperation::MorehSumNCIntFactory::create(
+
+tt::tt_metal::ProgramDescriptor MorehSumOperation::MorehSumNCIntFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
-    auto input = tensor_args.input;
-    const auto& output = output_tensor;
+    tensor_return_value_t& output) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    const auto& input = tensor_args.input;
     auto dim = operation_attributes.dim;
 
-    auto memory_config = operation_attributes.memory_config;
     const DeviceComputeKernelConfig& compute_kernel_config = operation_attributes.compute_kernel_config;
 
-    tt::tt_metal::IDevice* device{input.device()};
-    tt::tt_metal::Program program{tt::tt_metal::CreateProgram()};
+    IDevice* device{input.device()};
 
     const auto cb_data_format{datatype_to_dataformat_converter(output.dtype())};
 
@@ -32,7 +33,7 @@ MorehSumOperation::MorehSumNCIntFactory::cached_program_t MorehSumOperation::Mor
     const auto [Wt, Ht, inner_tile_size, reduce_tile_size] =
         extract_and_scale_spatial_dims(input_shape, static_cast<uint32_t>(dim));
     const auto num_reduce_input_tile{input_shape[dim]};
-    const auto num_output_tiles{output.physical_volume() / tt::constants::TILE_HW};
+    const auto num_output_tiles{output.physical_volume() / constants::TILE_HW};
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
 
@@ -68,64 +69,111 @@ MorehSumOperation::MorehSumNCIntFactory::cached_program_t MorehSumOperation::Mor
          core_group_1,
          core_group_2,
          num_cols_per_core_group_1,
-         num_cols_per_core_group_2] = tt::tt_metal::split_work_to_cores(grid, num_output_tiles);
+         num_cols_per_core_group_2] = split_work_to_cores(grid, num_output_tiles);
 
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        cb_data_format,
-        {
-            {tt::CBIndex::c_0, in0_t},         // input
-            {tt::CBIndex::c_24, intermed0_t},  // accumulated sum
-            {tt::CBIndex::c_16, out0_t},       // output
-        });
+    uint32_t cb_tile_size = tile_size(cb_data_format);
 
-    std::vector<uint32_t> reader_compile_time_args = {};
-    std::vector<uint32_t> writer_compile_time_args = {};
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in0_t * cb_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = cb_data_format,
+            .page_size = cb_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = intermed0_t * cb_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = cb_data_format,
+            .page_size = cb_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = out0_t * cb_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = cb_data_format,
+            .page_size = cb_tile_size,
+        }}},
+    });
+
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args;
     TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
-    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
-    const auto* const reader_kernel_file =
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/reader_moreh_sum_nc.cpp";
-    const auto* const writer_kernel_file =
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args;
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/writer_moreh_sum_nc.cpp";
-    const auto reader_kernel_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args);
-    const auto writer_kernel_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const std::vector<uint32_t> compute_args_group_1{num_cols_per_core_group_1, num_reduce_input_tile};
-    std::map<std::string, std::string> compute_defines;
+    KernelDescriptor::Defines compute_defines;
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines.emplace_back("FP32_DEST_ACC_EN", "1");
     }
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+
     const auto* const compute_kernel_file =
         "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_int_sum_nc.cpp";
-    CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {core_group_1, num_cols_per_core_group_1, compute_args_group_1},
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
 
-    std::optional<KernelHandle> compute_kernel_2_id = std::nullopt;
-    if (!core_group_2.ranges().empty()) {
-        const std::vector<uint32_t> compute_args_group_2{num_cols_per_core_group_2, num_reduce_input_tile};
-        compute_kernel_2_id = CreateComputeKernel(
-            program,
-            compute_kernel_file,
-            {core_group_2, num_cols_per_core_group_2, compute_args_group_2},
-            compute_defines,
-            math_fidelity,
-            fp32_dest_acc_en,
-            math_approx_mode);
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {num_cols_per_core_group_1, static_cast<uint32_t>(num_reduce_input_tile)};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {num_cols_per_core_group_2, static_cast<uint32_t>(num_reduce_input_tile)};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
     }
 
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
+    auto* const input_buf = input.buffer();
+    auto* const output_buf = output.buffer();
     for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
@@ -138,51 +186,29 @@ MorehSumOperation::MorehSumNCIntFactory::cached_program_t MorehSumOperation::Mor
             TT_THROW("Core not in specified core ranges.");
         }
 
-        SetRuntimeArgs(
-            program,
-            reader_kernel_id,
+        reader_desc.emplace_runtime_args(
             core,
-            {input.buffer()->address(),
-             num_reduce_input_tile,
+            {input_buf,
+             static_cast<uint32_t>(num_reduce_input_tile),
              num_tiles_per_core,
              tile_offset,
              static_cast<uint32_t>(dim),
              reduce_tile_size,
              inner_tile_size});
 
-        SetRuntimeArgs(program, writer_kernel_id, core, {output.buffer()->address(), num_tiles_per_core, tile_offset});
+        writer_desc.emplace_runtime_args(core, {output_buf, num_tiles_per_core, tile_offset});
 
         tile_offset += num_tiles_per_core;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores_to_be_used, num_cores_y}};
-}
-
-void MorehSumOperation::MorehSumNCIntFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto num_cores = cached_program.shared_variables.num_cores;
-    auto num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    log_debug(tt::LogOp, "{}:{} args_callback ", __func__, __LINE__);
-    const auto* input_buffer{tensor_args.input.buffer()};
-    const auto* output_buffer{tensor_return_value.buffer()};
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = input_buffer->address();
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = output_buffer->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::operations::moreh::moreh_sum

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_w_program_factory.cpp
@@ -12,18 +12,18 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 namespace ttnn::operations::moreh::moreh_sum {
-MorehSumOperation::MorehSumWIntFactory::cached_program_t MorehSumOperation::MorehSumWIntFactory::create(
+
+tt::tt_metal::ProgramDescriptor MorehSumOperation::MorehSumWIntFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
-    auto input = tensor_args.input;
-    const auto& output = output_tensor;
+    tensor_return_value_t& output) {
+    using namespace tt;
+    using namespace tt::tt_metal;
 
-    auto memory_config = operation_attributes.memory_config;
+    const auto& input = tensor_args.input;
     const DeviceComputeKernelConfig& compute_kernel_config = operation_attributes.compute_kernel_config;
 
-    tt::tt_metal::IDevice* device{input.device()};
-    tt::tt_metal::Program program{tt::tt_metal::CreateProgram()};
+    IDevice* device{input.device()};
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
@@ -32,16 +32,16 @@ MorehSumOperation::MorehSumWIntFactory::cached_program_t MorehSumOperation::More
     const auto& shape{input.padded_shape()};
 
     const auto [W, H, other_dims_product] = extract_spatial_dims(shape);
-    uint32_t Wt{W / tt::constants::TILE_WIDTH};
-    uint32_t Ht{H / tt::constants::TILE_HEIGHT};
-    [[maybe_unused]] uint32_t num_tiles = input.physical_volume() / tt::constants::TILE_HW;
+    uint32_t Wt{W / constants::TILE_WIDTH};
+    uint32_t Ht{H / constants::TILE_HEIGHT};
+    [[maybe_unused]] uint32_t num_tiles = input.physical_volume() / constants::TILE_HW;
     auto num_rows{other_dims_product * Ht};
 
     // check mask for w-dim
     const auto& input_shape_without_padding{input.logical_shape()};
     const auto origin_W{input_shape_without_padding[-1]};
-    const bool do_mask_w{(origin_W % tt::constants::TILE_WIDTH) != 0};
-    const auto mask_w{do_mask_w ? origin_W % tt::constants::TILE_WIDTH : tt::constants::TILE_WIDTH};
+    const bool do_mask_w{(origin_W % constants::TILE_WIDTH) != 0};
+    const auto mask_w{do_mask_w ? origin_W % constants::TILE_WIDTH : constants::TILE_WIDTH};
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
@@ -71,7 +71,7 @@ MorehSumOperation::MorehSumWIntFactory::cached_program_t MorehSumOperation::More
     const uint32_t out0_t{2};       // output
     const auto
         [num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2] =
-            tt::tt_metal::split_work_to_cores(grid, num_rows);
+            split_work_to_cores(grid, num_rows);
 
     log_debug(
         tt::LogOp,
@@ -81,82 +81,137 @@ MorehSumOperation::MorehSumWIntFactory::cached_program_t MorehSumOperation::More
         num_rows_per_core_group_1,
         num_rows_per_core_group_2);
 
+    uint32_t cb_tile_size = tile_size(cb_data_format);
+
+    ProgramDescriptor desc;
+
     ////////////////////////////////////////////////////////////////////////////
     //                         CircularBuffer Setup
     ////////////////////////////////////////////////////////////////////////////
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        cb_data_format,
-        {
-            {tt::CBIndex::c_0, in0_t},         // input
-            {tt::CBIndex::c_1, in1_t},         // mask
-            {tt::CBIndex::c_24, intermed0_t},  // accumulated sum
-            {tt::CBIndex::c_16, out0_t},       // output
-        });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in0_t * cb_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = cb_data_format,
+            .page_size = cb_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in1_t * cb_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+            .data_format = cb_data_format,
+            .page_size = cb_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = intermed0_t * cb_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = cb_data_format,
+            .page_size = cb_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = out0_t * cb_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = cb_data_format,
+            .page_size = cb_tile_size,
+        }}},
+    });
+
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> reader_compile_time_args = {};
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args;
     TensorAccessorArgs(input.buffer()).append_to(reader_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines{};
+    KernelDescriptor::Defines reader_defines;
     if (do_mask_w) {
-        reader_defines["DO_MASK_W"] = "1";
+        reader_defines.emplace_back("DO_MASK_W", "1");
     }
-    std::vector<uint32_t> writer_compile_time_args = {};
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_int_sum_w.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args;
     TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
-    const auto* const reader_kernel_file{
-        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_int_sum_w.cpp"};
-    const auto* const writer_kernel_file{
-        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/writer_moreh_int_sum_w.cpp"};
-    const auto reader_kernel_id{
-        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines)};
-    const auto writer_kernel_id{CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args)};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/writer_moreh_int_sum_w.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const std::vector<uint32_t> compute_args_group_1{
+    KernelDescriptor::Defines compute_defines;
+    if (fp32_dest_acc_en) {
+        compute_defines.emplace_back("FP32_DEST_ACC_EN", "1");
+    }
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+
+    const auto* const compute_kernel_file{
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_int_sum_w.cpp"};
+
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {
         num_rows_per_core_group_1,  // num_rows
         Wt,                         // Wt
         origin_W};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
 
-    std::map<std::string, std::string> compute_defines;
-    if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
-    }
-    const auto* const compute_kernel_file{
-        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_int_sum_w.cpp"};
-    CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {core_group_1, num_rows_per_core_group_1, compute_args_group_1},
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode);
-
-    std::optional<KernelHandle> compute_kernel_2_id{std::nullopt};
-    if (!core_group_2.ranges().empty()) {
-        const std::vector<uint32_t> compute_args_group_2{
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {
             num_rows_per_core_group_2,  // num_rows
             Wt,                         // Wt
             origin_W};
-        compute_kernel_2_id = CreateComputeKernel(
-            program,
-            compute_kernel_file,
-            {core_group_2, num_rows_per_core_group_2, compute_args_group_2},
-            compute_defines,
-            math_fidelity,
-            fp32_dest_acc_en,
-            math_approx_mode);
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
     }
 
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
     uint32_t out_dim_divider{Wt};
+    auto* const input_buf = input.buffer();
+    auto* const output_buf = output.buffer();
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
@@ -170,21 +225,18 @@ MorehSumOperation::MorehSumWIntFactory::cached_program_t MorehSumOperation::More
         }
 
         uint32_t num_tensor_tiles_per_core{num_rows_per_core * Wt};
-        SetRuntimeArgs(
-            program,
-            reader_kernel_id,
+
+        reader_desc.emplace_runtime_args(
             core,
-            {input.buffer()->address(),
+            {input_buf,
              num_tensor_tiles_per_core,
              tile_offset,  // tile index of row to start reading from
              mask_w});
 
-        SetRuntimeArgs(
-            program,
-            writer_kernel_id,
+        writer_desc.emplace_runtime_args(
             core,
             {
-                output.buffer()->address(),
+                output_buf,
                 num_tensor_tiles_per_core / out_dim_divider,  // number of tiles to write
                 tile_offset / out_dim_divider                 // output tile start index
             });
@@ -192,36 +244,14 @@ MorehSumOperation::MorehSumWIntFactory::cached_program_t MorehSumOperation::More
         tile_offset += num_tensor_tiles_per_core;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, num_cores_y}};
-}
-
-void MorehSumOperation::MorehSumWIntFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto num_cores = cached_program.shared_variables.num_cores;
-    auto num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    log_debug(tt::LogOp, "{}:{} args_callback ", __func__, __LINE__);
-    auto* src_dram_buffer{tensor_args.input.buffer()};
-    auto* dst_dram_buffer{tensor_return_value.buffer()};
-
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = src_dram_buffer->address();
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = dst_dram_buffer->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::operations::moreh::moreh_sum

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.hpp
@@ -10,29 +10,7 @@
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/types.hpp"
 #include "ttnn/device_operation.hpp"
-
-#define MOREH_SUM_FACTORY_H(name)                                                           \
-    struct name {                                                                           \
-        struct shared_variables_t {                                                         \
-            tt::tt_metal::KernelHandle unary_reader_kernel_id;                              \
-            tt::tt_metal::KernelHandle unary_writer_kernel_id;                              \
-            std::size_t num_cores;                                                          \
-            std::size_t num_cores_y;                                                        \
-        };                                                                                  \
-                                                                                            \
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>; \
-                                                                                            \
-        static cached_program_t create(                                                     \
-            const operation_attributes_t& operation_attributes,                             \
-            const tensor_args_t& tensor_args,                                               \
-            tensor_return_value_t& output_tensor);                                          \
-                                                                                            \
-        static void override_runtime_arguments(                                             \
-            cached_program_t& cached_program,                                               \
-            const operation_attributes_t& operation_attributes,                             \
-            const tensor_args_t& tensor_args,                                               \
-            tensor_return_value_t& output_tensor);                                          \
-    };
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::operations::moreh::moreh_sum {
 struct MorehSumOperation {
@@ -52,12 +30,47 @@ struct MorehSumOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
-    MOREH_SUM_FACTORY_H(MorehSumHFactory)
-    MOREH_SUM_FACTORY_H(MorehSumNCFactory)
-    MOREH_SUM_FACTORY_H(MorehSumWFactory)
-    MOREH_SUM_FACTORY_H(MorehSumHIntFactory)
-    MOREH_SUM_FACTORY_H(MorehSumNCIntFactory)
-    MOREH_SUM_FACTORY_H(MorehSumWIntFactory)
+    struct MorehSumHFactory {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
+
+    struct MorehSumNCFactory {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
+
+    struct MorehSumWFactory {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
+
+    struct MorehSumHIntFactory {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
+
+    struct MorehSumNCIntFactory {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
+
+    struct MorehSumWIntFactory {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
 
     using program_factory_t = std::variant<
         MorehSumHFactory,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_program_factory.cpp
@@ -13,30 +13,31 @@
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 
 namespace ttnn::operations::moreh::moreh_sum {
-MorehSumOperation::MorehSumHFactory::cached_program_t MorehSumOperation::MorehSumHFactory::create(
+
+tt::tt_metal::ProgramDescriptor MorehSumOperation::MorehSumHFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
-    auto input = tensor_args.input;
-    const auto& output = output_tensor;
+    tensor_return_value_t& output) {
+    using namespace tt;
+    using namespace tt::tt_metal;
 
-    auto memory_config = operation_attributes.memory_config;
+    const auto& input = tensor_args.input;
     const DeviceComputeKernelConfig& compute_kernel_config = operation_attributes.compute_kernel_config;
 
-    tt::tt_metal::ReduceOpMath reduce_op = tt::tt_metal::ReduceOpMath::SUM;
-    tt::tt_metal::ReduceOpDim reduce_dim = tt::tt_metal::ReduceOpDim::H;
+    ReduceOpMath reduce_op = ReduceOpMath::SUM;
+    ReduceOpDim reduce_dim = ReduceOpDim::H;
     const auto& shape = input.padded_shape();
     const auto [W, H, other_dims_product] = extract_spatial_dims(shape);
 
-    uint32_t Wt = W / tt::constants::TILE_WIDTH;
-    uint32_t Ht = H / tt::constants::TILE_HEIGHT;
+    uint32_t Wt = W / constants::TILE_WIDTH;
+    uint32_t Ht = H / constants::TILE_HEIGHT;
     uint32_t HtWt = Ht * Wt;
 
     // check mask for h-dim
     const auto& input_shape_without_padding = input.logical_shape();
     const auto origin_H = input_shape_without_padding[-2];
-    const bool do_mask_h = (origin_H % tt::constants::TILE_HEIGHT) != 0;
-    const auto mask_h = do_mask_h ? origin_H % tt::constants::TILE_HEIGHT : tt::constants::TILE_HEIGHT;
+    const bool do_mask_h = (origin_H % constants::TILE_HEIGHT) != 0;
+    const auto mask_h = do_mask_h ? origin_H % constants::TILE_HEIGHT : constants::TILE_HEIGHT;
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
@@ -48,21 +49,19 @@ MorehSumOperation::MorehSumHFactory::cached_program_t MorehSumOperation::MorehSu
         fp32_dest_acc_en,
         packer_l1_acc);
 
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+    DataFormat src0_cb_data_format = datatype_to_dataformat_converter(input.dtype());
+    uint32_t src0_single_tile_size = tile_size(src0_cb_data_format);
+    DataFormat scaler_cb_data_format = DataFormat::Float16_b;
+    uint32_t scaler_single_tile_size = tile_size(scaler_cb_data_format);
+    DataFormat mask_h_cb_data_format = DataFormat::Float16_b;
+    uint32_t mask_h_single_tile_size = tile_size(mask_h_cb_data_format);
+    DataFormat intermed_cb_data_format = (fp32_dest_acc_en) ? DataFormat::Float32 : DataFormat::Float16_b;
+    DataFormat intermed1_cb_data_format = DataFormat::Float16_b;
+    uint32_t intermed_single_tile_size = tile_size(intermed_cb_data_format);
+    DataFormat dst_cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    uint32_t dst_single_tile_size = tile_size(dst_cb_data_format);
 
-    tt::DataFormat src0_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
-    uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
-    tt::DataFormat scaler_cb_data_format = tt::DataFormat::Float16_b;
-    uint32_t scaler_single_tile_size = tt::tile_size(scaler_cb_data_format);
-    tt::DataFormat mask_h_cb_data_format = tt::DataFormat::Float16_b;
-    uint32_t mask_h_single_tile_size = tt::tile_size(mask_h_cb_data_format);
-    tt::DataFormat intermed_cb_data_format = (fp32_dest_acc_en) ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
-    tt::DataFormat intermed1_cb_data_format = tt::DataFormat::Float16_b;
-    uint32_t intermed_single_tile_size = tt::tile_size(intermed_cb_data_format);
-    tt::DataFormat dst_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
-    uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
-
-    tt::tt_metal::IDevice* device = input.device();
+    IDevice* device = input.device();
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
@@ -77,117 +76,153 @@ MorehSumOperation::MorehSumHFactory::cached_program_t MorehSumOperation::MorehSu
     std::string compute_kernel_name =
         "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_sum_h.cpp";
 
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
-    uint32_t num_input_tiles = 2;
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_input_tiles * src0_single_tile_size, {{src0_cb_index, src0_cb_data_format}})
-            .set_page_size(src0_cb_index, src0_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    ProgramDescriptor desc;
 
-    uint32_t scaler_cb_index = tt::CBIndex::c_2;
-    tt::tt_metal::CircularBufferConfig cb_scaler_config =
-        tt::tt_metal::CircularBufferConfig(1 * scaler_single_tile_size, {{scaler_cb_index, scaler_cb_data_format}})
-            .set_page_size(scaler_cb_index, scaler_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_scaler_config);
+    // ---- Circular buffers ----
+    constexpr uint32_t num_input_tiles = 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * src0_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = src0_cb_data_format,
+            .page_size = src0_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = scaler_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_2),
+            .data_format = scaler_cb_data_format,
+            .page_size = scaler_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = mask_h_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_3),
+            .data_format = mask_h_cb_data_format,
+            .page_size = mask_h_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = intermed_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = intermed_cb_data_format,
+            .page_size = intermed_single_tile_size,
+        }}},
+    });
+    uint32_t intermed1_single_tile_size = tile_size(intermed1_cb_data_format);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = intermed1_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = intermed1_cb_data_format,
+            .page_size = intermed1_single_tile_size,
+        }}},
+    });
+    constexpr uint32_t num_output_tiles = 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * dst_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = dst_cb_data_format,
+            .page_size = dst_single_tile_size,
+        }}},
+    });
 
-    tt::tt_metal::CircularBufferConfig cb_mask_h_config =
-        tt::tt_metal::CircularBufferConfig(mask_h_single_tile_size, {{tt::CBIndex::c_3, mask_h_cb_data_format}})
-            .set_page_size(tt::CBIndex::c_3, mask_h_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_mask_h_config);
+    // ---- Reader kernel ----
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args = {Ht, Wt, HtWt};
+    TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
 
-    tt::tt_metal::CircularBufferConfig cb_intermed0_config =
-        tt::tt_metal::CircularBufferConfig(intermed_single_tile_size, {{tt::CBIndex::c_24, intermed_cb_data_format}})
-            .set_page_size(tt::CBIndex::c_24, intermed_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed0_config);
-
-    uint32_t intermed1_single_tile_size = tt::tile_size(intermed1_cb_data_format);
-    tt::tt_metal::CircularBufferConfig cb_intermed1_config =
-        tt::tt_metal::CircularBufferConfig(intermed1_single_tile_size, {{tt::CBIndex::c_25, intermed1_cb_data_format}})
-            .set_page_size(tt::CBIndex::c_25, intermed1_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed1_config);
-
-    uint32_t output_cb_index = tt::CBIndex::c_16;  // output operands start at index 16
-    uint32_t num_output_tiles = 2;
-    tt::tt_metal::CircularBufferConfig cb_output_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_output_tiles * dst_single_tile_size, {{output_cb_index, dst_cb_data_format}})
-            .set_page_size(output_cb_index, dst_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
-    tt::tt_metal::Buffer* src0_buffer = input.buffer();
-    tt::tt_metal::KernelHandle reader_kernel_id;
-    std::vector<uint32_t> reader_compile_time_args = {Ht, Wt, HtWt};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-
-    std::map<std::string, std::string> reader_defines;
-    reader_defines["REDUCE_SCALER"] = "1";
+    KernelDescriptor::Defines reader_defines = {{"REDUCE_SCALER", "1"}};
     if (do_mask_h) {
-        reader_defines["DO_MASK_H"] = "1";
+        reader_defines.emplace_back("DO_MASK_H", "1");
     }
-    reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_sum_h.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
 
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    tt::tt_metal::KernelHandle writer_kernel_id;
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_sum_h.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    // ---- Writer kernel ----
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args = {static_cast<uint32_t>(CBIndex::c_16)};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
 
-    writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/writer_moreh_sum_h.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
-    std::map<std::string, std::string> reduce_defines = reduce_op_utils::get_defines(reduce_op, reduce_dim);
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/writer_moreh_sum_h.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // ---- Compute kernels (two groups) ----
+    auto reduce_defines_map = reduce_op_utils::get_defines(reduce_op, reduce_dim);
     if (fp32_dest_acc_en) {
-        reduce_defines["FP32_DEST_ACC_EN"] = "1";
+        reduce_defines_map["FP32_DEST_ACC_EN"] = "1";
+    }
+    KernelDescriptor::Defines reduce_defines(reduce_defines_map.begin(), reduce_defines_map.end());
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (fp32_dest_acc_en) {
+        unpack_to_dest_mode[CBIndex::c_24] = UnpackToDestMode::UnpackToDestFp32;
     }
 
-    std::vector<uint32_t> compute_kernel_args_group_1 = {
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_name;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {
         Ht,                         // Ht
         num_cols_per_core_group_1,  // Wt
         1,                          // NC
-        origin_H};
+        origin_H,
+    };
+    compute_desc_1.defines = reduce_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
 
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
-    if (fp32_dest_acc_en) {
-        unpack_to_dest_mode[tt::CBIndex::c_24] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
-    }
-    tt::tt_metal::CreateKernel(
-        program,
-        compute_kernel_name,
-        core_group_1,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .math_approx_mode = math_approx_mode,
-            .compile_args = compute_kernel_args_group_1,
-            .defines = reduce_defines});
-
-    if (!core_group_2.ranges().empty()) {
-        std::vector<uint32_t> compute_kernel_args_group_2 = {
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_name;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {
             Ht,                         // Ht
             num_cols_per_core_group_2,  // Wt
             1,                          // NC
-            origin_H};
-
-        tt::tt_metal::CreateKernel(
-            program,
-            compute_kernel_name,
-            core_group_2,
-            tt::tt_metal::ComputeConfig{
-                .math_fidelity = math_fidelity,
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .math_approx_mode = math_approx_mode,
-                .compile_args = compute_kernel_args_group_2,
-                .defines = reduce_defines});
+            origin_H,
+        };
+        compute_desc_2.defines = reduce_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
     }
 
+    // ---- Runtime args per core ----
+    auto* const input_buf = input.buffer();
+    auto* const output_buf = output.buffer();
     for (uint32_t i = 0, num_cols_read = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_cols_per_core = 0;
@@ -198,58 +233,32 @@ MorehSumOperation::MorehSumHFactory::cached_program_t MorehSumOperation::MorehSu
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");
         }
-        tt::tt_metal::SetRuntimeArgs(
-            program,
-            reader_kernel_id,
+        reader_desc.emplace_runtime_args(
             core,
-            {input.buffer()->address(),
+            {input_buf,
              (num_cols_read / Wt * HtWt) + (num_cols_read % Wt),
              num_cols_read % Wt,
              num_cols_per_core,
              mask_h});
 
-        tt::tt_metal::SetRuntimeArgs(
-            program,
-            writer_kernel_id,
+        writer_desc.emplace_runtime_args(
             core,
             {
-                output.buffer()->address(),
+                output_buf,
                 num_cols_per_core,  // number of tiles to write
                 num_cols_read       // output tile start index
             });
         num_cols_read += num_cols_per_core;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, num_cores_y}};
-}
-
-void MorehSumOperation::MorehSumHFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto num_cores = cached_program.shared_variables.num_cores;
-    auto num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    log_debug(tt::LogOp, "{}:{} args_callback ", __func__, __LINE__);
-    auto* src_buffer = tensor_args.input.buffer();
-    auto* dst_buffer = tensor_return_value.buffer();
-
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = src_buffer->address();
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = dst_buffer->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::operations::moreh::moreh_sum

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_program_factory.cpp
@@ -12,19 +12,20 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 namespace ttnn::operations::moreh::moreh_sum {
-MorehSumOperation::MorehSumNCFactory::cached_program_t MorehSumOperation::MorehSumNCFactory::create(
+
+tt::tt_metal::ProgramDescriptor MorehSumOperation::MorehSumNCFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
-    auto input = tensor_args.input;
-    const auto& output = output_tensor;
+    tensor_return_value_t& output) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    const auto& input = tensor_args.input;
     auto dim = operation_attributes.dim;
 
-    auto memory_config = operation_attributes.memory_config;
     const DeviceComputeKernelConfig& compute_kernel_config = operation_attributes.compute_kernel_config;
 
-    auto* device = input.device();
-    auto program = Program();
+    IDevice* device = input.device();
 
     const auto cb_data_format = datatype_to_dataformat_converter(output.dtype());
 
@@ -32,7 +33,7 @@ MorehSumOperation::MorehSumNCFactory::cached_program_t MorehSumOperation::MorehS
     const auto [Wt, Ht, inner_tile_size, reduce_tile_size] =
         extract_and_scale_spatial_dims(input_shape, static_cast<uint32_t>(dim));
     const auto num_reduce_input_tile = input_shape[dim];
-    const auto num_output_tiles = output.physical_volume() / tt::constants::TILE_HW;
+    const auto num_output_tiles = output.physical_volume() / constants::TILE_HW;
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
 
@@ -64,77 +65,129 @@ MorehSumOperation::MorehSumNCFactory::cached_program_t MorehSumOperation::MorehS
          core_group_1,
          core_group_2,
          num_cols_per_core_group_1,
-         num_cols_per_core_group_2] = tt::tt_metal::split_work_to_cores(grid, num_output_tiles);
+         num_cols_per_core_group_2] = split_work_to_cores(grid, num_output_tiles);
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                         CircularBuffer Setup
-    ////////////////////////////////////////////////////////////////////////////
-    CreateCircularBuffer(
-        program,
-        all_cores,
-        cb_data_format,
-        {
-            {tt::CBIndex::c_0, in0_t},  // input
-            {tt::CBIndex::c_1, in1_t},  // zero
-            {tt::CBIndex::c_24, intermed0_t, (fp32_dest_acc_en) ? tt::DataFormat::Float32 : cb_data_format},
-            {tt::CBIndex::c_16, out0_t},  // output
-        });
+    auto intermed_data_format = (fp32_dest_acc_en) ? DataFormat::Float32 : cb_data_format;
+    uint32_t tile_size_cb = tile_size(cb_data_format);
+    uint32_t intermed_tile_size = tile_size(intermed_data_format);
+
+    ProgramDescriptor desc;
+
+    // ---- Circular buffers ----
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in0_t * tile_size_cb,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = cb_data_format,
+            .page_size = tile_size_cb,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in1_t * tile_size_cb,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_1),
+            .data_format = cb_data_format,
+            .page_size = tile_size_cb,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = intermed0_t * intermed_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = intermed_data_format,
+            .page_size = intermed_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = out0_t * tile_size_cb,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = cb_data_format,
+            .page_size = tile_size_cb,
+        }}},
+    });
+
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> reader_compile_time_args = {};
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args;
     TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
-    std::map<std::string, std::string> reader_defines;
-    reader_defines["USE_FPU"] = "1";
-    std::vector<uint32_t> writer_compile_time_args = {};
-    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
-    const auto* const reader_kernel_file =
+
+    KernelDescriptor::Defines reader_defines = {{"USE_FPU", "1"}};
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/reader_moreh_sum_nc.cpp";
-    const auto* const writer_kernel_file =
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args;
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/writer_moreh_sum_nc.cpp";
-    const auto reader_kernel_id =
-        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines);
-    const auto writer_kernel_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const std::vector<uint32_t> compute_args_group_1{num_cols_per_core_group_1, num_reduce_input_tile};
-    std::map<std::string, std::string> compute_defines;
+    KernelDescriptor::Defines compute_defines;
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines.emplace_back("FP32_DEST_ACC_EN", "1");
     }
     // set unpack_to_dest_mode to the same value as fp32_dest_acc_en
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
-    const auto* compute_kernel_file =
-        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_sum_nc.cpp";
-    CreateComputeKernel(
-        program,
-        compute_kernel_file,
-        {core_group_1, num_cols_per_core_group_1, compute_args_group_1},
-        compute_defines,
-        math_fidelity,
-        fp32_dest_acc_en,
-        math_approx_mode,
-        unpack_to_dest_mode);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
 
-    std::optional<KernelHandle> compute_kernel_2_id = std::nullopt;
-    if (!core_group_2.ranges().empty()) {
-        const std::vector<uint32_t> compute_args_group_2{num_cols_per_core_group_2, num_reduce_input_tile};
-        compute_kernel_2_id = CreateComputeKernel(
-            program,
-            compute_kernel_file,
-            {core_group_2, num_cols_per_core_group_2, compute_args_group_2},
-            compute_defines,
-            math_fidelity,
-            fp32_dest_acc_en,
-            math_approx_mode,
-            unpack_to_dest_mode);
+    const auto* const compute_kernel_file =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_sum_nc.cpp";
+
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_file;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {num_cols_per_core_group_1, static_cast<uint32_t>(num_reduce_input_tile)};
+    compute_desc_1.defines = compute_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
+
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_file;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {num_cols_per_core_group_2, static_cast<uint32_t>(num_reduce_input_tile)};
+        compute_desc_2.defines = compute_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
     }
 
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
+    auto* const input_buf = input.buffer();
+    auto* const output_buf = output.buffer();
     for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
@@ -147,51 +200,29 @@ MorehSumOperation::MorehSumNCFactory::cached_program_t MorehSumOperation::MorehS
             TT_THROW("Core not in specified core ranges.");
         }
 
-        SetRuntimeArgs(
-            program,
-            reader_kernel_id,
+        reader_desc.emplace_runtime_args(
             core,
-            {input.buffer()->address(),
-             num_reduce_input_tile,
+            {input_buf,
+             static_cast<uint32_t>(num_reduce_input_tile),
              num_tiles_per_core,
              tile_offset,
              static_cast<uint32_t>(dim),
              reduce_tile_size,
              inner_tile_size});
 
-        SetRuntimeArgs(program, writer_kernel_id, core, {output.buffer()->address(), num_tiles_per_core, tile_offset});
+        writer_desc.emplace_runtime_args(core, {output_buf, num_tiles_per_core, tile_offset});
 
         tile_offset += num_tiles_per_core;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores_to_be_used, num_cores_y}};
-}
-
-void MorehSumOperation::MorehSumNCFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto num_cores = cached_program.shared_variables.num_cores;
-    auto num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    log_debug(tt::LogOp, "{}:{} args_callback ", __func__, __LINE__);
-    const auto* input_buffer = tensor_args.input.buffer();
-    const auto* output_buffer = tensor_return_value.buffer();
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = input_buffer->address();
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = output_buffer->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::operations::moreh::moreh_sum

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_program_factory.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include <tt-metalium/bfloat16.hpp>
 #include "moreh_sum_device_operation.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
@@ -13,31 +14,32 @@
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 
 namespace ttnn::operations::moreh::moreh_sum {
-MorehSumOperation::MorehSumWFactory::cached_program_t MorehSumOperation::MorehSumWFactory::create(
+
+tt::tt_metal::ProgramDescriptor MorehSumOperation::MorehSumWFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
-    auto input = tensor_args.input;
-    const auto& output = output_tensor;
+    tensor_return_value_t& output) {
+    using namespace tt;
+    using namespace tt::tt_metal;
 
-    auto memory_config = operation_attributes.memory_config;
+    const auto& input = tensor_args.input;
     const DeviceComputeKernelConfig& compute_kernel_config = operation_attributes.compute_kernel_config;
 
-    tt::tt_metal::ReduceOpMath reduce_op = tt::tt_metal::ReduceOpMath::SUM;
-    tt::tt_metal::ReduceOpDim reduce_dim = tt::tt_metal::ReduceOpDim::W;
+    ReduceOpMath reduce_op = ReduceOpMath::SUM;
+    ReduceOpDim reduce_dim = ReduceOpDim::W;
     float scaler = 1.0f;
 
     const auto& shape = input.padded_shape();
     const auto [W, H, other_dims_product] = extract_spatial_dims(shape);
 
-    uint32_t Wt = W / tt::constants::TILE_WIDTH;
-    uint32_t Ht = H / tt::constants::TILE_HEIGHT;
+    uint32_t Wt = W / constants::TILE_WIDTH;
+    uint32_t Ht = H / constants::TILE_HEIGHT;
 
     // check mask for w-dim
     const auto& input_shape_without_padding = input.logical_shape();
     const auto origin_W = input_shape_without_padding[-1];
-    const bool do_mask_w = (origin_W % tt::constants::TILE_WIDTH) != 0;
-    const auto mask_w = do_mask_w ? origin_W % tt::constants::TILE_WIDTH : tt::constants::TILE_WIDTH;
+    const bool do_mask_w = (origin_W % constants::TILE_WIDTH) != 0;
+    const auto mask_w = do_mask_w ? origin_W % constants::TILE_WIDTH : constants::TILE_WIDTH;
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
@@ -49,22 +51,20 @@ MorehSumOperation::MorehSumWFactory::cached_program_t MorehSumOperation::MorehSu
         fp32_dest_acc_en,
         packer_l1_acc);
 
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
-
-    tt::DataFormat src0_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
-    uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
+    DataFormat src0_cb_data_format = datatype_to_dataformat_converter(input.dtype());
+    uint32_t src0_single_tile_size = tile_size(src0_cb_data_format);
     // Scaler datatype is hardcoded bfloat16 due to tile creation in reader
-    tt::DataFormat scaler_cb_data_format = tt::DataFormat::Float16_b;
-    uint32_t scaler_single_tile_size = tt::tile_size(scaler_cb_data_format);
-    tt::DataFormat mask_w_cb_data_format = tt::DataFormat::Float16_b;
-    uint32_t mask_w_single_tile_size = tt::tile_size(mask_w_cb_data_format);
-    tt::DataFormat intermed_cb_data_format = (fp32_dest_acc_en) ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
-    tt::DataFormat intermed1_cb_data_format = tt::DataFormat::Float16_b;
-    uint32_t intermed_single_tile_size = tt::tile_size(intermed_cb_data_format);
-    tt::DataFormat dst_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
-    uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
+    DataFormat scaler_cb_data_format = DataFormat::Float16_b;
+    uint32_t scaler_single_tile_size = tile_size(scaler_cb_data_format);
+    DataFormat mask_w_cb_data_format = DataFormat::Float16_b;
+    uint32_t mask_w_single_tile_size = tile_size(mask_w_cb_data_format);
+    DataFormat intermed_cb_data_format = (fp32_dest_acc_en) ? DataFormat::Float32 : DataFormat::Float16_b;
+    DataFormat intermed1_cb_data_format = DataFormat::Float16_b;
+    uint32_t intermed_single_tile_size = tile_size(intermed_cb_data_format);
+    DataFormat dst_cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    uint32_t dst_single_tile_size = tile_size(dst_cb_data_format);
 
-    tt::tt_metal::IDevice* device = input.device();
+    IDevice* device = input.device();
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
@@ -79,119 +79,158 @@ MorehSumOperation::MorehSumWFactory::cached_program_t MorehSumOperation::MorehSu
     std::string compute_kernel_name =
         "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_sum_w.cpp";
 
-    uint32_t src0_cb_index = 0;
-    uint32_t num_input_tiles = 2;
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_input_tiles * src0_single_tile_size, {{src0_cb_index, src0_cb_data_format}})
-            .set_page_size(src0_cb_index, src0_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    ProgramDescriptor desc;
 
-    tt::tt_metal::CircularBufferConfig cb_scaler_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_input_tiles * scaler_single_tile_size, {{tt::CBIndex::c_2, scaler_cb_data_format}})
-            .set_page_size(tt::CBIndex::c_2, scaler_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_scaler_config);
+    // ---- Circular buffers ----
+    constexpr uint32_t num_input_tiles = 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * src0_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
+            .data_format = src0_cb_data_format,
+            .page_size = src0_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * scaler_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_2),
+            .data_format = scaler_cb_data_format,
+            .page_size = scaler_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = mask_w_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_3),
+            .data_format = mask_w_cb_data_format,
+            .page_size = mask_w_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = intermed_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_24),
+            .data_format = intermed_cb_data_format,
+            .page_size = intermed_single_tile_size,
+        }}},
+    });
+    uint32_t intermed1_single_tile_size = tile_size(intermed1_cb_data_format);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = intermed1_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_25),
+            .data_format = intermed1_cb_data_format,
+            .page_size = intermed1_single_tile_size,
+        }}},
+    });
+    constexpr uint32_t num_output_tiles = 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * dst_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(CBIndex::c_16),
+            .data_format = dst_cb_data_format,
+            .page_size = dst_single_tile_size,
+        }}},
+    });
 
-    tt::tt_metal::CircularBufferConfig cb_mask_w_config =
-        tt::tt_metal::CircularBufferConfig(mask_w_single_tile_size, {{tt::CBIndex::c_3, mask_w_cb_data_format}})
-            .set_page_size(tt::CBIndex::c_3, mask_w_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_mask_w_config);
-
-    tt::tt_metal::CircularBufferConfig cb_intermed0_config =
-        tt::tt_metal::CircularBufferConfig(intermed_single_tile_size, {{tt::CBIndex::c_24, intermed_cb_data_format}})
-            .set_page_size(tt::CBIndex::c_24, intermed_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed0_config);
-
-    uint32_t intermed1_single_tile_size = tt::tile_size(intermed1_cb_data_format);
-    tt::tt_metal::CircularBufferConfig cb_intermed1_config =
-        tt::tt_metal::CircularBufferConfig(intermed1_single_tile_size, {{tt::CBIndex::c_25, intermed1_cb_data_format}})
-            .set_page_size(tt::CBIndex::c_25, intermed1_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed1_config);
-
-    uint32_t output_cb_index = tt::CBIndex::c_16;
-    uint32_t num_output_tiles = 2;
-    tt::tt_metal::CircularBufferConfig cb_output_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_output_tiles * dst_single_tile_size, {{output_cb_index, dst_cb_data_format}})
-            .set_page_size(output_cb_index, dst_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
-
+    // ---- Reader kernel ----
     bfloat16 bfloat_scaler_value(scaler);
     uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
-    tt::tt_metal::Buffer* src_buffer = input.buffer();
-    std::vector<uint32_t> reader_compile_time_args = {};
-    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+
+    KernelDescriptor::CompileTimeArgs reader_compile_time_args;
+    TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
     reader_compile_time_args.push_back(packed_scaler_value);
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> reader_defines{};
+    KernelDescriptor::Defines reader_defines;
     if (do_mask_w) {
-        reader_defines["DO_MASK_W"] = "1";
+        reader_defines.emplace_back("DO_MASK_W", "1");
     }
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_sum_w.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
 
-    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/writer_moreh_sum_w.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_sum_w.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.defines = std::move(reader_defines);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    std::map<std::string, std::string> reduce_defines = reduce_op_utils::get_defines(reduce_op, reduce_dim);
+    // ---- Writer kernel ----
+    KernelDescriptor::CompileTimeArgs writer_compile_time_args = {static_cast<uint32_t>(CBIndex::c_16)};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/writer_moreh_sum_w.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // ---- Compute kernels (two groups) ----
+    auto reduce_defines_map = reduce_op_utils::get_defines(reduce_op, reduce_dim);
     if (fp32_dest_acc_en) {
-        reduce_defines["FP32_DEST_ACC_EN"] = "1";
+        reduce_defines_map["FP32_DEST_ACC_EN"] = "1";
     }
-    std::vector<uint32_t> compute_kernel_args_group_1 = {
+    KernelDescriptor::Defines reduce_defines(reduce_defines_map.begin(), reduce_defines_map.end());
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (fp32_dest_acc_en) {
+        unpack_to_dest_mode[CBIndex::c_24] = UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    KernelDescriptor compute_desc_1;
+    compute_desc_1.kernel_source = compute_kernel_name;
+    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc_1.core_ranges = core_group_1;
+    compute_desc_1.compile_time_args = {
         num_rows_per_core_group_1,  // Ht
         Wt,                         // Wt
         1,                          // NC
         origin_W,
     };
+    compute_desc_1.defines = reduce_defines;
+    compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
+        .math_approx_mode = math_approx_mode,
+    };
 
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
-    if (fp32_dest_acc_en) {
-        unpack_to_dest_mode[tt::CBIndex::c_24] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
-    }
-    tt::tt_metal::CreateKernel(
-        program,
-        compute_kernel_name,
-        core_group_1,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .math_approx_mode = math_approx_mode,
-            .compile_args = compute_kernel_args_group_1,
-            .defines = reduce_defines});
-
-    if (!core_group_2.ranges().empty()) {
-        std::vector<uint32_t> compute_kernel_args_group_2 = {
+    KernelDescriptor compute_desc_2;
+    bool has_core_group_2 = !core_group_2.ranges().empty();
+    if (has_core_group_2) {
+        compute_desc_2.kernel_source = compute_kernel_name;
+        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc_2.core_ranges = core_group_2;
+        compute_desc_2.compile_time_args = {
             num_rows_per_core_group_2,  // Ht
             Wt,                         // Wt
             1,                          // NC
             origin_W,
         };
-
-        tt::tt_metal::CreateKernel(
-            program,
-            compute_kernel_name,
-            core_group_2,
-            tt::tt_metal::ComputeConfig{
-                .math_fidelity = math_fidelity,
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .math_approx_mode = math_approx_mode,
-                .compile_args = compute_kernel_args_group_2,
-                .defines = reduce_defines});
+        compute_desc_2.defines = reduce_defines;
+        compute_desc_2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .math_approx_mode = math_approx_mode,
+        };
     }
 
+    // ---- Runtime args per core ----
     uint32_t out_dim_divider = Wt;
+    auto* const input_buf = input.buffer();
+    auto* const output_buf = output.buffer();
     for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_rows_per_core = 0;
@@ -203,57 +242,32 @@ MorehSumOperation::MorehSumWFactory::cached_program_t MorehSumOperation::MorehSu
             TT_ASSERT(false, "Core not in specified core ranges");
         }
         uint32_t num_tensor_tiles_per_core = num_rows_per_core * Wt;
-        tt::tt_metal::SetRuntimeArgs(
-            program,
-            reader_kernel_id,
+
+        reader_desc.emplace_runtime_args(
             core,
-            {input.buffer()->address(),
+            {input_buf,
              num_tensor_tiles_per_core,
              num_tiles_read,  // tile index of row to start reading from
              mask_w});
 
-        tt::tt_metal::SetRuntimeArgs(
-            program,
-            writer_kernel_id,
+        writer_desc.emplace_runtime_args(
             core,
             {
-                output.buffer()->address(),
+                output_buf,
                 num_tensor_tiles_per_core / out_dim_divider,  // number of tiles to write
                 num_tiles_read / out_dim_divider              // output tile start index
             });
         num_tiles_read += num_tensor_tiles_per_core;
     }
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, num_cores_y}};
-}
-
-void MorehSumOperation::MorehSumWFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto num_cores = cached_program.shared_variables.num_cores;
-    auto num_cores_y = cached_program.shared_variables.num_cores_y;
-
-    log_debug(tt::LogOp, "{}:{} args_callback ", __func__, __LINE__);
-    auto* src_dram_buffer = tensor_args.input.buffer();
-    auto* dst_dram_buffer = tensor_return_value.buffer();
-
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = src_dram_buffer->address();
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = dst_dram_buffer->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc_1));
+    if (has_core_group_2) {
+        desc.kernels.push_back(std::move(compute_desc_2));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::operations::moreh::moreh_sum


### PR DESCRIPTION
Closes #42206. Part of #42193.

Migrates the **15 remaining moreh ops** still on legacy `CachedProgram` / `override_runtime_arguments` to `ProgramDescriptor` + `create_descriptor` with `BufferBinding` fast cache-hit patching.

The other 12 moreh ops originally in this PR (moreh_abs_pow, moreh_adam, moreh_adamw, moreh_arange, moreh_clip_grad_norm × 3 sub-ops, moreh_dot_backward, moreh_fold, moreh_group_norm, moreh_mean_backward, moreh_norm_backward, moreh_sgd, moreh_sum_backward) were split out into separate PRs while this one sat open and have already merged: #42462, #42465, #42468, #42476, #42479, #42480, #42481, #42482, #42492, #42493, #42494, #42496.

## Ops migrated (15 ops, ~34 factory files)

- `moreh_dot`
- `moreh_getitem` (rm + tilized)
- `moreh_group_norm_backward` (gamma_beta_grad + input_grad)
- `moreh_layer_norm`, `moreh_layer_norm_backward` (input_grad + gamma_beta_grad)
- `moreh_linear_backward` (single + multi core)
- `moreh_matmul`
- `moreh_mean` (H, NC, W)
- `moreh_nll_loss` step1/step2, `moreh_nll_loss_backward`, `moreh_nll_loss_unreduced_backward`
- `moreh_norm` (3 ord variants)
- `moreh_softmax` (5 variants), `moreh_softmax_backward` (5 variants)
- `moreh_sum` (H, NC, W + int variants)

Each factory now exposes a single `static create_descriptor(...)` returning `ProgramDescriptor`; `shared_variables_t` / `cached_program_t` / `create()` / `override_runtime_arguments()` are dropped. Buffer address patching on cache hits is handled by the framework via `emplace_runtime_args(Buffer*, ...)`.

## Tests

Moreh unit-test bucket — green (1536 passed, 2602 skipped for unsupported dtypes).

## Performance

Host-side dispatch only (device kernel time unchanged). Wormhole B0, fresh process per round, 15 paired rounds alternating legacy / migrated, N_WARMUP=10 + N_MEAS=100 per process. Compared `origin/main` (current main, no migration) vs this PR rebased on the same main.

| Op | Legacy main (µs) | Descriptor + binding (µs) | Δ slow-mode | Δ fast-mode |
|---|---:|---:|---:|---:|
| `moreh_softmax dim=3 [1,1,128,128]` | 32.84 | 32.66 | **−0.5%** | +2.1% (n=3) |
| `moreh_sum dim=2 [1,1,64,64]` | 35.02 | 34.69 | **−1.0%** | (n=2) |
| `moreh_layer_norm [1,1,64,64]` | 32.15 | 32.38 | **+0.7%** | (n=2) |
| `moreh_dot [1,1,1,32]` | 32.70 | 35.25 | **+7.8%** | **+9.8%** |

The host runs bimodally: a "fast" mode ~18-26 µs and a "slow" mode ~32-35 µs that each process locks into. Reporting slow-mode median because it has the larger sample size on most ops; fast-mode column shown where the sample is solid (`moreh_dot` had 7+8 samples in each mode).

`moreh_dot` shows a consistent +8-10% in both modes — that's the floor framework-overhead cost vs hand-written `override_runtime_arguments` (matches the SDPA pattern in #43281 before #43675's `apply_resolved_bindings` opts close it). Smaller absolute dispatch budget on `moreh_dot` (1 core, 3 BufferBindings) makes the ~1-2 µs overhead show up as a larger percent. After #43675 lands and this rebases, expect that to drop to ~+2-3%.

### Probe data (300 cache hits across the 3 ops above)

| Stage | Avg | Notes |
|---|---:|---|
| `cache_hit.total` | 10.7 µs | Entire `handle_mesh_adapter_cache_hit` |
| ├─ `apply_descriptor.fast_path` | **305 ns** | BufferBinding patching is engaging |
| ├─ `apply_descriptor_branch` wrapper | 533 ns | |
| └─ `enqueue_mesh_workload` | 9.7 µs | Common to legacy and migrated (dispatch hardware path) |

The migration's BufferBinding fast path is sub-microsecond. `enqueue_mesh_workload` (9.7 µs) is the dominant cost and is identical on both legacy and migrated. Wall-clock 18-19 µs fast-mode per op = cache-hit-total + Python/pybind/validation entry overhead.

The bimodal ~32 µs "slow mode" is not inside the migration code path — it's outside `handle_mesh_adapter_cache_hit`. Likely device dispatch-queue back-pressure (next `EnqueueProgram` blocks waiting for a queue slot); same characteristic on both legacy and migrated.

### Methodology notes
- `PYTHONPATH=<worktree>/ttnn` (with the `/ttnn` suffix) so each side actually loads its own `_ttnn.so`. Verified via `print(ttnn.__file__)` at bench start.
- `TT_METAL_HOME=<worktree>` so the kernel resolver picks up the worktree's `.cpp` (the resolver's priority-1 CWD lookup will otherwise find the main worktree's kernel files).
- Each round is a fresh process to expose the bimodal locking.
- A previous attempt at perf measurement used a baseline forked from `1dabc7` (~3 months stale); cross-binary drift in main's dispatch infra over that window contaminated the delta. Rebuilt baseline at current `origin/main` so legacy and migrated share the same dispatch infrastructure.

UB / type cleanups along the way:
- `*reinterpret_cast<uint32_t*>(&f)` replaced with `std::bit_cast<uint32_t>(f)`.
- bare `sqrt`/`pow` qualified with `std::`; `auto x = sqrt(...)` traps fixed.
- `buffer_index` narrowed via `static_cast<uint8_t>(CBIndex::c_X)`.
- `dst_full_sync_en` propagated into `ComputeConfigDescriptor`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/migrate-reduce-ops-to-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/migrate-reduce-ops-to-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/migrate-reduce-ops-to-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/migrate-reduce-ops-to-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/migrate-reduce-ops-to-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/migrate-reduce-ops-to-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/migrate-reduce-ops-to-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/migrate-reduce-ops-to-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/migrate-reduce-ops-to-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/migrate-reduce-ops-to-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/migrate-reduce-ops-to-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/migrate-reduce-ops-to-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/migrate-reduce-ops-to-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/migrate-reduce-ops-to-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/migrate-reduce-ops-to-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/migrate-reduce-ops-to-descriptor)


