### PR TITLE
Optimize pack out of local sdpa output

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sdpa_reduce_row.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sdpa_reduce_row.h
@@ -18,6 +18,7 @@ namespace sfpu {
 namespace sdpa_reduce_row {
 constexpr std::uint8_t ZERO_ADDR_MOD = ADDR_MOD_7;
 constexpr std::uint8_t TILE_OFFSET_ADDR_MOD = ADDR_MOD_5;
+constexpr uint32_t replay_start = 16;
 }  // namespace sdpa_reduce_row
 inline void sfpu_sdpa_reduce_row_subblock_8x32_configure_addrmod() {
     addr_mod_t{
@@ -68,7 +69,7 @@ inline void _init_sdpa_reduce_max_row_8x32_replay_buffers_() {
     // Record replay buffer
     // LREG0 will contain the first 4 rows, LREG2 will contain the second 4 rows
     // Max will be the first 16 instructions, SUM will be the last 16 instructions
-    load_replay_buf<NoExec>(0, 16, [] {
+    load_replay_buf<NoExec>(sdpa_reduce_row::replay_start, 16, [] {
         // Max instructions
         reduce_row_8x32_instrs<PoolType::MAX>();
     });
@@ -79,20 +80,7 @@ inline void _init_sdpa_reduce_sum_row_8x32_replay_buffers_() {
     // Record replay buffer
     // LREG0 will contain the first 4 rows, LREG2 will contain the second 4 rows
     // Max will be the first 16 instructions, SUM will be the last 16 instructions
-    load_replay_buf<NoExec>(0, 16, [] {
-        // Sum instructions
-        reduce_row_8x32_instrs<PoolType::SUM>();
-    });
-}
-
-inline void _init_sdpa_reduce_row_8x32_replay_buffers_() {
-    // ***********************************************************
-    // Record replay buffer
-    // LREG0 will contain the first 4 rows, LREG2 will contain the second 4 rows
-    // Max will be the first 16 instructions, SUM will be the last 16 instructions
-    load_replay_buf<NoExec>(0, 32, [] {
-        // Max instructions
-        reduce_row_8x32_instrs<PoolType::MAX>();
+    load_replay_buf<NoExec>(sdpa_reduce_row::replay_start, 16, [] {
         // Sum instructions
         reduce_row_8x32_instrs<PoolType::SUM>();
     });
@@ -104,8 +92,6 @@ inline void _init_sdpa_reduce_row_8x32_() {
 
     _init_sfpu_config_reg();
     sfpu_sdpa_reduce_row_subblock_8x32_configure_addrmod();
-
-    _init_sdpa_reduce_row_8x32_replay_buffers_();
 }
 
 template <DataFormat format, PoolType pool_type>
@@ -158,7 +144,6 @@ inline void _calculate_sdpa_reduce_row_8x32_(uint src_index) {
     static_assert(format == DataFormat::Float16_b, "SFPU reduce max col only supports Float16_b format");
 
     TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, src_index + get_dest_buffer_base());
-    constexpr uint32_t replay_start = pool_type == PoolType::MAX ? 0 : 16;
 
     // TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
     // TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::PACK);
@@ -171,7 +156,7 @@ inline void _calculate_sdpa_reduce_row_8x32_(uint src_index) {
 
     TTI_SFPLOAD(p_sfpu::LREG0, 0, sdpa_reduce_row::ZERO_ADDR_MOD, 0);
     TTI_SFPLOAD(p_sfpu::LREG2, 0, sdpa_reduce_row::ZERO_ADDR_MOD, 4);
-    lltt::replay(replay_start + 4, 12);
+    lltt::replay(sdpa_reduce_row::replay_start + 4, 12);
 
     if constexpr (block_width > 1) {
         for (uint32_t i = 0; i < block_width - 1; i++) {
@@ -179,7 +164,7 @@ inline void _calculate_sdpa_reduce_row_8x32_(uint src_index) {
                 t6_semaphore_get<p_stall::WAIT_SFPU>(semaphore::FPU_SFPU);
                 t6_semaphore_wait_on_zero<p_stall::STALL_SFPU>(semaphore::FPU_SFPU);
             }
-            lltt::replay(replay_start, 16);
+            lltt::replay(sdpa_reduce_row::replay_start, 16);
         }
     }
     _sdpa_reduce_row_8x32_epilogue_<format, pool_type>();

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sdpa_reduce_row.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sdpa_reduce_row.h
@@ -68,7 +68,6 @@ inline void _init_sdpa_reduce_max_row_8x32_replay_buffers_() {
     // ***********************************************************
     // Record replay buffer
     // LREG0 will contain the first 4 rows, LREG2 will contain the second 4 rows
-    // Max will be the first 16 instructions, SUM will be the last 16 instructions
     load_replay_buf<NoExec>(sdpa_reduce_row::replay_start, 16, [] {
         // Max instructions
         reduce_row_8x32_instrs<PoolType::MAX>();
@@ -79,7 +78,6 @@ inline void _init_sdpa_reduce_sum_row_8x32_replay_buffers_() {
     // ***********************************************************
     // Record replay buffer
     // LREG0 will contain the first 4 rows, LREG2 will contain the second 4 rows
-    // Max will be the first 16 instructions, SUM will be the last 16 instructions
     load_replay_buf<NoExec>(sdpa_reduce_row::replay_start, 16, [] {
         // Sum instructions
         reduce_row_8x32_instrs<PoolType::SUM>();

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_sdpa_custom_mm_reuse_dest_srcb_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_sdpa_custom_mm_reuse_dest_srcb_api.h
@@ -41,7 +41,11 @@ inline void llk_math_sdpa_custom_mm_reuse_dest_srcb_init(
 // Runtime parameter signal_output:
 //   false (default): Full sdpa_custom_mm_reuse_dest_srcb - MVMULs + finalization
 //   true: Partial K accumulation - MVMULs only, no finalization (for intermediate K subblocks)
-template <MathFidelity math_fidelity>
+//
+// Compile-time parameter output_granularity:
+//   Number of output tiles produced between successive FPU->SFPU semaphore posts when
+//   signal_output is true. nt_dim must be divisible by output_granularity.
+template <MathFidelity math_fidelity, std::uint32_t output_granularity = 2>
 inline void llk_math_sdpa_custom_mm_reuse_dest_srcb(
     const uint src_index,
     const uint dst_index,
@@ -49,5 +53,6 @@ inline void llk_math_sdpa_custom_mm_reuse_dest_srcb(
     const std::uint32_t kt_dim = 1,
     const std::uint32_t nt_dim = 1,
     bool signal_output = false) {
-    _llk_math_sdpa_custom_mm_reuse_dest_srcb_(src_index, dst_index, transpose, kt_dim, nt_dim, signal_output);
+    _llk_math_sdpa_custom_mm_reuse_dest_srcb_<output_granularity>(
+        src_index, dst_index, transpose, kt_dim, nt_dim, signal_output);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_sdpa_custom_mm_reuse_dest_srcb_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_sdpa_custom_mm_reuse_dest_srcb_api.h
@@ -45,7 +45,7 @@ inline void llk_math_sdpa_custom_mm_reuse_dest_srcb_init(
 // Compile-time parameter output_granularity:
 //   Number of output tiles produced between successive FPU->SFPU semaphore posts when
 //   signal_output is true. nt_dim must be divisible by output_granularity.
-template <MathFidelity math_fidelity, std::uint32_t output_granularity = 2>
+template <MathFidelity math_fidelity, std::uint32_t output_granularity>
 inline void llk_math_sdpa_custom_mm_reuse_dest_srcb(
     const uint src_index,
     const uint dst_index,

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h
@@ -135,7 +135,6 @@ ALWI void sdpa_reduce_sum_row(uint src_index, uint dst_index, bool prev_sum = fa
 
 #ifdef TRISC_PACK
 // Packer:
-// All 32 slots of replay buffer are used for red sum and red max
 // Fast Approx Exp uses 3 constants and LoadMacro
 // Non-Approx Exp uses 1 constant for recip. TODO: Look into integrating new polynomial exp in
 // ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -168,7 +167,8 @@ inline void init_fast_approx_exp_constants() {
 
 inline void fast_approx_exp(uint32_t dst_index) {
     TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, dst_index + get_dest_buffer_base());
-    ckernel::sfpu::calculate_exponential<true, DST_ACCUM_MODE, true, 4, true>();
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+    ckernel::sfpu::calculate_exponential<true, DST_ACCUM_MODE, true, 8, true>();
 }
 
 // TODO: Currently hardcodes the lregs used by red max
@@ -245,7 +245,7 @@ template <
     bool transpose_v,
     uint32_t packed_tile_size,
     bool exp_approx_mode = false,
-    uint32_t output_granularity = 2,
+    uint32_t output_granularity = 1,
     bool mm_pack_init = true>
 void compute_sdpa_chunk(
     uint32_t cb_q,
@@ -302,6 +302,7 @@ void compute_sdpa_chunk(
     for (uint32_t i = 0; i < chunk_size; i++) {
         // Wait for FPU that tile is ready (sem is non-zero)
         PACK((t6_semaphore_wait_on_zero<p_stall::STALL_SFPU>(semaphore::FPU_SFPU)));
+        // Each tile is 8x32, which is the same as a full 16x16 face
         PACK((fast_approx_exp(mm1_dst_offset + i * packed_tile_size)));
         PACK((t6_semaphore_get<p_stall::WAIT_SFPU>(semaphore::FPU_SFPU)));
         // No stall since we waited on sfpu already

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h
@@ -245,7 +245,8 @@ template <
     bool transpose_v,
     uint32_t packed_tile_size,
     bool exp_approx_mode = false,
-    uint32_t output_granularity = 2>
+    uint32_t output_granularity = 2,
+    bool mm_pack_init = true>
 void compute_sdpa_chunk(
     uint32_t cb_q,
     uint32_t cb_k,
@@ -262,7 +263,7 @@ void compute_sdpa_chunk(
     static_assert(DST_ACCUM_MODE == false, "FP32 destination accumulation mode is not supported");
     static_assert(num_tiles_v % output_granularity == 0, "num_tiles_v must be divisible by output_granularity");
     PACK((ckernel::sfpu::_init_sdpa_reduce_max_row_8x32_replay_buffers_()));
-    sdpa_custom_mm_block_init_short<transpose_k>(cb_q, cb_k, cb_out, chunk_size);
+    sdpa_custom_mm_block_init_short<transpose_k, mm_pack_init>(cb_q, cb_k, cb_out, chunk_size);
     cb_wait_front(cb_k, num_tiles_k * chunk_size);
     // Q @ K (FPU)
     // Make sure SFPU of previous chunk is done (sem is zero)

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h
@@ -231,6 +231,10 @@ inline void recip_sum(uint32_t curr_sum_index, uint32_t recip_dst_index) {
 
 // First chunk controls whether we run the correction path with prev sum, max, out
 // Last chunk controls whether we signal out packer to start packing as output is produced
+//
+// output_granularity controls how often the QK^T*V matmul (sdpa_custom_mm_reuse_dest_srcb_block)
+// signals the packer via the FPU->SFPU semaphore. The packer must consume tiles in matching
+// groups of output_granularity. num_tiles_v must be divisible by output_granularity.
 template <
     uint32_t chunk_size,
     uint32_t num_tiles_k,
@@ -240,7 +244,8 @@ template <
     bool transpose_k,
     bool transpose_v,
     uint32_t packed_tile_size,
-    bool exp_approx_mode = false>
+    bool exp_approx_mode = false,
+    uint32_t output_granularity = 2>
 void compute_sdpa_chunk(
     uint32_t cb_q,
     uint32_t cb_k,
@@ -255,6 +260,7 @@ void compute_sdpa_chunk(
     bool last_chunk,
     bool mask_chunk) {
     static_assert(DST_ACCUM_MODE == false, "FP32 destination accumulation mode is not supported");
+    static_assert(num_tiles_v % output_granularity == 0, "num_tiles_v must be divisible by output_granularity");
     PACK((ckernel::sfpu::_init_sdpa_reduce_max_row_8x32_replay_buffers_()));
     sdpa_custom_mm_block_init_short<transpose_k>(cb_q, cb_k, cb_out, chunk_size);
     cb_wait_front(cb_k, num_tiles_k * chunk_size);
@@ -303,7 +309,7 @@ void compute_sdpa_chunk(
 
     // MM (FPU)
     sdpa_custom_mm_reuse_dest_srcb_block_init_short(cb_q, cb_k, cb_out, transpose_v, chunk_size, num_tiles_v);
-    sdpa_custom_mm_reuse_dest_srcb_block(
+    sdpa_custom_mm_reuse_dest_srcb_block<output_granularity>(
         cb_q,
         cb_k,
         0,

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa_custom_mm.h
@@ -14,6 +14,11 @@
 #endif
 namespace ckernel {
 
+ALWI void sdpa_custom_mm_block_init_pack_short() {
+    PACK((cfg_reg_rmw_tensix<PCK0_ADDR_CTRL_ZW_REG_0_Zstride_RMW>(FACE_C_DIM * 8 * 2)));
+    PACK((cfg_reg_rmw_tensix<PCK0_ADDR_CTRL_ZW_REG_0_Wstride_RMW>((TILE_NUM_FACES / 2) * FACE_C_DIM * 8 * 2)));
+}
+
 template <bool transpose = false>
 ALWI void sdpa_custom_mm_block_init(
     const std::uint32_t in0_cb_id,
@@ -31,11 +36,10 @@ ALWI void sdpa_custom_mm_block_init(
     PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(out_cb_id)));
     PACK((llk_pack_init<false, false>(out_cb_id)));
 
-    PACK((cfg_reg_rmw_tensix<PCK0_ADDR_CTRL_ZW_REG_0_Zstride_RMW>(FACE_C_DIM * 8 * 2)));
-    PACK((cfg_reg_rmw_tensix<PCK0_ADDR_CTRL_ZW_REG_0_Wstride_RMW>((TILE_NUM_FACES / 2) * FACE_C_DIM * 8 * 2)));
+    sdpa_custom_mm_block_init_pack_short();
 }
 
-template <bool transpose = false>
+template <bool transpose = false, bool init_pack = true>
 ALWI void sdpa_custom_mm_block_init_short(
     const std::uint32_t in0_cb_id,
     const std::uint32_t in1_cb_id,
@@ -44,8 +48,9 @@ ALWI void sdpa_custom_mm_block_init_short(
     UNPACK((llk_unpack_AB_custom_mm_init<transpose>(in0_cb_id, in1_cb_id, ct_dim)));
     MATH((llk_math_sdpa_custom_mm_init<transpose>(in0_cb_id, in1_cb_id, ct_dim)));
 
-    PACK((cfg_reg_rmw_tensix<PCK0_ADDR_CTRL_ZW_REG_0_Zstride_RMW>(FACE_C_DIM * 8 * 2)));
-    PACK((cfg_reg_rmw_tensix<PCK0_ADDR_CTRL_ZW_REG_0_Wstride_RMW>((TILE_NUM_FACES / 2) * FACE_C_DIM * 8 * 2)));
+    if constexpr (init_pack) {
+        sdpa_custom_mm_block_init_pack_short();
+    }
 }
 
 template <bool read_transposed = false>

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa_custom_mm_reuse_dest_srcb.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa_custom_mm_reuse_dest_srcb.h
@@ -105,14 +105,9 @@ ALWI void sdpa_custom_mm_reuse_dest_srcb_block_init_short(
  * | kt_dim         | The inner dimension (K reduction dimension).                            | uint32_t | Must be equal to block A column dimension      | True     |
  * | in1_k_stride   | Stride between K tiles in in1 CB (default 1 for contiguous K tiles).    | uint32_t | >= 1                                           | False    |
  * | signal_output  | Signal SFPU semaphore for pipelining (default false).                   | bool     | true or false                                  | False    |
- *
- * Compile-time template parameter:
- * | output_granularity | Number of output tiles produced between successive FPU->SFPU semaphore
- * |                    | posts when signal_output is true. nt_dim must be divisible by it.
- * |                    | Default is 2.                                                       | uint32_t | >= 1
  */
 // clang-format on
-template <std::uint32_t output_granularity = 2>
+template <std::uint32_t output_granularity>
 ALWI void sdpa_custom_mm_reuse_dest_srcb_block(
     uint32_t in0_cb_id,
     uint32_t in1_cb_id,

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa_custom_mm_reuse_dest_srcb.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa_custom_mm_reuse_dest_srcb.h
@@ -84,7 +84,7 @@ ALWI void sdpa_custom_mm_reuse_dest_srcb_block_init_short(
  *
  * Runtime parameter signal_output:
  *   false (default): Normal operation without signaling
- *   true: Signal SFPU semaphore every other tile for pipelining with subsequent operations
+ *   true: Signal SFPU semaphore for pipelining with subsequent operations
  *
  * Usage pattern for partial K:
  *   for (k = 0; k < num_k_subblocks - 1; k++) {

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa_custom_mm_reuse_dest_srcb.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa_custom_mm_reuse_dest_srcb.h
@@ -105,8 +105,14 @@ ALWI void sdpa_custom_mm_reuse_dest_srcb_block_init_short(
  * | kt_dim         | The inner dimension (K reduction dimension).                            | uint32_t | Must be equal to block A column dimension      | True     |
  * | in1_k_stride   | Stride between K tiles in in1 CB (default 1 for contiguous K tiles).    | uint32_t | >= 1                                           | False    |
  * | signal_output  | Signal SFPU semaphore for pipelining (default false).                   | bool     | true or false                                  | False    |
+ *
+ * Compile-time template parameter:
+ * | output_granularity | Number of output tiles produced between successive FPU->SFPU semaphore
+ * |                    | posts when signal_output is true. nt_dim must be divisible by it.
+ * |                    | Default is 2.                                                       | uint32_t | >= 1
  */
 // clang-format on
+template <std::uint32_t output_granularity = 2>
 ALWI void sdpa_custom_mm_reuse_dest_srcb_block(
     uint32_t in0_cb_id,
     uint32_t in1_cb_id,
@@ -122,8 +128,8 @@ ALWI void sdpa_custom_mm_reuse_dest_srcb_block(
     UNPACK((llk_unpack_A_sdpa_set_srcb_dummy_valid()));
     UNPACK((llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb(
         in0_cb_id, in1_cb_id, in0_tile_index, in1_tile_index, kt_dim, nt_dim, in1_k_stride)));
-    MATH(
-        (llk_math_sdpa_custom_mm_reuse_dest_srcb<MATH_FIDELITY>(isrc, idst, transpose, kt_dim, nt_dim, signal_output)));
+    MATH((llk_math_sdpa_custom_mm_reuse_dest_srcb<MATH_FIDELITY, output_granularity>(
+        isrc, idst, transpose, kt_dim, nt_dim, signal_output)));
 }
 
 }  // namespace ckernel

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_sdpa_custom_mm_reuse_dest_srcb.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_sdpa_custom_mm_reuse_dest_srcb.h
@@ -106,11 +106,7 @@ inline void _llk_math_sdpa_custom_mm_reuse_dest_srcb_init_(
 // Runtime parameter signal_output:
 //   false (default): Full sdpa_custom_mm_reuse_dest_srcb - MVMULs for all K tiles + finalization
 //   true: Partial K accumulation - MVMULs only, NO finalization (for intermediate K subblocks)
-//
-// Compile-time parameter output_granularity:
-//   Number of output tiles produced between successive FPU->SFPU semaphore posts when
-//   signal_output is true. nt_dim must be divisible by output_granularity.
-template <std::uint32_t output_granularity = 2>
+template <std::uint32_t output_granularity>
 inline void _llk_math_sdpa_custom_mm_reuse_dest_srcb_(
     uint src_index,
     uint dst_index,
@@ -134,7 +130,6 @@ inline void _llk_math_sdpa_custom_mm_reuse_dest_srcb_(
         TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, dst_index + dest_buffer_base);
         if (signal_output && i == kt_dim - 1) {
             for (uint32_t j = 0; j < nt_dim / output_granularity; j++) {
-                // output_granularity is a small compile-time constant; let the compiler unroll.
                 for (std::uint32_t g = 0; g < output_granularity; g++) {
                     lltt::replay(ckernel::math::replay_buf_offset, 4);
                 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_sdpa_custom_mm_reuse_dest_srcb.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_sdpa_custom_mm_reuse_dest_srcb.h
@@ -106,6 +106,11 @@ inline void _llk_math_sdpa_custom_mm_reuse_dest_srcb_init_(
 // Runtime parameter signal_output:
 //   false (default): Full sdpa_custom_mm_reuse_dest_srcb - MVMULs for all K tiles + finalization
 //   true: Partial K accumulation - MVMULs only, NO finalization (for intermediate K subblocks)
+//
+// Compile-time parameter output_granularity:
+//   Number of output tiles produced between successive FPU->SFPU semaphore posts when
+//   signal_output is true. nt_dim must be divisible by output_granularity.
+template <std::uint32_t output_granularity = 2>
 inline void _llk_math_sdpa_custom_mm_reuse_dest_srcb_(
     uint src_index,
     uint dst_index,
@@ -113,6 +118,7 @@ inline void _llk_math_sdpa_custom_mm_reuse_dest_srcb_(
     const std::uint32_t kt_dim = 1,
     const std::uint32_t nt_dim = 1,
     bool signal_output = false) {
+    static_assert(output_granularity >= 1, "output_granularity must be >= 1");
     constexpr uint32_t SFPU_FPU = ckernel::semaphore::UNPACK_MATH_DONE;
     uint32_t dest_buffer_base = get_dest_buffer_base();
     TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
@@ -126,11 +132,12 @@ inline void _llk_math_sdpa_custom_mm_reuse_dest_srcb_(
         TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_2, p_movd2b::MOV_4_ROWS, 12);
         t6_semaphore_get<p_stall::MATH>(SFPU_FPU);
         TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, dst_index + dest_buffer_base);
-        // TODO: Evaluate if we need to manually unroll the last iter
         if (signal_output && i == kt_dim - 1) {
-            for (uint32_t j = 0; j < nt_dim / 2; j++) {
-                lltt::replay(ckernel::math::replay_buf_offset, 4);
-                lltt::replay(ckernel::math::replay_buf_offset, 4);
+            for (uint32_t j = 0; j < nt_dim / output_granularity; j++) {
+                // output_granularity is a small compile-time constant; let the compiler unroll.
+                for (std::uint32_t g = 0; g < output_granularity; g++) {
+                    lltt::replay(ckernel::math::replay_buf_offset, 4);
+                }
                 t6_semaphore_post<p_stall::MATH>(semaphore::FPU_SFPU);
             }
         } else {

--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa/kernels/sdpa_compute.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa/kernels/sdpa_compute.cpp
@@ -41,19 +41,17 @@ void kernel_main() {
 
     constexpr bool exp_approx_mode = false;
 
-    // Number of output tiles produced between FPU->SFPU semaphore signals from the QK^T*V matmul.
-    // The packer loop below must consume tiles in matching groups.
-    // num_tiles_v must be divisible by output_granularity.
-    constexpr uint32_t output_granularity = 2;
+    constexpr uint32_t output_granularity = num_tiles_v;
     static_assert(num_tiles_v % output_granularity == 0, "num_tiles_v must be divisible by output_granularity");
-
-    PACK((llk_math_sfpu_sdpa_reduce_row_init<false, DST_ACCUM_MODE, DataFormat::Float16_b>()));
-    PACK(SFPU_TEMPLATE_INIT_KERNEL(exponential, sfpu::exp_init, true, scale_fp32, true));
-    sdpa_custom_mm_block_init<transpose_k>(cb_q, cb_k, cb_out, chunk_size);
 
     // TODO: Init ahead of time
     MATH(ckernel::t6_semaphore_init(ckernel::semaphore::FPU_SFPU, 0, 1));
     PACK(ckernel::t6_semaphore_init(SFPU_FPU, 0, 1));
+
+    PACK((llk_math_sfpu_sdpa_reduce_row_init<false, DST_ACCUM_MODE, DataFormat::Float16_b>()));
+    PACK(SFPU_TEMPLATE_INIT_KERNEL(exponential, sfpu::exp_init, true, scale_fp32, true));
+    sdpa_custom_mm_block_init<transpose_k>(cb_q, cb_k, cb_out, chunk_size);
+    pack_block_contiguous_init(cb_out);
 
     cb_wait_front(cb_q, num_tiles_k);
     cb_reserve_back(cb_out, num_tiles_v);
@@ -88,14 +86,12 @@ void kernel_main() {
     // Sem is incremented once per output_granularity tiles since sem can only go up to 15
     for (uint32_t i = 0; i < num_tiles_v; i += output_granularity) {
         PACK(t6_semaphore_wait_on_zero<p_stall::STALL_PACK>(semaphore::FPU_SFPU));
-        for (uint32_t g = 0; g < output_granularity; g++) {
-            pack_tile(mm2_dst_tile_offset + i + g, cb_out);
-        }
+        pack_block_contiguous(mm2_dst_tile_offset + i, cb_out, output_granularity);
         PACK(t6_semaphore_get<p_stall::PACK>(semaphore::FPU_SFPU));
     }
     // Stall for Red Sum to finish
     PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
-    pack_tile(max_dst_tile_offset, cb_stats);
+    pack_block_contiguous(max_dst_tile_offset, cb_stats, 1);
 
     // Validation that all counters are reset to 0
     // MATH(t6_semaphore_wait_on_max<p_stall::STALL_MATH>(SFPU_FPU));

--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa/kernels/sdpa_compute.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa/kernels/sdpa_compute.cpp
@@ -41,6 +41,12 @@ void kernel_main() {
 
     constexpr bool exp_approx_mode = false;
 
+    // Number of output tiles produced between FPU->SFPU semaphore signals from the QK^T*V matmul.
+    // The packer loop below must consume tiles in matching groups.
+    // num_tiles_v must be divisible by output_granularity.
+    constexpr uint32_t output_granularity = 2;
+    static_assert(num_tiles_v % output_granularity == 0, "num_tiles_v must be divisible by output_granularity");
+
     PACK((llk_math_sfpu_sdpa_reduce_row_init<false, DST_ACCUM_MODE, DataFormat::Float16_b>()));
     PACK(SFPU_TEMPLATE_INIT_KERNEL(exponential, sfpu::exp_init, true, scale_fp32, true));
     sdpa_custom_mm_block_init<transpose_k>(cb_q, cb_k, cb_out, chunk_size);
@@ -63,7 +69,8 @@ void kernel_main() {
             transpose_k,
             transpose_v,
             packed_tile_size,
-            exp_approx_mode>(
+            exp_approx_mode,
+            output_granularity>(
             cb_q,
             cb_k,
             0,  // cb_mask
@@ -78,11 +85,12 @@ void kernel_main() {
             false /* mask_last_chunk */);
     }
 
-    // Sem is incremented once per 2 tiles since sem can only go up to 15
-    for (uint32_t i = 0; i < num_tiles_v; i += 2) {
+    // Sem is incremented once per output_granularity tiles since sem can only go up to 15
+    for (uint32_t i = 0; i < num_tiles_v; i += output_granularity) {
         PACK(t6_semaphore_wait_on_zero<p_stall::STALL_PACK>(semaphore::FPU_SFPU));
-        pack_tile(mm2_dst_tile_offset + i, cb_out);
-        pack_tile(mm2_dst_tile_offset + i + 1, cb_out);
+        for (uint32_t g = 0; g < output_granularity; g++) {
+            pack_tile(mm2_dst_tile_offset + i + g, cb_out);
+        }
         PACK(t6_semaphore_get<p_stall::PACK>(semaphore::FPU_SFPU));
     }
     // Stall for Red Sum to finish

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -716,6 +716,13 @@ struct FlashMLADecode {
 
             constexpr bool exp_approx_mode = false;
 
+            // Number of output tiles produced between FPU->SFPU semaphore signals from the
+            // QK^T*V matmul. The packer below must consume tiles in matching groups.
+            // out_chunk_tiles must be divisible by output_granularity.
+            constexpr uint32_t output_granularity = 2;
+            static_assert(
+                out_chunk_tiles % output_granularity == 0, "out_chunk_tiles must be divisible by output_granularity");
+
             bool sdpa_output_is_final = do_output && (!do_reduce || num_cores_to_wait == 0);
             uint32_t sdpa_output_cb = 0;
             uint32_t sdpa_ms_cb = 0;
@@ -750,7 +757,8 @@ struct FlashMLADecode {
                     transpose_k,
                     transpose_v,
                     packed_tile_size,
-                    exp_approx_mode>(
+                    exp_approx_mode,
+                    output_granularity>(
                     cb_q_in,
                     cb_k_in,
                     cb_mask,
@@ -772,10 +780,11 @@ struct FlashMLADecode {
                 compute_sdpa_recip<out_chunk_tiles, exp_approx_mode, scale_bf16>(
                     cb_q_in, sum_dst_offset, corr_exp_dst_offset, mm2_dst_offset);
             }
-            for (uint32_t i = 0; i < out_chunk_tiles; i += 2) {
+            for (uint32_t i = 0; i < out_chunk_tiles; i += output_granularity) {
                 PACK(t6_semaphore_wait_on_zero<p_stall::STALL_PACK>(semaphore::FPU_SFPU));
-                pack_tile(mm2_dst_tile_offset + i, sdpa_output_cb);
-                pack_tile(mm2_dst_tile_offset + i + 1, sdpa_output_cb);
+                for (uint32_t g = 0; g < output_granularity; g++) {
+                    pack_tile(mm2_dst_tile_offset + i + g, sdpa_output_cb);
+                }
                 PACK(t6_semaphore_get<p_stall::PACK>(semaphore::FPU_SFPU));
             }
             cb_push_back(sdpa_output_cb, out_chunk_tiles);

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -717,10 +717,7 @@ struct FlashMLADecode {
 
             constexpr bool exp_approx_mode = false;
 
-            // Number of output tiles produced between FPU->SFPU semaphore signals from the
-            // QK^T*V matmul. The packer below must consume tiles in matching groups.
-            // out_chunk_tiles must be divisible by output_granularity.
-            constexpr uint32_t output_granularity = 2;
+            constexpr uint32_t output_granularity = out_chunk_tiles;
             static_assert(
                 out_chunk_tiles % output_granularity == 0, "out_chunk_tiles must be divisible by output_granularity");
 
@@ -738,6 +735,7 @@ struct FlashMLADecode {
                 sdpa_output_cb = cb_out_o;
                 sdpa_ms_cb = cb_out_ms;
             }
+            pack_block_contiguous_init(sdpa_output_cb);
             uint32_t num_chunks = (k_chunk_end - k_chunk_start + args.num_cores_per_head - 1) / args.num_cores_per_head;
             bool mask_last_chunk = k_chunk_end == k_num_chunks && (cur_pos + 1) % args.k_chunk_size != 0;
             if (mask_last_chunk) {
@@ -776,7 +774,7 @@ struct FlashMLADecode {
             }
             if (!sdpa_output_is_final) {
                 PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
-                pack_tile(max_dst_tile_offset, sdpa_ms_cb);
+                pack_block_contiguous(max_dst_tile_offset, sdpa_ms_cb, 1);
                 cb_push_back(sdpa_ms_cb, Sq_chunk_t);
             } else {
                 compute_sdpa_recip<out_chunk_tiles, exp_approx_mode, scale_bf16>(
@@ -784,9 +782,7 @@ struct FlashMLADecode {
             }
             for (uint32_t i = 0; i < out_chunk_tiles; i += output_granularity) {
                 PACK(t6_semaphore_wait_on_zero<p_stall::STALL_PACK>(semaphore::FPU_SFPU));
-                for (uint32_t g = 0; g < output_granularity; g++) {
-                    pack_tile(mm2_dst_tile_offset + i + g, sdpa_output_cb);
-                }
+                pack_block_contiguous(mm2_dst_tile_offset + i, sdpa_output_cb, output_granularity);
                 PACK(t6_semaphore_get<p_stall::PACK>(semaphore::FPU_SFPU));
             }
             cb_push_back(sdpa_output_cb, out_chunk_tiles);

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -684,6 +684,7 @@ struct FlashMLADecode {
             pack_reconfig_data_format<true>(cb_out_o);
             PACK((llk_math_sfpu_sdpa_reduce_row_init<false, DST_ACCUM_MODE, DataFormat::Float16_b>()));
             PACK(SFPU_TEMPLATE_INIT_KERNEL(exponential, sfpu::exp_init, true, scale_fp32, true));
+            sdpa_custom_mm_block_init_pack_short();
 
             uint32_t cur_pos = args.local_cur_pos;
             auto [k_num_chunks, k_chunk_start, k_chunk_end] = get_runtime_args(
@@ -758,7 +759,8 @@ struct FlashMLADecode {
                     transpose_v,
                     packed_tile_size,
                     exp_approx_mode,
-                    output_granularity>(
+                    output_granularity,
+                    false>(
                     cb_q_in,
                     cb_k_in,
                     cb_mask,


### PR DESCRIPTION
### Summary
Switch to pack_block_contiguous for sdpa output.
Fix replay start offsets for reduce row.
Add missing clear in fast_approx_exp.
Change output granularity from 2 to all tiles. Packer seems to be behind math, so there is no gain from chunking the output.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/sdpa-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/sdpa-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aho/sdpa-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aho/sdpa-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/sdpa-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/sdpa-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/sdpa-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/sdpa-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aho/sdpa-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aho/sdpa-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/sdpa-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/sdpa-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/sdpa-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/sdpa-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/sdpa-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/sdpa-ops)