### PR TITLE
to_string using decode_tensor_data

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_tensor_repr.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_tensor_repr.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/base_functionality/test_tensor_repr.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_tensor_repr.py
@@ -14,20 +14,21 @@ import torch
 import ttnn
 
 
+# Shapes to test - includes edge cases that trigger padding bugs
+TEST_SHAPES = [
+    [32, 32],  # Simple tile-aligned
+    [8, 1, 32],  # Bug case: middle dim < tile height
+    [1, 8, 32],  # Batch = 1, height < tile
+    [1, 1, 32, 64],  # 4D with small batch/channel
+    [64, 64],  # Multiple tiles
+    [33, 33],  # Non-tile-aligned (will be padded)
+]
+
+
 class TestTensorRepr:
     """Tests for tensor repr/to_string functionality."""
 
-    @pytest.mark.parametrize(
-        "shape",
-        [
-            [32, 32],  # Simple tile-aligned
-            [8, 1, 32],  # Bug case: middle dim < tile height
-            [1, 8, 32],  # Batch = 1, height < tile
-            [1, 1, 32, 64],  # 4D with small batch/channel
-            [64, 64],  # Multiple tiles
-            [33, 33],  # Non-tile-aligned (will be padded)
-        ],
-    )
+    @pytest.mark.parametrize("shape", TEST_SHAPES)
     @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
     @pytest.mark.parametrize("on_device", [False, True])
     def test_repr_no_spurious_zeros(self, device, shape, layout, on_device):
@@ -73,14 +74,7 @@ class TestTensorRepr:
             f"repr:\n{repr_str[:500]}"
         )
 
-    @pytest.mark.parametrize(
-        "shape",
-        [
-            [32, 32],  # Simple tile-aligned
-            [8, 1, 32],  # Bug case: middle dim < tile height
-            [1, 1, 32, 64],  # 4D with small batch/channel
-        ],
-    )
+    @pytest.mark.parametrize("shape", TEST_SHAPES)
     @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
     def test_repr_different_dtypes(self, device, shape, dtype):
         """Test repr works for different data types."""
@@ -104,14 +98,7 @@ class TestTensorRepr:
         assert torch.allclose(result, data, rtol=0.01, atol=0.01)
         assert "0.0000" not in repr_str
 
-    @pytest.mark.parametrize(
-        "shape",
-        [
-            [32, 32],  # Simple tile-aligned
-            [8, 1, 32],  # Bug case: middle dim < tile height
-            [1, 8, 32],  # Batch = 1, height < tile
-        ],
-    )
+    @pytest.mark.parametrize("shape", TEST_SHAPES)
     @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
     def test_repr_cpu_tensor(self, shape, layout):
         """Test repr for CPU-only tensor (no device)."""
@@ -127,14 +114,7 @@ class TestTensorRepr:
         assert torch.allclose(result, data, rtol=0.01, atol=0.01)
         assert "0.0000" not in repr_str
 
-    @pytest.mark.parametrize(
-        "shape",
-        [
-            [32, 32],  # Simple tile-aligned
-            [8, 1, 32],  # Bug case: middle dim < tile height
-            [1, 1, 32, 64],  # 4D with small batch/channel
-        ],
-    )
+    @pytest.mark.parametrize("shape", TEST_SHAPES)
     @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
     def test_repr_different_memory_configs(self, device, shape, memory_config):
         """Test repr works for different memory configurations."""

--- a/tests/ttnn/unit_tests/base_functionality/test_tensor_repr.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_tensor_repr.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for tensor repr/to_string functionality.
+
+These tests verify that repr() (which uses tensor_impl::to_string()) correctly
+displays tensor values for various shapes, layouts, and memory configurations.
+"""
+
+import pytest
+import torch
+import ttnn
+
+
+class TestTensorRepr:
+    """Tests for tensor repr/to_string functionality."""
+
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            [32, 32],  # Simple tile-aligned
+            [8, 1, 32],  # Bug case: middle dim < tile height
+            [1, 8, 32],  # Batch = 1, height < tile
+            [1, 1, 32, 64],  # 4D with small batch/channel
+            [64, 64],  # Multiple tiles
+            [33, 33],  # Non-tile-aligned (will be padded)
+        ],
+    )
+    @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+    @pytest.mark.parametrize("on_device", [False, True])
+    def test_repr_no_spurious_zeros(self, device, shape, layout, on_device):
+        """
+        Verify repr() doesn't show zeros when data contains none.
+
+        This catches the bug where to_string reads wrong physical indices
+        for tiled tensors with padding.
+        """
+        # Create data with no zeros: [1, 2, 3, ...]
+        numel = 1
+        for dim in shape:
+            numel *= dim
+        data = (torch.arange(numel, dtype=torch.bfloat16) + 1).reshape(shape)
+
+        # Create tensor
+        if on_device:
+            tensor = ttnn.from_torch(
+                data,
+                dtype=ttnn.bfloat16,
+                layout=layout,
+                device=device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+        else:
+            tensor = ttnn.from_torch(data, dtype=ttnn.bfloat16, layout=layout)
+
+        # Get repr and to_torch
+        repr_str = repr(tensor)
+        result = ttnn.to_torch(tensor)
+
+        # Verify to_torch is correct (sanity check)
+        assert torch.allclose(
+            result, data, rtol=0.01, atol=0.01
+        ), f"to_torch mismatch for shape={shape}, layout={layout}, on_device={on_device}"
+
+        # Key check: repr should not contain "0.0000" since our data has no zeros
+        # (values start at 1.0)
+        assert "0.0000" not in repr_str, (
+            f"BUG: repr() shows zeros but data has none.\n"
+            f"Shape={shape}, layout={layout}, on_device={on_device}\n"
+            f"First few values from to_torch: {result.flatten()[:8].tolist()}\n"
+            f"repr:\n{repr_str[:500]}"
+        )
+
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            [32, 32],  # Simple tile-aligned
+            [8, 1, 32],  # Bug case: middle dim < tile height
+            [1, 1, 32, 64],  # 4D with small batch/channel
+        ],
+    )
+    @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+    def test_repr_different_dtypes(self, device, shape, dtype):
+        """Test repr works for different data types."""
+        torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+        numel = 1
+        for dim in shape:
+            numel *= dim
+        data = (torch.arange(numel, dtype=torch_dtype) + 1).reshape(shape)
+
+        tensor = ttnn.from_torch(
+            data,
+            dtype=dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        repr_str = repr(tensor)
+        result = ttnn.to_torch(tensor)
+
+        assert torch.allclose(result, data, rtol=0.01, atol=0.01)
+        assert "0.0000" not in repr_str
+
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            [32, 32],  # Simple tile-aligned
+            [8, 1, 32],  # Bug case: middle dim < tile height
+            [1, 8, 32],  # Batch = 1, height < tile
+        ],
+    )
+    @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+    def test_repr_cpu_tensor(self, shape, layout):
+        """Test repr for CPU-only tensor (no device)."""
+        numel = 1
+        for dim in shape:
+            numel *= dim
+        data = (torch.arange(numel, dtype=torch.bfloat16) + 1).reshape(shape)
+        tensor = ttnn.from_torch(data, dtype=ttnn.bfloat16, layout=layout)
+
+        repr_str = repr(tensor)
+        result = ttnn.to_torch(tensor)
+
+        assert torch.allclose(result, data, rtol=0.01, atol=0.01)
+        assert "0.0000" not in repr_str
+
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            [32, 32],  # Simple tile-aligned
+            [8, 1, 32],  # Bug case: middle dim < tile height
+            [1, 1, 32, 64],  # 4D with small batch/channel
+        ],
+    )
+    @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
+    def test_repr_different_memory_configs(self, device, shape, memory_config):
+        """Test repr works for different memory configurations."""
+        numel = 1
+        for dim in shape:
+            numel *= dim
+        data = (torch.arange(numel, dtype=torch.bfloat16) + 1).reshape(shape)
+
+        tensor = ttnn.from_torch(
+            data,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=memory_config,
+        )
+
+        repr_str = repr(tensor)
+        result = ttnn.to_torch(tensor)
+
+        assert torch.allclose(result, data, rtol=0.01, atol=0.01)
+        assert "0.0000" not in repr_str

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -302,14 +302,14 @@ std::string to_string_impl(const Tensor& tensor) {
 
     const auto& tensor_spec = cpu_tensor.tensor_spec();
     const auto strides = compute_logical_strides(shape);
-    const auto& coords = storage.coords;
+    const auto coords = storage.get_coords();
     auto coords_it = coords.begin();
     const std::vector<HostBuffer> buffers = get_host_buffers(cpu_tensor.host_storage());
     std::stringstream ss;
     for (size_t i = 0; i < buffers.size(); i++) {
         const distributed::MeshCoordinate coord = *coords_it++;
-        if (mesh_device->is_local(coord)) {
-            ss << "device_id: " << mesh_device->get_device(coord)->id() << ", " << coord << std::endl;
+        if (mesh_device.is_local(coord)) {
+            ss << "device_id: " << mesh_device.get_device(coord)->id() << ", " << coord << std::endl;
             // Use decode_tensor_data to properly convert physical data to logical (removes padding)
             auto logical_data = decode_tensor_data<T>(buffers[i].view_as<T>(), tensor_spec);
             detail::to_string(ss, ttsl::make_const_span(logical_data), shape, strides, tensor.dtype(), tensor.layout());

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -261,20 +261,13 @@ std::string to_string_impl(const Tensor& tensor) {
         return buffers;
     };
 
-    // Compute simple row-major strides for logical shape (no padding alignment)
-    auto compute_logical_strides = [](const tt::tt_metal::Shape& logical_shape) -> Strides {
-        const int rank = static_cast<int>(logical_shape.rank());
-        Strides strides(rank, 1);
-        for (int i = rank - 2; i >= 0; i--) {
-            strides[i] = strides[i + 1] * logical_shape[i + 1];
-        }
-        return strides;
-    };
+    // Use simple row-major strides for logical shape (no padding alignment)
+    const auto logical_strides = tt::tt_metal::compute_strides(shape);
+    const Strides strides(logical_strides.begin(), logical_strides.end());
 
     if (is_cpu_tensor(tensor)) {
         const auto& tensor_spec = tensor.tensor_spec();
         const std::vector<HostBuffer> buffers = get_host_buffers(tensor.host_storage());
-        const auto strides = compute_logical_strides(shape);
         std::stringstream ss;
         for (size_t i = 0; i < buffers.size(); i++) {
             // Use decode_tensor_data to properly convert physical data to logical (removes padding)
@@ -301,7 +294,6 @@ std::string to_string_impl(const Tensor& tensor) {
     // }
 
     const auto& tensor_spec = cpu_tensor.tensor_spec();
-    const auto strides = compute_logical_strides(shape);
     const auto coords = storage.get_coords();
     auto coords_it = coords.begin();
     const std::vector<HostBuffer> buffers = get_host_buffers(cpu_tensor.host_storage());

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -255,29 +255,31 @@ std::string to_string_impl(const Tensor& tensor) {
             tensor.layout());
     }
 
-    auto get_row_major_tensor = [&](const Tensor& tensor) -> Tensor {
-        if (tensor.layout() == Layout::ROW_MAJOR) {
-            return tensor;
-        }
-        if (tensor.dtype() == DataType::BFLOAT8_B || tensor.dtype() == DataType::BFLOAT4_B) {
-            return to_layout(tt::tt_metal::to_dtype(tensor, DataType::FLOAT32), Layout::ROW_MAJOR);
-        }
-        return to_layout(tensor, Layout::ROW_MAJOR);
-    };
-
     auto get_host_buffers = [&](const HostStorage& storage) {
         std::vector<HostBuffer> buffers;
         storage.buffer().apply([&](const HostBuffer& shard) { buffers.push_back(shard); });
         return buffers;
     };
 
+    // Compute simple row-major strides for logical shape (no padding alignment)
+    auto compute_logical_strides = [](const tt::tt_metal::Shape& logical_shape) -> Strides {
+        const int rank = static_cast<int>(logical_shape.rank());
+        Strides strides(rank, 1);
+        for (int i = rank - 2; i >= 0; i--) {
+            strides[i] = strides[i + 1] * logical_shape[i + 1];
+        }
+        return strides;
+    };
+
     if (is_cpu_tensor(tensor)) {
-        const Tensor row_major_tensor = get_row_major_tensor(tensor);
-        const auto strides = row_major_tensor.tensor_spec().compute_strides();
-        const std::vector<HostBuffer> buffers = get_host_buffers(row_major_tensor.host_storage());
+        const auto& tensor_spec = tensor.tensor_spec();
+        const std::vector<HostBuffer> buffers = get_host_buffers(tensor.host_storage());
+        const auto strides = compute_logical_strides(shape);
         std::stringstream ss;
         for (size_t i = 0; i < buffers.size(); i++) {
-            detail::to_string(ss, buffers[i].view_as<T>(), shape, strides, tensor.dtype(), tensor.layout());
+            // Use decode_tensor_data to properly convert physical data to logical (removes padding)
+            auto logical_data = decode_tensor_data<T>(buffers[i].view_as<T>(), tensor_spec);
+            detail::to_string(ss, ttsl::make_const_span(logical_data), shape, strides, tensor.dtype(), tensor.layout());
             if (i + 1 != buffers.size()) {
                 ss << std::endl;
             }
@@ -298,17 +300,19 @@ std::string to_string_impl(const Tensor& tensor) {
     //     return to_string<T>(ttnn::distributed::get_device_tensors(cpu_tensor).at(0));
     // }
 
-    const Tensor row_major_tensor = get_row_major_tensor(cpu_tensor);
-    const auto strides = row_major_tensor.tensor_spec().compute_strides();
-    const auto coords = storage.get_coords();
+    const auto& tensor_spec = cpu_tensor.tensor_spec();
+    const auto strides = compute_logical_strides(shape);
+    const auto& coords = storage.coords;
     auto coords_it = coords.begin();
-    const std::vector<HostBuffer> buffers = get_host_buffers(row_major_tensor.host_storage());
+    const std::vector<HostBuffer> buffers = get_host_buffers(cpu_tensor.host_storage());
     std::stringstream ss;
     for (size_t i = 0; i < buffers.size(); i++) {
         const distributed::MeshCoordinate coord = *coords_it++;
-        if (mesh_device.is_local(coord)) {
-            ss << "device_id: " << mesh_device.get_device(coord)->id() << ", " << coord << std::endl;
-            detail::to_string(ss, buffers[i].view_as<T>(), shape, strides, tensor.dtype(), tensor.layout());
+        if (mesh_device->is_local(coord)) {
+            ss << "device_id: " << mesh_device->get_device(coord)->id() << ", " << coord << std::endl;
+            // Use decode_tensor_data to properly convert physical data to logical (removes padding)
+            auto logical_data = decode_tensor_data<T>(buffers[i].view_as<T>(), tensor_spec);
+            detail::to_string(ss, ttsl::make_const_span(logical_data), shape, strides, tensor.dtype(), tensor.layout());
         }
         if (i + 1 != buffers.size()) {
             ss << std::endl;


### PR DESCRIPTION
### Summary
Closes #43215 

The tensor to_string() path does not account for padding in tilized tensors, leading it to dump padding zeroes instead of actual tensor data. This makes it very confusing as a debug tool.

This PR uses decode_tensor_data to get padding-aware indices to read out of the physical tensor data buffer, and adds tests using python repr(), which invokes to_string() path.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jzx/to_string_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jzx/to_string_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jzx/to_string_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jzx/to_string_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jzx/to_string_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jzx/to_string_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jzx/to_string_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jzx/to_string_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jzx/to_string_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jzx/to_string_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jzx/to_string_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jzx/to_string_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jzx/to_string_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jzx/to_string_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jzx/to_string_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jzx/to_string_fix)