### PR TITLE
Add shard spec validation in normalization ops

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/normalization/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources(
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
         FILES ${kernels}
     PRIVATE
+        shard_spec_validation.cpp
         batch_norm/batch_norm.cpp
         batch_norm/device/batch_norm_device_operation.cpp
         batch_norm/device/batch_norm_program_factory.cpp

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.hpp"
+#include "ttnn/operations/normalization/shard_spec_validation.hpp"
 
 using namespace tt::tt_metal;
 
@@ -67,61 +68,11 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
         tile_height);
 
     if (a.is_sharded()) {
-        const auto& shard_spec = a.shard_spec().value();
-        const auto& shard_shape = shard_spec.shape;
-        const auto& shard_grid = shard_spec.grid;
-
-        const auto device_grid = a.device()->compute_with_storage_grid_size();
         const auto program_grid =
             std::visit([](const auto& config) { return config.compute_with_storage_grid_size; }, args.program_config);
-
-        TT_FATAL(shard_grid.num_cores() > 0, "Shard grid must have at least one core");
-
-        const CoreRange device_range(CoreCoord{0, 0}, CoreCoord{device_grid.x - 1, device_grid.y - 1});
-        const CoreRange program_range(CoreCoord{0, 0}, CoreCoord{program_grid.x - 1, program_grid.y - 1});
-        TT_FATAL(
-            device_range.contains(program_range),
-            "program_config grid ({}x{}) must be contained within device grid ({}x{})",
-            program_grid.x,
-            program_grid.y,
-            device_grid.x,
-            device_grid.y);
-
-        const auto shard_bbox = shard_grid.bounding_box();
-        const auto shard_offset = shard_bbox.start_coord;
-        const CoreRange shifted_shard_bbox(
-            CoreCoord{0, 0},
-            CoreCoord{shard_bbox.end_coord.x - shard_offset.x, shard_bbox.end_coord.y - shard_offset.y});
-        TT_FATAL(
-            program_range.contains(shifted_shard_bbox),
-            "shard_spec.grid size {}x{} does not fit within program_config grid {}x{}",
-            shard_bbox.end_coord.x - shard_bbox.start_coord.x + 1,
-            shard_bbox.end_coord.y - shard_bbox.start_coord.y + 1,
-            program_grid.x,
-            program_grid.y);
-
-        TT_FATAL(
-            shard_shape[0] > 0 && shard_shape[1] > 0,
-            "shard shape must be non-zero, got H={} W={}",
-            shard_shape[0],
-            shard_shape[1]);
-
-        TT_FATAL(
-            shard_shape[0] % tile_height == 0,
-            "shard height {} must be divisible by tile height {}",
-            shard_shape[0],
-            tile_height);
-
-        const auto num_cores = shard_grid.num_cores();
-        const auto total_from_shards = static_cast<uint64_t>(num_cores) * shard_shape[0] * shard_shape[1];
-        TT_FATAL(
-            total_from_shards == a.physical_volume(),
-            "Total elements from shards ({} cores * {}x{}) = {} does not match tensor physical volume {}",
-            num_cores,
-            shard_shape[0],
-            shard_shape[1],
-            total_from_shards,
-            a.physical_volume());
+        // groupnorm operates on per-channel slices, so its kernels accept shard widths that are not tile-aligned.
+        ttnn::operations::normalization::detail::validate_sharded_input(
+            a, program_grid, /*require_shard_width_tile_aligned=*/false);
     }
     if (gamma.has_value()) {
         if (gamma.value().layout() == Layout::TILE) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -66,7 +66,6 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
         a.padded_shape()[2],
         tile_height);
 
-    // SHARD SPEC VALIDATION
     if (a.is_sharded()) {
         const auto& shard_spec = a.shard_spec().value();
         const auto& shard_shape = shard_spec.shape;
@@ -76,7 +75,6 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
         const auto program_grid =
             std::visit([](const auto& config) { return config.compute_with_storage_grid_size; }, args.program_config);
 
-        // 1. Grid hierarchy: shard_spec.grid ⊆ program_config.grid ⊆ device.grid
         TT_FATAL(shard_grid.num_cores() > 0, "Shard grid must have at least one core");
 
         const CoreRange device_range(CoreCoord{0, 0}, CoreCoord{device_grid.x - 1, device_grid.y - 1});
@@ -94,25 +92,18 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
             program_grid.x,
             program_grid.y);
 
-        // 2. Shard shape must be non-zero
         TT_FATAL(
             shard_shape[0] > 0 && shard_shape[1] > 0,
             "shard shape must be non-zero, got H={} W={}",
             shard_shape[0],
             shard_shape[1]);
 
-        // 3. Tile alignment.
-        //    Shard height (per_core_M) MUST be tile-aligned; the kernel divides exactly by tile_height.
-        //    Shard width  (per_core_N) is intentionally NOT enforced here: groupnorm_sharded_program_factory
-        //    handles non-tile-aligned widths via per_core_Nt = ceil(per_core_N / tile_width) and the
-        //    `reader_repack_output` path. Other normalization ops without that path must enforce it.
         TT_FATAL(
             shard_shape[0] % tile_height == 0,
             "shard height {} must be divisible by tile height {}",
             shard_shape[0],
             tile_height);
 
-        // 4. Total elements: num_cores * per-shard elements == physical tensor volume
         const auto num_cores = shard_grid.num_cores();
         const auto total_from_shards = static_cast<uint64_t>(num_cores) * shard_shape[0] * shard_shape[1];
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -69,38 +69,60 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
     // SHARD SPEC VALIDATION
     if (a.is_sharded()) {
         const auto& shard_spec = a.shard_spec().value();
-
-        // shard spec
-        std::cout << "Shard shape: H=" << shard_spec.shape[0] << " W=" << shard_spec.shape[1] << std::endl;
-
-        std::cout << "Shard orientation: " << (int)shard_spec.orientation << std::endl;
-
+        const auto& shard_shape = shard_spec.shape;
         const auto& shard_grid = shard_spec.grid;
 
-        // shard grid
-        std::cout << "Shard grid num cores: " << shard_grid.num_cores() << std::endl;
-
-        // device grid
-        auto device_grid = a.device()->compute_with_storage_grid_size();
-        std::cout << "Device grid: x=" << device_grid.x << " y=" << device_grid.y << std::endl;
-
-        // program grid
-        auto program_grid =
+        const auto device_grid = a.device()->compute_with_storage_grid_size();
+        const auto program_grid =
             std::visit([](const auto& config) { return config.compute_with_storage_grid_size; }, args.program_config);
 
-        std::cout << "Program grid: x=" << program_grid.x << " y=" << program_grid.y << std::endl;
-
-        // validation
+        // 1. Grid hierarchy: shard_spec.grid ⊆ program_config.grid ⊆ device.grid
         TT_FATAL(shard_grid.num_cores() > 0, "Shard grid must have at least one core");
 
+        const CoreRange device_range(CoreCoord{0, 0}, CoreCoord{device_grid.x - 1, device_grid.y - 1});
+        const CoreRange program_range(CoreCoord{0, 0}, CoreCoord{program_grid.x - 1, program_grid.y - 1});
         TT_FATAL(
-            program_grid.x <= device_grid.x && program_grid.y <= device_grid.y,
-            "Program grid must be within device grid");
+            device_range.contains(program_range),
+            "program_config grid ({}x{}) must be contained within device grid ({}x{})",
+            program_grid.x,
+            program_grid.y,
+            device_grid.x,
+            device_grid.y);
+        TT_FATAL(
+            program_range.contains(shard_grid),
+            "shard_spec.grid is not contained within program_config grid ({}x{})",
+            program_grid.x,
+            program_grid.y);
 
-        CoreCoord end(program_grid.x - 1, program_grid.y - 1);
-        CoreRange program_range(CoreCoord(0, 0), end);
+        // 2. Shard shape must be non-zero
+        TT_FATAL(
+            shard_shape[0] > 0 && shard_shape[1] > 0,
+            "shard shape must be non-zero, got H={} W={}",
+            shard_shape[0],
+            shard_shape[1]);
 
-        TT_FATAL(program_range.contains(shard_grid), "Shard grid must be within program grid");
+        // 3. Tile alignment.
+        //    Shard height (per_core_M) MUST be tile-aligned; the kernel divides exactly by tile_height.
+        //    Shard width  (per_core_N) is intentionally NOT enforced here: groupnorm_sharded_program_factory
+        //    handles non-tile-aligned widths via per_core_Nt = ceil(per_core_N / tile_width) and the
+        //    `reader_repack_output` path. Other normalization ops without that path must enforce it.
+        TT_FATAL(
+            shard_shape[0] % tile_height == 0,
+            "shard height {} must be divisible by tile height {}",
+            shard_shape[0],
+            tile_height);
+
+        // 4. Total elements: num_cores * per-shard elements == physical tensor volume
+        const auto num_cores = shard_grid.num_cores();
+        const auto total_from_shards = static_cast<uint64_t>(num_cores) * shard_shape[0] * shard_shape[1];
+        TT_FATAL(
+            total_from_shards == a.physical_volume(),
+            "Total elements from shards ({} cores * {}x{}) = {} does not match tensor physical volume {}",
+            num_cores,
+            shard_shape[0],
+            shard_shape[1],
+            total_from_shards,
+            a.physical_volume());
     }
     if (gamma.has_value()) {
         if (gamma.value().layout() == Layout::TILE) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -86,9 +86,17 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
             program_grid.y,
             device_grid.x,
             device_grid.y);
+
+        const auto shard_bbox = shard_grid.bounding_box();
+        const auto shard_offset = shard_bbox.start_coord;
+        const CoreRange shifted_shard_bbox(
+            CoreCoord{0, 0},
+            CoreCoord{shard_bbox.end_coord.x - shard_offset.x, shard_bbox.end_coord.y - shard_offset.y});
         TT_FATAL(
-            program_range.contains(shard_grid),
-            "shard_spec.grid is not contained within program_config grid ({}x{})",
+            program_range.contains(shifted_shard_bbox),
+            "shard_spec.grid size {}x{} does not fit within program_config grid {}x{}",
+            shard_bbox.end_coord.x - shard_bbox.start_coord.x + 1,
+            shard_bbox.end_coord.y - shard_bbox.start_coord.y + 1,
             program_grid.x,
             program_grid.y);
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -70,7 +70,6 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
     if (a.is_sharded()) {
         const auto program_grid =
             std::visit([](const auto& config) { return config.compute_with_storage_grid_size; }, args.program_config);
-        // groupnorm operates on per-channel slices, so its kernels accept shard widths that are not tile-aligned.
         ttnn::operations::normalization::detail::validate_sharded_input(
             a, program_grid, /*require_shard_width_tile_aligned=*/false);
     }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -66,6 +66,42 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
         a.padded_shape()[2],
         tile_height);
 
+    // SHARD SPEC VALIDATION
+    if (a.is_sharded()) {
+        const auto& shard_spec = a.shard_spec().value();
+
+        // shard spec
+        std::cout << "Shard shape: H=" << shard_spec.shape[0] << " W=" << shard_spec.shape[1] << std::endl;
+
+        std::cout << "Shard orientation: " << (int)shard_spec.orientation << std::endl;
+
+        const auto& shard_grid = shard_spec.grid;
+
+        // shard grid
+        std::cout << "Shard grid num cores: " << shard_grid.num_cores() << std::endl;
+
+        // device grid
+        auto device_grid = a.device()->compute_with_storage_grid_size();
+        std::cout << "Device grid: x=" << device_grid.x << " y=" << device_grid.y << std::endl;
+
+        // program grid
+        auto program_grid =
+            std::visit([](const auto& config) { return config.compute_with_storage_grid_size; }, args.program_config);
+
+        std::cout << "Program grid: x=" << program_grid.x << " y=" << program_grid.y << std::endl;
+
+        // validation
+        TT_FATAL(shard_grid.num_cores() > 0, "Shard grid must have at least one core");
+
+        TT_FATAL(
+            program_grid.x <= device_grid.x && program_grid.y <= device_grid.y,
+            "Program grid must be within device grid");
+
+        CoreCoord end(program_grid.x - 1, program_grid.y - 1);
+        CoreRange program_range(CoreCoord(0, 0), end);
+
+        TT_FATAL(program_range.contains(shard_grid), "Shard grid must be within program grid");
+    }
     if (gamma.has_value()) {
         if (gamma.value().layout() == Layout::TILE) {
             TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -192,9 +192,15 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
                 program_grid.y,
                 device_grid.x,
                 device_grid.y);
+
+            const auto shard_offset = bbox.start_coord;
+            const CoreRange shifted_shard_bbox(
+                CoreCoord{0, 0}, CoreCoord{bbox.end_coord.x - shard_offset.x, bbox.end_coord.y - shard_offset.y});
             TT_FATAL(
-                program_range.contains(shard_grid),
-                "shard_spec.grid is not contained within program_config grid ({}x{})",
+                program_range.contains(shifted_shard_bbox),
+                "shard_spec.grid size {}x{} does not fit within program_config grid {}x{}",
+                bbox.end_coord.x - bbox.start_coord.x + 1,
+                bbox.end_coord.y - bbox.start_coord.y + 1,
                 program_grid.x,
                 program_grid.y);
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -172,18 +172,15 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
             bbox.end_coord.x - bbox.start_coord.x + 1,
             bbox.end_coord.y - bbox.start_coord.y + 1);
 
-        // SHARD SPEC VALIDATION
         {
             const auto& shard_shape = shard_spec.shape;
             const auto& shard_grid = shard_spec.grid;
 
-            // When sharded, layernorm always selects LayerNormShardedMultiCoreProgramConfig.
             const auto& sharded_pc =
                 std::get<LayerNormShardedMultiCoreProgramConfig>(operation_attributes.program_config);
             const auto device_grid = a.device()->compute_with_storage_grid_size();
             const auto program_grid = sharded_pc.compute_with_storage_grid_size;
 
-            // 1. Grid hierarchy: shard_spec.grid ⊆ program_config.grid ⊆ device.grid
             TT_FATAL(shard_grid.num_cores() > 0, "Shard grid must have at least one core");
 
             const CoreRange device_range(CoreCoord{0, 0}, CoreCoord{device_grid.x - 1, device_grid.y - 1});
@@ -201,16 +198,12 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
                 program_grid.x,
                 program_grid.y);
 
-            // 2. Shard shape must be non-zero
             TT_FATAL(
                 shard_shape[0] > 0 && shard_shape[1] > 0,
                 "shard shape must be non-zero, got H={} W={}",
                 shard_shape[0],
                 shard_shape[1]);
 
-            // 3. Tile alignment. Sharded layernorm derives block_h = shard_h / tile_height and
-            //    block_w = shard_w / tile_width as integer divisions; both shard dims must be tile-aligned
-            //    (no repack path, unlike group_norm).
             TT_FATAL(
                 shard_shape[0] % tile_height == 0,
                 "shard height {} must be divisible by tile height {}",
@@ -222,7 +215,6 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
                 shard_shape[1],
                 tile_width);
 
-            // 4. Total elements: num_cores * per-shard elements == physical tensor volume
             const auto num_cores = shard_grid.num_cores();
             const auto total_from_shards = static_cast<uint64_t>(num_cores) * shard_shape[0] * shard_shape[1];
             TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -171,6 +171,69 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
             bbox_num_cores,
             bbox.end_coord.x - bbox.start_coord.x + 1,
             bbox.end_coord.y - bbox.start_coord.y + 1);
+
+        // SHARD SPEC VALIDATION
+        {
+            const auto& shard_shape = shard_spec.shape;
+            const auto& shard_grid = shard_spec.grid;
+
+            // When sharded, layernorm always selects LayerNormShardedMultiCoreProgramConfig.
+            const auto& sharded_pc =
+                std::get<LayerNormShardedMultiCoreProgramConfig>(operation_attributes.program_config);
+            const auto device_grid = a.device()->compute_with_storage_grid_size();
+            const auto program_grid = sharded_pc.compute_with_storage_grid_size;
+
+            // 1. Grid hierarchy: shard_spec.grid ⊆ program_config.grid ⊆ device.grid
+            TT_FATAL(shard_grid.num_cores() > 0, "Shard grid must have at least one core");
+
+            const CoreRange device_range(CoreCoord{0, 0}, CoreCoord{device_grid.x - 1, device_grid.y - 1});
+            const CoreRange program_range(CoreCoord{0, 0}, CoreCoord{program_grid.x - 1, program_grid.y - 1});
+            TT_FATAL(
+                device_range.contains(program_range),
+                "program_config grid ({}x{}) must be contained within device grid ({}x{})",
+                program_grid.x,
+                program_grid.y,
+                device_grid.x,
+                device_grid.y);
+            TT_FATAL(
+                program_range.contains(shard_grid),
+                "shard_spec.grid is not contained within program_config grid ({}x{})",
+                program_grid.x,
+                program_grid.y);
+
+            // 2. Shard shape must be non-zero
+            TT_FATAL(
+                shard_shape[0] > 0 && shard_shape[1] > 0,
+                "shard shape must be non-zero, got H={} W={}",
+                shard_shape[0],
+                shard_shape[1]);
+
+            // 3. Tile alignment. Sharded layernorm derives block_h = shard_h / tile_height and
+            //    block_w = shard_w / tile_width as integer divisions; both shard dims must be tile-aligned
+            //    (no repack path, unlike group_norm).
+            TT_FATAL(
+                shard_shape[0] % tile_height == 0,
+                "shard height {} must be divisible by tile height {}",
+                shard_shape[0],
+                tile_height);
+            TT_FATAL(
+                shard_shape[1] % tile_width == 0,
+                "shard width {} must be divisible by tile width {}",
+                shard_shape[1],
+                tile_width);
+
+            // 4. Total elements: num_cores * per-shard elements == physical tensor volume
+            const auto num_cores = shard_grid.num_cores();
+            const auto total_from_shards = static_cast<uint64_t>(num_cores) * shard_shape[0] * shard_shape[1];
+            TT_FATAL(
+                total_from_shards == a.physical_volume(),
+                "Total elements from shards ({} cores * {}x{}) = {} does not match tensor physical volume {}",
+                num_cores,
+                shard_shape[0],
+                shard_shape[1],
+                total_from_shards,
+                a.physical_volume());
+        }
     }
     if (operation_attributes.distributed_norm_stage == DistributedLayerNormStage::PRE_ALL_GATHER ||
         operation_attributes.distributed_norm_stage == DistributedLayerNormStage::POST_ALL_GATHER) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -172,7 +172,6 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
             bbox.end_coord.x - bbox.start_coord.x + 1,
             bbox.end_coord.y - bbox.start_coord.y + 1);
 
-        {
             const auto& shard_shape = shard_spec.shape;
             const auto& shard_grid = shard_spec.grid;
 
@@ -231,7 +230,6 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
                 shard_shape[1],
                 total_from_shards,
                 a.physical_volume());
-        }
     }
     if (operation_attributes.distributed_norm_stage == DistributedLayerNormStage::PRE_ALL_GATHER ||
         operation_attributes.distributed_norm_stage == DistributedLayerNormStage::POST_ALL_GATHER) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/operations/math.hpp"
+#include "ttnn/operations/normalization/shard_spec_validation.hpp"
 using uint32_t = std::uint32_t;
 using namespace tt::tt_metal;
 
@@ -172,64 +173,8 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
             bbox.end_coord.x - bbox.start_coord.x + 1,
             bbox.end_coord.y - bbox.start_coord.y + 1);
 
-            const auto& shard_shape = shard_spec.shape;
-            const auto& shard_grid = shard_spec.grid;
-
-            const auto& sharded_pc =
-                std::get<LayerNormShardedMultiCoreProgramConfig>(operation_attributes.program_config);
-            const auto device_grid = a.device()->compute_with_storage_grid_size();
-            const auto program_grid = sharded_pc.compute_with_storage_grid_size;
-
-            TT_FATAL(shard_grid.num_cores() > 0, "Shard grid must have at least one core");
-
-            const CoreRange device_range(CoreCoord{0, 0}, CoreCoord{device_grid.x - 1, device_grid.y - 1});
-            const CoreRange program_range(CoreCoord{0, 0}, CoreCoord{program_grid.x - 1, program_grid.y - 1});
-            TT_FATAL(
-                device_range.contains(program_range),
-                "program_config grid ({}x{}) must be contained within device grid ({}x{})",
-                program_grid.x,
-                program_grid.y,
-                device_grid.x,
-                device_grid.y);
-
-            const auto shard_offset = bbox.start_coord;
-            const CoreRange shifted_shard_bbox(
-                CoreCoord{0, 0}, CoreCoord{bbox.end_coord.x - shard_offset.x, bbox.end_coord.y - shard_offset.y});
-            TT_FATAL(
-                program_range.contains(shifted_shard_bbox),
-                "shard_spec.grid size {}x{} does not fit within program_config grid {}x{}",
-                bbox.end_coord.x - bbox.start_coord.x + 1,
-                bbox.end_coord.y - bbox.start_coord.y + 1,
-                program_grid.x,
-                program_grid.y);
-
-            TT_FATAL(
-                shard_shape[0] > 0 && shard_shape[1] > 0,
-                "shard shape must be non-zero, got H={} W={}",
-                shard_shape[0],
-                shard_shape[1]);
-
-            TT_FATAL(
-                shard_shape[0] % tile_height == 0,
-                "shard height {} must be divisible by tile height {}",
-                shard_shape[0],
-                tile_height);
-            TT_FATAL(
-                shard_shape[1] % tile_width == 0,
-                "shard width {} must be divisible by tile width {}",
-                shard_shape[1],
-                tile_width);
-
-            const auto num_cores = shard_grid.num_cores();
-            const auto total_from_shards = static_cast<uint64_t>(num_cores) * shard_shape[0] * shard_shape[1];
-            TT_FATAL(
-                total_from_shards == a.physical_volume(),
-                "Total elements from shards ({} cores * {}x{}) = {} does not match tensor physical volume {}",
-                num_cores,
-                shard_shape[0],
-                shard_shape[1],
-                total_from_shards,
-                a.physical_volume());
+        const auto& sharded_pc = std::get<LayerNormShardedMultiCoreProgramConfig>(operation_attributes.program_config);
+        ttnn::operations::normalization::detail::validate_sharded_input(a, sharded_pc.compute_with_storage_grid_size);
     }
     if (operation_attributes.distributed_norm_stage == DistributedLayerNormStage::PRE_ALL_GATHER ||
         operation_attributes.distributed_norm_stage == DistributedLayerNormStage::POST_ALL_GATHER) {

--- a/ttnn/cpp/ttnn/operations/normalization/shard_spec_validation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/shard_spec_validation.cpp
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "shard_spec_validation.hpp"
+
+#include <tt-metalium/math.hpp>
+
+namespace ttnn::operations::normalization::detail {
+
+using namespace tt::tt_metal;
+
+void validate_sharded_input(
+    const Tensor& tensor, const CoreCoord& program_grid_size, bool require_shard_width_tile_aligned) {
+    TT_FATAL(tensor.is_sharded(), "validate_sharded_input called on non-sharded tensor");
+
+    const auto& shard_spec = tensor.shard_spec().value();
+    const auto& shard_shape = shard_spec.shape;
+    const auto& shard_grid = shard_spec.grid;
+    const uint32_t tile_h = tensor.tensor_spec().tile().get_height();
+    const uint32_t tile_w = tensor.tensor_spec().tile().get_width();
+
+    TT_FATAL(shard_grid.num_cores() > 0, "Shard grid must have at least one core");
+
+    const auto device_grid = tensor.device()->compute_with_storage_grid_size();
+    const CoreRange device_range(CoreCoord{0, 0}, CoreCoord{device_grid.x - 1, device_grid.y - 1});
+    const CoreRange program_range(CoreCoord{0, 0}, CoreCoord{program_grid_size.x - 1, program_grid_size.y - 1});
+    TT_FATAL(
+        device_range.contains(program_range),
+        "program_config grid ({}x{}) must be contained within device grid ({}x{})",
+        program_grid_size.x,
+        program_grid_size.y,
+        device_grid.x,
+        device_grid.y);
+
+    const auto bbox = shard_grid.bounding_box();
+    const auto shard_offset = bbox.start_coord;
+    const CoreRange shifted_shard_bbox(
+        CoreCoord{0, 0}, CoreCoord{bbox.end_coord.x - shard_offset.x, bbox.end_coord.y - shard_offset.y});
+    TT_FATAL(
+        program_range.contains(shifted_shard_bbox),
+        "shard_spec.grid size {}x{} does not fit within program_config grid {}x{}",
+        bbox.end_coord.x - bbox.start_coord.x + 1,
+        bbox.end_coord.y - bbox.start_coord.y + 1,
+        program_grid_size.x,
+        program_grid_size.y);
+
+    TT_FATAL(
+        shard_shape[0] > 0 && shard_shape[1] > 0,
+        "shard shape must be non-zero, got H={} W={}",
+        shard_shape[0],
+        shard_shape[1]);
+    TT_FATAL(
+        shard_shape[0] % tile_h == 0, "shard height {} must be divisible by tile height {}", shard_shape[0], tile_h);
+    if (require_shard_width_tile_aligned) {
+        TT_FATAL(
+            shard_shape[1] % tile_w == 0, "shard width {} must be divisible by tile width {}", shard_shape[1], tile_w);
+    }
+
+    const auto num_cores = shard_grid.num_cores();
+    const uint64_t W_phys = tensor.padded_shape()[-1];
+    const uint64_t H_phys = tensor.physical_volume() / W_phys;
+    const auto memory_layout = tensor.memory_config().memory_layout();
+
+    uint32_t num_shards_h = 1;
+    uint32_t num_shards_w = 1;
+    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+        num_shards_h = num_cores;
+    } else if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+        num_shards_w = num_cores;
+    } else {
+        num_shards_h = tt::div_up(static_cast<uint32_t>(H_phys), shard_shape[0]);
+        num_shards_w = tt::div_up(static_cast<uint32_t>(W_phys), shard_shape[1]);
+    }
+    TT_FATAL(
+        static_cast<uint64_t>(num_shards_h) * num_shards_w == num_cores,
+        "Shard layout requires {}x{} = {} shards but shard grid has {} cores",
+        num_shards_h,
+        num_shards_w,
+        static_cast<uint64_t>(num_shards_h) * num_shards_w,
+        num_cores);
+
+    const uint64_t shard_padded_h = static_cast<uint64_t>(num_shards_h) * shard_shape[0];
+    const uint64_t shard_padded_w = static_cast<uint64_t>(num_shards_w) * shard_shape[1];
+    TT_FATAL(
+        shard_padded_h >= H_phys && (shard_padded_h - H_phys) < shard_shape[0],
+        "Shard-padded height ({}x{} = {}) does not align with tensor height {}: trailing pad {} must be less than one "
+        "shard height ({})",
+        num_shards_h,
+        shard_shape[0],
+        shard_padded_h,
+        H_phys,
+        shard_padded_h - H_phys,
+        shard_shape[0]);
+    TT_FATAL(
+        shard_padded_w >= W_phys && (shard_padded_w - W_phys) < shard_shape[1],
+        "Shard-padded width ({}x{} = {}) does not align with tensor width {}: trailing pad {} must be less than one "
+        "shard width ({})",
+        num_shards_w,
+        shard_shape[1],
+        shard_padded_w,
+        W_phys,
+        shard_padded_w - W_phys,
+        shard_shape[1]);
+}
+
+}  // namespace ttnn::operations::normalization::detail

--- a/ttnn/cpp/ttnn/operations/normalization/shard_spec_validation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/shard_spec_validation.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/core_coord.hpp>
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::normalization::detail {
+
+// Validates the standard shard-spec invariants shared by sharded normalization inputs
+// (groupnorm / layernorm / softmax). Aborts via TT_FATAL on any violation.
+//
+// Checks performed:
+//   * The input is sharded and has a populated shard_spec.
+//   * The shard grid is non-empty and its bounding box fits within `program_grid_size`,
+//     which in turn fits within the device grid.
+//   * Shard dimensions are non-zero and shard height is a multiple of tile height.
+//     Shard width is a multiple of tile width unless `require_shard_width_tile_aligned`
+//     is false.
+//   * The number of shards along H/W (derived from the layout) multiplied together
+//     equals `shard_spec.grid.num_cores()`.
+//   * Shards collectively cover the padded tensor with strictly less than one shard
+//     of trailing pad along each axis (i.e. the last shard along an axis may be
+//     partially filled, but a fully empty trailing shard is not allowed).
+//
+// `require_shard_width_tile_aligned` should be set to false for ops whose kernels are
+// known to support shard widths that are not a multiple of the tile width
+// (currently: groupnorm).
+void validate_sharded_input(
+    const tt::tt_metal::Tensor& tensor,
+    const CoreCoord& program_grid_size,
+    bool require_shard_width_tile_aligned = true);
+
+}  // namespace ttnn::operations::normalization::detail

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -9,7 +9,7 @@
 
 #include "ttnn/device_operation.hpp"
 #include "softmax_operation_types.hpp"
-
+#include "ttnn/operations/normalization/shard_spec_validation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp"
@@ -328,67 +328,8 @@ void SoftmaxDeviceOperation::validate_on_program_cache_miss(
 
                 const auto& a = tensors_args.input_tensor;
                 if (a.is_sharded()) {
-                    const auto& shard_spec = a.shard_spec().value();
-                    const auto& shard_shape = shard_spec.shape;
-                    const auto& shard_grid = shard_spec.grid;
-                    const uint32_t tile_height = a.tensor_spec().tile().get_height();
-                    const uint32_t tile_width = a.tensor_spec().tile().get_width();
-
-                    const auto device_grid = a.device()->compute_with_storage_grid_size();
-                    const auto program_grid = program_config.compute_with_storage_grid_size;
-
-                    TT_FATAL(shard_grid.num_cores() > 0, "Shard grid must have at least one core");
-
-                    const CoreRange device_range(CoreCoord{0, 0}, CoreCoord{device_grid.x - 1, device_grid.y - 1});
-                    const CoreRange program_range(CoreCoord{0, 0}, CoreCoord{program_grid.x - 1, program_grid.y - 1});
-                    TT_FATAL(
-                        device_range.contains(program_range),
-                        "program_config grid ({}x{}) must be contained within device grid ({}x{})",
-                        program_grid.x,
-                        program_grid.y,
-                        device_grid.x,
-                        device_grid.y);
-
-                    const auto shard_bbox = shard_grid.bounding_box();
-                    const auto shard_offset = shard_bbox.start_coord;
-                    const CoreRange shifted_shard_bbox(
-                        CoreCoord{0, 0},
-                        CoreCoord{shard_bbox.end_coord.x - shard_offset.x, shard_bbox.end_coord.y - shard_offset.y});
-                    TT_FATAL(
-                        program_range.contains(shifted_shard_bbox),
-                        "shard_spec.grid size {}x{} does not fit within program_config grid {}x{}",
-                        shard_bbox.end_coord.x - shard_bbox.start_coord.x + 1,
-                        shard_bbox.end_coord.y - shard_bbox.start_coord.y + 1,
-                        program_grid.x,
-                        program_grid.y);
-
-                    TT_FATAL(
-                        shard_shape[0] > 0 && shard_shape[1] > 0,
-                        "shard shape must be non-zero, got H={} W={}",
-                        shard_shape[0],
-                        shard_shape[1]);
-
-                    TT_FATAL(
-                        shard_shape[0] % tile_height == 0,
-                        "shard height {} must be divisible by tile height {}",
-                        shard_shape[0],
-                        tile_height);
-                    TT_FATAL(
-                        shard_shape[1] % tile_width == 0,
-                        "shard width {} must be divisible by tile width {}",
-                        shard_shape[1],
-                        tile_width);
-
-                    const auto num_cores = shard_grid.num_cores();
-                    const auto total_from_shards = static_cast<uint64_t>(num_cores) * shard_shape[0] * shard_shape[1];
-                    TT_FATAL(
-                        total_from_shards == a.physical_volume(),
-                        "Total elements from shards ({} cores * {}x{}) = {} does not match tensor physical volume {}",
-                        num_cores,
-                        shard_shape[0],
-                        shard_shape[1],
-                        total_from_shards,
-                        a.physical_volume());
+                    ttnn::operations::normalization::detail::validate_sharded_input(
+                        a, program_config.compute_with_storage_grid_size);
                 }
             }
         },

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -325,6 +325,69 @@ void SoftmaxDeviceOperation::validate_on_program_cache_miss(
                     shard_shape[0],
                     shard_shape[1],
                     tensors_args.input_tensor.tensor_spec().tile().get_width());
+
+                // SHARD SPEC VALIDATION
+                const auto& a = tensors_args.input_tensor;
+                if (a.is_sharded()) {
+                    const auto& shard_spec = a.shard_spec().value();
+                    const auto& shard_shape = shard_spec.shape;
+                    const auto& shard_grid = shard_spec.grid;
+                    const uint32_t tile_height = a.tensor_spec().tile().get_height();
+                    const uint32_t tile_width = a.tensor_spec().tile().get_width();
+
+                    const auto device_grid = a.device()->compute_with_storage_grid_size();
+                    const auto program_grid = program_config.compute_with_storage_grid_size;
+
+                    // 1. Grid hierarchy: shard_spec.grid ⊆ program_config.grid ⊆ device.grid
+                    TT_FATAL(shard_grid.num_cores() > 0, "Shard grid must have at least one core");
+
+                    const CoreRange device_range(CoreCoord{0, 0}, CoreCoord{device_grid.x - 1, device_grid.y - 1});
+                    const CoreRange program_range(CoreCoord{0, 0}, CoreCoord{program_grid.x - 1, program_grid.y - 1});
+                    TT_FATAL(
+                        device_range.contains(program_range),
+                        "program_config grid ({}x{}) must be contained within device grid ({}x{})",
+                        program_grid.x,
+                        program_grid.y,
+                        device_grid.x,
+                        device_grid.y);
+                    TT_FATAL(
+                        program_range.contains(shard_grid),
+                        "shard_spec.grid is not contained within program_config grid ({}x{})",
+                        program_grid.x,
+                        program_grid.y);
+
+                    // 2. Shard shape must be non-zero
+                    TT_FATAL(
+                        shard_shape[0] > 0 && shard_shape[1] > 0,
+                        "shard shape must be non-zero, got H={} W={}",
+                        shard_shape[0],
+                        shard_shape[1]);
+
+                    // 3. Tile alignment. Sharded softmax derives block_h / block_w as integer division of
+                    //    the shard dims by the tile size; both shard dims must be tile-aligned (no repack path).
+                    TT_FATAL(
+                        shard_shape[0] % tile_height == 0,
+                        "shard height {} must be divisible by tile height {}",
+                        shard_shape[0],
+                        tile_height);
+                    TT_FATAL(
+                        shard_shape[1] % tile_width == 0,
+                        "shard width {} must be divisible by tile width {}",
+                        shard_shape[1],
+                        tile_width);
+
+                    // 4. Total elements: num_cores * per-shard elements == physical tensor volume
+                    const auto num_cores = shard_grid.num_cores();
+                    const auto total_from_shards = static_cast<uint64_t>(num_cores) * shard_shape[0] * shard_shape[1];
+                    TT_FATAL(
+                        total_from_shards == a.physical_volume(),
+                        "Total elements from shards ({} cores * {}x{}) = {} does not match tensor physical volume {}",
+                        num_cores,
+                        shard_shape[0],
+                        shard_shape[1],
+                        total_from_shards,
+                        a.physical_volume());
+                }
             }
         },
         attributes.program_config);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -348,9 +348,17 @@ void SoftmaxDeviceOperation::validate_on_program_cache_miss(
                         program_grid.y,
                         device_grid.x,
                         device_grid.y);
+
+                    const auto shard_bbox = shard_grid.bounding_box();
+                    const auto shard_offset = shard_bbox.start_coord;
+                    const CoreRange shifted_shard_bbox(
+                        CoreCoord{0, 0},
+                        CoreCoord{shard_bbox.end_coord.x - shard_offset.x, shard_bbox.end_coord.y - shard_offset.y});
                     TT_FATAL(
-                        program_range.contains(shard_grid),
-                        "shard_spec.grid is not contained within program_config grid ({}x{})",
+                        program_range.contains(shifted_shard_bbox),
+                        "shard_spec.grid size {}x{} does not fit within program_config grid {}x{}",
+                        shard_bbox.end_coord.x - shard_bbox.start_coord.x + 1,
+                        shard_bbox.end_coord.y - shard_bbox.start_coord.y + 1,
                         program_grid.x,
                         program_grid.y);
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -9,10 +9,11 @@
 
 #include "ttnn/device_operation.hpp"
 #include "softmax_operation_types.hpp"
-#include "ttnn/operations/normalization/shard_spec_validation.hpp"
+
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp"
+#include "ttnn/operations/normalization/shard_spec_validation.hpp"
 
 using namespace tt::tt_metal;
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -326,7 +326,6 @@ void SoftmaxDeviceOperation::validate_on_program_cache_miss(
                     shard_shape[1],
                     tensors_args.input_tensor.tensor_spec().tile().get_width());
 
-                // SHARD SPEC VALIDATION
                 const auto& a = tensors_args.input_tensor;
                 if (a.is_sharded()) {
                     const auto& shard_spec = a.shard_spec().value();
@@ -338,7 +337,6 @@ void SoftmaxDeviceOperation::validate_on_program_cache_miss(
                     const auto device_grid = a.device()->compute_with_storage_grid_size();
                     const auto program_grid = program_config.compute_with_storage_grid_size;
 
-                    // 1. Grid hierarchy: shard_spec.grid ⊆ program_config.grid ⊆ device.grid
                     TT_FATAL(shard_grid.num_cores() > 0, "Shard grid must have at least one core");
 
                     const CoreRange device_range(CoreCoord{0, 0}, CoreCoord{device_grid.x - 1, device_grid.y - 1});
@@ -356,15 +354,12 @@ void SoftmaxDeviceOperation::validate_on_program_cache_miss(
                         program_grid.x,
                         program_grid.y);
 
-                    // 2. Shard shape must be non-zero
                     TT_FATAL(
                         shard_shape[0] > 0 && shard_shape[1] > 0,
                         "shard shape must be non-zero, got H={} W={}",
                         shard_shape[0],
                         shard_shape[1]);
 
-                    // 3. Tile alignment. Sharded softmax derives block_h / block_w as integer division of
-                    //    the shard dims by the tile size; both shard dims must be tile-aligned (no repack path).
                     TT_FATAL(
                         shard_shape[0] % tile_height == 0,
                         "shard height {} must be divisible by tile height {}",
@@ -376,7 +371,6 @@ void SoftmaxDeviceOperation::validate_on_program_cache_miss(
                         shard_shape[1],
                         tile_width);
 
-                    // 4. Total elements: num_cores * per-shard elements == physical tensor volume
                     const auto num_cores = shard_grid.num_cores();
                     const auto total_from_shards = static_cast<uint64_t>(num_cores) * shard_shape[0] * shard_shape[1];
                     TT_FATAL(


### PR DESCRIPTION
### Summary

Link to Github Issue : #40497 

#### Problem description

Sharded normalization operations (GroupNorm, LayerNorm, Softmax) were not validating `shard_spec` in `validate_on_program_cache_miss`. As aresult, invalid shard configurations could pass initial checks and cause unclear runtime errors later in program factories or kernels

### What's changed

Added shard spec validation in `validate_on_program_cache_miss` for the following device operations:

* `groupnorm/device/groupnorm_device_operation.cpp`
* `layernorm/device/layernorm_device_operation.cpp`
* `softmax/device/softmax_device_operation.cpp`

The validation includes:

* **Grid hierarchy:**
    Ensures: 
    * `shard_spec.grid` fits within `program_config.grid`
    * `program_config.grid` fits within `device.grid`
    * shard grid has non-zero cores
* **Shard shape:**
    * Dimensions must be non-zero  
* **Tile alignment:**
  * Height must be tile-aligned
  * Width must be tile-aligned
* **Total elements:** 
    * Ensures `num_cores * shard_shape[0] * shard_shape[1] == tensor.physical_volume()` 


### Notes for Reviewers
* `RMSNorm` and `distributed LayerNorm/RMSNorm` reuse the `LayerNorm` path and are covered by this validation.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/add-shard-spec-validation-normalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/add-shard-spec-validation-normalization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/add-shard-spec-validation-normalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/add-shard-spec-validation-normalization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/add-shard-spec-validation-normalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/add-shard-spec-validation-normalization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/add-shard-spec-validation-normalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/add-shard-spec-validation-normalization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/add-shard-spec-validation-normalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/add-shard-spec-validation-normalization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/add-shard-spec-validation-normalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/add-shard-spec-validation-normalization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/add-shard-spec-validation-normalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/add-shard-spec-validation-normalization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/add-shard-spec-validation-normalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/add-shard-spec-validation-normalization)