### PR TITLE
#38972: Add uint32 support for addcmul

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
@@ -293,6 +293,41 @@ def test_addcmul_with_int32_inputs(device, in_data1_shape, in_data2_shape, in_da
 
 
 @pytest.mark.parametrize(
+    "in_data1_shape, in_data2_shape, in_data3_shape",
+    [
+        ((1, 1, 32, 32), (1, 1, 32, 32), (1, 1, 32, 32)),
+        ((1, 1, 1, 1), (1, 1, 32, 32), (1, 1, 1, 1)),
+    ],
+)
+@pytest.mark.parametrize("value", [6, -6.0, float(2**31 + 7), 2**32 - 1])
+def test_addcmul_with_uint32_inputs(device, in_data1_shape, in_data2_shape, in_data3_shape, value):
+    # Use values spanning the full uint32 range. Store them as int32 bit-patterns;
+    # TTNN interprets those bit-patterns as uint32, and the golden is compared via 32-bit wraparound.
+    in_data1 = torch.randint(0, 2**32, in_data1_shape, dtype=torch.int64).to(torch.int32)
+    in_data2 = torch.randint(0, 2**16, in_data2_shape, dtype=torch.int64).to(torch.int32)
+    in_data3 = torch.randint(0, 2**16, in_data3_shape, dtype=torch.int64).to(torch.int32)
+
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.uint32, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor2 = ttnn.from_torch(in_data2, dtype=ttnn.uint32, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor3 = ttnn.from_torch(in_data3, dtype=ttnn.uint32, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.addcmul(input_tensor1, input_tensor2, input_tensor3, value=value)
+    output_tensor = ttnn.to_torch(output_tensor, dtype=torch.int32)
+
+    # Float values are narrowed to float32 by the C++ binding, so apply the same rounding
+    # to the golden to keep both sides in sync (e.g. float(2**31+7) → 2147483648.0 in float32).
+    golden_value = float(torch.tensor(value, dtype=torch.float32).item()) if isinstance(value, float) else value
+
+    # Promote to int64 before calling the golden function to prevent intermediate overflow,
+    # then truncate back to int32 to match the 32-bit wraparound semantics of uint32 hardware.
+    golden_fn = ttnn.get_golden_function(ttnn.addcmul)
+    golden_tensor = golden_fn(
+        in_data1.to(torch.int64), in_data2.to(torch.int64), in_data3.to(torch.int64), value=golden_value
+    ).to(torch.int32)
+
+    assert_equal(golden_tensor, output_tensor)
+
+
+@pytest.mark.parametrize(
     "torch_dtype, ttnn_dtype",
     [
         (torch.bfloat16, ttnn.bfloat16),

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu.cpp
@@ -41,14 +41,14 @@ void kernel_main() {
         copy_tile(cb_in2, 0 /*in_tile_index*/, 2 /*dst_tile_index*/);
 
         fill_tile_init();
-        fill_tile_int<DataFormat::Int32>(3, scalar_arg);
+        fill_tile_int<ADDCMUL_DATA_FORMAT>(3, scalar_arg);
 
-        mul_int_tile_init<DataFormat::Int32>();
-        mul_int_tile<DataFormat::Int32>(3, 1, 3);
-        mul_int_tile<DataFormat::Int32>(3, 2, 2);
+        mul_int_tile_init<ADDCMUL_DATA_FORMAT>();
+        mul_int_tile<ADDCMUL_DATA_FORMAT>(3, 1, 3);
+        mul_int_tile<ADDCMUL_DATA_FORMAT>(3, 2, 2);
 
         add_int_tile_init();
-        add_int_tile<DataFormat::Int32>(0, 2, 0);
+        add_int_tile<ADDCMUL_DATA_FORMAT>(0, 2, 0);
 
         tile_regs_commit();
         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu_bcast.cpp
@@ -59,14 +59,14 @@ ALWI void process_tile(
         copy_tile(cb_in2, 0 /*in_tile_index*/, 2 /*dst_tile_index*/);
 
         fill_tile_init();
-        fill_tile_int<DataFormat::Int32>(3, scalar_arg);
+        fill_tile_int<ADDCMUL_DATA_FORMAT>(3, scalar_arg);
 
-        mul_int_tile_init<DataFormat::Int32>();
-        mul_int_tile<DataFormat::Int32>(3, 1, 3);
-        mul_int_tile<DataFormat::Int32>(3, 2, 2);
+        mul_int_tile_init<ADDCMUL_DATA_FORMAT>();
+        mul_int_tile<ADDCMUL_DATA_FORMAT>(3, 1, 3);
+        mul_int_tile<ADDCMUL_DATA_FORMAT>(3, 2, 2);
 
         add_int_tile_init();
-        add_int_tile<DataFormat::Int32>(0, 2, 0);
+        add_int_tile<ADDCMUL_DATA_FORMAT>(0, 2, 0);
 
         tile_regs_commit();
         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
@@ -349,9 +349,31 @@ std::string override_addcmul_compute_kernel(KernelName kernel_name) {
     }
 }
 
+std::map<std::string, std::string> get_addcmul_int_kernel_defines(DataType dtype) {
+    TT_FATAL(
+        dtype == DataType::INT32 || dtype == DataType::UINT32,
+        "get_addcmul_int_kernel_defines: expected INT32 or UINT32, got {}",
+        dtype);
+    std::string fmt = (dtype == DataType::UINT32) ? "DataFormat::UInt32" : "DataFormat::Int32";
+    return {{"ADDCMUL_DATA_FORMAT", fmt}};
+}
+
 inline uint32_t pack_scalar_runtime_arg_float(const float scalar, const DataType dtype) {
     if (dtype == DataType::INT32) {
+        // float → int32 (truncate towards zero) → reinterpret bits as uint32.
+        // bit_cast preserves the two's complement bit-pattern without any value conversion.
+        //   6.0f  → static_cast<int32_t> →  6         → bit_cast → 0x00000006
+        //  -6.0f  → static_cast<int32_t> → -6         → bit_cast → 0xFFFFFFFA
         return std::bit_cast<uint32_t>(static_cast<int32_t>(scalar));
+    }
+    if (dtype == DataType::UINT32) {
+        // float → int64 → uint32 (mod 2^32).
+        // A direct float → uint32 cast is UB in C++ for negative values, so we route
+        // through int64 (which can represent all float values in the int32 range) and
+        // then narrow to uint32 (C++ guarantees this is mod 2^32, always well-defined).
+        //   6.0f  → static_cast<int64_t> →  6LL → static_cast<uint32_t> → 0x00000006
+        //  -6.0f  → static_cast<int64_t> → -6LL → static_cast<uint32_t> → 0xFFFFFFFA
+        return static_cast<uint32_t>(static_cast<int64_t>(scalar));
     }
     return std::bit_cast<uint32_t>(scalar);
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.hpp
@@ -59,6 +59,8 @@ std::string get_kernel_file_path(KernelName kernel_name, bool is_fpu = false);
 
 std::string override_addcmul_compute_kernel(KernelName kernel_name);
 
+std::map<std::string, std::string> get_addcmul_int_kernel_defines(DataType dtype);
+
 uint32_t pack_scalar_runtime_arg(ScalarVariant scalar, DataType dtype);
 
 std::map<std::string, std::string> make_dataflow_defines(

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
@@ -1266,10 +1266,16 @@ tt::tt_metal::ProgramDescriptor TernaryDeviceOperation::TernaryProgramFactory::c
         kernel_defines["FILL_WITH_VALUE_FLOAT"] = "1";
     }
 
-    std::string compute_kernel_path = (operation_attributes.ternary_op_type == TernaryOpType::ADDCMUL &&
-                                       operation_attributes.dtype == DataType::INT32)
-                                          ? override_addcmul_compute_kernel(compute_kernel)
-                                          : get_kernel_file_path(compute_kernel, is_fpu);
+    const bool use_addcmul_int_kernel =
+        operation_attributes.ternary_op_type == TernaryOpType::ADDCMUL &&
+        (operation_attributes.dtype == DataType::INT32 || operation_attributes.dtype == DataType::UINT32);
+    if (use_addcmul_int_kernel) {
+        for (const auto& [k, v] : get_addcmul_int_kernel_defines(operation_attributes.dtype.value())) {
+            kernel_defines[k] = v;
+        }
+    }
+    std::string compute_kernel_path = use_addcmul_int_kernel ? override_addcmul_compute_kernel(compute_kernel)
+                                                             : get_kernel_file_path(compute_kernel, is_fpu);
 
     KernelDescriptor compute_desc;
     compute_desc.kernel_source = compute_kernel_path;

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
@@ -254,11 +254,18 @@ Tensor addcmul(
 
     bool is_supported_dtype =
         (input_a.dtype() == DataType::BFLOAT16 || input_a.dtype() == DataType::FLOAT32 ||
-         input_a.dtype() == DataType::INT32 || input_a.dtype() == DataType::BFLOAT8_B);  // TODO(#38972): UINT32 support
+         input_a.dtype() == DataType::INT32 || input_a.dtype() == DataType::BFLOAT8_B ||
+         input_a.dtype() == DataType::UINT32);
     TT_FATAL(
         is_supported_dtype,
-        "Addcmul supports only BFLOAT16, BFLOAT8_B, FLOAT32, and INT32 dtypes. Got {}",
+        "Addcmul supports only BFLOAT16, BFLOAT8_B, FLOAT32, INT32, and UINT32 dtypes. Got {}",
         input_a.dtype());
+    TT_FATAL(
+        input_b.dtype() == input_a.dtype() && input_c.dtype() == input_a.dtype(),
+        "Addcmul TTT requires all input tensors to have the same dtype. Got input_a={}, input_b={}, input_c={}",
+        input_a.dtype(),
+        input_b.dtype(),
+        input_c.dtype());
 
     // Only TTT variant is supported for addcmul
     auto broadcast_type = get_broadcast_type(input_a.logical_shape(), input_b.logical_shape(), input_c.logical_shape());

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_nanobind.cpp
@@ -200,7 +200,7 @@ void bind_ternary_addcmul(
 
                * - Dtypes
                  - Layouts
-               * - FLOAT32, BFLOAT16, BFLOAT8_B, INT32
+               * - {4}
                  - TILE
 
             Only TTT (tensor-tensor-tensor) variant is supported.
@@ -345,7 +345,7 @@ void py_module(nb::module_& mod) {
             :attr:`input_tensor_a`.
             Returns a tensor with the same layout as :attr:`input_tensor_a`.)doc",
         R"doc(\mathrm{{output\_tensor}}_i = \mathrm{{input\_tensor\_a}}_i + (value * \mathrm{input\_tensor\_b}_i * \mathrm{input\_tensor\_c}_i))doc",
-        "FLOAT32, BFLOAT16, BFLOAT8_B, INT32");
+        "FLOAT32, BFLOAT16, BFLOAT8_B, INT32, UINT32");
 
     bind_ternary_addcdiv(
         mod,


### PR DESCRIPTION
### Summary
Added uint32 support for addcmul.
  

Closes #38972

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/uint32_addcmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/uint32_addcmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/uint32_addcmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/uint32_addcmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/uint32_addcmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/uint32_addcmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/uint32_addcmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/uint32_addcmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/uint32_addcmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/uint32_addcmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/uint32_addcmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/uint32_addcmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/uint32_addcmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/uint32_addcmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/uint32_addcmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/uint32_addcmul)