### PR TITLE
Fix RMS allgather second reduce hang on multi-chip WH

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
@@ -1001,6 +1001,69 @@ def test_rms_fuse(
     )
 
 
+@skip_for_blackhole("This is a wormhole test")
+@pytest.mark.skipif(is_6u(), reason="This test is for N300 (2-chip WH)")
+@pytest.mark.parametrize(
+    "num_devices, elements_per_batch, input_shard_grid, output_shard_grid",
+    [
+        (
+            2,
+            2048,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 7))}),
+            None,
+        ),
+    ],
+)
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize("num_iters", [5])
+@pytest.mark.parametrize("fused_add", [True, False])
+@pytest.mark.parametrize("use_noc1_only", [False])
+@pytest.mark.parametrize("mesh_device", [pytest.param((2, 1), id="2x1_grid")], indirect=True)
+@pytest.mark.parametrize("input_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("residual_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("output_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    indirect=True,
+)
+@pytest.mark.parametrize("topology", [ttnn.Topology.Linear])
+def test_rms_fuse_n300(
+    mesh_device,
+    num_devices,
+    elements_per_batch,
+    num_links,
+    num_iters,
+    function_level_defaults,
+    input_shard_grid,
+    output_shard_grid,
+    fused_add,
+    use_noc1_only,
+    input_dtype,
+    residual_dtype,
+    output_dtype,
+    topology,
+):
+    if mesh_device.get_num_devices() != 2:
+        pytest.skip("Not N300 - this test targets 2-chip Wormhole")
+    run_rms_fuse_impl_deepseek(
+        mesh_device,
+        num_devices,
+        elements_per_batch,
+        num_links,
+        function_level_defaults,
+        input_shard_grid,
+        output_shard_grid,
+        topology,
+        fused_add,
+        use_noc1_only=use_noc1_only,
+        output_dtype=output_dtype,
+        num_iters=num_iters,
+        input_dtype=input_dtype,
+        residual_dtype=residual_dtype,
+    )
+
+
 # Enumerate the post-commit cases explicitly
 @skip_for_blackhole("This is a wormhole test")
 @pytest.mark.skipif(is_6u(), reason="This test is not for 6U devices")

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/compute/rms_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/compute/rms_compute.cpp
@@ -193,12 +193,13 @@ void kernel_main() {
             compute_kernel_lib::reduce<
                 PoolType::AVG,
                 ReduceDim::REDUCE_ROW,
-                compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
+                compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop,
                 compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
                 cb_stats,
                 post_cb_scaler_global,
                 cb_var,
                 compute_kernel_lib::ReduceInputBlockShape::row(num_distributed_blocks));
+            cb_pop_front(cb_stats, num_distributed_blocks);
 
             // 1/[sqrt(Var + eps)],
             reconfig_data_format(cb_var, cb_eps);  // cb_var is cb_stats in case of RMS norm


### PR DESCRIPTION
### Summary
Fixes a hang in `ttnn.fused_rms_minimal` (the `rms_allgather` op) introduced when its compute kernel was migrated to use `compute_kernel_lib::reduce`. Closes [#41637](https://github.com/tenstorrent/tt-metal/issues/43173).

### Root cause
The migration to `compute_kernel_lib::reduce` is the regression source. The kernel has two reduce calls:

1. The first reduce on `cb_ex_external2` — properly produced by `rms_receiver_reader` via `cb_push_back` on each tile.
2. The second reduce on `cb_stats` — `cb_stats` is the persistent stats CB whose contents arrive via NoC writes during the all-gather. **Nothing ever calls `cb_push_back(cb_stats, …)`** (grep over the whole op directory: only `cb_stats_reduced` is push'd). Readiness is signaled out-of-band via `signaling_cb`.

The previous manual loop on `cb_stats` worked because it never called `cb_wait_front` on it — it just called `reduce_tile(idx=0)` then `cb_pop_front` per iteration. The helper's default policy `WaitAndPopPerTile` calls `input_cb.wait_front(onetile)` per iteration ([`reduce_helpers_compute.inl:364`](ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl#L364)), which blocks forever on `cb_stats` since the front counter is never incremented.

This deadlocks the whole graph: TRISC0 stuck in the helper → BRISC sender stuck on `cb_wait_front(cb_stats_reduced)` waiting for compute → BRISC receiver stuck on `noc_semaphore_wait` waiting for sender's `global_semaphore_set()`.

### Fix
Switch the second reduce to `ReduceInputPolicy::NoWaitNoPop` (uses indexed access, no wait, no pop) and explicitly call `cb_pop_front(cb_stats, num_distributed_blocks)` after the helper to advance the read pointer for subsequent iterations. This restores the manual-loop semantics while keeping the helper. Diff is two lines in [`rms_compute.cpp`](ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/compute/rms_compute.cpp).

### CI gap
**This op had no live unit-test signal in CI.** Every existing rms test in `tests/ttnn/unit_tests/operations/ccl/test_minimals.py` hardcodes `mesh_device=(8,4)` (TG/galaxy), but the L2 nightly hardware matrix is N150/N300/P100/P150b — so all of them silently self-skip via the `mesh_device` fixture's "not enough devices available" branch.

Production use is limited: `fused_rms_minimal` is called in tt-metal **only** from `models/demos/llama3_70b_galaxy/tt/llama_ccl.py:tt_sharded_distributed_rmsnorm`, and only in **decode mode** (prefill takes a separate non-fused path). Llama 70B / Qwen3 32B Galaxy decode in `vllm-nightly`, `galaxy-stress-tests`, and tier-1 model workflows would have caught a hang here at end-to-end level — but nightly Galaxy CI has been red on unrelated failures during this window, so it's unclear whether the regression actually impacted those runs.

### What's added
- **`test_rms_fuse_n300`** in `test_minimals.py` — fast unit-level signal on N300, parameterized for both `fused_add={True, False}`, routed through `run_rms_fuse_impl_deepseek` (the only properly num-devices-parameterized helper). 5 iterations, bf16 in/out. Picked up by L2-nightly group 1.

### CI infrastructure note (separate follow-up)
To prove the new test actually runs in nightly CI on this branch, I had to apply two L2-nightly workflow fixes locally (kept on a separate branch, not in this PR):
- Add `if: ${{ !cancelled() }}` to the data_movement/ccl group 1 step. Group 1 had no `if:` clause, defaulting to `success()` — so any failure in the prior `tests/ttnn/nightly/.../data_movement` step (which uses `-x`) silently dropped 1/3 of the L2-nightly CCL coverage. Groups 2/3 already had this guard.
- Drop `-x` from group 1's pytest (kept `-v`) to surface all failures inside the group rather than stopping at the first.

Without these, group 1 (which is where `test_minimals.py` lives) had been silently skipping on every nightly where the prior step was red. Following up with the data-movement team to confirm whether that skipping behavior was intentional before sending those workflow changes as a separate PR.

### CI Status
Runs are on the `sjovic/rms-fix-ci` branch (which contains this PR's commit plus the workflow fixes mentioned above so the new test actually executes on the nightly N300 runner). Click a badge to see the runs.

- **L2 nightly** — N300 runner ran `test_rms_fuse_n300` in group 1, PASSED both parametrizations: [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sjovic/rms-fix-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sjovic/rms-fix-ci)
- **All Model Tests** (Tier 1, llama3.3-70b) — production decode path through `fused_rms_minimal`: [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sjovic/rms-fix-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sjovic/rms-fix-ci)
- **Sanity tests**: [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sjovic/rms-fix-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sjovic/rms-fix-ci)

### Test plan
- [x] Local repro of the hang on N300 captured via tt-triage (TRISC0 stuck in `reduce_helpers_compute.inl:364`)
- [x] Local pass after fix: `test_rms_fuse_n300` both parametrizations, PCC ≥ 0.9997
- [x] CI runs above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
