### PR TITLE
nlp_concat_heads_decode: support padded_heads > 32

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads_decode.py
@@ -104,7 +104,18 @@ def run_test_concat_head(
 
 @pytest.mark.parametrize(
     "n_local_heads, padded_local_heads, head_dim, batch_size",
-    ((8, 32, 128, 32), (17, 32, 96, 32), (32, 32, 64, 32), (8, 32, 128, 16)),
+    (
+        # Single head-tile (padded_local_heads == 32)
+        (8, 32, 128, 32),
+        (17, 32, 96, 32),
+        (32, 32, 64, 32),
+        (8, 32, 128, 16),
+        # Multiple head-tiles (padded_local_heads > 32)
+        (8, 64, 64, 32),  # 2 head-tiles, low utilization
+        (32, 64, 64, 32),  # 2 head-tiles, fully populated within first tile
+        (32, 64, 128, 32),  # 2 head-tiles + multi-tile head_dim
+        (16, 96, 64, 32),  # 3 head-tiles (non-power-of-2 padded_local_heads)
+    ),
 )
 @pytest.mark.parametrize("mesh_device", [pytest.param((1, 1), id="1x1_grid")], indirect=True)
 def test_concat_head(
@@ -150,6 +161,24 @@ def test_concat_head(
             ttnn.CoreRangeSet(
                 [
                     ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0)),
+                ]
+            ),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 1)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 2), ttnn.CoreCoord(2, 2)),
+                ]
+            ),
+        ),
+        (  # Test Case 2: padded_local_heads=64 (multi head-tile path) on subcoregrids
+            8,
+            64,
+            128,
+            8,
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 1)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 2), ttnn.CoreCoord(2, 2)),
                 ]
             ),
             ttnn.CoreRangeSet(

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads_decode.py
@@ -54,14 +54,17 @@ def run_test_concat_head(
         sub_core_grids = ttnn.num_cores_to_corerangeset_in_subcoregrids(
             shard_grid.bounding_box().start, n_local_heads, shard_grid, row_wise=True
         )
-    else:
-        assert (
-            compute_sub_core_grids is not None
-        ), "compute_sub_core_grids must be provided if shard_grid has less than n_local_heads cores"
+    elif compute_sub_core_grids is not None:
         sub_core_grids = compute_sub_core_grids
         assert (
             sub_core_grids.num_cores() >= n_local_heads
         ), "compute_sub_core_grids must have at least n_local_heads cores"
+    else:
+        # n_local_heads > input shard grid: auto-generate a compute grid that fits n_local_heads.
+        # The op requires input batch <= 32 (one input core per user) but allows num_heads up to
+        # the device's worker grid, so this branch is needed to exercise n_local_heads > 32 paths
+        # in test_concat_head (which doesn't pass an explicit compute grid).
+        sub_core_grids = ttnn.num_cores_to_corerangeset(n_local_heads, device.compute_with_storage_grid_size(), True)
 
     SCORES_BATCHED_MM_OUTPUT_MEMCFG = ttnn.MemoryConfig(
         ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
@@ -114,7 +117,12 @@ def run_test_concat_head(
         (8, 64, 64, 32),  # 2 head-tiles, low utilization
         (32, 64, 64, 32),  # 2 head-tiles, fully populated within first tile
         (32, 64, 128, 32),  # 2 head-tiles + multi-tile head_dim
-        (16, 96, 64, 32),  # 3 head-tiles (non-power-of-2 padded_local_heads)
+        (16, 96, 64, 32),  # 3 head-tiles
+        # n_local_heads > 32 — exercises head_tile_idx > 0 in the offset formula
+        # (batch is capped at 32 by the op; n_local_heads uses device compute grid)
+        (40, 64, 64, 8),  # heads 32..39 read from 2nd head-tile
+        (64, 64, 64, 8),  # all 32 heads in 2nd head-tile fully populated
+        (40, 96, 64, 8),  # 3 head-tiles, heads 32..39 from 2nd tile (non-power-of-2 padded_local_heads)
     ),
 )
 @pytest.mark.parametrize("mesh_device", [pytest.param((1, 1), id="1x1_grid")], indirect=True)
@@ -185,6 +193,22 @@ def test_concat_head(
                 [
                     ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 1)),
                     ttnn.CoreRange(ttnn.CoreCoord(1, 2), ttnn.CoreCoord(2, 2)),
+                ]
+            ),
+        ),
+        (  # Test Case 3: n_local_heads=64 — exercises head_tile_idx > 0 on subcoregrids
+            64,
+            64,
+            64,
+            8,
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0)),
+                ]
+            ),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7)),
                 ]
             ),
         ),

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
@@ -37,7 +37,7 @@ void NLPConcatHeadsDecodeDeviceOperation::validate_on_program_cache_miss(
         input_tensor.layout());
     TT_FATAL(input_shape[0] == 1, "seqlen=1 for decode");
     TT_FATAL(input_shape[1] <= 32, "currently only support less than 32 users");
-    TT_FATAL(input_shape[2] == 32, "currently only support 32 padded heads");
+    TT_FATAL(input_shape[2] % 32 == 0, "padded heads must be a multiple of TILE_HEIGHT (32), got {}", input_shape[2]);
     TT_FATAL(input_shape[2] >= args.num_heads, "head_dim must be multiple of TILE_WIDTH");
 
     // input tensor shard spec

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.cpp
@@ -99,8 +99,16 @@ NLPConcatHeadsDecodeProgramFactory::cached_program_t NLPConcatHeadsDecodeProgram
     uint32_t q_start_addr = q_base_addr;
 
     for (uint32_t i = 0; i < num_cores; ++i) {
+        // Each output core i corresponds to head index i. Within the input shard, that head lives in
+        // head-tile (i / 32) at row (i % 32). The two cases below pick the row's byte offset within
+        // a single 32x32 tile (face 0 for rows < 16, face 2 for rows >= 16); add the head-tile skip
+        // to land in the right tile when padded_heads > 32.
+        uint32_t head_tile_idx = i / 32;
+        uint32_t head_in_tile = i % 32;
         uint32_t in_tile_offset_by_batch =
-            i < 16 ? i * sub_tile_line_bytes : ((i - 16) * sub_tile_line_bytes) + (512 * element_size);
+            (head_in_tile < 16 ? head_in_tile * sub_tile_line_bytes
+                               : (head_in_tile - 16) * sub_tile_line_bytes + 512 * element_size) +
+            head_tile_idx * head_size;
 
         const auto& core = cores[i];
         std::vector<uint32_t> reader_runtime_args;
@@ -125,7 +133,8 @@ NLPConcatHeadsDecodeProgramFactory::cached_program_t NLPConcatHeadsDecodeProgram
             .element_size = element_size,
             .sub_tile_line_bytes = sub_tile_line_bytes,
             .num_cores = num_cores,
-            .cb_q_output = cb_q_output}};
+            .cb_q_output = cb_q_output,
+            .head_size = head_size}};
 }
 
 void NLPConcatHeadsDecodeProgramFactory::override_runtime_arguments(
@@ -144,9 +153,13 @@ void NLPConcatHeadsDecodeProgramFactory::override_runtime_arguments(
     uint32_t q_start_addr = q_base_addr;
 
     for (uint32_t i = 0; i < shared_variables.num_cores; ++i) {
+        uint32_t head_tile_idx = i / 32;
+        uint32_t head_in_tile = i % 32;
         uint32_t in_tile_offset_by_batch =
-            i < 16 ? i * shared_variables.sub_tile_line_bytes
-                   : ((i - 16) * shared_variables.sub_tile_line_bytes) + (512 * shared_variables.element_size);
+            (head_in_tile < 16
+                 ? head_in_tile * shared_variables.sub_tile_line_bytes
+                 : (head_in_tile - 16) * shared_variables.sub_tile_line_bytes + 512 * shared_variables.element_size) +
+            head_tile_idx * shared_variables.head_size;
         const auto& core = shared_variables.cores[i];
         auto& runtime_args = GetRuntimeArgs(program, shared_variables.reader_kernel_id, core);
         runtime_args[0] = in_tile_offset_by_batch;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.hpp
@@ -17,6 +17,7 @@ struct NLPConcatHeadsDecodeSharedVariables {
     uint32_t sub_tile_line_bytes{};
     uint32_t num_cores{};
     tt::tt_metal::CBHandle cb_q_output{};
+    uint32_t head_size{};
 };
 
 struct NLPConcatHeadsDecodeProgramFactory {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_subcoregrids_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_subcoregrids_program_factory.cpp
@@ -104,9 +104,16 @@ NLPConcatHeadsDecodeSubcoregridsProgramFactory::cached_program_t NLPConcatHeadsD
         tt_metal::WriterDataMovementConfig(reader_compile_time_args));
 
     for (uint32_t i = 0; i < num_cores; ++i) {
-        // in_tile_offset_by_batch is the start address of each batch in the input tile. The first face_h batches are in
-        // the upper half of the tile and rest are in the lower half of tile.
-        uint32_t in_tile_offset_by_batch = i < face_h ? i * sub_tile_line_bytes : (i + face_h) * sub_tile_line_bytes;
+        // in_tile_offset_by_batch is the byte offset of head row i within the input shard. Within
+        // a single 32x32 tile (= 2*face_h rows), the first face_h rows live in face 0 and the rest
+        // live in face 2 (the existing formula uses (i + face_h) * sub_tile_line_bytes to land at
+        // the start of face 2 directly). When padded_heads > 32 we additionally skip past
+        // (i / (2*face_h)) head-tiles' worth of bytes.
+        uint32_t head_tile_idx = i / (2 * face_h);
+        uint32_t head_in_tile = i % (2 * face_h);
+        uint32_t in_tile_offset_by_batch = (head_in_tile < face_h ? head_in_tile * sub_tile_line_bytes
+                                                                  : (head_in_tile + face_h) * sub_tile_line_bytes) +
+                                           head_tile_idx * head_size;
 
         const auto& core = cores[i];
         std::vector<uint32_t> reader_runtime_args;
@@ -132,7 +139,8 @@ NLPConcatHeadsDecodeSubcoregridsProgramFactory::cached_program_t NLPConcatHeadsD
          /* num_cores            = */ num_cores,
          /* cb_q_output          = */ cb_q_output,
          /* face_h               = */ face_h,
-         /* tile_w               = */ tile_w}};
+         /* tile_w               = */ tile_w,
+         /* head_size            = */ head_size}};
 }
 
 void NLPConcatHeadsDecodeSubcoregridsProgramFactory::override_runtime_arguments(
@@ -153,9 +161,13 @@ void NLPConcatHeadsDecodeSubcoregridsProgramFactory::override_runtime_arguments(
     auto& writer_args_by_core = GetRuntimeArgs(program, shared_variables.writer_kernel_id);
 
     for (uint32_t i = 0; i < shared_variables.num_cores; ++i) {
-        uint32_t in_tile_offset_by_batch = i < shared_variables.face_h
-                                               ? i * shared_variables.sub_tile_line_bytes
-                                               : (i + shared_variables.face_h) * shared_variables.sub_tile_line_bytes;
+        uint32_t head_tile_idx = i / (2 * shared_variables.face_h);
+        uint32_t head_in_tile = i % (2 * shared_variables.face_h);
+        uint32_t in_tile_offset_by_batch =
+            (head_in_tile < shared_variables.face_h
+                 ? head_in_tile * shared_variables.sub_tile_line_bytes
+                 : (head_in_tile + shared_variables.face_h) * shared_variables.sub_tile_line_bytes) +
+            head_tile_idx * shared_variables.head_size;
         const auto& core = shared_variables.cores[i];
         auto& runtime_args_reader = reader_args_by_core[core.x][core.y];
         runtime_args_reader[0] = in_tile_offset_by_batch;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_subcoregrids_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_subcoregrids_program_factory.hpp
@@ -19,6 +19,7 @@ struct NLPConcatHeadsDecodeSubcoregridsSharedVariables {
     tt::tt_metal::CBHandle cb_q_output{};
     uint32_t face_h{};
     uint32_t tile_w{};
+    uint32_t head_size{};
 };
 
 struct NLPConcatHeadsDecodeSubcoregridsProgramFactory {


### PR DESCRIPTION
## Summary

Extends `ttnn.experimental.nlp_concat_heads_decode` to accept input shards where `padded_heads` is any multiple of 32, not just exactly 32. Previously the op asserted `input_shape[2] == 32` and computed an offset into a single 32×32 head tile; now it adds a head-tile skip `(i / 32) * head_size` so each output core lands in the correct head-tile.

The change is purely host-side — the kernel walks head_dim tiles per row but never navigates in the head direction, so the multi-head-tile dimension can be folded into the per-core `in_tile_offset_by_batch` runtime arg without touching any kernel.

The new formula collapses identically to the old one when `padded_heads == 32`, so all existing callers are bit-exact unchanged.

This unblocks gpt-oss-20b on a single Blackhole card, where `tp=1` gives `num_local_heads=64`. The model-side workaround in `models/demos/gpt_oss/tt/attention/decode.py` (the `if num_local_heads > 32:` branch) is intentionally left in place; removing it is a follow-up.

## Files changed

- `device/nlp_concat_heads_decode_device_operation.cpp` — assertion relaxed from `== 32` to `% 32 == 0`.
- `device/nlp_concat_heads_decode_program_factory.{cpp,hpp}` — new offset formula in `create()` and `override_runtime_arguments()`; `head_size` plumbed through `SharedVariables` so the override sees it.
- `device/nlp_concat_heads_decode_subcoregrids_program_factory.{cpp,hpp}` — same change for the subcoregrids variant (uses `face_h` parameterization instead of hardcoded 16/32).
- No kernel changes.

## Test plan

- [x] Existing `test_concat_head` and `test_concat_head_subcoregrids` cases still pass (6/6) — formula is bit-exact at `padded_heads == 32`.
- [x] New `test_concat_head` cases at `padded_local_heads ∈ {64, 96}`:
  - `(8, 64, 64, 32)` — 2 head-tiles, low utilization
  - `(32, 64, 64, 32)` — 2 head-tiles, fully populated
  - `(32, 64, 128, 32)` — 2 head-tiles + multi-tile head_dim
  - `(16, 96, 64, 32)` — 3 head-tiles
- [x] New `test_concat_head_subcoregrids` case at `padded_local_heads=64` (8 heads, head_dim=128, batch=8).
- [ ] Manual: gpt-oss decode on 1×1 Blackhole with `num_local_heads=64` calling `nlp_concat_heads_decode` directly (covered when the workaround is deleted in the follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=handrews/concat-heads-decode-multi-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:handrews/concat-heads-decode-multi-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=handrews/concat-heads-decode-multi-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:handrews/concat-heads-decode-multi-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=handrews/concat-heads-decode-multi-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:handrews/concat-heads-decode-multi-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=handrews/concat-heads-decode-multi-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:handrews/concat-heads-decode-multi-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=handrews/concat-heads-decode-multi-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:handrews/concat-heads-decode-multi-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=handrews/concat-heads-decode-multi-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:handrews/concat-heads-decode-multi-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=handrews/concat-heads-decode-multi-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:handrews/concat-heads-decode-multi-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=handrews/concat-heads-decode-multi-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:handrews/concat-heads-decode-multi-tile)