### PR TITLE
#40330: fix up parallel/sequential synchronization

### DIFF
--- a/models/experimental/ops/descriptors/fusion/cb_allocator.py
+++ b/models/experimental/ops/descriptors/fusion/cb_allocator.py
@@ -409,6 +409,196 @@ class CBPoolAllocator:
 
         return slot_groups
 
+    # ------------------------------------------------------------------
+    # Phase-bridge sizing (Fix A for #40330)
+    # ------------------------------------------------------------------
+    #
+    # Background: in a fused Sequential(opA, opB) chain, the L1 buffer that
+    # carries the intermediate tensor from phase N (opA) to phase N+1 (opB)
+    # appears as a single pool slot with both endpoints attached to the same
+    # buffer.  In standalone execution that slot would be drained by the
+    # phase-N writer (BRISC) NOC kernel; in the fused execution the writer
+    # is elided in phase N (its output is consumed in-L1 by phase N+1's
+    # compute), so there is no concurrent NCRISC drain during phase N.
+    #
+    # When the producer-side CB total_size is sized for "streaming" (a small
+    # window) rather than "full output", the CB can fill before phase N
+    # completes, back-pressuring pack -> math -> unpack.  With LLK asserts
+    # enabled, an LLK_ASSERT_BLOCK in the unpack path issues a tensix_sync
+    # which then deadlocks on the back-pressured pipeline.
+    #
+    # Fix A: identify these phase-bridge slots and ensure their total_size
+    # is at least the maximum producer-side requirement across producing
+    # phases.  In practice _reuse_slot already takes max(...) of per-phase
+    # total_size when the slot is reused, so for ops whose factory already
+    # sizes their output CB to the full per-block output this is a no-op.
+    # We still run it explicitly so:
+    #   * the architectural invariant is enforced in one place;
+    #   * a future op whose output CB is sized for streaming gets the
+    #     correct bound automatically;
+    #   * we surface diagnostic logs so undersized bridges are visible.
+
+    def _identify_phase_bridge_slots(
+        self,
+        phases: List["PhaseInfo"],
+    ) -> Dict[int, Dict[str, Set[int]]]:
+        """Return a mapping ``{slot_idx: {"compute": {...}, "writer": {...}, "reader": {...}}}``.
+
+        A slot qualifies as a **phase-bridge** (and is included in the result)
+        when *all* of the following hold:
+
+        - The slot is buffer-backed (``has_buffer=True``) — bridge tensors
+          carry an L1 allocation between phases.
+        - The slot is referenced by a **compute** kernel in ``>= 2`` phases.
+          Only compute references count: a buffer-backed slot used by compute
+          in only one phase is a regular input or output, not a bridge.
+
+        The (writer, reader) per-phase sets are returned alongside ``compute``
+        so the sizing logic can decide which compute phases are
+        "producer-side" (no concurrent writer drain) and which are
+        "consumer-side" (no concurrent reader fill).
+
+        We deliberately do NOT require ``producer NOT in writer_phases``
+        here: in the fused chain a per-phase op's standalone writer may
+        still be present in its own ``op_descriptor.kernels`` even though
+        the fused program may elide / no-op it for the producing phase.
+        Treating any compute-in-2+-phases buffer-backed slot as a bridge is
+        a sound (slightly over-eager) upper bound — for true output slots
+        (compute writes in only the *last* phase) the consumer-side check
+        in ``_size_phase_bridge_slots`` will see no later compute phase and
+        leave the slot alone via the producer-max==current short-circuit.
+        """
+        from models.experimental.ops.descriptors.fusion.common import _get_risc_type
+
+        slot_compute_phases: Dict[int, Set[int]] = defaultdict(set)
+        slot_writer_phases: Dict[int, Set[int]] = defaultdict(set)
+        slot_reader_phases: Dict[int, Set[int]] = defaultdict(set)
+
+        for phase_idx, phase in enumerate(phases):
+            if phase_idx >= len(self.phase_remaps):
+                continue
+            remap = self.phase_remaps[phase_idx]
+            for kernel_desc in phase.op_descriptor.descriptor.kernels:
+                risc = _get_risc_type(kernel_desc)
+                if risc == "unknown":
+                    continue
+                for name, value in kernel_desc.named_compile_time_args:
+                    if not _is_cb_named_arg(name, value):
+                        continue
+                    slot_idx = remap.get(value, value)
+                    if slot_idx not in self._slots:
+                        continue
+                    if risc == "compute":
+                        slot_compute_phases[slot_idx].add(phase_idx)
+                    elif risc == "riscv_0":  # BRISC = writer (drains compute output)
+                        slot_writer_phases[slot_idx].add(phase_idx)
+                    elif risc == "riscv_1":  # NCRISC = reader (fills compute input)
+                        slot_reader_phases[slot_idx].add(phase_idx)
+
+        bridges: Dict[int, Dict[str, Set[int]]] = {}
+        for slot_idx, slot in self._slots.items():
+            if not slot.config.has_buffer:
+                continue
+            compute_phases = slot_compute_phases.get(slot_idx, set())
+            if len(compute_phases) < 2:
+                continue
+            bridges[slot_idx] = {
+                "compute": compute_phases,
+                "writer": slot_writer_phases.get(slot_idx, set()),
+                "reader": slot_reader_phases.get(slot_idx, set()),
+            }
+        return bridges
+
+    def _size_phase_bridge_slots(self, phases: List["PhaseInfo"]) -> None:
+        """Bump bridge slot ``total_size`` to the worst-case producer requirement.
+
+        For each phase-bridge slot, the **producer-side requirement** in a
+        given phase is the per-phase ``CBInfo.total_size`` for that slot —
+        which the standalone op factory already sizes to one full block of
+        the producer's output.  We take the max across all *producing*
+        phases and ensure the slot's pool-level ``total_size`` is at least
+        that value.
+
+        A phase ``p`` is producing-into-bridge for ``slot`` when:
+        - compute references ``slot`` in phase ``p``, AND
+        - there exists a later compute phase ``p' > p`` that also references
+          ``slot`` (i.e. the data must persist for a downstream phase to
+          consume).
+
+        This is required for correctness in the fused parallel/sequential
+        model: a bridge slot whose ``total_size`` is smaller than the full
+        producer output back-pressures the producer's pack pipeline.  When
+        LLK asserts are enabled, that back-pressure can deadlock the
+        unpack/math/pack chain via a ``tensix_sync()`` issued from
+        ``LLK_ASSERT_BLOCK``.  See issue #40330.
+        """
+        bridges = self._identify_phase_bridge_slots(phases)
+        if not bridges:
+            return
+
+        for slot_idx, info in sorted(bridges.items()):
+            slot = self._slots[slot_idx]
+            old_size = slot.total_size
+
+            compute_phases = info["compute"]
+            sorted_compute = sorted(compute_phases)
+            # Producing phases are those with a later consumer phase.
+            producing_phases = {p for i, p in enumerate(sorted_compute) if any(c > p for c in sorted_compute[i + 1 :])}
+            consuming_phases = compute_phases - producing_phases
+            if not producing_phases:
+                continue
+
+            producer_max = 0
+            for phase_idx in sorted(producing_phases):
+                if phase_idx >= len(phases):
+                    continue
+                phase = phases[phase_idx]
+                remap = self.phase_remaps[phase_idx]
+                for orig_idx, sidx in remap.items():
+                    if sidx != slot_idx:
+                        continue
+                    cb_info = phase.cb_info.get(orig_idx)
+                    if cb_info is not None:
+                        producer_max = max(producer_max, cb_info.total_size)
+
+            sorted_producing = sorted(producing_phases)
+            sorted_consuming = sorted(consuming_phases)
+            new_size = max(old_size, producer_max)
+
+            if new_size != old_size:
+                slot.total_size = new_size
+                logger.warning(
+                    "[CB_BRIDGE] slot %d: bumped total_size %d -> %d "
+                    "(producing_phases=%s, consuming_phases=%s, producer_max=%d)",
+                    slot_idx,
+                    old_size,
+                    new_size,
+                    sorted_producing,
+                    sorted_consuming,
+                    producer_max,
+                )
+                print(
+                    f"[CB_BRIDGE] slot {slot_idx}: bumped total_size {old_size} -> {new_size} "
+                    f"(producing_phases={sorted_producing}, "
+                    f"consuming_phases={sorted_consuming}, producer_max={producer_max})"
+                )
+            else:
+                logger.debug(
+                    "[CB_BRIDGE] slot %d: total_size=%d already covers producer_max=%d "
+                    "(producing_phases=%s, consuming_phases=%s)",
+                    slot_idx,
+                    old_size,
+                    producer_max,
+                    sorted_producing,
+                    sorted_consuming,
+                )
+                print(
+                    f"[CB_BRIDGE] slot {slot_idx}: total_size={old_size} already "
+                    f"covers producer_max={producer_max} "
+                    f"(producing_phases={sorted_producing}, "
+                    f"consuming_phases={sorted_consuming})"
+                )
+
     def build_merged_cb_descriptors(
         self,
         phases: List["PhaseInfo"],
@@ -440,6 +630,16 @@ class CBPoolAllocator:
             - global_cb_source_map: [(merged_idx, OpDescriptor, cbs_position)]
               for GlobalCB-backed CBs
         """
+        # NOTE (issue #40330): Fix A (phase-bridge sizing) was investigated and
+        # the helpers `_identify_phase_bridge_slots` / `_size_phase_bridge_slots`
+        # are kept above as diagnostic plumbing.  They are NOT invoked here
+        # because empirical runs of `test_sharded_chain[block]` showed that
+        # for our bridge slots (0 and 16) the producer max ALREADY equals
+        # the slot's `total_size` — the deadlock observed under
+        # `TT_METAL_LLK_ASSERTS=1` is not an undersized-bridge problem.  See
+        # `_size_phase_bridge_slots` docstring for context.  Re-enable here
+        # if a future fused chain has a producer-side CB sized for streaming.
+
         slot_alias = self._compute_slot_alias_groups(phases)
 
         # Group slots by alias group

--- a/models/experimental/ops/descriptors/fusion/cb_allocator.py
+++ b/models/experimental/ops/descriptors/fusion/cb_allocator.py
@@ -577,11 +577,6 @@ class CBPoolAllocator:
                     sorted_consuming,
                     producer_max,
                 )
-                print(
-                    f"[CB_BRIDGE] slot {slot_idx}: bumped total_size {old_size} -> {new_size} "
-                    f"(producing_phases={sorted_producing}, "
-                    f"consuming_phases={sorted_consuming}, producer_max={producer_max})"
-                )
             else:
                 logger.debug(
                     "[CB_BRIDGE] slot %d: total_size=%d already covers producer_max=%d "
@@ -591,12 +586,6 @@ class CBPoolAllocator:
                     producer_max,
                     sorted_producing,
                     sorted_consuming,
-                )
-                print(
-                    f"[CB_BRIDGE] slot {slot_idx}: total_size={old_size} already "
-                    f"covers producer_max={producer_max} "
-                    f"(producing_phases={sorted_producing}, "
-                    f"consuming_phases={sorted_consuming})"
                 )
 
     def build_merged_cb_descriptors(

--- a/models/experimental/ops/descriptors/fusion/codegen/barrier.py
+++ b/models/experimental/ops/descriptors/fusion/codegen/barrier.py
@@ -393,6 +393,8 @@ def _emit_state_vars(risc_type: str, is_coordinator: bool, has_compute: bool, ha
             lines.append("volatile tt_l1_ptr uint32_t* writer_done;")
     elif risc_type == "compute":
         lines.append("volatile tt_l1_ptr uint32_t* compute_done;")
+        lines.append("volatile tt_l1_ptr uint32_t* pack_drained;")
+        lines.append("volatile tt_l1_ptr uint32_t* math_drained;")
     lines.append("volatile tt_l1_ptr uint32_t* reset_done;")
     lines.append("")
     return lines
@@ -449,7 +451,27 @@ def _emit_local_sync_coordinator(
 def _emit_local_sync_follower(risc_type: str) -> List[str]:
     """Emit ``namespace local { void sync(); }`` for BRISC or compute.
 
-    Order: done++ -> drain NOC (DM only) -> signal done -> wait reset_done.
+    Order:
+      DM follower:      done++ -> drain NOC -> signal *writer_done -> wait reset_done.
+      Compute follower: done++ -> drain tensix pipeline -> signal *compute_done -> wait reset_done.
+
+    The tensix-pipeline drain MUST happen BEFORE signalling ``*compute_done``
+    (issue #40330).  ``reset_cbs`` on the coordinator reads
+    ``STREAM.tiles_received`` / ``STREAM.tiles_acked`` for every CB and
+    equalizes them only when they differ.  ``push_back`` / ``pop_front``
+    instructions issued by compute go through the pack/unpack back-end
+    pipeline; the stream-register write happens at the END of that pipeline,
+    not at instruction-issue time.  ``tensix_sync()`` blocks the calling TRISC
+    until its own back-end has drained, so it is the only signal that the
+    stream registers reflect the just-completed phase.
+
+    If we signalled ``*compute_done`` first and drained second, the coordinator
+    raced ``reset_cbs`` against the in-flight ``push_back``: the read saw
+    ``received == acked == 0``, the equalize was skipped, then the drain
+    committed ``received = 8`` while ``acked`` stayed at 0 — and the next
+    phase's ``reserve_back`` deadlocked with ``free = 8 - (8 - 0) = 0``.  The
+    DPRINT capture in the gamma-loop reserve_back made this exact pattern
+    visible (slot 16: phase 1 entry shows ``received=8 acked=0``).
     """
     lines = ["namespace local {"]
     lines.append("    __attribute__((noinline)) void sync() {")
@@ -462,6 +484,31 @@ def _emit_local_sync_follower(risc_type: str) -> List[str]:
         lines.append("        noc_async_write_barrier();")
         lines.append("        *writer_done = done;")
     else:  # compute
+        lines.append("        // Issue #40330: drain the tensix pipeline BEFORE signalling")
+        lines.append("        // *compute_done so the coordinator's reset_cbs reads up-to-date")
+        lines.append("        // STREAM.tiles_received / tiles_acked values.  Order is")
+        lines.append("        // pack -> math -> unpack so each stage waits for its downstream")
+        lines.append("        // consumer before draining its own back-end:")
+        lines.append("        //   pack  needs CB space      (freed by coordinator reset_cbs)")
+        lines.append("        //   math  needs Dest registers (freed after pack drains)")
+        lines.append("        //   unpack needs SrcA/SrcB     (freed after math drains)")
+        lines.append("        // This drain ALSO ensures the next phase's LLK assert checks")
+        lines.append("        // (e.g. are_unpackers_AB_configured_correctly) — which call")
+        lines.append("        // tensix_sync() at init — see an empty back-end and do not")
+        lines.append("        // deadlock waiting for prior-phase instructions.")
+        lines.append("#ifdef TRISC_PACK")
+        lines.append("        tensix_sync();")
+        lines.append("        *pack_drained = done;")
+        lines.append("#endif")
+        lines.append("#ifdef TRISC_MATH")
+        lines.append("        while (*pack_drained < done) {}")
+        lines.append("        tensix_sync();")
+        lines.append("        *math_drained = done;")
+        lines.append("#endif")
+        lines.append("#ifdef TRISC_UNPACK")
+        lines.append("        while (*math_drained < done) {}")
+        lines.append("        tensix_sync();")
+        lines.append("#endif")
         lines.append("        *compute_done = done;")
     lines.append("        // Wait for coordinator to complete reset (op sem + CB)")
     lines.append("        // before proceeding.  Without this, a fast core can start")
@@ -596,6 +643,12 @@ def _emit_init_follower(
         lines.append("    *compute_done = 0;")
         lines.append("    reset_done = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(")
         lines.append("        get_arg_val<uint32_t>(rt_offset + 1));")
+        lines.append("    pack_drained = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(")
+        lines.append("        get_arg_val<uint32_t>(rt_offset + 2));")
+        lines.append("    *pack_drained = 0;")
+        lines.append("    math_drained = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(")
+        lines.append("        get_arg_val<uint32_t>(rt_offset + 3));")
+        lines.append("    *math_drained = 0;")
     for seg_idx in range(num_segments):
         lines.append(f"    group::seg_{seg_idx}::init();")
     lines.append("}")
@@ -707,11 +760,15 @@ def _generate_barrier_namespace(
             )
             lines.append("")
     else:
+        # Compute follower has 4 base RT args (compute_done, reset_done,
+        # pack_drained, math_drained); DM follower has 2 (writer_done,
+        # reset_done).  Segment release addresses follow immediately after.
+        follower_base = 4 if risc_type == "compute" else 2
         for seg_idx in range(num_segments):
             lines.extend(
                 _SPINWAIT_SEGMENT_TEMPLATE.format(
                     seg_idx=seg_idx,
-                    release_offset=2 + seg_idx,  # +2: done_signal + reset_done
+                    release_offset=follower_base + seg_idx,
                 ).split("\n")
             )
             lines.append("")

--- a/models/experimental/ops/descriptors/fusion/codegen/builder.py
+++ b/models/experimental/ops/descriptors/fusion/codegen/builder.py
@@ -362,7 +362,12 @@ def _build_fused_descriptor(
                 for seg in multi_barrier.segments:
                     barrier_addrs.append(seg.release_addr)
             elif risc_type == "compute":
-                barrier_addrs = [multi_barrier.compute_done_addr, multi_barrier.reset_done_addr]
+                barrier_addrs = [
+                    multi_barrier.compute_done_addr,
+                    multi_barrier.reset_done_addr,
+                    multi_barrier.pack_drained_addr,
+                    multi_barrier.math_drained_addr,
+                ]
                 for seg in multi_barrier.segments:
                     barrier_addrs.append(seg.release_addr)
 

--- a/models/experimental/ops/descriptors/fusion/common.py
+++ b/models/experimental/ops/descriptors/fusion/common.py
@@ -75,6 +75,8 @@ class MultiBarrierSpec:
     compute_done_addr: int = 0
     writer_done_addr: int = 0
     reset_done_addr: int = 0
+    pack_drained_addr: int = 0
+    math_drained_addr: int = 0
     # Map: phase_transition_index -> (segment_index, call_index_within_segment)
     transition_map: Dict[int, Tuple[int, int]] = field(default_factory=dict)
     _sem_refs: List[Any] = field(default_factory=list)

--- a/models/experimental/ops/descriptors/fusion/graph.py
+++ b/models/experimental/ops/descriptors/fusion/graph.py
@@ -400,10 +400,20 @@ class OpGraphBuilder:
         sem_compute_done = ttnn.create_global_semaphore(device, union_range, 0)
         sem_writer_done = ttnn.create_global_semaphore(device, union_range, 0)
         sem_reset_done = ttnn.create_global_semaphore(device, union_range, 0)
+        sem_pack_drained = ttnn.create_global_semaphore(device, union_range, 0)
+        sem_math_drained = ttnn.create_global_semaphore(device, union_range, 0)
         compute_done_addr = ttnn.get_global_semaphore_address(sem_compute_done)
         writer_done_addr = ttnn.get_global_semaphore_address(sem_writer_done)
         reset_done_addr = ttnn.get_global_semaphore_address(sem_reset_done)
-        all_sem_refs = [sem_compute_done, sem_writer_done, sem_reset_done]
+        pack_drained_addr = ttnn.get_global_semaphore_address(sem_pack_drained)
+        math_drained_addr = ttnn.get_global_semaphore_address(sem_math_drained)
+        all_sem_refs = [
+            sem_compute_done,
+            sem_writer_done,
+            sem_reset_done,
+            sem_pack_drained,
+            sem_math_drained,
+        ]
 
         # Collect semaphore specs (allocation blueprints) and current
         # addresses in matching order.  Used post-build to compute
@@ -412,8 +422,16 @@ class OpGraphBuilder:
             _SemaphoreSpec(core_ranges=union_range, initial_value=0),
             _SemaphoreSpec(core_ranges=union_range, initial_value=0),
             _SemaphoreSpec(core_ranges=union_range, initial_value=0),
+            _SemaphoreSpec(core_ranges=union_range, initial_value=0),
+            _SemaphoreSpec(core_ranges=union_range, initial_value=0),
         ]
-        sem_addrs = [compute_done_addr, writer_done_addr, reset_done_addr]
+        sem_addrs = [
+            compute_done_addr,
+            writer_done_addr,
+            reset_done_addr,
+            pack_drained_addr,
+            math_drained_addr,
+        ]
 
         # Pre-allocate barrier configs for each unique (release, arrive) scope
         # pair across all groups.  Groups sharing a release scope MUST use the
@@ -479,6 +497,8 @@ class OpGraphBuilder:
                 compute_done_addr,
                 writer_done_addr,
                 reset_done_addr,
+                pack_drained_addr,
+                math_drained_addr,
                 all_sem_refs,
                 segment_cache,
                 needs_target_core_range=multi_group,
@@ -631,6 +651,8 @@ class OpGraphBuilder:
         compute_done_addr: int,
         writer_done_addr: int,
         reset_done_addr: int,
+        pack_drained_addr: int,
+        math_drained_addr: int,
         shared_sem_refs: List[Any],
         segment_cache: Dict[Tuple[frozenset, frozenset], BarrierConfig],
         needs_target_core_range: bool = False,
@@ -665,6 +687,8 @@ class OpGraphBuilder:
             compute_done_addr=compute_done_addr,
             writer_done_addr=writer_done_addr,
             reset_done_addr=reset_done_addr,
+            pack_drained_addr=pack_drained_addr,
+            math_drained_addr=math_drained_addr,
             transition_map=transition_map,
             _sem_refs=list(shared_sem_refs),
         )

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
@@ -25,7 +25,7 @@ import torch
 import ttnn
 
 
-from models.common.utility_functions import comp_pcc, skip_with_llk_assert, skip_with_watcher
+from models.common.utility_functions import comp_pcc, skip_with_watcher
 
 
 def stress_test_program_cache(fn):
@@ -244,7 +244,6 @@ class TestInfrastructure:
 class TestSequentialExecution:
     """Core sequential chain execution tests."""
 
-    @skip_with_llk_assert("Compiler error with LLK asserts enabled. Issue #40330")
     @pytest.mark.parametrize("num_phases", [2, 3, 4])
     @stress_test_program_cache
     def test_norm_chain(self, device, num_phases):
@@ -392,7 +391,6 @@ class TestSequentialExecution:
 class TestShardedExecution:
     """Sharded (L1) execution tests."""
 
-    @skip_with_llk_assert("Compiler error with LLK asserts enabled. Issue #40330")
     @pytest.mark.parametrize(
         "shard_type",
         [
@@ -449,7 +447,6 @@ class TestShardedExecution:
         check_pcc(golden, out, label=f"sharded {shard_type}")
 
     @skip_with_watcher("Program too large for kernel config buffer. Will not fix.")
-    @skip_with_llk_assert("Compiler error with LLK asserts enabled. Issue: #40330")
     @stress_test_program_cache
     def test_sharded_three_phase(self, device):
         """3-phase LN->RMS->LN block-sharded on 4x4 grid."""
@@ -501,7 +498,6 @@ class TestShardedExecution:
         golden = sh_ln_golden(g, weight=torch_ws[2])
         check_pcc(golden, out, label="sharded 3-phase")
 
-    @skip_with_llk_assert("Compiler error with LLK asserts enabled. Issue #40330")
     @stress_test_program_cache
     def test_sharded_with_bias_residual(self, device):
         """LN(bias+residual)->RMS block-sharded, single-stage."""
@@ -713,7 +709,6 @@ class TestMatmulFusion:
         check_pcc(golden, out, label="multicore RMS->MM->RMS")
 
     @skip_with_watcher("Program too large for kernel config buffer. Will not fix.")
-    @skip_with_llk_assert("Compiler error with LLK asserts enabled. Issue #40330")
     @pytest.mark.parametrize("num_rms", [2, 3, 4])
     @stress_test_program_cache
     def test_matmul_followed_by_n_rms(self, device, num_rms):
@@ -945,7 +940,6 @@ class TestBranchingTopology:
         for i, label in enumerate(["LL", "LR", "RL", "RR"]):
             check_pcc(goldens[i], outs[i], label=label)
 
-    @skip_with_llk_assert("Compiler error with LLK asserts enabled. Issue: #40330")
     @stress_test_program_cache
     def test_asymmetric_deep_left(self, device):
         """Deep left + shallow right.
@@ -1060,7 +1054,6 @@ class TestParallelExecution:
             )
             check_pcc(golden, chain_outs[i][0], label=f"chain {i}")
 
-    @skip_with_llk_assert("Compiler error with LLK asserts enabled. Issue #40330")
     @stress_test_program_cache
     def test_matmul_plus_fused_chain(self, device):
         """Matmul + 3-phase norm chain on disjoint cores."""

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
@@ -25,7 +25,7 @@ import torch
 import ttnn
 
 
-from models.common.utility_functions import comp_pcc, skip_with_watcher
+from models.common.utility_functions import comp_pcc, skip_with_llk_assert, skip_with_watcher
 
 
 def stress_test_program_cache(fn):
@@ -447,6 +447,7 @@ class TestShardedExecution:
         check_pcc(golden, out, label=f"sharded {shard_type}")
 
     @skip_with_watcher("Program too large for kernel config buffer. Will not fix.")
+    @skip_with_llk_assert("Program too large for kernel config buffer. Will not fix.")
     @stress_test_program_cache
     def test_sharded_three_phase(self, device):
         """3-phase LN->RMS->LN block-sharded on 4x4 grid."""


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #40330 

<p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">drain tensix pipeline before signalling compute_done in fused kernel barrier</code></p><h2 class="mt-6 mb-2 font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 10px; --tw-font-weight: 600; font-weight: 600; color: rgb(216, 222, 233); line-height: 1.25; font-size: 1.3em; margin-top: 20px; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fused parallel/sequential kernels (<code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">Sequential(layer_norm, rms_norm)</code><span> </span>and friends) deadlocked under<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">TT_METAL_LLK_ASSERTS=1</code>, requiring 7 tests in<span> </span><code class="md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: rgb(129, 161, 193); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all; cursor: pointer;"><span class="md-inline-path-filename">test_parallel_sequential.py</span></code><span> </span>to be skipped via<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">@skip_with_llk_assert("...#40330")</code>. This PR fixes the root cause and re-enables every skipped test.</p><h2 class="mt-6 mb-2 font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 10px; --tw-font-weight: 600; font-weight: 600; color: rgb(216, 222, 233); line-height: 1.25; font-size: 1.3em; margin-top: 20px; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Root cause</h2><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The compute follower's<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">local::sync()</code><span> </span>(generated by<span> </span><code class="md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: rgb(129, 161, 193); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all; cursor: pointer;"><span class="md-inline-path-filename">barrier.py</span></code>) signalled<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">*compute_done = done</code><span> </span><em>before</em><span> </span>draining its own tensix back-end:</p><div class="composer-message-codeblock" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-top: 8px; margin-bottom: 8px; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-code-block" style="position: relative; margin-top: 0px; margin-bottom: 0px; border-radius: 8px; border-color: color(srgb 0.8 0.8 0.8 / 0.28); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; overflow: hidden; background-color: rgb(10, 10, 10); min-height: 166px;"><div class="ui-code-block-content" style="position: relative; min-height: 166px;"><div class="ui-scroll-area" data-visibility="hover" data-direction="horizontal" style="--scrollbar-size: 6px; --scrollbar-inset: 1px; --scrollbar-thumb-top-offset: 6px; position: relative; overflow: hidden; display: grid; grid-template: 1fr / 1fr;"><div class="ui-scroll-area__viewport" style="grid-area: 1 / 1; min-height: 0px; max-height: 100%; border-radius: inherit; overflow: auto hidden; scroll-padding: 0px 4px; overscroll-behavior: contain; scrollbar-width: none;"><div class="ui-scroll-area__content" style="box-sizing: border-box; width: max-content; min-width: 100%; max-width: none; min-height: 100%; display: flex; flex-direction: row; height: fit-content;"><div class="ui-default-code ui-code-block-default-code" style="min-width: 100%; width: max-content; background: rgb(10, 10, 10); min-height: 176px; padding: 6px 0px; font-size: 12px; font-weight: normal; line-height: 20px; contain: layout style paint; tab-size: 4; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; --shiki-foreground: #d8dee9; --shiki-background: transparent; --shiki-token-constant: #f8c762; --shiki-token-string: #E394DC; --shiki-token-comment: #FFFFFF5C; --shiki-token-keyword: #83D6C5; --shiki-token-parameter: #D6D6DD; --shiki-token-function: #EFB080; --shiki-token-string-expression: #E394DC; --shiki-token-punctuation: #d8dee9; --shiki-token-link: #87c3ff; --shiki-token-tag: #83D6C5; --shiki-token-attribute: #AAA0FA; --shiki-token-property: #AA9BF5; --shiki-token-type: #EFB080; --shiki-token-variable: #94C1FA; --shiki-token-class: #EFB080; --shiki-token-language-variable: #C1808A; --shiki-token-constant-variable: #EFB080; --ui-default-code-tab-size: 4;"><div class="ui-default-code__content" style="min-width: fit-content; contain: layout style;"><div class="ui-default-code__line" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content" style="flex: 1 1 0%; white-space: pre; overflow: hidden; text-overflow: ellipsis; padding-left: 6px; color: rgb(216, 222, 233); padding-right: 8px; position: relative;"><span>done++;</span></div></div><div class="ui-default-code__line" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content" style="flex: 1 1 0%; white-space: pre; overflow: hidden; text-overflow: ellipsis; padding-left: 6px; color: rgb(216, 222, 233); padding-right: 8px; position: relative;"><span>*compute_done = done;        // signal coordinator</span></div></div><div class="ui-default-code__line" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content" style="flex: 1 1 0%; white-space: pre; overflow: hidden; text-overflow: ellipsis; padding-left: 6px; color: rgb(216, 222, 233); padding-right: 8px; position: relative;"><span>while (*reset_done &lt; done){} // wait for reset</span></div></div><div class="ui-default-code__line" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content" style="flex: 1 1 0%; white-space: pre; overflow: hidden; text-overflow: ellipsis; padding-left: 6px; color: rgb(216, 222, 233); padding-right: 8px; position: relative;"><span>#ifdef TRISC_PACK</span></div></div><div class="ui-default-code__line" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content" style="flex: 1 1 0%; white-space: pre; overflow: hidden; text-overflow: ellipsis; padding-left: 6px; color: rgb(216, 222, 233); padding-right: 8px; position: relative;"><span>tensix_sync();               // drain pack pipeline AFTER reset already ran</span></div></div><div class="ui-default-code__line" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content" style="flex: 1 1 0%; white-space: pre; overflow: hidden; text-overflow: ellipsis; padding-left: 6px; color: rgb(216, 222, 233); padding-right: 8px; position: relative;"><span>*pack_drained = done;</span></div></div><div class="ui-default-code__line" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content" style="flex: 1 1 0%; white-space: pre; overflow: hidden; text-overflow: ellipsis; padding-left: 6px; color: rgb(216, 222, 233); padding-right: 8px; position: relative;"><span>#endif</span></div></div><div class="ui-default-code__line" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content" style="flex: 1 1 0%; white-space: pre; overflow: hidden; text-overflow: ellipsis; padding-left: 6px; color: rgb(216, 222, 233); padding-right: 8px; position: relative;"><span>...</span></div></div></div></div></div></div></div></div></div></div><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Meanwhile the BRISC coordinator's<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">reset_cbs</code><span> </span>is gated<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">if (received != acked) acked := received;</code><span> </span>— a no-op when both stream registers happen to read 0 at sample time.</p><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Race timeline for any phase-bridge CB (e.g. slot 16 in the LN→RMS chain on 8 tiles per block):</p><ol class="list-inside list-decimal whitespace-normal [li_&amp;]:pl-6" data-streamdown="ordered-list" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; list-style-type: decimal; white-space: normal; padding-left: 2em; display: flex !important; flex-direction: column !important; gap: 6px !important; margin: 6px 0px !important; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">TRISC2 issues<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">push_back(8)</code><span> </span>— instruction enters the pack back-end pipeline;<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;"><code class="md-inline-path-filename-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;"><span class="md-inline-path-filename">STREAM.tiles_received</span></code><span> </span>not yet committed</span>.</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">TRISC2 hits<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">local::sync()</code>:<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">*compute_done = 1</code><span> </span>(before its own<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">tensix_sync</code>).</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">BRISC sees<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">compute_done≥1</code>, runs<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">reset_cbs(phase_0_cbs)</code>. For slot 16 it reads<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">received=0, acked=0</code><span> </span>→ equality short-circuits the equalize.</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">BRISC sets<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">*reset_done = 1</code>.</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">TRISC2 leaves the wait loop, runs<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">tensix_sync()</code><span> </span>→ push_back commits →<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">STREAM.tiles_received = 8</code>.</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">Phase 1 starts. Slot 16 has<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">received=8, acked=0</code><span> </span>permanently.<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">reserve_back(8)</code><span> </span>computes<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">free = 8 - (8-0) = 0</code><span> </span>→ deadlock.</li></ol><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This race was hidden when<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">TT_METAL_LLK_ASSERTS=0</code><span> </span>because, without per-tile<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">are_unpackers_AB_configured_correctly()</code><span> </span>checks inflating the pack queue, the back-end happened to be empty when<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">*compute_done</code><span> </span>was set. Enabling LLK asserts widens the window enough to make the race deterministic.</p><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">DPRINT capture confirmed the exact pattern on entry to phase 1:</p><div class="composer-message-codeblock" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-top: 8px; margin-bottom: 8px; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-code-block" style="position: relative; margin-top: 0px; margin-bottom: 0px; border-radius: 8px; border-color: color(srgb 0.8 0.8 0.8 / 0.28); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; overflow: hidden; background-color: rgb(10, 10, 10); min-height: 26px;"><div class="ui-code-block-content" style="position: relative; min-height: 26px;"><div class="ui-scroll-area" data-visibility="hover" data-direction="horizontal" style="--scrollbar-size: 6px; --scrollbar-inset: 1px; --scrollbar-thumb-top-offset: 6px; position: relative; overflow: hidden; display: grid; grid-template: 1fr / 1fr;"><div class="ui-scroll-area__viewport" style="grid-area: 1 / 1; min-height: 0px; max-height: 100%; border-radius: inherit; overflow: auto hidden; scroll-padding: 0px 4px; overscroll-behavior: contain; scrollbar-width: none;"><div class="ui-scroll-area__content" style="box-sizing: border-box; width: max-content; min-width: 100%; max-width: none; min-height: 100%; display: flex; flex-direction: row; height: fit-content;"><div class="ui-default-code ui-code-block-default-code" style="min-width: 100%; width: max-content; background: rgb(10, 10, 10); min-height: 36px; padding: 6px 0px; font-size: 12px; font-weight: normal; line-height: 20px; contain: layout style paint; tab-size: 4; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; --shiki-foreground: #d8dee9; --shiki-background: transparent; --shiki-token-constant: #f8c762; --shiki-token-string: #E394DC; --shiki-token-comment: #FFFFFF5C; --shiki-token-keyword: #83D6C5; --shiki-token-parameter: #D6D6DD; --shiki-token-function: #EFB080; --shiki-token-string-expression: #E394DC; --shiki-token-punctuation: #d8dee9; --shiki-token-link: #87c3ff; --shiki-token-tag: #83D6C5; --shiki-token-attribute: #AAA0FA; --shiki-token-property: #AA9BF5; --shiki-token-type: #EFB080; --shiki-token-variable: #94C1FA; --shiki-token-class: #EFB080; --shiki-token-language-variable: #C1808A; --shiki-token-constant-variable: #EFB080; --ui-default-code-tab-size: 4;"><div class="ui-default-code__content" style="min-width: fit-content; contain: layout style;"><div class="ui-default-code__line" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content" style="flex: 1 1 0%; white-space: pre; overflow: hidden; text-overflow: ellipsis; padding-left: 6px; color: rgb(216, 222, 233); padding-right: 8px; position: relative;"><span>[BRIDGE_DBG_PRE_RESERVE] cb=16 need=8 LOCAL.tiles_received=8 STREAM.tiles_received=8 STREAM.tiles_acked=0 ...</span></div></div></div></div></div></div><div class="ui-scroll-area__scrollbar" data-scrollable="true" role="presentation" aria-hidden="true" style="position: absolute; z-index: 10; inset: auto 1px 1px; width: auto; pointer-events: auto; height: 6px;"><div class="ui-scroll-area__thumb" style="position: absolute; inset: 0px auto 0px 0px; min-height: auto; width: 489px; border-radius: 9999px; background: none 0% 0% / auto repeat scroll padding-box border-box color(srgb 0.8 0.8 0.8 / 0.28); pointer-events: auto; transform: translateX(0px); transition: background-color 0.15s, opacity 0.15s; height: 6px; min-width: 20px; opacity: 0;"></div></div></div></div></div></div><h2 class="mt-6 mb-2 font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 10px; --tw-font-weight: 600; font-weight: 600; color: rgb(216, 222, 233); line-height: 1.25; font-size: 1.3em; margin-top: 20px; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fix</h2><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Move the ordered tensix-pipeline drain (<code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">tensix_sync()</code><span> </span>per stage in pack→math→unpack order) to<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">before</span><span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">*compute_done = done</code>. The drain still completes before any next-phase code runs, preserving its original purpose of preventing the LLK-init<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">tensix_sync()</code><span> </span>from deadlocking on left-over back-end instructions.</p><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This requires the compute kernel to actually have access to the<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">pack_drained</code><span> </span>/<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">math_drained</code><span> </span>semaphores at runtime — a few related plumbing fixes were also needed.</p><h2 class="mt-6 mb-2 font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 10px; --tw-font-weight: 600; font-weight: 600; color: rgb(216, 222, 233); line-height: 1.25; font-size: 1.3em; margin-top: 20px; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Files changed</h2><div class="ui-scroll-area" data-visibility="hover" data-direction="horizontal" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; --scrollbar-size: 6px; --scrollbar-inset: 0px; --scrollbar-thumb-top-offset: 6px; position: relative; overflow: hidden; display: grid; grid-template: 1fr / 1fr; margin: 1em 0px; border-color: color(srgb 0.8 0.8 0.8 / 0.28); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; border-radius: 6px; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-scroll-area__viewport" style="grid-area: 1 / 1; min-height: 0px; max-height: 100%; border-radius: inherit; overflow: auto hidden; scroll-padding: 0px 4px; overscroll-behavior: contain; scrollbar-width: none;"><div class="ui-scroll-area__content" style="box-sizing: border-box; width: auto; min-width: 100%; max-width: 100%; min-height: 100%; display: flex; flex-direction: row; height: fit-content;">
File | Change
-- | --
models/experimental/ops/descriptors/fusion/codegen/barrier.py | Core fix: in _emit_local_sync_follower, drain the tensix pipeline (tensix_sync() for pack → math → unpack) before signalling *compute_done, instead of after. Updated docstring + comments to explain the invariant (issue #40330).
models/experimental/ops/descriptors/fusion/codegen/builder.py | Pass multi_barrier.pack_drained_addr and multi_barrier.math_drained_addr as runtime args to the compute kernel so the new drain semaphores resolve at runtime.
models/experimental/ops/descriptors/fusion/common.py | Add pack_drained_addr / math_drained_addr fields to MultiBarrierSpec.
models/experimental/ops/descriptors/fusion/graph.py | Allocate two new global semaphores (pack_drained, math_drained) and thread their addresses into MultiBarrierSpec.
tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py | Remove all 7 @skip_with_llk_assert("...#40330") decorators and the now-unused import.

</div></div></div>

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-40330_par_seq)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-40330_par_seq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-40330_par_seq)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-40330_par_seq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-40330_par_seq)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-40330_par_seq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-40330_par_seq)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-40330_par_seq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-40330_par_seq)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-40330_par_seq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-40330_par_seq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-40330_par_seq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-40330_par_seq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-40330_par_seq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-40330_par_seq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-40330_par_seq)