### PR TITLE
ds_prefill(disable debug token count read)

### DIFF
--- a/models/demos/deepseek_v3_d_p/README.md
+++ b/models/demos/deepseek_v3_d_p/README.md
@@ -8,6 +8,7 @@ This directory will contain the implementation of prefill stage for DeepSeek V3 
 - **`TT_DS_PREFILL_TTNN_CACHE`** — Directory for cached TTNN weight tensors (`.tensorbin` files). First run writes cache, subsequent runs load directly. Defaults to `{model_path}/tensor_cache_{arch}_{num_devices}dev/`.
 - **`TT_DS_PREFILL_HOST_REF_CACHE`** — Directory for cached host reference snapshots used in PCC validation. Defaults to `/tmp/deepseek_v3_transformer_ref_cache`.
 - **`TT_DS_PREFILL_INFINITEBENCH_CACHE`** — Directory for cached InfiniteBench prompt data. Defaults to `/tmp/deepseek_v3_transformer_inputs`.
+- **`TT_DS_PREFILL_DEBUG_TOKEN_COUNT`** — Enable debug output for per-expert token counts in MoE forward pass. Set to `1`, `true`, or `yes` to enable. Defaults to disabled. Warning: enabling this adds device-to-host transfer overhead on every MoE layer forward.
 
 ## Weight Loading and TTNN Cache
 

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -14,6 +14,7 @@ This module assembles the full MoE pipeline:
 6. Final: Add routed output + shared output
 """
 
+import os
 from pathlib import Path
 from typing import Optional, Union
 
@@ -337,6 +338,9 @@ class TtMoe(LightweightModule):
             topology=self.col_topology,
         )
 
+        # Load debug flags from environment
+        self.debug_token_count = os.getenv("TT_DS_PREFILL_DEBUG_TOKEN_COUNT", "0").lower() in ("1", "true", "yes")
+
         logger.debug("TtMoe initialization complete")
 
     def forward(
@@ -375,18 +379,17 @@ class TtMoe(LightweightModule):
             else ttnn.deallocate(gate_logits)
         )  # gate_logits is only used for debugging/intermediates, move to DRAM or deallocate immediately
 
-        # DEBUG
-        # Print full token counts per expert for monitoring
-        _counts_4d = ttnn.unsqueeze_to_4D(tt_expert_token_counts)
-        _ep_composer = ttnn.create_mesh_composer(self.mesh_device, ttnn.MeshComposerConfig(dims=[1, 0]))
-        _counts_host = ttnn.to_torch(_counts_4d, mesh_composer=_ep_composer).squeeze(2)
-        logger.info(f"[TtMoe.forward] expert_token_counts: {_counts_host.flatten().tolist()}")
+        if self.debug_token_count:
+            # DEBUG: Print full token counts per expert for monitoring (controlled by env var)
+            _counts_4d = ttnn.unsqueeze_to_4D(tt_expert_token_counts)
+            _ep_composer = ttnn.create_mesh_composer(self.mesh_device, ttnn.MeshComposerConfig(dims=[1, 0]))
+            _counts_host = ttnn.to_torch(_counts_4d, mesh_composer=_ep_composer).squeeze(2)
+            logger.info(f"[TtMoe.forward] expert_token_counts: {_counts_host.flatten().tolist()}")
 
-        # DEBUG
-        # Print full region offsets per expert for monitoring
-        _offsets_4d = ttnn.unsqueeze_to_4D(tt_expert_region_offsets)
-        _offsets_host = ttnn.to_torch(_offsets_4d, mesh_composer=_ep_composer).squeeze(2)
-        logger.info(f"[TtMoe.forward] expert_region_offsets: {_offsets_host.flatten().tolist()}")
+            # DEBUG: Print full region offsets per expert for monitoring
+            _offsets_4d = ttnn.unsqueeze_to_4D(tt_expert_region_offsets)
+            _offsets_host = ttnn.to_torch(_offsets_4d, mesh_composer=_ep_composer).squeeze(2)
+            logger.info(f"[TtMoe.forward] expert_region_offsets: {_offsets_host.flatten().tolist()}")
 
         # Gate outputs uint16 indices; dispatch requires int32.
         # this should be aligned in the further PR.


### PR DESCRIPTION
## Summary
- Add `TT_DS_PREFILL_DEBUG_TOKEN_COUNT` environment variable to control per-expert token count debug output in MoE forward pass
- Reduces runtime by ~0.3s on average on GLX by avoiding device-to-host transfer overhead when debug is disabled (default)
- Debug output is now opt-in via environment variable (set to `1`, `true`, or `yes` to enable)
- See README.md for full environment variable documentation

## Test plan
- `/deepseek-pipelines` (all 4 CI workflows)

### DeepSeek Prefill CI
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mbezulj/2604-disable-token-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:mbezulj/2604-disable-token-count) Galaxy
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/2604-disable-token-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mbezulj/2604-disable-token-count) T3K
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=mbezulj/2604-disable-token-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:mbezulj/2604-disable-token-count) Single Card
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/2604-disable-token-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/2604-disable-token-count) Blackhole

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2604-disable-token-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2604-disable-token-count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/2604-disable-token-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/2604-disable-token-count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2604-disable-token-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2604-disable-token-count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2604-disable-token-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2604-disable-token-count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/2604-disable-token-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/2604-disable-token-count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2604-disable-token-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2604-disable-token-count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2604-disable-token-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2604-disable-token-count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2604-disable-token-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2604-disable-token-count)