### PR TITLE
Fix wrong old-CB in SRCA reconfig on matmul-accumulate reload

### DIFF
--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -107,7 +107,8 @@ ALWI void reload_accumulator_if_needed(
         if (!accumulate.is_first()) {  // Reload on all iterations except first
             constexpr uint32_t onetile = 1;
             accum_cb.wait_front(onetile);
-            copy_tile_to_dst_init_short_with_dt(input_cb_id, accumulate.config.cb_accumulator);
+            const uint32_t prev_srca_cb = use_matmul ? scaler_cb_id : input_cb_id;
+            copy_tile_to_dst_init_short_with_dt(prev_srca_cb, accumulate.config.cb_accumulator);
             copy_tile(accumulate.config.cb_accumulator, 0, accumulate.config.dst_index);
             accum_cb.pop_front(onetile);
 


### PR DESCRIPTION
## Summary

In `reload_accumulator_if_needed` (`ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl`), `copy_tile_to_dst_init_short_with_dt` was always being passed `input_cb_id` as the previous SRCA CB. On the matmul reduce path (`SUM`/`AVG` + `REDUCE_ROW`), the prior iteration leaves SRCA configured for the **scaler** CB, not the input CB — `reduce_with_matmul_init` reconfigs SRCA to `in1` = scaler.

Lying about the old CB makes the reconfig's old/new format comparison wrong: it skips when it should reconfig if `input_fmt == accumulator_fmt` but `scaler_fmt != accumulator_fmt`, leaving SRCA in scaler format when `copy_tile` reads the accumulator.

Pass `scaler_cb_id` as old when `use_matmul` is true. Non-matmul branch unchanged.

## Reachability

The bug is currently **latent on main**. The only caller that combines `compute_kernel_lib::Accumulate::at(...)` with `SUM`/`AVG` + `REDUCE_ROW` is `moreh_dot.cpp`, and its program factory creates input/scaler/accumulator CBs all with the same data format (derived from the input tensor's dtype) — so the wrong-old-CB reconfig is always a no-op. Future callers that pair a different-format scaler with this path would have hit the bug silently.

## Manual reproduction

To actually exercise the bug, the scaler CB format has to differ from input/accumulator. That doesn't happen with the current moreh_dot host op, so I patched it locally to test the fix.

The multi-block parametrization `test_moreh_dot[dtype=DataType.BFLOAT16-input_shape=[1, 1, 1, 352]]` is a clean A/B for the helper-fix:

| Helper fix | Max ATOL Delta on shape 352 | Result |
|---|---|---|
| Applied (this PR) | 0.0 | PASS |
| Reverted | 83.0 | FAIL |

None of the moreh_dot-side patches are part of this PR — they were only used to expose the bug. They're separate latent issues in moreh_dot that should be fixed in their own change.

## CI

[![Sanity tests](https://img.shields.io/badge/sanity--tests-passed-brightgreen?logo=githubactions)](https://github.com/tenstorrent/tt-metal/actions/runs/25052346468) [![BH post-commit](https://img.shields.io/badge/blackhole--post--commit-failed%20(unrelated)-yellow?logo=githubactions)](https://github.com/tenstorrent/tt-metal/actions/runs/25052348276) [![L2 nightly moreh](https://img.shields.io/badge/L2--nightly--moreh-failed%20(pre--existing)-yellow?logo=githubactions)](https://github.com/tenstorrent/tt-metal/actions/runs/25052350022)

- **Sanity tests** ✅ — passed.
- **Blackhole post-commit** ❌ — three failed jobs (`P300-viommu Host IO`, `deepseek blitz fast/slow dispatch`). None of those call sites use `compute_kernel_lib::Accumulate`, so they cannot reach the modified code path. Look like infrastructure/model issues unrelated to this PR.
- **L2 nightly (moreh only)** ❌ — single failing test `test_moreh_nll_loss[…reduction=mean-ignore_index=1-shape=[5, 10]]`. `moreh_nll_loss` does not include the reduce helper or use `Accumulate::at`. **Confirmed reproducible on `main`** with the kernel change reverted — pre-existing.

## Test plan

- [x] Existing `tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_dot.py` passes (21 passed, 4 bfloat8_b skipped — same as baseline on main).
- [x] Manual reproduction described above: full `test_moreh_dot.py` PASS with the helper fix, FAIL without (multi-block parametrization).
- [x] Sanity tests pipeline.
- [x] Blackhole post-commit and L2 nightly (moreh) — failures triaged above.
