### PR TITLE
[Feature]: Adding intra-tensix DFBs (packer producer and unpacker consumer)

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -1056,4 +1056,213 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Bool(),
     ImplicitSyncParamName);
 
+// Runs an intra-tensix DFB program on one core.
+static void run_intra_tensix_dfb_program(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    uint32_t entry_size,
+    uint32_t num_entries,
+    uint32_t num_threads) {
+    IDevice* device = mesh_device->get_devices()[0];
+
+    experimental::dfb::DataflowBufferConfig dfb_config{
+        .entry_size = entry_size,
+        .num_entries = num_entries,
+        .num_producers = num_threads,
+        .pap = dfb::AccessPattern::STRIDED,
+        .num_consumers = num_threads,
+        .cap = dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = false,
+        .tensix_scope = experimental::dfb::TensixScope::INTRA};
+
+    Program program = CreateProgram();
+    CoreCoord logical_core = CoreCoord(0, 0);
+    CoreRangeSet core_range_set(CoreRange(logical_core, logical_core));
+
+    const uint32_t words_per_entry = entry_size / sizeof(uint32_t);
+
+    TT_FATAL(
+        num_entries % num_threads == 0,
+        "num_entries ({}) must be divisible by num_threads ({}) for intra-tensix block partitioning",
+        num_entries, num_threads);
+    const uint32_t entries_per_neo = num_entries / num_threads;
+
+    const std::string intra_kernel_path = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra.cpp";
+    std::vector<uint32_t> cta = {entries_per_neo, words_per_entry};
+
+    KernelHandle compute_kernel = CreateKernel(
+        program,
+        intra_kernel_path,
+        core_range_set,
+        experimental::quasar::QuasarComputeConfig{
+            .num_threads_per_cluster = num_threads,
+            .compile_args = cta});
+
+    auto logical_dfb_id = experimental::dfb::CreateDataflowBuffer(program, core_range_set, dfb_config);
+    // Bind the same kernel as both producer and consumer: packer TRISC2 and unpacker TRISC0
+    // on each Neo share the Tensix-only TC allocated for that Neo.
+    experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+        program, logical_dfb_id, compute_kernel, compute_kernel);
+
+    const uint32_t total_size = num_entries * entry_size;
+    auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(
+        0, 100, total_size / sizeof(uint32_t));
+
+    const uint32_t dfb_l1_addr =
+        static_cast<uint32_t>(device->allocator()->get_base_allocator_addr(HalMemType::L1));
+
+    detail::WriteToDeviceL1(device, logical_core, dfb_l1_addr, input);
+
+    detail::LaunchProgram(device, program, true /*wait_until_cores_done*/);
+
+    // Packer increments each word by 1, then unpacker increments it by 1 → +2 per word.
+    // This holds for every Neo's ring independently, so the entire L1 region is input + 2.
+    std::vector<uint32_t> expected(input.size());
+    for (size_t i = 0; i < input.size(); i++) {
+        expected[i] = input[i] + 2;
+    }
+
+    std::vector<uint32_t> l1_data;
+    detail::ReadFromDeviceL1(device, logical_core, dfb_l1_addr, total_size, l1_data);
+    EXPECT_EQ(expected, l1_data) << "Intra-tensix DFB L1 mismatch";
+}
+
+TEST_F(MeshDeviceFixture, TensixIntraTest1xDFB1Sx1S) {
+    run_intra_tensix_dfb_program(this->devices_.at(0), /*entry_size=*/1024, /*num_entries=*/16, /*num_threads=*/1);
+}
+
+TEST_F(MeshDeviceFixture, TensixIntraTest1xDFB4Sx4S) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping intra-tensix DFB test for WH/BH until DFB is backported";
+    }
+    run_intra_tensix_dfb_program(this->devices_.at(0), /*entry_size=*/1024, /*num_entries=*/16, /*num_threads=*/4);
+}
+
+TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4B) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping combined intra-tensix + remapper DFB test for WH/BH until DFB is backported";
+    }
+
+    IDevice* device = this->devices_.at(0)->get_devices()[0];
+    CoreCoord logical_core(0, 0);
+    CoreRangeSet core_range_set(CoreRange(logical_core, logical_core));
+
+    constexpr uint32_t entry_size  = 1024;
+    constexpr uint32_t num_entries = 16;
+    constexpr uint32_t num_neos    = 4;
+    const uint32_t words_per_entry = entry_size / sizeof(uint32_t);
+    const uint32_t entries_per_neo = num_entries / num_neos;  // = 4
+
+    // dfb(0): DM->Tensix, 1Sx4B with remapper, implicit sync enabled.
+    experimental::dfb::DataflowBufferConfig remapper_dfb_config{
+        .entry_size           = entry_size,
+        .num_entries          = num_entries,
+        .num_producers        = 1,
+        .pap                  = dfb::AccessPattern::STRIDED,
+        .num_consumers        = num_neos,
+        .cap                  = dfb::AccessPattern::ALL,
+        .enable_implicit_sync = true};
+
+    // dfb(1): intra-tensix, 4 packer->unpacker pairs, hidden TCs.
+    experimental::dfb::DataflowBufferConfig intra_dfb_config{
+        .entry_size           = entry_size,
+        .num_entries          = num_entries,
+        .num_producers        = num_neos,
+        .pap                  = dfb::AccessPattern::STRIDED,
+        .num_consumers        = num_neos,
+        .cap                  = dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = false,
+        .tensix_scope         = experimental::dfb::TensixScope::INTRA};
+
+    const uint32_t buf_size = num_entries * entry_size;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    distributed::DeviceLocalBufferConfig local_cfg{.page_size = entry_size, .buffer_type = BufferType::DRAM};
+    auto in_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = buf_size}, local_cfg, this->devices_.at(0).get());
+
+    Program program = CreateProgram();
+
+    // DM producer (1 thread, implicit sync enabled): reads DRAM in_buffer -> dfb(0) via NOC.
+    std::vector<uint32_t> dm_cta = {
+        (uint32_t)in_buffer->address(),
+        num_entries,   // num_entries_per_producer: 1 producer owns all entries
+        1u,            // implicit_sync = true
+        0u};           // consume_all = false (producer is always STRIDED)
+    tt::tt_metal::TensorAccessorArgs(in_buffer).append_to(dm_cta);
+
+    auto dm_producer_kernel = experimental::quasar::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
+        core_range_set,
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = 1, .compile_args = dm_cta});
+
+    // Create DFBs: remapper first (-> logical ID 0), intra-tensix second (-> logical ID 1).
+    auto remapper_dfb_id = experimental::dfb::CreateDataflowBuffer(program, core_range_set, remapper_dfb_config);
+    auto intra_dfb_id    = experimental::dfb::CreateDataflowBuffer(program, core_range_set, intra_dfb_config);
+
+    // Combined compute kernel (4 Neo clusters):
+    //   CTA[0] = num_entries      - ALL consumer loop count (each UNPACK sees all 16 entries)
+    //   CTA[1] = entries_per_neo  - intra-tensix loop count per Neo (= 4)
+    //   CTA[2] = words_per_entry  - words per dfb(1) entry for in-place increment
+    std::vector<uint32_t> compute_cta = {num_entries, entries_per_neo, words_per_entry};
+
+    auto compute_kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/compute/dfb_intra_and_consume_all.cpp",
+        core_range_set,
+        experimental::quasar::QuasarComputeConfig{
+            .num_threads_per_cluster = num_neos, .compile_args = compute_cta});
+
+    // dfb(0): DM producer -> compute ALL consumer (remapper fans out 1 TC post to 4 UNPACK TCs).
+    experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+        program, remapper_dfb_id, dm_producer_kernel, compute_kernel);
+    // dfb(1): compute kernel is both producer (PACK TRISC) and consumer (UNPACK TRISC).
+    experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+        program, intra_dfb_id, compute_kernel, compute_kernel);
+
+    // Runtime args for DM producer (dfb_producer.cpp: [0]=producer_mask, [1]=chunk_offset).
+    auto remapper_dfb_impl = program.impl().get_dataflow_buffer(remapper_dfb_id);
+    const uint32_t dm_producer_mask = remapper_dfb_impl->config.producer_risc_mask;
+    SetRuntimeArgs(program, dm_producer_kernel, logical_core, {dm_producer_mask, 0u /*chunk_offset*/});
+
+    // L1 layout follows DFB creation order:
+    //   [l1_base + 0              ] -> dfb(0) remapper ring  (num_entries * entry_size bytes)
+    //   [l1_base + remapper_size  ] -> dfb(1) intra ring     (num_entries * entry_size bytes)
+    const uint32_t l1_base           = static_cast<uint32_t>(device->allocator()->get_base_allocator_addr(HalMemType::L1));
+    const uint32_t remapper_ring_size = num_entries * entry_size;
+    const uint32_t intra_l1_addr     = l1_base + remapper_ring_size;
+
+    // Pre-fill dfb(1)'s intra-tensix ring; kernel adds +2 per word.
+    auto input_intra = tt::test_utils::generate_uniform_random_vector<uint32_t>(
+        0, 100, num_entries * words_per_entry);
+    detail::WriteToDeviceL1(device, logical_core, intra_l1_addr, input_intra);
+
+    // Fill DRAM in_buffer; DM NOC-reads this into dfb(0)'s ring.
+    auto input_remapper = tt::test_utils::generate_uniform_random_vector<uint32_t>(
+        0, 100, num_entries * words_per_entry);
+    distributed::WriteShard(this->devices_.at(0)->mesh_command_queue(), in_buffer, input_remapper, zero_coord, true);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    detail::LaunchProgram(device, program, true /*wait_until_cores_done*/);
+
+    // Verify dfb(1): packer +1, unpacker +1 -> net +2 per word.
+    {
+        std::vector<uint32_t> expected(input_intra.size());
+        for (size_t i = 0; i < input_intra.size(); i++) {
+            expected[i] = input_intra[i] + 2;
+        }
+        std::vector<uint32_t> l1_data;
+        detail::ReadFromDeviceL1(device, logical_core, intra_l1_addr, num_entries * entry_size, l1_data);
+        EXPECT_EQ(expected, l1_data) << "Intra-tensix DFB L1 mismatch";
+    }
+
+    // Verify dfb(0): DM NOC-wrote input_remapper into L1; Tensix consumed but did not overwrite.
+    {
+        std::vector<uint32_t> l1_data;
+        detail::ReadFromDeviceL1(device, logical_core, l1_base, num_entries * entry_size, l1_data);
+        EXPECT_EQ(input_remapper, l1_data) << "DM->Tensix strided x all DFB L1 mismatch";
+    }
+}
+
 }  // end namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -857,4 +857,77 @@ TEST_F(MeshDeviceFixture, MultiCoreDFB_HomogeneousGrid_SingleGroup) {
     validate_multicore_dfb_groups(program, core_range_set, /*expected_num_groups=*/1, /*expected_cores_per_group=*/4);
 }
 
+// ---------------------------------------------------------------------------
+// Intra-tensix DFB config test
+// ---------------------------------------------------------------------------
+
+// Validates an intra-tensix DFB (pack TRISC producer → unpack TRISC consumer, same Neo):
+//   - Exactly one per-risc config entry (shared Neo bit) marked is_producer=true.
+//   - The tensix-only TC (id ≥ TC_TENSIX_POOL_START) is assigned to Neo tensix_id derived from producer_risc_mask.
+void validate_intra_tensix_dfb(
+    Program& program,
+    const CoreCoord& logical_core,
+    const experimental::dfb::DataflowBufferConfig& config) {
+    program.impl().finalize_dataflow_buffer_configs();
+
+    auto dfbs = program.impl().dataflow_buffers_on_core(logical_core);
+    ASSERT_EQ(dfbs.size(), 1u) << "Expected exactly 1 DFB on core";
+    const auto& dfb = dfbs[0];
+
+    ASSERT_EQ(dfb->risc_mask, config.producer_risc_mask)
+        << "Intra-tensix risc_mask should equal producer_risc_mask (same Neo bit)";
+    ASSERT_FALSE(dfb->use_remapper) << "Intra-tensix DFB must not use the remapper";
+    ASSERT_FALSE(dfb->groups.empty()) << "DFB has no groups (configs not finalized?)";
+
+    const auto& hw_risc_configs = dfb->groups[0].hw_risc_configs;
+    ASSERT_EQ(hw_risc_configs.size(), 1u)
+        << "Intra-tensix DFB should have exactly 1 per-risc config entry (shared Neo)";
+
+    const auto& rc = hw_risc_configs[0];
+    EXPECT_TRUE(rc.is_producer) << "Intra-tensix per-risc entry must be marked is_producer (pack TRISC inits TC)";
+
+    uint8_t expected_tensix_id =
+        static_cast<uint8_t>(__builtin_ctz(config.producer_risc_mask >> ::dfb::TENSIX_RISC_OFFSET));
+    uint8_t expected_risc_id = static_cast<uint8_t>(::dfb::TENSIX_RISC_OFFSET + expected_tensix_id);
+    EXPECT_EQ(rc.risc_id, expected_risc_id)
+        << "Intra-tensix per-risc risc_id should match Neo bit in producer_risc_mask";
+
+    ASSERT_EQ(rc.config.num_tcs_to_rr, 1u) << "Intra-tensix DFB should have exactly 1 TC";
+    uint8_t tc_id = ::dfb::get_counter_id(rc.config.packed_tile_counter[0]);
+    uint8_t actual_tensix_id = ::dfb::get_tensix_id(rc.config.packed_tile_counter[0]);
+    EXPECT_EQ(actual_tensix_id, expected_tensix_id) << "TC tensix_id must match Neo";
+    EXPECT_GE(tc_id, ::dfb::TC_TENSIX_POOL_START)
+        << "Intra-tensix DFB must use a Tensix-only TC (id ≥ " << (int)::dfb::TC_TENSIX_POOL_START << ")";
+
+    log_info(
+        tt::LogTest,
+        "Intra-tensix DFB: Neo{} Tensix-only TC (tensix_id={}, tc_id={})",
+        expected_tensix_id, (int)actual_tensix_id, (int)tc_id);
+}
+
+TEST_F(MeshDeviceFixture, TensixIntraTest1xDFB1Sx1SConfig) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    // Intra-tensix: pack TRISC (producer) → unpack TRISC (consumer) on Neo0.
+    // producer_risc_mask == consumer_risc_mask == bit 8 (Neo0).
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 4,
+        .producer_risc_mask = 0x100,  // bit 8 = Neo0
+        .num_producers = 1,
+        .pap = dfb::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0x100,  // bit 8 = Neo0 (same as producer — intentional for INTRA)
+        .num_consumers = 1,
+        .cap = dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = false,
+        .tensix_scope = experimental::dfb::TensixScope::INTRA};
+
+    Program program = CreateProgram();
+    CoreCoord logical_core = CoreCoord(0, 0);
+    experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
+
+    validate_intra_tensix_dfb(program, logical_core, config);
+}
+
 }  // end namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_intra_and_consume_all.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_intra_and_consume_all.cpp
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Combined compute kernel for the intra-tensix + remapper strided x blocked co-existence test.
+//
+// Two DFBs live in the same program on one Tensix cluster (N Neo threads):
+//
+//   dfb(0) - DM->Tensix, 1 strided producer x N blocked consumers (uses remapper).
+//            Produced by a concurrent DM kernel; this kernel acts as the blocked consumer.
+//
+//   dfb(1) - Intra-tensix, N packer-producer -> N unpacker-consumer pairs (hidden TCs, no remapper).
+//            This kernel acts as both producer and consumer for dfb(1).
+//
+// Execution order (all 4 TRISCs per Neo run kernel_main concurrently):
+//
+//   Phase 1 - blocked consumer of dfb(0):
+//     UNPACK TRISC: wait_front / pop_front for every entry (active).
+//     PACK / MATH TRISCs: wait_front and pop_front are no-ops; they race through Phase 1.
+//
+//   Phase 2 - intra-tensix on dfb(1):
+//     PACK TRISC:   reserve_back -> increment words in entry (+1) -> push_back
+//                   [then wait_front / pop_front are no-ops for PACK]
+//     UNPACK TRISC: [reserve_back / push_back are no-ops for UNPACK]
+//                   wait_front -> increment words in entry (+1) -> pop_front
+//
+// Net result for dfb(1) L1 ring: every word = original_value + 2.
+//
+// CTA layout:
+//   [0] num_entries_consumer - entries each UNPACK TRISC consumes from dfb(0) (BLOCKED: all entries)
+//   [1] entries_per_neo      - dfb(1) loop count per Neo (= total_entries_dfb1 / num_neos)
+//   [2] words_per_entry      - words per dfb(1) entry for in-place increment
+
+#include "experimental/dataflow_buffer.h"
+
+void kernel_main() {
+    const uint32_t num_entries_consumer = get_compile_time_arg_val(0);
+    const uint32_t entries_per_neo      = get_compile_time_arg_val(1);
+    const uint32_t words_per_entry      = get_compile_time_arg_val(2);
+
+    // Phase 1: consume all entries from the DM-produced strided x blocked DFB.
+    // UNPACK TRISC: each Neo's unpacker waits for its own TC credit (remapper fans out 1 DM post
+    // to N consumer TCs so every blocked UNPACK TRISC sees the full set of entries).
+    // PACK / MATH TRISCs: wait_front and pop_front are no-ops; they exit Phase 1 immediately.
+    experimental::DataflowBuffer dfb_consumer(0);
+    for (uint32_t i = 0; i < num_entries_consumer; i++) {
+        dfb_consumer.wait_front(1);
+        dfb_consumer.pop_front(1);
+    }
+    dfb_consumer.finish();
+
+    // Phase 2: intra-tensix DFB credit flow (packer -> unpacker, hidden TC per Neo).
+    // PACK TRISC fills its Neo's TC slot; UNPACK TRISC drains it.
+    // Because PACK races through Phase 1 (no-ops), it can pre-fill the entire TC capacity
+    // of dfb(1) before the UNPACK TRISC arrives from Phase 1. PACK then blocks in finish()
+    // until UNPACK has consumed all entries and called its own finish().
+    experimental::DataflowBuffer dfb_intra(1);
+
+#ifdef UCK_CHLKC_UNPACK
+    uint32_t trisc_id = ckernel::csr_read<ckernel::CSR::TRISC_ID>();
+#endif
+
+    for (uint32_t i = 0; i < entries_per_neo; i++) {
+        // PACK: wait for a free ring slot, increment the entry in-place, post credit.
+        // UNPACK / MATH: reserve_back and push_back are no-ops.
+        dfb_intra.reserve_back(1);
+#ifdef UCK_CHLKC_PACK
+        {
+            volatile uint32_t* entry = reinterpret_cast<volatile uint32_t*>(dfb_intra.get_write_ptr() << 4);
+            for (uint32_t w = 0; w < words_per_entry; w++) {
+                entry[w] += 1;
+            }
+        }
+#endif
+        dfb_intra.push_back(1);
+
+        // UNPACK: wait for credit, increment the entry in-place, pop credit.
+        // PACK / MATH: wait_front and pop_front are no-ops.
+        dfb_intra.wait_front(1);
+#ifdef UCK_CHLKC_UNPACK
+        if (trisc_id == 0) {
+            volatile uint32_t* entry = reinterpret_cast<volatile uint32_t*>(dfb_intra.get_read_ptr() << 4);
+            for (uint32_t w = 0; w < words_per_entry; w++) {
+                entry[w] += 1;
+            }
+        }
+#endif
+        dfb_intra.pop_front(1);
+    }
+    dfb_intra.finish();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "experimental/dataflow_buffer.h"
+
+void kernel_main() {
+    const uint32_t entries_per_neo = get_compile_time_arg_val(0);
+    const uint32_t words_per_entry = get_compile_time_arg_val(1);
+
+    experimental::DataflowBuffer dfb(0);
+
+#ifdef UCK_CHLKC_UNPACK
+    uint32_t trisc_id = ckernel::csr_read<ckernel::CSR::TRISC_ID>();
+#endif
+
+    for (uint32_t i = 0; i < entries_per_neo; i++) {
+        // Pack TRISC: wait for free space, increment entry in-place, post credit.
+        dfb.reserve_back(1);
+#ifdef UCK_CHLKC_PACK
+        {
+            volatile uint32_t* entry = reinterpret_cast<volatile uint32_t*>(dfb.get_write_ptr() << 4);
+            for (uint32_t w = 0; w < words_per_entry; w++) {
+                entry[w] += 1;
+            }
+        }
+#endif
+        dfb.push_back(1);
+
+        // Unpack TRISC: wait for credit, increment entry in-place, consume credit.
+        dfb.wait_front(1);
+#ifdef UCK_CHLKC_UNPACK
+        {
+            if (trisc_id == 0) {
+                volatile uint32_t* entry = reinterpret_cast<volatile uint32_t*>(dfb.get_read_ptr() << 4);
+                for (uint32_t w = 0; w < words_per_entry; w++) {
+                    entry[w] += 1;
+                }
+            }
+        }
+#endif
+        dfb.pop_front(1);
+    }
+    dfb.finish();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
@@ -11,12 +11,12 @@ void kernel_main() {
     const uint32_t src_addr_base = get_compile_time_arg_val(0);
     const uint32_t num_entries_per_producer = get_compile_time_arg_val(1);
     constexpr uint32_t implicit_sync = get_compile_time_arg_val(2);
-    // BLOCKED consumer does block reads (TC0 fully exhausted before TC1, etc.), so the DFB
+    // ALL consumer does contiguous reads (TC0 fully exhausted before TC1, etc.), so the DFB
     // uses a contiguous layout per producer. Producer i must write pages [i*N .. i*N+(N-1)]
     // so that each consumer TC sees a contiguous, in-order slice.
     // STRIDED consumer reads in round-robin (TC0, TC1, ..., TC0, ...), so the DFB uses an
     // interleaved layout and producer i writes pages [i, i+P, i+2P, ...].
-    constexpr uint32_t blocked_consumer = get_compile_time_arg_val(3);
+    constexpr uint32_t consume_all = get_compile_time_arg_val(3);
     constexpr auto src_args = TensorAccessorArgs<4>();
 
     uint32_t producer_mask = get_arg_val<uint32_t>(0);
@@ -41,7 +41,7 @@ void kernel_main() {
     const auto tensor_accessor = TensorAccessor(src_args, src_addr_base);
 
     for (uint32_t tile_id = 0; tile_id < num_entries_per_producer; tile_id++) {
-        const uint32_t page_id = blocked_consumer ? chunk_offset + producer_idx * num_entries_per_producer + tile_id
+        const uint32_t page_id = consume_all ? chunk_offset + producer_idx * num_entries_per_producer + tile_id
                                                   : chunk_offset + tile_id * num_producers + producer_idx;
         // DPRINT << "producer tile id " << tile_id << " page id " << page_id << ENDL();
         // DEVICE_PRINT("producer tile id {} page id {}\n", tile_id, page_id);

--- a/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
@@ -24,6 +24,13 @@ namespace tt::tt_metal::experimental::dfb {
 
 using AccessPattern = ::dfb::AccessPattern;
 
+// This enum is used to distinguish DFBs within one Neo vs DFBs across Neos
+// Both cases run the same compute kernel on all Neos
+enum class TensixScope : uint8_t {
+    INTRA,
+    INTER,
+};
+
 struct DataflowBufferConfig {
     uint32_t entry_size = 0;
     uint32_t num_entries = 0;
@@ -36,6 +43,8 @@ struct DataflowBufferConfig {
     bool enable_implicit_sync = false;
     DataFormat data_format = tt::DataFormat::Float16_b;
     std::optional<Tile> tile = std::nullopt;
+    // Set only when both producer and consumer are the same compute kernel
+    std::optional<TensixScope> tensix_scope = std::nullopt;
 };
 
 // Note: This API and the DataflowBufferConfig are placeholder only, the final DataflowBuffer APIs will conform with

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
@@ -21,6 +21,9 @@ constexpr uint8_t MAX_ACTIVE_DFBS_PACK = 16;
 constexpr uint8_t NUM_TENSIX = 4;
 constexpr uint8_t NUM_TILE_COUNTERS_PER_TENSIX = 32;
 constexpr uint8_t NUM_TENSIX_TILE_COUNTERS_FOR_DM = 16;
+// First TC ID in the default Tensix-only pool (not accessible by DM); used for intra/inter-tensix DFBs.
+// Note: The Remapper can be programmed to expose these TCs to DMs.
+constexpr uint8_t TC_TENSIX_POOL_START = NUM_TENSIX_TILE_COUNTERS_FOR_DM;  // = 16
 constexpr uint8_t NUM_REMAPPER_PAIRINGS = 64;
 constexpr uint8_t NUM_TXN_IDS = 4;
 constexpr uint8_t MAX_NUM_TILE_COUNTERS_TO_RR = 4;

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
@@ -331,8 +331,10 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
                     llk_intf_set_capacity(tensix_id, tc_id, init_ptr->capacity);
 #endif
                 }
-                // Single writer per per_risc entry; no atomic needed
+                // Only the RISC that actually performed the TC hardware init sets tc_init_done.
+#if !defined(COMPILE_FOR_TRISC) || defined(UCK_CHLKC_PACK)
                 per_risc_ptr->num_tcs_and_init.tc_init_done = 1;
+#endif
             }
         }
 

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -102,14 +102,25 @@ void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_
 
 namespace detail {
 
-::dfb::PackedTileCounter TileCounterAllocator::allocate(const CoreCoord& core, uint8_t tensix_id) {
+::dfb::PackedTileCounter TileCounterAllocator::allocate(
+    const CoreCoord& core, uint8_t tensix_id, bool use_t6_only) {
     TT_FATAL(tensix_id < ::dfb::NUM_TENSIX, "Invalid tensix_id: {}", tensix_id);
-    auto& tc_ids = next_tc_id_[core];
-    TT_FATAL(
-        tc_ids[tensix_id] < ::dfb::NUM_TENSIX_TILE_COUNTERS_FOR_DM,
-        "Out of tile counters for tensix {} on core ({}, {})",
-        tensix_id, core.x, core.y);
-    uint8_t tc_id = tc_ids[tensix_id]++;
+    auto& counters = next_tc_id_[core];
+
+    uint8_t tc_id;
+    if (use_t6_only) {
+        TT_FATAL(
+            ::dfb::TC_TENSIX_POOL_START + counters.t6_only_next[tensix_id] < ::dfb::NUM_TILE_COUNTERS_PER_TENSIX,
+            "Out of Tensix-only tile counters for tensix {} on core ({}, {})",
+            tensix_id, core.x, core.y);
+        tc_id = ::dfb::TC_TENSIX_POOL_START + counters.t6_only_next[tensix_id]++;
+    } else {
+        TT_FATAL(
+            counters.dm_next[tensix_id] < ::dfb::NUM_TENSIX_TILE_COUNTERS_FOR_DM,
+            "Out of DM-visible tile counters for tensix {} on core ({}, {})",
+            tensix_id, core.x, core.y);
+        tc_id = counters.dm_next[tensix_id]++;
+    }
     return static_cast<::dfb::PackedTileCounter>(
         (tensix_id << ::dfb::PACKED_TC_COUNTER_ID_BITS) | tc_id);
 }
@@ -563,6 +574,25 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
         "ALL consumer pattern supports at most 4 consumers, but {} were specified",
         config.num_consumers);
 
+    if (config.tensix_scope.has_value()) {
+        TT_FATAL(
+            *config.tensix_scope != TensixScope::INTER,
+            "Inter-tensix DFBs are not yet supported. Use TensixScope::INTRA for same-Neo packer→unpacker DFBs.");
+        // INTRA: each Neo has an independent packer (TRISC2) → unpacker (TRISC0) credit flow, one Tensix-only TC per Neo.
+        // Always STRIDED for both producer and consumer — blocked access and remapper are never used.
+        // num_producers == num_consumers == number of Neos (one packer-unpacker pair per Neo).
+        TT_FATAL(
+            config.num_producers == config.num_consumers,
+            "Intra-tensix DFBs require equal producers (packers) and consumers (unpackers), got {} and {}",
+            config.num_producers, config.num_consumers);
+        TT_FATAL(
+            config.pap == dfb::AccessPattern::STRIDED && config.cap == dfb::AccessPattern::STRIDED,
+            "Intra-tensix DFBs require STRIDED access for both producer (packer) and consumer (unpacker)");
+        TT_FATAL(
+            !config.enable_implicit_sync,
+            "Intra-tensix DFBs do not support implicit sync (ISR-based credits)");
+    }
+
     auto dfb = std::make_shared<DataflowBufferImpl>();
 
     dfb->id = static_cast<uint32_t>(this->dataflow_buffers_.size());
@@ -729,21 +759,84 @@ void ProgramImpl::finalize_single_dfb_config(
     const auto& config = dfb->config;
     std::vector<DFBRiscConfig> new_hw_risc_configs;
 
+    // Finds the DfbGroup whose hw_risc_configs match new_hw_risc_configs (creating one
+    // if none exists), extends its core_ranges to include `core`, and appends an
+    // l1_by_core entry.  base_addr/limit are not part of the equality check because
+    // they are derived per-core in serialize_for_core() from each core's alloc_addr.
+    auto bin_into_group = [&]() {
+        auto hw_risc_configs_equal = [](const std::vector<DFBRiscConfig>& a, const std::vector<DFBRiscConfig>& b) {
+            if (a.size() != b.size()) {
+                return false;
+            }
+            for (size_t i = 0; i < a.size(); i++) {
+                if (a[i].risc_id != b[i].risc_id || a[i].is_producer != b[i].is_producer) {
+                    return false;
+                }
+                const auto& ca = a[i].config;
+                const auto& cb = b[i].config;
+                if (ca.num_tcs_to_rr != cb.num_tcs_to_rr ||
+                    ca.broadcast_tc != cb.broadcast_tc ||
+                    ca.remapper_pair_index != cb.remapper_pair_index ||
+                    ca.consumer_tcs != cb.consumer_tcs ||
+                    ca.remapper_consumer_ids_mask != cb.remapper_consumer_ids_mask ||
+                    ca.producer_client_type != cb.producer_client_type) {
+                    return false;
+                }
+                for (int j = 0; j < ca.num_tcs_to_rr; j++) {
+                    if (ca.packed_tile_counter[j] != cb.packed_tile_counter[j]) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        };
+
+        DfbGroup* matching_group = nullptr;
+        for (auto& grp : dfb->groups) {
+            if (hw_risc_configs_equal(grp.hw_risc_configs, new_hw_risc_configs)) {
+                matching_group = &grp;
+                break;
+            }
+        }
+        if (matching_group == nullptr) {
+            DfbGroup new_group;
+            new_group.hw_risc_configs = new_hw_risc_configs;
+            dfb->groups.push_back(std::move(new_group));
+            matching_group = &dfb->groups.back();
+        }
+        CoreRange core_as_range(core, core);
+        if (matching_group->core_ranges.ranges().empty()) {
+            matching_group->core_ranges = CoreRangeSet(core_as_range);
+        } else {
+            matching_group->core_ranges = matching_group->core_ranges.merge(CoreRangeSet(core_as_range));
+        }
+        matching_group->l1_by_core.emplace_back(core, 0u);
+    };
+
     TT_FATAL(config.producer_risc_mask != 0, "producer_risc_mask must be set before program launch. Either set it in DataflowBufferConfig or call BindDataflowBufferToProducerConsumerKernels after creating kernels");
     TT_FATAL(config.consumer_risc_mask != 0, "consumer_risc_mask must be set before program launch. Either set it in DataflowBufferConfig or call BindDataflowBufferToProducerConsumerKernels after creating kernels");
 
-    TT_FATAL(
-        (config.producer_risc_mask & config.consumer_risc_mask) == 0,
-        "producer_risc_mask and consumer_risc_mask must not overlap");
+    const bool is_intra_tensix =
+        config.tensix_scope.has_value() && *config.tensix_scope == TensixScope::INTRA;
+
+    // Intra-tensix: producer and consumer share the same Neo bit — overlap is intentional.
+    if (!is_intra_tensix) {
+        TT_FATAL(
+            (config.producer_risc_mask & config.consumer_risc_mask) == 0,
+            "producer_risc_mask and consumer_risc_mask must not overlap");
+    }
 
     bool producer_has_dm = has_dm_risc(config.producer_risc_mask);
     bool consumer_has_dm = has_dm_risc(config.consumer_risc_mask);
     bool producer_is_tensix_only = !producer_has_dm && has_tensix_risc(config.producer_risc_mask);
     bool consumer_is_tensix_only = !consumer_has_dm && has_tensix_risc(config.consumer_risc_mask);
-    TT_FATAL(
-        !(producer_is_tensix_only && consumer_is_tensix_only),
-        "Both producer and consumer cannot be Tensix-only RISCs - at least one DM RISC is required to initialize tile "
-        "counters");
+
+    if (producer_is_tensix_only && consumer_is_tensix_only) {
+        TT_FATAL(
+            config.tensix_scope.has_value(),
+            "Both producer and consumer are Tensix-only RISCs. Set tensix_scope to INTRA (same Neo) or INTER "
+            "(different Neos). Un-scoped Tensix-to-Tensix DFBs are not allowed.");
+    }
 
     // TRISC pack/unpack store ring extent in uint16_t L1-aligned units; host must reject oversized rings.
     if (MetalContext::instance().hal().has_tile_counter_registers()) {
@@ -777,6 +870,49 @@ void ProgramImpl::finalize_single_dfb_config(
     }
 
     dfb->risc_mask = config.producer_risc_mask | config.consumer_risc_mask;
+
+    // ---------------------------------------------------------------------------
+    // Intra-tensix: packer TRISC2 (producer) → unpacker TRISC0 (consumer) within the same Neo.
+    // No DM RISC, no remapper, no strided/blocked access pattern — each Neo is a fully
+    // independent packer→unpacker credit flow backed by one Tensix-only TC on that Neo.
+    // For N Neos (num_producers == num_consumers == N): N Tensix-only TCs, one per Neo.
+    // ---------------------------------------------------------------------------
+    if (is_intra_tensix) {
+        // Iterate over every Neo bit in producer_risc_mask and allocate a separate Tensix-only
+        // TC for each, giving each Neo its own independent credit counter.
+        dfb->use_remapper = false;
+
+        for (uint8_t risc_id = ::dfb::TENSIX_RISC_OFFSET;
+             risc_id < ::dfb::TENSIX_RISC_OFFSET + ::dfb::NUM_TENSIX;
+             risc_id++) {
+            if (!(config.producer_risc_mask & (1u << risc_id))) {
+                continue;
+            }
+            uint8_t tensix_id = risc_id - ::dfb::TENSIX_RISC_OFFSET;
+
+            ::dfb::PackedTileCounter t6_only_tc =
+                tile_counter_allocator_.allocate(core, tensix_id, /*use_t6_only=*/true);
+
+            log_info(
+                tt::LogMetal,
+                "Intra-tensix DFB {}: Neo{} Tensix-only TC (tensix_id={}, tc_id={})",
+                dfb->id,
+                tensix_id,
+                (uint32_t)::dfb::get_tensix_id(t6_only_tc),
+                (uint32_t)::dfb::get_counter_id(t6_only_tc));
+
+            DFBRiscConfig risc_config;
+            risc_config.risc_id = risc_id;
+            risc_config.is_producer = true;
+            risc_config.config.packed_tile_counter[0] = t6_only_tc;
+            risc_config.config.num_tcs_to_rr = 1;
+            risc_config.config.broadcast_tc = false;
+            new_hw_risc_configs.push_back(risc_config);
+        }
+
+        bin_into_group();
+        return;
+    }
 
     // DM-DM ALL: producer broadcasts to N TCs (one per consumer) instead of using remapper.
     // No Tensix involved on either side.
@@ -1137,58 +1273,7 @@ void ProgramImpl::finalize_single_dfb_config(
     log_debug(
         tt::LogMetal, "DFB {} finalized risc_mask: 0x{:x} use_remapper: {}", dfb->id, dfb->risc_mask, use_remapper);
 
-    // Bin this core into a DfbGroup with matching HW config (TC/remapper fields).
-    // base_addr/limit are not set here; they are derived per-core in DataflowBufferImpl::serialize_for_core()
-    // from each core's alloc_addr, so they are intentionally ignored in this HW config equality check.
-    auto hw_risc_configs_equal = [](const std::vector<DFBRiscConfig>& a, const std::vector<DFBRiscConfig>& b) -> bool {
-        if (a.size() != b.size()) {
-            return false;
-        }
-        for (size_t i = 0; i < a.size(); i++) {
-            if (a[i].risc_id != b[i].risc_id || a[i].is_producer != b[i].is_producer) {
-                return false;
-            }
-            const auto& ca = a[i].config;
-            const auto& cb = b[i].config;
-            if (ca.num_tcs_to_rr != cb.num_tcs_to_rr ||
-                ca.broadcast_tc != cb.broadcast_tc ||
-                ca.remapper_pair_index != cb.remapper_pair_index ||
-                ca.consumer_tcs != cb.consumer_tcs ||
-                ca.remapper_consumer_ids_mask != cb.remapper_consumer_ids_mask ||
-                ca.producer_client_type != cb.producer_client_type) {
-                return false;
-            }
-            for (int j = 0; j < ca.num_tcs_to_rr; j++) {
-                if (ca.packed_tile_counter[j] != cb.packed_tile_counter[j]) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    };
-
-    DfbGroup* matching_group = nullptr;
-    for (auto& grp : dfb->groups) {
-        if (hw_risc_configs_equal(grp.hw_risc_configs, new_hw_risc_configs)) {
-            matching_group = &grp;
-            break;
-        }
-    }
-    if (matching_group == nullptr) {
-        DfbGroup new_group;
-        new_group.hw_risc_configs = new_hw_risc_configs;
-        dfb->groups.push_back(std::move(new_group));
-        matching_group = &dfb->groups.back();
-    }
-
-    // Extend core_ranges to include this core.
-    CoreRange core_as_range(core, core);
-    if (matching_group->core_ranges.ranges().empty()) {
-        matching_group->core_ranges = CoreRangeSet(core_as_range);
-    } else {
-        matching_group->core_ranges = matching_group->core_ranges.merge(CoreRangeSet(core_as_range));
-    }
-    matching_group->l1_by_core.emplace_back(core, 0u);
+    bin_into_group();
 }
 
 void ProgramImpl::invalidate_dataflow_buffer_allocation() {

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -91,12 +91,19 @@ struct DataflowBufferImpl {
 
 class TileCounterAllocator {
 public:
-    // Allocate a tile counter for (core, tensix_id). Each core has an independent counter sequence
-    ::dfb::PackedTileCounter allocate(const CoreCoord& core, uint8_t tensix_id);
+    // Allocate a tile counter for (core, tensix_id).
+    // use_t6_only=false → DM-visible pool [0, NUM_TENSIX_TILE_COUNTERS_FOR_DM)
+    // use_t6_only=true  → Tensix-only pool [TC_TENSIX_POOL_START, NUM_TILE_COUNTERS_PER_TENSIX)
+    // The remapper can reference any of the 32 TCs, so both pools live in one allocator.
+    ::dfb::PackedTileCounter allocate(const CoreCoord& core, uint8_t tensix_id, bool use_t6_only = false);
     void reset() { next_tc_id_.clear(); }
 
 private:
-    std::unordered_map<CoreCoord, std::array<uint8_t, 4>> next_tc_id_;
+    struct PerCoreCounters {
+        std::array<uint8_t, 4> dm_next     = {};  // next available TC id in [0, NUM_TENSIX_TILE_COUNTERS_FOR_DM)
+        std::array<uint8_t, 4> t6_only_next = {};  // next available TC id offset from TC_TENSIX_POOL_START
+    };
+    std::unordered_map<CoreCoord, PerCoreCounters> next_tc_id_;
 };
 
 class RemapperIndexAllocator {


### PR DESCRIPTION
### Summary
Adding support for intra-tensix DFBs. Sync occurs within each tensix neo with packers acting as producers and unpackers acting as consumers. A multi-threaded intra-tensix DFB looks like multiple single intra-tensix DFBs. Only strided producer and consumer access patterns are supported.  

Inter-tensix DFBs require remapper and will be added in a separate PR. 

### Notes for reviewers
@atatuzunerTT this likely needs to be revisited when trisc3 support is added

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/intra-tensix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/intra-tensix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/intra-tensix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/intra-tensix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abhullar/intra-tensix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/intra-tensix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/intra-tensix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/intra-tensix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/intra-tensix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/intra-tensix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/intra-tensix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/intra-tensix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/intra-tensix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/intra-tensix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/intra-tensix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/intra-tensix)