### PR TITLE
Allocator: add persistent bottom-up DRAM high-water mark

### DIFF
--- a/tt_metal/api/tt-metalium/memory_reporter.hpp
+++ b/tt_metal/api/tt-metalium/memory_reporter.hpp
@@ -88,12 +88,27 @@ void DumpDeviceMemoryState(const IDevice* device, const std::string& prefix = ""
  * */
 MemoryView GetMemoryView(const IDevice* device, const BufferType& buffer_type);
 
+/**
+ * Reset the persistent bottom-up DRAM high-water mark to 0.
+ *
+ * Unlike the existing HWM tracked through BeginDramHighWaterMarkTracking, this
+ * counter is always on, tracks only bottom-up allocations, and is never reset
+ * by trace internals. Intended for end-to-end memory profiling: call this
+ * before the workload, run, then read MemoryView::allocation_high_water_mark_per_bank
+ * via GetMemoryView(device, BufferType::DRAM).
+ */
+void ResetDramPersistentBottomUpHwm(IDevice* device);
+
 struct MemoryView {
     std::uint64_t num_banks = 0;
     size_t total_bytes_per_bank = 0;
     size_t total_bytes_allocated_per_bank = 0;
     size_t total_bytes_free_per_bank = 0;
     size_t largest_contiguous_bytes_free_per_bank = 0;
+    // Highest end-address ever consumed by bottom-up allocations.
+    // Populated for BufferType::DRAM only (0 otherwise). Persistent across
+    // trace internals; reset explicitly via ResetDramPersistentBottomUpHwm.
+    size_t allocation_high_water_mark_per_bank = 0;
     MemoryBlockTable block_table;
 };
 

--- a/tt_metal/detail/reports/memory_reporter.cpp
+++ b/tt_metal/detail/reports/memory_reporter.cpp
@@ -163,17 +163,27 @@ MemoryView MemoryReporter::get_memory_view(const IDevice* device, const BufferTy
     auto stats = device->allocator()->get_statistics(buffer_type);
     auto num_banks_ = device->allocator()->get_num_banks(buffer_type);
 
+    size_t alloc_hwm = 0;
+    if (buffer_type == BufferType::DRAM) {
+        alloc_hwm = static_cast<size_t>(device->allocator_impl()->get_dram_persistent_bottom_up_hwm());
+    }
+
     return MemoryView{
         .num_banks = num_banks_,
         .total_bytes_per_bank = stats.total_allocatable_size_bytes,
         .total_bytes_allocated_per_bank = stats.total_allocated_bytes,
         .total_bytes_free_per_bank = stats.total_free_bytes,
         .largest_contiguous_bytes_free_per_bank = stats.largest_free_block_bytes,
+        .allocation_high_water_mark_per_bank = alloc_hwm,
         .block_table = device->allocator_impl()->get_memory_block_table(buffer_type)};
 }
 
 MemoryView GetMemoryView(const IDevice* device, const BufferType& buffer_type) {
     return MemoryReporter::inst().get_memory_view(device, buffer_type);
+}
+
+void ResetDramPersistentBottomUpHwm(IDevice* device) {
+    device->allocator_impl()->reset_dram_persistent_bottom_up_hwm();
 }
 
 bool MemoryReporter::enabled() { return is_enabled_; }

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -486,6 +486,16 @@ DeviceAddr AllocatorImpl::get_dram_deletion_high_water_mark() const {
     return dram_manager_->get_deletion_high_water_mark();
 }
 
+DeviceAddr AllocatorImpl::get_dram_persistent_bottom_up_hwm() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return dram_manager_->get_persistent_bottom_up_hwm();
+}
+
+void AllocatorImpl::reset_dram_persistent_bottom_up_hwm() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    dram_manager_->reset_persistent_bottom_up_hwm();
+}
+
 void AllocatorImpl::clear() {
     std::lock_guard<std::mutex> lock(mutex_);
     dram_manager_->clear();

--- a/tt_metal/impl/allocator/allocator.hpp
+++ b/tt_metal/impl/allocator/allocator.hpp
@@ -88,6 +88,11 @@ public:
     DeviceAddr get_dram_allocation_high_water_mark() const;
     DeviceAddr get_dram_deletion_high_water_mark() const;
 
+    // Persistent bottom-up DRAM HWM: always-on, never reset by trace internals.
+    // Intended for end-to-end memory profiling.
+    DeviceAddr get_dram_persistent_bottom_up_hwm() const;
+    void reset_dram_persistent_bottom_up_hwm();
+
     // what does clear even mean on an allocator???
     void clear();
 

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -472,6 +472,12 @@ uint64_t BankManager::allocate_buffer(
             allocation_high_water_mark_ = std::max(allocation_high_water_mark_, end_address);
         }
 
+        // Persistent bottom-up HWM: always-on, only bottom-up allocs.
+        if (bottom_up) {
+            DeviceAddr end_address = address.value() + size_per_bank;
+            persistent_bottom_up_hwm_ = std::max(persistent_bottom_up_hwm_, end_address);
+        }
+
         // No neighbors, nothing to invalidate
         return address.value();
     }
@@ -535,6 +541,12 @@ uint64_t BankManager::allocate_buffer(
         // are done in interleaved space where both allocations have the same bank offset applied
         DeviceAddr end_address = address.value() + size_per_bank;
         allocation_high_water_mark_ = std::max(allocation_high_water_mark_, end_address);
+    }
+
+    // Persistent bottom-up HWM: always-on, only bottom-up allocs.
+    if (bottom_up) {
+        DeviceAddr end_address = address.value() + size_per_bank;
+        persistent_bottom_up_hwm_ = std::max(persistent_bottom_up_hwm_, end_address);
     }
 
     // Allocation in this allocator invalidates caches in allocators that depend on this allocator
@@ -633,6 +645,10 @@ DeviceAddr BankManager::get_high_water_mark() const {
 DeviceAddr BankManager::get_allocation_high_water_mark() const { return allocation_high_water_mark_; }
 
 DeviceAddr BankManager::get_deletion_high_water_mark() const { return deletion_high_water_mark_; }
+
+DeviceAddr BankManager::get_persistent_bottom_up_hwm() const { return persistent_bottom_up_hwm_; }
+
+void BankManager::reset_persistent_bottom_up_hwm() { persistent_bottom_up_hwm_ = 0; }
 
 void BankManager::dump_blocks(std::ostream& out, BankManager::AllocatorDependencies::AllocatorID allocator_id) const {
     const auto* alloc = this->get_allocator_from_id(allocator_id);

--- a/tt_metal/impl/allocator/bank_manager.hpp
+++ b/tt_metal/impl/allocator/bank_manager.hpp
@@ -137,6 +137,13 @@ public:
     DeviceAddr get_allocation_high_water_mark() const;
     DeviceAddr get_deletion_high_water_mark() const;
 
+    // Persistent bottom-up HWM (always-on; tracks only bottom-up allocations).
+    // Unlike allocation_high_water_mark_, this counter is never reset by trace
+    // internals or BankManager::clear() — it can only be reset explicitly via
+    // reset_persistent_bottom_up_hwm(). Intended for end-to-end memory profiling.
+    DeviceAddr get_persistent_bottom_up_hwm() const;
+    void reset_persistent_bottom_up_hwm();
+
     // Cross-allocator mirroring: mark a region as allocated/deallocated in a specific sub-allocator.
     // Used to mirror lockstep allocations from the mesh-level allocator into per-device allocators.
     void mark_allocated(AllocatorDependencies::AllocatorID allocator_id, DeviceAddr address, DeviceAddr size);
@@ -189,6 +196,10 @@ private:
     bool tracking_high_water_mark_ = false;
     DeviceAddr allocation_high_water_mark_ = 0;
     DeviceAddr deletion_high_water_mark_ = 0;
+
+    // Persistent bottom-up HWM: always-on, only bottom-up allocs, never reset
+    // by trace internals or BankManager::clear(). See public accessors above.
+    DeviceAddr persistent_bottom_up_hwm_ = 0;
 
     /*********************************
      * Allocator-independent methods *

--- a/ttnn/cpp/ttnn-nanobind/device.cpp
+++ b/ttnn/cpp/ttnn-nanobind/device.cpp
@@ -172,6 +172,9 @@ void py_device_module_types(nb::module_& m_device) {
         .def_ro(
             "largest_contiguous_bytes_free_per_bank",
             &tt::tt_metal::detail::MemoryView::largest_contiguous_bytes_free_per_bank)
+        .def_ro(
+            "allocation_high_water_mark_per_bank",
+            &tt::tt_metal::detail::MemoryView::allocation_high_water_mark_per_bank)
         .def_ro("block_table", &tt::tt_metal::detail::MemoryView::block_table);
 }
 
@@ -521,6 +524,31 @@ void device_module(nb::module_& m_device) {
         nb::arg("device").noconvert(),
         nb::arg("buffer_type").noconvert(),
         get_allocator_base_address_doc.data());
+
+    constexpr std::string_view reset_dram_persistent_hwm_doc = R"doc(
+        Reset the persistent bottom-up DRAM high-water mark to 0.
+
+        Unlike begin_dram_high_water_mark_tracking, this counter is always on,
+        tracks only bottom-up allocations, and is never reset by trace internals.
+        Intended for end-to-end memory profiling: reset before the workload, run,
+        then read the result via GetMemoryView(device, BufferType::DRAM).allocation_high_water_mark_per_bank.
+
+        +------------------+----------------------------------+-----------------------+-------------+----------+
+        | Argument         | Description                      | Data type             | Valid range | Required |
+        +==================+==================================+=======================+=============+==========+
+        | device           | Device whose DRAM HWM is reset   | ttnn.Device           |             | Yes      |
+        +------------------+----------------------------------+-----------------------+-------------+----------+
+    )doc";
+    m_device.def(
+        "ResetDramPersistentBottomUpHwm",
+        &tt::tt_metal::detail::ResetDramPersistentBottomUpHwm,
+        nb::arg("device").noconvert(),
+        reset_dram_persistent_hwm_doc.data());
+    m_device.def(
+        "ResetDramPersistentBottomUpHwm",
+        [](MeshDevice* device) { tt::tt_metal::detail::ResetDramPersistentBottomUpHwm(device); },
+        nb::arg("device").noconvert(),
+        reset_dram_persistent_hwm_doc.data());
 
     constexpr std::string_view synchronize_device_doc = R"doc(
                 Synchronize the device with host by waiting for all operations to complete.

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -300,6 +300,7 @@ from ttnn.device import (
     dump_device_memory_state,
     get_memory_view,
     get_allocator_base_address,
+    reset_dram_persistent_bottom_up_hwm,
     get_max_worker_l1_unreserved_size,
     get_dram_alignment,
     get_l1_alignment,

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -282,6 +282,10 @@ def get_allocator_base_address(device, buffer_type):
     return ttnn._ttnn.device.GetAllocatorBaseAddress(device, buffer_type)
 
 
+def reset_dram_persistent_bottom_up_hwm(device):
+    ttnn._ttnn.device.ResetDramPersistentBottomUpHwm(device)
+
+
 pad_to_tile_shape = ttnn._ttnn.device.pad_to_tile_shape
 
 SubDevice = ttnn._ttnn.device.SubDevice


### PR DESCRIPTION
### Ticket

#43267

### Problem description

The existing `BankManager::allocation_high_water_mark_` (surfaced via `AllocatorImpl::get_dram_allocation_high_water_mark()`) is reset internally by trace operations, and it tracks both bottom-up and top-down allocations, so its value after a workload does not reflect the true peak reached by the
bottom-up region.

### What's changed

Add **persistent bottom-up DRAM HWM** to the allocator, specifically intended for memory profiling. The new counter:
- updates only on bottom-up allocations,
- is never reset by trace internals or `BankManager::clear()`,
- can only be reset explicitly via the new public APIs.

Public surface added:

- `BankManager::get_persistent_bottom_up_hwm()` / `reset_persistent_bottom_up_hwm()`
- `AllocatorImpl::get_dram_persistent_bottom_up_hwm()` / `reset_dram_persistent_bottom_up_hwm()`
- `tt::tt_metal::detail::ResetDramPersistentBottomUpHwm(IDevice*)`
- `tt::tt_metal::detail::MemoryView::allocation_high_water_mark_per_bank`
  (populated for `BufferType::DRAM` only; 0 otherwise)
- Python: `ttnn.reset_dram_persistent_bottom_up_hwm(device)` and the new
  `MemoryView.allocation_high_water_mark_per_bank` attribute, so profiling
  tools can do `reset → run workload → read HWM` from Python.

No behavior change to existing HWM counters or APIs.

### Checklist

- [ ] All post-commit pipelines pass after the final rebase against `main`.
- [ ] Relevant unit tests run locally.
- [ ] New code formatted via `.clang-format` / pre-commit hooks.