### PR TITLE
(Not for checkin, ignore)

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -28,14 +28,15 @@ inline constexpr const char* MINIMAL_KERNEL_SOURCE = "void kernel_main() {}";
 // ============================================================================
 // Spec Creation Helpers
 // ============================================================================
+//
+// Note: KernelSpec and DataflowBufferSpec no longer carry target_nodes.
+// Placement is stated on WorkerSpec; pass node sets to MakeMinimalWorker instead.
 
 // Helper to create a minimal valid KernelSpec for data movement (Gen2/Quasar)
-inline KernelSpec MakeMinimalDMKernel(
-    const std::string& name, const std::variant<NodeCoord, NodeRange, NodeRangeSet>& nodes, uint8_t num_threads = 1) {
+inline KernelSpec MakeMinimalDMKernel(const std::string& name, uint8_t num_threads = 1) {
     return KernelSpec{
         .unique_id = name,
         .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
-        .target_nodes = nodes,
         .num_threads = num_threads,
         .config_spec =
             DataMovementConfiguration{
@@ -47,12 +48,10 @@ inline KernelSpec MakeMinimalDMKernel(
 // Helper to create a minimal valid KernelSpec for data movement (Gen1/WH/BH)
 inline KernelSpec MakeMinimalGen1DMKernel(
     const std::string& name,
-    const std::variant<NodeCoord, NodeRange, NodeRangeSet>& nodes,
     tt::tt_metal::DataMovementProcessor processor = tt::tt_metal::DataMovementProcessor::RISCV_0) {
     return KernelSpec{
         .unique_id = name,
         .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
-        .target_nodes = nodes,
         .num_threads = 1,
         .config_spec =
             DataMovementConfiguration{
@@ -65,12 +64,10 @@ inline KernelSpec MakeMinimalGen1DMKernel(
 }
 
 // Helper to create a minimal valid KernelSpec for compute
-inline KernelSpec MakeMinimalComputeKernel(
-    const std::string& name, const std::variant<NodeCoord, NodeRange, NodeRangeSet>& nodes, uint8_t num_threads = 1) {
+inline KernelSpec MakeMinimalComputeKernel(const std::string& name, uint8_t num_threads = 1) {
     return KernelSpec{
         .unique_id = name,
         .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
-        .target_nodes = nodes,
         .num_threads = num_threads,
         .config_spec = ComputeConfiguration{},
     };
@@ -78,13 +75,9 @@ inline KernelSpec MakeMinimalComputeKernel(
 
 // Helper to create a minimal valid DataflowBufferSpec
 inline DataflowBufferSpec MakeMinimalDFB(
-    const std::string& name,
-    const std::variant<NodeCoord, NodeRange, NodeRangeSet>& nodes,
-    uint32_t entry_size = 1024,
-    uint32_t num_entries = 2) {
+    const std::string& name, uint32_t entry_size = 1024, uint32_t num_entries = 2) {
     return DataflowBufferSpec{
         .unique_id = name,
-        .target_nodes = nodes,
         .entry_size = entry_size,
         .num_entries = num_entries,
     };
@@ -94,12 +87,10 @@ inline DataflowBufferSpec MakeMinimalDFB(
 inline WorkerSpec MakeMinimalWorker(
     const std::string& name,
     const std::variant<NodeCoord, NodeRange, NodeRangeSet>& nodes,
-    const std::vector<KernelSpecName>& kernels,
-    const std::vector<DFBSpecName>& dfbs = {}) {
+    const std::vector<KernelSpecName>& kernels) {
     return WorkerSpec{
         .unique_id = name,
         .kernels = kernels,
-        .dataflow_buffers = dfbs,
         .target_nodes = nodes,
     };
 }
@@ -126,10 +117,10 @@ inline ProgramSpec MakeMinimalGen1ValidProgramSpec() {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel", node, tt::tt_metal::DataMovementProcessor::RISCV_0);
-    auto compute_kernel = MakeMinimalComputeKernel("compute_kernel", node);
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel", tt::tt_metal::DataMovementProcessor::RISCV_0);
+    auto compute_kernel = MakeMinimalComputeKernel("compute_kernel");
 
-    auto dfb = MakeMinimalDFB("dfb_0", node);
+    auto dfb = MakeMinimalDFB("dfb_0");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
     BindDFBToKernel(dm_kernel, "dfb_0", "input_dfb", KernelSpec::DFBEndpointType::PRODUCER);
@@ -137,8 +128,7 @@ inline ProgramSpec MakeMinimalGen1ValidProgramSpec() {
 
     spec.kernels = {dm_kernel, compute_kernel};
     spec.dataflow_buffers = {dfb};
-    spec.workers =
-        std::vector<WorkerSpec>{MakeMinimalWorker("worker_0", node, {"dm_kernel", "compute_kernel"}, {"dfb_0"})};
+    spec.workers = {MakeMinimalWorker("worker_0", node, {"dm_kernel", "compute_kernel"})};
 
     return spec;
 }
@@ -151,11 +141,11 @@ inline ProgramSpec MakeMinimalValidProgramSpec() {
     spec.program_id = "test_program";
 
     // Create a DM kernel (producer) and compute kernel (consumer)
-    auto dm_kernel = MakeMinimalDMKernel("dm_kernel", node);
-    auto compute_kernel = MakeMinimalComputeKernel("compute_kernel", node);
+    auto dm_kernel = MakeMinimalDMKernel("dm_kernel");
+    auto compute_kernel = MakeMinimalComputeKernel("compute_kernel");
 
     // Create a DFB with data format (required for compute endpoint)
-    auto dfb = MakeMinimalDFB("dfb_0", node);
+    auto dfb = MakeMinimalDFB("dfb_0");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
     // Bind the DFB
@@ -166,8 +156,7 @@ inline ProgramSpec MakeMinimalValidProgramSpec() {
     spec.dataflow_buffers = {dfb};
 
     // Create a WorkerSpec
-    spec.workers =
-        std::vector<WorkerSpec>{MakeMinimalWorker("worker_0", node, {"dm_kernel", "compute_kernel"}, {"dfb_0"})};
+    spec.workers = {MakeMinimalWorker("worker_0", node, {"dm_kernel", "compute_kernel"})};
 
     return spec;
 }

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -30,7 +30,7 @@ inline constexpr const char* MINIMAL_KERNEL_SOURCE = "void kernel_main() {}";
 // ============================================================================
 //
 // Note: KernelSpec and DataflowBufferSpec no longer carry target_nodes.
-// Placement is stated on WorkerSpec; pass node sets to MakeMinimalWorker instead.
+// Placement is stated on WorkUnitSpec; pass node sets to MakeMinimalWorkUnit instead.
 
 // Helper to create a minimal valid KernelSpec for data movement (Gen2/Quasar)
 inline KernelSpec MakeMinimalDMKernel(const std::string& name, uint8_t num_threads = 1) {
@@ -83,12 +83,12 @@ inline DataflowBufferSpec MakeMinimalDFB(
     };
 }
 
-// Helper to create a minimal valid WorkerSpec
-inline WorkerSpec MakeMinimalWorker(
+// Helper to create a minimal valid WorkUnitSpec
+inline WorkUnitSpec MakeMinimalWorkUnit(
     const std::string& name,
     const std::variant<NodeCoord, NodeRange, NodeRangeSet>& nodes,
     const std::vector<KernelSpecName>& kernels) {
-    return WorkerSpec{
+    return WorkUnitSpec{
         .unique_id = name,
         .kernels = kernels,
         .target_nodes = nodes,
@@ -128,7 +128,7 @@ inline ProgramSpec MakeMinimalGen1ValidProgramSpec() {
 
     spec.kernels = {dm_kernel, compute_kernel};
     spec.dataflow_buffers = {dfb};
-    spec.workers = {MakeMinimalWorker("worker_0", node, {"dm_kernel", "compute_kernel"})};
+    spec.work_units = {MakeMinimalWorkUnit("work_unit_0", node, {"dm_kernel", "compute_kernel"})};
 
     return spec;
 }
@@ -155,8 +155,8 @@ inline ProgramSpec MakeMinimalValidProgramSpec() {
     spec.kernels = {dm_kernel, compute_kernel};
     spec.dataflow_buffers = {dfb};
 
-    // Create a WorkerSpec
-    spec.workers = {MakeMinimalWorker("worker_0", node, {"dm_kernel", "compute_kernel"})};
+    // Create a WorkUnitSpec
+    spec.work_units = {MakeMinimalWorkUnit("work_unit_0", node, {"dm_kernel", "compute_kernel"})};
 
     return spec;
 }

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -35,7 +35,7 @@ using test_helpers::MakeMinimalDFB;
 using test_helpers::MakeMinimalDMKernel;
 using test_helpers::MakeMinimalGen1ValidProgramSpec;
 using test_helpers::MakeMinimalValidProgramSpec;
-using test_helpers::MakeMinimalWorker;
+using test_helpers::MakeMinimalWorkUnit;
 
 // Shorthand for the per-node-override vararg type (needed at call sites because
 // std::optional<T> can't be brace-init from an initializer-list of T's elements).
@@ -463,7 +463,7 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_MultiNodeKernel) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", all_nodes, {"producer", "consumer"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", all_nodes, {"producer", "consumer"})};
 
     Program program = MakeProgramFromSpec(spec);
 
@@ -507,7 +507,7 @@ TEST_F(ProgramRunParamsTestQuasar, MultiNode_MissingOneNodeFails) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", all_nodes, {"producer", "consumer"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", all_nodes, {"producer", "consumer"})};
 
     Program program = MakeProgramFromSpec(spec);
 
@@ -662,7 +662,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyMultiNodeDifferingCountsSucceeds) {
     auto kernel = MakeMinimalDMKernel("dm_kernel");
     kernel.runtime_arguments_schema.num_runtime_varargs_per_node = NumVarargsPerNode{{node_a, 2}, {node_b, 5}};
     spec.kernels = {kernel};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker_0", nodes, {"dm_kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", nodes, {"dm_kernel"})};
     Program program = MakeProgramFromSpec(spec);
 
     ProgramRunParams params;
@@ -693,7 +693,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargPerNodeOverrideMixedEntryTypesSucceeds)
     // Node c has count 5 (declared via a NodeCoord entry).
     kernel.runtime_arguments_schema.num_runtime_varargs_per_node = NumVarargsPerNode{{ab, 3}, {node_c, 5}};
     spec.kernels = {kernel};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker_0", all_nodes, {"dm_kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", all_nodes, {"dm_kernel"})};
     Program program = MakeProgramFromSpec(spec);
 
     ProgramRunParams params;
@@ -722,7 +722,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargScalarDefaultWithSparseOverrideSucceeds
     kernel.runtime_arguments_schema.num_runtime_varargs_per_node =
         NumVarargsPerNode{{node_c, 5}};  // node_c is the exception
     spec.kernels = {kernel};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker_0", all_nodes, {"dm_kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", all_nodes, {"dm_kernel"})};
     Program program = MakeProgramFromSpec(spec);
 
     ProgramRunParams params;
@@ -754,7 +754,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargSparseOverrideZeroErasesScalarDefault) 
     kernel.runtime_arguments_schema.num_runtime_varargs_per_node =
         NumVarargsPerNode{{node_b, 0}};  // node_b: no varargs despite scalar default
     spec.kernels = {kernel};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker_0", both, {"dm_kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", both, {"dm_kernel"})};
     Program program = MakeProgramFromSpec(spec);
 
     // node_b is treated as having no varargs — run-params needs no entry for it.
@@ -795,7 +795,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyRTAsMissingNodeCoverageFails) {
     auto kernel = MakeMinimalDMKernel("dm_kernel");
     kernel.runtime_arguments_schema.num_runtime_varargs = 2;  // uniform across both nodes
     spec.kernels = {kernel};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker_0", nodes, {"dm_kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", nodes, {"dm_kernel"})};
     Program program = MakeProgramFromSpec(spec);
 
     ProgramRunParams params;

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -446,8 +446,8 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_MultiNodeKernel) {
     spec.program_id = "multi_node_program";
 
     // Kernels span both nodes
-    auto producer = MakeMinimalDMKernel("producer", all_nodes);
-    auto consumer = MakeMinimalDMKernel("consumer", all_nodes);
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalDMKernel("consumer");
 
     // Throw in some varargs (the normal kind, not the weird per-node override kind)
     producer.runtime_arguments_schema.num_runtime_varargs = 2;
@@ -456,14 +456,14 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_MultiNodeKernel) {
     // consumer has no varargs (defaults)
 
     // Single DFB spanning all nodes
-    auto dfb = MakeMinimalDFB("dfb", all_nodes);
+    auto dfb = MakeMinimalDFB("dfb");
 
     BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", all_nodes, {"producer", "consumer"}, {"dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", all_nodes, {"producer", "consumer"})};
 
     Program program = MakeProgramFromSpec(spec);
 
@@ -492,22 +492,22 @@ TEST_F(ProgramRunParamsTestQuasar, MultiNode_MissingOneNodeFails) {
     ProgramSpec spec;
     spec.program_id = "multi_node_program";
 
-    auto producer = MakeMinimalDMKernel("producer", all_nodes);
-    auto consumer = MakeMinimalDMKernel("consumer", all_nodes);
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalDMKernel("consumer");
 
     // Throw in some varargs (the normal kind, not the weird per-node override kind)
     producer.runtime_arguments_schema.num_runtime_varargs = 2;
     // consumer has no varargs (defaults)
 
     // Single DFB spanning all nodes
-    auto dfb = MakeMinimalDFB("dfb", all_nodes);
+    auto dfb = MakeMinimalDFB("dfb");
 
     BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", all_nodes, {"producer", "consumer"}, {"dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", all_nodes, {"producer", "consumer"})};
 
     Program program = MakeProgramFromSpec(spec);
 
@@ -659,7 +659,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyMultiNodeDifferingCountsSucceeds) {
 
     ProgramSpec spec;
     spec.program_id = "vararg_differing_counts";
-    auto kernel = MakeMinimalDMKernel("dm_kernel", nodes);
+    auto kernel = MakeMinimalDMKernel("dm_kernel");
     kernel.runtime_arguments_schema.num_runtime_varargs_per_node = NumVarargsPerNode{{node_a, 2}, {node_b, 5}};
     spec.kernels = {kernel};
     spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker_0", nodes, {"dm_kernel"})};
@@ -688,7 +688,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargPerNodeOverrideMixedEntryTypesSucceeds)
 
     ProgramSpec spec;
     spec.program_id = "vararg_mixed_entry_types";
-    auto kernel = MakeMinimalDMKernel("dm_kernel", all_nodes);
+    auto kernel = MakeMinimalDMKernel("dm_kernel");
     // Nodes a and b share count 3 (declared via a NodeRangeSet entry).
     // Node c has count 5 (declared via a NodeCoord entry).
     kernel.runtime_arguments_schema.num_runtime_varargs_per_node = NumVarargsPerNode{{ab, 3}, {node_c, 5}};
@@ -717,7 +717,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargScalarDefaultWithSparseOverrideSucceeds
 
     ProgramSpec spec;
     spec.program_id = "vararg_scalar_with_sparse_override";
-    auto kernel = MakeMinimalDMKernel("dm_kernel", all_nodes);
+    auto kernel = MakeMinimalDMKernel("dm_kernel");
     kernel.runtime_arguments_schema.num_runtime_varargs = 2;  // default for unlisted nodes
     kernel.runtime_arguments_schema.num_runtime_varargs_per_node =
         NumVarargsPerNode{{node_c, 5}};  // node_c is the exception
@@ -749,7 +749,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargSparseOverrideZeroErasesScalarDefault) 
 
     ProgramSpec spec;
     spec.program_id = "vararg_zero_override";
-    auto kernel = MakeMinimalDMKernel("dm_kernel", both);
+    auto kernel = MakeMinimalDMKernel("dm_kernel");
     kernel.runtime_arguments_schema.num_runtime_varargs = 3;
     kernel.runtime_arguments_schema.num_runtime_varargs_per_node =
         NumVarargsPerNode{{node_b, 0}};  // node_b: no varargs despite scalar default
@@ -792,7 +792,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyRTAsMissingNodeCoverageFails) {
 
     ProgramSpec spec;
     spec.program_id = "vararg_missing_node";
-    auto kernel = MakeMinimalDMKernel("dm_kernel", nodes);
+    auto kernel = MakeMinimalDMKernel("dm_kernel");
     kernel.runtime_arguments_schema.num_runtime_varargs = 2;  // uniform across both nodes
     spec.kernels = {kernel};
     spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker_0", nodes, {"dm_kernel"})};

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -7,7 +7,7 @@
 // Test categories:
 //   1. ProgramSpec "structural" validation (CollectSpecData)
 //   2. ProgramSpec semantic validation (ValidateProgramSpec)
-//   3. WorkerSpec validation
+//   3. WorkUnitSpec validation
 //   4. DFB validation
 //   5. Program creation (using Quasar mock device)
 //   6. Aggregate type enforcement (designated initializers)
@@ -35,7 +35,7 @@ using test_helpers::MakeMinimalDMKernel;
 using test_helpers::MakeMinimalGen1DMKernel;
 using test_helpers::MakeMinimalGen1ValidProgramSpec;
 using test_helpers::MakeMinimalValidProgramSpec;
-using test_helpers::MakeMinimalWorker;
+using test_helpers::MakeMinimalWorkUnit;
 
 // ============================================================================
 // Test Fixtures
@@ -97,7 +97,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateSemaphoreNameFails) {
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, DuplicateWorkerNameFails) {
+TEST_F(ProgramSpecTestQuasar, DuplicateWorkUnitNameFails) {
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
 
@@ -109,10 +109,10 @@ TEST_F(ProgramSpecTestQuasar, DuplicateWorkerNameFails) {
     auto kernel1 = MakeMinimalDMKernel("kernel1");
     spec.kernels = {kernel0, kernel1};
 
-    // Two workers with the same unique_id!
-    auto worker0 = MakeMinimalWorker("same_name", node0, {"kernel0"});
-    auto worker1 = MakeMinimalWorker("same_name", node1, {"kernel1"});  // Duplicate!
-    spec.workers = std::vector<WorkerSpec>{worker0, worker1};
+    // Two work_units with the same unique_id!
+    auto work_unit0 = MakeMinimalWorkUnit("same_name", node0, {"kernel0"});
+    auto work_unit1 = MakeMinimalWorkUnit("same_name", node1, {"kernel1"});  // Duplicate!
+    spec.work_units = std::vector<WorkUnitSpec>{work_unit0, work_unit1};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -133,7 +133,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateLocalAccessorNameFails) {
 
     spec.kernels = {kernel};
     spec.dataflow_buffers = {dfb0, dfb1};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -166,7 +166,7 @@ TEST_F(ProgramSpecTestQuasar, InvalidLocalAccessorNameFails) {
 
         spec.kernels = {kernel};
         spec.dataflow_buffers = {dfb};
-        spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
+        spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
         EXPECT_ANY_THROW(MakeProgramFromSpec(spec)) << "Expected rejection for name: '" << bad_name << "'";
     }
@@ -183,7 +183,7 @@ TEST_F(ProgramSpecTestQuasar, KernelReferencesUnknownDFBFails) {
     BindDFBToKernel(kernel, "nonexistent_dfb", "accessor", KernelSpec::DFBEndpointType::PRODUCER);
 
     spec.kernels = {kernel};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -202,7 +202,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithNoBindingsFails) {
     auto orphan_dfb = MakeMinimalDFB("orphan_dfb");
     spec.dataflow_buffers = {orphan_dfb};
 
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -221,7 +221,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithOnlyProducerFails) {
 
     spec.kernels = {kernel};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -240,7 +240,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithOnlyConsumerFails) {
 
     spec.kernels = {kernel};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -265,7 +265,8 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersFails) {
 
     spec.kernels = {producer1, producer2, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer1", "producer2", "consumer"})};
+    spec.work_units =
+        std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer1", "producer2", "consumer"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -290,7 +291,8 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersFails) {
 
     spec.kernels = {producer, consumer1, consumer2};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer1", "consumer2"})};
+    spec.work_units =
+        std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer1", "consumer2"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -302,7 +304,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersFails) {
 TEST_F(ProgramSpecTestQuasar, EmptyKernelsFails) {
     ProgramSpec spec;
     spec.program_id = "empty_program";
-    spec.workers = std::vector<WorkerSpec>{};  // Empty workers too
+    spec.work_units = std::vector<WorkUnitSpec>{};  // Empty work_units too
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -315,7 +317,7 @@ TEST_F(ProgramSpecTestQuasar, KernelWithZeroThreadsFails) {
 
     auto kernel = MakeMinimalDMKernel("kernel", 0);  // 0 threads!
     spec.kernels = {kernel};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -329,7 +331,7 @@ TEST_F(ProgramSpecTestQuasar, DMKernelExceedingMaxThreadsFails) {
     // Quasar has 8 DM cores per node (we reserve 2 for internal use)
     auto kernel = MakeMinimalDMKernel("kernel", 9);  // Too many threads!
     spec.kernels = {kernel};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -343,7 +345,7 @@ TEST_F(ProgramSpecTestQuasar, ComputeKernelExceedingMaxThreadsFails) {
     // Quasar has 4 Tensix cores per node
     auto kernel = MakeMinimalComputeKernel("kernel", 5);  // Too many threads!
     spec.kernels = {kernel};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -367,7 +369,7 @@ TEST_F(ProgramSpecTestQuasar, DMKernelWithoutGen2ConfigFails) {
     };
 
     spec.kernels = {kernel};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -385,7 +387,7 @@ TEST_F(ProgramSpecTestQuasar, DMKernelWithNoConfigAtAllFails) {
     dm_config.gen2_data_movement_config = std::nullopt;
 
     spec.kernels = {kernel};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -409,9 +411,9 @@ TEST_F(ProgramSpecTestQuasar, RemoteDFBNotYetSupportedAtRuntime) {
         .dfb_spec = MakeMinimalDFB("dfb"),
         .producer_consumer_map = {{producer_node, consumer_node}},
     }};
-    spec.workers = std::vector<WorkerSpec>{
-        MakeMinimalWorker("producer_worker", producer_node, {"producer"}),
-        MakeMinimalWorker("consumer_worker", consumer_node, {"consumer"}),
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("producer_work_unit", producer_node, {"producer"}),
+        MakeMinimalWorkUnit("consumer_work_unit", consumer_node, {"consumer"}),
     };
 
     EXPECT_THAT(
@@ -422,9 +424,9 @@ TEST_F(ProgramSpecTestQuasar, RemoteDFBNotYetSupportedAtRuntime) {
 TEST_F(ProgramSpecTestQuasar, RemoteDFBWithSameNodeProducerConsumerPairFails) {
     // A remote DFB's producer_consumer_map must have p_node != c_node for every entry.
     // Same-node communication is structurally local and should use a DataflowBufferSpec.
-    // (Note: producer-worker and consumer-worker target_nodes ARE allowed to overlap —
-    //  the cross-node-ness is established per-pair, not per-worker. E.g. A↔B would have
-    //  producer-worker = consumer-worker = {A, B} and is legal.)
+    // (Note: producer-work_unit and consumer-work_unit target_nodes ARE allowed to overlap —
+    //  the cross-node-ness is established per-pair, not per-work_unit. E.g. A↔B would have
+    //  producer-work_unit = consumer-work_unit = {A, B} and is legal.)
     NodeCoord node_a{0, 0};
     NodeCoord node_b{1, 0};
 
@@ -443,9 +445,9 @@ TEST_F(ProgramSpecTestQuasar, RemoteDFBWithSameNodeProducerConsumerPairFails) {
         // Degenerate map: node_a → node_a is structurally local.
         .producer_consumer_map = {{node_a, node_b}, {node_b, node_b}},
     }};
-    spec.workers = std::vector<WorkerSpec>{
-        MakeMinimalWorker("worker_a", node_a, {"producer"}),
-        MakeMinimalWorker("worker_b", node_b, {"producer", "consumer"}),
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("work_unit_a", node_a, {"producer"}),
+        MakeMinimalWorkUnit("work_unit_b", node_b, {"producer", "consumer"}),
     };
 
     EXPECT_THAT(
@@ -454,7 +456,7 @@ TEST_F(ProgramSpecTestQuasar, RemoteDFBWithSameNodeProducerConsumerPairFails) {
             ::testing::HasSubstr("producer node and the consumer node are the same")));
 }
 
-TEST_F(ProgramSpecTestQuasar, RemoteDFBWithSameWorkerNodeSetSucceedsAtValidation) {
+TEST_F(ProgramSpecTestQuasar, RemoteDFBWithSameWorkUnitNodeSetSucceedsAtValidation) {
     // A↔B pattern: producer and consumer kernels both run on {A, B}, communicating
     // exclusively cross-node. Validation should accept this; the runtime gate then
     // reports "not yet supported."
@@ -476,8 +478,8 @@ TEST_F(ProgramSpecTestQuasar, RemoteDFBWithSameWorkerNodeSetSucceedsAtValidation
         .dfb_spec = MakeMinimalDFB("dfb"),
         .producer_consumer_map = {{node_a, node_b}, {node_b, node_a}},
     }};
-    spec.workers = std::vector<WorkerSpec>{
-        MakeMinimalWorker("worker", both, {"producer", "consumer"}),
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("work_unit", both, {"producer", "consumer"}),
     };
 
     // Validation passes; the unsupported-at-runtime gate fires last.
@@ -504,7 +506,7 @@ TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBFails) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -527,7 +529,7 @@ TEST_F(ProgramSpecTestQuasar, DFBAliasingFails) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -726,7 +728,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithComputeEndpointRequiresDataFormat) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -752,7 +754,7 @@ TEST_F(ProgramSpecTestQuasar, ComputeConfigUnpackToDestModeReferencesUnknownDFBF
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -775,27 +777,27 @@ TEST_F(ProgramSpecTestQuasar, DataFormatNotSupportedOnTargetArchitectureFails) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
 
 // ============================================================================
-// SECTION 3: WorkerSpec Validation Tests
+// SECTION 3: WorkUnitSpec Validation Tests
 // ============================================================================
 
-TEST_F(ProgramSpecTestQuasar, EmptyWorkerSpecsFails) {
+TEST_F(ProgramSpecTestQuasar, EmptyWorkUnitSpecsFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
     auto kernel = MakeMinimalDMKernel("kernel");
     spec.kernels = {kernel};
-    spec.workers = std::vector<WorkerSpec>{};  // Empty!
+    spec.work_units = std::vector<WorkUnitSpec>{};  // Empty!
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, WorkerSpecWithNoKernelsFails) {
+TEST_F(ProgramSpecTestQuasar, WorkUnitSpecWithNoKernelsFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -804,16 +806,16 @@ TEST_F(ProgramSpecTestQuasar, WorkerSpecWithNoKernelsFails) {
     auto kernel = MakeMinimalDMKernel("kernel");
     spec.kernels = {kernel};
 
-    WorkerSpec worker;
-    worker.unique_id = "worker";
-    worker.target_nodes = node;
-    worker.kernels = {};  // No kernels!
-    spec.workers = std::vector<WorkerSpec>{worker};
+    WorkUnitSpec work_unit;
+    work_unit.unique_id = "work_unit";
+    work_unit.target_nodes = node;
+    work_unit.kernels = {};  // No kernels!
+    spec.work_units = std::vector<WorkUnitSpec>{work_unit};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, WorkerSpecReferencesUnknownKernelFails) {
+TEST_F(ProgramSpecTestQuasar, WorkUnitSpecReferencesUnknownKernelFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -822,14 +824,14 @@ TEST_F(ProgramSpecTestQuasar, WorkerSpecReferencesUnknownKernelFails) {
     auto kernel = MakeMinimalDMKernel("real_kernel");
     spec.kernels = {kernel};
 
-    // Worker references a kernel that doesn't exist
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"nonexistent_kernel"})};
+    // WorkUnit references a kernel that doesn't exist
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"nonexistent_kernel"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, OverlappingWorkerSpecsFails) {
-    // Two workers cannot target overlapping nodes
+TEST_F(ProgramSpecTestQuasar, OverlappingWorkUnitSpecsFails) {
+    // Two work_units cannot target overlapping nodes
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -839,29 +841,29 @@ TEST_F(ProgramSpecTestQuasar, OverlappingWorkerSpecsFails) {
     auto kernel2 = MakeMinimalDMKernel("kernel2");
     spec.kernels = {kernel1, kernel2};
 
-    // Both workers target the same node
-    spec.workers = std::vector<WorkerSpec>{
-        MakeMinimalWorker("worker1", node, {"kernel1"}), MakeMinimalWorker("worker2", node, {"kernel2"})};
+    // Both work_units target the same node
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("work_unit1", node, {"kernel1"}), MakeMinimalWorkUnit("work_unit2", node, {"kernel2"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, KernelNotInAnyWorkerSpecFails) {
+TEST_F(ProgramSpecTestQuasar, KernelNotInAnyWorkUnitSpecFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
     spec.program_id = "test_program";
 
     auto kernel1 = MakeMinimalDMKernel("kernel1");
-    auto kernel2 = MakeMinimalDMKernel("kernel2");  // Not in any worker!
+    auto kernel2 = MakeMinimalDMKernel("kernel2");  // Not in any work_unit!
     spec.kernels = {kernel1, kernel2};
 
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel1"})};  // Only kernel1
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel1"})};  // Only kernel1
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, WorkerExceedsDMCoreBudgetFails) {
+TEST_F(ProgramSpecTestQuasar, WorkUnitExceedsDMCoreBudgetFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -873,12 +875,12 @@ TEST_F(ProgramSpecTestQuasar, WorkerExceedsDMCoreBudgetFails) {
     auto kernel3 = MakeMinimalDMKernel("dm3", 3);  // Total: 9 > 8
 
     spec.kernels = {kernel1, kernel2, kernel3};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"dm1", "dm2", "dm3"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm1", "dm2", "dm3"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, WorkerExceedsComputeCoreBudgetFails) {
+TEST_F(ProgramSpecTestQuasar, WorkUnitExceedsComputeCoreBudgetFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -889,13 +891,13 @@ TEST_F(ProgramSpecTestQuasar, WorkerExceedsComputeCoreBudgetFails) {
     auto kernel2 = MakeMinimalComputeKernel("compute2", 3);  // Total: 5 > 4
 
     spec.kernels = {kernel1, kernel2};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"compute1", "compute2"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"compute1", "compute2"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, WorkerWithMultipleComputeKernelsFails) {
-    // A worker can have at most one compute kernel
+TEST_F(ProgramSpecTestQuasar, WorkUnitWithMultipleComputeKernelsFails) {
+    // A work_unit can have at most one compute kernel
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -905,14 +907,14 @@ TEST_F(ProgramSpecTestQuasar, WorkerWithMultipleComputeKernelsFails) {
     auto compute2 = MakeMinimalComputeKernel("compute2");
 
     spec.kernels = {compute1, compute2};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"compute1", "compute2"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"compute1", "compute2"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, LocalDFBProducerConsumerWorkerMembershipMismatchFails) {
+TEST_F(ProgramSpecTestQuasar, LocalDFBProducerConsumerWorkUnitMembershipMismatchFails) {
     // A local DFB requires its producer and consumer kernels to share IDENTICAL
-    // WorkerSpec membership.
+    // WorkUnitSpec membership.
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
 
@@ -928,10 +930,10 @@ TEST_F(ProgramSpecTestQuasar, LocalDFBProducerConsumerWorkerMembershipMismatchFa
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    // Producer is on worker_0 only; consumer is on both workers — membership doesn't match.
-    spec.workers = std::vector<WorkerSpec>{
-        MakeMinimalWorker("worker_0", node0, {"producer", "consumer"}),
-        MakeMinimalWorker("worker_1", node1, {"consumer"}),
+    // Producer is on work_unit_0 only; consumer is on both work_units — membership doesn't match.
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("work_unit_0", node0, {"producer", "consumer"}),
+        MakeMinimalWorkUnit("work_unit_1", node1, {"consumer"}),
     };
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
@@ -968,7 +970,7 @@ TEST_F(ProgramSpecTestQuasar, DMOnlyProgramSucceeds) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
@@ -989,27 +991,27 @@ TEST_F(ProgramSpecTestQuasar, MultiNodeProgramSucceeds) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", nodes, {"producer", "consumer"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", nodes, {"producer", "consumer"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, MultipleWorkersOnDifferentNodesSucceeds) {
-    // Multiple workers on non-overlapping nodes
+TEST_F(ProgramSpecTestQuasar, MultipleWorkUnitsOnDifferentNodesSucceeds) {
+    // Multiple work_units on non-overlapping nodes
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
     NodeRangeSet all_nodes(std::set<NodeRange>{NodeRange{node0, node0}, NodeRange{node1, node1}});
 
     ProgramSpec spec;
-    spec.program_id = "multi_worker_program";
+    spec.program_id = "multi_work_unit_program";
 
     // Kernels span both nodes
     auto kernel = MakeMinimalDMKernel("kernel");
     spec.kernels = {kernel};
 
-    // Two workers, each on a different node
-    spec.workers = std::vector<WorkerSpec>{
-        MakeMinimalWorker("worker0", node0, {"kernel"}), MakeMinimalWorker("worker1", node1, {"kernel"})};
+    // Two work_units, each on a different node
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("work_unit0", node0, {"kernel"}), MakeMinimalWorkUnit("work_unit1", node1, {"kernel"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
@@ -1031,7 +1033,7 @@ TEST_F(ProgramSpecTestQuasar, MaxDMThreadsSucceeds) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
@@ -1055,7 +1057,7 @@ TEST_F(ProgramSpecTestQuasar, MaxComputeThreadsSucceeds) {
 
     spec.kernels = {dm, compute};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"dm", "compute"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm", "compute"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
@@ -1081,7 +1083,7 @@ TEST_F(ProgramSpecTestQuasar, MultipleDFBsSucceeds) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb1, dfb2};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
@@ -1128,7 +1130,7 @@ TEST_F(ProgramSpecTestQuasar, VarargPerNodeOverlapFails) {
     kernel.runtime_arguments_schema.num_runtime_varargs_per_node =
         NumVarargsPerNode{{both, 3}, {node_a, 3}};  // node_a listed twice
     spec.kernels = {kernel};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker_0", both, {"dm_kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", both, {"dm_kernel"})};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(spec); },
@@ -1155,7 +1157,7 @@ TEST_F(ProgramSpecTestQuasar, NodeRangeSetTargetNodesSucceeds) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", nodes, {"producer", "consumer"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", nodes, {"producer", "consumer"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
@@ -1206,7 +1208,7 @@ TEST_F(ProgramSpecTestQuasar, ValidUnpackToDestModeSucceeds) {
 //
 // A) ALGORITHM FAILURE
 //    The original naive greedy algorithm could either pass or fail on logically
-//    equivalent ProgramSpecs, depending on the order of kernels and workers.
+//    equivalent ProgramSpecs, depending on the order of kernels and work_units.
 //    The ProgramSpec was legal and solvable (under the simplifying assumption),
 //    but the algorithm failed to find a solution.
 //    This class of failure should not occur with the backtracking solver.
@@ -1220,12 +1222,12 @@ TEST_F(ProgramSpecTestQuasar, ValidUnpackToDestModeSucceeds) {
 
 // Category A: Order-Independence Test
 // This test verifies that the backtracking solver finds valid assignments,
-// regardless of kernel and worker orderings.
+// regardless of kernel and work_unit orderings.
 TEST_F(ProgramSpecTestQuasar, BacktrackingSolverFindsAssignment_RegardlessOfOrder) {
     // This test verifies that semantically identical ProgramSpecs succeed
     // regardless of the order of:
-    //  - workers in spec.workers
-    //  - kernels within each worker
+    //  - work_units in spec.work_units
+    //  - kernels within each work_unit
     //  - kernel order within the ProgramSpec
     //
     // Scenario:
@@ -1264,18 +1266,18 @@ TEST_F(ProgramSpecTestQuasar, BacktrackingSolverFindsAssignment_RegardlessOfOrde
     auto k_bc = MakeMinimalDMKernel("k_bc", 3);
     auto k_c = MakeMinimalDMKernel("k_c", 3);
 
-    auto worker_a1 = MakeMinimalWorker("worker_a1", node_a, {"k_a", "k_ab"});
-    auto worker_b1 = MakeMinimalWorker("worker_b1", node_b, {"k_ab", "k_bc"});
-    auto worker_c1 = MakeMinimalWorker("worker_c1", node_c, {"k_bc", "k_c"});
-    auto worker_c2 = MakeMinimalWorker("worker_c2", node_c, {"k_c", "k_bc"});
+    auto work_unit_a1 = MakeMinimalWorkUnit("work_unit_a1", node_a, {"k_a", "k_ab"});
+    auto work_unit_b1 = MakeMinimalWorkUnit("work_unit_b1", node_b, {"k_ab", "k_bc"});
+    auto work_unit_c1 = MakeMinimalWorkUnit("work_unit_c1", node_c, {"k_bc", "k_c"});
+    auto work_unit_c2 = MakeMinimalWorkUnit("work_unit_c2", node_c, {"k_c", "k_bc"});
 
-    // Helper to create a ProgramSpec with a given id and worker ordering
+    // Helper to create a ProgramSpec with a given id and work_unit ordering
     auto make_spec =
-        [&](const std::string& id, std::vector<KernelSpec> kernels, const std::vector<WorkerSpec>& workers) {
+        [&](const std::string& id, std::vector<KernelSpec> kernels, const std::vector<WorkUnitSpec>& work_units) {
             ProgramSpec spec;
             spec.program_id = id;
             spec.kernels = std::move(kernels);
-            spec.workers = workers;
+            spec.work_units = work_units;
             return spec;
         };
 
@@ -1293,33 +1295,33 @@ TEST_F(ProgramSpecTestQuasar, BacktrackingSolverFindsAssignment_RegardlessOfOrde
         {k_c, k_a, k_ab, k_bc}, {k_c, k_a, k_bc, k_ab}, {k_c, k_ab, k_a, k_bc},
         {k_c, k_ab, k_bc, k_a}, {k_c, k_bc, k_a, k_ab}, {k_c, k_bc, k_ab, k_a}};
 
-    // All 6 possible permutations of worker orderings (using c1)
-    std::vector<std::vector<WorkerSpec>> worker_permutations1 = {
-        {worker_a1, worker_b1, worker_c1},
-        {worker_a1, worker_c1, worker_b1},
-        {worker_b1, worker_c1, worker_a1},
-        {worker_b1, worker_a1, worker_c1},
-        {worker_c1, worker_a1, worker_b1},
-        {worker_c1, worker_b1, worker_a1}};
+    // All 6 possible permutations of work_unit orderings (using c1)
+    std::vector<std::vector<WorkUnitSpec>> work_unit_permutations1 = {
+        {work_unit_a1, work_unit_b1, work_unit_c1},
+        {work_unit_a1, work_unit_c1, work_unit_b1},
+        {work_unit_b1, work_unit_c1, work_unit_a1},
+        {work_unit_b1, work_unit_a1, work_unit_c1},
+        {work_unit_c1, work_unit_a1, work_unit_b1},
+        {work_unit_c1, work_unit_b1, work_unit_a1}};
 
-    // All 6 possible permutations of worker orderings (using c2)
-    std::vector<std::vector<WorkerSpec>> worker_permutations2 = {
-        {worker_a1, worker_b1, worker_c2},
-        {worker_a1, worker_c2, worker_b1},
-        {worker_b1, worker_c2, worker_a1},
-        {worker_b1, worker_a1, worker_c2},
-        {worker_c2, worker_a1, worker_b1},
-        {worker_c2, worker_b1, worker_a1}};
+    // All 6 possible permutations of work_unit orderings (using c2)
+    std::vector<std::vector<WorkUnitSpec>> work_unit_permutations2 = {
+        {work_unit_a1, work_unit_b1, work_unit_c2},
+        {work_unit_a1, work_unit_c2, work_unit_b1},
+        {work_unit_b1, work_unit_c2, work_unit_a1},
+        {work_unit_b1, work_unit_a1, work_unit_c2},
+        {work_unit_c2, work_unit_a1, work_unit_b1},
+        {work_unit_c2, work_unit_b1, work_unit_a1}};
 
-    // All kernel permutations should succeed with all worker permutations.
+    // All kernel permutations should succeed with all work_unit permutations.
     for (const auto& kernel_perm : kernel_permutations) {
-        for (const auto& worker_perm : worker_permutations1) {
-            EXPECT_NO_THROW(MakeProgramFromSpec(make_spec("", kernel_perm, worker_perm)));
+        for (const auto& work_unit_perm : work_unit_permutations1) {
+            EXPECT_NO_THROW(MakeProgramFromSpec(make_spec("", kernel_perm, work_unit_perm)));
         }
     }
     for (const auto& kernel_perm : kernel_permutations) {
-        for (const auto& worker_perm : worker_permutations2) {
-            EXPECT_NO_THROW(MakeProgramFromSpec(make_spec("", kernel_perm, worker_perm)));
+        for (const auto& work_unit_perm : work_unit_permutations2) {
+            EXPECT_NO_THROW(MakeProgramFromSpec(make_spec("", kernel_perm, work_unit_perm)));
         }
     }
 }
@@ -1370,10 +1372,10 @@ TEST_F(ProgramSpecTestQuasar, SimplifyingAssumptionViolation_OverlappingMultiNod
 
     spec.kernels = {kernel_a, kernel_b, kernel_c};
 
-    spec.workers = std::vector<WorkerSpec>{
-        MakeMinimalWorker("worker_00", node_00, {"kernel_a", "kernel_b"}),
-        MakeMinimalWorker("worker_01", node_01, {"kernel_a", "kernel_c"}),
-        MakeMinimalWorker("worker_02", node_02, {"kernel_b", "kernel_c"}),
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("work_unit_00", node_00, {"kernel_a", "kernel_b"}),
+        MakeMinimalWorkUnit("work_unit_01", node_01, {"kernel_a", "kernel_c"}),
+        MakeMinimalWorkUnit("work_unit_02", node_02, {"kernel_b", "kernel_c"}),
     };
 
     // EXPECTED BEHAVIOR: FAILS due to simplifying assumption violation.
@@ -1404,7 +1406,7 @@ TEST_F(ProgramSpecTestQuasar, SimplifyingAssumptionViolation_OverlappingMultiNod
 static_assert(
     std::is_aggregate_v<ProgramSpec>, "ProgramSpec must remain an aggregate to support designated initializers");
 static_assert(
-    std::is_aggregate_v<WorkerSpec>, "WorkerSpec must remain an aggregate to support designated initializers");
+    std::is_aggregate_v<WorkUnitSpec>, "WorkUnitSpec must remain an aggregate to support designated initializers");
 static_assert(
     std::is_aggregate_v<KernelSpec>, "KernelSpec must remain an aggregate to support designated initializers");
 static_assert(
@@ -1505,16 +1507,16 @@ TEST(AggregateSpecTypes, DataflowBufferSpecDesignatedInitializers) {
     EXPECT_TRUE(borrowed_dfb.disable_implicit_sync);
 }
 
-TEST(AggregateSpecTypes, WorkerSpecDesignatedInitializers) {
-    // Demonstrates constructing WorkerSpec with designated initializers
-    WorkerSpec worker{
-        .unique_id = "my_worker",
+TEST(AggregateSpecTypes, WorkUnitSpecDesignatedInitializers) {
+    // Demonstrates constructing WorkUnitSpec with designated initializers
+    WorkUnitSpec work_unit{
+        .unique_id = "my_work_unit",
         .kernels = {"kernel1", "kernel2"},
         .target_nodes = NodeCoord{0, 0},
     };
 
-    EXPECT_EQ(worker.unique_id, "my_worker");
-    EXPECT_EQ(worker.kernels.size(), 2u);
+    EXPECT_EQ(work_unit.unique_id, "my_work_unit");
+    EXPECT_EQ(work_unit.kernels.size(), 2u);
 }
 
 TEST(AggregateSpecTypes, RuntimeArgSchemaDesignatedInitializers) {
@@ -1620,10 +1622,10 @@ TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
                     .data_format_metadata = tt::DataFormat::Float16_b,
                 },
             },
-        .workers =
+        .work_units =
             {
-                WorkerSpec{
-                    .unique_id = "worker",
+                WorkUnitSpec{
+                    .unique_id = "work_unit",
                     .kernels = {"producer", "consumer"},
                     .target_nodes = NodeCoord{0, 0},
                 },
@@ -1633,7 +1635,7 @@ TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
     EXPECT_EQ(spec.program_id, "my_program");
     EXPECT_EQ(spec.kernels.size(), 2u);
     EXPECT_EQ(spec.dataflow_buffers.size(), 1u);
-    EXPECT_EQ(spec.workers.size(), 1u);
+    EXPECT_EQ(spec.work_units.size(), 1u);
 }
 
 TEST(AggregateSpecTypes, NestedStructsDesignatedInitializers) {
@@ -1711,7 +1713,7 @@ TEST_F(ProgramSpecTestGen1, DMOnlyProgramSucceeds) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
@@ -1727,7 +1729,7 @@ TEST_F(ProgramSpecTestGen1, TwoDMKernelsDifferentProcessorsSucceeds) {
     auto k1 = MakeMinimalGen1DMKernel("k1", DataMovementProcessor::RISCV_1);
 
     spec.kernels = {k0, k1};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"k0", "k1"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"k0", "k1"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
@@ -1742,7 +1744,7 @@ TEST_F(ProgramSpecTestGen1, MultiThreadedDMKernelFails) {
     kernel.num_threads = 2;
 
     spec.kernels = {kernel};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"dm_kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(spec); },
@@ -1759,7 +1761,7 @@ TEST_F(ProgramSpecTestGen1, MultiThreadedComputeKernelFails) {
     kernel.num_threads = 2;
 
     spec.kernels = {kernel};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"compute_kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"compute_kernel"})};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(spec); },
@@ -1777,7 +1779,7 @@ TEST_F(ProgramSpecTestGen1, DMKernelWithGen2ConfigFails) {
     auto kernel = MakeMinimalDMKernel("dm_kernel");
 
     spec.kernels = {kernel};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"dm_kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(spec); },
@@ -1795,7 +1797,7 @@ TEST_F(ProgramSpecTestGen1, ProcessorConflictFails) {
     auto k1 = MakeMinimalGen1DMKernel("k1", DataMovementProcessor::RISCV_0);  // conflict
 
     spec.kernels = {k0, k1};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"k0", "k1"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"k0", "k1"})};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(spec); },
@@ -1820,7 +1822,7 @@ TEST_F(ProgramSpecTestGen1, KernelTargetsNodeBeyondGridYFails) {
 
     auto kernel = MakeMinimalGen1DMKernel("dm_kernel");
     spec.kernels = {kernel};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", oob_node, {"dm_kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", oob_node, {"dm_kernel"})};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(spec); },
@@ -1836,7 +1838,7 @@ TEST_F(ProgramSpecTestGen1, KernelTargetsOutOfBoundsNodeFails) {
 
     auto kernel = MakeMinimalGen1DMKernel("dm_kernel");
     spec.kernels = {kernel};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", oob_node, {"dm_kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", oob_node, {"dm_kernel"})};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(spec); },
@@ -1908,7 +1910,7 @@ TEST_F(ProgramSpecTestGen1, DuplicateKernelNameFails) {
     auto k1 = MakeMinimalGen1DMKernel("dm_kernel", DataMovementProcessor::RISCV_1);  // duplicate name
 
     spec.kernels = {k0, k1};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"dm_kernel"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(spec); },

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -61,7 +61,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateKernelNameFails) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // Add a kernel with duplicate name
-    auto duplicate_kernel = MakeMinimalDMKernel("dm_kernel", NodeCoord{1, 0});
+    auto duplicate_kernel = MakeMinimalDMKernel("dm_kernel");
     DataMovementConfiguration dm_config;
     dm_config.gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{};
     duplicate_kernel.config_spec = dm_config;
@@ -74,7 +74,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateDFBNameFails) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // Add a DFB with duplicate name
-    auto duplicate_dfb = MakeMinimalDFB("dfb_0", NodeCoord{1, 0});
+    auto duplicate_dfb = MakeMinimalDFB("dfb_0");
     spec.dataflow_buffers.push_back(duplicate_dfb);
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
@@ -105,8 +105,8 @@ TEST_F(ProgramSpecTestQuasar, DuplicateWorkerNameFails) {
     spec.program_id = "test_program";
 
     // Two kernels on different nodes
-    auto kernel0 = MakeMinimalDMKernel("kernel0", node0);
-    auto kernel1 = MakeMinimalDMKernel("kernel1", node1);
+    auto kernel0 = MakeMinimalDMKernel("kernel0");
+    auto kernel1 = MakeMinimalDMKernel("kernel1");
     spec.kernels = {kernel0, kernel1};
 
     // Two workers with the same unique_id!
@@ -123,9 +123,9 @@ TEST_F(ProgramSpecTestQuasar, DuplicateLocalAccessorNameFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto kernel = MakeMinimalDMKernel("kernel", node);
-    auto dfb0 = MakeMinimalDFB("dfb_0", node);
-    auto dfb1 = MakeMinimalDFB("dfb_1", node);
+    auto kernel = MakeMinimalDMKernel("kernel");
+    auto dfb0 = MakeMinimalDFB("dfb_0");
+    auto dfb1 = MakeMinimalDFB("dfb_1");
 
     // Bind two DFBs with the same local_accessor_name
     BindDFBToKernel(kernel, "dfb_0", "same_accessor", KernelSpec::DFBEndpointType::PRODUCER);
@@ -133,7 +133,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateLocalAccessorNameFails) {
 
     spec.kernels = {kernel};
     spec.dataflow_buffers = {dfb0, dfb1};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"}, {"dfb_0", "dfb_1"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -159,14 +159,14 @@ TEST_F(ProgramSpecTestQuasar, InvalidLocalAccessorNameFails) {
         ProgramSpec spec;
         spec.program_id = "test_program";
 
-        auto kernel = MakeMinimalDMKernel("kernel", node);
-        auto dfb = MakeMinimalDFB("dfb", node);
+        auto kernel = MakeMinimalDMKernel("kernel");
+        auto dfb = MakeMinimalDFB("dfb");
 
         BindDFBToKernel(kernel, "dfb", bad_name, KernelSpec::DFBEndpointType::PRODUCER);
 
         spec.kernels = {kernel};
         spec.dataflow_buffers = {dfb};
-        spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"}, {"dfb"})};
+        spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
 
         EXPECT_ANY_THROW(MakeProgramFromSpec(spec)) << "Expected rejection for name: '" << bad_name << "'";
     }
@@ -178,7 +178,7 @@ TEST_F(ProgramSpecTestQuasar, KernelReferencesUnknownDFBFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto kernel = MakeMinimalDMKernel("kernel", node);
+    auto kernel = MakeMinimalDMKernel("kernel");
     // Bind to a DFB that doesn't exist
     BindDFBToKernel(kernel, "nonexistent_dfb", "accessor", KernelSpec::DFBEndpointType::PRODUCER);
 
@@ -195,14 +195,14 @@ TEST_F(ProgramSpecTestQuasar, DFBWithNoBindingsFails) {
     spec.program_id = "test_program";
 
     // Create a kernel with no DFB bindings
-    auto kernel = MakeMinimalDMKernel("kernel", node);
+    auto kernel = MakeMinimalDMKernel("kernel");
     spec.kernels = {kernel};
 
     // Create a DFB that is never bound
-    auto orphan_dfb = MakeMinimalDFB("orphan_dfb", node);
+    auto orphan_dfb = MakeMinimalDFB("orphan_dfb");
     spec.dataflow_buffers = {orphan_dfb};
 
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"}, {"orphan_dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -213,15 +213,15 @@ TEST_F(ProgramSpecTestQuasar, DFBWithOnlyProducerFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto kernel = MakeMinimalDMKernel("kernel", node);
-    auto dfb = MakeMinimalDFB("dfb", node);
+    auto kernel = MakeMinimalDMKernel("kernel");
+    auto dfb = MakeMinimalDFB("dfb");
 
     // Only bind as producer, no consumer
     BindDFBToKernel(kernel, "dfb", "accessor", KernelSpec::DFBEndpointType::PRODUCER);
 
     spec.kernels = {kernel};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"}, {"dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -232,15 +232,15 @@ TEST_F(ProgramSpecTestQuasar, DFBWithOnlyConsumerFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto kernel = MakeMinimalDMKernel("kernel", node);
-    auto dfb = MakeMinimalDFB("dfb", node);
+    auto kernel = MakeMinimalDMKernel("kernel");
+    auto dfb = MakeMinimalDFB("dfb");
 
     // Only bind as consumer, no producer
     BindDFBToKernel(kernel, "dfb", "accessor", KernelSpec::DFBEndpointType::CONSUMER);
 
     spec.kernels = {kernel};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"}, {"dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -251,11 +251,11 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto producer1 = MakeMinimalDMKernel("producer1", node);
-    auto producer2 = MakeMinimalDMKernel("producer2", node);
-    auto consumer = MakeMinimalComputeKernel("consumer", node);
+    auto producer1 = MakeMinimalDMKernel("producer1");
+    auto producer2 = MakeMinimalDMKernel("producer2");
+    auto consumer = MakeMinimalComputeKernel("consumer");
 
-    auto dfb = MakeMinimalDFB("dfb", node);
+    auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
     // Two producers for same DFB
@@ -265,8 +265,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersFails) {
 
     spec.kernels = {producer1, producer2, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers =
-        std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer1", "producer2", "consumer"}, {"dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer1", "producer2", "consumer"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -277,11 +276,11 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto producer = MakeMinimalDMKernel("producer", node);
-    auto consumer1 = MakeMinimalComputeKernel("consumer1", node);
-    auto consumer2 = MakeMinimalDMKernel("consumer2", node);
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer1 = MakeMinimalComputeKernel("consumer1");
+    auto consumer2 = MakeMinimalDMKernel("consumer2");
 
-    auto dfb = MakeMinimalDFB("dfb", node);
+    auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
     // Two consumers for same DFB
@@ -291,8 +290,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersFails) {
 
     spec.kernels = {producer, consumer1, consumer2};
     spec.dataflow_buffers = {dfb};
-    spec.workers =
-        std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer1", "consumer2"}, {"dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer1", "consumer2"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -315,7 +313,7 @@ TEST_F(ProgramSpecTestQuasar, KernelWithZeroThreadsFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto kernel = MakeMinimalDMKernel("kernel", node, 0);  // 0 threads!
+    auto kernel = MakeMinimalDMKernel("kernel", 0);  // 0 threads!
     spec.kernels = {kernel};
     spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
 
@@ -329,7 +327,7 @@ TEST_F(ProgramSpecTestQuasar, DMKernelExceedingMaxThreadsFails) {
     spec.program_id = "test_program";
 
     // Quasar has 8 DM cores per node (we reserve 2 for internal use)
-    auto kernel = MakeMinimalDMKernel("kernel", node, 9);  // Too many threads!
+    auto kernel = MakeMinimalDMKernel("kernel", 9);  // Too many threads!
     spec.kernels = {kernel};
     spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
 
@@ -343,7 +341,7 @@ TEST_F(ProgramSpecTestQuasar, ComputeKernelExceedingMaxThreadsFails) {
     spec.program_id = "test_program";
 
     // Quasar has 4 Tensix cores per node
-    auto kernel = MakeMinimalComputeKernel("kernel", node, 5);  // Too many threads!
+    auto kernel = MakeMinimalComputeKernel("kernel", 5);  // Too many threads!
     spec.kernels = {kernel};
     spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel"})};
 
@@ -356,7 +354,7 @@ TEST_F(ProgramSpecTestQuasar, DMKernelWithoutGen2ConfigFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto kernel = MakeMinimalDMKernel("kernel", node);
+    auto kernel = MakeMinimalDMKernel("kernel");
     // Remove the Gen2 config
     auto& dm_config = std::get<DataMovementConfiguration>(kernel.config_spec);
     dm_config.gen2_data_movement_config = std::nullopt;
@@ -380,7 +378,7 @@ TEST_F(ProgramSpecTestQuasar, DMKernelWithNoConfigAtAllFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto kernel = MakeMinimalDMKernel("kernel", node);
+    auto kernel = MakeMinimalDMKernel("kernel");
     // Remove both Gen1 and Gen2 configs
     auto& dm_config = std::get<DataMovementConfiguration>(kernel.config_spec);
     dm_config.gen1_data_movement_config = std::nullopt;
@@ -392,27 +390,100 @@ TEST_F(ProgramSpecTestQuasar, DMKernelWithNoConfigAtAllFails) {
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
 
-// Remove once implemented
-TEST_F(ProgramSpecTestQuasar, RemoteDFBFails) {
-    // Remote DFBs are not yet implemented
-    NodeCoord node{0, 0};
+// Remote DFBs are part of the API surface but not yet supported by the runtime.
+TEST_F(ProgramSpecTestQuasar, RemoteDFBNotYetSupportedAtRuntime) {
+    NodeCoord producer_node{0, 0};
+    NodeCoord consumer_node{1, 0};
 
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto producer = MakeMinimalDMKernel("producer", node);
-    auto consumer = MakeMinimalDMKernel("consumer", node);
-    auto dfb = MakeMinimalDFB("dfb", node);
-    dfb.remote_dfb_info = DataflowBufferSpec::RemoteDFBInfo{.producer_consumer_map = {{node, node}}};  // Not supported!
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalDMKernel("consumer");
 
     BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
 
     spec.kernels = {producer, consumer};
-    spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"}, {"dfb"})};
+    spec.remote_dataflow_buffers = {RemoteDataflowBufferSpec{
+        .dfb_spec = MakeMinimalDFB("dfb"),
+        .producer_consumer_map = {{producer_node, consumer_node}},
+    }};
+    spec.workers = std::vector<WorkerSpec>{
+        MakeMinimalWorker("producer_worker", producer_node, {"producer"}),
+        MakeMinimalWorker("consumer_worker", consumer_node, {"consumer"}),
+    };
 
-    EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("not yet supported")));
+}
+
+TEST_F(ProgramSpecTestQuasar, RemoteDFBWithSameNodeProducerConsumerPairFails) {
+    // A remote DFB's producer_consumer_map must have p_node != c_node for every entry.
+    // Same-node communication is structurally local and should use a DataflowBufferSpec.
+    // (Note: producer-worker and consumer-worker target_nodes ARE allowed to overlap —
+    //  the cross-node-ness is established per-pair, not per-worker. E.g. A↔B would have
+    //  producer-worker = consumer-worker = {A, B} and is legal.)
+    NodeCoord node_a{0, 0};
+    NodeCoord node_b{1, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalDMKernel("consumer");
+
+    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {producer, consumer};
+    spec.remote_dataflow_buffers = {RemoteDataflowBufferSpec{
+        .dfb_spec = MakeMinimalDFB("dfb"),
+        // Degenerate map: node_a → node_a is structurally local.
+        .producer_consumer_map = {{node_a, node_b}, {node_b, node_b}},
+    }};
+    spec.workers = std::vector<WorkerSpec>{
+        MakeMinimalWorker("worker_a", node_a, {"producer"}),
+        MakeMinimalWorker("worker_b", node_b, {"producer", "consumer"}),
+    };
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("producer node and the consumer node are the same")));
+}
+
+TEST_F(ProgramSpecTestQuasar, RemoteDFBWithSameWorkerNodeSetSucceedsAtValidation) {
+    // A↔B pattern: producer and consumer kernels both run on {A, B}, communicating
+    // exclusively cross-node. Validation should accept this; the runtime gate then
+    // reports "not yet supported."
+    NodeCoord node_a{0, 0};
+    NodeCoord node_b{1, 0};
+    NodeRangeSet both(std::set<NodeRange>{NodeRange{node_a, node_a}, NodeRange{node_b, node_b}});
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalDMKernel("consumer");
+
+    BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {producer, consumer};
+    spec.remote_dataflow_buffers = {RemoteDataflowBufferSpec{
+        .dfb_spec = MakeMinimalDFB("dfb"),
+        .producer_consumer_map = {{node_a, node_b}, {node_b, node_a}},
+    }};
+    spec.workers = std::vector<WorkerSpec>{
+        MakeMinimalWorker("worker", both, {"producer", "consumer"}),
+    };
+
+    // Validation passes; the unsupported-at-runtime gate fires last.
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("not yet supported")));
 }
 
 // Remove once implemented
@@ -423,9 +494,9 @@ TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto producer = MakeMinimalDMKernel("producer", node);
-    auto consumer = MakeMinimalDMKernel("consumer", node);
-    auto dfb = MakeMinimalDFB("dfb", node);
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalDMKernel("consumer");
+    auto dfb = MakeMinimalDFB("dfb");
     dfb.uses_borrowed_memory = true;  // Not supported!
 
     BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
@@ -433,7 +504,7 @@ TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBFails) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"}, {"dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -446,9 +517,9 @@ TEST_F(ProgramSpecTestQuasar, DFBAliasingFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto producer = MakeMinimalDMKernel("producer", node);
-    auto consumer = MakeMinimalDMKernel("consumer", node);
-    auto dfb = MakeMinimalDFB("dfb", node);
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalDMKernel("consumer");
+    auto dfb = MakeMinimalDFB("dfb");
     dfb.alias_with = std::vector<DFBSpecName>{"other_dfb"};  // Not supported yet!
 
     BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
@@ -456,7 +527,7 @@ TEST_F(ProgramSpecTestQuasar, DFBAliasingFails) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"}, {"dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -468,7 +539,6 @@ TEST_F(ProgramSpecTestQuasar, SemaphoresSucceed) {
     sem.unique_id = "sem_0";
     sem.target_nodes = NodeCoord{0, 0};
     spec.semaphores = {sem};
-    spec.workers.value()[0].semaphores = {"sem_0"};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
@@ -480,7 +550,6 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingsSucceed) {
     sem.unique_id = "sem_0";
     sem.target_nodes = NodeCoord{0, 0};
     spec.semaphores = {sem};
-    spec.workers.value()[0].semaphores = {"sem_0"};
 
     KernelSpec::SemaphoreBinding binding;
     binding.semaphore_spec_name = "sem_0";
@@ -499,7 +568,6 @@ TEST_F(ProgramSpecTestQuasar, SemaphoreBoundToComputeKernelSucceedsOnQuasar) {
     sem.unique_id = "sem_0";
     sem.target_nodes = NodeCoord{0, 0};
     spec.semaphores = {sem};
-    spec.workers.value()[0].semaphores = {"sem_0"};
 
     // kernels[1] is the compute kernel in MakeMinimalValidProgramSpec
     ASSERT_TRUE(spec.kernels[1].is_compute_kernel());
@@ -530,7 +598,6 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingInvalidAccessorFails) {
     sem.unique_id = "sem_0";
     sem.target_nodes = NodeCoord{0, 0};
     spec.semaphores = {sem};
-    spec.workers.value()[0].semaphores = {"sem_0"};
 
     KernelSpec::SemaphoreBinding binding;
     binding.semaphore_spec_name = "sem_0";
@@ -555,7 +622,6 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingDuplicateAccessorFails) {
     sem1.target_nodes = NodeCoord{0, 0};
 
     spec.semaphores = {sem0, sem1};
-    spec.workers.value()[0].semaphores = {"sem_0", "sem_1"};
 
     spec.kernels[0].semaphore_bindings = {
         KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "same"},
@@ -574,7 +640,6 @@ TEST_F(ProgramSpecTestQuasar, SemaphoreNonZeroInitialValueFailsOnQuasar) {
     sem.target_nodes = NodeCoord{0, 0};
     sem.initial_value = 1;
     spec.semaphores = {sem};
-    spec.workers.value()[0].semaphores = {"sem_0"};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(spec); },
@@ -651,9 +716,9 @@ TEST_F(ProgramSpecTestQuasar, DFBWithComputeEndpointRequiresDataFormat) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto producer = MakeMinimalDMKernel("producer", node);
-    auto consumer = MakeMinimalComputeKernel("consumer", node);  // Compute!
-    auto dfb = MakeMinimalDFB("dfb", node);
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalComputeKernel("consumer");  // Compute!
+    auto dfb = MakeMinimalDFB("dfb");
     // dfb.data_format_metadata is NOT set (nullopt)
 
     BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
@@ -661,7 +726,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithComputeEndpointRequiresDataFormat) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"}, {"dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -672,14 +737,14 @@ TEST_F(ProgramSpecTestQuasar, ComputeConfigUnpackToDestModeReferencesUnknownDFBF
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto producer = MakeMinimalDMKernel("producer", node);
-    auto consumer = MakeMinimalComputeKernel("consumer", node);
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalComputeKernel("consumer");
 
     // Set unpack_to_dest_mode referencing a DFB that doesn't exist
     auto& compute_config = std::get<ComputeConfiguration>(consumer.config_spec);
     compute_config.unpack_to_dest_mode = {{"nonexistent_dfb", UnpackToDestMode::UnpackToDestFp32}};
 
-    auto dfb = MakeMinimalDFB("dfb", node);
+    auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
     BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
@@ -687,7 +752,7 @@ TEST_F(ProgramSpecTestQuasar, ComputeConfigUnpackToDestModeReferencesUnknownDFBF
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"}, {"dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -698,9 +763,9 @@ TEST_F(ProgramSpecTestQuasar, DataFormatNotSupportedOnTargetArchitectureFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto producer = MakeMinimalDMKernel("producer", node);
-    auto consumer = MakeMinimalComputeKernel("consumer", node);
-    auto dfb = MakeMinimalDFB("dfb", node);
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalComputeKernel("consumer");
+    auto dfb = MakeMinimalDFB("dfb");
 
     // Legacy block-float format; not supported on Quasar.
     dfb.data_format_metadata = tt::DataFormat::Bfp8;
@@ -710,7 +775,7 @@ TEST_F(ProgramSpecTestQuasar, DataFormatNotSupportedOnTargetArchitectureFails) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"}, {"dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -719,27 +784,11 @@ TEST_F(ProgramSpecTestQuasar, DataFormatNotSupportedOnTargetArchitectureFails) {
 // SECTION 3: WorkerSpec Validation Tests
 // ============================================================================
 
-TEST_F(ProgramSpecTestQuasar, MissingWorkerSpecsFails) {
-    // Gen2 requires WorkerSpecs
-    NodeCoord node{0, 0};
-
-    ProgramSpec spec;
-    spec.program_id = "test_program";
-
-    auto kernel = MakeMinimalDMKernel("kernel", node);
-    spec.kernels = {kernel};
-    // spec.workers is NOT set (nullopt)
-
-    EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
-}
-
 TEST_F(ProgramSpecTestQuasar, EmptyWorkerSpecsFails) {
-    NodeCoord node{0, 0};
-
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto kernel = MakeMinimalDMKernel("kernel", node);
+    auto kernel = MakeMinimalDMKernel("kernel");
     spec.kernels = {kernel};
     spec.workers = std::vector<WorkerSpec>{};  // Empty!
 
@@ -752,7 +801,7 @@ TEST_F(ProgramSpecTestQuasar, WorkerSpecWithNoKernelsFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto kernel = MakeMinimalDMKernel("kernel", node);
+    auto kernel = MakeMinimalDMKernel("kernel");
     spec.kernels = {kernel};
 
     WorkerSpec worker;
@@ -770,45 +819,11 @@ TEST_F(ProgramSpecTestQuasar, WorkerSpecReferencesUnknownKernelFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto kernel = MakeMinimalDMKernel("real_kernel", node);
+    auto kernel = MakeMinimalDMKernel("real_kernel");
     spec.kernels = {kernel};
 
     // Worker references a kernel that doesn't exist
     spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"nonexistent_kernel"})};
-
-    EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
-}
-
-TEST_F(ProgramSpecTestQuasar, WorkerSpecReferencesUnknownDFBFails) {
-    NodeCoord node{0, 0};
-
-    ProgramSpec spec;
-    spec.program_id = "test_program";
-
-    auto kernel = MakeMinimalDMKernel("kernel", node);
-    spec.kernels = {kernel};
-
-    // Worker references a DFB that doesn't exist
-    auto worker = MakeMinimalWorker("worker", node, {"kernel"});
-    worker.dataflow_buffers = {"nonexistent_dfb"};
-    spec.workers = std::vector<WorkerSpec>{worker};
-
-    EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
-}
-
-TEST_F(ProgramSpecTestQuasar, WorkerSpecReferencesUnknownSemaphoreFails) {
-    NodeCoord node{0, 0};
-
-    ProgramSpec spec;
-    spec.program_id = "test_program";
-
-    auto kernel = MakeMinimalDMKernel("kernel", node);
-    spec.kernels = {kernel};
-
-    // Worker references a semaphore that doesn't exist
-    auto worker = MakeMinimalWorker("worker", node, {"kernel"});
-    worker.semaphores = {"nonexistent_semaphore"};
-    spec.workers = std::vector<WorkerSpec>{worker};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -820,8 +835,8 @@ TEST_F(ProgramSpecTestQuasar, OverlappingWorkerSpecsFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto kernel1 = MakeMinimalDMKernel("kernel1", node);
-    auto kernel2 = MakeMinimalDMKernel("kernel2", node);
+    auto kernel1 = MakeMinimalDMKernel("kernel1");
+    auto kernel2 = MakeMinimalDMKernel("kernel2");
     spec.kernels = {kernel1, kernel2};
 
     // Both workers target the same node
@@ -837,29 +852,11 @@ TEST_F(ProgramSpecTestQuasar, KernelNotInAnyWorkerSpecFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto kernel1 = MakeMinimalDMKernel("kernel1", node);
-    auto kernel2 = MakeMinimalDMKernel("kernel2", node);  // Not in any worker!
+    auto kernel1 = MakeMinimalDMKernel("kernel1");
+    auto kernel2 = MakeMinimalDMKernel("kernel2");  // Not in any worker!
     spec.kernels = {kernel1, kernel2};
 
     spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"kernel1"})};  // Only kernel1
-
-    EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
-}
-
-TEST_F(ProgramSpecTestQuasar, KernelTargetNodesMismatchWorkerNodesFails) {
-    // Kernel target nodes must contain worker target nodes
-    NodeCoord node0{0, 0};
-    NodeCoord node1{1, 0};
-
-    ProgramSpec spec;
-    spec.program_id = "test_program";
-
-    // Kernel only targets node0
-    auto kernel = MakeMinimalDMKernel("kernel", node0);
-    spec.kernels = {kernel};
-
-    // But worker targets node1
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node1, {"kernel"})};
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -871,9 +868,9 @@ TEST_F(ProgramSpecTestQuasar, WorkerExceedsDMCoreBudgetFails) {
     spec.program_id = "test_program";
 
     // Create enough DM kernels to exceed the 8 DM core budget
-    auto kernel1 = MakeMinimalDMKernel("dm1", node, 3);
-    auto kernel2 = MakeMinimalDMKernel("dm2", node, 3);
-    auto kernel3 = MakeMinimalDMKernel("dm3", node, 3);  // Total: 9 > 8
+    auto kernel1 = MakeMinimalDMKernel("dm1", 3);
+    auto kernel2 = MakeMinimalDMKernel("dm2", 3);
+    auto kernel3 = MakeMinimalDMKernel("dm3", 3);  // Total: 9 > 8
 
     spec.kernels = {kernel1, kernel2, kernel3};
     spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"dm1", "dm2", "dm3"})};
@@ -888,8 +885,8 @@ TEST_F(ProgramSpecTestQuasar, WorkerExceedsComputeCoreBudgetFails) {
     spec.program_id = "test_program";
 
     // Create enough compute kernels to exceed the 4 Tensix core budget
-    auto kernel1 = MakeMinimalComputeKernel("compute1", node, 2);
-    auto kernel2 = MakeMinimalComputeKernel("compute2", node, 3);  // Total: 5 > 4
+    auto kernel1 = MakeMinimalComputeKernel("compute1", 2);
+    auto kernel2 = MakeMinimalComputeKernel("compute2", 3);  // Total: 5 > 4
 
     spec.kernels = {kernel1, kernel2};
     spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"compute1", "compute2"})};
@@ -904,8 +901,8 @@ TEST_F(ProgramSpecTestQuasar, WorkerWithMultipleComputeKernelsFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto compute1 = MakeMinimalComputeKernel("compute1", node, 1);
-    auto compute2 = MakeMinimalComputeKernel("compute2", node, 1);
+    auto compute1 = MakeMinimalComputeKernel("compute1");
+    auto compute2 = MakeMinimalComputeKernel("compute2");
 
     spec.kernels = {compute1, compute2};
     spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"compute1", "compute2"})};
@@ -913,24 +910,29 @@ TEST_F(ProgramSpecTestQuasar, WorkerWithMultipleComputeKernelsFails) {
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBNotInAnyWorkerSpecFails) {
-    NodeCoord node{0, 0};
+TEST_F(ProgramSpecTestQuasar, LocalDFBProducerConsumerWorkerMembershipMismatchFails) {
+    // A local DFB requires its producer and consumer kernels to share IDENTICAL
+    // WorkerSpec membership.
+    NodeCoord node0{0, 0};
+    NodeCoord node1{1, 0};
 
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto producer = MakeMinimalDMKernel("producer", node);
-    auto consumer = MakeMinimalDMKernel("consumer", node);
-    auto dfb = MakeMinimalDFB("dfb", node);
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalDMKernel("consumer");
+    auto dfb = MakeMinimalDFB("dfb");
 
     BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-
-    // Worker doesn't include the DFB in its dataflow_buffers list
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"}, {})};
+    // Producer is on worker_0 only; consumer is on both workers — membership doesn't match.
+    spec.workers = std::vector<WorkerSpec>{
+        MakeMinimalWorker("worker_0", node0, {"producer", "consumer"}),
+        MakeMinimalWorker("worker_1", node1, {"consumer"}),
+    };
 
     EXPECT_ANY_THROW(MakeProgramFromSpec(spec));
 }
@@ -956,9 +958,9 @@ TEST_F(ProgramSpecTestQuasar, DMOnlyProgramSucceeds) {
     ProgramSpec spec;
     spec.program_id = "dm_only_program";
 
-    auto producer = MakeMinimalDMKernel("producer", node);
-    auto consumer = MakeMinimalDMKernel("consumer", node);
-    auto dfb = MakeMinimalDFB("dfb", node);
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalDMKernel("consumer");
+    auto dfb = MakeMinimalDFB("dfb");
     // No data_format_metadata needed for DM-only DFBs
 
     BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
@@ -966,7 +968,7 @@ TEST_F(ProgramSpecTestQuasar, DMOnlyProgramSucceeds) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"}, {"dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
@@ -978,16 +980,16 @@ TEST_F(ProgramSpecTestQuasar, MultiNodeProgramSucceeds) {
     ProgramSpec spec;
     spec.program_id = "multi_node_program";
 
-    auto producer = MakeMinimalDMKernel("producer", nodes);
-    auto consumer = MakeMinimalDMKernel("consumer", nodes);
-    auto dfb = MakeMinimalDFB("dfb", nodes);
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalDMKernel("consumer");
+    auto dfb = MakeMinimalDFB("dfb");
 
     BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", nodes, {"producer", "consumer"}, {"dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", nodes, {"producer", "consumer"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
@@ -1002,7 +1004,7 @@ TEST_F(ProgramSpecTestQuasar, MultipleWorkersOnDifferentNodesSucceeds) {
     spec.program_id = "multi_worker_program";
 
     // Kernels span both nodes
-    auto kernel = MakeMinimalDMKernel("kernel", all_nodes);
+    auto kernel = MakeMinimalDMKernel("kernel");
     spec.kernels = {kernel};
 
     // Two workers, each on a different node
@@ -1019,9 +1021,9 @@ TEST_F(ProgramSpecTestQuasar, MaxDMThreadsSucceeds) {
     ProgramSpec spec;
     spec.program_id = "max_dm_threads";
 
-    auto producer = MakeMinimalDMKernel("producer", node, 3);
-    auto consumer = MakeMinimalDMKernel("consumer", node, 3);  // Total: 6
-    auto dfb = MakeMinimalDFB("dfb", node);
+    auto producer = MakeMinimalDMKernel("producer", 3);
+    auto consumer = MakeMinimalDMKernel("consumer", 3);  // Total: 6
+    auto dfb = MakeMinimalDFB("dfb");
     dfb.num_entries = 9;  // must be a multiple of the number of threads
 
     BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
@@ -1029,7 +1031,7 @@ TEST_F(ProgramSpecTestQuasar, MaxDMThreadsSucceeds) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"}, {"dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
@@ -1041,10 +1043,10 @@ TEST_F(ProgramSpecTestQuasar, MaxComputeThreadsSucceeds) {
     ProgramSpec spec;
     spec.program_id = "max_compute_threads";
 
-    auto dm = MakeMinimalDMKernel("dm", node);
-    auto compute = MakeMinimalComputeKernel("compute", node, 4);  // Max threads
+    auto dm = MakeMinimalDMKernel("dm");
+    auto compute = MakeMinimalComputeKernel("compute", 4);  // Max threads
 
-    auto dfb = MakeMinimalDFB("dfb", node);
+    auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
     dfb.num_entries = 4;  // must be a multiple of the number of threads
 
@@ -1053,7 +1055,7 @@ TEST_F(ProgramSpecTestQuasar, MaxComputeThreadsSucceeds) {
 
     spec.kernels = {dm, compute};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"dm", "compute"}, {"dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"dm", "compute"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
@@ -1064,12 +1066,12 @@ TEST_F(ProgramSpecTestQuasar, MultipleDFBsSucceeds) {
     ProgramSpec spec;
     spec.program_id = "multi_dfb_program";
 
-    auto producer = MakeMinimalDMKernel("producer", node);
-    auto consumer = MakeMinimalComputeKernel("consumer", node);
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalComputeKernel("consumer");
 
-    auto dfb1 = MakeMinimalDFB("dfb1", node);
+    auto dfb1 = MakeMinimalDFB("dfb1");
     dfb1.data_format_metadata = tt::DataFormat::Float16_b;
-    auto dfb2 = MakeMinimalDFB("dfb2", node);
+    auto dfb2 = MakeMinimalDFB("dfb2");
     dfb2.data_format_metadata = tt::DataFormat::Int8;
 
     BindDFBToKernel(producer, "dfb1", "out1", KernelSpec::DFBEndpointType::PRODUCER);
@@ -1079,8 +1081,7 @@ TEST_F(ProgramSpecTestQuasar, MultipleDFBsSucceeds) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb1, dfb2};
-    spec.workers =
-        std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"}, {"dfb1", "dfb2"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
@@ -1123,7 +1124,7 @@ TEST_F(ProgramSpecTestQuasar, VarargPerNodeOverlapFails) {
 
     ProgramSpec spec;
     spec.program_id = "vararg_overlap_test";
-    auto kernel = MakeMinimalDMKernel("dm_kernel", both);
+    auto kernel = MakeMinimalDMKernel("dm_kernel");
     kernel.runtime_arguments_schema.num_runtime_varargs_per_node =
         NumVarargsPerNode{{both, 3}, {node_a, 3}};  // node_a listed twice
     spec.kernels = {kernel};
@@ -1145,16 +1146,16 @@ TEST_F(ProgramSpecTestQuasar, NodeRangeSetTargetNodesSucceeds) {
     ProgramSpec spec;
     spec.program_id = "range_set_program";
 
-    auto producer = MakeMinimalDMKernel("producer", nodes);
-    auto consumer = MakeMinimalDMKernel("consumer", nodes);
-    auto dfb = MakeMinimalDFB("dfb", nodes);
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalDMKernel("consumer");
+    auto dfb = MakeMinimalDFB("dfb");
 
     BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", nodes, {"producer", "consumer"}, {"dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", nodes, {"producer", "consumer"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
@@ -1258,15 +1259,15 @@ TEST_F(ProgramSpecTestQuasar, BacktrackingSolverFindsAssignment_RegardlessOfOrde
     NodeRangeSet nodes_ab(std::set<NodeRange>{NodeRange{node_a, node_a}, NodeRange{node_b, node_b}});
     NodeRangeSet nodes_bc(std::set<NodeRange>{NodeRange{node_b, node_b}, NodeRange{node_c, node_c}});
 
-    auto k_a = MakeMinimalDMKernel("k_a", node_a, 3);
-    auto k_ab = MakeMinimalDMKernel("k_ab", nodes_ab, 3);
-    auto k_bc = MakeMinimalDMKernel("k_bc", nodes_bc, 3);
-    auto k_c = MakeMinimalDMKernel("k_c", node_c, 3);
+    auto k_a = MakeMinimalDMKernel("k_a", 3);
+    auto k_ab = MakeMinimalDMKernel("k_ab", 3);
+    auto k_bc = MakeMinimalDMKernel("k_bc", 3);
+    auto k_c = MakeMinimalDMKernel("k_c", 3);
 
-    auto worker_a1 = MakeMinimalWorker("worker_a1", node_a, {"k_a", "k_ab"}, {});
-    auto worker_b1 = MakeMinimalWorker("worker_b1", node_b, {"k_ab", "k_bc"}, {});
-    auto worker_c1 = MakeMinimalWorker("worker_c1", node_c, {"k_bc", "k_c"}, {});
-    auto worker_c2 = MakeMinimalWorker("worker_c2", node_c, {"k_c", "k_bc"}, {});
+    auto worker_a1 = MakeMinimalWorker("worker_a1", node_a, {"k_a", "k_ab"});
+    auto worker_b1 = MakeMinimalWorker("worker_b1", node_b, {"k_ab", "k_bc"});
+    auto worker_c1 = MakeMinimalWorker("worker_c1", node_c, {"k_bc", "k_c"});
+    auto worker_c2 = MakeMinimalWorker("worker_c2", node_c, {"k_c", "k_bc"});
 
     // Helper to create a ProgramSpec with a given id and worker ordering
     auto make_spec =
@@ -1363,16 +1364,16 @@ TEST_F(ProgramSpecTestQuasar, SimplifyingAssumptionViolation_OverlappingMultiNod
     ProgramSpec spec;
     spec.program_id = "triangle_of_doom";
 
-    auto kernel_a = MakeMinimalDMKernel("kernel_a", nodes_A, 3);
-    auto kernel_b = MakeMinimalDMKernel("kernel_b", nodes_B, 3);
-    auto kernel_c = MakeMinimalDMKernel("kernel_c", nodes_C, 3);
+    auto kernel_a = MakeMinimalDMKernel("kernel_a", 3);
+    auto kernel_b = MakeMinimalDMKernel("kernel_b", 3);
+    auto kernel_c = MakeMinimalDMKernel("kernel_c", 3);
 
     spec.kernels = {kernel_a, kernel_b, kernel_c};
 
     spec.workers = std::vector<WorkerSpec>{
-        MakeMinimalWorker("worker_00", node_00, {"kernel_a", "kernel_b"}, {}),
-        MakeMinimalWorker("worker_01", node_01, {"kernel_a", "kernel_c"}, {}),
-        MakeMinimalWorker("worker_02", node_02, {"kernel_b", "kernel_c"}, {}),
+        MakeMinimalWorker("worker_00", node_00, {"kernel_a", "kernel_b"}),
+        MakeMinimalWorker("worker_01", node_01, {"kernel_a", "kernel_c"}),
+        MakeMinimalWorker("worker_02", node_02, {"kernel_b", "kernel_c"}),
     };
 
     // EXPECTED BEHAVIOR: FAILS due to simplifying assumption violation.
@@ -1436,8 +1437,8 @@ static_assert(
     std::is_aggregate_v<KernelSpec::RuntimeArgSchema>,
     "RuntimeArgSchema must remain an aggregate to support designated initializers");
 static_assert(
-    std::is_aggregate_v<DataflowBufferSpec::RemoteDFBInfo>,
-    "RemoteDFBInfo must remain an aggregate to support designated initializers");
+    std::is_aggregate_v<RemoteDataflowBufferSpec>,
+    "RemoteDataflowBufferSpec must remain an aggregate to support designated initializers");
 
 // These tests document the intended construction pattern using designated initializers.
 // They serve as living documentation and will fail to compile if aggregate status is broken.
@@ -1447,7 +1448,6 @@ TEST(AggregateSpecTypes, KernelSpecDesignatedInitializers) {
     KernelSpec dm_kernel{
         .unique_id = "my_dm_kernel",
         .source = KernelSpec::SourceCode{"void kernel_main() {}"},
-        .target_nodes = NodeCoord{0, 0},
         .num_threads = 2,
         .config_spec =
             DataMovementConfiguration{
@@ -1462,7 +1462,6 @@ TEST(AggregateSpecTypes, KernelSpecDesignatedInitializers) {
     KernelSpec compute_kernel{
         .unique_id = "my_compute_kernel",
         .source = KernelSpec::SourceCode{"void kernel_main() {}"},
-        .target_nodes = NodeRange{{0, 0}, {1, 1}},
         .num_threads = 4,
         .compiler_options =
             KernelSpec::CompilerOptions{
@@ -1484,7 +1483,6 @@ TEST(AggregateSpecTypes, DataflowBufferSpecDesignatedInitializers) {
     // Demonstrates constructing DataflowBufferSpec with designated initializers
     DataflowBufferSpec dfb{
         .unique_id = "my_dfb",
-        .target_nodes = NodeCoord{0, 0},
         .entry_size = 2048,
         .num_entries = 4,
         .data_format_metadata = tt::DataFormat::Float16_b,
@@ -1497,7 +1495,6 @@ TEST(AggregateSpecTypes, DataflowBufferSpecDesignatedInitializers) {
     // DFB with advanced options
     DataflowBufferSpec borrowed_dfb{
         .unique_id = "borrowed_dfb",
-        .target_nodes = NodeRange{{0, 0}, {1, 1}},
         .entry_size = 1024,
         .num_entries = 8,
         .uses_borrowed_memory = true,
@@ -1513,14 +1510,11 @@ TEST(AggregateSpecTypes, WorkerSpecDesignatedInitializers) {
     WorkerSpec worker{
         .unique_id = "my_worker",
         .kernels = {"kernel1", "kernel2"},
-        .dataflow_buffers = {"dfb1", "dfb2"},
-        .semaphores = {"sem1"},
         .target_nodes = NodeCoord{0, 0},
     };
 
     EXPECT_EQ(worker.unique_id, "my_worker");
     EXPECT_EQ(worker.kernels.size(), 2u);
-    EXPECT_EQ(worker.dataflow_buffers.size(), 2u);
 }
 
 TEST(AggregateSpecTypes, RuntimeArgSchemaDesignatedInitializers) {
@@ -1555,7 +1549,6 @@ TEST(AggregateSpecTypes, KernelSpecNamedRuntimeArgsDesignatedInitializers) {
     KernelSpec k{
         .unique_id = "k",
         .source = KernelSpec::SourceCode{"void kernel_main() {}"},
-        .target_nodes = NodeCoord{0, 0},
         .runtime_arguments_schema =
             KernelSpec::RuntimeArgSchema{
                 .named_runtime_args = {"input_ptr"},
@@ -1589,7 +1582,6 @@ TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
                 KernelSpec{
                     .unique_id = "producer",
                     .source = KernelSpec::SourceCode{"void kernel_main() {}"},
-                    .target_nodes = NodeCoord{0, 0},
                     .dfb_bindings =
                         {
                             KernelSpec::DFBBinding{
@@ -1607,7 +1599,6 @@ TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
                 KernelSpec{
                     .unique_id = "consumer",
                     .source = KernelSpec::SourceCode{"void kernel_main() {}"},
-                    .target_nodes = NodeCoord{0, 0},
                     .dfb_bindings =
                         {
                             KernelSpec::DFBBinding{
@@ -1624,18 +1615,16 @@ TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
             {
                 DataflowBufferSpec{
                     .unique_id = "dfb",
-                    .target_nodes = NodeCoord{0, 0},
                     .entry_size = 1024,
                     .num_entries = 2,
                     .data_format_metadata = tt::DataFormat::Float16_b,
                 },
             },
         .workers =
-            std::vector<WorkerSpec>{
+            {
                 WorkerSpec{
                     .unique_id = "worker",
                     .kernels = {"producer", "consumer"},
-                    .dataflow_buffers = {"dfb"},
                     .target_nodes = NodeCoord{0, 0},
                 },
             },
@@ -1644,8 +1633,7 @@ TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
     EXPECT_EQ(spec.program_id, "my_program");
     EXPECT_EQ(spec.kernels.size(), 2u);
     EXPECT_EQ(spec.dataflow_buffers.size(), 1u);
-    EXPECT_TRUE(spec.workers.has_value());
-    EXPECT_EQ(spec.workers->size(), 1u);
+    EXPECT_EQ(spec.workers.size(), 1u);
 }
 
 TEST(AggregateSpecTypes, NestedStructsDesignatedInitializers) {
@@ -1678,10 +1666,17 @@ TEST(AggregateSpecTypes, NestedStructsDesignatedInitializers) {
     };
     EXPECT_EQ(gen1.processor, tt::tt_metal::DataMovementProcessor::RISCV_1);
 
-    DataflowBufferSpec::RemoteDFBInfo remote_info{
+    RemoteDataflowBufferSpec remote_dfb{
+        .dfb_spec =
+            DataflowBufferSpec{
+                .unique_id = "remote_dfb",
+                .entry_size = 1024,
+                .num_entries = 2,
+            },
         .producer_consumer_map = {{NodeCoord{0, 0}, NodeCoord{1, 0}}},
     };
-    EXPECT_EQ(remote_info.producer_consumer_map.size(), 1u);
+    EXPECT_EQ(remote_dfb.producer_consumer_map.size(), 1u);
+    EXPECT_EQ(remote_dfb.dfb_spec.unique_id, "remote_dfb");
 }
 
 // ============================================================================
@@ -1707,16 +1702,16 @@ TEST_F(ProgramSpecTestGen1, DMOnlyProgramSucceeds) {
     ProgramSpec spec;
     spec.program_id = "dm_only_program";
 
-    auto producer = MakeMinimalGen1DMKernel("producer", node, DataMovementProcessor::RISCV_0);
-    auto consumer = MakeMinimalGen1DMKernel("consumer", node, DataMovementProcessor::RISCV_1);
-    auto dfb = MakeMinimalDFB("dfb", node);
+    auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
+    auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
+    auto dfb = MakeMinimalDFB("dfb");
 
     BindDFBToKernel(producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"}, {"dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"producer", "consumer"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
@@ -1728,8 +1723,8 @@ TEST_F(ProgramSpecTestGen1, TwoDMKernelsDifferentProcessorsSucceeds) {
     ProgramSpec spec;
     spec.program_id = "two_dm_program";
 
-    auto k0 = MakeMinimalGen1DMKernel("k0", node, DataMovementProcessor::RISCV_0);
-    auto k1 = MakeMinimalGen1DMKernel("k1", node, DataMovementProcessor::RISCV_1);
+    auto k0 = MakeMinimalGen1DMKernel("k0", DataMovementProcessor::RISCV_0);
+    auto k1 = MakeMinimalGen1DMKernel("k1", DataMovementProcessor::RISCV_1);
 
     spec.kernels = {k0, k1};
     spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"k0", "k1"})};
@@ -1743,7 +1738,7 @@ TEST_F(ProgramSpecTestGen1, MultiThreadedDMKernelFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto kernel = MakeMinimalGen1DMKernel("dm_kernel", node);
+    auto kernel = MakeMinimalGen1DMKernel("dm_kernel");
     kernel.num_threads = 2;
 
     spec.kernels = {kernel};
@@ -1760,7 +1755,7 @@ TEST_F(ProgramSpecTestGen1, MultiThreadedComputeKernelFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto kernel = MakeMinimalComputeKernel("compute_kernel", node);
+    auto kernel = MakeMinimalComputeKernel("compute_kernel");
     kernel.num_threads = 2;
 
     spec.kernels = {kernel};
@@ -1779,7 +1774,7 @@ TEST_F(ProgramSpecTestGen1, DMKernelWithGen2ConfigFails) {
     spec.program_id = "test_program";
 
     // MakeMinimalDMKernel produces a gen2 (Quasar) DM config
-    auto kernel = MakeMinimalDMKernel("dm_kernel", node);
+    auto kernel = MakeMinimalDMKernel("dm_kernel");
 
     spec.kernels = {kernel};
     spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"dm_kernel"})};
@@ -1796,8 +1791,8 @@ TEST_F(ProgramSpecTestGen1, ProcessorConflictFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto k0 = MakeMinimalGen1DMKernel("k0", node, DataMovementProcessor::RISCV_0);
-    auto k1 = MakeMinimalGen1DMKernel("k1", node, DataMovementProcessor::RISCV_0);  // conflict
+    auto k0 = MakeMinimalGen1DMKernel("k0", DataMovementProcessor::RISCV_0);
+    auto k1 = MakeMinimalGen1DMKernel("k1", DataMovementProcessor::RISCV_0);  // conflict
 
     spec.kernels = {k0, k1};
     spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"k0", "k1"})};
@@ -1823,7 +1818,7 @@ TEST_F(ProgramSpecTestGen1, KernelTargetsNodeBeyondGridYFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto kernel = MakeMinimalGen1DMKernel("dm_kernel", oob_node);
+    auto kernel = MakeMinimalGen1DMKernel("dm_kernel");
     spec.kernels = {kernel};
     spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", oob_node, {"dm_kernel"})};
 
@@ -1839,34 +1834,9 @@ TEST_F(ProgramSpecTestGen1, KernelTargetsOutOfBoundsNodeFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto kernel = MakeMinimalGen1DMKernel("dm_kernel", oob_node);
+    auto kernel = MakeMinimalGen1DMKernel("dm_kernel");
     spec.kernels = {kernel};
     spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", oob_node, {"dm_kernel"})};
-
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("out of bounds")));
-}
-
-TEST_F(ProgramSpecTestGen1, DFBTargetsOutOfBoundsNodeFails) {
-    // Bounds checking applies to DFBs as well as kernels. The kernel itself is on a
-    // valid node, but the DFB it produces to targets an OOB node.
-    const NodeCoord valid_node{0, 0};
-    const NodeCoord oob_node{0, 9};  // just outside the 9-row slow-dispatch grid
-
-    ProgramSpec spec;
-    spec.program_id = "test_program";
-
-    auto producer = MakeMinimalGen1DMKernel("producer", valid_node);
-    auto consumer = MakeMinimalGen1DMKernel("consumer", valid_node, DataMovementProcessor::RISCV_1);
-    auto dfb = MakeMinimalDFB("dfb_0", oob_node);  // DFB on OOB node
-
-    BindDFBToKernel(producer, "dfb_0", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb_0", "in", KernelSpec::DFBEndpointType::CONSUMER);
-
-    spec.kernels = {producer, consumer};
-    spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", valid_node, {"producer", "consumer"})};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(spec); },
@@ -1882,7 +1852,6 @@ TEST_F(ProgramSpecTestGen1, SemaphoreBoundToComputeKernelFailsOnGen1) {
     sem.unique_id = "sem_0";
     sem.target_nodes = NodeCoord{0, 0};
     spec.semaphores = {sem};
-    spec.workers.value()[0].semaphores = {"sem_0"};
 
     // kernels[1] is the compute kernel in MakeMinimalGen1ValidProgramSpec
     ASSERT_TRUE(spec.kernels[1].is_compute_kernel());
@@ -1903,7 +1872,6 @@ TEST_F(ProgramSpecTestGen1, SemaphoreBoundToDMKernelSucceedsOnGen1) {
     sem.unique_id = "sem_0";
     sem.target_nodes = NodeCoord{0, 0};
     spec.semaphores = {sem};
-    spec.workers.value()[0].semaphores = {"sem_0"};
 
     // kernels[0] is the DM kernel in MakeMinimalGen1ValidProgramSpec
     ASSERT_TRUE(spec.kernels[0].is_dm_kernel());
@@ -1922,7 +1890,6 @@ TEST_F(ProgramSpecTestGen1, SemaphoresWithNonZeroInitialValueSucceedOnGen1) {
     sem.target_nodes = NodeCoord{0, 0};
     sem.initial_value = 3;
     spec.semaphores = {sem};
-    spec.workers.value()[0].semaphores = {"sem_0"};
 
     spec.kernels[0].semaphore_bindings = {
         KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "done_flag"}};
@@ -1937,8 +1904,8 @@ TEST_F(ProgramSpecTestGen1, DuplicateKernelNameFails) {
     ProgramSpec spec;
     spec.program_id = "test_program";
 
-    auto k0 = MakeMinimalGen1DMKernel("dm_kernel", node, DataMovementProcessor::RISCV_0);
-    auto k1 = MakeMinimalGen1DMKernel("dm_kernel", node, DataMovementProcessor::RISCV_1);  // duplicate name
+    auto k0 = MakeMinimalGen1DMKernel("dm_kernel", DataMovementProcessor::RISCV_0);
+    auto k1 = MakeMinimalGen1DMKernel("dm_kernel", DataMovementProcessor::RISCV_1);  // duplicate name
 
     spec.kernels = {k0, k1};
     spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker", node, {"dm_kernel"})};

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -96,27 +96,26 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
     spec.program_id = "dfb_accessor_loopback";
 
     // Producer: BRISC reads from DRAM → DFB
-    auto producer = MakeMinimalGen1DMKernel("producer", node, DataMovementProcessor::RISCV_0);
+    auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
     producer.source =
         KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_producer.cpp"};
     producer.runtime_arguments_schema.num_runtime_varargs = 3;
 
     // Consumer: NCRISC reads DFB → DRAM
-    auto consumer = MakeMinimalGen1DMKernel("consumer", node, DataMovementProcessor::RISCV_1);
+    auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
     consumer.source =
         KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp"};
     consumer.runtime_arguments_schema.num_runtime_varargs = 3;
 
     // DFB: both kernels bind it, with different local accessor names
-    auto dfb = MakeMinimalDFB("loopback_dfb", node, entry_size, num_entries);
+    auto dfb = MakeMinimalDFB("loopback_dfb", entry_size, num_entries);
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
     BindDFBToKernel(producer, "loopback_dfb", "my_local_dfb_name", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(consumer, "loopback_dfb", "a_dfb_named_bob", KernelSpec::DFBEndpointType::CONSUMER);
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers =
-        std::vector<WorkerSpec>{MakeMinimalWorker("worker_0", node, {"producer", "consumer"}, {"loopback_dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker_0", node, {"producer", "consumer"})};
 
     // -------------------------------------------------------
     // Create Program
@@ -228,7 +227,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
 
     // Producer: BRISC reads DRAM → DFB. 1 named RTA, 1 named CRTA, 2 named CTAs, 3 RTA
     // varargs, 1 CRTA vararg.
-    auto producer = MakeMinimalGen1DMKernel("producer", node, DataMovementProcessor::RISCV_0);
+    auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
     producer.source =
         KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_producer.cpp"};
     producer.runtime_arguments_schema.named_runtime_args = {"src_addr"};
@@ -240,7 +239,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     // Consumer: NCRISC reads DFB → DRAM. Uses default `args` namespace, 1 named RTA,
     // 1 named CRTA, 2 named CTAs, 2 RTA varargs (note: different count from producer —
     // this verifies the named_rta_words offset is baked per-kernel), 1 CRTA vararg.
-    auto consumer = MakeMinimalGen1DMKernel("consumer", node, DataMovementProcessor::RISCV_1);
+    auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
     consumer.source =
         KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_consumer.cpp"};
     consumer.runtime_arguments_schema.named_runtime_args = {"dst_addr"};
@@ -249,15 +248,14 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     consumer.runtime_arguments_schema.num_common_runtime_varargs = 1;
     consumer.compile_time_arg_bindings = {{"bank_id", 0}, {"entry_size", entry_size}};
 
-    auto dfb = MakeMinimalDFB("loopback_dfb", node, entry_size, num_entries_in_dfb);
+    auto dfb = MakeMinimalDFB("loopback_dfb", entry_size, num_entries_in_dfb);
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
     BindDFBToKernel(producer, "loopback_dfb", "loopback_dfb", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(consumer, "loopback_dfb", "loopback_dfb", KernelSpec::DFBEndpointType::CONSUMER);
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers =
-        std::vector<WorkerSpec>{MakeMinimalWorker("worker_0", node, {"producer", "consumer"}, {"loopback_dfb"})};
+    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker_0", node, {"producer", "consumer"})};
 
     Program program = MakeProgramFromSpec(spec);
 
@@ -348,7 +346,6 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
         .source =
             KernelSpec::SourceFilePath{
                 "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_producer.cpp"},
-        .target_nodes = node,
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = "only_sem", .accessor_name = "signal"}},
         .config_spec =
@@ -364,7 +361,6 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
         .source =
             KernelSpec::SourceFilePath{
                 "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_consumer.cpp"},
-        .target_nodes = node,
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = "only_sem", .accessor_name = "waiter"}},
         .config_spec =
@@ -376,11 +372,10 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
             },
     };
 
-    // A WorkerSpec ties together the kernels, DFBs, and semaphores that share a node.
+    // A WorkerSpec ties together the kernels that run on a shared set of nodes.
     WorkerSpec worker{
         .unique_id = "worker_0",
         .kernels = {"producer", "consumer"},
-        .semaphores = {"only_sem"},
         .target_nodes = node,
     };
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -33,7 +33,7 @@ namespace {
 using test_helpers::BindDFBToKernel;
 using test_helpers::MakeMinimalDFB;
 using test_helpers::MakeMinimalGen1DMKernel;
-using test_helpers::MakeMinimalWorker;
+using test_helpers::MakeMinimalWorkUnit;
 
 // ============================================================================
 // Test Fixture
@@ -115,7 +115,7 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker_0", node, {"producer", "consumer"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", node, {"producer", "consumer"})};
 
     // -------------------------------------------------------
     // Create Program
@@ -255,7 +255,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    spec.workers = std::vector<WorkerSpec>{MakeMinimalWorker("worker_0", node, {"producer", "consumer"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", node, {"producer", "consumer"})};
 
     Program program = MakeProgramFromSpec(spec);
 
@@ -372,9 +372,9 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
             },
     };
 
-    // A WorkerSpec ties together the kernels that run on a shared set of nodes.
-    WorkerSpec worker{
-        .unique_id = "worker_0",
+    // A WorkUnitSpec ties together the kernels that run on a shared set of nodes.
+    WorkUnitSpec work_unit{
+        .unique_id = "work_unit_0",
         .kernels = {"producer", "consumer"},
         .target_nodes = node,
     };
@@ -384,7 +384,7 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
         .program_id = "semaphore_accessor_loopback",
         .kernels = {producer, consumer},
         .semaphores = {sem},
-        .workers = std::vector<WorkerSpec>{worker},
+        .work_units = std::vector<WorkUnitSpec>{work_unit},
     };
 
     Program program = MakeProgramFromSpec(spec);

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -27,7 +27,25 @@ using DFBSpecName = std::string;
 enum class DFBAccessPattern { STRIDED, BLOCKED, CONTIGUOUS };
 
 // A DataflowBufferSpec describes a "local" Dataflow Buffer (DFB):
-// Its producer and consumer kernels run on the SAME node, and the DFB is allocated in that node's local SRAM.
+//  - Backing memory parameters
+//  - Entry format metadata (data format, tile layout)
+//  - Advanced options
+//
+// A DFB's endpoint info is specified at the DFB binding site in KernelSpec, not here.
+// (producer/consumer kernel identity, threads, and access patterns)
+//
+// Invariant: A local DFB has exactly one producer kernel and one consumer kernel.
+// Both must share identical WorkUnitSpec membership.
+// (For cross-node communication, use RemoteDataflowBufferSpec instead.)
+//
+// Instancing: Like KernelSpec, a DataflowBufferSpec is a *per-node template*. One
+// independent DFB instance is allocated per node where its endpoint kernels run, in
+// that node's local SRAM. That instance serves the same-node producer and consumer
+// kernel instances.
+//
+// Placement: Derived — the DFB's effective node set is the union of its bound
+// kernels' WorkUnitSpec target_nodes.
+//
 struct DataflowBufferSpec {
     // DFB identifier: used to reference this DFB within the ProgramSpec
     DFBSpecName unique_id;
@@ -36,16 +54,6 @@ struct DataflowBufferSpec {
     uint32_t entry_size = 0;  // in bytes
     uint32_t num_entries = 0;
     // Note: It is possible to override these per-Program execution (via ProgramRunParams).
-
-    // Endpoint info
-    // Configuring a DFB requires endpoint-specific info.
-    // This endpoint info is specified at the DFB binding site in the KernelSpec:
-    //   - Producer and consumer kernel identity
-    //   - Number of producer threads, number of consumer threads
-    //   - Producer and consumer access patterns
-
-    // Target nodes
-    // This is a derived property, based on the kernel bindings for this DFB
 
     ////////////////////////////////////
     // Entry format metadata
@@ -70,7 +78,8 @@ struct DataflowBufferSpec {
 
     // Alias two or more DFBs
     // Aliased DFBs are logically distinct, but physically share the same backing memory.
-    // All aliased DFBs must have size and target nodes, and must mutually declare each other as aliases.
+    // All aliased DFBs must have the same total size (num_entries * entry_size), must be bound to the same kernels,
+    // and must mutually declare each other as aliases.
     // (Aliased DFBs offer NO guarantees against data clobbering; the kernel author must ensure safety.)
     using DFBIdentifiers = std::vector<DFBSpecName>;
     DFBIdentifiers alias_with;  // empty vector means no aliasing
@@ -81,14 +90,30 @@ struct DataflowBufferSpec {
     bool disable_implicit_sync = false;
 };
 
-// A RemoteDataflowBufferSpec describes a "remote" DFB:
-// Its producer and consumer kernels run on DIFFERENT nodes, and data is transferred over the NOC.
+// A RemoteDataflowBufferSpec describes a "remote" DFB: like DataflowBufferSpec, but
+// its producer and consumer kernels run on DIFFERENT nodes, with data flowing over
+// the NoC. The producer_consumer_map enumerates the (producer_node, consumer_node)
+// pairs.
+//
+// Invariant: Every entry in producer_consumer_map has producer_node != consumer_node.
+// (Same-node communication is structurally local and belongs in DataflowBufferSpec.)
+// Producer-WorkUnit and consumer-WorkUnit target_nodes are allowed to overlap, even
+// to be equal: e.g. an A↔B pattern (map = [(A, B), (B, A)]) is legal because every
+// pair is genuinely cross-node.
+//
+// Instancing: At runtime, one remote DFB instance is allocated per entry in
+// producer_consumer_map, mediating data flow between its named producer and consumer
+// nodes over the NoC.
+//
+// Placement: Specified directly via producer_consumer_map (rather than derived as
+// for local DFBs).
+//
 struct RemoteDataflowBufferSpec {
     // A remote DFB has all of the same properties as a local DFB
     DataflowBufferSpec dfb_spec;
 
-    // You must additionally specify a producer-consumer node mapping:
-    // This specifies which producer node communicates with which consumer node.
+    // Producer-consumer node mapping: each entry pairs a producer node with the
+    // consumer node it feeds.
     using ProducerConsumerMap = std::vector<std::pair<NodeCoord, NodeCoord>>;
     ProducerConsumerMap producer_consumer_map;
 };

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -26,13 +26,11 @@ using DFBSpecName = std::string;
 
 enum class DFBAccessPattern { STRIDED, BLOCKED, CONTIGUOUS };
 
+// A DataflowBufferSpec describes a "local" Dataflow Buffer (DFB):
+// Its producer and consumer kernels run on the SAME node, and the DFB is allocated in that node's local SRAM.
 struct DataflowBufferSpec {
     // DFB identifier: used to reference this DFB within the ProgramSpec
     DFBSpecName unique_id;
-
-    // Target nodes
-    using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>;
-    Nodes target_nodes;
 
     // Backing memory
     uint32_t entry_size = 0;  // in bytes
@@ -41,21 +39,13 @@ struct DataflowBufferSpec {
 
     // Endpoint info
     // Configuring a DFB requires endpoint-specific info.
-    // This is specified when the DFB is bound to a kernel:
+    // This endpoint info is specified at the DFB binding site in the KernelSpec:
     //   - Producer and consumer kernel identity
     //   - Number of producer threads, number of consumer threads
     //   - Producer and consumer access patterns
 
-    // Remote DFB
-    // A DFB is "local" by default. Its producer and consumer kernels are on the same node,
-    // sharing common L1 memory.
-    // A "remote DFB" has its producer and consumer kernels on different nodes.
-    // For a remote DFB, you must specify the producer-consumer map.
-    struct RemoteDFBInfo {
-        using ProducerConsumerMap = std::vector<std::pair<NodeCoord, NodeCoord>>;
-        ProducerConsumerMap producer_consumer_map;
-    };
-    std::optional<RemoteDFBInfo> remote_dfb_info = std::nullopt;
+    // Target nodes
+    // This is a derived property, based on the kernel bindings for this DFB
 
     ////////////////////////////////////
     // Entry format metadata
@@ -89,6 +79,18 @@ struct DataflowBufferSpec {
     // Implicit sync is handled via ISR (available on Gen2 only)
     // Disabling may be useful in niche cases for fine tuning performance or performance debug.
     bool disable_implicit_sync = false;
+};
+
+// A RemoteDataflowBufferSpec describes a "remote" DFB:
+// Its producer and consumer kernels run on DIFFERENT nodes, and data is transferred over the NOC.
+struct RemoteDataflowBufferSpec {
+    // A remote DFB has all of the same properties as a local DFB
+    DataflowBufferSpec dfb_spec;
+
+    // You must additionally specify a producer-consumer node mapping:
+    // This specifies which producer node communicates with which consumer node.
+    using ProducerConsumerMap = std::vector<std::pair<NodeCoord, NodeCoord>>;
+    ProducerConsumerMap producer_consumer_map;
 };
 
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -24,19 +24,27 @@ namespace tt::tt_metal::experimental::metal2_host_api {
 // Reusing a single constant helps catch typos and errors at compile time.
 using DFBSpecName = std::string;
 
+// DataflowBuffer endpoint access pattern:
+//  - STRIDED: a kernel thread accesses every N-th entry (where N = num_threads)
+//  - BLOCKED: each kernel thread accesses all N entries in a contiguous block
+//  - CONTIGUOUS: ???
 enum class DFBAccessPattern { STRIDED, BLOCKED, CONTIGUOUS };
 
-// A DataflowBufferSpec describes a "local" Dataflow Buffer (DFB):
-//  - Backing memory parameters
-//  - Entry format metadata (data format, tile layout)
-//  - Advanced options
+// A DataflowBufferSpec is a descriptor for a Dataflow Buffer (DFB):
+// A software FIFO for sharing data between a producer kernel and a consumer kernel.
 //
-// A DFB's endpoint info is specified at the DFB binding site in KernelSpec, not here.
+// A DFB has the following properties:
+//  - Entry size
+//  - Number of entries
+//  - (Optional) entry format metadata (data format, tile format)
+//  - (Additional advanced options)
+//
+// A DFB's endpoint configuration is specified at the DFB binding site in KernelSpec, not here.
 // (producer/consumer kernel identity, threads, and access patterns)
 //
 // Invariant: A local DFB has exactly one producer kernel and one consumer kernel.
 // Both must share identical WorkUnitSpec membership.
-// (For cross-node communication, use RemoteDataflowBufferSpec instead.)
+// (For cross-node communication, use RemoteDataflowBufferSpec.)
 //
 // Instancing: Like KernelSpec, a DataflowBufferSpec is a *per-node template*. One
 // independent DFB instance is allocated per node where its endpoint kernels run, in

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -83,7 +83,7 @@ struct KernelSpec {
     std::variant<SourceFilePath, SourceCode> source;
 
     // NOTE: The kernel's target node set is a DERIVED property, based on the
-    //       WorkerSpec(s) that include this kernel.
+    //       WorkUnitSpec(s) that include this kernel.
 
     // Kernel threading:
     // Number of kernel threads

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -82,17 +82,19 @@ struct KernelSpec {
     };
     std::variant<SourceFilePath, SourceCode> source;
 
-    // Target nodes
-    // The logical coordinates for the set of device nodes on which the kernel will run
-    using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>;
-    Nodes target_nodes;
+    // NOTE: The kernel's target node set is a DERIVED property, based on the
+    //       WorkerSpec(s) that include this kernel.
 
-    // Threading
-    // Number of kernel threads (this can be specified globally or per-node)
+    // Kernel threading:
+    // Number of kernel threads
     uint8_t num_threads = 1;
-    // Optional per-node thread count specification (overrides global num_threads)
-    // This is currently unsupported, and an open question if we ever want to support it.
-    using NodeSpecificThreadCount = std::pair<Nodes, uint8_t>;  // {node, num_threads}
+
+    // OPTIONAL per-node thread count specification
+    // The default threading is num_threads. However, you may override this on a per-node basis.
+    // NOTE: This feature is currently unsupported. It's an open question if we EVER want to support it.
+    //       Here as a placeholder; specifying it will trigger a runtime error.
+    using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>;
+    using NodeSpecificThreadCount = std::pair<Nodes, uint8_t>;  // {node_set, num_threads}
     using NodeSpecificThreadCounts = std::vector<NodeSpecificThreadCount>;
     std::optional<NodeSpecificThreadCounts> node_specific_thread_counts = std::nullopt;
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -50,7 +50,7 @@ struct DataMovementConfiguration {
 
     struct Gen2DataMovementConfig {
         // Currently, no configuration is needed for Gen2!
-        // Might want to revisit the API if so....
+        // The empty struct is still used to express a Gen2 DM kernel.
     };
     std::optional<Gen2DataMovementConfig> gen2_data_movement_config = std::nullopt;
 };
@@ -63,15 +63,17 @@ struct DataMovementConfiguration {
 // Reusing a single constant helps catch typos and errors at compile time.
 using KernelSpecName = std::string;
 
-// A KernelSpec describes a compute or data movement kernel:
-//  - The kernel's source code
-//  - Compiler options for generating the kernel binary
-//  - Resource bindings, giving the kernel access to DFBs, semaphores, etc.
-//  - Kernel argument schema (for runtime arguments, specified when the Program is enqueued)
+// A KernelSpec is a descriptor for a Tenstorrent kernel:
+// A single computational task compiled into one or more executable files that work
+// collaboratively on a single node.
+//
+// The KernelSpec describes the properties of a compute or data movement kernel:
+//  - Source code
+//  - Compiler options for generating the kernel binary(ies)s
+//  - Resource bindings (access to DFBs, semaphores, etc.)
+//  - Kernel argument schema (for arguments specified when the Program is enqueued)
 //  - Kernel argument bindings (for compile-time constant arguments)
 //  - The configuration of any hardware resources controlled by the kernel
-//
-// Invariant: A KernelSpec maps 1:1 with a kernel binary within the Program.
 //
 // Instancing: A KernelSpec is a *per-node template*. At runtime, one independent
 // instance runs on each node where the kernel is placed, with its own runtime arguments.
@@ -87,8 +89,7 @@ struct KernelSpec {
     KernelSpecName unique_id;
 
     // Kernel source: either a path to a source file, or the source code itself.
-    // (Wrapper types disambiguate the string-constructible variant alternatives,
-    // ensuring compile-time enforcement.)
+    // (Force callers to choose explicitly between path and inline code.)
     struct SourceFilePath {
         std::filesystem::path path;
     };
@@ -104,7 +105,7 @@ struct KernelSpec {
     // Number of kernel threads
     uint8_t num_threads = 1;
 
-    // OPTIONAL per-node thread count specification
+    // (Optional) Per-node thread count specification
     // The default threading is num_threads. However, you may override this on a per-node basis.
     // NOTE: This feature is currently unsupported. It's an open question if we EVER want to support it.
     //       Here as a placeholder; specifying it will trigger a runtime error.

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -63,6 +63,21 @@ struct DataMovementConfiguration {
 // Reusing a single constant helps catch typos and errors at compile time.
 using KernelSpecName = std::string;
 
+// A KernelSpec describes a compute or data movement kernel:
+//  - The kernel's source code
+//  - Compiler options for generating the kernel binary
+//  - Resource bindings, giving the kernel access to DFBs, semaphores, etc.
+//  - Kernel argument schema (for runtime arguments, specified when the Program is enqueued)
+//  - Kernel argument bindings (for compile-time constant arguments)
+//  - The configuration of any hardware resources controlled by the kernel
+//
+// Invariant: A KernelSpec maps 1:1 with a kernel binary within the Program.
+//
+// Instancing: A KernelSpec is a *per-node template*. At runtime, one independent
+// instance runs on each node where the kernel is placed, with its own runtime arguments.
+//
+// Placement: The nodes the kernel runs on is derived from WorkUnitSpec membership.
+//
 struct KernelSpec {
     ///////////////////////////////////////////////////////////////////
     // Basic kernel info

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -25,22 +25,25 @@ namespace tt::tt_metal::experimental::metal2_host_api {
 // Reusing a single constant helps catch typos and errors at compile time.
 using ProgramSpecName = std::string;
 
-// A name identifying a WorkerSpec within a ProgramSpec.
+// A name identifying a WorkUnitSpec within a ProgramSpec.
 // CONVENTION: define names as `constexpr const char*` constants (see above).
-using WorkerSpecName = std::string;
+using WorkUnitSpecName = std::string;
 
 //------------------------------------------------
-// ProgramSpec & WorkerSpec
+// ProgramSpec & WorkUnitSpec
 //------------------------------------------------
 
-// WorkerSpec describes the configuration of a worker node
-struct WorkerSpec {
-    WorkerSpecName unique_id;
+// A WorkUnitSpec names a unit of execution: a set of kernels that run together on a
+// shared set of compute worker nodes. It is the sole source of placement for kernels;
+// DFB placement is derived from kernel bindings, and semaphores carry their own
+// program-scope target_nodes.
+struct WorkUnitSpec {
+    WorkUnitSpecName unique_id;
 
-    // The kernels that run on this WorkerSpec's nodes.
+    // The kernels that run on this WorkUnitSpec's nodes.
     std::vector<KernelSpecName> kernels;
 
-    // The set of nodes configured by this WorkerSpec.
+    // The set of nodes configured by this WorkUnitSpec.
     std::variant<NodeCoord, NodeRange, NodeRangeSet> target_nodes;
 };
 
@@ -56,10 +59,10 @@ struct ProgramSpec {
     std::vector<RemoteDataflowBufferSpec> remote_dataflow_buffers;
     std::vector<SemaphoreSpec> semaphores;
 
-    // Worker specifications. Required: a valid ProgramSpec has at least one WorkerSpec.
-    // Each kernel must be referenced by at least one WorkerSpec; the kernel's effective
-    // node set is the union of those WorkerSpecs' target_nodes.
-    std::vector<WorkerSpec> workers;
+    // WorkUnit specifications. Required: a valid ProgramSpec has at least one WorkUnitSpec.
+    // Each kernel must be referenced by at least one WorkUnitSpec; the kernel's effective
+    // node set is the union of those WorkUnitSpecs' target_nodes.
+    std::vector<WorkUnitSpec> work_units;
 };
 
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -35,15 +35,12 @@ using WorkerSpecName = std::string;
 
 // WorkerSpec describes the configuration of a worker node
 struct WorkerSpec {
-    // Worker type identifier
     WorkerSpecName unique_id;
 
-    // Kernels, DFBs, and semaphores for this worker
+    // The kernels that run on this WorkerSpec's nodes.
     std::vector<KernelSpecName> kernels;
-    std::vector<DFBSpecName> dataflow_buffers;
-    std::vector<SemaphoreSpecName> semaphores;
 
-    // The set of nodes configured by this WorkerSpec
+    // The set of nodes configured by this WorkerSpec.
     std::variant<NodeCoord, NodeRange, NodeRangeSet> target_nodes;
 };
 
@@ -53,15 +50,16 @@ struct ProgramSpec {
     // Program identifier (identifies a Program within a MeshWorkload)
     ProgramSpecName program_id;
 
-    // Kernels, DFBs, and semaphores for this Program
+    // Kernels, DFBs, and semaphores that make up the Program.
     std::vector<KernelSpec> kernels;
     std::vector<DataflowBufferSpec> dataflow_buffers;
+    std::vector<RemoteDataflowBufferSpec> remote_dataflow_buffers;
     std::vector<SemaphoreSpec> semaphores;
 
-    // Worker specifications (optional on Gen1, required on Gen2+)
-    // This info is redundant, but improves clarity and messaging.
-    // (Done to simplify porting from ProgramDescriptor.)
-    std::optional<std::vector<WorkerSpec>> workers = std::nullopt;
+    // Worker specifications. Required: a valid ProgramSpec has at least one WorkerSpec.
+    // Each kernel must be referenced by at least one WorkerSpec; the kernel's effective
+    // node set is the union of those WorkerSpecs' target_nodes.
+    std::vector<WorkerSpec> workers;
 };
 
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -33,10 +33,10 @@ using WorkUnitSpecName = std::string;
 // ProgramSpec & WorkUnitSpec
 //------------------------------------------------
 
-// A WorkUnitSpec names a unit of execution: a set of kernels that run together on a
-// shared set of compute worker nodes. It is the sole source of placement for kernels;
-// DFB placement is derived from kernel bindings, and semaphores carry their own
-// program-scope target_nodes.
+// A WorkUnitSpec describes a unit of execution:
+// A set of kernels that run together on a shared set of nodes.
+// It is the sole source of kernel placement — each listed kernel is instantiated
+// once per node in target_nodes.
 struct WorkUnitSpec {
     WorkUnitSpecName unique_id;
 
@@ -47,21 +47,23 @@ struct WorkUnitSpec {
     std::variant<NodeCoord, NodeRange, NodeRangeSet> target_nodes;
 };
 
-// ProgramSpec describes the immutable properties of a Program
-//   (analogous to a function's signature and body)
+// A ProgramSpec describes the immutable properties of a Program:
+// its kernels, DFBs, semaphores, and where they run.
+// Analogous to a function's signature and body — declared once, executed many times.
+// (Each time with a new ProgramRunParams configuring the mutable execution parameters.)
 struct ProgramSpec {
     // Program identifier (identifies a Program within a MeshWorkload)
     ProgramSpecName program_id;
 
-    // Kernels, DFBs, and semaphores that make up the Program.
+    // Kernels, DFBs (local + remote), and semaphores that make up the Program
     std::vector<KernelSpec> kernels;
     std::vector<DataflowBufferSpec> dataflow_buffers;
     std::vector<RemoteDataflowBufferSpec> remote_dataflow_buffers;
     std::vector<SemaphoreSpec> semaphores;
 
-    // WorkUnit specifications. Required: a valid ProgramSpec has at least one WorkUnitSpec.
-    // Each kernel must be referenced by at least one WorkUnitSpec; the kernel's effective
-    // node set is the union of those WorkUnitSpecs' target_nodes.
+    // WorkUnit specifications:
+    // A valid ProgramSpec has at least one WorkUnitSpec.
+    // Each kernel must be referenced by at least one WorkUnitSpec.
     std::vector<WorkUnitSpec> work_units;
 };
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -33,10 +33,11 @@ using WorkUnitSpecName = std::string;
 // ProgramSpec & WorkUnitSpec
 //------------------------------------------------
 
-// A WorkUnitSpec describes a unit of execution:
-// A set of kernels that run together on a shared set of nodes.
-// It is the sole source of kernel placement — each listed kernel is instantiated
-// once per node in target_nodes.
+// A WorkUnitSpec describes a set of kernels that run together on a set of nodes.
+// Each node in the WorkUnitSpec's target_nodes runs an identical set of kernel instances.
+//
+// Placement: The WorkUnitSpec defines the node placement of its kernels.
+// (A kernel may be included in multiple WorkUnitSpecs.)
 struct WorkUnitSpec {
     WorkUnitSpecName unique_id;
 
@@ -48,7 +49,7 @@ struct WorkUnitSpec {
 };
 
 // A ProgramSpec describes the immutable properties of a Program:
-// its kernels, DFBs, semaphores, and where they run.
+// its kernels, DFBs, semaphores, and where they all run.
 // Analogous to a function's signature and body — declared once, executed many times.
 // (Each time with a new ProgramRunParams configuring the mutable execution parameters.)
 struct ProgramSpec {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
@@ -22,6 +22,12 @@ namespace tt::tt_metal::experimental::metal2_host_api {
 // Reusing a single constant helps catch typos and errors at compile time.
 using SemaphoreSpecName = std::string;
 
+// A SemaphoreSpec describes a semaphore, which can be used for kernel synchronization.
+//
+// Instancing: Unlike KernelSpec and DataflowBufferSpec, a SemaphoreSpec is *program-scope*,
+// not per-node. target_nodes specify where the SRAM (L1) cells live, but any kernel with a
+// noc-addressable view can signal or wait on it.
+//
 struct SemaphoreSpec {
     // Semaphore identifier: used to reference this Semaphore within the ProgramSpec
     SemaphoreSpecName unique_id;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
@@ -22,11 +22,17 @@ namespace tt::tt_metal::experimental::metal2_host_api {
 // Reusing a single constant helps catch typos and errors at compile time.
 using SemaphoreSpecName = std::string;
 
-// A SemaphoreSpec describes a semaphore, which can be used for kernel synchronization.
+// A SemaphoreSpec is a descriptor for a Tenstorrent semaphore,
+// which can be used for inter-kernel instance synchronization.
 //
-// Instancing: Unlike KernelSpec and DataflowBufferSpec, a SemaphoreSpec is *program-scope*,
-// not per-node. target_nodes specify where the SRAM (L1) cells live, but any kernel with a
-// noc-addressable view can signal or wait on it.
+// Instancing: One SRAM cell per node in the set of target_nodes,
+//
+// Placement: Specified directly via target_nodes (unlike Dataflow Buffers, semaphores
+// placement is not derived from kernel bindings).
+//
+// Binding scope: Program-scope. Any kernel can bind to any semaphore, regardless of
+// placement. Any kernel instance can signal or wait on any semaphore instance.
+// A SemaphoreSpec has *program-scope*, not per-node scope.
 //
 struct SemaphoreSpec {
     // Semaphore identifier: used to reference this Semaphore within the ProgramSpec

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -42,12 +42,16 @@ static constexpr uint32_t QUASAR_TENSIX_ENGINES_PER_NODE = 4;
 
 // Data structure built up from ProgramSpec to enable fast lookups
 struct CollectedSpecData {
-    // Name -> spec lookups
+    // Name -> spec lookups.
+    // dfb_by_name covers BOTH local and remote DFBs (for remote, the pointee is the
+    // inner dfb_spec). The is-it-remote question is answered by remote_dfb_by_name.
     std::unordered_map<KernelSpecName, const KernelSpec*> kernel_by_name;
     std::unordered_map<DFBSpecName, const DataflowBufferSpec*> dfb_by_name;
+    std::unordered_map<DFBSpecName, const RemoteDataflowBufferSpec*> remote_dfb_by_name;
     std::unordered_map<SemaphoreSpecName, const SemaphoreSpec*> semaphore_by_name;
 
-    // DFB endpoint info (derived from kernel bindings)
+    // DFB endpoint info (derived from kernel bindings).
+    // Populated for both local and remote DFBs.
     struct DFBEndpointInfo {
         const KernelSpec* producer = nullptr;
         const KernelSpec* consumer = nullptr;
@@ -55,6 +59,15 @@ struct CollectedSpecData {
         const KernelSpec::DFBBinding* consumer_binding = nullptr;
     };
     std::unordered_map<DFBSpecName, DFBEndpointInfo> dfb_endpoints;
+
+    // Worker membership: a kernel may belong to multiple WorkerSpecs.
+    std::unordered_map<KernelSpecName, std::vector<const WorkerSpec*>> kernel_workers;
+
+    // Derived node sets:
+    //  - kernel_node_set: union of containing WorkerSpec target_nodes
+    //  - dfb_node_set: union of binding-kernels' node sets (local DFBs only).
+    std::unordered_map<KernelSpecName, NodeRangeSet> kernel_node_set;
+    std::unordered_map<DFBSpecName, NodeRangeSet> dfb_node_set;
 };
 
 // Bitmask for tracking processor allocation on a node
@@ -141,40 +154,6 @@ bool nodes_intersect(
     return a_set.intersects(b_set);
 }
 
-bool nodes_contains(
-    const std::variant<NodeCoord, NodeRange, NodeRangeSet>& superset,
-    const std::variant<NodeCoord, NodeRange, NodeRangeSet>& subset) {
-    NodeRangeSet superset_node_range_set = to_node_range_set(superset);
-    NodeRangeSet subset_node_range_set = to_node_range_set(subset);
-    return superset_node_range_set.contains(subset_node_range_set);
-}
-
-// Compare two node specifications for semantic equality (same set of nodes).
-// This normalizes both sides before comparison because CoreRangeSet structural
-// equality can fail even when both sets cover identical nodes (e.g., two adjacent
-// single-node ranges vs. one merged range).
-bool nodes_equal(
-    const std::variant<NodeCoord, NodeRange, NodeRangeSet>& a,
-    const std::variant<NodeCoord, NodeRange, NodeRangeSet>& b) {
-    NodeRangeSet a_normalized = to_node_range_set(a).merge_ranges();
-    NodeRangeSet b_normalized = to_node_range_set(b).merge_ranges();
-    return a_normalized == b_normalized;
-}
-
-// Accumulate nodes into a map, merging with any existing entry.
-// Used to collect the union of all worker nodes for a given kernel/DFB.
-void accumulate_nodes(
-    std::unordered_map<std::string, NodeRangeSet>& node_map,
-    const std::string& key,
-    const std::variant<NodeCoord, NodeRange, NodeRangeSet>& nodes_to_add) {
-    NodeRangeSet nodes = to_node_range_set(nodes_to_add);
-    if (node_map.contains(key)) {
-        node_map[key] = node_map[key].merge(nodes);
-    } else {
-        node_map[key] = nodes;
-    }
-}
-
 // Local accessor names for kernel resource bindings must be valid C++ identifiers
 // They are used verbatim in the generated kernel source code.
 // TODO: Move this to ttsl in a follow up PR
@@ -253,10 +232,21 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
         TT_FATAL(inserted, "Duplicate KernelSpec name '{}'", kernel.unique_id);
     }
 
-    // Collect DataflowBufferSpecs
+    // Collect DataflowBufferSpecs (local DFBs)
     for (const auto& dfb : spec.dataflow_buffers) {
         auto [it, inserted] = collected.dfb_by_name.try_emplace(dfb.unique_id, &dfb);
         TT_FATAL(inserted, "Duplicate DataflowBufferSpec name '{}'", dfb.unique_id);
+    }
+
+    // Collect RemoteDataflowBufferSpecs (remote DFBs).
+    // Remote DFBs share the DFB name space with local DFBs, since kernel bindings
+    // refer to either kind by the same DFBSpecName.
+    for (const auto& remote_dfb : spec.remote_dataflow_buffers) {
+        const DFBSpecName& name = remote_dfb.dfb_spec.unique_id;
+        auto [it1, inserted1] = collected.dfb_by_name.try_emplace(name, &remote_dfb.dfb_spec);
+        TT_FATAL(inserted1, "Duplicate DataflowBufferSpec name '{}' (across local and remote DFBs)", name);
+        auto [it2, inserted2] = collected.remote_dfb_by_name.try_emplace(name, &remote_dfb);
+        TT_FATAL(inserted2, "Duplicate RemoteDataflowBufferSpec name '{}'", name);
     }
 
     // Build DFB endpoint info from kernel bindings
@@ -313,12 +303,19 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
         TT_FATAL(endpoint_info.consumer != nullptr, "DFB '{}' has no consumer", dfb_name);
     }
 
-    // Referential integrity: every declared DFB must be bound by some kernel
+    // Referential integrity: every declared DFB (local or remote) must be bound by some kernel
     for (const auto& dfb : spec.dataflow_buffers) {
         TT_FATAL(
             collected.dfb_endpoints.contains(dfb.unique_id),
             "DFB '{}' is defined but not bound by any kernel",
             dfb.unique_id);
+    }
+    for (const auto& remote_dfb : spec.remote_dataflow_buffers) {
+        const DFBSpecName& name = remote_dfb.dfb_spec.unique_id;
+        TT_FATAL(
+            collected.dfb_endpoints.contains(name),
+            "RemoteDataflowBufferSpec '{}' is defined but not bound by any kernel",
+            name);
     }
 
     // Collect SemaphoreSpecs
@@ -350,13 +347,53 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
         }
     }
 
-    // Check for duplicate WorkerSpec unique_ids (not collected)
-    if (spec.workers.has_value()) {
+    // Check for duplicate WorkerSpec unique_ids
+    {
         std::unordered_set<WorkerSpecName> worker_names;
-        for (const auto& worker : *spec.workers) {
+        for (const auto& worker : spec.workers) {
             auto [it, inserted] = worker_names.insert(worker.unique_id);
             TT_FATAL(inserted, "Duplicate WorkerSpec name '{}'", worker.unique_id);
         }
+    }
+
+    // Build WorkerSpec membership for each kernel, validating references along the way.
+    // A kernel may belong to multiple WorkerSpecs; its effective target node set is the union.
+    for (const auto& worker : spec.workers) {
+        for (const auto& kernel_name : worker.kernels) {
+            TT_FATAL(
+                collected.kernel_by_name.contains(kernel_name),
+                "WorkerSpec '{}' references unknown kernel '{}'",
+                worker.unique_id,
+                kernel_name);
+            collected.kernel_workers[kernel_name].push_back(&worker);
+        }
+    }
+
+    // Every declared kernel must be referenced by at least one WorkerSpec
+    // (otherwise, it has no node placement and would never run).
+    for (const auto& kernel : spec.kernels) {
+        TT_FATAL(
+            collected.kernel_workers.contains(kernel.unique_id),
+            "Kernel '{}' is not referenced by any WorkerSpec",
+            kernel.unique_id);
+    }
+
+    // Derive each kernel's effective target node set: union of containing WorkerSpec target_nodes.
+    for (const auto& [kernel_name, workers] : collected.kernel_workers) {
+        NodeRangeSet node_set;
+        for (const WorkerSpec* worker : workers) {
+            node_set = node_set.merge(to_node_range_set(worker->target_nodes));
+        }
+        collected.kernel_node_set[kernel_name] = node_set;
+    }
+
+    // Derive each local DFB's allocation node set: union of binding-kernels' node sets.
+    // (Collected, but unvalidated. Semantic integrity checks for DFB take place in ValidateProgramSpec.)
+    for (const auto& dfb : spec.dataflow_buffers) {
+        const auto& endpoints = collected.dfb_endpoints.at(dfb.unique_id);
+        NodeRangeSet node_set = collected.kernel_node_set.at(endpoints.producer->unique_id);
+        node_set = node_set.merge(collected.kernel_node_set.at(endpoints.consumer->unique_id));
+        collected.dfb_node_set[dfb.unique_id] = node_set;
     }
 
     return collected;
@@ -366,11 +403,12 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
 // ValidateNodeBounds: Node coordinate bounds checking
 // ----------------------------------------------------------------------------
 //
-// Validates that every NodeCoord referenced in kernels, DFBs, and semaphores
+// Validates that every NodeCoord referenced by a WorkerSpec or SemaphoreSpec
 // is within the compute worker grid on this device.
+// (Kernel and DFB placement is derived from WorkerSpec membership, so
+// bounds-checking the WorkerSpecs covers them too.)
 //
-// NOTE: We're dealing in logical coordinates, so harvesting is handled
-// transparently at the UMD coordinate-translation layer.
+// NOTE: We're dealing in logical coordinates. (Harvesting is handled by UMD.)
 //
 // ASSUMPTION: All chips in a MeshDevice are identical, so chip 0 is
 // representative of every device in the mesh.
@@ -420,11 +458,8 @@ void ValidateNodeBounds(const ProgramSpec& spec) {
         }
     };
 
-    for (const auto& kernel : spec.kernels) {
-        check_target_nodes(kernel.target_nodes, "KernelSpec", kernel.unique_id);
-    }
-    for (const auto& dfb : spec.dataflow_buffers) {
-        check_target_nodes(dfb.target_nodes, "DataflowBufferSpec", dfb.unique_id);
+    for (const auto& worker : spec.workers) {
+        check_target_nodes(worker.target_nodes, "WorkerSpec", worker.unique_id);
     }
     for (const auto& sem : spec.semaphores) {
         check_target_nodes(sem.target_nodes, "SemaphoreSpec", sem.unique_id);
@@ -581,6 +616,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     }
 
     // On Gen1 (WH/BH), check that no two DM kernels on the same node claim the same processor.
+    // (The kernel's effective node set is derived from WorkerSpec membership.)
     if (is_gen1_arch()) {
         // Maps (node, processor) -> the kernel that already claimed it
         std::map<std::pair<NodeCoord, DataMovementProcessor>, KernelSpecName> claimed;
@@ -590,7 +626,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             }
             const auto& dm_config = std::get<DataMovementConfiguration>(kernel.config_spec);
             const auto& gen1 = dm_config.gen1_data_movement_config.value();
-            const NodeRangeSet nodes = to_node_range_set(kernel.target_nodes);
+            const NodeRangeSet& nodes = collected.kernel_node_set.at(kernel.unique_id);
             for (const auto& range : nodes.ranges()) {
                 for (const auto& node : range) {
                     auto key = std::make_pair(node, gen1.processor);
@@ -625,12 +661,48 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // Validate DataflowBufferSpecs
     //////////////////////////////////
 
-    // Remote DFBs are not supported yet
+    // Validate local DFB endpoint placement:
+    // A local DFB's producer and consumer kernels must be on the same node (sharing SRAM memory).
+    // For this to be true, the producer and consumer kernels need IDENTICAL WorkerSpec membership.
+    auto kernel_worker_set = [&](const KernelSpecName& name) {
+        std::set<const WorkerSpec*> workers;
+        for (const WorkerSpec* w : collected.kernel_workers.at(name)) {
+            workers.insert(w);
+        }
+        return workers;
+    };
     for (const auto& dfb : spec.dataflow_buffers) {
-        TT_FATAL(!dfb.remote_dfb_info.has_value(), "Remote DFBs are not supported yet");
+        const auto& endpoints = collected.dfb_endpoints.at(dfb.unique_id);
+        const auto producer_workers = kernel_worker_set(endpoints.producer->unique_id);
+        const auto consumer_workers = kernel_worker_set(endpoints.consumer->unique_id);
+        TT_FATAL(
+            producer_workers == consumer_workers,
+            "Local DFB '{}' is bound by producer kernel '{}' and consumer kernel '{}', but they "
+            "do not share identical WorkerSpec membership. Local DFBs require both endpoints to "
+            "live on the same set of WorkerSpecs; either refactor the placement, or model this as "
+            "a RemoteDataflowBufferSpec.",
+            dfb.unique_id,
+            endpoints.producer->unique_id,
+            endpoints.consumer->unique_id);
     }
 
-    // Borrowed memory is not supported yet
+    // Validate remote DFB endpoint placement:
+    // The producer and consumer must not be on the same node.
+    for (const auto& remote_dfb : spec.remote_dataflow_buffers) {
+        const DFBSpecName& name = remote_dfb.dfb_spec.unique_id;
+        for (const auto& [p_node, c_node] : remote_dfb.producer_consumer_map) {
+            TT_FATAL(
+                p_node != c_node,
+                "RemoteDataflowBufferSpec '{}' has a producer-consumer map entry where the "
+                "producer node and the consumer node are the same ({}, {}). Same-node "
+                "communication should be modeled as a (local) DataflowBufferSpec.",
+                name,
+                p_node.x,
+                p_node.y);
+        }
+    }
+
+    // Borrowed memory is not yet implemented
     for (const auto& dfb : spec.dataflow_buffers) {
         TT_FATAL(
             !dfb.uses_borrowed_memory,
@@ -706,12 +778,8 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // Validate WorkerSpecs
     //////////////////////////////
 
-    // WorkerSpecs are now required for all architectures.
-    // NOTE: WorkerSpec data is strictly redundant, but improves clarity and messaging.
-    //       If it's hated, we can make it optional, and derive the WorkerSpec if absent.
-    //       (Only on WH/BH though, I definitely want to require it on Quasar.)
-    TT_FATAL(spec.workers.has_value(), "Workers are required");
-    const auto& workers = spec.workers.value();
+    // WorkerSpec is required: a valid ProgramSpec has at least one WorkerSpec.
+    const auto& workers = spec.workers;
     TT_FATAL(!workers.empty(), "At least one WorkerSpec is required");
 
     // WorkerSpecs may not overlap in their target nodes
@@ -733,31 +801,6 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // A WorkerSpec must have at least one kernel
     for (const auto& worker : workers) {
         TT_FATAL(!worker.kernels.empty(), "WorkerSpec '{}' has no kernels", worker.unique_id);
-    }
-
-    // WorkerSpec kernel/DFB/semaphore references must exist
-    for (const auto& worker : workers) {
-        for (const auto& kernel_name : worker.kernels) {
-            TT_FATAL(
-                collected.kernel_by_name.contains(kernel_name),
-                "WorkerSpec '{}' references unknown kernel '{}'",
-                worker.unique_id,
-                kernel_name);
-        }
-        for (const auto& dfb_name : worker.dataflow_buffers) {
-            TT_FATAL(
-                collected.dfb_by_name.contains(dfb_name),
-                "WorkerSpec '{}' references unknown DFB '{}'",
-                worker.unique_id,
-                dfb_name);
-        }
-        for (const auto& semaphore_name : worker.semaphores) {
-            TT_FATAL(
-                collected.semaphore_by_name.contains(semaphore_name),
-                "WorkerSpec '{}' references unknown semaphore '{}'",
-                worker.unique_id,
-                semaphore_name);
-        }
     }
 
     // Does the Worker have enough cores to run all of its kernels?
@@ -813,74 +856,11 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         TT_FATAL(num_compute_kernels <= 1, "WorkerSpec '{}' has more than one compute kernel", worker.unique_id);
     }
 
-    // Kernels in a WorkerSpec must contain the WorkerSpec's target nodes
-    for (const auto& worker : workers) {
-        for (const auto& kernel_name : worker.kernels) {
-            const auto& kernel_spec = collected.kernel_by_name.at(kernel_name);
-            TT_FATAL(
-                nodes_contains(kernel_spec->target_nodes, worker.target_nodes),
-                "Kernel '{}' target nodes must contain WorkerSpec '{}' target nodes",
-                kernel_name,
-                worker.unique_id);
-        }
-    }
-
-    // DFBs in a WorkerSpec must contain the WorkerSpec's target nodes
-    for (const auto& worker : workers) {
-        for (const auto& dfb_name : worker.dataflow_buffers) {
-            const auto& dfb_spec = collected.dfb_by_name.at(dfb_name);
-            TT_FATAL(
-                nodes_contains(dfb_spec->target_nodes, worker.target_nodes),
-                "DFB '{}' target nodes must contain WorkerSpec '{}' target nodes",
-                dfb_name,
-                worker.unique_id);
-        }
-    }
-
-    // Semaphores in a WorkerSpec must contain the WorkerSpec's target nodes
-    for (const auto& worker : workers) {
-        for (const auto& semaphore_name : worker.semaphores) {
-            const auto& semaphore_spec = collected.semaphore_by_name.at(semaphore_name);
-            TT_FATAL(
-                nodes_contains(semaphore_spec->target_nodes, worker.target_nodes),
-                "Semaphore '{}' target nodes must contain WorkerSpec '{}' target nodes",
-                semaphore_name,
-                worker.unique_id);
-        }
-    }
-
-    // Check that all kernel target nodes are "accounted for" by a WorkerSpec
-    std::unordered_map<KernelSpecName, NodeRangeSet> kernel_node_ranges;
-    for (const auto& worker : workers) {
-        for (const auto& kernel_name : worker.kernels) {
-            accumulate_nodes(kernel_node_ranges, kernel_name, worker.target_nodes);
-        }
-    }
-    for (const auto& kernel : spec.kernels) {
-        KernelSpecName kernel_name = kernel.unique_id;
-        TT_FATAL(kernel_node_ranges.contains(kernel_name), "Kernel '{}' is not part of any WorkerSpec", kernel_name);
-        TT_FATAL(
-            nodes_equal(kernel_node_ranges.at(kernel_name), kernel.target_nodes),
-            "Kernel '{}' has target nodes that are not accounted for by any WorkerSpec",
-            kernel_name);
-    }
-
-    // Check that all DFB target nodes are "accounted for" by a WorkerSpec
-    // (May revisit this, depending on how remote DFBs are implemented)
-    std::unordered_map<DFBSpecName, NodeRangeSet> dfb_node_ranges;
-    for (const auto& worker : workers) {
-        for (const auto& dfb_name : worker.dataflow_buffers) {
-            accumulate_nodes(dfb_node_ranges, dfb_name, worker.target_nodes);
-        }
-    }
-    for (const auto& dfb : spec.dataflow_buffers) {
-        DFBSpecName dfb_name = dfb.unique_id;
-        TT_FATAL(dfb_node_ranges.contains(dfb_name), "DFB '{}' is not part of any WorkerSpec", dfb_name);
-        TT_FATAL(
-            nodes_equal(dfb_node_ranges.at(dfb_name), dfb.target_nodes),
-            "DFB '{}' has target nodes that are not accounted for by any WorkerSpec",
-            dfb_name);
-    }
+    // NOTE:
+    // Placement consistency between kernels, DFBs, and WorkerSpecs is now structural,
+    // not validated:
+    //  - Kernels' effective node sets ARE the union of their containing WorkerSpecs' target_nodes
+    //  - DFBs' allocation node sets are the union of their binding kernels' node sets
 }
 
 // ============================================================================
@@ -983,6 +963,10 @@ ComputeEngineMask AssignComputeProcessors(const KernelSpec* kernel_spec, const K
 
 namespace dm_solver {
 
+// Map from kernel name to its derived effective node set (union of containing
+// WorkerSpec target_nodes). Used by the solver to read each kernel's placement.
+using KernelNodeSetMap = std::unordered_map<KernelSpecName, NodeRangeSet>;
+
 // State for tracking per-node processor usage
 class NodeUsageTracker {
 public:
@@ -1028,18 +1012,17 @@ private:
     std::map<NodeCoord, DMProcessorMask> node_used_masks_;
 };
 
-// Constraint score for sorting: higher = more constrained (should be assigned earlier)
-int ConstraintScore(const KernelSpec* k) {
-    NodeRangeSet nodes = to_node_range_set(k->target_nodes);
-    int node_count = static_cast<int>(nodes.num_cores());
+// Constraint score for sorting: higher = more constrained (RISC cores should be assigned earlier)
+int ConstraintScore(const KernelSpec* k, const NodeRangeSet& kernel_nodes) {
+    int node_count = static_cast<int>(kernel_nodes.num_cores());
     int thread_count = k->num_threads;
     return (node_count * 100) + thread_count;  // nodes dominate, threads break ties
 }
 
-void SortByConstraint(std::vector<const KernelSpec*>& kernels) {
-    std::sort(kernels.begin(), kernels.end(), [](const KernelSpec* a, const KernelSpec* b) {
-        int score_a = ConstraintScore(a);
-        int score_b = ConstraintScore(b);
+void SortByConstraint(std::vector<const KernelSpec*>& kernels, const KernelNodeSetMap& kernel_node_set) {
+    std::sort(kernels.begin(), kernels.end(), [&kernel_node_set](const KernelSpec* a, const KernelSpec* b) {
+        int score_a = ConstraintScore(a, kernel_node_set.at(a->unique_id));
+        int score_b = ConstraintScore(b, kernel_node_set.at(b->unique_id));
         if (score_a != score_b) {
             return score_a > score_b;  // Higher score first
         }
@@ -1051,9 +1034,12 @@ void SortByConstraint(std::vector<const KernelSpec*>& kernels) {
 // Try to assign all kernels in the given order using greedy selection
 // Returns true if successful, populates result map
 bool TryGreedyAssignment(
-    const std::vector<const KernelSpec*>& kernel_order, NodeUsageTracker& tracker, DMProcessorMaskMap& result) {
+    const std::vector<const KernelSpec*>& kernel_order,
+    const KernelNodeSetMap& kernel_node_set,
+    NodeUsageTracker& tracker,
+    DMProcessorMaskMap& result) {
     for (const KernelSpec* kernel : kernel_order) {
-        NodeRangeSet target_nodes = to_node_range_set(kernel->target_nodes);
+        const NodeRangeSet& target_nodes = kernel_node_set.at(kernel->unique_id);
         DMProcessorMask combined_used = tracker.get_combined_used_mask(target_nodes);
 
         auto selected = ReserveProcessors(kernel->num_threads, combined_used);
@@ -1076,10 +1062,11 @@ bool TryGreedyAssignment(
 //       We can revisit if this ever becomes a problem.
 bool SolveWithOrderingBacktrack(
     std::vector<const KernelSpec*> kernels,  // by value - we'll permute it
+    const KernelNodeSetMap& kernel_node_set,
     NodeUsageTracker& tracker,
     DMProcessorMaskMap& result) {
     // Try current ordering
-    if (TryGreedyAssignment(kernels, tracker, result)) {
+    if (TryGreedyAssignment(kernels, kernel_node_set, tracker, result)) {
         return true;
     }
 
@@ -1091,7 +1078,7 @@ bool SolveWithOrderingBacktrack(
     do {
         tracker.reset();
         result.clear();
-        if (TryGreedyAssignment(kernels, tracker, result)) {
+        if (TryGreedyAssignment(kernels, kernel_node_set, tracker, result)) {
             return true;
         }
     } while (std::next_permutation(kernels.begin(), kernels.end(), by_name));
@@ -1103,7 +1090,7 @@ bool SolveWithOrderingBacktrack(
 
 // Gen2 (Quasar) processor assignment: runs the backtracking DM solver and returns
 // a KernelRiscMaskMap using the Gen2 bit encoding (DM: bits 0-7, compute: bits 8-15).
-KernelRiscMaskMap SolveGen2KernelRiscMasks(const ProgramSpec& spec) {
+KernelRiscMaskMap SolveGen2KernelRiscMasks(const ProgramSpec& spec, const CollectedSpecData& collected) {
     DMProcessorMaskMap dm_assignments;
     ComputeEngineMaskMap compute_assignments;
 
@@ -1121,12 +1108,13 @@ KernelRiscMaskMap SolveGen2KernelRiscMasks(const ProgramSpec& spec) {
     // Sort by constraint score (most constrained first)
     constexpr bool kSortByConstraint = true;  // Toggle to disable upfront sorting
     if constexpr (kSortByConstraint) {
-        dm_solver::SortByConstraint(dm_kernels);
+        dm_solver::SortByConstraint(dm_kernels, collected.kernel_node_set);
     }
 
     // Solve DM assignments
     dm_solver::NodeUsageTracker tracker;
-    bool success = dm_solver::SolveWithOrderingBacktrack(dm_kernels, tracker, dm_assignments);
+    bool success =
+        dm_solver::SolveWithOrderingBacktrack(dm_kernels, collected.kernel_node_set, tracker, dm_assignments);
 
     TT_FATAL(
         success,
@@ -1436,11 +1424,21 @@ Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation) {
         ValidateProgramSpec(spec, collected);
     }
 
+    // Runtime feature gate (always on — outside the skip_validation block, since the build
+    // path below has no support for remote DFBs and would silently drop them on the floor).
+    // Remove this once runtime support for remote DFBs lands.
+    TT_FATAL(
+        spec.remote_dataflow_buffers.empty(),
+        "RemoteDataflowBufferSpec is part of the Metal 2.0 API surface but is not yet supported "
+        "by the runtime. (ProgramSpec '{}' has {} remote DFB(s).)",
+        spec.program_id,
+        spec.remote_dataflow_buffers.size());
+
     // Step 2: Build kernel risc masks (arch-specific)
     //  - Gen2: backtracking solver assigns DM cores automatically
     //  - Gen1: processor is user-specified in Gen1DataMovementConfig
     KernelRiscMaskMap kernel_to_risc_mask =
-        is_gen2_arch() ? SolveGen2KernelRiscMasks(spec) : BuildGen1KernelRiscMasks(spec);
+        is_gen2_arch() ? SolveGen2KernelRiscMasks(spec, collected) : BuildGen1KernelRiscMasks(spec);
 
     // Step 3: Build the Program
     auto program_impl = std::make_shared<detail::ProgramImpl>();
@@ -1455,8 +1453,9 @@ Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation) {
         const experimental::dfb::DataflowBufferConfig config =
             MakeDataflowBufferConfig(&dfb_spec, dfb_endpoint_info, kernel_to_risc_mask);
 
-        // Add the DFB to the ProgramImpl, and register the name -> handle mapping
-        uint32_t dfb_id = program_impl->add_dataflow_buffer(to_node_range_set(dfb_spec.target_nodes), config);
+        // Add the DFB to the ProgramImpl, and register the name -> handle mapping.
+        // Allocation nodes are derived from binding kernels' WorkerSpec membership.
+        uint32_t dfb_id = program_impl->add_dataflow_buffer(collected.dfb_node_set.at(dfb_name), config);
         program_impl->register_dfb_spec_name(dfb_name, dfb_id);
         dfb_name_to_id[dfb_name] = dfb_id;
     }
@@ -1475,7 +1474,7 @@ Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation) {
     // Create Kernels (arch-specific)
     for (const KernelSpec& kernel_spec : spec.kernels) {
         KernelSource kernel_src = MakeKernelSource(kernel_spec);
-        NodeRangeSet node_ranges = to_node_range_set(kernel_spec.target_nodes);
+        const NodeRangeSet& node_ranges = collected.kernel_node_set.at(kernel_spec.unique_id);
 
         // Make the local accessor name -> DFB ID map for this kernel
         const tt::tt_metal::DataflowBufferLocalAccessorHandleMap dfb_handles =
@@ -1571,8 +1570,7 @@ Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation) {
         runtime_schema.named_runtime_args = user_schema.named_runtime_args;
         runtime_schema.named_common_runtime_args = user_schema.named_common_runtime_args;
         if (user_schema.num_runtime_varargs > 0) {
-            const NodeRangeSet target_nodes = to_node_range_set(kernel_spec.target_nodes);
-            for (const NodeRange& range : target_nodes.ranges()) {
+            for (const NodeRange& range : node_ranges.ranges()) {
                 for (const NodeCoord& node : range) {
                     runtime_schema.num_runtime_varargs_per_node[node] = user_schema.num_runtime_varargs;
                 }

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -60,11 +60,11 @@ struct CollectedSpecData {
     };
     std::unordered_map<DFBSpecName, DFBEndpointInfo> dfb_endpoints;
 
-    // Worker membership: a kernel may belong to multiple WorkerSpecs.
-    std::unordered_map<KernelSpecName, std::vector<const WorkerSpec*>> kernel_workers;
+    // WorkUnit membership: a kernel may belong to multiple WorkUnitSpecs.
+    std::unordered_map<KernelSpecName, std::vector<const WorkUnitSpec*>> kernel_work_units;
 
     // Derived node sets:
-    //  - kernel_node_set: union of containing WorkerSpec target_nodes
+    //  - kernel_node_set: union of containing WorkUnitSpec target_nodes
     //  - dfb_node_set: union of binding-kernels' node sets (local DFBs only).
     std::unordered_map<KernelSpecName, NodeRangeSet> kernel_node_set;
     std::unordered_map<DFBSpecName, NodeRangeSet> dfb_node_set;
@@ -347,42 +347,42 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
         }
     }
 
-    // Check for duplicate WorkerSpec unique_ids
+    // Check for duplicate WorkUnitSpec unique_ids
     {
-        std::unordered_set<WorkerSpecName> worker_names;
-        for (const auto& worker : spec.workers) {
-            auto [it, inserted] = worker_names.insert(worker.unique_id);
-            TT_FATAL(inserted, "Duplicate WorkerSpec name '{}'", worker.unique_id);
+        std::unordered_set<WorkUnitSpecName> work_unit_names;
+        for (const auto& work_unit : spec.work_units) {
+            auto [it, inserted] = work_unit_names.insert(work_unit.unique_id);
+            TT_FATAL(inserted, "Duplicate WorkUnitSpec name '{}'", work_unit.unique_id);
         }
     }
 
-    // Build WorkerSpec membership for each kernel, validating references along the way.
-    // A kernel may belong to multiple WorkerSpecs; its effective target node set is the union.
-    for (const auto& worker : spec.workers) {
-        for (const auto& kernel_name : worker.kernels) {
+    // Build WorkUnitSpec membership for each kernel, validating references along the way.
+    // A kernel may belong to multiple WorkUnitSpecs; its effective target node set is the union.
+    for (const auto& work_unit : spec.work_units) {
+        for (const auto& kernel_name : work_unit.kernels) {
             TT_FATAL(
                 collected.kernel_by_name.contains(kernel_name),
-                "WorkerSpec '{}' references unknown kernel '{}'",
-                worker.unique_id,
+                "WorkUnitSpec '{}' references unknown kernel '{}'",
+                work_unit.unique_id,
                 kernel_name);
-            collected.kernel_workers[kernel_name].push_back(&worker);
+            collected.kernel_work_units[kernel_name].push_back(&work_unit);
         }
     }
 
-    // Every declared kernel must be referenced by at least one WorkerSpec
+    // Every declared kernel must be referenced by at least one WorkUnitSpec
     // (otherwise, it has no node placement and would never run).
     for (const auto& kernel : spec.kernels) {
         TT_FATAL(
-            collected.kernel_workers.contains(kernel.unique_id),
-            "Kernel '{}' is not referenced by any WorkerSpec",
+            collected.kernel_work_units.contains(kernel.unique_id),
+            "Kernel '{}' is not referenced by any WorkUnitSpec",
             kernel.unique_id);
     }
 
-    // Derive each kernel's effective target node set: union of containing WorkerSpec target_nodes.
-    for (const auto& [kernel_name, workers] : collected.kernel_workers) {
+    // Derive each kernel's effective target node set: union of containing WorkUnitSpec target_nodes.
+    for (const auto& [kernel_name, work_units] : collected.kernel_work_units) {
         NodeRangeSet node_set;
-        for (const WorkerSpec* worker : workers) {
-            node_set = node_set.merge(to_node_range_set(worker->target_nodes));
+        for (const WorkUnitSpec* work_unit : work_units) {
+            node_set = node_set.merge(to_node_range_set(work_unit->target_nodes));
         }
         collected.kernel_node_set[kernel_name] = node_set;
     }
@@ -403,10 +403,10 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
 // ValidateNodeBounds: Node coordinate bounds checking
 // ----------------------------------------------------------------------------
 //
-// Validates that every NodeCoord referenced by a WorkerSpec or SemaphoreSpec
+// Validates that every NodeCoord referenced by a WorkUnitSpec or SemaphoreSpec
 // is within the compute worker grid on this device.
-// (Kernel and DFB placement is derived from WorkerSpec membership, so
-// bounds-checking the WorkerSpecs covers them too.)
+// (Kernel and DFB placement is derived from WorkUnitSpec membership, so
+// bounds-checking the WorkUnitSpecs covers them too.)
 //
 // NOTE: We're dealing in logical coordinates. (Harvesting is handled by UMD.)
 //
@@ -458,8 +458,8 @@ void ValidateNodeBounds(const ProgramSpec& spec) {
         }
     };
 
-    for (const auto& worker : spec.workers) {
-        check_target_nodes(worker.target_nodes, "WorkerSpec", worker.unique_id);
+    for (const auto& work_unit : spec.work_units) {
+        check_target_nodes(work_unit.target_nodes, "WorkUnitSpec", work_unit.unique_id);
     }
     for (const auto& sem : spec.semaphores) {
         check_target_nodes(sem.target_nodes, "SemaphoreSpec", sem.unique_id);
@@ -473,7 +473,7 @@ void ValidateNodeBounds(const ProgramSpec& spec) {
 //   - Architecture requirements
 //   - Resource limits
 //   - Feature support
-//   - Target node constraints (worker overlap, node coverage, node validity)
+//   - Target node constraints (work_unit overlap, node coverage, node validity)
 //
 // Assumes CollectedSpecData is already built.
 
@@ -616,7 +616,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     }
 
     // On Gen1 (WH/BH), check that no two DM kernels on the same node claim the same processor.
-    // (The kernel's effective node set is derived from WorkerSpec membership.)
+    // (The kernel's effective node set is derived from WorkUnitSpec membership.)
     if (is_gen1_arch()) {
         // Maps (node, processor) -> the kernel that already claimed it
         std::map<std::pair<NodeCoord, DataMovementProcessor>, KernelSpecName> claimed;
@@ -663,23 +663,23 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
 
     // Validate local DFB endpoint placement:
     // A local DFB's producer and consumer kernels must be on the same node (sharing SRAM memory).
-    // For this to be true, the producer and consumer kernels need IDENTICAL WorkerSpec membership.
-    auto kernel_worker_set = [&](const KernelSpecName& name) {
-        std::set<const WorkerSpec*> workers;
-        for (const WorkerSpec* w : collected.kernel_workers.at(name)) {
-            workers.insert(w);
+    // For this to be true, the producer and consumer kernels need IDENTICAL WorkUnitSpec membership.
+    auto kernel_work_unit_set = [&](const KernelSpecName& name) {
+        std::set<const WorkUnitSpec*> work_units;
+        for (const WorkUnitSpec* w : collected.kernel_work_units.at(name)) {
+            work_units.insert(w);
         }
-        return workers;
+        return work_units;
     };
     for (const auto& dfb : spec.dataflow_buffers) {
         const auto& endpoints = collected.dfb_endpoints.at(dfb.unique_id);
-        const auto producer_workers = kernel_worker_set(endpoints.producer->unique_id);
-        const auto consumer_workers = kernel_worker_set(endpoints.consumer->unique_id);
+        const auto producer_work_units = kernel_work_unit_set(endpoints.producer->unique_id);
+        const auto consumer_work_units = kernel_work_unit_set(endpoints.consumer->unique_id);
         TT_FATAL(
-            producer_workers == consumer_workers,
+            producer_work_units == consumer_work_units,
             "Local DFB '{}' is bound by producer kernel '{}' and consumer kernel '{}', but they "
-            "do not share identical WorkerSpec membership. Local DFBs require both endpoints to "
-            "live on the same set of WorkerSpecs; either refactor the placement, or model this as "
+            "do not share identical WorkUnitSpec membership. Local DFBs require both endpoints to "
+            "live on the same set of WorkUnitSpecs; either refactor the placement, or model this as "
             "a RemoteDataflowBufferSpec.",
             dfb.unique_id,
             endpoints.producer->unique_id,
@@ -775,39 +775,39 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     }
 
     //////////////////////////////
-    // Validate WorkerSpecs
+    // Validate WorkUnitSpecs
     //////////////////////////////
 
-    // WorkerSpec is required: a valid ProgramSpec has at least one WorkerSpec.
-    const auto& workers = spec.workers;
-    TT_FATAL(!workers.empty(), "At least one WorkerSpec is required");
+    // WorkUnitSpec is required: a valid ProgramSpec has at least one WorkUnitSpec.
+    const auto& work_units = spec.work_units;
+    TT_FATAL(!work_units.empty(), "At least one WorkUnitSpec is required");
 
-    // WorkerSpecs may not overlap in their target nodes
-    for (const auto& worker : workers) {
-        for (const auto& other_worker : workers) {
-            if (worker.unique_id == other_worker.unique_id) {
+    // WorkUnitSpecs may not overlap in their target nodes
+    for (const auto& work_unit : work_units) {
+        for (const auto& other_work_unit : work_units) {
+            if (work_unit.unique_id == other_work_unit.unique_id) {
                 continue;
             }
-            if (nodes_intersect(worker.target_nodes, other_worker.target_nodes)) {
+            if (nodes_intersect(work_unit.target_nodes, other_work_unit.target_nodes)) {
                 TT_FATAL(
                     false,
-                    "WorkerSpecs '{}' and '{}' overlap in target nodes",
-                    worker.unique_id,
-                    other_worker.unique_id);
+                    "WorkUnitSpecs '{}' and '{}' overlap in target nodes",
+                    work_unit.unique_id,
+                    other_work_unit.unique_id);
             }
         }
     }
 
-    // A WorkerSpec must have at least one kernel
-    for (const auto& worker : workers) {
-        TT_FATAL(!worker.kernels.empty(), "WorkerSpec '{}' has no kernels", worker.unique_id);
+    // A WorkUnitSpec must have at least one kernel
+    for (const auto& work_unit : work_units) {
+        TT_FATAL(!work_unit.kernels.empty(), "WorkUnitSpec '{}' has no kernels", work_unit.unique_id);
     }
 
-    // Does the Worker have enough cores to run all of its kernels?
-    for (const auto& worker : workers) {
+    // Does the WorkUnit have enough cores to run all of its kernels?
+    for (const auto& work_unit : work_units) {
         uint32_t dm_cores_needed = 0;
         uint32_t compute_engines_needed = 0;
-        for (const auto& kernel_name : worker.kernels) {
+        for (const auto& kernel_name : work_unit.kernels) {
             const auto& kernel_spec = collected.kernel_by_name.at(kernel_name);
             if (kernel_spec->is_compute_kernel()) {
                 compute_engines_needed += kernel_spec->num_threads;
@@ -819,47 +819,47 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         if (is_gen2_arch()) {
             TT_FATAL(
                 compute_engines_needed <= QUASAR_TENSIX_ENGINES_PER_NODE,
-                "WorkerSpec '{}' needs {} Tensix engines, but only {} are available",
-                worker.unique_id,
+                "WorkUnitSpec '{}' needs {} Tensix engines, but only {} are available",
+                work_unit.unique_id,
                 compute_engines_needed,
                 QUASAR_TENSIX_ENGINES_PER_NODE);
             TT_FATAL(
                 dm_cores_needed <= QUASAR_USER_DM_CORES_PER_NODE,
-                "WorkerSpec '{}' requests {} data movement cores. This exceeds the permitted maximum of {}.",
-                worker.unique_id,
+                "WorkUnitSpec '{}' requests {} data movement cores. This exceeds the permitted maximum of {}.",
+                work_unit.unique_id,
                 dm_cores_needed,
                 QUASAR_USER_DM_CORES_PER_NODE);
         }
         if (is_gen1_arch()) {
             TT_FATAL(
                 compute_engines_needed <= 1,
-                "WorkerSpec '{}' has {} compute kernels. The target architecture supports at most one.",
-                worker.unique_id,
+                "WorkUnitSpec '{}' has {} compute kernels. The target architecture supports at most one.",
+                work_unit.unique_id,
                 compute_engines_needed);
             TT_FATAL(
                 dm_cores_needed <= 2,
-                "WorkerSpec '{}' has {} data movement kernels. The target architecture supports at most two.",
-                worker.unique_id,
+                "WorkUnitSpec '{}' has {} data movement kernels. The target architecture supports at most two.",
+                work_unit.unique_id,
                 dm_cores_needed);
         }
     }
 
-    // A worker can have at most one compute kernel
-    for (const auto& worker : workers) {
+    // A work_unit can have at most one compute kernel
+    for (const auto& work_unit : work_units) {
         uint32_t num_compute_kernels = 0;
-        for (const auto& kernel_name : worker.kernels) {
+        for (const auto& kernel_name : work_unit.kernels) {
             const auto& kernel_spec = collected.kernel_by_name.at(kernel_name);
             if (kernel_spec->is_compute_kernel()) {
                 num_compute_kernels++;
             }
         }
-        TT_FATAL(num_compute_kernels <= 1, "WorkerSpec '{}' has more than one compute kernel", worker.unique_id);
+        TT_FATAL(num_compute_kernels <= 1, "WorkUnitSpec '{}' has more than one compute kernel", work_unit.unique_id);
     }
 
     // NOTE:
-    // Placement consistency between kernels, DFBs, and WorkerSpecs is now structural,
+    // Placement consistency between kernels, DFBs, and WorkUnitSpecs is now structural,
     // not validated:
-    //  - Kernels' effective node sets ARE the union of their containing WorkerSpecs' target_nodes
+    //  - Kernels' effective node sets ARE the union of their containing WorkUnitSpecs' target_nodes
     //  - DFBs' allocation node sets are the union of their binding kernels' node sets
 }
 
@@ -894,28 +894,28 @@ std::optional<ProcessorMask<NUM_CORES>> ReserveProcessors(uint8_t n, const Proce
     return newly_reserved;
 }
 
-// Reserve DM processors for a kernel on a WorkerSpec.
+// Reserve DM processors for a kernel on a WorkUnitSpec.
 // Returns {this_kernel_mask, updated_cumulative_mask}
 // Throws TT_FATAL on conflict or allocation failure (see simplifying assumption notes)
 std::pair<DMProcessorMask, DMProcessorMask> ReserveDMProcessors(
     const KernelSpec* kernel_spec,
     std::optional<DMProcessorMask> existing_mask,
     DMProcessorMask cumulative_mask,
-    const WorkerSpecName& worker_id) {
-    // Was this kernel already assigned a mask from a previous WorkerSpec?
+    const WorkUnitSpecName& work_unit_id) {
+    // Was this kernel already assigned a mask from a previous WorkUnitSpec?
     if (existing_mask.has_value()) {
         DMProcessorMask existing = existing_mask.value();
 
-        // Check for conflict with what's already allocated on the current WorkerSpec
+        // Check for conflict with what's already allocated on the current WorkUnitSpec
         TT_FATAL(
             !existing.conflicts_with(cumulative_mask),
-            "Kernel '{}' requires processors already in use on WorkerSpec '{}'. "
+            "Kernel '{}' requires processors already in use on WorkUnitSpec '{}'. "
             "One of the following must be true: \n"
             " - The ProgramSpec is invalid, and the legality checks were bypassed. \n"
             " - A solution exists, but the greedy algorithm failed to find it. \n"
             " - The runtime's \"common DM cores\" assumption has been violated!",
             kernel_spec->unique_id,
-            worker_id);
+            work_unit_id);
 
         // Return existing mask and updated cumulative
         return {existing, cumulative_mask | existing};
@@ -925,10 +925,10 @@ std::pair<DMProcessorMask, DMProcessorMask> ReserveDMProcessors(
     std::optional<DMProcessorMask> reserved = ReserveProcessors(kernel_spec->num_threads, cumulative_mask);
     TT_FATAL(
         reserved.has_value(),
-        "Failed to reserve processors for DM kernel '{}' on WorkerSpec '{}'. "
+        "Failed to reserve processors for DM kernel '{}' on WorkUnitSpec '{}'. "
         "The \"common DM cores\" assumption has been violated!",
         kernel_spec->unique_id,
-        worker_id);
+        work_unit_id);
 
     DMProcessorMask mask = reserved.value();
     return {mask, cumulative_mask | mask};
@@ -964,7 +964,7 @@ ComputeEngineMask AssignComputeProcessors(const KernelSpec* kernel_spec, const K
 namespace dm_solver {
 
 // Map from kernel name to its derived effective node set (union of containing
-// WorkerSpec target_nodes). Used by the solver to read each kernel's placement.
+// WorkUnitSpec target_nodes). Used by the solver to read each kernel's placement.
 using KernelNodeSetMap = std::unordered_map<KernelSpecName, NodeRangeSet>;
 
 // State for tracking per-node processor usage
@@ -1454,7 +1454,7 @@ Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation) {
             MakeDataflowBufferConfig(&dfb_spec, dfb_endpoint_info, kernel_to_risc_mask);
 
         // Add the DFB to the ProgramImpl, and register the name -> handle mapping.
-        // Allocation nodes are derived from binding kernels' WorkerSpec membership.
+        // Allocation nodes are derived from binding kernels' WorkUnitSpec membership.
         uint32_t dfb_id = program_impl->add_dataflow_buffer(collected.dfb_node_set.at(dfb_name), config);
         program_impl->register_dfb_spec_name(dfb_name, dfb_id);
         dfb_name_to_id[dfb_name] = dfb_id;


### PR DESCRIPTION
## PR Type
Refactor

## Summary
This PR makes a non-trivial semantic change to how the Metal 2.0 host APIs specify the target nodes for kernels, DFBs, and semaphores. 

### Motivation / Problem
Human and AI feedback on the original APIs:

- The old definition of `WorkerSpec` was confusing (to humans).
- The original mechanism for specifying target nodes contained unnecessary redundancy. This trips up an AI author because it increases the error surface (need keep different sets of specified target nodes, in conceptually different spots, aligned) and because any mistakes manifest as runtime validation checks, not compile time errors.

Unnecessary redundancy in the original API definition:
 1. _Local DFB target nodes_: A local DFB (i.e. one without the remote "pairs" spec) had a `target_nodes` field. But, this info can be trivially inferred from its kernel bindings. 
 2. `WorkerSpec` _target nodes_: The `WorkerSpec` target nodes was redundant with the target_nodes specified by both the kernel and DFB specs.

The redundancies were the result of a compromise: We wanted to introduce `WorkerSpec`, but also maintain alignment with the legacy APIs. The compromise was bad.

### New Design

The refactor removes the unnecessary redundancies, and communicates the programming model more clearly (hopefully).
 
 1. `WorkerSpec` is renamed to `WorkUnitSpec`. 
          - "Worker" refers to a structure in the hardware. A "work unit" is its software counterpart: the set of kernels assigned to a worker.
          - _Note_: `WorkUnitSpec` is now pretty much the same concept as `KernelGroup` in the runtime internals. (I considered `KernelGroupSpec` but abandoned it. The subtle concept aliasing and grep hits could confuse AI authors; I also think it lacks intuition-grab.)
 2. `WorkUnitSpec` references kernels only (not DFBs or semaphores)
            - Referencing DFBs is redundant with kernel endpoint bindings.
            - Referencing semaphores never really made sense. Kernel semaphore binding has no implied locality.
 3. `KernelSpec` and `DataflowBufferSpec` both lose their `target_nodes` fields
           - Kernel nodes are now inferred from the `WorkUnitSpec`.
           - DFB nodes are transitively inferred from the kernel endpoint bindings.

I also overhauled the header comments pertaining to node placement / locations of things.

## Notes to Reviewers

The important changes are those to the API headers. The rest of the diff is just mechanically propagating the API changes through the implementation and tests.

## Future Work
Optimization: rework the backend so that the runtime can take advantage of the kernel groups in the API. Right now, I'm just sitting on top of the old APIs, so I discard this information and the runtime implementation reconstructs it later.


