### PR TITLE
Adds validation for generic reduce ops (min, max, mean, sum)

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/reduction/generic/device/common.hpp"
+#include <tt-metalium/work_split.hpp>
 
 namespace ttnn::prim {
 
@@ -37,6 +38,111 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
         "Only FLOAT32, BFLOAT16, BFLOAT8_B, and UINT32 are supported for generic reduction - got {}",
         tensor_args.dtype());
     validate_reduce_sharded_buffer_types(tensor_args.memory_config(), operation_attributes.output_mem_config, "reduce");
+
+    TT_FATAL(tensor_args.device() != nullptr, "Reduce input tensor must have a valid device");
+
+    switch (operation_attributes.dim) {
+        case ReduceOpDim::H:
+            TT_FATAL(
+                strategy == ReduceOpParallelizationStrategy::MULTI_CORE_H,
+                "Reduce dim H must use MULTI_CORE_H strategy, got enum value {}",
+                static_cast<int>(strategy));
+            break;
+        case ReduceOpDim::W:
+            TT_FATAL(
+                strategy == ReduceOpParallelizationStrategy::MULTI_CORE_W,
+                "Reduce dim W must use MULTI_CORE_W strategy, got enum value {}",
+                static_cast<int>(strategy));
+            break;
+        case ReduceOpDim::HW:
+            TT_FATAL(
+                strategy == ReduceOpParallelizationStrategy::SINGLE_CORE_HW ||
+                    strategy == ReduceOpParallelizationStrategy::MULTI_CORE_HW,
+                "Reduce dim HW must use SINGLE_CORE_HW or MULTI_CORE_HW strategy, got enum value {}",
+                static_cast<int>(strategy));
+            break;
+    }
+
+    const auto device_grid_size = tensor_args.device()->compute_with_storage_grid_size();
+    TT_FATAL(
+        device_grid_size.x > 0 && device_grid_size.y > 0,
+        "Device compute grid must be non-empty, got ({}, {})",
+        device_grid_size.x,
+        device_grid_size.y);
+    const CoreRangeSet device_grid =
+        num_cores_to_corerangeset(device_grid_size.x * device_grid_size.y, device_grid_size, false);
+
+    const CoreRangeSet program_grid = operation_attributes.sub_core_grids.value_or(device_grid);
+    TT_FATAL(!program_grid.ranges().empty(), "Program core grid must not be empty");
+    TT_FATAL(
+        device_grid.contains(program_grid),
+        "Program core grid {} must be contained in device grid {}",
+        program_grid,
+        device_grid);
+
+    if (tensor_args.shard_spec().has_value()) {
+        const auto& in_shard = tensor_args.shard_spec().value();
+        const auto& input_shard_grid = in_shard.grid;
+        TT_FATAL(
+            program_grid.contains(input_shard_grid),
+            "Input shard grid {} must be contained in program core grid {}",
+            input_shard_grid,
+            program_grid);
+        // Issue #41957: shard "face" in elements must be positive and tile-aligned (tilized reduce input).
+        const uint32_t th = tensor_args.tensor_spec().tile().get_height();
+        const uint32_t tw = tensor_args.tensor_spec().tile().get_width();
+        TT_FATAL(
+            in_shard.shape[0] > 0 && in_shard.shape[1] > 0,
+            "Sharded reduce input: shard face shape must be positive, got [{}, {}]",
+            in_shard.shape[0],
+            in_shard.shape[1]);
+        TT_FATAL(
+            in_shard.shape[0] % th == 0,
+            "Sharded reduce input: shard_shape[0]={} must be tile-height-aligned ({} px per tile face row)",
+            in_shard.shape[0],
+            th);
+        TT_FATAL(
+            in_shard.shape[1] % tw == 0,
+            "Sharded reduce input: shard_shape[1]={} must be tile-width-aligned ({} px per tile face col)",
+            in_shard.shape[1],
+            tw);
+    }
+
+    if (operation_attributes.output_mem_config.nd_shard_spec().has_value()) {
+        const auto& out_nd = *operation_attributes.output_mem_config.nd_shard_spec();
+        const auto& output_shard_grid = out_nd.grid;
+        const uint32_t oth = tensor_args.tensor_spec().tile().get_height();
+        const uint32_t otw = tensor_args.tensor_spec().tile().get_width();
+        TT_FATAL(
+            program_grid.contains(output_shard_grid),
+            "Output shard grid {} must be contained in program core grid {} (expected shard ⊆ program ⊆ device per "
+            "issue #41957)",
+            output_shard_grid,
+            program_grid);
+        TT_FATAL(
+            device_grid.contains(output_shard_grid),
+            "Output shard grid {} must be contained in device grid {}",
+            output_shard_grid,
+            device_grid);
+        if (out_nd.shard_shape.rank() >= 2) {
+            TT_FATAL(
+                out_nd.shard_shape[-2] > 0 && out_nd.shard_shape[-1] > 0,
+                "ND sharded output: last-2 shard dims must be positive, got [..., {}, {}] (height/width in "
+                "shard_shape)",
+                out_nd.shard_shape[-2],
+                out_nd.shard_shape[-1]);
+            TT_FATAL(
+                out_nd.shard_shape[-2] % oth == 0,
+                "ND sharded output: shard_shape[-2]={} must be tile-height-aligned ({}) for tilized output",
+                out_nd.shard_shape[-2],
+                oth);
+            TT_FATAL(
+                out_nd.shard_shape[-1] % otw == 0,
+                "ND sharded output: shard_shape[-1]={} must be tile-width-aligned ({}) for tilized output",
+                out_nd.shard_shape[-1],
+                otw);
+        }
+    }
 }
 
 ReduceDeviceOperation::spec_return_value_t ReduceDeviceOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -41,6 +41,9 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
 
     TT_FATAL(tensor_args.device() != nullptr, "Reduce input tensor must have a valid device");
 
+    using namespace tt::tt_metal;
+    const auto strategy = get_parallelization_strategy(tensor_args, operation_attributes.dim);
+
     switch (operation_attributes.dim) {
         case ReduceOpDim::H:
             TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -38,33 +38,33 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
         "Only FLOAT32, BFLOAT16, BFLOAT8_B, and UINT32 are supported for generic reduction - got {}",
         tensor_args.dtype());
     validate_reduce_sharded_buffer_types(tensor_args.memory_config(), operation_attributes.output_mem_config, "reduce");
+    /*
+        TT_FATAL(tensor_args.device() != nullptr, "Reduce input tensor must have a valid device");
 
-    TT_FATAL(tensor_args.device() != nullptr, "Reduce input tensor must have a valid device");
+        using namespace tt::tt_metal;
+        const auto strategy = get_parallelization_strategy(tensor_args, operation_attributes.dim);
 
-    using namespace tt::tt_metal;
-    const auto strategy = get_parallelization_strategy(tensor_args, operation_attributes.dim);
-
-    switch (operation_attributes.dim) {
-        case ReduceOpDim::H:
-            TT_FATAL(
-                strategy == ReduceOpParallelizationStrategy::MULTI_CORE_H,
-                "Reduce dim H must use MULTI_CORE_H strategy, got enum value {}",
-                static_cast<int>(strategy));
-            break;
-        case ReduceOpDim::W:
-            TT_FATAL(
-                strategy == ReduceOpParallelizationStrategy::MULTI_CORE_W,
-                "Reduce dim W must use MULTI_CORE_W strategy, got enum value {}",
-                static_cast<int>(strategy));
-            break;
-        case ReduceOpDim::HW:
-            TT_FATAL(
-                strategy == ReduceOpParallelizationStrategy::SINGLE_CORE_HW ||
-                    strategy == ReduceOpParallelizationStrategy::MULTI_CORE_HW,
-                "Reduce dim HW must use SINGLE_CORE_HW or MULTI_CORE_HW strategy, got enum value {}",
-                static_cast<int>(strategy));
-            break;
-    }
+        switch (operation_attributes.dim) {
+            case ReduceOpDim::H:
+                TT_FATAL(
+                    strategy == ReduceOpParallelizationStrategy::MULTI_CORE_H,
+                    "Reduce dim H must use MULTI_CORE_H strategy, got enum value {}",
+                    static_cast<int>(strategy));
+                break;
+            case ReduceOpDim::W:
+                TT_FATAL(
+                    strategy == ReduceOpParallelizationStrategy::MULTI_CORE_W,
+                    "Reduce dim W must use MULTI_CORE_W strategy, got enum value {}",
+                    static_cast<int>(strategy));
+                break;
+            case ReduceOpDim::HW:
+                TT_FATAL(
+                    strategy == ReduceOpParallelizationStrategy::SINGLE_CORE_HW ||
+                        strategy == ReduceOpParallelizationStrategy::MULTI_CORE_HW,
+                    "Reduce dim HW must use SINGLE_CORE_HW or MULTI_CORE_HW strategy, got enum value {}",
+                    static_cast<int>(strategy));
+                break;
+        }*/
 
     const auto device_grid_size = tensor_args.device()->compute_with_storage_grid_size();
     TT_FATAL(
@@ -91,7 +91,6 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
             "Input shard grid {} must be contained in program core grid {}",
             input_shard_grid,
             program_grid);
-        // Issue #41957: shard "face" in elements must be positive and tile-aligned (tilized reduce input).
         const uint32_t th = tensor_args.tensor_spec().tile().get_height();
         const uint32_t tw = tensor_args.tensor_spec().tile().get_width();
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -26,6 +26,7 @@ ReduceDeviceOperation::program_factory_t ReduceDeviceOperation::select_program_f
 
 void ReduceDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    using namespace tt::tt_metal;
     TT_FATAL(
         tensor_args.storage_type() == StorageType::DEVICE,
         "Operands to reduce need to be on device! Got storage type: {}",

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -64,30 +64,30 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
             "Input shard grid {} must be contained in program core grid {}",
             input_shard_grid,
             program_grid);
-        const uint32_t th = tensor_args.tensor_spec().tile().get_height();
-        const uint32_t tw = tensor_args.tensor_spec().tile().get_width();
+        const uint32_t tile_height = tensor_args.tensor_spec().tile().get_height();
+        const uint32_t tile_width = tensor_args.tensor_spec().tile().get_width();
         TT_FATAL(
             in_shard.shape[0] > 0 && in_shard.shape[1] > 0,
             "Sharded reduce input: shard face shape must be positive, got [{}, {}]",
             in_shard.shape[0],
             in_shard.shape[1]);
         TT_FATAL(
-            in_shard.shape[0] % th == 0,
+            in_shard.shape[0] % tile_height == 0,
             "Sharded reduce input: shard_shape[0]={} must be tile-height-aligned ({} px per tile face row)",
             in_shard.shape[0],
-            th);
+            tile_height);
         TT_FATAL(
-            in_shard.shape[1] % tw == 0,
+            in_shard.shape[1] % tile_width == 0,
             "Sharded reduce input: shard_shape[1]={} must be tile-width-aligned ({} px per tile face col)",
             in_shard.shape[1],
-            tw);
+            tile_width);
     }
 
     if (operation_attributes.output_mem_config.nd_shard_spec().has_value()) {
-        const auto& out_nd = *operation_attributes.output_mem_config.nd_shard_spec();
-        const auto& output_shard_grid = out_nd.grid;
-        const uint32_t oth = tensor_args.tensor_spec().tile().get_height();
-        const uint32_t otw = tensor_args.tensor_spec().tile().get_width();
+        const auto& output_nd_shard_spec = *operation_attributes.output_mem_config.nd_shard_spec();
+        const auto& output_shard_grid = output_nd_shard_spec.grid;
+        const uint32_t output_tile_height = tensor_args.tensor_spec().tile().get_height();
+        const uint32_t output_tile_width = tensor_args.tensor_spec().tile().get_width();
         TT_FATAL(
             program_grid.contains(output_shard_grid),
             "Output shard grid {} must be contained in program core grid {}",
@@ -98,23 +98,23 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
             "Output shard grid {} must be contained in device grid {}",
             output_shard_grid,
             device_grid);
-        if (out_nd.shard_shape.rank() >= 2) {
+        if (output_nd_shard_spec.shard_shape.rank() >= 2) {
             TT_FATAL(
-                out_nd.shard_shape[-2] > 0 && out_nd.shard_shape[-1] > 0,
+                output_nd_shard_spec.shard_shape[-2] > 0 && output_nd_shard_spec.shard_shape[-1] > 0,
                 "ND sharded output: last-2 shard dims must be positive, got [..., {}, {}] (height/width in "
                 "shard_shape)",
-                out_nd.shard_shape[-2],
-                out_nd.shard_shape[-1]);
+                output_nd_shard_spec.shard_shape[-2],
+                output_nd_shard_spec.shard_shape[-1]);
             TT_FATAL(
-                out_nd.shard_shape[-2] % oth == 0,
+                output_nd_shard_spec.shard_shape[-2] % output_tile_height == 0,
                 "ND sharded output: shard_shape[-2]={} must be tile-height-aligned ({}) for tilized output",
-                out_nd.shard_shape[-2],
-                oth);
+                output_nd_shard_spec.shard_shape[-2],
+                output_tile_height);
             TT_FATAL(
-                out_nd.shard_shape[-1] % otw == 0,
+                output_nd_shard_spec.shard_shape[-1] % output_tile_width == 0,
                 "ND sharded output: shard_shape[-1]={} must be tile-width-aligned ({}) for tilized output",
-                out_nd.shard_shape[-1],
-                otw);
+                output_nd_shard_spec.shard_shape[-1],
+                output_tile_width);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -38,34 +38,6 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
         "Only FLOAT32, BFLOAT16, BFLOAT8_B, and UINT32 are supported for generic reduction - got {}",
         tensor_args.dtype());
     validate_reduce_sharded_buffer_types(tensor_args.memory_config(), operation_attributes.output_mem_config, "reduce");
-    /*
-        TT_FATAL(tensor_args.device() != nullptr, "Reduce input tensor must have a valid device");
-
-        using namespace tt::tt_metal;
-        const auto strategy = get_parallelization_strategy(tensor_args, operation_attributes.dim);
-
-        switch (operation_attributes.dim) {
-            case ReduceOpDim::H:
-                TT_FATAL(
-                    strategy == ReduceOpParallelizationStrategy::MULTI_CORE_H,
-                    "Reduce dim H must use MULTI_CORE_H strategy, got enum value {}",
-                    static_cast<int>(strategy));
-                break;
-            case ReduceOpDim::W:
-                TT_FATAL(
-                    strategy == ReduceOpParallelizationStrategy::MULTI_CORE_W,
-                    "Reduce dim W must use MULTI_CORE_W strategy, got enum value {}",
-                    static_cast<int>(strategy));
-                break;
-            case ReduceOpDim::HW:
-                TT_FATAL(
-                    strategy == ReduceOpParallelizationStrategy::SINGLE_CORE_HW ||
-                        strategy == ReduceOpParallelizationStrategy::MULTI_CORE_HW,
-                    "Reduce dim HW must use SINGLE_CORE_HW or MULTI_CORE_HW strategy, got enum value {}",
-                    static_cast<int>(strategy));
-                break;
-        }*/
-
     const auto device_grid_size = tensor_args.device()->compute_with_storage_grid_size();
     TT_FATAL(
         device_grid_size.x > 0 && device_grid_size.y > 0,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -89,8 +89,7 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
         const uint32_t otw = tensor_args.tensor_spec().tile().get_width();
         TT_FATAL(
             program_grid.contains(output_shard_grid),
-            "Output shard grid {} must be contained in program core grid {} (expected shard ⊆ program ⊆ device per "
-            "issue #41957)",
+            "Output shard grid {} must be contained in program core grid {}",
             output_shard_grid,
             program_grid);
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -64,19 +64,6 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
             tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_cols);
     }
     TT_FATAL(num_cores > 0, "Reduce H requires at least one worker core");
-    TT_FATAL(
-        all_cores.num_cores() == num_cores,
-        "Split core count mismatch: num_cores={}, all_cores.num_cores()={}",
-        num_cores,
-        all_cores.num_cores());
-    uint32_t cols_assigned_to_group_1 = core_group_1.num_cores() * num_cols_per_core_group_1;
-    uint32_t cols_assigned_to_group_2 = core_group_2.num_cores() * num_cols_per_core_group_2;
-    TT_FATAL(
-        cols_assigned_to_group_1 + cols_assigned_to_group_2 == num_cols,
-        "Reduce H workload mismatch: group1_cols={} + group2_cols={} must equal total_cols={}",
-        cols_assigned_to_group_1,
-        cols_assigned_to_group_2,
-        num_cols);
 
     // Current sharding only supports width, and that input and output are sharded
     if (use_width_sharding) {
@@ -86,13 +73,6 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
         core_group_2 = CoreRangeSet();
         num_cols_per_core_group_1 = NC * (a.shard_spec().value().shape[1] / tile_width);
         num_cols_per_core_group_2 = 0;
-        cols_assigned_to_group_1 = core_group_1.num_cores() * num_cols_per_core_group_1;
-        cols_assigned_to_group_2 = 0;
-        TT_FATAL(
-            cols_assigned_to_group_1 == num_cols,
-            "Width-sharded Reduce H workload mismatch: assigned_cols={} must equal total_cols={}",
-            cols_assigned_to_group_1,
-            num_cols);
     }
 
     uint32_t src0_cb_index = CBIndex::c_0;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -10,7 +10,6 @@
 #include <bit>
 #include <cmath>
 #include <numeric>
-#include <limits>
 
 namespace ttnn::prim {
 
@@ -184,19 +183,6 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
         if (num_cols_per_core_group_2 > 0) {
             include_push_sizes(num_cols_per_core_group_2);
         }
-        // Accumulation CBs (acc / intermediate negate staging) scale with chunk_size tiles × dst tile bytes.
-        TT_FATAL(
-            chunk_size > 0, "Reduce H negate path: chunk_size (dest register tiling) must be > 0, got {}", chunk_size);
-        TT_FATAL(
-            dst_single_tile_size > 0,
-            "Reduce H negate path: dst tile byte size must be > 0, got {}",
-            dst_single_tile_size);
-        TT_FATAL(
-            static_cast<uint64_t>(chunk_size) * static_cast<uint64_t>(dst_single_tile_size) <=
-                static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()),
-            "Reduce H negate path: accumulation CB byte size overflows uint32 (chunk_size={}, dst_single_tile_size={})",
-            chunk_size,
-            dst_single_tile_size);
 
         uint32_t acc_cb_index = CBIndex::c_4;
         tt_metal::CircularBufferConfig cb_acc_config =

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -10,6 +10,7 @@
 #include <bit>
 #include <cmath>
 #include <numeric>
+#include <limits>
 
 namespace ttnn::prim {
 
@@ -63,6 +64,20 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
             num_cores, all_cores, core_group_1, core_group_2, num_cols_per_core_group_1, num_cols_per_core_group_2) =
             tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_cols);
     }
+    TT_FATAL(num_cores > 0, "Reduce H requires at least one worker core");
+    TT_FATAL(
+        all_cores.num_cores() == num_cores,
+        "Split core count mismatch: num_cores={}, all_cores.num_cores()={}",
+        num_cores,
+        all_cores.num_cores());
+    uint32_t cols_assigned_to_group_1 = core_group_1.num_cores() * num_cols_per_core_group_1;
+    uint32_t cols_assigned_to_group_2 = core_group_2.num_cores() * num_cols_per_core_group_2;
+    TT_FATAL(
+        cols_assigned_to_group_1 + cols_assigned_to_group_2 == num_cols,
+        "Reduce H workload mismatch: group1_cols={} + group2_cols={} must equal total_cols={}",
+        cols_assigned_to_group_1,
+        cols_assigned_to_group_2,
+        num_cols);
 
     // Current sharding only supports width, and that input and output are sharded
     if (use_width_sharding) {
@@ -72,6 +87,13 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
         core_group_2 = CoreRangeSet();
         num_cols_per_core_group_1 = NC * (a.shard_spec().value().shape[1] / tile_width);
         num_cols_per_core_group_2 = 0;
+        cols_assigned_to_group_1 = core_group_1.num_cores() * num_cols_per_core_group_1;
+        cols_assigned_to_group_2 = 0;
+        TT_FATAL(
+            cols_assigned_to_group_1 == num_cols,
+            "Width-sharded Reduce H workload mismatch: assigned_cols={} must equal total_cols={}",
+            cols_assigned_to_group_1,
+            num_cols);
     }
 
     uint32_t src0_cb_index = CBIndex::c_0;
@@ -162,6 +184,19 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
         if (num_cols_per_core_group_2 > 0) {
             include_push_sizes(num_cols_per_core_group_2);
         }
+        // Accumulation CBs (acc / intermediate negate staging) scale with chunk_size tiles × dst tile bytes.
+        TT_FATAL(
+            chunk_size > 0, "Reduce H negate path: chunk_size (dest register tiling) must be > 0, got {}", chunk_size);
+        TT_FATAL(
+            dst_single_tile_size > 0,
+            "Reduce H negate path: dst tile byte size must be > 0, got {}",
+            dst_single_tile_size);
+        TT_FATAL(
+            static_cast<uint64_t>(chunk_size) * static_cast<uint64_t>(dst_single_tile_size) <=
+                static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()),
+            "Reduce H negate path: accumulation CB byte size overflows uint32 (chunk_size={}, dst_single_tile_size={})",
+            chunk_size,
+            dst_single_tile_size);
 
         uint32_t acc_cb_index = CBIndex::c_4;
         tt_metal::CircularBufferConfig cb_acc_config =
@@ -293,6 +328,8 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
     } else {
         cores = grid_to_cores(num_cores, compute_with_storage_grid_size.x, compute_with_storage_grid_size.y, false);
     }
+    TT_FATAL(
+        cores.size() == num_cores, "Resolved core list size {} must match split num_cores {}", cores.size(), num_cores);
     if (use_width_sharding) {
         TT_FATAL(NC != 0, "Batch size NC must be non-zero (shape[0]={}, shape[1]={})", shape[0], shape[1]);
         uint32_t shard_Wt = num_cols_per_core_group_1 / NC;
@@ -335,6 +372,13 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
                     num_cols_read       // output tile start index
                 });
             num_cols_read += num_cols_per_core;
+            if (i == num_cores - 1) {
+                TT_FATAL(
+                    num_cols_read == num_cols,
+                    "Reduce H assigned {} columns across cores, expected {}",
+                    num_cols_read,
+                    num_cols);
+            }
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -57,19 +57,6 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
             tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_rows);
     }
     TT_FATAL(num_cores > 0, "Reduce W requires at least one worker core");
-    TT_FATAL(
-        all_cores.num_cores() == num_cores,
-        "Split core count mismatch: num_cores={}, all_cores.num_cores()={}",
-        num_cores,
-        all_cores.num_cores());
-    const uint32_t rows_assigned_to_group_1 = core_group_1.num_cores() * num_rows_per_core_group_1;
-    const uint32_t rows_assigned_to_group_2 = core_group_2.num_cores() * num_rows_per_core_group_2;
-    TT_FATAL(
-        rows_assigned_to_group_1 + rows_assigned_to_group_2 == num_rows,
-        "Reduce W workload mismatch: group1_rows={} + group2_rows={} must equal total_rows={}",
-        rows_assigned_to_group_1,
-        rows_assigned_to_group_2,
-        num_rows);
 
     uint32_t src0_cb_index = 0;
     uint32_t num_input_tiles = 2;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -56,6 +56,20 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
             num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2) =
             tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_rows);
     }
+    TT_FATAL(num_cores > 0, "Reduce W requires at least one worker core");
+    TT_FATAL(
+        all_cores.num_cores() == num_cores,
+        "Split core count mismatch: num_cores={}, all_cores.num_cores()={}",
+        num_cores,
+        all_cores.num_cores());
+    const uint32_t rows_assigned_to_group_1 = core_group_1.num_cores() * num_rows_per_core_group_1;
+    const uint32_t rows_assigned_to_group_2 = core_group_2.num_cores() * num_rows_per_core_group_2;
+    TT_FATAL(
+        rows_assigned_to_group_1 + rows_assigned_to_group_2 == num_rows,
+        "Reduce W workload mismatch: group1_rows={} + group2_rows={} must equal total_rows={}",
+        rows_assigned_to_group_1,
+        rows_assigned_to_group_2,
+        num_rows);
 
     uint32_t src0_cb_index = 0;
     uint32_t num_input_tiles = 2;
@@ -84,6 +98,11 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     if (operation_attributes.negate) {
+        TT_FATAL(
+            dst_single_tile_size > 0,
+            "Reduce W negate path: dst tile byte size must be > 0 for accumulation CBs, got {}",
+            dst_single_tile_size);
+
         uint32_t acc_cb_index = tt::CBIndex::c_4;
         uint32_t num_acc_tiles = 1;
         tt_metal::CircularBufferConfig cb_acc_config =
@@ -167,6 +186,9 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
     } else {
         cores = grid_to_cores(num_cores, compute_with_storage_grid_size.x, compute_with_storage_grid_size.y, false);
     }
+    TT_FATAL(
+        cores.size() == num_cores, "Resolved core list size {} must match split num_cores {}", cores.size(), num_cores);
+    TT_FATAL(num_rows == 0 || !cores.empty(), "Non-zero reduce workload requires non-empty core list");
     for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
         const CoreCoord& core = cores[i];
         uint32_t num_rows_per_core = 0;
@@ -198,6 +220,13 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
                 num_tiles_read / out_dim_divider              // output tile start index
             });
         num_tiles_read += num_tensor_tiles_per_core;
+        if (i == num_cores - 1) {
+            TT_FATAL(
+                num_tiles_read == num_rows * Wt,
+                "Reduce W assigned {} input tiles, expected {}",
+                num_tiles_read,
+                num_rows * Wt);
+        }
     }
 
     return {std::move(program), {reader_kernel_id, writer_kernel_id, cores}};

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -98,11 +98,6 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     if (operation_attributes.negate) {
-        TT_FATAL(
-            dst_single_tile_size > 0,
-            "Reduce W negate path: dst tile byte size must be > 0 for accumulation CBs, got {}",
-            dst_single_tile_size);
-
         uint32_t acc_cb_index = tt::CBIndex::c_4;
         uint32_t num_acc_tiles = 1;
         tt_metal::CircularBufferConfig cb_acc_config =

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -105,11 +105,6 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
     if (operation_attributes.negate) {
-        TT_FATAL(
-            dst_single_tile_size > 0,
-            "Reduce HW negate path: dst tile byte size must be > 0 for accumulation CBs, got {}",
-            dst_single_tile_size);
-
         uint32_t acc_cb_index = tt::CBIndex::c_4;
         uint32_t num_acc_tiles = 1;
         tt_metal::CircularBufferConfig cb_acc_config =

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -29,6 +29,11 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
 
     uint32_t Wt = W / tile_width;
     uint32_t Ht = H / tile_height;
+    TT_FATAL(Ht != 0 && Wt != 0, "Height and width in tiles must be non-zero (Ht={}, Wt={}, H={}, W={})", Ht, Wt, H, W);
+    TT_FATAL(
+        operation_attributes.dim == ReduceOpDim::HW,
+        "ReduceSingleCoreHwProgramFactory supports HW dim only, got dim enum value {}",
+        static_cast<int>(operation_attributes.dim));
 
     // The single-core HW path uses REDUCE_SCALAR mode, which applies the
     // scaler twice internally (once per dimension). Here we compensate with
@@ -38,7 +43,15 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
     TT_FATAL(operation_attributes.scaler >= 0, "Scalar must be non-negative");
     float scaler = std::sqrt(operation_attributes.scaler);
 
+    TT_FATAL(
+        H % tile_height == 0 && W % tile_width == 0, "Reduce HW expects tile-aligned padded shape H={}, W={}", H, W);
     uint32_t num_tensor_tiles = NC * H * W / tile_hw;
+    const uint32_t num_tensor_tiles_ht_wt = NC * Ht * Wt;
+    TT_FATAL(
+        num_tensor_tiles == num_tensor_tiles_ht_wt,
+        "Reduce HW tile count mismatch: tile_hw path={} vs Ht*Wt path={}",
+        num_tensor_tiles,
+        num_tensor_tiles_ht_wt);
 
     tt_metal::Program program = tt_metal::CreateProgram();
 
@@ -46,6 +59,11 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
     if (operation_attributes.sub_core_grids.has_value() && !operation_attributes.sub_core_grids->ranges().empty()) {
         const auto& r = operation_attributes.sub_core_grids->ranges().front();
         selected_core_coord = r.start_coord;
+        TT_FATAL(
+            operation_attributes.sub_core_grids->contains(selected_core_coord),
+            "Selected core {} must be contained in provided sub_core_grids {}",
+            selected_core_coord,
+            *operation_attributes.sub_core_grids);
     }
     CoreRange core(selected_core_coord, selected_core_coord);
 
@@ -87,6 +105,11 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
     if (operation_attributes.negate) {
+        TT_FATAL(
+            dst_single_tile_size > 0,
+            "Reduce HW negate path: dst tile byte size must be > 0 for accumulation CBs, got {}",
+            dst_single_tile_size);
+
         uint32_t acc_cb_index = tt::CBIndex::c_4;
         uint32_t num_acc_tiles = 1;
         tt_metal::CircularBufferConfig cb_acc_config =
@@ -145,6 +168,11 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
 
     TT_FATAL(Ht != 0 && Wt != 0, "Height and width in tiles must be non-zero (Ht={}, Wt={}, H={}, W={})", Ht, Wt, H, W);
     uint32_t out_dim_divider = Ht * Wt;
+    TT_FATAL(
+        num_tensor_tiles % out_dim_divider == 0,
+        "Reduce HW per-core input tiles {} must be divisible by Ht*Wt={}",
+        num_tensor_tiles,
+        out_dim_divider);
 
     tt_metal::SetRuntimeArgs(
         program, writer_kernel_id, core, {output.buffer()->address(), num_tensor_tiles / out_dim_divider, 0});

--- a/ttnn/cpp/ttnn/operations/reduction/reduction_common/reduction_common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/reduction_common/reduction_common.cpp
@@ -72,6 +72,14 @@ ttnn::SmallVector<int> generate_reduce_dim(
     }
 
     std::sort(dim.begin(), dim.end());
+    for (size_t i = 1; i < dim.size(); i++) {
+        TT_FATAL(
+            dim[i] != dim[i - 1],
+            "reduce dim list contains a duplicate axis after sorting (indices {} and {}, value {})",
+            i - 1,
+            i,
+            dim[i]);
+    }
     return dim;
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue: #41957

### Problem description
Reduction operations lack comprehensive validation for core grid configuration, reduction dimensions, and shard/tile alignment.
There is no strict verification of correct work distribution across cores, validity of reduction dimensions, or handling of non-tile-aligned tensors and padding.

### What's changed
- Implemented the following changes for generic reduction operations (min, max, mean, sum)
- Added validation check for proper work distribution across cores, containment relationship ```shard_spec.grid ⊆ program_config.grid ⊆ device.grid``` and validates workload assignment to cores.
- Added validation to reject duplicate reduction dimensions after sorting (e.g. dim = [1,2,1])
- Added reduce input shard validation in reduce_op_device_operation.cpp:
             - shard face dims must be positive
             - shard_shape[0] must be tile-height aligned
             - shard_shape[1] must be tile-width aligned
- Added ND sharded output validation in reduce_op_device_operation.cpp:
             - last two shard dims must be positive
             - shard_shape[-2] and shard_shape[-1] must be tile aligned

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/generic_reduce_ops_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/generic_reduce_ops_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/generic_reduce_ops_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/generic_reduce_ops_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/generic_reduce_ops_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/generic_reduce_ops_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/generic_reduce_ops_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/generic_reduce_ops_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/generic_reduce_ops_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/generic_reduce_ops_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/generic_reduce_ops_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/generic_reduce_ops_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/generic_reduce_ops_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/generic_reduce_ops_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/generic_reduce_ops_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/generic_reduce_ops_validation)