### PR TITLE
tt_metal: add experimental NoC page-size assertions

### DIFF
--- a/tt_metal/hw/inc/experimental/noc.h
+++ b/tt_metal/hw/inc/experimental/noc.h
@@ -23,6 +23,13 @@ struct noc_traits_t {
     static_assert(sizeof(T) == 0, "NoC transactions are not supported for this type");
 };
 
+// Opt-in bounds-check hook called from async_read/async_write. Endpoints that model a
+// bounded region (page, shard, CB page) specialize this to fail at the trait call —
+// with endpoint type and args visible — instead of later in the NOC stack. Default
+// no-op so endpoints without page semantics need not participate.
+template <typename T, typename Args>
+FORCE_INLINE void noc_traits_check_bounds(const T& /*endpoint*/, const Args& /*args*/, uint32_t /*size_bytes*/) {}
+
 /**
  * @brief Noc class that provides a high-level interface for asynchronous read and write operations.
  *
@@ -121,6 +128,8 @@ public:
         const dst_args_t<Dst>& dst_args,
         uint32_t read_req_vc = NOC_UNICAST_WRITE_VC,
         uint32_t trid = INVALID_TXN_ID) const {
+        noc_traits_check_bounds(src, src_args, size_bytes);
+        noc_traits_check_bounds(dst, dst_args, size_bytes);
         if constexpr (txn_id_mode == TxnIdMode::ENABLED) {
             noc_async_read_set_trid(trid, noc_id_);
             while (noc_available_transactions(noc_id_, trid) < ((NOC_MAX_TRANSACTION_ID_COUNT + 1) / 2)) {
@@ -253,6 +262,9 @@ public:
         uint32_t vc = NOC_UNICAST_WRITE_VC,
         uint32_t trid = INVALID_TXN_ID) const {
         constexpr bool posted = response_mode == ResponseMode::POSTED;
+
+        noc_traits_check_bounds(src, src_args, size_bytes);
+        noc_traits_check_bounds(dst, dst_args, size_bytes);
 
         if constexpr (txn_id_mode == TxnIdMode::ENABLED) {
             // TODO (#31535): Need to add check in ncrisc_noc_fast_write_any_len to ensure outstanding transaction

--- a/tt_metal/hw/inc/experimental/tensor.h
+++ b/tt_metal/hw/inc/experimental/tensor.h
@@ -43,6 +43,29 @@ struct noc_traits_t<TensorAccessor<DSpecT>> {
     }
 };
 
+// Bounds-check for TensorAccessor: assert the transaction stays inside one page
+// (interleaved — adjacent page_ids live in different banks) or inside the bytes left
+// in the shard containing args.page_id (sharded — pages within a shard are contiguous,
+// but starting mid-shard leaves only a partial shard of room).
+template <typename DSpecT, typename Args>
+FORCE_INLINE std::enable_if_t<
+    std::is_same_v<Args, typename noc_traits_t<TensorAccessor<DSpecT>>::src_args_type> ||
+    std::is_same_v<Args, typename noc_traits_t<TensorAccessor<DSpecT>>::dst_args_type>>
+noc_traits_check_bounds(const TensorAccessor<DSpecT>& endpoint, const Args& args, uint32_t size_bytes) {
+    if constexpr (DSpecT::is_interleaved) {
+        ASSERT(args.offset_bytes + size_bytes <= endpoint.get_aligned_page_size());
+    } else {
+        // Surface page_id check at the trait call (also asserted in get_bank_and_offset).
+        ASSERT(args.page_id < endpoint.dspec().tensor_volume());
+        const uint32_t shard_volume = endpoint.dspec().shard_volume();
+        const uint32_t page_size_b = endpoint.get_aligned_page_size();
+        const uint32_t page_in_shard =
+            static_cast<uint32_t>(endpoint.get_bank_and_offset(args.page_id).bank_page_offset % shard_volume);
+        const uint32_t bytes_left_in_shard = (shard_volume - page_in_shard) * page_size_b;
+        ASSERT(args.offset_bytes + size_bytes <= bytes_left_in_shard);
+    }
+}
+
 template <typename Accessor>
 struct noc_traits_t<PageView<Accessor>> {
     struct src_args_type {
@@ -74,6 +97,26 @@ struct noc_traits_t<PageView<Accessor>> {
         }
     }
 };
+
+// Bounds-check for PageView: same logic as TensorAccessor, delegating layout query
+// to the underlying accessor.
+template <typename Accessor, typename Args>
+FORCE_INLINE std::enable_if_t<
+    std::is_same_v<Args, typename noc_traits_t<PageView<Accessor>>::src_args_type> ||
+    std::is_same_v<Args, typename noc_traits_t<PageView<Accessor>>::dst_args_type>>
+noc_traits_check_bounds(const PageView<Accessor>& endpoint, const Args& args, uint32_t size_bytes) {
+    if constexpr (Accessor::DSpec::is_interleaved) {
+        ASSERT(args.offset_bytes + size_bytes <= endpoint.accessor.get_aligned_page_size());
+    } else {
+        ASSERT(args.page_id < endpoint.accessor.dspec().tensor_volume());
+        const uint32_t shard_volume = endpoint.accessor.dspec().shard_volume();
+        const uint32_t page_size_b = endpoint.accessor.get_aligned_page_size();
+        const uint32_t page_in_shard =
+            static_cast<uint32_t>(endpoint.accessor.get_bank_and_offset(args.page_id).bank_page_offset % shard_volume);
+        const uint32_t bytes_left_in_shard = (shard_volume - page_in_shard) * page_size_b;
+        ASSERT(args.offset_bytes + size_bytes <= bytes_left_in_shard);
+    }
+}
 
 template <typename Accessor>
 struct noc_traits_t<ShardView<Accessor>> {


### PR DESCRIPTION
## Summary
- Adds compile-time-dispatched bounds checks to the experimental `Noc` class so out-of-region transactions fail at the trait call (with endpoint type and user args visible) rather than later in the NOC stack with corrupted state.
- New `noc_traits_check_bounds<T, Args>()` primary template (no-op default, so endpoints without page semantics — `UnicastEndpoint`, `AllocatorBank` — do not have to opt in); bounds-check call inserted into `Noc::async_read` and `Noc::async_write`, guarded by the trait.
- Specializations for `TensorAccessor<DSpecT>` (interleaved bounds to one page; sharded bounds to remaining bytes in the shard containing `args.page_id`) and `PageView<Accessor>` (delegates to the underlying accessor).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mstaletovic/noc_page_assertions)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mstaletovic/noc_page_assertions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mstaletovic/noc_page_assertions)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mstaletovic/noc_page_assertions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mstaletovic/noc_page_assertions)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mstaletovic/noc_page_assertions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mstaletovic/noc_page_assertions)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mstaletovic/noc_page_assertions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mstaletovic/noc_page_assertions)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mstaletovic/noc_page_assertions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mstaletovic/noc_page_assertions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mstaletovic/noc_page_assertions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mstaletovic/noc_page_assertions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mstaletovic/noc_page_assertions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mstaletovic/noc_page_assertions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mstaletovic/noc_page_assertions)
