### PR TITLE
[DeepSeek V3 Prefill] Enable caching on local run for MoE and Prefill block test

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -188,33 +188,17 @@ def test_ttnn_moe(
     need_torch_weights = not ttnn_cache_complete or run_pcc_check
     logger.info(f"Cache status: TTNN={ttnn_cache_complete}, need_torch_weights={need_torch_weights}")
 
-    torch_weights_cache = moe_cache_dir / "torch_weights.pt"
     if need_torch_weights:
-        if torch_weights_cache.exists():
-            logger.info(f"Loading cached torch weights from {torch_weights_cache}")
-            profiler.start("weights_loading")
-            cached = torch.load(torch_weights_cache, weights_only=True)
-            all_routed_weights = cached["routed"]
-            shared_expert_weights = cached["shared"]
-            gate_weights = cached["gate"]
-            profiler.end("weights_loading")
+        logger.info("Creating torch weights...")
+        profiler.start("weights_creation")
+        if run_pcc_check:
+            all_routed_weights = create_torch_expert_weights(num_routed_experts, emb_dim, hidden_dim)
+            shared_expert_weights = create_shared_expert_weights(emb_dim, hidden_dim)
         else:
-            logger.info("Creating torch weights (cold cache)...")
-            profiler.start("weights_creation")
-            if run_pcc_check:
-                all_routed_weights = create_torch_expert_weights(num_routed_experts, emb_dim, hidden_dim)
-                shared_expert_weights = create_shared_expert_weights(emb_dim, hidden_dim)
-            else:
-                all_routed_weights = None
-                shared_expert_weights = None
-            gate_weights = create_gate_weights(num_routed_experts, emb_dim)
-            profiler.end("weights_creation")
-
-            logger.info(f"Saving torch weights to {torch_weights_cache}")
-            torch.save(
-                {"routed": all_routed_weights, "shared": shared_expert_weights, "gate": gate_weights},
-                torch_weights_cache,
-            )
+            all_routed_weights = None
+            shared_expert_weights = None
+        gate_weights = create_gate_weights(num_routed_experts, emb_dim)
+        profiler.end("weights_creation")
 
         # Build TTNN cache if not already complete
         if not ttnn_cache_complete:

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -50,6 +50,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import (
     log_validation_results,
     visualize_expert_dispatch_table,
 )
+from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
 from tests.ttnn.utils_for_testing import comp_pcc
 
 
@@ -171,39 +172,74 @@ def test_ttnn_moe(
     )
 
     # ========================================
-    # Step 1: Create weights (with torch-level caching)
+    # Step 1: Create weights (cache-aware)
     # ========================================
     moe_cache_dir = Path(
-        f"/tmp/tt_moe_test_cache/{num_routed_experts}experts_{n_sp_devices}x{n_tp_devices}mesh_{emb_dim}emb_{hidden_dim}hid"
+        f"/tmp/deepseek_v3_moe_cache/{num_routed_experts}experts_{n_sp_devices}x{n_tp_devices}mesh_{emb_dim}emb_{hidden_dim}hid"
     )
     moe_cache_dir.mkdir(parents=True, exist_ok=True)
 
+    init_checker(moe_cache_dir)
+    ttnn_cache_complete = TtMoe.check_cache_complete(moe_cache_dir, layer_idx=0, experts_per_chip=experts_per_chip)
+    need_torch_weights = not ttnn_cache_complete or run_pcc_check
+    logger.info(f"Cache status: TTNN={ttnn_cache_complete}, need_torch_weights={need_torch_weights}")
+
     torch_weights_cache = moe_cache_dir / "torch_weights.pt"
-    if torch_weights_cache.exists():
-        logger.info(f"Loading cached torch weights from {torch_weights_cache}")
-        profiler.start("weights_loading")
-        cached = torch.load(torch_weights_cache, weights_only=True)
-        all_routed_weights = cached["routed"] if run_pcc_check else None
-        shared_expert_weights = cached["shared"] if run_pcc_check else None
-        gate_weights = cached["gate"]
-        profiler.end("weights_loading")
-    else:
-        logger.info("Creating torch weights (cold cache)...")
-        if run_pcc_check:
-            profiler.start("weights_creation")
-            all_routed_weights = create_torch_expert_weights(num_routed_experts, emb_dim, hidden_dim)
-            shared_expert_weights = create_shared_expert_weights(emb_dim, hidden_dim)
-            profiler.end("weights_creation")
+    if need_torch_weights:
+        if torch_weights_cache.exists():
+            logger.info(f"Loading cached torch weights from {torch_weights_cache}")
+            profiler.start("weights_loading")
+            cached = torch.load(torch_weights_cache, weights_only=True)
+            all_routed_weights = cached["routed"]
+            shared_expert_weights = cached["shared"]
+            gate_weights = cached["gate"]
+            profiler.end("weights_loading")
         else:
+            logger.info("Creating torch weights (cold cache)...")
+            profiler.start("weights_creation")
+            if run_pcc_check:
+                all_routed_weights = create_torch_expert_weights(num_routed_experts, emb_dim, hidden_dim)
+                shared_expert_weights = create_shared_expert_weights(emb_dim, hidden_dim)
+            else:
+                all_routed_weights = None
+                shared_expert_weights = None
+            gate_weights = create_gate_weights(num_routed_experts, emb_dim)
+            profiler.end("weights_creation")
+
+            logger.info(f"Saving torch weights to {torch_weights_cache}")
+            torch.save(
+                {"routed": all_routed_weights, "shared": shared_expert_weights, "gate": gate_weights},
+                torch_weights_cache,
+            )
+
+        # Build TTNN cache if not already complete
+        if not ttnn_cache_complete:
+            logger.info("Building TTNN cache...")
+            profiler.start("ttnn_cache_build")
+            TtMoe.build_ttnn_cache(
+                gate_weights=gate_weights,
+                routed_expert_weights=all_routed_weights,
+                shared_expert_weights=shared_expert_weights,
+                experts_per_chip=experts_per_chip,
+                emb_dim=emb_dim,
+                hidden_dim=hidden_dim,
+                mesh_device=mesh_device,
+                routed_expert_weights_dtype=ttnn.bfloat4_b,
+                shared_expert_weights_dtype=ttnn.bfloat8_b,
+                cache_path=moe_cache_dir,
+                layer_idx=0,
+            )
+            profiler.end("ttnn_cache_build")
+
+        # For non-PCC runs, free the heavy weights now that TTNN cache is built
+        if not run_pcc_check:
             all_routed_weights = None
             shared_expert_weights = None
-
-        gate_weights = create_gate_weights(num_routed_experts, emb_dim)
-
-        logger.info(f"Saving torch weights to {torch_weights_cache}")
-        torch.save(
-            {"routed": all_routed_weights, "shared": shared_expert_weights, "gate": gate_weights}, torch_weights_cache
-        )
+    else:
+        logger.info("TTNN cache complete, skipping torch weight creation")
+        all_routed_weights = None
+        shared_expert_weights = None
+        gate_weights = None
 
     expert_dispatch_table = ExpertMapping.create_dispatch_table(
         num_routed_experts=num_routed_experts,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -142,6 +142,7 @@ def test_ttnn_moe(
     dispatch_group_size = mesh_config.dispatch_group_size
     num_dispatch_groups = mesh_config.num_dispatch_groups
     n_sp_devices, n_tp_devices = mesh_device.shape
+    layer_idx = 0
 
     logger.debug(f"\n{'='*60}")
     logger.debug("TtMoe PCC Test")
@@ -181,7 +182,9 @@ def test_ttnn_moe(
     moe_cache_dir.mkdir(parents=True, exist_ok=True)
 
     init_checker(moe_cache_dir)
-    ttnn_cache_complete = TtMoe.check_cache_complete(moe_cache_dir, layer_idx=0, experts_per_chip=experts_per_chip)
+    ttnn_cache_complete = TtMoe.check_cache_complete(
+        moe_cache_dir, layer_idx=layer_idx, experts_per_chip=experts_per_chip
+    )
     need_torch_weights = not ttnn_cache_complete or run_pcc_check
     logger.info(f"Cache status: TTNN={ttnn_cache_complete}, need_torch_weights={need_torch_weights}")
 
@@ -228,7 +231,7 @@ def test_ttnn_moe(
                 routed_expert_weights_dtype=ttnn.bfloat4_b,
                 shared_expert_weights_dtype=ttnn.bfloat8_b,
                 cache_path=moe_cache_dir,
-                layer_idx=0,
+                layer_idx=layer_idx,
             )
             profiler.end("ttnn_cache_build")
 
@@ -328,6 +331,7 @@ def test_ttnn_moe(
         gate_weights=gate_weights,
         gate_fallback_mode=gate_fallback_mode,
         weight_cache_path=moe_cache_dir,
+        layer_idx=layer_idx,
     )
     ttnn.synchronize_device(mesh_device)
     profiler.end("tt_moe_creation")

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -11,6 +11,7 @@ Gate → Dispatch → Routed Experts → Combine → Split → Add Shared.
 """
 
 import random
+from pathlib import Path
 
 import pytest
 import torch
@@ -18,7 +19,6 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
-from conftest import is_galaxy
 from models.common.utility_functions import is_blackhole, profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.moe import TorchMoe
@@ -171,18 +171,39 @@ def test_ttnn_moe(
     )
 
     # ========================================
-    # Step 1: Create weights
+    # Step 1: Create weights (with torch-level caching)
     # ========================================
-    if run_pcc_check:
-        profiler.start("weights_creation")
-        all_routed_weights = create_torch_expert_weights(num_routed_experts, emb_dim, hidden_dim)
-        shared_expert_weights = create_shared_expert_weights(emb_dim, hidden_dim)
-        profiler.end("weights_creation")
-    else:
-        all_routed_weights = None
-        shared_expert_weights = None
+    moe_cache_dir = Path(
+        f"/tmp/tt_moe_test_cache/{num_routed_experts}experts_{n_sp_devices}x{n_tp_devices}mesh_{emb_dim}emb_{hidden_dim}hid"
+    )
+    moe_cache_dir.mkdir(parents=True, exist_ok=True)
 
-    gate_weights = create_gate_weights(num_routed_experts, emb_dim)
+    torch_weights_cache = moe_cache_dir / "torch_weights.pt"
+    if torch_weights_cache.exists():
+        logger.info(f"Loading cached torch weights from {torch_weights_cache}")
+        profiler.start("weights_loading")
+        cached = torch.load(torch_weights_cache, weights_only=True)
+        all_routed_weights = cached["routed"] if run_pcc_check else None
+        shared_expert_weights = cached["shared"] if run_pcc_check else None
+        gate_weights = cached["gate"]
+        profiler.end("weights_loading")
+    else:
+        logger.info("Creating torch weights (cold cache)...")
+        if run_pcc_check:
+            profiler.start("weights_creation")
+            all_routed_weights = create_torch_expert_weights(num_routed_experts, emb_dim, hidden_dim)
+            shared_expert_weights = create_shared_expert_weights(emb_dim, hidden_dim)
+            profiler.end("weights_creation")
+        else:
+            all_routed_weights = None
+            shared_expert_weights = None
+
+        gate_weights = create_gate_weights(num_routed_experts, emb_dim)
+
+        logger.info(f"Saving torch weights to {torch_weights_cache}")
+        torch.save(
+            {"routed": all_routed_weights, "shared": shared_expert_weights, "gate": gate_weights}, torch_weights_cache
+        )
 
     expert_dispatch_table = ExpertMapping.create_dispatch_table(
         num_routed_experts=num_routed_experts,
@@ -269,6 +290,7 @@ def test_ttnn_moe(
         shared_expert_weights_dtype=ttnn.bfloat8_b,
         gate_weights=gate_weights,
         gate_fallback_mode=gate_fallback_mode,
+        weight_cache_path=moe_cache_dir,
     )
     ttnn.synchronize_device(mesh_device)
     profiler.end("tt_moe_creation")

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -19,6 +19,7 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
+from conftest import is_galaxy
 from models.common.utility_functions import is_blackhole, profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.moe import TorchMoe

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -137,7 +137,6 @@ def test_prefill_block(
 
     init_checker(cache_dir)
     ttnn_cache_complete = TtPrefillBlock.check_cache_complete(cache_dir, layer_idx, is_dense)
-    torch_weights_cache = cache_dir / "torch_weights.pt"
     torch_ref_cache = cache_dir / f"torch_reference_{input_source}.pt"
 
     need_hf_model = not ttnn_cache_complete or (
@@ -158,10 +157,6 @@ def test_prefill_block(
         hf_sd = hf_model.state_dict()
         state_dict = extract_layer_state_dict(hf_sd, layer_idx, hf_model.layers[layer_idx])
         profiler.end("weights_creation")
-
-        if not torch_weights_cache.exists():
-            logger.info(f"Saving torch weights to {torch_weights_cache}")
-            torch.save(state_dict, torch_weights_cache)
     else:
         logger.info("TTNN cache complete, skipping torch weight creation")
         state_dict = {}

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -11,6 +11,8 @@ Uses HF DeepseekV3Model layer as the reference: creates a model with random weig
 extracts those weights into our TT state_dict format, and compares forward passes.
 """
 
+from pathlib import Path
+
 import pytest
 import torch
 from loguru import logger
@@ -24,6 +26,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.moe.tt_prefill_block import TtPrefillBlock
+from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
     ABC_1K_PATH,
@@ -127,17 +130,44 @@ def test_prefill_block(
         f"input_source={input_source}"
     )
 
+    # --- Cache setup ---
+    is_dense = layer_idx < DeepSeekV3Config.NUM_DENSE_LAYERS
+    cache_dir = Path(f"/tmp/deepseek_v3_prefill_block/{layer_type}_{sp_factor}x{tp_factor}mesh_{isl_total}isl")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    init_checker(cache_dir)
+    ttnn_cache_complete = TtPrefillBlock.check_cache_complete(cache_dir, layer_idx, is_dense)
+    torch_weights_cache = cache_dir / "torch_weights.pt"
+    torch_ref_cache = cache_dir / f"torch_reference_{input_source}.pt"
+
+    need_hf_model = not ttnn_cache_complete or (
+        (pcc_validation or input_source == "abc_1k") and not torch_ref_cache.exists()
+    )
+    logger.info(
+        f"Cache status: TTNN={ttnn_cache_complete}, ref_cache={torch_ref_cache.exists()}, "
+        f"need_hf_model={need_hf_model}"
+    )
+
     # --- Build HF reference model and extract weights ---
-    profiler.start("weights_creation")
-    torch.manual_seed(42)
     num_layers = layer_idx + 1
-    hf_model = create_hf_model(config, num_layers)
-    hf_sd = hf_model.state_dict()
-    state_dict = extract_layer_state_dict(hf_sd, layer_idx, hf_model.layers[layer_idx])
-    profiler.end("weights_creation")
+    hf_model = None
+    if need_hf_model:
+        profiler.start("weights_creation")
+        torch.manual_seed(42)
+        hf_model = create_hf_model(config, num_layers)
+        hf_sd = hf_model.state_dict()
+        state_dict = extract_layer_state_dict(hf_sd, layer_idx, hf_model.layers[layer_idx])
+        profiler.end("weights_creation")
+
+        if not torch_weights_cache.exists():
+            logger.info(f"Saving torch weights to {torch_weights_cache}")
+            torch.save(state_dict, torch_weights_cache)
+    else:
+        logger.info("TTNN cache complete, skipping torch weight creation")
+        state_dict = {}
 
     # --- Create input ---
-    if input_source == "abc_1k":
+    if input_source == "abc_1k" and hf_model is not None:
         profiler.start("tokenization")
         prompts = load_prompts_from_json(str(ABC_1K_PATH))
         prompt_text = prompts[0] if isinstance(prompts, list) else prompts
@@ -150,33 +180,74 @@ def test_prefill_block(
         with torch.no_grad():
             torch_input = hf_model.embed_tokens(token_ids).to(torch.bfloat16)
         logger.info(f"Embedded input shape: {torch_input.shape}")
+    elif input_source == "abc_1k" and hf_model is None:
+        logger.info("Loading abc_1k torch_input from reference cache")
+        ref_cached = torch.load(torch_ref_cache, weights_only=True)
+        torch_input = ref_cached["torch_input"]
     else:
         torch.manual_seed(123)
         torch_input = torch.randn(1, isl_total, emb_dim, dtype=torch.bfloat16)
 
-    # --- Torch reference (only when pcc_validation is enabled) ---
+    # --- Torch reference (with caching) ---
     torch_output = None
     ref_kvpe = None
     if pcc_validation:
-        profiler.start("torch_reference")
-        logger.info("Running torch reference forward...")
-        position_ids = torch.arange(isl_total, dtype=torch.long).unsqueeze(0)
-        attention_mask = torch.zeros(1, 1, isl_total, isl_total, dtype=torch.bfloat16)
-        ref_cache = DynamicCache()
-        with torch.no_grad():
-            layer_out = hf_model.layers[layer_idx](
-                torch_input,
-                attention_mask=attention_mask,
-                position_ids=position_ids,
-                past_key_value=ref_cache,
-                use_cache=True,
+        if torch_ref_cache.exists():
+            logger.info(f"Loading cached reference from {torch_ref_cache}")
+            profiler.start("reference_loading")
+            ref_cached = torch.load(torch_ref_cache, weights_only=True)
+            torch_input = ref_cached["torch_input"]
+            torch_output = ref_cached["torch_output"]
+            ref_kvpe = ref_cached["ref_kvpe"]
+            profiler.end("reference_loading")
+        else:
+            profiler.start("torch_reference")
+            logger.info("Running torch reference forward...")
+            position_ids = torch.arange(isl_total, dtype=torch.long).unsqueeze(0)
+            attention_mask = torch.zeros(1, 1, isl_total, isl_total, dtype=torch.bfloat16)
+            ref_cache = DynamicCache()
+            with torch.no_grad():
+                layer_out = hf_model.layers[layer_idx](
+                    torch_input,
+                    attention_mask=attention_mask,
+                    position_ids=position_ids,
+                    past_key_value=ref_cache,
+                    use_cache=True,
+                )
+                torch_output = layer_out[0]
+            logger.info(f"Torch reference output shape: {torch_output.shape}")
+            if ref_cache is not None:
+                ref_kvpe = ref_cache.key_cache[layer_idx]
+                logger.info(f"Reference KVPE shape: {ref_kvpe.shape}")
+            profiler.end("torch_reference")
+
+            logger.info(f"Saving reference to {torch_ref_cache}")
+            torch.save(
+                {"torch_input": torch_input, "torch_output": torch_output, "ref_kvpe": ref_kvpe},
+                torch_ref_cache,
             )
-            torch_output = layer_out[0]
-        logger.info(f"Torch reference output shape: {torch_output.shape}")
-        if ref_cache is not None:
-            ref_kvpe = ref_cache.key_cache[layer_idx]
-            logger.info(f"Reference KVPE shape: {ref_kvpe.shape}")
-        profiler.end("torch_reference")
+
+    # Free HF model early
+    if hf_model is not None:
+        del hf_model
+
+    # --- Build TTNN cache if needed ---
+    if not ttnn_cache_complete:
+        logger.info("Building TTNN cache...")
+        profiler.start("ttnn_cache_build")
+        TtPrefillBlock.build_ttnn_cache(
+            state_dict=state_dict,
+            layer_idx=layer_idx,
+            cache_path=cache_dir,
+            mesh_device=mesh_device,
+            config=config,
+            seq_len=isl_total,
+            num_links=num_links,
+            topology=topology,
+            sp_axis=sp_axis,
+            tp_axis=tp_axis,
+        )
+        profiler.end("ttnn_cache_build")
 
     # --- TT block ---
     profiler.start("tt_block_creation")
@@ -191,6 +262,7 @@ def test_prefill_block(
         topology=topology,
         sp_axis=sp_axis,
         tp_axis=tp_axis,
+        weight_cache_path=cache_dir,
     )
     if gate_fallback_mode is not None:
         block_kwargs["gate_fallback_mode"] = gate_fallback_mode

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -139,9 +139,8 @@ def test_prefill_block(
     ttnn_cache_complete = TtPrefillBlock.check_cache_complete(cache_dir, layer_idx, is_dense)
     torch_ref_cache = cache_dir / f"torch_reference_{input_source}.pt"
 
-    need_hf_model = not ttnn_cache_complete or (
-        (pcc_validation or input_source == "abc_1k") and not torch_ref_cache.exists()
-    )
+    ref_cache_loadable = torch_ref_cache.exists() and (pcc_validation or input_source == "abc_1k")
+    need_hf_model = not ttnn_cache_complete or ((pcc_validation or input_source == "abc_1k") and not ref_cache_loadable)
     logger.info(
         f"Cache status: TTNN={ttnn_cache_complete}, ref_cache={torch_ref_cache.exists()}, "
         f"need_hf_model={need_hf_model}"
@@ -161,8 +160,19 @@ def test_prefill_block(
         logger.info("TTNN cache complete, skipping torch weight creation")
         state_dict = {}
 
-    # --- Create input ---
-    if input_source == "abc_1k" and hf_model is not None:
+    # --- Resolve torch_input and torch reference (single decision point for ref_cache) ---
+    torch_output = None
+    ref_kvpe = None
+    if ref_cache_loadable:
+        logger.info(f"Loading cached reference from {torch_ref_cache}")
+        profiler.start("reference_loading")
+        ref_cached = torch.load(torch_ref_cache, weights_only=True)
+        torch_input = ref_cached["torch_input"]
+        if pcc_validation:
+            torch_output = ref_cached["torch_output"]
+            ref_kvpe = ref_cached["ref_kvpe"]
+        profiler.end("reference_loading")
+    elif input_source == "abc_1k":
         profiler.start("tokenization")
         prompts = load_prompts_from_json(str(ABC_1K_PATH))
         prompt_text = prompts[0] if isinstance(prompts, list) else prompts
@@ -175,52 +185,36 @@ def test_prefill_block(
         with torch.no_grad():
             torch_input = hf_model.embed_tokens(token_ids).to(torch.bfloat16)
         logger.info(f"Embedded input shape: {torch_input.shape}")
-    elif input_source == "abc_1k" and hf_model is None:
-        logger.info("Loading abc_1k torch_input from reference cache")
-        ref_cached = torch.load(torch_ref_cache, weights_only=True)
-        torch_input = ref_cached["torch_input"]
     else:
         torch.manual_seed(123)
         torch_input = torch.randn(1, isl_total, emb_dim, dtype=torch.bfloat16)
 
-    # --- Torch reference (with caching) ---
-    torch_output = None
-    ref_kvpe = None
-    if pcc_validation:
-        if torch_ref_cache.exists():
-            logger.info(f"Loading cached reference from {torch_ref_cache}")
-            profiler.start("reference_loading")
-            ref_cached = torch.load(torch_ref_cache, weights_only=True)
-            torch_input = ref_cached["torch_input"]
-            torch_output = ref_cached["torch_output"]
-            ref_kvpe = ref_cached["ref_kvpe"]
-            profiler.end("reference_loading")
-        else:
-            profiler.start("torch_reference")
-            logger.info("Running torch reference forward...")
-            position_ids = torch.arange(isl_total, dtype=torch.long).unsqueeze(0)
-            attention_mask = torch.zeros(1, 1, isl_total, isl_total, dtype=torch.bfloat16)
-            ref_cache = DynamicCache()
-            with torch.no_grad():
-                layer_out = hf_model.layers[layer_idx](
-                    torch_input,
-                    attention_mask=attention_mask,
-                    position_ids=position_ids,
-                    past_key_value=ref_cache,
-                    use_cache=True,
-                )
-                torch_output = layer_out[0]
-            logger.info(f"Torch reference output shape: {torch_output.shape}")
-            if ref_cache is not None:
-                ref_kvpe = ref_cache.key_cache[layer_idx]
-                logger.info(f"Reference KVPE shape: {ref_kvpe.shape}")
-            profiler.end("torch_reference")
-
-            logger.info(f"Saving reference to {torch_ref_cache}")
-            torch.save(
-                {"torch_input": torch_input, "torch_output": torch_output, "ref_kvpe": ref_kvpe},
-                torch_ref_cache,
+    if pcc_validation and torch_output is None:
+        profiler.start("torch_reference")
+        logger.info("Running torch reference forward...")
+        position_ids = torch.arange(isl_total, dtype=torch.long).unsqueeze(0)
+        attention_mask = torch.zeros(1, 1, isl_total, isl_total, dtype=torch.bfloat16)
+        ref_cache = DynamicCache()
+        with torch.no_grad():
+            layer_out = hf_model.layers[layer_idx](
+                torch_input,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_value=ref_cache,
+                use_cache=True,
             )
+            torch_output = layer_out[0]
+        logger.info(f"Torch reference output shape: {torch_output.shape}")
+        if ref_cache is not None:
+            ref_kvpe = ref_cache.key_cache[layer_idx]
+            logger.info(f"Reference KVPE shape: {ref_kvpe.shape}")
+        profiler.end("torch_reference")
+
+        logger.info(f"Saving reference to {torch_ref_cache}")
+        torch.save(
+            {"torch_input": torch_input, "torch_output": torch_output, "ref_kvpe": ref_kvpe},
+            torch_ref_cache,
+        )
 
     # Free HF model early
     if hf_model is not None:


### PR DESCRIPTION
Ticket
https://github.com/tenstorrent/tt-metal/issues/43244

Problem description
Test execution for test_ttnn_moe.py and test_prefill_block.py takes too long, because of PyTorch and ttnn weights generation.

What's changed
Added generation PyTorch and ttnn weights for first run on both of these tests, so all other executions will work significantly faster (works only for local execution).

### DeepSeek CI

- [x] [![(T3K) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pmilojevic/cache-moe-prefillblock-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pmilojevic/cache-moe-prefillblock-test)
- [x] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pmilojevic/cache-moe-prefillblock-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pmilojevic/cache-moe-prefillblock-test)
- [x] [![Demo SP
Release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=pmilojevic/cache-moe-prefillblock-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:pmilojevic/cache-moe-prefillblock-test)
- [x] [![(Galaxy) DeepSeek Prefill
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=pmilojevic/cache-moe-prefillblock-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:pmilojevic/cache-moe-prefillblock-test)
