### PR TITLE
Add single-chip MLA proxy tests for ring SDPA

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
+++ b/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
@@ -2,18 +2,234 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+"""
+Single-chip SDPA tests for Blackhole covering WAN 2.2 and DeepSeek MLA 100K configurations.
+
+Layout and naming mirror tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py so each "suite"
+(WAN, MLA, ...) owns its own chunk-size sweep and dtype/shape parameters. The MLA suite is
+sized to replicate the work performed by ring_joint_sdpa at ring iteration 0 — where each
+device runs plain causal SDPA on its local Q/K/V slice (``balancing=false``, ``causality=true``,
+no KV halving).
+"""
+
 import os
 import math
 from unittest import mock
 
 import torch
+from dataclasses import dataclass
 from itertools import product
+from typing import Dict, List
+
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_pcc,
 )
 import ttnn
 from loguru import logger
 import pytest
+
+from tests.nightly.sdpa_perf_utils import (
+    post_process_ops_log,
+    compute_math_utilization,
+    compute_sdpa_flops,
+)
+
+
+# ============================================================================
+# HARDWARE CONFIGURATION (single chip, BH)
+# ============================================================================
+
+SDPA_GRID = [11, 10]  # 11 cols x 10 rows; matches Galaxy per-chip SDPA grid
+NUM_CORES = SDPA_GRID[0] * SDPA_GRID[1]  # 110
+
+BATCH_SIZE = 1
+
+
+# ============================================================================
+# MODEL CONFIGURATIONS
+# ============================================================================
+
+
+@dataclass
+class ModelConfig:
+    """Benchmark configuration for a single-chip SDPA suite (WAN, MLA, ...)."""
+
+    name: str
+    nhq: int
+    nkv: int  # 1 for MLA/MQA; nhq for standard MHA
+    seq_len: int
+    d_q: int  # Q head dim
+    d_k: int  # K head dim (must equal d_q: QK^T matmul constraint). Kept for parity with ring_joint_sdpa.
+    d_v: int  # V head dim (may differ from d_q/d_k for MLA)
+    is_causal: bool
+    q_dtype: ttnn.DataType
+    kv_dtype: ttnn.DataType
+
+    # Chunk-size sweep (cross-product is per-model)
+    q_chunk_sizes: List[int]
+    k_chunk_sizes: List[int]
+
+    # Ring-iter single-chip proxy (see sdpa_config.hpp). All non-"none" cases enable flat
+    # B*NH*q_num_chunks work distribution across the full programmed grid.
+    # "none" → hierarchical (default).
+    # "diag" → flat + causal. Mirrors ring iter 0 per-device work (requires is_causal=True).
+    # "up"   → flat + non-causal. K-loop halved (proxy of ring_index > ring_id).
+    # "down" → flat + non-causal. Only the heavy Q half assigned (proxy of ring_index < ring_id).
+    ring_proxy_case: str = "none"
+
+
+def generate_model_configs() -> Dict[str, ModelConfig]:
+    """Single-chip suites sized to match per-device work on Galaxy/QB."""
+    configs = [
+        # WAN 2.2 — 1xGalaxy analog (single-chip seq = per-device seq on Galaxy)
+        ModelConfig(
+            name="wan2_2_1xGLX_analog",
+            nhq=10,
+            nkv=10,
+            seq_len=9472,
+            d_q=128,
+            d_k=128,
+            d_v=128,
+            is_causal=False,
+            q_dtype=ttnn.bfloat16,
+            kv_dtype=ttnn.bfloat16,
+            q_chunk_sizes=[224, 256, 288],
+            k_chunk_sizes=[128, 256, 512],
+        ),
+        # WAN 2.2 — 4xGalaxy analog
+        ModelConfig(
+            name="wan2_2_4xGLX_analog",
+            nhq=10,
+            nkv=10,
+            seq_len=2368,
+            d_q=128,
+            d_k=128,
+            d_v=128,
+            is_causal=False,
+            q_dtype=ttnn.bfloat16,
+            kv_dtype=ttnn.bfloat16,
+            q_chunk_sizes=[224, 256, 288],
+            k_chunk_sizes=[128, 256, 512],
+        ),
+        # DeepSeek MLA 100K — replicates ring_joint_sdpa ring iter 0 per-device work.
+        # At iter 0 for causal+balanced: causality=true, balancing=false, iter_num_kv_chunks
+        # is not halved — i.e. plain causal SDPA on local Q/K/V. nhq=32 matches Galaxy per-device
+        # head count; grid 11x10 matches Galaxy per-chip SDPA columns.
+        ModelConfig(
+            name="mla_100k_ring_iter_0",
+            nhq=32,
+            nkv=1,
+            seq_len=3200,
+            d_q=576,
+            d_k=576,
+            d_v=128,
+            is_causal=True,
+            q_dtype=ttnn.bfloat16,
+            kv_dtype=ttnn.bfloat8_b,
+            q_chunk_sizes=[160],
+            k_chunk_sizes=[160],
+            ring_proxy_case="diag",
+        ),
+        # DeepSeek MLA 128K — same ring iter 0 semantics as the 100K suite, longer local seq.
+        ModelConfig(
+            name="mla_128k_ring_iter_0",
+            nhq=32,
+            nkv=1,
+            seq_len=4096,
+            d_q=576,
+            d_k=576,
+            d_v=128,
+            is_causal=True,
+            q_dtype=ttnn.bfloat16,
+            kv_dtype=ttnn.bfloat8_b,
+            q_chunk_sizes=[128],
+            k_chunk_sizes=[128],
+            ring_proxy_case="diag",
+        ),
+        # DeepSeek MLA 100K — ring non-diag iter UP proxy. Mirrors iter-0 shape/chunking; the kernel
+        # only walks the lower half of K per Q (k_num_chunks/2), matching the per-device K-iters a
+        # ring iter with ring_index > ring_id performs.
+        ModelConfig(
+            name="mla_100k_ring_iter_up",
+            nhq=32,
+            nkv=1,
+            seq_len=3200,
+            d_q=576,
+            d_k=576,
+            d_v=128,
+            is_causal=False,
+            q_dtype=ttnn.bfloat16,
+            kv_dtype=ttnn.bfloat8_b,
+            q_chunk_sizes=[160],
+            k_chunk_sizes=[160],
+            ring_proxy_case="up",
+        ),
+        # DeepSeek MLA 100K — ring non-diag iter DOWN proxy. Only the heavy Q half is assigned
+        # (q_num_chunks/2 slots) and each slot walks the full K length, matching the work a ring
+        # iter with ring_index < ring_id performs via its is_balanced Q-skip.
+        ModelConfig(
+            name="mla_100k_ring_iter_down",
+            nhq=32,
+            nkv=1,
+            seq_len=3200,
+            d_q=576,
+            d_k=576,
+            d_v=128,
+            is_causal=False,
+            q_dtype=ttnn.bfloat16,
+            kv_dtype=ttnn.bfloat8_b,
+            q_chunk_sizes=[160],
+            k_chunk_sizes=[160],
+            ring_proxy_case="down",
+        ),
+    ]
+    return {c.name: c for c in configs}
+
+
+MODEL_CONFIGS = generate_model_configs()
+
+
+def get_test_case_id(config: ModelConfig, q_chunk_size: int, k_chunk_size: int) -> str:
+    return f"{config.name}-q{q_chunk_size}-k{k_chunk_size}"
+
+
+def generate_test_configs(model_configs: Dict[str, ModelConfig]):
+    """Build flat (config_tuple, id) list for parametrize across all suites."""
+    configs = []
+    config_ids = []
+    for model in model_configs.values():
+        for q_chunk, k_chunk in product(model.q_chunk_sizes, model.k_chunk_sizes):
+            assert model.d_k == model.d_q, (
+                f"QK^T requires d_q == d_k; got d_q={model.d_q}, d_k={model.d_k} " f"in model {model.name}"
+            )
+            configs.append(
+                (
+                    BATCH_SIZE,
+                    model.nhq,
+                    model.nkv,
+                    model.seq_len,
+                    model.d_q,
+                    model.d_k,
+                    model.d_v,
+                    q_chunk,
+                    k_chunk,
+                    model.is_causal,
+                    model.q_dtype,
+                    model.kv_dtype,
+                    model.ring_proxy_case,
+                )
+            )
+            config_ids.append(get_test_case_id(model, q_chunk, k_chunk))
+    return configs, config_ids
+
+
+TEST_CONFIGS, TEST_CONFIG_IDS = generate_test_configs(MODEL_CONFIGS)
+TEST_CONFIG_MODELS = list(MODEL_CONFIGS.keys())
+
+
+# ============================================================================
+# HELPERS
+# ============================================================================
 
 
 def fa_rand(*shape):
@@ -27,34 +243,89 @@ def is_watcher_enabled():
     return os.environ.get("TT_METAL_WATCHER") is not None
 
 
-def run_sdpa_noncausal(
+def _build_tt_qkv(device, Q, K, V, q_dtype, kv_dtype):
+    tt_Q = ttnn.from_torch(Q, dtype=q_dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
+    tt_K = ttnn.from_torch(K, dtype=kv_dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
+    tt_V = ttnn.from_torch(V, dtype=kv_dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
+    return tt_Q, tt_K, tt_V
+
+
+def _torch_reference(Q, K, V, nhq, nkv, is_causal):
+    """Expand K/V to match Q heads (GQA/MQA), then run torch SDPA."""
+    if nkv != nhq:
+        assert nhq % nkv == 0
+        K = K.repeat_interleave(nhq // nkv, dim=1)
+        V = V.repeat_interleave(nhq // nkv, dim=1)
+    return torch.nn.functional.scaled_dot_product_attention(Q, K, V, is_causal=is_causal)
+
+
+def _proxy_compare_tensors(Q, K, V, tt_torch, sq, nhq, nkv, is_causal, ring_proxy_case):
+    """Build (gt, tt_slice) pair for accuracy/RMSE comparison given the proxy case.
+
+    UP   : kernel attends Q against K/V[:, :, :L/2] over all Q rows.
+    DOWN : kernel writes only the heavy-half Q rows; light-half rows are undefined.
+    other: full L × L attention.
+    """
+    if ring_proxy_case == "up":
+        half = sq // 2
+        gt = _torch_reference(Q, K[:, :, :half, :], V[:, :, :half, :], nhq, nkv, is_causal=False)
+        return gt, tt_torch
+    if ring_proxy_case == "down":
+        half = sq // 2
+        gt = _torch_reference(Q[:, :, half:, :], K, V, nhq, nkv, is_causal=False)
+        return gt, tt_torch[:, :, half:, :]
+    return _torch_reference(Q, K, V, nhq, nkv, is_causal), tt_torch
+
+
+def _proxy_geometry(s, is_causal, ring_proxy_case):
+    """Effective (sq, sk, mm_causal) and per-iter scale factors for perf accounting.
+
+    Returns: (mm_sq, mm_sk, mm_causal, q_slots_factor, k_iters_factor).
+    UP halves K-loop; DOWN halves assigned Q slots. Same FLOPs as iter-0 causal in both cases.
+    """
+    if ring_proxy_case == "up":
+        return s, s // 2, False, 1.0, 0.5
+    if ring_proxy_case == "down":
+        return s // 2, s, False, 0.5, 1.0
+    return s, s, is_causal, 1.0, 1.0
+
+
+# ============================================================================
+# CORE RUNNERS
+# ============================================================================
+
+
+def run_sdpa(
     device,
     b,
-    nh,
+    nhq,
     nkv,
     sq,
-    d,
+    d_q,
+    d_k,
+    d_v,
     q_chunk_size,
     k_chunk_size,
-    dtype,
-    sk=None,
-    pcc_threshold=0.9998,
+    is_causal,
+    q_dtype,
+    kv_dtype,
+    ring_proxy_case="none",
+    *,
+    pcc_threshold=0.9997,
     rmse_threshold=None,
     do_check=True,
 ):
-    # Ensure same seed, reproducibility
+    """Single-chip SDPA. Handles MHA (d_q == d_v, nkv == nhq) and MLA (d_v < d_q, nkv == 1)."""
+    assert d_k == d_q, f"QK^T requires d_q == d_k; got d_q={d_q}, d_k={d_k}"
     torch.manual_seed(1234)
-    if sk is None:
-        sk = sq
 
     program_config = ttnn.SDPAProgramConfig(
-        compute_with_storage_grid_size=[11, 10],
+        compute_with_storage_grid_size=SDPA_GRID,
         q_chunk_size=q_chunk_size,
         k_chunk_size=k_chunk_size,
         exp_approx_mode=False,
+        ring_proxy_case=_ring_proxy_case_enum(ring_proxy_case),
     )
-
-    # BH adaptation: use init_device_compute_kernel_config instead of WormholeComputeKernelConfig
     compute_kernel_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
         math_fidelity=ttnn.MathFidelity.HiFi2,
@@ -63,18 +334,16 @@ def run_sdpa_noncausal(
         packer_l1_acc=False,
     )
 
-    Q = fa_rand(b, nh, sq, d)
-    K = fa_rand(b, nkv, sk, d)
-    V = fa_rand(b, nkv, sk, d)
+    Q = fa_rand(b, nhq, sq, d_q)
+    K = fa_rand(b, nkv, sq, d_k)
+    V = fa_rand(b, nkv, sq, d_v)
 
-    tt_Q = ttnn.from_torch(Q, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
-    tt_K = ttnn.from_torch(K, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
-    tt_V = ttnn.from_torch(V, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
+    tt_Q, tt_K, tt_V = _build_tt_qkv(device, Q, K, V, q_dtype, kv_dtype)
     tt_back = ttnn.transformer.scaled_dot_product_attention(
         tt_Q,
         tt_K,
         tt_V,
-        is_causal=False,
+        is_causal=is_causal,
         program_config=program_config,
         compute_kernel_config=compute_kernel_config,
     )
@@ -82,56 +351,46 @@ def run_sdpa_noncausal(
     if not do_check:
         return
 
-    tt_back = ttnn.to_torch(tt_back)
-    # Slice out any tile-padding
-    tt_back = tt_back[:, :, :sq, :]
+    tt_torch = ttnn.to_torch(tt_back)[:, :, :sq, :d_v]
+    gt, tt_back_cmp = _proxy_compare_tensors(Q, K, V, tt_torch, sq, nhq, nkv, is_causal, ring_proxy_case)
 
-    if nkv > 1 and nkv != nh:
-        assert nh % nkv == 0
-        K = K.reshape(b, nkv, 1, sk, d).repeat(1, 1, nh // nkv, 1, 1).reshape(b, nh, sk, d)
-        V = V.reshape(b, nkv, 1, sk, d).repeat(1, 1, nh // nkv, 1, 1).reshape(b, nh, sk, d)
-
-    gt = torch.nn.functional.scaled_dot_product_attention(Q, K, V, is_causal=False)
-
-    out_pass, out_pcc = comp_pcc(gt, tt_back, pcc_threshold)
+    out_pass, out_pcc = comp_pcc(gt, tt_back_cmp, pcc_threshold)
+    rmse = torch.sqrt(((gt - tt_back_cmp) ** 2).mean()).item()
     logger.debug(f"python vs pytorch: {out_pcc}")
-    rmse = torch.sqrt(((gt - tt_back) ** 2).mean()).item()
     logger.debug(f"rmse: {rmse}")
     if rmse_threshold is not None:
         assert rmse < rmse_threshold
-
     assert out_pass
 
 
 def run_sdpa_determinism(
     device,
     b,
-    nh,
+    nhq,
     nkv,
     sq,
-    d,
+    d_q,
+    d_k,
+    d_v,
     q_chunk_size,
     k_chunk_size,
-    dtype,
+    is_causal,
+    q_dtype,
+    kv_dtype,
+    ring_proxy_case="none",
     num_iterations=10,
-    sk=None,
 ):
-    """
-    Run SDPA multiple times with the same inputs and return all outputs.
-    Efficient: creates inputs once and reuses them for all iterations.
-    """
+    """Run SDPA ``num_iterations`` times on the same input and assert bit-exact match."""
+    assert d_k == d_q, f"QK^T requires d_q == d_k; got d_q={d_q}, d_k={d_k}"
     torch.manual_seed(1234)
-    if sk is None:
-        sk = sq
 
     program_config = ttnn.SDPAProgramConfig(
-        compute_with_storage_grid_size=[11, 10],
+        compute_with_storage_grid_size=SDPA_GRID,
         q_chunk_size=q_chunk_size,
         k_chunk_size=k_chunk_size,
         exp_approx_mode=False,
+        ring_proxy_case=_ring_proxy_case_enum(ring_proxy_case),
     )
-
-    # BH adaptation: use init_device_compute_kernel_config instead of WormholeComputeKernelConfig
     compute_kernel_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
         math_fidelity=ttnn.MathFidelity.HiFi2,
@@ -140,28 +399,27 @@ def run_sdpa_determinism(
         packer_l1_acc=False,
     )
 
-    # Create inputs once
-    Q = fa_rand(b, nh, sq, d)
-    K = fa_rand(b, nkv, sk, d)
-    V = fa_rand(b, nkv, sk, d)
+    Q = fa_rand(b, nhq, sq, d_q)
+    K = fa_rand(b, nkv, sq, d_k)
+    V = fa_rand(b, nkv, sq, d_v)
+    tt_Q, tt_K, tt_V = _build_tt_qkv(device, Q, K, V, q_dtype, kv_dtype)
 
-    tt_Q = ttnn.from_torch(Q, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
-    tt_K = ttnn.from_torch(K, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
-    tt_V = ttnn.from_torch(V, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
+    # DOWN proxy leaves the light-half Q output rows untouched, so their values are determined
+    # by prior DRAM contents at buffer allocation — they can legally differ across iterations.
+    # Compare only the kernel-written rows.
+    light_half = sq // 2 if ring_proxy_case == "down" else 0
 
-    # Run SDPA multiple times and compare each output to the first
     reference = None
     for i in range(num_iterations):
         tt_out = ttnn.transformer.scaled_dot_product_attention(
             tt_Q,
             tt_K,
             tt_V,
-            is_causal=False,
+            is_causal=is_causal,
             program_config=program_config,
             compute_kernel_config=compute_kernel_config,
         )
-        # Convert to torch and slice out padding
-        torch_out = ttnn.to_torch(tt_out)[:, :, :sq, :]
+        torch_out = ttnn.to_torch(tt_out)[:, :, light_half:sq, :d_v]
         if reference is None:
             reference = torch_out
         elif not torch.equal(reference, torch_out):
@@ -175,63 +433,108 @@ def run_sdpa_determinism(
     logger.info(f"SDPA determinism verified: all {num_iterations} outputs are exactly equal")
 
 
-# WAN 2.2 model shapes for BH
-INPUT_SHAPES = [
-    # batch, num_heads, sequence_length, head_dim
-    [1, 10, 9472, 128],  # WAN 2.2: 1x Galaxy analog (single device seq len)
-    [1, 10, 2368, 128],  # WAN 2.2: 4x Galaxy analog (per-device seq len)
-]
-INPUT_IDS = [
-    "wan2_2_1xGLX_analog",
-    "wan2_2_4xGLX_analog",
-]
+# ============================================================================
+# TESTS
+# ============================================================================
 
-Q_CHUNK_SIZES = [224, 256, 288]
-K_CHUNK_SIZES = [128, 256, 512]
+_PARAMS = "b,nhq,nkv,s,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_causal,q_dtype,kv_dtype,ring_proxy_case"
+
+
+_RingProxyCase = ttnn._ttnn.operations.transformer.RingProxyCase
+_RING_PROXY_CASE_MAP = {
+    "none": _RingProxyCase.NONE,
+    "diag": _RingProxyCase.DIAG,
+    "up": _RingProxyCase.UP,
+    "down": _RingProxyCase.DOWN,
+}
+
+
+def _ring_proxy_case_enum(ring_proxy_case: str):
+    if ring_proxy_case not in _RING_PROXY_CASE_MAP:
+        raise ValueError(f"Invalid ring_proxy_case: {ring_proxy_case!r}")
+    return _RING_PROXY_CASE_MAP[ring_proxy_case]
 
 
 # === TEST 1: PERFORMANCE SWEEP (skipped on CI) ===
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test - skip on CI")
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
-@pytest.mark.parametrize("q_chunk_size", Q_CHUNK_SIZES, ids=[f"q{s}" for s in Q_CHUNK_SIZES])
-@pytest.mark.parametrize("k_chunk_size", K_CHUNK_SIZES, ids=[f"k{s}" for s in K_CHUNK_SIZES])
-@pytest.mark.parametrize(
-    "b, nh, s, d",
-    INPUT_SHAPES,
-    ids=INPUT_IDS,
-)
-def test_sdpa_sweep_perf_impl(device, b, nh, s, d, q_chunk_size, k_chunk_size, dtype):
-    # nkv = nh for non-GQA case
-    run_sdpa_noncausal(device, b, nh, nh, s, d, q_chunk_size, k_chunk_size, dtype, do_check=False)
+@pytest.mark.parametrize(_PARAMS, TEST_CONFIGS, ids=TEST_CONFIG_IDS)
+def test_sdpa_sweep_perf_impl(
+    device,
+    b,
+    nhq,
+    nkv,
+    s,
+    d_q,
+    d_k,
+    d_v,
+    q_chunk_size,
+    k_chunk_size,
+    is_causal,
+    q_dtype,
+    kv_dtype,
+    ring_proxy_case,
+):
+    run_sdpa(
+        device,
+        b,
+        nhq,
+        nkv,
+        s,
+        d_q,
+        d_k,
+        d_v,
+        q_chunk_size,
+        k_chunk_size,
+        is_causal,
+        q_dtype,
+        kv_dtype,
+        ring_proxy_case,
+        do_check=False,
+    )
 
 
 # === TEST 2: ACCURACY VERIFICATION ===
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
-@pytest.mark.parametrize("q_chunk_size", Q_CHUNK_SIZES, ids=[f"q{s}" for s in Q_CHUNK_SIZES])
-@pytest.mark.parametrize("k_chunk_size", K_CHUNK_SIZES, ids=[f"k{s}" for s in K_CHUNK_SIZES])
-@pytest.mark.parametrize(
-    "b, nh, s, d",
-    INPUT_SHAPES,
-    ids=INPUT_IDS,
-)
-def test_sdpa_accuracy(device, b, nh, s, d, q_chunk_size, k_chunk_size, dtype):
-    """
-    Test SDPA accuracy for the given shapes and chunk size configurations.
-    Verifies PCC > 0.9997 against PyTorch reference.
-    """
-    # nkv = nh for non-GQA case
-    pcc_threshold = 0.9997
-    rmse_threshold = 4e-2
-    run_sdpa_noncausal(
+@pytest.mark.parametrize(_PARAMS, TEST_CONFIGS, ids=TEST_CONFIG_IDS)
+def test_sdpa_accuracy(
+    device,
+    b,
+    nhq,
+    nkv,
+    s,
+    d_q,
+    d_k,
+    d_v,
+    q_chunk_size,
+    k_chunk_size,
+    is_causal,
+    q_dtype,
+    kv_dtype,
+    ring_proxy_case,
+):
+    """PCC + RMSE accuracy check against a torch SDPA reference."""
+    # MLA with bfloat8_b K/V needs a looser PCC threshold than bf16 MHA.
+    if kv_dtype == ttnn.bfloat8_b:
+        pcc_threshold = 0.994
+        rmse_threshold = None  # bf8 accumulation noise makes RMSE thresholds brittle
+    else:
+        pcc_threshold = 0.9997
+        rmse_threshold = 4e-2
+
+    run_sdpa(
         device,
         b,
-        nh,
-        nh,
+        nhq,
+        nkv,
         s,
-        d,
+        d_q,
+        d_k,
+        d_v,
         q_chunk_size,
         k_chunk_size,
-        dtype,
+        is_causal,
+        q_dtype,
+        kv_dtype,
+        ring_proxy_case,
         pcc_threshold=pcc_threshold,
         rmse_threshold=rmse_threshold,
         do_check=True,
@@ -239,67 +542,83 @@ def test_sdpa_accuracy(device, b, nh, s, d, q_chunk_size, k_chunk_size, dtype):
 
 
 # === TEST 3: DETERMINISM VERIFICATION ===
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
-@pytest.mark.parametrize("q_chunk_size", Q_CHUNK_SIZES, ids=[f"q{s}" for s in Q_CHUNK_SIZES])
-@pytest.mark.parametrize("k_chunk_size", K_CHUNK_SIZES, ids=[f"k{s}" for s in K_CHUNK_SIZES])
-@pytest.mark.parametrize(
-    "b, nh, s, d",
-    INPUT_SHAPES,
-    ids=INPUT_IDS,
-)
-def test_sdpa_determinism(device, b, nh, s, d, q_chunk_size, k_chunk_size, dtype):
-    """
-    Test SDPA determinism: run 10 times with same inputs and verify outputs match exactly.
-    """
-    num_iterations = 10
-    run_sdpa_determinism(device, b, nh, nh, s, d, q_chunk_size, k_chunk_size, dtype, num_iterations=num_iterations)
-
-
-from tests.nightly.sdpa_perf_utils import (
-    post_process_ops_log,
-    compute_cores_used,
-    compute_math_utilization,
-)
-
-
-def compute_sdpa_utilization(seqlen, head_dim, num_heads, duration_ns, core_count):
-    """Single-chip SDPA utilization (local_seq == total_seq, arch=blackhole)."""
-    return compute_math_utilization(seqlen, seqlen, head_dim, head_dim, num_heads, duration_ns, core_count)
+@pytest.mark.parametrize(_PARAMS, TEST_CONFIGS, ids=TEST_CONFIG_IDS)
+def test_sdpa_determinism(
+    device,
+    b,
+    nhq,
+    nkv,
+    s,
+    d_q,
+    d_k,
+    d_v,
+    q_chunk_size,
+    k_chunk_size,
+    is_causal,
+    q_dtype,
+    kv_dtype,
+    ring_proxy_case,
+):
+    run_sdpa_determinism(
+        device,
+        b,
+        nhq,
+        nkv,
+        s,
+        d_q,
+        d_k,
+        d_v,
+        q_chunk_size,
+        k_chunk_size,
+        is_causal,
+        q_dtype,
+        kv_dtype,
+        ring_proxy_case,
+        num_iterations=10,
+    )
 
 
 # === TEST 4: PERFORMANCE TABLE (skipped on CI) ===
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test - skip on CI")
-@pytest.mark.parametrize(
-    "b, nh, s, d",
-    INPUT_SHAPES,
-    ids=INPUT_IDS,
-)
-def test_sdpa_create_perf_table(b, nh, s, d):
+@pytest.mark.parametrize("model_name", TEST_CONFIG_MODELS)
+def test_sdpa_create_perf_table(model_name):
     """
-    Sweep chunk sizes for a given SDPA shape and print a performance table.
-    Shows the best chunk size configurations ranked by kernel duration.
-    Skipped on CI - run locally with tracy profiler.
+    Sweep a model's chunk-size configurations and print a ranked performance table.
+    Skipped on CI — run locally with the tracy profiler.
     """
     from tracy.process_model_log import run_device_profiler
 
-    # NOTE: Hardcoded for Blackhole (11x10 grid = 110 cores)
-    # Cannot query device here as it causes TLB resource contention with subprocess tests
-    num_cores = 110
+    model = MODEL_CONFIGS[model_name]
+
+    # Collect the parametrize ids that belong to this model.
+    sweep = [(cfg, cfg_id) for cfg, cfg_id in zip(TEST_CONFIGS, TEST_CONFIG_IDS) if cfg_id.startswith(model_name + "-")]
 
     subdir = "ttnn_sdpa_performance"
     perf_results = []
 
-    for q_chunk_size, k_chunk_size in product(Q_CHUNK_SIZES, K_CHUNK_SIZES):
+    for config, config_id in sweep:
+        (
+            b,
+            nhq,
+            nkv,
+            s,
+            d_q,
+            d_k,
+            d_v,
+            q_chunk_size,
+            k_chunk_size,
+            is_causal,
+            q_dtype,
+            kv_dtype,
+            ring_proxy_case,
+        ) = config
+        flatten_work = ring_proxy_case != "none"
         float_cols = ["CORE COUNT", "DEVICE KERNEL DURATION [ns]"]
         cols = ["ATTRIBUTES"]
-
-        # Build the test command for this specific configuration
-        test_id = f"k{k_chunk_size}-q{q_chunk_size}-bf16"
-        shape_id = INPUT_IDS[INPUT_SHAPES.index([b, nh, s, d])]
         command = (
             f"pytest tests/nightly/blackhole/sdpa/"
             f"test_scaled_dot_product_attention_sprint.py::test_sdpa_sweep_perf_impl"
-            f"[{shape_id}-{test_id}]"
+            f"[{config_id}]"
         )
 
         try:
@@ -307,39 +626,48 @@ def test_sdpa_create_perf_table(b, nh, s, d):
             r = post_process_ops_log(
                 subdir, float_columns=float_cols, columns=cols, op_name="", sum_vals=False, has_signposts=False
             )
-
             core_count = int(r["CORE COUNT"][0])
             duration_ns = int(r["DEVICE KERNEL DURATION [ns]"].min())
 
-            # Compute parallelization factors
-            B = 1
-            batch_parallel = min(B, num_cores)
-            nh_parallel = min(num_cores // batch_parallel, nh)
-            max_q_parallel = num_cores // (batch_parallel * nh_parallel)
-
-            cores_used = compute_cores_used(s, q_chunk_size, compute_cores=num_cores, num_heads=nh)
-            cores_idle = num_cores - cores_used
-            core_util_pct = (cores_used * 100.0) / num_cores
-
-            # Compute iterations per core
             k_num_chunks = math.ceil(s / k_chunk_size)
             q_num_chunks = math.ceil(s / q_chunk_size)
-            q_per_core = math.ceil(q_num_chunks / max_q_parallel)
-            iters_per_core = q_per_core * k_num_chunks
+            mm_sq, mm_sk, mm_causal, q_slots_factor, k_iters_factor = _proxy_geometry(s, is_causal, ring_proxy_case)
 
-            # Compute padding waste
+            if flatten_work:
+                # Flat work spreads B*NH*q_num_chunks evenly across the full programmed grid,
+                # so every core does real work — no hierarchical batch × heads × q_parallel idle tail.
+                total_q_slots_work = int(b * nhq * q_num_chunks * q_slots_factor)
+                q_per_core = math.ceil(total_q_slots_work / NUM_CORES)
+                cores_used = NUM_CORES
+                total_q_slots = q_per_core * NUM_CORES
+                wasted_q_slots = max(0, total_q_slots - total_q_slots_work)
+            else:
+                # Hierarchical distribution: batch × heads × q_chunks — cores beyond the product are idle.
+                batch_parallel = min(b, NUM_CORES)
+                nh_parallel = min(NUM_CORES // batch_parallel, nhq)
+                max_q_parallel = NUM_CORES // (batch_parallel * nh_parallel)
+                q_per_core = math.ceil(q_num_chunks / max_q_parallel)
+                cores_used = batch_parallel * nh_parallel * max_q_parallel
+                total_q_slots = max_q_parallel * q_per_core
+                wasted_q_slots = max(0, total_q_slots - q_num_chunks)
+
+            iters_per_core = int(q_per_core * k_num_chunks * k_iters_factor)
+            cores_idle = NUM_CORES - cores_used
+            core_util_pct = (cores_used * 100.0) / NUM_CORES
+
             q_padded_total = q_num_chunks * q_chunk_size
             k_padded_total = k_num_chunks * k_chunk_size
             actual_work = s * s
             padded_work = q_padded_total * k_padded_total
             total_waste_pct = ((padded_work - actual_work) / padded_work) * 100 if padded_work > 0 else 0
 
-            # Compute work distribution (slot) waste
-            total_q_slots = max_q_parallel * q_per_core
-            wasted_q_slots = total_q_slots - q_num_chunks
             slot_waste_pct = (wasted_q_slots / total_q_slots) * 100 if total_q_slots > 0 else 0
 
-            utilization = compute_sdpa_utilization(s, d, nh, duration_ns, core_count)
+            # Math util uses distinct d_q/d_v and respects causal masking. Denominator uses the
+            # full programmed grid (NUM_CORES), matching what the op is actually scheduled on.
+            utilization = compute_math_utilization(
+                mm_sq, mm_sk, d_q, d_v, nhq, duration_ns, NUM_CORES, is_causal=mm_causal
+            )
 
             perf_results.append(
                 {
@@ -358,32 +686,35 @@ def test_sdpa_create_perf_table(b, nh, s, d):
                 }
             )
             logger.info(
-                f"q={q_chunk_size}, k={k_chunk_size}: {duration_ns/1e6:.3f} ms, "
-                f"util={utilization:.1f}%, cores={cores_used}/{num_cores} ({core_util_pct:.0f}%), "
+                f"[{model_name}] q={q_chunk_size}, k={k_chunk_size}: {duration_ns/1e6:.3f} ms, "
+                f"util={utilization:.1f}%, cores={cores_used}/{NUM_CORES} ({core_util_pct:.0f}%), "
                 f"iters/core={iters_per_core}"
             )
 
         except Exception as e:
             if isinstance(e, KeyboardInterrupt):
                 raise
-            logger.error(f"Error running SDPA with q_chunk_size={q_chunk_size}, k_chunk_size={k_chunk_size}: {e}")
-            perf_results.append(
-                {
-                    "q_chunk_size": q_chunk_size,
-                    "k_chunk_size": k_chunk_size,
-                    "duration_ns": None,
-                }
+            logger.error(
+                f"Error running [{model_name}] with q_chunk_size={q_chunk_size}, k_chunk_size={k_chunk_size}: {e}"
             )
+            perf_results.append({"q_chunk_size": q_chunk_size, "k_chunk_size": k_chunk_size, "duration_ns": None})
 
-    # Sort by duration (best first)
     valid_results = [r for r in perf_results if r["duration_ns"] is not None]
     valid_results.sort(key=lambda x: x["duration_ns"])
 
-    mm_flops = 4 * s * s * d * nh
+    # Model-level FLOPs summary; geometry mirrors per-config accounting above.
+    summary_sq, summary_sk, summary_causal, _, _ = _proxy_geometry(
+        model.seq_len, model.is_causal, model.ring_proxy_case
+    )
+    mm_flops = compute_sdpa_flops(summary_sq, summary_sk, model.d_q, model.d_v, model.nhq, summary_causal)
 
-    # Print summary table
     print(f"\n{'='*170}")
-    print(f"SDPA Performance Sweep: b={b}, nh={nh}, s={s}, d={d}")
+    print(
+        f"SDPA Performance Sweep ({model_name.upper()}): "
+        f"b={BATCH_SIZE}, nhq={model.nhq}, nkv={model.nkv}, s={model.seq_len}, "
+        f"d_q={model.d_q}, d_v={model.d_v}, causal={model.is_causal}, "
+        f"ring_proxy_case={model.ring_proxy_case}"
+    )
     print(f"MM FLOPs: {mm_flops:,} ({mm_flops/1e9:.2f} GFLOPs)")
     print(f"{'='*170}")
     header = "| Rank | q_chunk | k_chunk | Duration (ms) | Cores Used | Cores Idle | Core Util | Iters/Core | Pad Waste | Slot Waste | Math Util |"
@@ -407,10 +738,9 @@ def test_sdpa_create_perf_table(b, nh, s, d):
     if valid_results:
         best = valid_results[0]
         print(
-            f"\nBest configuration: q_chunk_size={best['q_chunk_size']}, "
-            f"k_chunk_size={best['k_chunk_size']} "
+            f"\nBest configuration: q_chunk_size={best['q_chunk_size']}, k_chunk_size={best['k_chunk_size']} "
             f"({best['duration_ms']:.3f} ms, {best['utilization']:.1f}% math util, "
-            f"{best['cores_used']}/{num_cores} cores, {best['iters_per_core']} iters/core, "
+            f"{best['cores_used']}/{NUM_CORES} cores, {best['iters_per_core']} iters/core, "
             f"{best['total_waste_pct']:.1f}% pad waste, {best['slot_waste_pct']:.1f}% slot waste)"
         )
     print(f"{'='*170}\n")

--- a/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
+++ b/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
@@ -127,7 +127,7 @@ def generate_model_configs() -> Dict[str, ModelConfig]:
             q_dtype=ttnn.bfloat16,
             kv_dtype=ttnn.bfloat8_b,
             q_chunk_sizes=[160],
-            k_chunk_sizes=[160],
+            k_chunk_sizes=[320],
             ring_proxy_case="diag",
         ),
         # DeepSeek MLA 128K — same ring iter 0 semantics as the 100K suite, longer local seq.
@@ -161,7 +161,7 @@ def generate_model_configs() -> Dict[str, ModelConfig]:
             q_dtype=ttnn.bfloat16,
             kv_dtype=ttnn.bfloat8_b,
             q_chunk_sizes=[160],
-            k_chunk_sizes=[160],
+            k_chunk_sizes=[320],
             ring_proxy_case="up",
         ),
         # DeepSeek MLA 100K — ring non-diag iter DOWN proxy. Only the heavy Q half is assigned
@@ -179,7 +179,7 @@ def generate_model_configs() -> Dict[str, ModelConfig]:
             q_dtype=ttnn.bfloat16,
             kv_dtype=ttnn.bfloat8_b,
             q_chunk_sizes=[160],
-            k_chunk_sizes=[160],
+            k_chunk_sizes=[320],
             ring_proxy_case="down",
         ),
     ]

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1670,7 +1670,9 @@ template <
     bool is_chunked,
     uint32_t scale_fp32,
     uint32_t sliding_window_size,
-    bool lightweight_mask_enabled = false>
+    bool lightweight_mask_enabled = false,
+    bool flatten_work = false,
+    RingProxyCase proxy_mode = RingProxyCase::None>
 void sdpa_inner_loop(
     const uint32_t Skt,
     const uint32_t qk_in0_block_w,
@@ -1730,7 +1732,8 @@ void sdpa_inner_loop(
     const bool is_causal = false,
     const bool is_balanced = false,
     const bool use_zigzag_balancing = false,
-    const bool is_last_ring_iter = true) {
+    const bool is_last_ring_iter = true,
+    const bool is_chain_participant = false) {
     constexpr uint32_t dst_size = compute_kernel_lib::DEST_AUTO_LIMIT;
     uint32_t KV_chunks_processed_in_iter = 0;
     const uint32_t q_per_core = iter_q_end - iter_q_start;
@@ -1741,17 +1744,23 @@ void sdpa_inner_loop(
         uint32_t causal_k_limit = 0;  // RING: K-chunk index beyond which all K is above the diagonal
         if constexpr (sdpa_type == STANDARD) {
             uint32_t q_chunk;
-#if defined BALANCED_Q_PARALLEL
-            uint32_t q_chunk_div_2 = iter_q_end / 2;  // q_chunks_per_core / 2.
-            if (q_iter < q_chunk_div_2) {             // bottom half
-                q_chunk = local_q_start + q_iter;
+            if constexpr (flatten_work) {
+                // Flat work: q_iter is a global index into B*NQH*q_num_effective. Reader/writer do
+                // the (nb, nq, q_chunk) decomposition; compute only needs q_chunk.
+                q_chunk = proxy_q_chunk(q_iter, q_num_chunks, use_zigzag_balancing, proxy_mode);
             } else {
-                uint32_t back_q_iter = q_iter - q_chunk_div_2;  // Back half should start at 0
-                q_chunk = q_num_chunks - 1 - (local_q_start + back_q_iter);
-            }
+#if defined BALANCED_Q_PARALLEL
+                uint32_t q_chunk_div_2 = iter_q_end / 2;  // q_chunks_per_core / 2.
+                if (q_iter < q_chunk_div_2) {             // bottom half
+                    q_chunk = local_q_start + q_iter;
+                } else {
+                    uint32_t back_q_iter = q_iter - q_chunk_div_2;  // Back half should start at 0
+                    q_chunk = q_num_chunks - 1 - (local_q_start + back_q_iter);
+                }
 #else
-            q_chunk = local_q_start + q_iter;
+                q_chunk = local_q_start + q_iter;
 #endif
+            }
             // Get Q chunk
             if constexpr (is_chunked) {
                 q_chunk = chunked_q_chunk_offset + q_chunk;
@@ -1763,6 +1772,9 @@ void sdpa_inner_loop(
                 // past total K (Sq_chunk_t > Skt) → CB deadlock.
                 const uint32_t q_high_unclamped = q_start_tile + Sq_chunk_t;
                 q_high_tile = q_high_unclamped < Skt ? q_high_unclamped : Skt;
+                // Chain participants loop full K for CB sync; this bound lets them pop & skip past
+                // the diagonal instead of doing masked-out matmul/softmax cycles.
+                causal_k_limit = (q_high_tile + Sk_chunk_t - 1) / Sk_chunk_t;
             } else {
                 q_high_tile = Skt;
             }
@@ -1788,8 +1800,15 @@ void sdpa_inner_loop(
 
         uint32_t k_chunk_end;
         if constexpr (sdpa_type == STANDARD) {
-            // loop while k_low < q_high => (k_chunk * Sk_chunk_t) < q_high_tile.
-            k_chunk_end = (q_high_tile + Sk_chunk_t - 1) / Sk_chunk_t;
+            // UP proxy halves the K loop. Chain cores walk the full K range so reader + writer +
+            // compute stay in lockstep; the lightweight causal mask zeroes columns past q_high.
+            if constexpr (proxy_mode == RingProxyCase::Up) {
+                k_chunk_end = iter_k_chunk_end / 2;
+            } else if (is_chain_participant) {
+                k_chunk_end = iter_k_chunk_end;
+            } else {
+                k_chunk_end = (q_high_tile + Sk_chunk_t - 1) / Sk_chunk_t;
+            }
         } else {  // RING or JOINT.
             k_chunk_end = iter_k_chunk_end;
         }
@@ -1809,7 +1828,8 @@ void sdpa_inner_loop(
 
             KV_chunks_processed_in_iter++;
 
-            if (sdpa_type == RING && k_chunk >= causal_k_limit && is_causal) {
+            if (is_causal && k_chunk >= causal_k_limit &&
+                (sdpa_type == RING || (sdpa_type == STANDARD && is_chain_participant))) {
                 cb_wait_front(cb_k_in, k_chunk_tiles);
                 cb_wait_front(cb_v_in, v_chunk_tiles);
                 cb_pop_front(cb_k_in, k_chunk_tiles);
@@ -2158,7 +2178,9 @@ template <
     bool is_chunked,
     uint32_t scale_fp32,
     uint32_t sliding_window_size,
-    bool lightweight_mask_enabled = false>
+    bool lightweight_mask_enabled = false,
+    bool flatten_work = false,
+    RingProxyCase proxy_mode = RingProxyCase::None>
 void sdpa_standard(
     const uint32_t Skt,
     const uint32_t qk_in0_block_w,
@@ -2197,7 +2219,9 @@ void sdpa_standard(
     const uint32_t cb_sum_B,
     const uint32_t cb_exp_max_diff,
     const uint32_t cb_out,
-    const LightweightMaskContext& lw_mask = {}) {
+    const LightweightMaskContext& lw_mask = {},
+    const bool use_zigzag_balancing = false,
+    const bool is_chain_participant = false) {
     sdpa_inner_loop<
         STANDARD,
         cb_qk_im,
@@ -2216,7 +2240,9 @@ void sdpa_standard(
         is_chunked,
         scale_fp32,
         sliding_window_size,
-        lightweight_mask_enabled>(
+        lightweight_mask_enabled,
+        flatten_work,
+        proxy_mode>(
         Skt,
         qk_in0_block_w,
         qk_subblock_w,
@@ -2272,7 +2298,11 @@ void sdpa_standard(
         0,  // cb_prev_out (not used)
         cb_out,
         lw_mask,
-        is_causal);
+        is_causal,
+        /*is_balanced=*/false,
+        use_zigzag_balancing,
+        /*is_last_ring_iter=*/true,
+        is_chain_participant);
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -1249,7 +1249,9 @@ template <
     uint32_t cb_normalized_out,
     uint32_t cb_mask_in,
     bool uniform_dataformat = false,
-    bool is_causal_sdpa = false>
+    bool is_causal_sdpa = false,
+    bool flatten_work = false,
+    RingProxyCase proxy_mode = RingProxyCase::None>
 void sdpa_standard_v2(
     const uint32_t q_chunks_per_core,
     const uint32_t k_num_chunks,
@@ -1262,7 +1264,9 @@ void sdpa_standard_v2(
     const uint32_t local_q_start = 0,
     const uint32_t chunked_q_chunk_offset = 0,
     const LightweightMaskContext& lw_mask = {},
-    const uint32_t q_num_chunks = 0) {
+    const uint32_t q_num_chunks = 0,
+    const bool use_zigzag = false,
+    const bool is_chain_participant = false) {
     // use_padded_mask + is_causal_sdpa is handled at the host level (mutually exclusive).
     static_assert(
         !(use_padded_mask && is_causal_sdpa), "use_padded_mask and is_causal_sdpa are mutually exclusive in v2");
@@ -1299,9 +1303,21 @@ void sdpa_standard_v2(
         // Causal-only: BALANCED_Q_PARALLEL Q-chunk remap, per-Q diagonal K-chunk limit, and
         // q_start_tile (the only causal-mask consumer downstream). Non-causal builds skip
         // the whole block — q_chunk_local stays in-order, q_start_tile=0, k_loop_end=full.
-        uint32_t q_chunk_local = local_q_start + q;
+        // Flat work overrides the q_chunk_local computation via proxy_q_chunk, mirroring the
+        // non-streaming path's flat-iter decode (compute_common.hpp:1750).
+        uint32_t q_chunk_local;
+        if constexpr (flatten_work) {
+            q_chunk_local = proxy_q_chunk(local_q_start + q, q_num_chunks, use_zigzag, proxy_mode);
+        } else {
+            q_chunk_local = local_q_start + q;
+        }
         uint32_t q_start_tile = 0;
         uint32_t k_loop_end = k_num_chunks;
+        // UP proxy halves the K loop (mirrors compute_common.hpp:1805). Applied for both
+        // causal/non-causal so the streaming path is loop-symmetric to the non-flat causal trim.
+        if constexpr (proxy_mode == RingProxyCase::Up) {
+            k_loop_end = k_num_chunks / 2;
+        }
         if constexpr (is_causal_sdpa) {
 #if defined BALANCED_Q_PARALLEL
             // Pair a light (top-half) Q chunk with a heavy (bottom-half) Q chunk per core to
@@ -1440,6 +1456,21 @@ void sdpa_standard_v2(
             }
         }
         // Q already popped inside sdpa_inner_loop_step after Phase 1 of the last K chunk.
+
+        // Chain participant drain (causal only): the reader walks full K so all chain cores
+        // stay in CB lockstep. Compute already finished real work at the diagonal chunk
+        // (k_loop_end), normalized prev/cur, and wrote output. Just drain remaining K/V tiles
+        // so the K/V CBs don't fill up. Mirrors compute_common.hpp:1831 pop+continue.
+        if constexpr (is_causal_sdpa) {
+            if (is_chain_participant) {
+                for (uint32_t k_chunk = k_loop_end; k_chunk < k_num_chunks; k_chunk++) {
+                    cb_wait_front(cb_kt_in, DHt * Sk_chunk_t);
+                    cb_pop_front(cb_kt_in, DHt * Sk_chunk_t);
+                    cb_wait_front(cb_v_in, Sk_chunk_t * vDHt);
+                    cb_pop_front(cb_v_in, Sk_chunk_t * vDHt);
+                }
+            }
+        }
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -49,6 +49,10 @@ void kernel_main() {
     constexpr uint32_t valid_Skt = get_compile_time_arg_val(31);
     constexpr bool uniform_dataformat = get_compile_time_arg_val(32) == 1;
     constexpr uint32_t k_partial_col = get_compile_time_arg_val(33);
+    constexpr RingProxyCase proxy_mode = static_cast<RingProxyCase>(get_compile_time_arg_val(34));
+    constexpr bool chain_enabled = get_compile_time_arg_val(35) == 1;
+    constexpr bool flatten_work = proxy_uses_flat_work(proxy_mode);
+    constexpr bool flat_use_zigzag = flatten_work && is_causal && (q_num_chunks % 2 == 0);
 
     const uint32_t core_id = get_arg_val<uint32_t>(0);
     const uint32_t local_batch_start = get_arg_val<uint32_t>(1);
@@ -57,13 +61,27 @@ void kernel_main() {
     const uint32_t local_nh_end = get_arg_val<uint32_t>(4);
     const uint32_t local_q_start = get_arg_val<uint32_t>(5);
     const uint32_t local_q_end = get_arg_val<uint32_t>(6);
-    // const uint32_t chunked_q_chunk_offset = get_arg_val<uint32_t>(7);
     const uint32_t num_phases = get_arg_val<uint32_t>(7);
     const uint32_t use_chunk_start_idx_tensor = get_arg_val<uint32_t>(8);
     uint32_t chunked_q_chunk_offset_phase_1 = get_arg_val<uint32_t>(9);
+    // Tail args (phase-2, flat-work, chain) are read in the order the host emits them; each pair
+    // is gated by the matching host predicate so slots never collide.
+    uint32_t argidx = 10;
     uint32_t chunked_q_chunk_offset_phase_2 = 0;
     if (num_phases == 2) {
-        chunked_q_chunk_offset_phase_2 = get_arg_val<uint32_t>(10);
+        chunked_q_chunk_offset_phase_2 = get_arg_val<uint32_t>(argidx++);
+    }
+
+    uint32_t global_q_start = 0;
+    uint32_t global_q_count = 0;
+    if constexpr (flatten_work) {
+        global_q_start = get_arg_val<uint32_t>(argidx++);
+        global_q_count = get_arg_val<uint32_t>(argidx++);
+    }
+
+    uint32_t is_chain_participant = 0;
+    if constexpr (chain_enabled) {
+        is_chain_participant = get_arg_val<uint32_t>(argidx++);
     }
 
     const uint32_t q_chunks_per_core = local_q_end - local_q_start;
@@ -194,15 +212,23 @@ void kernel_main() {
             cb_wait_front(cb_mask_in, 2);
         }
 
-        for (uint32_t phase = 0; phase < num_phases; ++phase) {
-            if (phase == 0) {
-                chunked_q_chunk_offset = chunked_q_chunk_offset_phase_1;
-            } else {
-                chunked_q_chunk_offset = chunked_q_chunk_offset_phase_2;
-            }
+        // Flat work folds (nb, nq, q_iter) into one global range. Reader/writer decode (nb, nq)
+        // per work-item from global_q_start, so compute only needs q_chunk via proxy_q_chunk
+        // inside sdpa_inner_loop. Collapse the (nb, nq) loop to a single iteration in flat mode
+        // so there's one call-site for sdpa_standard.
+        const uint32_t iter_q_start = flatten_work ? global_q_start : 0;
+        const uint32_t iter_q_end = flatten_work ? global_q_start + global_q_count : q_chunks_per_core;
+        const uint32_t sdpa_local_q_start = flatten_work ? 0u : local_q_start;
+        const uint32_t batch_start_eff = flatten_work ? 0u : local_batch_start;
+        const uint32_t batch_end_eff = flatten_work ? 1u : local_batch_end;
+        const uint32_t nh_start_eff = flatten_work ? 0u : local_nh_start;
+        const uint32_t nh_end_eff = flatten_work ? 1u : local_nh_end;
 
-            for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
-                for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {
+        for (uint32_t phase = 0; phase < num_phases; ++phase) {
+            chunked_q_chunk_offset = (phase == 0) ? chunked_q_chunk_offset_phase_1 : chunked_q_chunk_offset_phase_2;
+
+            for (uint32_t nb = batch_start_eff; nb < batch_end_eff; ++nb) {
+                for (uint32_t nq = nh_start_eff; nq < nh_end_eff; ++nq) {
                     sdpa_standard<
                         cb_qk_im,
                         cb_identity_scale_in,
@@ -218,7 +244,9 @@ void kernel_main() {
                         is_chunked,
                         scale_fp32,
                         sliding_window_size,
-                        use_lightweight_causal_mask>(
+                        use_lightweight_causal_mask,
+                        flatten_work,
+                        proxy_mode>(
                         Skt,
                         qk_in0_block_w,
                         qk_subblock_w,
@@ -232,10 +260,10 @@ void kernel_main() {
                         out_in0_num_subblocks,
                         out_in1_num_subblocks,
                         out_num_blocks,
-                        0,                  // iter_q_start
-                        q_chunks_per_core,  // iter_q_end
+                        iter_q_start,
+                        iter_q_end,
                         q_num_chunks,
-                        local_q_start,
+                        sdpa_local_q_start,
                         chunked_q_chunk_offset,
                         k_num_chunks,
                         q_chunk_tiles,
@@ -256,7 +284,9 @@ void kernel_main() {
                         cb_sum_B,
                         cb_exp_max_diff,
                         cb_out,
-                        lw_mask);
+                        lw_mask,
+                        /*use_zigzag_balancing=*/flat_use_zigzag,
+                        /*is_chain_participant=*/is_chain_participant != 0);
                 }
             }
         }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -156,11 +156,21 @@ void kernel_main() {
             cb_wait_front(cb_mask_in, 2);
         }
 
+        // Flat work folds (nb, nq, q_iter) into a single global range. Reader/writer decode
+        // (nb, nq) from global_q_start, so compute only iterates the q range and resolves
+        // q_chunk via proxy_q_chunk inside sdpa_standard_v2.
+        const uint32_t streaming_q_count = flatten_work ? global_q_count : q_chunks_per_core;
+        const uint32_t streaming_q_start = flatten_work ? global_q_start : local_q_start;
+        const uint32_t streaming_batch_start = flatten_work ? 0u : local_batch_start;
+        const uint32_t streaming_batch_end = flatten_work ? 1u : local_batch_end;
+        const uint32_t streaming_nh_start = flatten_work ? 0u : local_nh_start;
+        const uint32_t streaming_nh_end = flatten_work ? 1u : local_nh_end;
+
         for (uint32_t phase = 0; phase < num_phases; ++phase) {
             const uint32_t phase_chunked_offset =
                 (phase == 0) ? chunked_q_chunk_offset_phase_1 : chunked_q_chunk_offset_phase_2;
-            for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
-                for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {
+            for (uint32_t nb = streaming_batch_start; nb < streaming_batch_end; ++nb) {
+                for (uint32_t nq = streaming_nh_start; nq < streaming_nh_end; ++nq) {
                     sdpa_standard_v2<
                         Sq_chunk_t,
                         Sk_chunk_t,
@@ -184,8 +194,10 @@ void kernel_main() {
                         cb_out,  // normalized output goes directly to output CB
                         cb_mask_in,
                         uniform_dataformat,
-                        is_causal>(
-                        q_chunks_per_core,
+                        is_causal,
+                        flatten_work,
+                        proxy_mode>(
+                        streaming_q_count,
                         k_num_chunks,
                         cb_out_im_A,
                         cb_out_im_B,
@@ -193,10 +205,12 @@ void kernel_main() {
                         cb_max_B,
                         cb_sum_A,
                         cb_sum_B,
-                        local_q_start,
+                        streaming_q_start,
                         phase_chunked_offset,
                         lw_mask,
-                        q_num_chunks);
+                        q_num_chunks,
+                        flat_use_zigzag,
+                        is_chain_participant != 0);
                 }
             }
         }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -98,7 +98,11 @@ public:
     }
 };
 
-template <uint32_t tile_bytes, typename ReaderType, bool push_num_tiles = true>
+// enable_mid_barrier=true (default) preserves the original mid-loop threshold barrier.
+// enable_mid_barrier=false skips it; callers that know their read volume fits the NOC queue
+// can opt in for better overlap with compute (matches ring_joint_reader's fetch_block pattern,
+// ~20% faster on the single-chip MLA DOWN proxy).
+template <uint32_t tile_bytes, typename ReaderType, bool push_num_tiles = true, bool enable_mid_barrier = true>
 uint32_t read_chunk_with_padding(
     const ReaderType& reader,
     const uint32_t cb_id,
@@ -107,7 +111,7 @@ uint32_t read_chunk_with_padding(
     const uint32_t src_cols,
     const uint32_t dst_rows,
     const uint32_t dst_cols,
-    const uint32_t barrier_threshold,
+    [[maybe_unused]] const uint32_t barrier_threshold,
     const bool transpose = false,
     const uint32_t skip_src_cols = 0) {
     /*
@@ -124,7 +128,7 @@ uint32_t read_chunk_with_padding(
     uint32_t outer_ptr_stride = transpose ? tile_bytes : dst_cols * tile_bytes;
     uint32_t inner_ptr_stride = transpose ? tile_bytes * dst_rows : tile_bytes;
 
-    uint32_t barrier_count = 0;
+    [[maybe_unused]] uint32_t barrier_count = 0;
     for (uint32_t row = 0; row < src_rows; ++row) {
         uint32_t write_ptr = base_write_ptr + row * outer_ptr_stride;
         for (uint32_t col = 0; col < src_cols; ++col) {
@@ -132,9 +136,11 @@ uint32_t read_chunk_with_padding(
             start_tile_id += 1;
             write_ptr += inner_ptr_stride;
 
-            if (++barrier_count == barrier_threshold) {
-                noc_async_read_barrier();
-                barrier_count = 0;
+            if constexpr (enable_mid_barrier) {
+                if (++barrier_count == barrier_threshold) {
+                    noc_async_read_barrier();
+                    barrier_count = 0;
+                }
             }
         }
         start_tile_id += skip_src_cols;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -75,8 +75,13 @@ void kernel_main() {
     constexpr uint32_t receiver_semaphore_id = get_compile_time_arg_val(28);
     constexpr uint32_t valid_semaphore_id = get_compile_time_arg_val(29);
     constexpr bool mcast_enabled = get_compile_time_arg_val(30) == 1;
+    // Batch-level K chain (MLA: NKH==1 && B==1). Always 2D-mcast across the full grid.
+    constexpr uint32_t batch_sender_semaphore_id = get_compile_time_arg_val(31);
+    constexpr uint32_t batch_receiver_semaphore_id = get_compile_time_arg_val(32);
+    constexpr uint32_t batch_valid_semaphore_id = get_compile_time_arg_val(33);
+    constexpr bool batch_k_chain_enabled = get_compile_time_arg_val(34) == 1;
 
-    constexpr auto q_args = TensorAccessorArgs<31>();
+    constexpr auto q_args = TensorAccessorArgs<35>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto mask_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
@@ -191,6 +196,61 @@ void kernel_main() {
         }
     }
 
+    // Batch-level K chain (MLA mode). Mirrors the head chain's mcast wiring but the rect is the
+    // full grid (mcast_start..mcast_end), and the injector is the heaviest-loaded core, not the
+    // chain head. Iteration loop is padded to max_q_per_core so every core mcasts/receives the
+    // same number of K chunks (otherwise lighter-loaded receivers desync the injector's signal).
+    struct BatchChainState {
+        uint32_t participates = 0;
+        uint32_t is_injector = 0;
+        uint32_t is_sink = 0;
+        uint32_t batch = 0;
+        uint32_t mcast_num_dests = 0;
+        uint32_t sender_wait_count = 1;
+
+        volatile tt_l1_ptr uint32_t* sender_sem_ptr = nullptr;
+        volatile tt_l1_ptr uint32_t* receiver_sem_ptr = nullptr;
+        uint64_t sender_sem_noc_addr = 0;
+        uint32_t valid_sem_addr = 0;
+        uint64_t mcast_data_base_noc_addr = 0;  // OR with the L1 data addr at use
+        uint64_t mcast_sem_noc_addr = 0;
+    } batch_chain;
+    uint32_t batch_max_q_per_core = 0;
+
+    if constexpr (batch_k_chain_enabled) {
+        batch_chain.participates = get_arg_val<uint32_t>(argidx++);
+        batch_chain.is_injector = get_arg_val<uint32_t>(argidx++);
+        batch_chain.is_sink = get_arg_val<uint32_t>(argidx++);
+        batch_chain.batch = get_arg_val<uint32_t>(argidx++);
+        const uint32_t batch_mcast_start_x = get_arg_val<uint32_t>(argidx++);
+        const uint32_t batch_mcast_start_y = get_arg_val<uint32_t>(argidx++);
+        const uint32_t batch_mcast_end_x = get_arg_val<uint32_t>(argidx++);
+        const uint32_t batch_mcast_end_y = get_arg_val<uint32_t>(argidx++);
+        const uint32_t batch_injector_x = get_arg_val<uint32_t>(argidx++);
+        const uint32_t batch_injector_y = get_arg_val<uint32_t>(argidx++);
+        batch_chain.mcast_num_dests = get_arg_val<uint32_t>(argidx++);
+        const uint32_t batch_mcast_sender_wait = get_arg_val<uint32_t>(argidx++);
+        batch_max_q_per_core = get_arg_val<uint32_t>(argidx++);
+
+        if (batch_chain.participates) {
+            const uint32_t batch_sender_sem = get_semaphore(batch_sender_semaphore_id);
+            const uint32_t batch_receiver_sem = get_semaphore(batch_receiver_semaphore_id);
+            batch_chain.valid_sem_addr = get_semaphore(batch_valid_semaphore_id);
+            batch_chain.sender_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(batch_sender_sem);
+            batch_chain.receiver_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(batch_receiver_sem);
+            *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(batch_chain.valid_sem_addr) = VALID;
+
+            // Receivers signal the injector directly (mcast: single shared sender semaphore on injector core).
+            batch_chain.sender_sem_noc_addr = get_noc_addr(batch_injector_x, batch_injector_y, batch_sender_sem);
+            if (batch_chain.is_injector) {
+                batch_chain.mcast_data_base_noc_addr = get_noc_multicast_addr(
+                    batch_mcast_start_x, batch_mcast_start_y, batch_mcast_end_x, batch_mcast_end_y, 0);
+                batch_chain.mcast_sem_noc_addr = batch_chain.mcast_data_base_noc_addr | batch_receiver_sem;
+                batch_chain.sender_wait_count = batch_mcast_sender_wait;
+            }
+        }
+    }
+
     // When chunked: only process K/V up to (chunk_start_idx + Q_chunk_length) tokens.
     // valid_Skt_bound = min(offset_tiles + valid_Sqt, valid_Skt); cap at valid_Skt for callers that pass
     // different valid_Sqt (e.g. ring_distributed uses full Q length in tiles).
@@ -285,6 +345,12 @@ void kernel_main() {
         const uint32_t total_q_iters =
             flatten_work ? global_q_count : (local_batch_end - local_batch_start) * heads_local * q_chunks_per_core;
 
+        // Batch K mcast (MLA): every core loops max_q_per_core so receivers stay aligned with the
+        // injector. Lighter cores' tail iterations are "padded" — they do the K mcast hand-off only,
+        // skipping Q/V/mask/attention-sink work.
+        const uint32_t loop_q_iters =
+            batch_k_chain_enabled ? std::max(total_q_iters, batch_max_q_per_core) : total_q_iters;
+
         uint32_t prev_nb = kFirstIteration;
         uint32_t prev_nq = kFirstIteration;
         // Flat path tracks q_iter_local across same-head iterations (chain-only); hierarchical
@@ -292,8 +358,12 @@ void kernel_main() {
         uint32_t flat_prev_head_id = kFirstIteration;
         uint32_t flat_q_iter_local = 0;
 
-        for (uint32_t gq = 0; gq < total_q_iters; ++gq) {
+        for (uint32_t gq = 0; gq < loop_q_iters; ++gq) {
+            const bool is_padded_iter = (gq >= total_q_iters);
             // 1. Resolve the work item (nb, nq, q_chunk, q_iter_local) for this gq.
+            // Padded (batch K mcast sync only) iterations decode out-of-range indices; they're
+            // never used to address Q/V/mask, only K via the batch chain which doesn't read DRAM
+            // by (nb, nq) — the injector reads K from a fixed (nb=0, k_head=0) shape.
             uint32_t nb, nq, q_chunk, q_iter_local = 0;
             if constexpr (flatten_work) {
                 const auto w =
@@ -302,10 +372,12 @@ void kernel_main() {
                 nq = w.nq;
                 q_chunk = w.q_chunk;
                 if constexpr (chain_enabled) {
-                    const uint32_t cur_head_id = nb * NQH + nq;
-                    flat_q_iter_local = (cur_head_id == flat_prev_head_id) ? (flat_q_iter_local + 1) : 0;
-                    flat_prev_head_id = cur_head_id;
-                    q_iter_local = flat_q_iter_local;
+                    if (!is_padded_iter) {
+                        const uint32_t cur_head_id = nb * NQH + nq;
+                        flat_q_iter_local = (cur_head_id == flat_prev_head_id) ? (flat_q_iter_local + 1) : 0;
+                        flat_prev_head_id = cur_head_id;
+                        q_iter_local = flat_q_iter_local;
+                    }
                 }
             } else {
                 const auto w = decompose_hierarchical_index(gq, heads_local, q_chunks_per_core);
@@ -394,22 +466,30 @@ void kernel_main() {
 
             // q_iter_local is the per-(nb, nq) slot index on this core, so a straddling flat-mode
             // core gates forwards against the next core's head slot count, not its whole-range gq.
+            // These flags drive V via the head chain (and K too when batch K chain is off — when
+            // batch K chain is on, K is dispatched via batch_chain instead).
             // Both stay false when chain_enabled=false so the forward/receive branches below dead.
+            // On padded iters (batch K mcast only), V/mask/Q are skipped, so these flags don't fire.
             bool should_forward = false;
             bool should_receive = false;
             if constexpr (chain_enabled) {
                 const bool on_chain_head = (nb == chain.batch) && (nq == chain.head);
-                should_forward =
-                    chain.participates && !chain.is_sink && on_chain_head && (q_iter_local < chain.next_core_q_chunks);
-                should_receive = chain.participates && !chain.is_injector && on_chain_head;
+                should_forward = !is_padded_iter && chain.participates && !chain.is_sink && on_chain_head &&
+                                 (q_iter_local < chain.next_core_q_chunks);
+                should_receive = !is_padded_iter && chain.participates && !chain.is_injector && on_chain_head;
             }
 
             // UP proxy halves the K loop. Chain cores walk the full K range so injector + receivers
             // stay in lockstep; the lightweight causal mask zeroes softmax columns past q_high.
+            // Batch K chain receivers must walk the same K count as the injector — if the head
+            // chain isn't engaged (chain.participates==false) the legacy "q_high_idx" trim would
+            // desync them, so we override to the full range when batch K chain is on.
             uint32_t k_chunk_end;
             if constexpr (proxy_mode == RingProxyCase::Up) {
                 k_chunk_end = k_num_chunks / 2;
             } else if (chain_enabled && chain.participates) {
+                k_chunk_end = k_num_chunks;
+            } else if constexpr (batch_k_chain_enabled) {
                 k_chunk_end = k_num_chunks;
             } else {
                 k_chunk_end = (q_high_idx + Sk_chunk_t - 1) / Sk_chunk_t;
@@ -425,7 +505,46 @@ void kernel_main() {
                 // K: either read locally (injector or not participant) or receive from previous core
                 uint32_t cb_k_start_address = 0;
 
-                if (should_receive) {
+                if constexpr (batch_k_chain_enabled) {
+                    // Batch K chain (MLA): one injector reads K from DRAM and 2D-mcasts to every
+                    // other core. Padded iters reuse a 2-slot staging window (no push_back, write
+                    // ptr stays put), keeping the K mcast hand-off in lock-step without disturbing
+                    // compute's view of the CB.
+                    const uint32_t reserve_tiles = is_padded_iter ? 2 * k_chunk_tiles : k_chunk_tiles;
+                    cb_reserve_back(cb_k_in, reserve_tiles);
+                    cb_k_start_address = get_write_ptr(cb_k_in);
+
+                    if (batch_chain.is_injector) {
+                        // K is shared across all heads in MLA (NHK==1, B==1) — index from (0, 0).
+                        const uint32_t batch_k_tile_id = k_tile_shape.id_of(0, 0, kv_row_start_tile, 0);
+                        read_chunk_for_forwarding<k_tile_bytes, true>(
+                            k_reader, cb_k_start_address, batch_k_tile_id, kv_row_tile_count, DHt, Sk_chunk_t, DHt);
+                        // Wait for receivers to signal ready, then mcast linked write + companion sem.
+                        noc_semaphore_wait(batch_chain.sender_sem_ptr, batch_chain.sender_wait_count);
+                        noc_semaphore_set(batch_chain.sender_sem_ptr, 0);
+                        const uint64_t k_mcast_addr = batch_chain.mcast_data_base_noc_addr | cb_k_start_address;
+                        noc_async_write_multicast(
+                            cb_k_start_address,
+                            k_mcast_addr,
+                            k_chunk_tiles * k_tile_bytes,
+                            batch_chain.mcast_num_dests,
+                            true /* linked: semaphore mcast follows */);
+                        noc_semaphore_set_multicast(
+                            batch_chain.valid_sem_addr, batch_chain.mcast_sem_noc_addr, batch_chain.mcast_num_dests);
+                        noc_async_writes_flushed();
+                    } else if (batch_chain.participates) {
+                        // Receiver: signal sender we're ready, wait for K data + companion sem.
+                        noc_semaphore_set(batch_chain.receiver_sem_ptr, INVALID);
+                        noc_semaphore_inc(batch_chain.sender_sem_noc_addr, 1);
+                        noc_semaphore_wait(batch_chain.receiver_sem_ptr, VALID);
+                    }
+
+                    if (is_padded_iter) {
+                        // Padded iters do K mcast sync only — skip mask, Q, V; don't push K to compute.
+                        continue;
+                    }
+                    cb_push_back(cb_k_in, k_chunk_tiles);
+                } else if (should_receive) {
                     // Receive forwarded K chunk from previous core
                     cb_reserve_back(cb_k_in, k_chunk_tiles);
                     cb_k_start_address = get_write_ptr(cb_k_in);
@@ -479,27 +598,30 @@ void kernel_main() {
                 // The companion must be issued immediately after the linked write —
                 // any noc_async_read_barrier() between them deadlocks (the read barrier
                 // blocks while a linked write awaits its companion).
-                if (should_forward) {
-                    noc_semaphore_wait(chain.sender_sem_ptr, chain.sender_wait_count);
-                    noc_semaphore_set(chain.sender_sem_ptr, 0);
-                    if constexpr (mcast_enabled) {
-                        const uint64_t k_mcast_addr = chain.mcast_data_base_noc_addr | cb_k_start_address;
-                        noc_async_write_multicast(
-                            cb_k_start_address,
-                            k_mcast_addr,
-                            k_chunk_tiles * k_tile_bytes,
-                            chain.mcast_num_dests,
-                            true /* linked: semaphore mcast follows */);
-                        noc_semaphore_set_multicast(
-                            chain.valid_sem_addr, chain.mcast_sem_noc_addr, chain.mcast_num_dests);
-                        noc_async_writes_flushed();
-                        if (!should_receive) {
-                            cb_push_back(cb_k_in, k_chunk_tiles);
+                // Skipped when batch K chain is on — K already mcast through batch_chain above.
+                if constexpr (!batch_k_chain_enabled) {
+                    if (should_forward) {
+                        noc_semaphore_wait(chain.sender_sem_ptr, chain.sender_wait_count);
+                        noc_semaphore_set(chain.sender_sem_ptr, 0);
+                        if constexpr (mcast_enabled) {
+                            const uint64_t k_mcast_addr = chain.mcast_data_base_noc_addr | cb_k_start_address;
+                            noc_async_write_multicast(
+                                cb_k_start_address,
+                                k_mcast_addr,
+                                k_chunk_tiles * k_tile_bytes,
+                                chain.mcast_num_dests,
+                                true /* linked: semaphore mcast follows */);
+                            noc_semaphore_set_multicast(
+                                chain.valid_sem_addr, chain.mcast_sem_noc_addr, chain.mcast_num_dests);
+                            noc_async_writes_flushed();
+                            if (!should_receive) {
+                                cb_push_back(cb_k_in, k_chunk_tiles);
+                            }
+                        } else {
+                            const uint64_t k_unicast_addr =
+                                get_noc_addr(chain.next_physical_x, chain.next_physical_y, cb_k_start_address);
+                            noc_async_write(cb_k_start_address, k_unicast_addr, k_chunk_tiles * k_tile_bytes);
                         }
-                    } else {
-                        const uint64_t k_unicast_addr =
-                            get_noc_addr(chain.next_physical_x, chain.next_physical_y, cb_k_start_address);
-                        noc_async_write(cb_k_start_address, k_unicast_addr, k_chunk_tiles * k_tile_bytes);
                     }
                 }
 
@@ -543,13 +665,16 @@ void kernel_main() {
 
                 // Complete K forward: flush write and signal receiver(s)
                 // (mcast path already completed above — companion sent with linked write)
-                if (should_forward) {
-                    if constexpr (!mcast_enabled) {
-                        noc_async_writes_flushed();
-                        if (!should_receive) {
-                            cb_push_back(cb_k_in, k_chunk_tiles);
+                // Skipped when batch K chain is on — K is dispatched via batch_chain.
+                if constexpr (!batch_k_chain_enabled) {
+                    if (should_forward) {
+                        if constexpr (!mcast_enabled) {
+                            noc_async_writes_flushed();
+                            if (!should_receive) {
+                                cb_push_back(cb_k_in, k_chunk_tiles);
+                            }
+                            noc_semaphore_set_remote(chain.valid_sem_addr, chain.receiver_sem_noc_addr);
                         }
-                        noc_semaphore_set_remote(chain.valid_sem_addr, chain.receiver_sem_noc_addr);
                     }
                 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -71,7 +71,6 @@ void kernel_main() {
     constexpr uint32_t mla_kv_overlap = get_compile_time_arg_val(25) == 1;
     constexpr uint32_t qk_subblock_h = get_compile_time_arg_val(26);
 
-    // Semaphore IDs for KV chain forwarding (non-causal only, but always present in compile args)
     constexpr uint32_t sender_semaphore_id = get_compile_time_arg_val(27);
     constexpr uint32_t receiver_semaphore_id = get_compile_time_arg_val(28);
     constexpr uint32_t valid_semaphore_id = get_compile_time_arg_val(29);
@@ -84,6 +83,13 @@ void kernel_main() {
     constexpr auto page_table_args = TensorAccessorArgs<mask_args.next_compile_time_args_offset()>();
     constexpr auto attention_sink_args = TensorAccessorArgs<page_table_args.next_compile_time_args_offset()>();
     constexpr auto chunk_start_idx_args = TensorAccessorArgs<attention_sink_args.next_compile_time_args_offset()>();
+    // Tail CT args: proxy_case drives flat work distribution + K/Q halving, chain_enabled gates
+    // the runtime-arg chain block below and the forward/receive branches in the K/V loop.
+    constexpr uint32_t proxy_case_ct_idx = chunk_start_idx_args.next_compile_time_args_offset();
+    constexpr RingProxyCase proxy_mode = static_cast<RingProxyCase>(get_compile_time_arg_val(proxy_case_ct_idx));
+    constexpr bool chain_enabled = get_compile_time_arg_val(proxy_case_ct_idx + 1) == 1;
+    constexpr bool flatten_work = proxy_uses_flat_work(proxy_mode);
+    constexpr bool flat_use_zigzag = flatten_work && is_causal && (q_num_chunks % 2 == 0);
 
     uint32_t argidx = 0;
     const uint32_t q_addr = get_arg_val<uint32_t>(argidx++);
@@ -112,78 +118,75 @@ void kernel_main() {
     uint32_t chunked_q_chunk_offset_phase_1_local = chunked_q_chunk_offset_phase_1;
     uint32_t chunked_q_chunk_offset_phase_2_local = chunked_q_chunk_offset_phase_2;
 
+    // Per-core [start, count) slice of the B*NQH*q_num_effective flat range.
+    uint32_t global_q_start = 0;
+    uint32_t global_q_count = 0;
+    if constexpr (flatten_work) {
+        global_q_start = get_arg_val<uint32_t>(argidx++);
+        global_q_count = get_arg_val<uint32_t>(argidx++);
+    }
+
     const uint32_t q_chunks_per_core = local_q_end - local_q_start;
 
-    // Parse chain metadata for KV forwarding (non-causal only)
-    uint32_t is_chain_participant = 0;
-    uint32_t is_injector = 0;
-    uint32_t is_sink = 0;
-    uint32_t chain_batch = 0;
-    uint32_t chain_head = 0;
-    uint32_t prev_physical_x = 0;
-    uint32_t prev_physical_y = 0;
-    uint32_t next_physical_x = 0;
-    uint32_t next_physical_y = 0;
-    uint32_t next_core_q_chunks = 0;
-    uint32_t mcast_num_dests = 0;
-    uint32_t mcast_sender_wait = 0;
-    uint64_t mcast_base_noc_addr = 0;
+    // KV chain forwarding: every field defaults such that should_forward/should_receive stay
+    // false and forward branches are dead when chain_enabled=false.
+    struct ChainState {
+        uint32_t participates = 0;
+        uint32_t is_injector = 0;
+        uint32_t is_sink = 0;
+        uint32_t batch = 0;
+        uint32_t head = 0;
+        uint32_t next_core_q_chunks = 0;
+        uint32_t mcast_num_dests = 0;
+        uint32_t sender_wait_count = 1;
+        uint32_t next_physical_x = 0;
+        uint32_t next_physical_y = 0;
 
-    // Initialize semaphore addresses and NOC addresses for chain forwarding
-    volatile tt_l1_ptr uint32_t* sender_semaphore_addr_ptr = nullptr;
-    volatile tt_l1_ptr uint32_t* receiver_semaphore_addr_ptr = nullptr;
-    volatile tt_l1_ptr uint32_t* valid_semaphore_addr_ptr = nullptr;
-    uint64_t sender_semaphore_noc_addr = 0;
-    uint64_t receiver_semaphore_noc_addr = 0;
-    uint32_t valid_semaphore_addr = 0;
-    uint32_t receiver_semaphore_l1_addr = 0;
-    uint64_t mcast_sem_noc_addr = 0;
-    uint32_t sender_wait_count = 1;
+        volatile tt_l1_ptr uint32_t* sender_sem_ptr = nullptr;
+        volatile tt_l1_ptr uint32_t* receiver_sem_ptr = nullptr;
+        uint64_t sender_sem_noc_addr = 0;
+        uint64_t receiver_sem_noc_addr = 0;
+        uint32_t valid_sem_addr = 0;
+        uint64_t mcast_data_base_noc_addr = 0;  // OR with the L1 data addr at use
+        uint64_t mcast_sem_noc_addr = 0;
+    } chain;
 
-    if constexpr (!is_causal) {
-        is_chain_participant = get_arg_val<uint32_t>(argidx++);
-        is_injector = get_arg_val<uint32_t>(argidx++);
-        is_sink = get_arg_val<uint32_t>(argidx++);
-        chain_batch = get_arg_val<uint32_t>(argidx++);
-        chain_head = get_arg_val<uint32_t>(argidx++);
+    if constexpr (chain_enabled) {
+        chain.participates = get_arg_val<uint32_t>(argidx++);
+        chain.is_injector = get_arg_val<uint32_t>(argidx++);
+        chain.is_sink = get_arg_val<uint32_t>(argidx++);
+        chain.batch = get_arg_val<uint32_t>(argidx++);
+        chain.head = get_arg_val<uint32_t>(argidx++);
         argidx += 2;  // skip chain_q_chunk_start, chain_q_chunk_count (host-only metadata)
-        prev_physical_x = get_arg_val<uint32_t>(argidx++);
-        prev_physical_y = get_arg_val<uint32_t>(argidx++);
-        next_physical_x = get_arg_val<uint32_t>(argidx++);
-        next_physical_y = get_arg_val<uint32_t>(argidx++);
-        next_core_q_chunks = get_arg_val<uint32_t>(argidx++);
-        mcast_num_dests = get_arg_val<uint32_t>(argidx++);
-        mcast_sender_wait = get_arg_val<uint32_t>(argidx++);
+        const uint32_t prev_physical_x = get_arg_val<uint32_t>(argidx++);
+        const uint32_t prev_physical_y = get_arg_val<uint32_t>(argidx++);
+        chain.next_physical_x = get_arg_val<uint32_t>(argidx++);
+        chain.next_physical_y = get_arg_val<uint32_t>(argidx++);
+        chain.next_core_q_chunks = get_arg_val<uint32_t>(argidx++);
+        chain.mcast_num_dests = get_arg_val<uint32_t>(argidx++);
+        const uint32_t mcast_sender_wait = get_arg_val<uint32_t>(argidx++);
 
-        if (is_chain_participant) {
-            const uint32_t sender_semaphore_addr = get_semaphore(sender_semaphore_id);
-            const uint32_t receiver_semaphore_addr = get_semaphore(receiver_semaphore_id);
-            valid_semaphore_addr = get_semaphore(valid_semaphore_id);
-            receiver_semaphore_l1_addr = receiver_semaphore_addr;
+        if (chain.participates) {
+            const uint32_t sender_sem = get_semaphore(sender_semaphore_id);
+            const uint32_t receiver_sem = get_semaphore(receiver_semaphore_id);
+            chain.valid_sem_addr = get_semaphore(valid_semaphore_id);
+            chain.sender_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_sem);
+            chain.receiver_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_sem);
+            *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(chain.valid_sem_addr) = VALID;
 
-            sender_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_semaphore_addr);
-            receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_semaphore_addr);
-            valid_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(valid_semaphore_addr);
-
-            *valid_semaphore_addr_ptr = VALID;
-
+            chain.sender_sem_noc_addr = get_noc_addr(prev_physical_x, prev_physical_y, sender_sem);
             if constexpr (mcast_enabled) {
-                // All chains use mcast (all-or-nothing compile-time decision)
-                sender_semaphore_noc_addr = get_noc_addr(prev_physical_x, prev_physical_y, sender_semaphore_addr);
-                if (is_injector) {
-                    // prev_physical = mcast_start (first receiver), next_physical = mcast_end (last receiver)
-                    mcast_base_noc_addr = get_noc_multicast_addr(
-                        prev_physical_x,
-                        prev_physical_y,
-                        next_physical_x,
-                        next_physical_y,
-                        0);  // addr=0; will OR in actual L1 addr at use site
-                    mcast_sem_noc_addr = mcast_base_noc_addr | receiver_semaphore_l1_addr;
-                    sender_wait_count = mcast_sender_wait;
+                // All chains mcast (all-or-nothing host decision). Injector mcasts across the
+                // [prev_physical, next_physical] rectangle on its row; receivers only need
+                // sender_sem_noc_addr to signal the injector.
+                if (chain.is_injector) {
+                    chain.mcast_data_base_noc_addr = get_noc_multicast_addr(
+                        prev_physical_x, prev_physical_y, chain.next_physical_x, chain.next_physical_y, 0);
+                    chain.mcast_sem_noc_addr = chain.mcast_data_base_noc_addr | receiver_sem;
+                    chain.sender_wait_count = mcast_sender_wait;
                 }
             } else {
-                sender_semaphore_noc_addr = get_noc_addr(prev_physical_x, prev_physical_y, sender_semaphore_addr);
-                receiver_semaphore_noc_addr = get_noc_addr(next_physical_x, next_physical_y, receiver_semaphore_addr);
+                chain.receiver_sem_noc_addr = get_noc_addr(chain.next_physical_x, chain.next_physical_y, receiver_sem);
             }
         }
     }
@@ -241,7 +244,6 @@ void kernel_main() {
 
     volatile tt_l1_ptr uint32_t* page_table_ptr;
 
-    uint32_t chunked_q_chunk_offset = 0;
     if constexpr (is_chunked) {
         if (chunk_start_idx_addr != 0) {
             cb_reserve_back(cb_id_chunk_start_idx_compute, 1);
@@ -264,399 +266,413 @@ void kernel_main() {
             }
         }
     }
-    uint32_t read_offset = 0;
     for (uint32_t phase = 0; phase < num_phases; ++phase) {
-        if (phase == 0) {
-            chunked_q_chunk_offset = chunked_q_chunk_offset_phase_1_local;
-            read_offset = read_offset_phase_1;
-        } else {
-            chunked_q_chunk_offset = chunked_q_chunk_offset_phase_2_local;
-            read_offset = read_offset_phase_2;
-        }
-        uint32_t valid_Skt_bound;
-        if (chunk_start_idx_addr != 0) {
-            // Flexible or ring: cap at valid_Skt so we never read past K/V extent.
-            valid_Skt_bound = std::min(chunked_q_chunk_offset * Sq_chunk_t + valid_Sqt, valid_Skt);
-        } else {
-            // Legacy: extend by offset so one program can serve all chunks (valid_Skt is chunk 0's).
-            valid_Skt_bound = valid_Skt + chunked_q_chunk_offset * Sq_chunk_t;
-        }
+        const uint32_t chunked_q_chunk_offset =
+            (phase == 0) ? chunked_q_chunk_offset_phase_1_local : chunked_q_chunk_offset_phase_2_local;
+        const uint32_t read_offset = (phase == 0) ? read_offset_phase_1 : read_offset_phase_2;
+        const uint32_t valid_Skt_bound =
+            (chunk_start_idx_addr != 0)
+                ? std::min(chunked_q_chunk_offset * Sq_chunk_t + valid_Sqt, valid_Skt)  // flexible/ring
+                : (valid_Skt + chunked_q_chunk_offset * Sq_chunk_t);                    // legacy
 
-        for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
-            if constexpr (is_chunked) {
-                // Chunked means that we have paged attention
-                cb_reserve_back(cb_id_page_table, 1);
-                page_table_ptr = read_page_table_for_batch(
-                    cb_id_page_table, nb, page_table_args, page_table_addr, page_table_stick_size);
-                cb_push_back(cb_id_page_table, 1);
+        // Walk the (nb, nq, q_chunk) work items this core owns. Flat proxy mode decodes each slot
+        // from a single linear index; hierarchical mode linearises its (nb, nq, q_iter) nested
+        // iteration into the same loop so the 250-line K/V body below appears once. Host
+        // guarantees !is_chunked and !use_attention_sink when flatten_work is true, so the paged
+        // page_table and attention_sink blocks only engage on the hierarchical path.
+        constexpr uint32_t kFirstIteration = static_cast<uint32_t>(-1);
+        const uint32_t heads_local = local_nh_end - local_nh_start;
+        const uint32_t total_q_iters =
+            flatten_work ? global_q_count : (local_batch_end - local_batch_start) * heads_local * q_chunks_per_core;
+
+        uint32_t prev_nb = kFirstIteration;
+        uint32_t prev_nq = kFirstIteration;
+        // Flat path tracks q_iter_local across same-head iterations (chain-only); hierarchical
+        // gets it for free from its inner q_iter counter.
+        uint32_t flat_prev_head_id = kFirstIteration;
+        uint32_t flat_q_iter_local = 0;
+
+        for (uint32_t gq = 0; gq < total_q_iters; ++gq) {
+            // 1. Resolve the work item (nb, nq, q_chunk, q_iter_local) for this gq.
+            uint32_t nb, nq, q_chunk, q_iter_local = 0;
+            if constexpr (flatten_work) {
+                const auto w =
+                    decompose_flat_q_index(global_q_start + gq, q_num_chunks, NQH, flat_use_zigzag, proxy_mode);
+                nb = w.nb;
+                nq = w.nq;
+                q_chunk = w.q_chunk;
+                if constexpr (chain_enabled) {
+                    const uint32_t cur_head_id = nb * NQH + nq;
+                    flat_q_iter_local = (cur_head_id == flat_prev_head_id) ? (flat_q_iter_local + 1) : 0;
+                    flat_prev_head_id = cur_head_id;
+                    q_iter_local = flat_q_iter_local;
+                }
+            } else {
+                const auto w = decompose_hierarchical_index(gq, heads_local, q_chunks_per_core);
+                nb = local_batch_start + w.nb_idx;
+                nq = local_nh_start + w.nq_idx;
+#if defined BALANCED_Q_PARALLEL
+                constexpr bool kBalancedQParallel = true;
+#else
+                constexpr bool kBalancedQParallel = false;
+#endif
+                q_chunk =
+                    balanced_q_chunk(w.q_iter, local_q_start, q_chunks_per_core, q_num_chunks, kBalancedQParallel);
+                q_iter_local = w.q_iter;
             }
 
-            // Calculate mask batch offset based on broadcasting (using unpadded mask dimensions):
-            // - If batch is broadcasted [1 x ...]: always use batch=0, so offset = 0
-            // - If batch is not broadcasted [b x ...]: use actual batch nb
+            // 2. Per-batch paged-page-table handoff on nb transitions (hierarchical + chunked).
+            //    Pop the previous batch's page_table, push the new one. First iteration skips pop.
+            if constexpr (!flatten_work && is_chunked) {
+                if (nb != prev_nb) {
+                    if (prev_nb != kFirstIteration) {
+                        cb_pop_front(cb_id_page_table, 1);
+                    }
+                    cb_reserve_back(cb_id_page_table, 1);
+                    page_table_ptr = read_page_table_for_batch(
+                        cb_id_page_table, nb, page_table_args, page_table_addr, page_table_stick_size);
+                    cb_push_back(cb_id_page_table, 1);
+                }
+            }
+
+            // 3. Mask batch offset: depends on nb only.
             uint32_t mask_batch_offset = 0;
             if constexpr (!broadcast_provided_mask_batch) {
-                if constexpr (broadcast_provided_mask_heads) {
-                    // [b x 1 x s x s]: batch offset without head factor
-                    mask_batch_offset = nb * valid_Sqt * valid_Skt;
-                } else {
-                    // [b x h x s x s]: batch offset with all heads
-                    mask_batch_offset = nb * valid_Sqt * valid_Skt * NQH;
-                }
+                constexpr uint32_t heads_factor = broadcast_provided_mask_heads ? 1u : NQH;
+                mask_batch_offset = nb * valid_Sqt * valid_Skt * heads_factor;
             }
-            for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {
-                // Read attention sink for this Q chunk if enabled
-                if constexpr (use_attention_sink) {
+
+            // 4. Per-(nb, nq) attention sink read, on (nb, nq) transitions (hierarchical + sink).
+            if constexpr (!flatten_work && use_attention_sink) {
+                if (nb != prev_nb || nq != prev_nq) {
                     cb_reserve_back(cb_attention_sink, Sq_chunk_t);
                     uint32_t attention_sink_write_ptr = get_write_ptr(cb_attention_sink);
-
-                    // Attention sink has shape [1, NH, 1, 1] - single value per head
-                    // Read the single tile for this head into the first tile of the CB
-                    const uint32_t sink_tile_id =
-                        attention_sink_tile_shape.id_of(0, nq, 0, 0);  // batch=0 since shape is [1,NH,1,1]
+                    const uint32_t sink_tile_id = attention_sink_tile_shape.id_of(0, nq, 0, 0);
                     noc_async_read_tile(sink_tile_id, attention_sink_reader, attention_sink_write_ptr);
                     noc_async_read_barrier();
-
-                    // Fill all Sq_chunk_t tiles in the CB by copying the first element of the source tile
-                    // to the first element of every row in each destination tile
                     fill_attention_sink_tiles<attention_sink_tile_bytes>(
                         cb_attention_sink, Sq_chunk_t, attention_sink_write_ptr);
-
                     cb_push_back(cb_attention_sink, Sq_chunk_t);
-                }
-                for (uint32_t q_iter = 0; q_iter < q_chunks_per_core; ++q_iter) {
-                    /*
-                    Read a chunk of Q. BALANCED_Q_PARALLEL evenly distributes Q chunks
-                    across cores when causal and other conditions are met.
-                    When chunked, we must treat Q as offset by some factor.
-                    When causal, we set up the bounds such that we only read the lower triangle of K and V.
-                    When non-causal, read all of K and V.
-                    */
-                    uint32_t q_chunk;
-#if defined BALANCED_Q_PARALLEL
-                    uint32_t q_chunk_div_2 = q_chunks_per_core / 2;
-                    if (q_iter < q_chunk_div_2) {  // bottom half
-                        q_chunk = local_q_start + q_iter;
-                    } else {
-                        uint32_t back_q_iter = q_iter - q_chunk_div_2;  // Back half should start at 0
-                        q_chunk = q_num_chunks - 1 - (local_q_start + back_q_iter);
-                    }
-#else
-                    q_chunk = local_q_start + q_iter;
-#endif
-                    /*
-                    Determine how many rows of Q will be read. Both start and end rows are
-                    capped by valid_Sqt, since Sq padding is independent of Sk padding.
-                    */
-                    const uint32_t q_row_start_tile = std::min(q_chunk * Sq_chunk_t, valid_Sqt);
-                    const uint32_t q_row_end_tile = std::min(q_row_start_tile + Sq_chunk_t, valid_Sqt);
-                    const uint32_t q_row_tile_count = q_row_end_tile - q_row_start_tile;
-                    uint32_t q_read_tile_id = q_tile_shape.id_of(nb, nq, read_offset + q_row_start_tile, 0);
-
-                    // Q read is deferred into the K loop (k_chunk==0) for subblock interleaving.
-                    // When use_q_subblock_push is false, Q is read in full before the K loop (original behavior).
-                    if constexpr (!use_q_subblock_push) {
-                        read_chunk_with_padding<q_tile_bytes>(
-                            q_reader,
-                            cb_q_in,
-                            q_read_tile_id,
-                            q_row_tile_count,
-                            DHt,
-                            Sq_chunk_t,
-                            DHt,
-                            barrier_threshold);
-                    }
-
-                    q_chunk = chunked_q_chunk_offset + q_chunk;
-                    uint32_t q_low_idx =
-                        q_chunk * Sq_chunk_t;  // This is the sequence index of the first tile of this chunk
-                    uint32_t q_high_idx;
-                    if constexpr (is_causal) {
-                        // Clamp to total K-tile extent (Skt = k_num_chunks * Sk_chunk_t). Without
-                        // this, when Q-chunk extends past K (e.g., Sq_chunk_t > k_num_chunks*Sk_chunk_t),
-                        // the K-loop pushes more chunks than compute consumes → CB deadlock.
-                        const uint32_t q_high_unclamped = q_low_idx + Sq_chunk_t;
-                        q_high_idx = q_high_unclamped < Skt ? q_high_unclamped : Skt;
-                    } else {
-                        q_high_idx = Skt;
-                    }
-
-                    const uint32_t k_head = nq / q_heads_per_k;
-                    const uint32_t v_head = nq / q_heads_per_v;
-
-                    // Chain forwarding conditions are loop-invariant — compute once
-                    bool should_forward = false;
-                    bool should_receive = false;
-                    if constexpr (!is_causal) {
-                        should_forward = is_chain_participant && !is_sink && (nb == chain_batch && nq == chain_head) &&
-                                         (q_iter < next_core_q_chunks);
-                        should_receive =
-                            is_chain_participant && !is_injector && (nb == chain_batch && nq == chain_head);
-                    }
-
-                    // loop while k_low < q_high
-                    for (uint32_t k_chunk = 0; (k_chunk * Sk_chunk_t) < q_high_idx; ++k_chunk) {
-                        const uint32_t kv_row_start_tile = std::min(k_chunk * Sk_chunk_t, valid_Skt_bound);
-                        const uint32_t kv_row_end_tile = std::min(kv_row_start_tile + Sk_chunk_t, valid_Skt_bound);
-                        const uint32_t kv_row_tile_count = kv_row_end_tile - kv_row_start_tile;
-                        const uint32_t k_start_tile_id = k_tile_shape.id_of(nb, k_head, kv_row_start_tile, 0);
-                        const uint32_t v_start_tile_id = v_tile_shape.id_of(nb, v_head, kv_row_start_tile, 0);
-
-                        // K: either read locally (injector or not participant) or receive from previous core
-                        uint32_t cb_k_start_address = 0;
-
-                        if (should_receive) {
-                            // Receive forwarded K chunk from previous core
-                            cb_reserve_back(cb_k_in, k_chunk_tiles);
-                            cb_k_start_address = get_write_ptr(cb_k_in);
-                            noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
-                            noc_semaphore_inc(sender_semaphore_noc_addr, 1);
-                            noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
-                            cb_push_back(cb_k_in, k_chunk_tiles);
-                        } else {
-                            // Read K chunk from DRAM
-                            if constexpr (is_chunked) {
-                                // Use page table to read K chunk (forwarding not supported for paged mode)
-                                const uint32_t k_chunk_start_row_num = k_chunk * Sk_chunk_t;
-                                read_paged_chunk_with_padding<NKH, block_size_t, DHt>(
-                                    k_reader,
-                                    cb_k_in,
-                                    k_head,
-                                    k_chunk_start_row_num,
-                                    kv_row_tile_count,
-                                    DHt,
-                                    Sk_chunk_t,
-                                    DHt,
-                                    k_tile_bytes,
-                                    barrier_threshold,
-                                    page_table_ptr,
-                                    true  // transpose=true for K reads
-                                );
-                            } else {
-                                if (should_forward) {
-                                    cb_reserve_back(cb_k_in, k_chunk_tiles);
-                                    cb_k_start_address = get_write_ptr(cb_k_in);
-                                    read_chunk_for_forwarding<k_tile_bytes, true>(
-                                        k_reader,
-                                        cb_k_start_address,
-                                        k_start_tile_id,
-                                        kv_row_tile_count,
-                                        DHt,
-                                        Sk_chunk_t,
-                                        DHt);
-                                } else {
-                                    read_chunk_with_padding<k_tile_bytes>(
-                                        k_reader,
-                                        cb_k_in,
-                                        k_start_tile_id,
-                                        kv_row_tile_count,
-                                        DHt,
-                                        Sk_chunk_t,
-                                        DHt,
-                                        barrier_threshold,
-                                        true  // transpose=true for K reads
-                                    );
-                                }
-                            }
-                        }
-
-                        // Forward K chunk to next core(s): initiate async write (NOC write channel)
-                        // For mcast: send linked data + companion semaphore back-to-back.
-                        // The companion must be issued immediately after the linked write —
-                        // any noc_async_read_barrier() between them deadlocks (the read barrier
-                        // blocks while a linked write awaits its companion).
-                        if (should_forward) {
-                            noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
-                            noc_semaphore_set(sender_semaphore_addr_ptr, 0);
-                            if constexpr (mcast_enabled) {
-                                uint64_t k_mcast_addr = mcast_base_noc_addr | cb_k_start_address;
-                                noc_async_write_multicast(
-                                    cb_k_start_address,
-                                    k_mcast_addr,
-                                    k_chunk_tiles * k_tile_bytes,
-                                    mcast_num_dests,
-                                    true /* linked: semaphore mcast follows */);
-                                noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
-                                noc_async_writes_flushed();
-                                if (!should_receive) {
-                                    cb_push_back(cb_k_in, k_chunk_tiles);
-                                }
-                            } else {
-                                uint64_t k_unicast_data_addr =
-                                    get_noc_addr(next_physical_x, next_physical_y, cb_k_start_address);
-                                noc_async_write(cb_k_start_address, k_unicast_data_addr, k_chunk_tiles * k_tile_bytes);
-                            }
-                        }
-
-                        // Mask read — safe after linked write pair is complete
-                        if constexpr (use_provided_mask) {
-                            cb_reserve_back(cb_mask_in, mask_chunk_tiles);
-                            uint32_t mask_write_ptr = get_write_ptr(cb_mask_in);
-                            uint32_t barrier_count = 0;
-
-                            uint32_t mask_row_start = mask_batch_offset + q_chunk * Sq_chunk_t * valid_Skt;
-                            if constexpr (!broadcast_provided_mask_heads) {
-                                mask_row_start += nq * valid_Sqt * valid_Skt;
-                            }
-
-                            uint32_t tile_idx = 0;
-                            for (uint32_t row = 0; row < Sq_chunk_t; ++row) {
-                                const uint32_t global_q_tile = q_chunk * Sq_chunk_t + row;
-                                const bool q_valid = !use_padded_mask || (global_q_tile < valid_Sqt);
-                                for (uint32_t col = 0; col < Sk_chunk_t; ++col) {
-                                    const uint32_t global_k_tile = k_chunk * Sk_chunk_t + col;
-                                    const bool k_valid = !use_padded_mask || (global_k_tile < valid_Skt);
-                                    if (q_valid && k_valid) {
-                                        noc_async_read_tile(
-                                            mask_row_start + global_k_tile, mask_reader, mask_write_ptr);
-                                    } else {
-                                        fill_neginf_tile<mask_tile_bytes>(cb_mask_in, tile_idx);
-                                    }
-                                    mask_write_ptr += mask_tile_bytes;
-                                    tile_idx++;
-                                    if (++barrier_count == barrier_threshold) {
-                                        noc_async_read_barrier();
-                                        barrier_count = 0;
-                                    }
-                                }
-                                if (q_valid) {
-                                    mask_row_start += valid_Skt;
-                                }
-                            }
-                            noc_async_read_barrier();
-                            cb_push_back(cb_mask_in, mask_chunk_tiles);
-                        }
-
-                        // Complete K forward: flush write and signal receiver(s)
-                        // (mcast path already completed above — companion sent with linked write)
-                        if (should_forward) {
-                            if constexpr (!mcast_enabled) {
-                                noc_async_writes_flushed();
-                                if (!should_receive) {
-                                    cb_push_back(cb_k_in, k_chunk_tiles);
-                                }
-                                noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
-                            }
-                        }
-
-                        // Q subblock push: K is fully forwarded, now push Q one subblock at
-                        // a time. Compute waits for K first (cb_wait_front(cb_k_in, K*N)),
-                        // then waits for Q subblocks incrementally (accumulating cb_wait_front).
-                        // Each push unblocks the next QK subblock computation.
-                        // Placed after K forward complete so no outstanding NOC writes remain
-                        // (noc_async_read_barrier inside read_q_subblock deadlocks on BH
-                        // when NOC writes are in-flight).
-                        if constexpr (use_q_subblock_push) {
-                            if (k_chunk == 0) {
-                                for (uint32_t q_sub = 0; q_sub < q_num_subblocks; ++q_sub) {
-                                    read_q_subblock<q_tile_bytes>(
-                                        q_reader,
-                                        cb_q_in,
-                                        q_read_tile_id,
-                                        q_sub * qk_subblock_h,
-                                        qk_subblock_h,
-                                        q_row_tile_count,
-                                        DHt,
-                                        DHt,
-                                        barrier_threshold);
-                                }
-                            }
-                        }
-
-                        // V: either read locally (injector or not participant) or receive from previous core
-                        uint32_t cb_v_start_address = 0;
-
-                        if (should_receive) {
-                            // Receive forwarded V chunk from previous core
-                            cb_reserve_back(cb_v_in, v_chunk_tiles);
-                            cb_v_start_address = get_write_ptr(cb_v_in);
-                            noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
-                            noc_semaphore_inc(sender_semaphore_noc_addr, 1);
-                            noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
-                            cb_push_back(cb_v_in, v_chunk_tiles);
-                        } else {
-                            // Read V chunk from DRAM
-                            if constexpr (is_chunked) {
-                                // Use page table to read V chunk (forwarding not supported for paged mode)
-                                const uint32_t kv_chunk_start_row_num = k_chunk * Sk_chunk_t;
-                                constexpr uint32_t head_dim = (use_mla && !mla_kv_overlap) ? vDHt : DHt;
-                                read_paged_chunk_with_padding<NVH, block_size_t, head_dim>(
-                                    v_reader,
-                                    cb_v_in,
-                                    v_head,
-                                    kv_chunk_start_row_num,
-                                    kv_row_tile_count,
-                                    vDHt,
-                                    Sk_chunk_t,
-                                    vDHt,
-                                    v_tile_bytes,
-                                    barrier_threshold,
-                                    page_table_ptr,
-                                    false,
-                                    skip_src_cols);
-                            } else {
-                                if (should_forward) {
-                                    cb_reserve_back(cb_v_in, v_chunk_tiles);
-                                    cb_v_start_address = get_write_ptr(cb_v_in);
-                                    read_chunk_for_forwarding<v_tile_bytes, false>(
-                                        v_reader,
-                                        cb_v_start_address,
-                                        v_start_tile_id,
-                                        kv_row_tile_count,
-                                        vDHt,
-                                        Sk_chunk_t,
-                                        vDHt,
-                                        skip_src_cols);
-                                } else {
-                                    read_chunk_with_padding<v_tile_bytes>(
-                                        v_reader,
-                                        cb_v_in,
-                                        v_start_tile_id,
-                                        kv_row_tile_count,
-                                        vDHt,
-                                        Sk_chunk_t,
-                                        vDHt,
-                                        barrier_threshold,
-                                        false,
-                                        skip_src_cols);
-                                }
-                            }
-                        }
-
-                        // Forward V chunk to next core(s) before push_back — prevents compute from
-                        // popping the buffer while the mcast is still reading from it.
-                        if (should_forward) {
-                            noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
-                            noc_semaphore_set(sender_semaphore_addr_ptr, 0);
-                            if constexpr (mcast_enabled) {
-                                uint64_t v_mcast_addr = mcast_base_noc_addr | cb_v_start_address;
-                                noc_async_write_multicast(
-                                    cb_v_start_address,
-                                    v_mcast_addr,
-                                    v_chunk_tiles * v_tile_bytes,
-                                    mcast_num_dests,
-                                    true /* linked: semaphore mcast follows */);
-                                noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
-                            } else {
-                                uint64_t v_unicast_data_addr =
-                                    get_noc_addr(next_physical_x, next_physical_y, cb_v_start_address);
-                                noc_async_write(cb_v_start_address, v_unicast_data_addr, v_chunk_tiles * v_tile_bytes);
-                            }
-                            noc_async_writes_flushed();
-                            if constexpr (!mcast_enabled) {
-                                noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
-                            }
-                            if (!should_receive) {
-                                cb_push_back(cb_v_in, v_chunk_tiles);
-                            }
-                        }
-                    }
                 }
             }
 
-            if constexpr (is_chunked) {
+            prev_nb = nb;
+            prev_nq = nq;
+
+            // 5. Q read + K/V loop.
+
+            // Determine how many rows of Q will be read. Both start and end rows are capped by valid_Sqt,
+            // since Sq padding is independent of Sk padding.
+            const uint32_t q_row_start_tile = std::min(q_chunk * Sq_chunk_t, valid_Sqt);
+            const uint32_t q_row_end_tile = std::min(q_row_start_tile + Sq_chunk_t, valid_Sqt);
+            const uint32_t q_row_tile_count = q_row_end_tile - q_row_start_tile;
+            // Non-const: read_q_subblock advances the tile id by reference.
+            uint32_t q_read_tile_id = q_tile_shape.id_of(nb, nq, read_offset + q_row_start_tile, 0);
+
+            // Q read is deferred into the K loop (k_chunk==0) for subblock interleaving.
+            // When use_q_subblock_push is false, Q is read in full before the K loop (original behavior).
+            if constexpr (!use_q_subblock_push) {
+                read_chunk_with_padding<q_tile_bytes>(
+                    q_reader, cb_q_in, q_read_tile_id, q_row_tile_count, DHt, Sq_chunk_t, DHt, barrier_threshold);
+            }
+
+            const uint32_t q_chunk_offs = chunked_q_chunk_offset + q_chunk;
+            const uint32_t q_low_idx = q_chunk_offs * Sq_chunk_t;  // sequence index of first tile in this chunk
+            uint32_t q_high_idx;
+            if constexpr (is_causal) {
+                // Clamp to total K-tile extent (Skt = k_num_chunks * Sk_chunk_t). Without this,
+                // when Q-chunk extends past K (e.g., Sq_chunk_t > k_num_chunks*Sk_chunk_t), the
+                // K-loop pushes more chunks than compute consumes → CB deadlock. Mirrors compute_common.hpp.
+                const uint32_t q_high_unclamped = q_low_idx + Sq_chunk_t;
+                q_high_idx = q_high_unclamped < Skt ? q_high_unclamped : Skt;
+            } else {
+                q_high_idx = Skt;
+            }
+
+            const uint32_t k_head = nq / q_heads_per_k;
+            const uint32_t v_head = nq / q_heads_per_v;
+
+            // q_iter_local is the per-(nb, nq) slot index on this core, so a straddling flat-mode
+            // core gates forwards against the next core's head slot count, not its whole-range gq.
+            // Both stay false when chain_enabled=false so the forward/receive branches below dead.
+            bool should_forward = false;
+            bool should_receive = false;
+            if constexpr (chain_enabled) {
+                const bool on_chain_head = (nb == chain.batch) && (nq == chain.head);
+                should_forward =
+                    chain.participates && !chain.is_sink && on_chain_head && (q_iter_local < chain.next_core_q_chunks);
+                should_receive = chain.participates && !chain.is_injector && on_chain_head;
+            }
+
+            // UP proxy halves the K loop. Chain cores walk the full K range so injector + receivers
+            // stay in lockstep; the lightweight causal mask zeroes softmax columns past q_high.
+            uint32_t k_chunk_end;
+            if constexpr (proxy_mode == RingProxyCase::Up) {
+                k_chunk_end = k_num_chunks / 2;
+            } else if (chain_enabled && chain.participates) {
+                k_chunk_end = k_num_chunks;
+            } else {
+                k_chunk_end = (q_high_idx + Sk_chunk_t - 1) / Sk_chunk_t;
+            }
+
+            for (uint32_t k_chunk = 0; k_chunk < k_chunk_end; ++k_chunk) {
+                const uint32_t kv_row_start_tile = std::min(k_chunk * Sk_chunk_t, valid_Skt_bound);
+                const uint32_t kv_row_end_tile = std::min(kv_row_start_tile + Sk_chunk_t, valid_Skt_bound);
+                const uint32_t kv_row_tile_count = kv_row_end_tile - kv_row_start_tile;
+                const uint32_t k_start_tile_id = k_tile_shape.id_of(nb, k_head, kv_row_start_tile, 0);
+                const uint32_t v_start_tile_id = v_tile_shape.id_of(nb, v_head, kv_row_start_tile, 0);
+
+                // K: either read locally (injector or not participant) or receive from previous core
+                uint32_t cb_k_start_address = 0;
+
+                if (should_receive) {
+                    // Receive forwarded K chunk from previous core
+                    cb_reserve_back(cb_k_in, k_chunk_tiles);
+                    cb_k_start_address = get_write_ptr(cb_k_in);
+                    noc_semaphore_set(chain.receiver_sem_ptr, INVALID);
+                    noc_semaphore_inc(chain.sender_sem_noc_addr, 1);
+                    noc_semaphore_wait(chain.receiver_sem_ptr, VALID);
+                    cb_push_back(cb_k_in, k_chunk_tiles);
+                } else {
+                    // Read K chunk from DRAM
+                    if constexpr (is_chunked) {
+                        // Use page table to read K chunk (forwarding not supported for paged mode)
+                        const uint32_t k_chunk_start_row_num = k_chunk * Sk_chunk_t;
+                        read_paged_chunk_with_padding<NKH, block_size_t, DHt>(
+                            k_reader,
+                            cb_k_in,
+                            k_head,
+                            k_chunk_start_row_num,
+                            kv_row_tile_count,
+                            DHt,
+                            Sk_chunk_t,
+                            DHt,
+                            k_tile_bytes,
+                            barrier_threshold,
+                            page_table_ptr,
+                            true  // transpose=true for K reads
+                        );
+                    } else {
+                        if (should_forward) {
+                            cb_reserve_back(cb_k_in, k_chunk_tiles);
+                            cb_k_start_address = get_write_ptr(cb_k_in);
+                            read_chunk_for_forwarding<k_tile_bytes, true>(
+                                k_reader, cb_k_start_address, k_start_tile_id, kv_row_tile_count, DHt, Sk_chunk_t, DHt);
+                        } else {
+                            read_chunk_with_padding<k_tile_bytes, decltype(k_reader), true, false>(
+                                k_reader,
+                                cb_k_in,
+                                k_start_tile_id,
+                                kv_row_tile_count,
+                                DHt,
+                                Sk_chunk_t,
+                                DHt,
+                                barrier_threshold,
+                                true  // transpose=true for K reads
+                            );
+                        }
+                    }
+                }
+
+                // Forward K chunk to next core(s): initiate async write (NOC write channel)
+                // For mcast: send linked data + companion semaphore back-to-back.
+                // The companion must be issued immediately after the linked write —
+                // any noc_async_read_barrier() between them deadlocks (the read barrier
+                // blocks while a linked write awaits its companion).
+                if (should_forward) {
+                    noc_semaphore_wait(chain.sender_sem_ptr, chain.sender_wait_count);
+                    noc_semaphore_set(chain.sender_sem_ptr, 0);
+                    if constexpr (mcast_enabled) {
+                        const uint64_t k_mcast_addr = chain.mcast_data_base_noc_addr | cb_k_start_address;
+                        noc_async_write_multicast(
+                            cb_k_start_address,
+                            k_mcast_addr,
+                            k_chunk_tiles * k_tile_bytes,
+                            chain.mcast_num_dests,
+                            true /* linked: semaphore mcast follows */);
+                        noc_semaphore_set_multicast(
+                            chain.valid_sem_addr, chain.mcast_sem_noc_addr, chain.mcast_num_dests);
+                        noc_async_writes_flushed();
+                        if (!should_receive) {
+                            cb_push_back(cb_k_in, k_chunk_tiles);
+                        }
+                    } else {
+                        const uint64_t k_unicast_addr =
+                            get_noc_addr(chain.next_physical_x, chain.next_physical_y, cb_k_start_address);
+                        noc_async_write(cb_k_start_address, k_unicast_addr, k_chunk_tiles * k_tile_bytes);
+                    }
+                }
+
+                // Mask read — safe after linked write pair is complete
+                if constexpr (use_provided_mask) {
+                    cb_reserve_back(cb_mask_in, mask_chunk_tiles);
+                    uint32_t mask_write_ptr = get_write_ptr(cb_mask_in);
+                    uint32_t barrier_count = 0;
+
+                    uint32_t mask_row_start = mask_batch_offset + q_chunk * Sq_chunk_t * valid_Skt;
+                    if constexpr (!broadcast_provided_mask_heads) {
+                        mask_row_start += nq * valid_Sqt * valid_Skt;
+                    }
+
+                    uint32_t tile_idx = 0;
+                    for (uint32_t row = 0; row < Sq_chunk_t; ++row) {
+                        const uint32_t global_q_tile = q_chunk * Sq_chunk_t + row;
+                        const bool q_valid = !use_padded_mask || (global_q_tile < valid_Sqt);
+                        for (uint32_t col = 0; col < Sk_chunk_t; ++col) {
+                            const uint32_t global_k_tile = k_chunk * Sk_chunk_t + col;
+                            const bool k_valid = !use_padded_mask || (global_k_tile < valid_Skt);
+                            if (q_valid && k_valid) {
+                                noc_async_read_tile(mask_row_start + global_k_tile, mask_reader, mask_write_ptr);
+                            } else {
+                                fill_neginf_tile<mask_tile_bytes>(cb_mask_in, tile_idx);
+                            }
+                            mask_write_ptr += mask_tile_bytes;
+                            tile_idx++;
+                            if (++barrier_count == barrier_threshold) {
+                                noc_async_read_barrier();
+                                barrier_count = 0;
+                            }
+                        }
+                        if (q_valid) {
+                            mask_row_start += valid_Skt;
+                        }
+                    }
+                    noc_async_read_barrier();
+                    cb_push_back(cb_mask_in, mask_chunk_tiles);
+                }
+
+                // Complete K forward: flush write and signal receiver(s)
+                // (mcast path already completed above — companion sent with linked write)
+                if (should_forward) {
+                    if constexpr (!mcast_enabled) {
+                        noc_async_writes_flushed();
+                        if (!should_receive) {
+                            cb_push_back(cb_k_in, k_chunk_tiles);
+                        }
+                        noc_semaphore_set_remote(chain.valid_sem_addr, chain.receiver_sem_noc_addr);
+                    }
+                }
+
+                // Q subblock push: K is fully forwarded, now push Q one subblock at
+                // a time. Compute waits for K first (cb_wait_front(cb_k_in, K*N)),
+                // then waits for Q subblocks incrementally (accumulating cb_wait_front).
+                // Each push unblocks the next QK subblock computation.
+                // Placed after K forward complete so no outstanding NOC writes remain
+                // (noc_async_read_barrier inside read_q_subblock deadlocks on BH
+                // when NOC writes are in-flight).
+                if constexpr (use_q_subblock_push) {
+                    if (k_chunk == 0) {
+                        for (uint32_t q_sub = 0; q_sub < q_num_subblocks; ++q_sub) {
+                            read_q_subblock<q_tile_bytes>(
+                                q_reader,
+                                cb_q_in,
+                                q_read_tile_id,
+                                q_sub * qk_subblock_h,
+                                qk_subblock_h,
+                                q_row_tile_count,
+                                DHt,
+                                DHt,
+                                barrier_threshold);
+                        }
+                    }
+                }
+
+                // V: either read locally (injector or not participant) or receive from previous core
+                uint32_t cb_v_start_address = 0;
+
+                if (should_receive) {
+                    // Receive forwarded V chunk from previous core
+                    cb_reserve_back(cb_v_in, v_chunk_tiles);
+                    cb_v_start_address = get_write_ptr(cb_v_in);
+                    noc_semaphore_set(chain.receiver_sem_ptr, INVALID);
+                    noc_semaphore_inc(chain.sender_sem_noc_addr, 1);
+                    noc_semaphore_wait(chain.receiver_sem_ptr, VALID);
+                    cb_push_back(cb_v_in, v_chunk_tiles);
+                } else {
+                    // Read V chunk from DRAM
+                    if constexpr (is_chunked) {
+                        // Use page table to read V chunk (forwarding not supported for paged mode)
+                        const uint32_t kv_chunk_start_row_num = k_chunk * Sk_chunk_t;
+                        constexpr uint32_t head_dim = (use_mla && !mla_kv_overlap) ? vDHt : DHt;
+                        read_paged_chunk_with_padding<NVH, block_size_t, head_dim>(
+                            v_reader,
+                            cb_v_in,
+                            v_head,
+                            kv_chunk_start_row_num,
+                            kv_row_tile_count,
+                            vDHt,
+                            Sk_chunk_t,
+                            vDHt,
+                            v_tile_bytes,
+                            barrier_threshold,
+                            page_table_ptr,
+                            false,
+                            skip_src_cols);
+                    } else {
+                        if (should_forward) {
+                            cb_reserve_back(cb_v_in, v_chunk_tiles);
+                            cb_v_start_address = get_write_ptr(cb_v_in);
+                            read_chunk_for_forwarding<v_tile_bytes, false>(
+                                v_reader,
+                                cb_v_start_address,
+                                v_start_tile_id,
+                                kv_row_tile_count,
+                                vDHt,
+                                Sk_chunk_t,
+                                vDHt,
+                                skip_src_cols);
+                        } else {
+                            read_chunk_with_padding<v_tile_bytes, decltype(v_reader), true, false>(
+                                v_reader,
+                                cb_v_in,
+                                v_start_tile_id,
+                                kv_row_tile_count,
+                                vDHt,
+                                Sk_chunk_t,
+                                vDHt,
+                                barrier_threshold,
+                                false,
+                                skip_src_cols);
+                        }
+                    }
+                }
+
+                // Forward V chunk to next core(s) before push_back — prevents compute from
+                // popping the buffer while the mcast is still reading from it.
+                if (should_forward) {
+                    noc_semaphore_wait(chain.sender_sem_ptr, chain.sender_wait_count);
+                    noc_semaphore_set(chain.sender_sem_ptr, 0);
+                    if constexpr (mcast_enabled) {
+                        const uint64_t v_mcast_addr = chain.mcast_data_base_noc_addr | cb_v_start_address;
+                        noc_async_write_multicast(
+                            cb_v_start_address,
+                            v_mcast_addr,
+                            v_chunk_tiles * v_tile_bytes,
+                            chain.mcast_num_dests,
+                            true /* linked: semaphore mcast follows */);
+                        noc_semaphore_set_multicast(
+                            chain.valid_sem_addr, chain.mcast_sem_noc_addr, chain.mcast_num_dests);
+                    } else {
+                        const uint64_t v_unicast_addr =
+                            get_noc_addr(chain.next_physical_x, chain.next_physical_y, cb_v_start_address);
+                        noc_async_write(cb_v_start_address, v_unicast_addr, v_chunk_tiles * v_tile_bytes);
+                    }
+                    noc_async_writes_flushed();
+                    if constexpr (!mcast_enabled) {
+                        noc_semaphore_set_remote(chain.valid_sem_addr, chain.receiver_sem_noc_addr);
+                    }
+                    if (!should_receive) {
+                        cb_push_back(cb_v_in, v_chunk_tiles);
+                    }
+                }
+            }  // close k_chunk
+        }  // close gq
+
+        // Close out the last batch's page_table push — phase loop invariant is "no entries left".
+        if constexpr (!flatten_work && is_chunked) {
+            if (prev_nb != kFirstIteration) {
                 cb_pop_front(cb_id_page_table, 1);
             }
         }
-    }
+    }  // close phase
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
@@ -34,6 +34,10 @@ void kernel_main() {
     constexpr uint32_t k_partial_col = get_compile_time_arg_val(23);
 
     constexpr auto out_args = TensorAccessorArgs<24>();
+    constexpr RingProxyCase proxy_mode =
+        static_cast<RingProxyCase>(get_compile_time_arg_val(out_args.next_compile_time_args_offset()));
+    constexpr bool flatten_work = proxy_uses_flat_work(proxy_mode);
+    constexpr bool flat_use_zigzag = flatten_work && is_causal && (q_num_chunks % 2 == 0);
 
     const uint32_t out_addr = get_arg_val<uint32_t>(0);
     const uint32_t core_id = get_arg_val<uint32_t>(1);
@@ -47,11 +51,19 @@ void kernel_main() {
     const uint32_t use_chunk_start_idx_tensor = get_arg_val<uint32_t>(9);
     uint32_t chunk_start_t_in_q_chunks_phase_1 = get_arg_val<uint32_t>(10);
     const uint32_t write_offset_phase_1 = get_arg_val<uint32_t>(11);
+    uint32_t argidx = 12;
     uint32_t chunk_start_t_in_q_chunks_phase_2 = 0;
     uint32_t write_offset_phase_2 = 0;
     if (num_phases == 2) {
-        chunk_start_t_in_q_chunks_phase_2 = get_arg_val<uint32_t>(12);
-        write_offset_phase_2 = get_arg_val<uint32_t>(13);
+        chunk_start_t_in_q_chunks_phase_2 = get_arg_val<uint32_t>(argidx++);
+        write_offset_phase_2 = get_arg_val<uint32_t>(argidx++);
+    }
+
+    uint32_t global_q_start = 0;
+    uint32_t global_q_count = 0;
+    if constexpr (flatten_work) {
+        global_q_start = get_arg_val<uint32_t>(argidx++);
+        global_q_count = get_arg_val<uint32_t>(argidx++);
     }
 
     const uint32_t q_chunks_per_core = local_q_end - local_q_start;
@@ -104,83 +116,76 @@ void kernel_main() {
         }
     }
 
-    uint32_t chunk_start_t_in_q_chunks = 0;
-    uint32_t write_offset = 0;
     for (uint32_t phase = 0; phase < num_phases; ++phase) {
-        if (phase == 0) {
-            chunk_start_t_in_q_chunks = chunk_start_t_in_q_chunks_phase_1;
-            write_offset = write_offset_phase_1;
-        } else {
-            chunk_start_t_in_q_chunks = chunk_start_t_in_q_chunks_phase_2;
-            write_offset = write_offset_phase_2;
-        }
-        for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
-            const uint32_t q_batch_offset = nb * NQH * Sqt * DHt;
-            for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {
-                for (uint32_t q_iter = 0; q_iter < q_chunks_per_core; ++q_iter) {
-                    uint32_t q_chunk;
+        const uint32_t chunk_start_t_in_q_chunks =
+            (phase == 0) ? chunk_start_t_in_q_chunks_phase_1 : chunk_start_t_in_q_chunks_phase_2;
+        const uint32_t write_offset = (phase == 0) ? write_offset_phase_1 : write_offset_phase_2;
+
+        // Walk the (nb, nq, q_chunk) work items this core owns. Flat proxy mode decodes each
+        // slot from a single linear index; hierarchical mode linearises its (nb, nq, q_iter)
+        // nested iteration into the same loop so the mask-gen + write body appears once.
+        const uint32_t heads_local = local_nh_end - local_nh_start;
+        const uint32_t total_q_iters =
+            flatten_work ? global_q_count : (local_batch_end - local_batch_start) * heads_local * q_chunks_per_core;
+
+        for (uint32_t gq = 0; gq < total_q_iters; ++gq) {
+            uint32_t nb, nq, q_chunk;
+            if constexpr (flatten_work) {
+                const auto w =
+                    decompose_flat_q_index(global_q_start + gq, q_num_chunks, NQH, flat_use_zigzag, proxy_mode);
+                nb = w.nb;
+                nq = w.nq;
+                q_chunk = w.q_chunk;
+            } else {
+                const auto w = decompose_hierarchical_index(gq, heads_local, q_chunks_per_core);
+                nb = local_batch_start + w.nb_idx;
+                nq = local_nh_start + w.nq_idx;
 #if defined BALANCED_Q_PARALLEL
-                    uint32_t q_chunk_div_2 = q_chunks_per_core / 2;
-                    if (q_iter < q_chunk_div_2) {  // bottom half
-                        q_chunk = local_q_start + q_iter;
-                    } else {
-                        uint32_t back_q_iter = q_iter - q_chunk_div_2;  // Back half should start at 0
-                        q_chunk = q_num_chunks - 1 - (local_q_start + back_q_iter);
-                    }
+                constexpr bool kBalancedQParallel = true;
 #else
-                    q_chunk = local_q_start + q_iter;
+                constexpr bool kBalancedQParallel = false;
 #endif
+                q_chunk =
+                    balanced_q_chunk(w.q_iter, local_q_start, q_chunks_per_core, q_num_chunks, kBalancedQParallel);
+            }
 
-                    // Generate mask only when user didn't provide one.
-                    // Lightweight path already has a single -inf tile fronted — skip generate_mask.
-                    if constexpr (!use_provided_mask && !use_lightweight_mask) {
-                        generate_mask<is_chunked, sliding_window_size, use_padded_mask, cb_mask_in>(
-                            Sq_chunk_t,
-                            Sk_chunk_t,
-                            q_chunk,
-                            chunk_start_t_in_q_chunks,
-                            true,
-                            false,
-                            unpadded_Sk,
-                            0,
-                            is_causal);
-                    }
+            // Generate mask only when user didn't provide one.
+            // Lightweight path already has a single -inf tile fronted — skip generate_mask.
+            if constexpr (!use_provided_mask && !use_lightweight_mask) {
+                generate_mask<is_chunked, sliding_window_size, use_padded_mask, cb_mask_in>(
+                    Sq_chunk_t, Sk_chunk_t, q_chunk, chunk_start_t_in_q_chunks, true, false, unpadded_Sk, 0, is_causal);
+            }
 
-                    // Wait for compute to deliver output chunk
-                    /*
-                      Determine how many rows of OUT will be written. Both start and end rows are
-                      capped by valid_Sqt, since Sq padding is independent of Sk padding.
-                    */
-                    const uint32_t out_row_start_tile = std::min(q_chunk * Sq_chunk_t, valid_Sqt);
-                    const uint32_t out_row_end_tile = std::min(out_row_start_tile + Sq_chunk_t, valid_Sqt);
-                    const uint32_t out_row_tile_count = out_row_end_tile - out_row_start_tile;
-                    uint32_t out_tile_id = out_tile_shape.id_of(nb, nq, write_offset + out_row_start_tile, 0);
-                    if constexpr (use_streaming_compute) {
-                        // Streaming: drain per row-group (cb_out is a 2-slot ping-pong).
-                        // Compute always pushes Sq_chunk_t rows; rows past out_row_tile_count
-                        // are padding and get popped without being written.
-                        write_block_row_grouped(
-                            out_writer,
-                            cb_out,
-                            Sq_chunk_t,
-                            out_row_tile_count,
-                            vDHt,
-                            out_tile_id,
-                            tile_bytes,
-                            out_subblock_h,
-                            barrier_threshold);
-                    } else {
-                        write_block(
-                            out_writer,
-                            cb_out,
-                            out_chunk_tiles,
-                            out_row_tile_count,
-                            vDHt,
-                            out_tile_id,
-                            tile_bytes,
-                            barrier_threshold);
-                    }
-                }
+            // Wait for compute to deliver output chunk. Both start and end rows are capped by valid_Sqt,
+            // since Sq padding is independent of Sk padding.
+            const uint32_t out_row_start_tile = std::min(q_chunk * Sq_chunk_t, valid_Sqt);
+            const uint32_t out_row_end_tile = std::min(out_row_start_tile + Sq_chunk_t, valid_Sqt);
+            const uint32_t out_row_tile_count = out_row_end_tile - out_row_start_tile;
+            const uint32_t out_tile_id = out_tile_shape.id_of(nb, nq, write_offset + out_row_start_tile, 0);
+            if constexpr (use_streaming_compute) {
+                // Streaming: drain per row-group (cb_out is a 2-slot ping-pong).
+                // Compute always pushes Sq_chunk_t rows; rows past out_row_tile_count
+                // are padding and get popped without being written.
+                write_block_row_grouped(
+                    out_writer,
+                    cb_out,
+                    Sq_chunk_t,
+                    out_row_tile_count,
+                    vDHt,
+                    out_tile_id,
+                    tile_bytes,
+                    out_subblock_h,
+                    barrier_threshold);
+            } else {
+                write_block(
+                    out_writer,
+                    cb_out,
+                    out_chunk_tiles,
+                    out_row_tile_count,
+                    vDHt,
+                    out_tile_id,
+                    tile_bytes,
+                    barrier_threshold);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/q_chunk_remapping.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/q_chunk_remapping.hpp
@@ -6,6 +6,9 @@
 
 #include <cstdint>
 #include "internal/risc_attribs.h"
+#include "cpp/ttnn/operations/transformer/sdpa/device/ring_proxy_case.hpp"
+
+using ttnn::operations::transformer::RingProxyCase;
 
 /**
  * Convert linear flat index to zigzag flat index for per-head load balancing.
@@ -56,4 +59,75 @@ FORCE_INLINE uint32_t remap_q_index(uint32_t linear_index, uint32_t num_q_chunks
         return linear_to_zigzag(linear_index, num_q_chunks);
     }
     return linear_index;
+}
+
+FORCE_INLINE constexpr bool proxy_uses_flat_work(RingProxyCase m) { return m != RingProxyCase::None; }
+
+struct FlatQIndex {
+    uint32_t nb;
+    uint32_t nq;
+    uint32_t q_chunk;
+};
+
+// Effective Q chunk count + offset for a given proxy mode. Down halves the Q space and points at
+// the heavy half; Diag / Up / None keep the full range at offset 0.
+struct ProxyQRange {
+    uint32_t q_num_effective;
+    uint32_t q_chunk_offset;
+};
+
+FORCE_INLINE constexpr ProxyQRange proxy_q_range(uint32_t q_num_chunks, RingProxyCase proxy) {
+    if (proxy == RingProxyCase::Down) {
+        return {q_num_chunks / 2, q_num_chunks / 2};
+    }
+    return {q_num_chunks, 0};
+}
+
+// Decompose a flat index in [0, B*NQH*q_num_effective) into (nb, nq, q_chunk). q_chunk is shifted
+// into the physical Q range (so Down returns the heavy half directly).
+FORCE_INLINE FlatQIndex decompose_flat_q_index(
+    uint32_t linear_index, uint32_t q_num_chunks, uint32_t NQH, bool use_zigzag, RingProxyCase proxy) {
+    const ProxyQRange range = proxy_q_range(q_num_chunks, proxy);
+    const uint32_t flat = remap_q_index(linear_index, range.q_num_effective, use_zigzag);
+    return {
+        /*nb=*/flat / (NQH * range.q_num_effective),
+        /*nq=*/(flat / range.q_num_effective) % NQH,
+        /*q_chunk=*/flat % range.q_num_effective + range.q_chunk_offset,
+    };
+}
+
+// Compute-side q_chunk lookup. Compute doesn't need the (nb, nq) split — reader/writer do.
+FORCE_INLINE uint32_t proxy_q_chunk(uint32_t q_iter, uint32_t q_num_chunks, bool use_zigzag, RingProxyCase proxy) {
+    const ProxyQRange range = proxy_q_range(q_num_chunks, proxy);
+    return remap_q_index(q_iter, range.q_num_effective, use_zigzag) % range.q_num_effective + range.q_chunk_offset;
+}
+
+// Hierarchical iteration: decompose a linear gq ∈ [0, B_local * H_local * Q_per_core) into
+// (nb_idx, nq_idx, q_iter) in lexicographic order (nb outer, nq middle, q_iter inner).
+struct HierarchicalIndex {
+    uint32_t nb_idx;
+    uint32_t nq_idx;
+    uint32_t q_iter;
+};
+FORCE_INLINE HierarchicalIndex
+decompose_hierarchical_index(uint32_t gq, uint32_t heads_local, uint32_t q_chunks_per_core) {
+    return {
+        /*nb_idx=*/gq / (q_chunks_per_core * heads_local),
+        /*nq_idx=*/(gq / q_chunks_per_core) % heads_local,
+        /*q_iter=*/gq % q_chunks_per_core,
+    };
+}
+
+// Pick the q_chunk for a given q_iter slot. BALANCED_Q_PARALLEL (causal + even chunks) interleaves
+// light and heavy halves so cores see even work; plain mode is consecutive.
+FORCE_INLINE uint32_t balanced_q_chunk(
+    uint32_t q_iter, uint32_t local_q_start, uint32_t q_chunks_per_core, uint32_t q_num_chunks, bool balanced) {
+    if (!balanced) {
+        return local_q_start + q_iter;
+    }
+    const uint32_t half = q_chunks_per_core / 2;
+    if (q_iter < half) {
+        return local_q_start + q_iter;  // bottom half: forward from local_q_start
+    }
+    return q_num_chunks - 1 - (local_q_start + (q_iter - half));  // top half: backward from end
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -243,6 +243,8 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
         .append_to(reader_compile_time_args);                  // page table
     TensorAccessorArgs().append_to(reader_compile_time_args);  // attention sink (not used in ring)
     TensorAccessorArgs().append_to(reader_compile_time_args);  // chunk_start_idx_tensor (ring has no flexible chunked)
+    reader_compile_time_args.push_back(0);  // proxy_case (None / hierarchical)
+    reader_compile_time_args.push_back(0);  // chain_enabled (off)
 
     std::vector<uint32_t> writer_compile_time_args = {
         // interleaved accessor args
@@ -272,6 +274,7 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
         0,      // arg 23: k_partial_col — non-streaming, no partial mask emitted
     };
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
+    writer_compile_time_args.push_back(0);  // proxy_case (None / hierarchical)
 
     std::vector<uint32_t> compute_compile_time_args = {
         // matmul args
@@ -307,6 +310,10 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
         0,          //(std::uint32_t)use_attention_sink,
         0,          //(std::uint32_t)use_streaming_compute — always false for ring distributed (causal)
         valid_Skt,  // arg 31: unpadded K tiles for streaming padded_k_tiles
+        0,          // arg 32: uniform_dataformat (unused, no streaming)
+        0,          // arg 33: k_partial_col (no partial mask)
+        0,          // arg 34: proxy_case (None / hierarchical)
+        0,          // arg 35: chain_enabled (off)
     };
     TensorAccessorArgs(output_tensor.buffer()).append_to(compute_compile_time_args);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_proxy_case.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_proxy_case.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+// Shared between host (SDPAProgramConfig) and kernel (q_chunk_remapping.hpp). Keep this header
+// dependency-free so kernel translation units can include it.
+
+namespace ttnn::operations::transformer {
+
+// Single-chip perf proxy for multi-chip ring-joint SDPA. All non-None cases distribute work flat
+// across cores (B * NQH * q_num_chunks split evenly) instead of hierarchical batch × heads × q,
+// matching what ring_joint_sdpa does per device.
+//
+// - None: hierarchical batch/heads/q split (default).
+// - Diag: flat; full Q × full K. Mirrors the iter-0 (diag) work on each ring device. Requires
+//         is_causal=true.
+// - Up:   flat; full Q, K-loop capped at k_num_chunks/2. Mirrors a non-diag iter where
+//         ring_index > ring_id (half-K per Q). Requires is_causal=false.
+// - Down: flat; only the heavy Q half (q_num_chunks/2 slots), full K per slot. Mirrors a non-diag
+//         iter where ring_index < ring_id (is_balanced Q-skip). Requires is_causal=false.
+enum class RingProxyCase : uint8_t {
+    None = 0,
+    Diag = 1,
+    Up = 2,
+    Down = 3,
+};
+
+}  // namespace ttnn::operations::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -88,12 +88,7 @@ bool can_use_streaming_compute(
     bool use_provided_mask,
     bool use_attention_sink,
     const std::optional<uint32_t>& sliding_window_size,
-    bool fp32_dest_acc_en,
-    bool flatten_work) {
-    // Streaming SDPA doesn't honor flat work distribution yet.
-    if (flatten_work) {
-        return false;
-    }
+    bool fp32_dest_acc_en) {
     if (use_provided_mask || use_attention_sink) {
         return false;
     }
@@ -490,7 +485,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         detail::determine_largest_subblock_size(Sq_chunk_t, Sk_chunk_t, dst_size);
 
     const bool use_streaming_compute = can_use_streaming_compute(
-        use_provided_mask, use_attention_sink, sliding_window_size, fp32_dest_acc_en, flatten_work);
+        use_provided_mask, use_attention_sink, sliding_window_size, fp32_dest_acc_en);
 
     const bool lightweight_causal = is_causal && !use_provided_mask && sliding_window_size.value_or(0) == 0;
     const bool lightweight_mask = (use_streaming_compute && use_padded_mask) || lightweight_causal;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -73,7 +73,12 @@ bool can_use_streaming_compute(
     bool use_provided_mask,
     bool use_attention_sink,
     const std::optional<uint32_t>& sliding_window_size,
-    bool fp32_dest_acc_en) {
+    bool fp32_dest_acc_en,
+    bool flatten_work) {
+    // Streaming SDPA doesn't honor flat work distribution yet.
+    if (flatten_work) {
+        return false;
+    }
     if (use_provided_mask || use_attention_sink) {
         return false;
     }
@@ -115,6 +120,97 @@ bool get_exp_approx_mode(const std::optional<ttnn::operations::transformer::SDPA
         return program_config->exp_approx_mode.value();
     }
     return true;
+}
+
+using ttnn::operations::transformer::RingProxyCase;
+
+constexpr bool proxy_uses_flat_work(RingProxyCase c) { return c != RingProxyCase::None; }
+
+// Validate ring_proxy_case vs. the other SDPA features. Single source of truth for the matrix
+// of legal combinations.
+void validate_ring_proxy_config(
+    RingProxyCase proxy_case,
+    bool is_causal,
+    bool is_chunked,
+    bool use_attention_sink,
+    bool use_provided_mask,
+    uint32_t q_num_chunks,
+    uint32_t k_num_chunks) {
+    if (proxy_case == RingProxyCase::None) {
+        return;
+    }
+    TT_FATAL(!is_chunked, "ring_proxy_case does not support chunked prefill");
+    TT_FATAL(!use_attention_sink, "ring_proxy_case does not support attention_sink");
+    if (proxy_case == RingProxyCase::Diag) {
+        TT_FATAL(is_causal, "ring_proxy_case=DIAG requires is_causal=true");
+        return;
+    }
+    // Up / Down: non-diag ring iters — non-causal by construction, and the user-provided mask
+    // codepath would conflict with the proxy's implicit K/Q halving.
+    TT_FATAL(!is_causal, "ring_proxy_case=UP/DOWN requires is_causal=false");
+    TT_FATAL(!use_provided_mask, "ring_proxy_case=UP/DOWN does not support a user-provided attn mask");
+    TT_FATAL(q_num_chunks % 2 == 0, "ring_proxy_case=UP/DOWN requires even q_num_chunks");
+    if (proxy_case == RingProxyCase::Up) {
+        TT_FATAL(k_num_chunks % 2 == 0, "ring_proxy_case=UP requires even k_num_chunks (K loop caps at k/2)");
+    }
+}
+
+// Per-core [start, count) slice over B * NQH * q_num_effective, mirroring the kernel's
+// decompose_flat_q_index. Zigzag distributes in pairs so linear_to_zigzag balances light/heavy
+// causal Q chunks across cores.
+struct FlatWorkDistribution {
+    uint32_t q_num_effective = 0;
+    uint32_t total_q_chunks = 0;
+    uint32_t base_chunks_per_core = 0;
+    uint32_t cores_doing_extra = 0;
+    uint32_t extra_chunks_per_core = 0;
+    bool zigzag = false;
+
+    struct CoreRange {
+        uint32_t start;
+        uint32_t count;
+    };
+
+    CoreRange core_range(uint32_t core_idx) const {
+        uint32_t start =
+            core_idx * base_chunks_per_core + std::min(core_idx, cores_doing_extra) * extra_chunks_per_core;
+        uint32_t count = base_chunks_per_core + ((core_idx < cores_doing_extra) ? extra_chunks_per_core : 0u);
+        if (start >= total_q_chunks) {
+            return {total_q_chunks, 0};
+        }
+        if (start + count > total_q_chunks) {
+            count = total_q_chunks - start;
+        }
+        return {start, count};
+    }
+
+    // Upper bound on per-core count — sizes the Q CB in flatten mode.
+    uint32_t max_chunks_per_core() const {
+        return base_chunks_per_core + (cores_doing_extra > 0 ? extra_chunks_per_core : 0);
+    }
+};
+
+FlatWorkDistribution compute_flat_distribution(
+    uint32_t B, uint32_t NQH, uint32_t q_num_chunks, uint32_t num_cores, RingProxyCase proxy_case, bool is_causal) {
+    FlatWorkDistribution fd{};
+    const bool is_down = proxy_case == RingProxyCase::Down;
+    fd.q_num_effective = is_down ? (q_num_chunks / 2) : q_num_chunks;
+    fd.total_q_chunks = B * NQH * fd.q_num_effective;
+    fd.zigzag = is_causal && (q_num_chunks % 2 == 0);
+    if (num_cores == 0) {
+        return fd;
+    }
+    if (fd.zigzag) {
+        const uint32_t total_pairs = fd.total_q_chunks / 2;
+        fd.base_chunks_per_core = (total_pairs / num_cores) * 2;
+        fd.cores_doing_extra = total_pairs % num_cores;
+        fd.extra_chunks_per_core = 2;
+    } else {
+        fd.base_chunks_per_core = fd.total_q_chunks / num_cores;
+        fd.cores_doing_extra = fd.total_q_chunks % num_cores;
+        fd.extra_chunks_per_core = 1;
+    }
+    return fd;
 }
 
 // Chunked prefill parameters collected from page table layout.
@@ -332,6 +428,14 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         num_cores,
         device->compute_with_storage_grid_size().x * device->compute_with_storage_grid_size().y);
 
+    // Ring-iter proxy. None => hierarchical batch × heads × q split (default). Anything else
+    // switches to a flat B*NQH*q_num_chunks distribution that matches the per-device work each
+    // ring_joint_sdpa iteration does; see RingProxyCase in sdpa_config.hpp.
+    const RingProxyCase proxy_case = program_config.has_value() ? program_config->ring_proxy_case : RingProxyCase::None;
+    const bool flatten_work = proxy_uses_flat_work(proxy_case);
+    validate_ring_proxy_config(
+        proxy_case, is_causal, is_chunked, use_attention_sink, use_provided_mask, q_num_chunks, k_num_chunks);
+
     // Parallelization scheme
     // We will choose parallelization factors for batch, num_heads, and q_seq_len in that order
     uint32_t batch_parallel_factor = std::min(B, num_cores);
@@ -354,7 +458,12 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     const uint32_t nh_per_core = (NQH + nh_parallel_factor - 1) / nh_parallel_factor;
     const uint32_t q_per_core = (q_num_chunks + q_parallel_factor - 1) / q_parallel_factor;
 
-    const uint32_t q_buffer_factor = (q_per_core > 1) ? 2 : 1;
+    const FlatWorkDistribution flat_dist =
+        compute_flat_distribution(B, NQH, q_num_chunks, num_cores, proxy_case, is_causal);
+
+    const uint32_t q_buffer_factor_hier = (q_per_core > 1) ? 2 : 1;
+    const uint32_t q_buffer_factor_flat = (flat_dist.max_chunks_per_core() > 1) ? 2 : 1;
+    const uint32_t q_buffer_factor = flatten_work ? q_buffer_factor_flat : q_buffer_factor_hier;
 
     log_debug(tt::LogOp, "q_per_core: {}", q_per_core);
 
@@ -365,8 +474,8 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     auto [qk_out_subblock_h, qk_out_subblock_w] =
         detail::determine_largest_subblock_size(Sq_chunk_t, Sk_chunk_t, dst_size);
 
-    const bool use_streaming_compute =
-        can_use_streaming_compute(use_provided_mask, use_attention_sink, sliding_window_size, fp32_dest_acc_en);
+    const bool use_streaming_compute = can_use_streaming_compute(
+        use_provided_mask, use_attention_sink, sliding_window_size, fp32_dest_acc_en, flatten_work);
 
     const bool lightweight_causal = is_causal && !use_provided_mask && sliding_window_size.value_or(0) == 0;
     const bool lightweight_mask = (use_streaming_compute && use_padded_mask) || lightweight_causal;
@@ -374,6 +483,12 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     const uint32_t k_partial_col =
         (use_streaming_compute && use_padded_mask && (Sk % TILE_HEIGHT != 0)) ? (Sk % TILE_HEIGHT) : 0;
     const bool lw_partial_active = (k_partial_col > 0);
+
+    // KV chain forwarding runs for non-causal SDPA, and for flat-work causal when the lightweight
+    // causal mask is available — chain cores over-read K past each Q's q_high, and the mask is
+    // what zeroes those extra softmax columns. Without lightweight_causal the phantom columns
+    // can't be killed, so causal non-flat stays on the per-Q truncated-K (no-chain) path.
+    const bool chain_enabled = !is_chunked && (!is_causal || (flatten_work && lightweight_causal));
     // These tile capacity counts for CBs need to match the number of tiles expected by the kernel (softmax.cpp)
     uint32_t q_tiles = Sq_chunk_t * DHt * q_buffer_factor;
     uint32_t k_tiles = Sk_chunk_t * DHt * 2;            // double buffer
@@ -511,14 +626,16 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         .append_to(reader_compile_time_args);
     TensorAccessorArgs(flexible_chunked ? operation_attributes.chunk_start_idx_tensor.value().buffer() : nullptr)
         .append_to(reader_compile_time_args);
+    reader_compile_time_args.push_back(static_cast<uint32_t>(proxy_case));
+    reader_compile_time_args.push_back(static_cast<uint32_t>(chain_enabled));
 
-    // Create semaphores for KV chain forwarding BEFORE kernel compilation (non-causal only)
+    // Create semaphores for KV chain forwarding BEFORE kernel compilation (when chain_enabled)
     // This must happen before CreateKernel so the actual semaphore IDs are in the compile-time args
     uint32_t sender_semaphore_id = 0;
     uint32_t receiver_semaphore_id = 0;
     uint32_t valid_semaphore_id = 0;
 
-    if (!is_causal) {
+    if (chain_enabled) {
         sender_semaphore_id = CreateSemaphore(program, core_grid, INVALID);
         receiver_semaphore_id = CreateSemaphore(program, core_grid, INVALID);
         valid_semaphore_id = CreateSemaphore(program, core_grid, VALID);
@@ -565,6 +682,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
+    writer_compile_time_args.push_back(static_cast<uint32_t>(proxy_case));
 
     const bool uniform_dataformat = check_uniform_dataformat(
         input_tensor_q, input_tensor_k, input_tensor_v, output_tensor, attn_mask, use_streaming_compute);
@@ -605,6 +723,8 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         valid_Skt,                             // arg 31: unpadded K tile count for streaming padded_k_tiles
         (std::uint32_t)uniform_dataformat,     // arg 32: skip reconfig when all formats match
         k_partial_col,                         // arg 33: K partial-tile col (0 = no partial)
+        (std::uint32_t)proxy_case,             // arg 34: ring proxy case (None => hierarchical)
+        (std::uint32_t)chain_enabled,          // arg 35: KV chain forwarding active
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(compute_compile_time_args);
@@ -617,15 +737,13 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     defines["REDUCE_GRANULARITY"] = std::to_string(reduce_granularity);
     defines["EXP_APPROX_MODE"] = std::to_string(exp_approx_mode);
     uint32_t balanced_q_parallel =
-        (is_causal && (q_per_core * q_parallel_factor == q_num_chunks) && (q_per_core % 2 == 0));
+        (!flatten_work && is_causal && (q_per_core * q_parallel_factor == q_num_chunks) && (q_per_core % 2 == 0));
     if (balanced_q_parallel) {
         defines["BALANCED_Q_PARALLEL"] = "1";
     }
 
     log_debug(tt::LogOp, "BALANCED_Q_PARALLEL: {}", balanced_q_parallel);
-
-    // NOTE: CreateKernel calls are deferred until after chain construction so that
-    // the mcast_enabled compile-time arg can be determined first.
+    log_debug(tt::LogOp, "ring_proxy_case: {}", static_cast<uint32_t>(proxy_case));
 
     // Create circular buffers
 
@@ -780,9 +898,6 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
 
     CreateCircularBuffer(program, core_grid, c_out0_config);
 
-    // Note: Semaphores for KV chain forwarding are now created earlier (before kernel compilation)
-    // to ensure the actual semaphore IDs are available in the compile-time args
-
     uint32_t q_addr = q_buffer->address();
     uint32_t k_addr = k_buffer->address();
     uint32_t v_addr = v_buffer->address();
@@ -794,60 +909,93 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     uint32_t read_offset = 0;
     uint32_t write_offset = 0;
 
-    // Build chain topology for KV forwarding (non-causal only)
+    // Build chain topology for KV forwarding (non-causal, or flat-work causal w/ lightweight mask).
     std::vector<CoreWork> core_work(num_cores);
     std::vector<CoreChainInfo> core_chain_info(num_cores);
     const uint32_t total_heads = B * NQH;
     std::vector<std::vector<HeadSegmentRef>> head_segments;
     uint32_t mcast_chains = 0;
 
-    if (!is_causal && !is_chunked) {
+    if (chain_enabled) {
         head_segments.resize(total_heads);
 
         log_debug(tt::LogOp, "=== Building KV chain forwarding topology ===");
         log_debug(tt::LogOp, "Total heads (B * NQH): {}", total_heads);
-        log_debug(tt::LogOp, "Q chunks per head: {}", q_num_chunks);
+        log_debug(tt::LogOp, "Q chunks per head (effective): {}", flat_dist.q_num_effective);
         log_debug(tt::LogOp, "Grid size: {}x{} = {} cores", grid_size.x, grid_size.y, num_cores);
 
         // First pass: Record work distribution for each core
         for (uint32_t i = 0; i < num_cores; ++i) {
             CoreCoord core = {i % grid_size.x, i / grid_size.x};
 
-            uint32_t local_batch_start = (i / (nh_parallel_factor * q_parallel_factor)) * batch_per_core;
-            uint32_t local_batch_end = local_batch_start + batch_per_core;
-            uint32_t local_nh_start = ((i / q_parallel_factor) % nh_parallel_factor) * nh_per_core;
-            uint32_t local_nh_end = local_nh_start + nh_per_core;
-            uint32_t local_q_start = (i % q_parallel_factor) * q_per_core;
-            uint32_t local_q_end = local_q_start + q_per_core;
-
-            // Clamp to max values
-            local_batch_start = std::min(local_batch_start, B);
-            local_batch_end = std::min(local_batch_end, B);
-            local_nh_start = std::min(local_nh_start, NQH);
-            local_nh_end = std::min(local_nh_end, NQH);
-            local_q_start = std::min(local_q_start, q_num_chunks);
-            local_q_end = std::min(local_q_end, q_num_chunks);
-
             auto& work = core_work[i];
             work.logical_core = core;
             work.physical_core = device->worker_core_from_logical_core(core);
 
-            // Track each (batch, head, q_chunk_range) this core handles
-            for (uint32_t b = local_batch_start; b < local_batch_end; ++b) {
-                for (uint32_t h = local_nh_start; h < local_nh_end; ++h) {
-                    uint32_t q_count = local_q_end - local_q_start;
-                    if (q_count > 0) {
-                        work.head_work.push_back(CoreHeadWork{
-                            .batch = b,
-                            .head = h,
-                            .q_chunk_start = local_q_start,
-                            .q_chunk_count = q_count,
-                        });
+            if (flatten_work) {
+                // Core owns [start, start+count) in B * NQH * q_num_effective space; decompose into
+                // per-(batch, head) segments matching the reader's decompose_flat_q_index.
+                const auto core_range = flat_dist.core_range(i);
 
-                        uint32_t head_id = (b * NQH) + h;
-                        if (head_id < head_segments.size()) {
-                            head_segments[head_id].push_back(HeadSegmentRef{
-                                .core_idx = i, .head_work_index = static_cast<uint32_t>(work.head_work.size() - 1)});
+                uint32_t remaining = core_range.count;
+                uint32_t flat_chunk = core_range.start;
+                while (remaining > 0) {
+                    const uint32_t nb = flat_chunk / (NQH * flat_dist.q_num_effective);
+                    const uint32_t nq = (flat_chunk / flat_dist.q_num_effective) % NQH;
+                    const uint32_t q_chunk_idx = flat_chunk % flat_dist.q_num_effective;
+                    const uint32_t chunk_capacity_in_head = flat_dist.q_num_effective - q_chunk_idx;
+                    const uint32_t chunk_take = std::min(remaining, chunk_capacity_in_head);
+
+                    work.head_work.push_back(CoreHeadWork{
+                        .batch = nb,
+                        .head = nq,
+                        .q_chunk_start = q_chunk_idx,
+                        .q_chunk_count = chunk_take,
+                    });
+
+                    const uint32_t head_id = (nb * NQH) + nq;
+                    if (head_id < head_segments.size()) {
+                        head_segments[head_id].push_back(HeadSegmentRef{
+                            .core_idx = i, .head_work_index = static_cast<uint32_t>(work.head_work.size() - 1)});
+                    }
+
+                    remaining -= chunk_take;
+                    flat_chunk += chunk_take;
+                }
+            } else {
+                uint32_t local_batch_start = (i / (nh_parallel_factor * q_parallel_factor)) * batch_per_core;
+                uint32_t local_batch_end = local_batch_start + batch_per_core;
+                uint32_t local_nh_start = ((i / q_parallel_factor) % nh_parallel_factor) * nh_per_core;
+                uint32_t local_nh_end = local_nh_start + nh_per_core;
+                uint32_t local_q_start = (i % q_parallel_factor) * q_per_core;
+                uint32_t local_q_end = local_q_start + q_per_core;
+
+                // Clamp to max values
+                local_batch_start = std::min(local_batch_start, B);
+                local_batch_end = std::min(local_batch_end, B);
+                local_nh_start = std::min(local_nh_start, NQH);
+                local_nh_end = std::min(local_nh_end, NQH);
+                local_q_start = std::min(local_q_start, q_num_chunks);
+                local_q_end = std::min(local_q_end, q_num_chunks);
+
+                // Track each (batch, head, q_chunk_range) this core handles
+                for (uint32_t b = local_batch_start; b < local_batch_end; ++b) {
+                    for (uint32_t h = local_nh_start; h < local_nh_end; ++h) {
+                        uint32_t q_count = local_q_end - local_q_start;
+                        if (q_count > 0) {
+                            work.head_work.push_back(CoreHeadWork{
+                                .batch = b,
+                                .head = h,
+                                .q_chunk_start = local_q_start,
+                                .q_chunk_count = q_count,
+                            });
+
+                            uint32_t head_id = (b * NQH) + h;
+                            if (head_id < head_segments.size()) {
+                                head_segments[head_id].push_back(HeadSegmentRef{
+                                    .core_idx = i,
+                                    .head_work_index = static_cast<uint32_t>(work.head_work.size() - 1)});
+                            }
                         }
                     }
                 }
@@ -906,20 +1054,37 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
 
             const std::size_t start = chain_start_idx.value();
 
-            // Build chain in wrap order: start, start+1, ..., N-1, 0, 1, ..., start-1.
-            // Break on conflict (core already in a different chain).
+            // Flat: linear forward traversal — chain_start_idx already picks the first non-straddling
+            // core, so any lighter straddler stays at the tail (satisfies the descending-q invariant
+            // without an explicit sort). Hierarchical: wrap + optional injector reselect below.
             std::vector<std::size_t> chain_order;
-            for (std::size_t step = 0; step < segments.size(); ++step) {
-                std::size_t idx = (start + step) % segments.size();
-                const auto& seg = segments[idx];
-                const uint32_t core_idx = seg.core_idx;
-                if (core_idx >= core_work.size() || seg.head_work_index >= core_work[core_idx].head_work.size()) {
-                    continue;
+            if (flatten_work) {
+                for (std::size_t idx = start; idx < segments.size(); ++idx) {
+                    const auto& seg = segments[idx];
+                    const uint32_t core_idx = seg.core_idx;
+                    if (core_idx >= core_work.size() || seg.head_work_index >= core_work[core_idx].head_work.size()) {
+                        continue;
+                    }
+                    if (core_chain_info[core_idx].participates) {
+                        break;
+                    }
+                    chain_order.push_back(idx);
                 }
-                if (core_chain_info[core_idx].participates) {
-                    break;
+            } else {
+                // Wrap order: start, start+1, ..., N-1, 0, 1, ..., start-1.
+                // Break on conflict (core already in a different chain).
+                for (std::size_t step = 0; step < segments.size(); ++step) {
+                    std::size_t idx = (start + step) % segments.size();
+                    const auto& seg = segments[idx];
+                    const uint32_t core_idx = seg.core_idx;
+                    if (core_idx >= core_work.size() || seg.head_work_index >= core_work[core_idx].head_work.size()) {
+                        continue;
+                    }
+                    if (core_chain_info[core_idx].participates) {
+                        break;
+                    }
+                    chain_order.push_back(idx);
                 }
-                chain_order.push_back(idx);
             }
 
             if (chain_order.size() < 2) {
@@ -946,7 +1111,9 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
                 }
             }
 
-            if (uniform_q) {
+            if (flatten_work) {
+                // chain_order[0] stays the injector; straddler-at-tail order is already correct.
+            } else if (uniform_q) {
                 // All cores have equal q_chunk_count — safe to pick any injector.
                 // Choose the core whose physical X is furthest from existing
                 // injectors to spread DRAM reads across channels.
@@ -1285,7 +1452,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     for (uint32_t i = 0; i < num_cores; ++i) {
         CoreCoord core = {i % grid_size.x, i / grid_size.x};
 
-        // log_debug(tt::LogOp, "core: {} getting runtime args for idx {i}", core, i);
+        // Hierarchical per-core slice; flat mode ignores these and uses global_q_{start,count} below.
         uint32_t local_batch_start = (i / (nh_parallel_factor * q_parallel_factor)) * batch_per_core;
         uint32_t local_batch_end = local_batch_start + batch_per_core;
         uint32_t local_nh_start = ((i / q_parallel_factor) % nh_parallel_factor) * nh_per_core;
@@ -1301,6 +1468,14 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         local_q_start = std::min(local_q_start, q_num_chunks);
         local_q_end = std::min(local_q_end, q_num_chunks);
 
+        uint32_t global_q_start = 0;
+        uint32_t global_q_count = 0;
+        if (flatten_work) {
+            const auto core_range = flat_dist.core_range(i);
+            global_q_start = core_range.start;
+            global_q_count = core_range.count;
+        }
+
         // log the above
         log_debug(tt::LogOp, "core: {}", i);
         log_debug(tt::LogOp, "x={},y={}", core.x, core.y);
@@ -1310,6 +1485,9 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         log_debug(tt::LogOp, "local_nh_end: {}", local_nh_end);
         log_debug(tt::LogOp, "local_q_start: {}", local_q_start);
         log_debug(tt::LogOp, "local_q_end: {}", local_q_end);
+        if (flatten_work) {
+            log_debug(tt::LogOp, "global_q_start: {}, global_q_count: {}", global_q_start, global_q_count);
+        }
 
         // Get chain info for this core
         const auto& chain = core_chain_info[i];
@@ -1331,11 +1509,18 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
             local_q_end,
             num_phases,
             chunked_q_chunk_offset,
-            read_offset  // read_offset
+            read_offset,  // read_offset
         };
 
-        // Add chain metadata for non-causal case
-        if (!is_causal) {
+        // Tail args are only pushed when the matching kernel gate is on. Kernels walk argidx
+        // through the same set so slots never collide with the num_phases==2 args above.
+        if (flatten_work) {
+            reader_args.push_back(global_q_start);
+            reader_args.push_back(global_q_count);
+        }
+
+        // Chain metadata: only pushed when chain forwarding is active (non-causal, or flat-work causal).
+        if (chain_enabled) {
             reader_args.push_back(static_cast<uint32_t>(chain.participates));
             reader_args.push_back(static_cast<uint32_t>(chain.is_injector));
             reader_args.push_back(static_cast<uint32_t>(chain.is_sink));
@@ -1353,36 +1538,49 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         }
 
         SetRuntimeArgs(program, reader_kernels_id, core, reader_args);
-        SetRuntimeArgs(
-            program,
-            writer_kernels_id,
-            core,
-            {out_addr,
-             i,
-             local_batch_start,
-             local_batch_end,
-             local_nh_start,
-             local_nh_end,
-             local_q_start,
-             local_q_end,
-             num_phases,
-             static_cast<uint32_t>(flexible_chunked ? 1 : 0),
-             chunked_q_chunk_offset,
-             write_offset});  // write_offset
-        SetRuntimeArgs(
-            program,
-            compute_kernels_id,
-            core,
-            {i,
-             local_batch_start,
-             local_batch_end,
-             local_nh_start,
-             local_nh_end,
-             local_q_start,
-             local_q_end,
-             num_phases,
-             static_cast<uint32_t>(flexible_chunked ? 1 : 0),
-             chunked_q_chunk_offset});
+
+        std::vector<uint32_t> writer_args = {
+            out_addr,
+            i,
+            local_batch_start,
+            local_batch_end,
+            local_nh_start,
+            local_nh_end,
+            local_q_start,
+            local_q_end,
+            num_phases,
+            static_cast<uint32_t>(flexible_chunked ? 1 : 0),
+            chunked_q_chunk_offset,
+            write_offset,  // write_offset
+        };
+        if (flatten_work) {
+            writer_args.push_back(global_q_start);
+            writer_args.push_back(global_q_count);
+        }
+        SetRuntimeArgs(program, writer_kernels_id, core, writer_args);
+
+        std::vector<uint32_t> compute_args = {
+            i,
+            local_batch_start,
+            local_batch_end,
+            local_nh_start,
+            local_nh_end,
+            local_q_start,
+            local_q_end,
+            num_phases,
+            static_cast<uint32_t>(flexible_chunked ? 1 : 0),
+            chunked_q_chunk_offset,
+        };
+        if (flatten_work) {
+            compute_args.push_back(global_q_start);
+            compute_args.push_back(global_q_count);
+        }
+        if (chain_enabled) {
+            // Chain cores loop the full k_num_chunks to stay in sync with reader/writer, which
+            // over-read K under causal + chain; lightweight_causal_mask zeroes the extra columns.
+            compute_args.push_back(static_cast<uint32_t>(chain.participates));
+        }
+        SetRuntimeArgs(program, compute_kernels_id, core, compute_args);
     }
 
     return cached_program_t{

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -56,6 +56,21 @@ struct CoreChainInfo {
     uint32_t mcast_sender_wait = 0;  // number of actual receivers that signal back (always chain_size - 1)
 };
 
+// Batch-level K chain (MLA mode: NKH==1 && B==1). 2D mcast across the full worker grid:
+// the heaviest-loaded core injects each K chunk, every other core receives. Ports the
+// K-chain mechanism from ring_joint_sdpa_program_factory.cpp.
+struct CoreBatchChainInfo {
+    bool participates = false;
+    bool is_injector = false;
+    bool is_sink = false;
+    uint32_t batch = 0;
+    CoreCoord mcast_start = CoreCoord{0, 0};
+    CoreCoord mcast_end = CoreCoord{0, 0};
+    CoreCoord injector_physical = CoreCoord{0, 0};
+    uint32_t mcast_num_dests = 0;
+    uint32_t mcast_sender_wait = 0;
+};
+
 namespace {
 
 // Select the mask data format: user-provided mask dtype, or Float16_b for streaming (avoids Bfp4_b precision loss),
@@ -609,13 +624,24 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
                                                       (std::uint32_t)mla_kv_overlap,
                                                       qk_out_subblock_h};
 
+    // Batch-level K chain is the MLA optimization (port of ring_joint_sdpa K-chain): when K is
+    // shared across heads (NKH == 1) and there's a single batch (B == 1), the full grid joins one
+    // 2D-mcast chain so K is read from DRAM once by an injector and broadcast to every other core.
+    // Restricted to flat-work distribution because the iteration loop is padded to max global_q_count
+    // (a flat-work concept) — receivers walk the same global index range as the injector.
+    const bool batch_k_chain_eligible = chain_enabled && flatten_work && (NKH == 1) && (B == 1) && (num_cores >= 2);
+
     // Placeholder semaphore IDs for KV chain forwarding (will be filled later if enabled)
     // Add these BEFORE TensorAccessorArgs to keep indexing consistent with kernel expectations
     const auto sem_args_offset = reader_compile_time_args.size();
-    reader_compile_time_args.push_back(0);  // sender_semaphore_id placeholder
-    reader_compile_time_args.push_back(0);  // receiver_semaphore_id placeholder
-    reader_compile_time_args.push_back(0);  // valid_semaphore_id placeholder
-    reader_compile_time_args.push_back(0);  // mcast_enabled placeholder
+    reader_compile_time_args.push_back(0);  // [+0] head sender_semaphore_id placeholder
+    reader_compile_time_args.push_back(0);  // [+1] head receiver_semaphore_id placeholder
+    reader_compile_time_args.push_back(0);  // [+2] head valid_semaphore_id placeholder
+    reader_compile_time_args.push_back(0);  // [+3] head mcast_enabled placeholder
+    reader_compile_time_args.push_back(0);  // [+4] batch sender_semaphore_id placeholder
+    reader_compile_time_args.push_back(0);  // [+5] batch receiver_semaphore_id placeholder
+    reader_compile_time_args.push_back(0);  // [+6] batch valid_semaphore_id placeholder
+    reader_compile_time_args.push_back(0);  // [+7] batch_k_chain_enabled placeholder (1 ⇒ K mcast on)
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args);
@@ -651,6 +677,21 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
             sender_semaphore_id,
             receiver_semaphore_id,
             valid_semaphore_id);
+    }
+
+    // Batch-level K chain semaphores (MLA mode). Allocated up front so the kernel sees stable
+    // CT-arg slots; whether the kernel actually uses them is gated by the [+7] flag patched
+    // after chain construction.
+    uint32_t batch_sender_semaphore_id = 0;
+    uint32_t batch_receiver_semaphore_id = 0;
+    uint32_t batch_valid_semaphore_id = 0;
+    if (batch_k_chain_eligible) {
+        batch_sender_semaphore_id = CreateSemaphore(program, core_grid, INVALID);
+        batch_receiver_semaphore_id = CreateSemaphore(program, core_grid, INVALID);
+        batch_valid_semaphore_id = CreateSemaphore(program, core_grid, VALID);
+        reader_compile_time_args[sem_args_offset + 4] = batch_sender_semaphore_id;
+        reader_compile_time_args[sem_args_offset + 5] = batch_receiver_semaphore_id;
+        reader_compile_time_args[sem_args_offset + 6] = batch_valid_semaphore_id;
     }
 
     std::vector<uint32_t> writer_compile_time_args = {
@@ -1424,6 +1465,63 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     // Update mcast_enabled compile-time arg now that chain construction is complete
     reader_compile_time_args[sem_args_offset + 3] = (mcast_chains > 0) ? 1 : 0;
 
+    // Build the batch-level K chain (MLA mode): a single full-grid 2D mcast where the heaviest-
+    // loaded core is the injector. Receivers loop the same number of q iterations as the injector
+    // (max_q_per_core), padding lighter cores' tails with K-only mcast-sync iterations.
+    std::vector<CoreBatchChainInfo> core_batch_chain_info(num_cores);
+    uint32_t batch_chain_max_q_per_core = 0;
+    bool batch_k_chain_enabled = false;
+    if (batch_k_chain_eligible) {
+        // Pick injector = core with the most q work. For flat-work this is global_q_count;
+        // hierarchical SDPA never sets flatten_work, but we fall back to the head-segment
+        // sum so the injector is still the loaded core if the path ever activates there.
+        uint32_t injector_idx = 0;
+        for (uint32_t ci = 0; ci < num_cores; ++ci) {
+            uint32_t total_q = core_work[ci].global_q_count;
+            if (total_q == 0) {
+                for (const auto& hw : core_work[ci].head_work) {
+                    total_q += hw.q_chunk_count;
+                }
+            }
+            if (total_q > batch_chain_max_q_per_core) {
+                batch_chain_max_q_per_core = total_q;
+                injector_idx = ci;
+            }
+        }
+        if (batch_chain_max_q_per_core > 0) {
+            const CoreCoord phys_start = device->worker_core_from_logical_core(CoreCoord{0, 0});
+            const CoreCoord phys_end =
+                device->worker_core_from_logical_core(CoreCoord{grid_size.x - 1, grid_size.y - 1});
+            const uint32_t num_receivers = num_cores - 1;
+            for (uint32_t ci = 0; ci < num_cores; ++ci) {
+                auto& bc = core_batch_chain_info[ci];
+                bc.participates = true;
+                bc.batch = 0;
+                bc.mcast_start = phys_start;
+                bc.mcast_end = phys_end;
+                bc.injector_physical = core_work[injector_idx].physical_core;
+                bc.is_injector = (ci == injector_idx);
+                bc.is_sink = !bc.is_injector;
+                if (bc.is_injector) {
+                    bc.mcast_num_dests = num_receivers;
+                    bc.mcast_sender_wait = num_receivers;
+                }
+            }
+            batch_k_chain_enabled = true;
+            log_debug(
+                tt::LogOp,
+                "Batch K mcast enabled: {} cores, injector=core {} (max_q={}), rect ({},{}) to ({},{})",
+                num_cores,
+                injector_idx,
+                batch_chain_max_q_per_core,
+                phys_start.x,
+                phys_start.y,
+                phys_end.x,
+                phys_end.y);
+        }
+    }
+    reader_compile_time_args[sem_args_offset + 7] = batch_k_chain_enabled ? 1 : 0;
+
     // Create kernels (deferred until after chain construction for mcast_enabled flag)
     auto reader_kernels_id = CreateKernel(
         program,
@@ -1535,6 +1633,23 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
             reader_args.push_back(chain.next_core_q_chunks);
             reader_args.push_back(chain.mcast_num_dests);
             reader_args.push_back(chain.mcast_sender_wait);
+        }
+
+        if (batch_k_chain_enabled) {
+            const auto& bc = core_batch_chain_info[i];
+            reader_args.push_back(static_cast<uint32_t>(bc.participates));
+            reader_args.push_back(static_cast<uint32_t>(bc.is_injector));
+            reader_args.push_back(static_cast<uint32_t>(bc.is_sink));
+            reader_args.push_back(bc.batch);
+            reader_args.push_back(static_cast<uint32_t>(bc.mcast_start.x));
+            reader_args.push_back(static_cast<uint32_t>(bc.mcast_start.y));
+            reader_args.push_back(static_cast<uint32_t>(bc.mcast_end.x));
+            reader_args.push_back(static_cast<uint32_t>(bc.mcast_end.y));
+            reader_args.push_back(static_cast<uint32_t>(bc.injector_physical.x));
+            reader_args.push_back(static_cast<uint32_t>(bc.injector_physical.y));
+            reader_args.push_back(bc.mcast_num_dests);
+            reader_args.push_back(bc.mcast_sender_wait);
+            reader_args.push_back(batch_chain_max_q_per_core);
         }
 
         SetRuntimeArgs(program, reader_kernels_id, core, reader_args);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -57,6 +57,12 @@ ttnn::Tensor scaled_dot_product_attention(
         }
     }
 
+    // d_v < d_q routes to MLA; equal dims stay on the non-MLA path; d_v > d_q falls through so
+    // validation emits the clearer "K and V hidden dim must match" error.
+    const uint32_t d_q = input_tensor_q.logical_shape()[-1];
+    const uint32_t d_v = input_tensor_v.logical_shape()[-1];
+    const bool use_mla = d_v < d_q;
+
     return ttnn::prim::sdpa(
         input_tensor_q,
         input_tensor_k,
@@ -69,8 +75,8 @@ ttnn::Tensor scaled_dot_product_attention(
         sliding_window_size,
         std::nullopt,  // chunk_start_idx
         std::nullopt,  // chunk_start_idx_tensor
-        false,         // use_mla
-        std::nullopt,  // head_dim_v
+        use_mla,
+        use_mla ? std::optional<uint32_t>(d_v) : std::nullopt,
         memory_config.value_or(tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG),
         std::move(program_config),
         kernel_config_val);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -244,7 +244,10 @@ void bind_sdpa(nb::module_& mod) {
 
 
         Returns:
-            ttnn.Tensor: the output tensor [b x nqh x s x dh].
+            ttnn.Tensor: the output tensor [b x nqh x s x dh_v] (dh_v = V's last dim; equals dh for standard SDPA, can be smaller for MLA-style inputs).
+
+        Note:
+            MLA-style inputs are supported: when ``input_tensor_v`` has a smaller head dim than Q/K (i.e. ``dh_v < dh``), the op runs in multi-latent attention mode. The head dim of V is inferred from the V tensor shape, consistent with how Q and K head dims are derived.
 
         )doc";
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_config.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_config.hpp
@@ -7,6 +7,8 @@
 #include <cstddef>
 #include <tt-metalium/core_coord.hpp>
 
+#include "ttnn/operations/transformer/sdpa/device/ring_proxy_case.hpp"
+
 namespace ttnn::operations::transformer {
 
 struct SDPAProgramConfig {
@@ -16,6 +18,7 @@ struct SDPAProgramConfig {
     std::size_t k_chunk_size;
     std::optional<bool> exp_approx_mode;
     uint32_t max_cores_per_head_batch = 16;
+    RingProxyCase ring_proxy_case = RingProxyCase::None;
 };
 
 }  // namespace ttnn::operations::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/transformer_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/transformer_nanobind.cpp
@@ -22,32 +22,48 @@
 namespace ttnn::operations::transformer {
 
 void py_module(nb::module_& mod) {
+    nb::enum_<RingProxyCase>(mod, "RingProxyCase")
+        .value("NONE", RingProxyCase::None)
+        .value("DIAG", RingProxyCase::Diag)
+        .value("UP", RingProxyCase::Up)
+        .value("DOWN", RingProxyCase::Down);
+
     nb::class_<SDPAProgramConfig>(mod, "SDPAProgramConfig")
         .def(
-            nb::init<CoreCoord, std::optional<CoreRangeSet>, std::size_t, std::size_t, std::optional<bool>, uint32_t>(),
+            nb::init<
+                CoreCoord,
+                std::optional<CoreRangeSet>,
+                std::size_t,
+                std::size_t,
+                std::optional<bool>,
+                uint32_t,
+                RingProxyCase>(),
             nb::kw_only(),
             nb::arg("compute_with_storage_grid_size"),
             nb::arg("sub_core_grids") = nb::none(),
             nb::arg("q_chunk_size").noconvert(),
             nb::arg("k_chunk_size").noconvert(),
             nb::arg("exp_approx_mode") = nb::none(),
-            nb::arg("max_cores_per_head_batch") = 16)
+            nb::arg("max_cores_per_head_batch") = 16,
+            nb::arg("ring_proxy_case") = RingProxyCase::None)
         .def_rw("compute_with_storage_grid_size", &SDPAProgramConfig::compute_with_storage_grid_size)
         .def_rw("sub_core_grids", &SDPAProgramConfig::sub_core_grids)
         .def_rw("q_chunk_size", &SDPAProgramConfig::q_chunk_size)
         .def_rw("k_chunk_size", &SDPAProgramConfig::k_chunk_size)
         .def_rw("exp_approx_mode", &SDPAProgramConfig::exp_approx_mode)
         .def_rw("max_cores_per_head_batch", &SDPAProgramConfig::max_cores_per_head_batch)
+        .def_rw("ring_proxy_case", &SDPAProgramConfig::ring_proxy_case)
         .def("__repr__", [](const SDPAProgramConfig& config) {
             return fmt::format(
                 "SDPAProgramConfig(compute_with_storage_grid_size={}, sub_core_grids={}, q_chunk_size={}, "
-                "k_chunk_size={}, exp_approx_mode={}, max_cores_per_head_batch={})",
+                "k_chunk_size={}, exp_approx_mode={}, max_cores_per_head_batch={}, ring_proxy_case={})",
                 config.compute_with_storage_grid_size,
                 config.sub_core_grids,
                 config.q_chunk_size,
                 config.k_chunk_size,
                 config.exp_approx_mode,
-                config.max_cores_per_head_batch);
+                config.max_cores_per_head_batch,
+                static_cast<uint8_t>(config.ring_proxy_case));
         });
 
     bind_attention_softmax(mod);


### PR DESCRIPTION
## What this does

- Adds a single-chip SDPA path that reproduces, in isolation, the per-device work each ring iteration of balanced causal ring SDPA does on Galaxy. Lets us measure MLA-shaped perf/accuracy without standing up a multi-device ring.
- New `SDPAProgramConfig.ring_proxy_case` knob (`None | Diag | Up | Down`):
  - `Diag`: flat causal SDPA — mirrors ring iter 0 per-device work.
  - `Up`: full Q, K-loop halved — mirrors a non-diag iter where `ring_index > ring_id`.
  - `Down`: heavy Q half only, full K — mirrors `is_balanced` Q-skip when `ring_index < ring_id`.
- Default behavior (`None`) is the existing hierarchical batch × heads × q split — unchanged.

## Ported from ring_joint_sdpa

- Flat `B*NQH*q_num_chunks` work distribution + per-head zigzag remap (light/heavy interleaving).
- KV chain forwarding (L1→L1 store-and-forward of K/V across cores sharing a `(batch, head)`), plus its mcast-eligibility check. Cleaned up in the port: chain-enable is a CT bool; reader's chain-state locals are collapsed into a `ChainState` struct.
- Lightweight causal mask hookup so chain participants can over-read K past each Q's `q_high` and have softmax columns past the diagonal zeroed.

## MLA 100K single-chip perf (q160/k160, 110 cores, b=1, nhq=32, nkv=1, s=3200, d_q=576, d_v=128)

| Proxy | Duration | Math util |
|---|---|---|
| `ring_iter_0` (Diag, causal) | 2.45 ms | **31.0%** |
| `ring_iter_up` (Up, non-causal) | 1.42 ms | **53.4%** |
| `ring_iter_down` (Down, non-causal) | 1.34 ms | **56.6%** |

All three pass the 0.994 bf8 PCC threshold. The proxy numbers almost match the per-iter isolated perf measured on the multi-chip ring-joint baseline (UP 52–53%, DOWN 56–56.5%, iter-0 30.8–31.4%) — the single-chip path is a faithful proxy for tuning per-iter ring work.

## Tests

- `tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py` is reconfigured along the same lines as `tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py` — per-suite `ModelConfig` dataclass, per-model chunk-size sweep, shared parametrize tuple, and a `test_sdpa_create_perf_table[<model>]` that prints a ranked perf table.
- New suites: `mla_100k_ring_iter_{0,up,down}` and `mla_128k_ring_iter_0`. Existing `wan2_2_{1xGLX,4xGLX}` configs unchanged.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/single-chip-mla-proxy-tests-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/single-chip-mla-proxy-tests-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/single-chip-mla-proxy-tests-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/single-chip-mla-proxy-tests-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/single-chip-mla-proxy-tests-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/single-chip-mla-proxy-tests-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/single-chip-mla-proxy-tests-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/single-chip-mla-proxy-tests-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/single-chip-mla-proxy-tests-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/single-chip-mla-proxy-tests-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/single-chip-mla-proxy-tests-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/single-chip-mla-proxy-tests-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/single-chip-mla-proxy-tests-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/single-chip-mla-proxy-tests-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/single-chip-mla-proxy-tests-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/single-chip-mla-proxy-tests-v2)