### PR TITLE
Remove dual tests

### DIFF
--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -699,9 +699,6 @@ run_all_needed_local_tests() {
     local saved_upr_mode="${DEEPSEEK_DEMO_UPR_MODE:-}"
     export DEEPSEEK_DEMO_UPR_MODE="all"
 
-    run_dual_teacher_forced_test
-    run_dual_demo_test
-    run_dual_demo_stress_test
     run_quad_teacher_forced_test
     run_quad_demo_test
     run_quad_demo_stress_test


### PR DESCRIPTION
## Summary
- Remove dual test entries from `tests/scripts/multihost/run_quad_galaxy_tests.sh` for `run_all_needed_local_tests` option to streamline the quad-galaxy test run list.

