### PR TITLE
compute  api: fix missing icb in unary datacopy

### DIFF
--- a/tt_metal/hw/inc/api/compute/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/pack_untilize.h
@@ -159,7 +159,7 @@ ALWI void pack_untilize_block(uint32_t icb, uint32_t block_rt_dim, uint32_t ocb,
 #ifndef ARCH_QUASAR
             UNPACK(
                 (llk_unpack_A<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(icb, c)));
-            MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(c)));
+            MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(c, icb)));
 #else
             UNPACK((llk_unpack_A(icb, c)));
             MATH((llk_math_eltwise_unary_datacopy(c, icb)));

--- a/tt_metal/hw/inc/api/compute/tilize.h
+++ b/tt_metal/hw/inc/api/compute/tilize.h
@@ -160,7 +160,7 @@ ALWI void tilize_block(
 #ifndef ARCH_QUASAR
         // Datacopy
         MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(
-            0 /*dst index*/)));
+            0 /*dst index*/, icb)));
         PACK((llk_pack<DST_ACCUM_MODE, true, false>(0 /*tile index*/, ocb, t + output_tile_index)));
 #else
         MATH((llk_math_eltwise_unary_datacopy(0 /*dst index*/, icb)));

--- a/tt_metal/hw/inc/api/compute/untilize.h
+++ b/tt_metal/hw/inc/api/compute/untilize.h
@@ -67,7 +67,7 @@ ALWI void untilize_block(uint32_t icb, uint32_t full_ct_dim, uint32_t ocb) {
 
         // Datacopy
         for (uint32_t reg_id = 0; reg_id < block_ct_dim; reg_id++) {
-            MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(reg_id)));
+            MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(reg_id, icb)));
         }
 
         MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Cherry-picked from `llk/san/dev`. Came across this while testing the sanitizer. 

This can cause issues when ICB != CB0 when one contains 32bit datums, and the other does not

The result would be that the wrong path is is hit in LLK LIB. Example:
- ICB - 16b, CB0 - 32bit -> 32bit unpack to Dest would be issued from ICB.

I assume this wasn't found before because it isn't common to mix 32bit and 16bit datums in a correct way inside a single kernel.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sstanisic/datacopy-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sstanisic/datacopy-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sstanisic/datacopy-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sstanisic/datacopy-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sstanisic/datacopy-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sstanisic/datacopy-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sstanisic/datacopy-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sstanisic/datacopy-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sstanisic/datacopy-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sstanisic/datacopy-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sstanisic/datacopy-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sstanisic/datacopy-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sstanisic/datacopy-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sstanisic/datacopy-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sstanisic/datacopy-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sstanisic/datacopy-bug)