### PR TITLE
[POOL] Always pack 2 faces in pool output (with 1-face exception for single partial tile per core case)    

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.cpp
@@ -102,10 +102,18 @@ TensorSpec ShardedToInterleavedDeviceOperation::compute_output_specs(
     }
 
     const auto& input_tensor = tensor_args.input_tensor;
+    // Propagate the input's padded_shape so the destination DRAM tensor has matching stick stride.
+    // Without this, when the source shard width exceeds the destination's logical width, the writer
+    // kernel writes more bytes per stick than the destination tensor's stick page can hold, causing
+    // inter-stick byte overlap and data corruption.
     return tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        tt::tt_metal::TensorLayout(
-            args.output_dtype, tt::tt_metal::PageConfig(input_tensor.layout()), args.output_mem_config));
+        tt::tt_metal::TensorLayout::fromPaddedShape(
+            args.output_dtype,
+            tt::tt_metal::PageConfig(input_tensor.layout()),
+            args.output_mem_config,
+            input_tensor.logical_shape(),
+            input_tensor.padded_shape()));
 }
 
 Tensor ShardedToInterleavedDeviceOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -58,11 +58,17 @@ void kernel_main() {
     constexpr bool last_tile_is_partial = in_c % TILE_WIDTH != 0;
     constexpr uint32_t num_faces_in_input_tile =
         (max_sticks_for_reduction < TILE_HEIGHT || window_size_hw <= FACE_HEIGHT) ? 2 : 4;
-    constexpr uint32_t num_faces_in_output_tile = 2;
-    // When the last tile has exactly FACE_WIDTH valid channels (channels % 32 == 16), keep 1-face
-    // packing — the output CB was NOT padded to a full tile for this case.  For a strictly partial
-    // last face (channels % 32 < 16 but > 0) the output is padded to TILE_WIDTH so 2 faces fit.
-    constexpr uint32_t num_faces_in_last_output_tile = last_tile_is_partial && in_c % TILE_WIDTH == FACE_WIDTH ? 1 : 2;
+    // "Single partial tile per core that fits in one face": when there is only one output tile
+    // per core (in_c < TILE_WIDTH) and it fits in a single face (in_c <= FACE_WIDTH), pack just
+    // one face for that tile. The host correspondingly aligns output_shard_width to FACE_WIDTH,
+    // so the per-shard layout has no internal padding and downstream consumers (e.g.
+    // sharded_to_interleaved) read contiguous data.
+    constexpr bool single_partial_fits_in_face = last_tile_is_partial && in_c <= FACE_WIDTH;
+    constexpr uint32_t num_faces_in_output_tile = single_partial_fits_in_face ? 1 : 2;
+    // When the last tile has exactly FACE_WIDTH valid channels (channels % 32 == 16) OR the only
+    // tile is partial-fits-in-one-face, pack 1 face for the last tile.
+    constexpr uint32_t num_faces_in_last_output_tile =
+        last_tile_is_partial && (in_c % TILE_WIDTH == FACE_WIDTH || single_partial_fits_in_face) ? 1 : 2;
     constexpr uint32_t num_out_sticks = 1;
 
     constexpr bool is_avg_pool = REDUCE_OP == PoolType::AVG;
@@ -137,7 +143,8 @@ void kernel_main() {
                 tilize_reconfig ? (last_c_block ? partial_iter_output_tiles : max_tiles_per_iter) : max_tiles_per_iter;
             const uint32_t number_of_tiles = last_c_block ? partial_iter_output_tiles : max_tiles_per_iter;
             const uint32_t output_faces =
-                (last_tile_is_partial && last_c_block && in_c % TILE_WIDTH == FACE_WIDTH)
+                (last_tile_is_partial && last_c_block &&
+                 (in_c % TILE_WIDTH == FACE_WIDTH || single_partial_fits_in_face))
                     ? (number_of_tiles - 1) * num_faces_in_output_tile + num_faces_in_last_output_tile
                     : number_of_tiles * num_faces_in_output_tile;
             if constexpr (!is_output_tiled) {

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -59,7 +59,10 @@ void kernel_main() {
     constexpr uint32_t num_faces_in_input_tile =
         (max_sticks_for_reduction < TILE_HEIGHT || window_size_hw <= FACE_HEIGHT) ? 2 : 4;
     constexpr uint32_t num_faces_in_output_tile = 2;
-    constexpr uint32_t num_faces_in_last_output_tile = last_tile_is_partial && in_c % TILE_WIDTH <= FACE_WIDTH ? 1 : 2;
+    // When the last tile has exactly FACE_WIDTH valid channels (channels % 32 == 16), keep 1-face
+    // packing — the output CB was NOT padded to a full tile for this case.  For a strictly partial
+    // last face (channels % 32 < 16 but > 0) the output is padded to TILE_WIDTH so 2 faces fit.
+    constexpr uint32_t num_faces_in_last_output_tile = last_tile_is_partial && in_c % TILE_WIDTH == FACE_WIDTH ? 1 : 2;
     constexpr uint32_t num_out_sticks = 1;
 
     constexpr bool is_avg_pool = REDUCE_OP == PoolType::AVG;
@@ -134,7 +137,7 @@ void kernel_main() {
                 tilize_reconfig ? (last_c_block ? partial_iter_output_tiles : max_tiles_per_iter) : max_tiles_per_iter;
             const uint32_t number_of_tiles = last_c_block ? partial_iter_output_tiles : max_tiles_per_iter;
             const uint32_t output_faces =
-                (last_tile_is_partial && last_c_block)
+                (last_tile_is_partial && last_c_block && in_c % TILE_WIDTH == FACE_WIDTH)
                     ? (number_of_tiles - 1) * num_faces_in_output_tile + num_faces_in_last_output_tile
                     : number_of_tiles * num_faces_in_output_tile;
             if constexpr (!is_output_tiled) {

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_mpwi.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_mpwi.cpp
@@ -310,9 +310,14 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
                         }
                     } else {
                         if (kernel_complete) {  // write output once all chunks are done
-                            constexpr uint32_t num_faces_in_output_tile = 2;
+                            // Mirror compute_pool_2d.cpp: pack 1 face for "single partial tile
+                            // fits in one face" or "last tile has exactly FACE_WIDTH valid".
+                            constexpr bool single_partial_fits_in_face = last_tile_is_partial && in_c <= FACE_WIDTH;
+                            constexpr uint32_t num_faces_in_output_tile = single_partial_fits_in_face ? 1 : 2;
                             constexpr uint32_t num_faces_in_last_output_tile =
-                                last_tile_is_partial && in_c % TILE_WIDTH == FACE_WIDTH ? 1 : 2;
+                                last_tile_is_partial && (in_c % TILE_WIDTH == FACE_WIDTH || single_partial_fits_in_face)
+                                    ? 1
+                                    : 2;
                             uint32_t output_faces =
                                 c_i == in_nblocks_c - 1 ? num_faces_in_last_output_tile : num_faces_in_output_tile;
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_mpwi.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_mpwi.cpp
@@ -312,7 +312,7 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
                         if (kernel_complete) {  // write output once all chunks are done
                             constexpr uint32_t num_faces_in_output_tile = 2;
                             constexpr uint32_t num_faces_in_last_output_tile =
-                                last_tile_is_partial && in_c % TILE_WIDTH <= FACE_WIDTH ? 1 : 2;
+                                last_tile_is_partial && in_c % TILE_WIDTH == FACE_WIDTH ? 1 : 2;
                             uint32_t output_faces =
                                 c_i == in_nblocks_c - 1 ? num_faces_in_last_output_tile : num_faces_in_output_tile;
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -108,10 +108,20 @@ Pool2D::spec_return_value_t Pool2D::compute_output_specs(
     auto layout = mem_config.memory_layout();
 
     uint32_t out_nhw_padded = tt::round_up(out_nhw, tile_rows * num_cores_nhw);
-    uint32_t out_c_padded = tt::round_up(out_c, tt::constants::TILE_WIDTH / 2);
+    // When the last per-shard tile is strictly less than one full face wide (channels % 32 < 16),
+    // round up to TILE_WIDTH so the packer can always write 2 full faces without reconfiguring.
+    // When channels % 32 == FACE_WIDTH (e.g. 80, 48 …), the last tile is exactly one face wide
+    // and the old FACE_WIDTH alignment is correct — no extra padding needed.
+    // Use ceiling division so that for WIDTH/BLOCK sharding, where channels may not divide evenly,
+    // we check the maximum per-shard channel count and avoid false partial-tile detection.
+    uint32_t channels_per_shard = tt::div_up(out_c, num_cores_c);
+    uint32_t cps_mod_tile = channels_per_shard % tt::constants::TILE_WIDTH;
+    bool needs_tile_pad = cps_mod_tile > 0 && cps_mod_tile < tt::constants::FACE_WIDTH;
+    uint32_t base_alignment = needs_tile_pad ? tt::constants::TILE_WIDTH : tt::constants::TILE_WIDTH / 2;
+    uint32_t out_c_padded = tt::round_up(out_c, base_alignment);
     if (mem_config.is_sharded()) {
         if (layout == TensorMemoryLayout::WIDTH_SHARDED || layout == TensorMemoryLayout::BLOCK_SHARDED) {
-            out_c_padded = tt::round_up(out_c, sliding_window_config.num_cores_c * tt::constants::TILE_WIDTH / 2);
+            out_c_padded = tt::round_up(out_c, num_cores_c * base_alignment);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -116,7 +116,12 @@ Pool2D::spec_return_value_t Pool2D::compute_output_specs(
     // we check the maximum per-shard channel count and avoid false partial-tile detection.
     uint32_t channels_per_shard = tt::div_up(out_c, num_cores_c);
     uint32_t cps_mod_tile = channels_per_shard % tt::constants::TILE_WIDTH;
-    bool needs_tile_pad = cps_mod_tile > 0 && cps_mod_tile < tt::constants::FACE_WIDTH;
+    // Skip tile-padding when the only tile per core is partial and fits in one face (single
+    // partial tile, first==last). In that case the kernel packs just 1 face, so FACE_WIDTH
+    // alignment matches the kernel output. See compute_pool_2d.cpp for the matching kernel
+    // condition (single_partial_fits_in_face).
+    bool needs_tile_pad =
+        cps_mod_tile > 0 && cps_mod_tile < tt::constants::FACE_WIDTH && channels_per_shard > tt::constants::FACE_WIDTH;
     uint32_t base_alignment = needs_tile_pad ? tt::constants::TILE_WIDTH : tt::constants::TILE_WIDTH / 2;
     uint32_t out_c_padded = tt::round_up(out_c, base_alignment);
     if (mem_config.is_sharded()) {

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -282,8 +282,11 @@ static std::vector<Tensor> pool2d_L1(
     //      channels=290, num_cores_c=1:  ceil(290/1)=290, 290%32=2 → tile pad needed.
     uint32_t channels_per_shard = tt::div_up(output_c, num_cores_c);
     uint32_t cps_mod_tile = channels_per_shard % tt::constants::TILE_WIDTH;
-    bool needs_tile_pad = cps_mod_tile > 0 && cps_mod_tile < tt::constants::FACE_WIDTH;
-    uint32_t base_alignment = needs_tile_pad ? tt::constants::TILE_WIDTH : tt::constants::TILE_WIDTH / 2;
+    // For TILE output the shard width must be TILE_WIDTH-aligned regardless; for ROW_MAJOR
+    // we only round up to TILE_WIDTH when channels_per_shard is strictly partial (< FACE_WIDTH).
+    bool needs_tile_pad = !is_out_tiled && cps_mod_tile > 0 && cps_mod_tile < tt::constants::FACE_WIDTH;
+    uint32_t base_alignment =
+        (is_out_tiled || needs_tile_pad) ? tt::constants::TILE_WIDTH : tt::constants::TILE_WIDTH / 2;
     uint32_t output_c_padded = tt::round_up(output_c, num_cores_c * base_alignment);
     uint32_t output_shard_width_padded = output_c_padded / num_cores_c;
     log_debug(

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -273,8 +273,18 @@ static std::vector<Tensor> pool2d_L1(
         tt::round_up(output_nhw, num_cores_nhw * (is_out_tiled ? tt::constants::TILE_HEIGHT : 1));
     uint32_t output_shard_height_padded = output_nhw_padded / num_cores_nhw;
     uint32_t output_c = channels;
-    uint32_t output_c_padded = tt::round_up(
-        output_c, num_cores_c * (is_out_tiled ? tt::constants::TILE_WIDTH : tt::constants::TILE_WIDTH / 2));
+    // When the last per-shard tile is strictly less than one full face wide (channels % 32 < 16),
+    // round up to TILE_WIDTH so the packer always writes 2 full faces without reconfiguring.
+    // When channels % 32 == FACE_WIDTH the last tile has exactly one face and no extra padding is needed.
+    // Use ceiling division so that for WIDTH/BLOCK sharding, where channels may not divide evenly,
+    // we check the maximum per-shard channel count and avoid false partial-tile detection.
+    // E.g. channels=290, num_cores_c=19: ceil(290/19)=16 = FACE_WIDTH → no tile pad needed.
+    //      channels=290, num_cores_c=1:  ceil(290/1)=290, 290%32=2 → tile pad needed.
+    uint32_t channels_per_shard = tt::div_up(output_c, num_cores_c);
+    uint32_t cps_mod_tile = channels_per_shard % tt::constants::TILE_WIDTH;
+    bool needs_tile_pad = cps_mod_tile > 0 && cps_mod_tile < tt::constants::FACE_WIDTH;
+    uint32_t base_alignment = needs_tile_pad ? tt::constants::TILE_WIDTH : tt::constants::TILE_WIDTH / 2;
+    uint32_t output_c_padded = tt::round_up(output_c, num_cores_c * base_alignment);
     uint32_t output_shard_width_padded = output_c_padded / num_cores_c;
     log_debug(
         tt::LogOp,

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -282,9 +282,15 @@ static std::vector<Tensor> pool2d_L1(
     //      channels=290, num_cores_c=1:  ceil(290/1)=290, 290%32=2 → tile pad needed.
     uint32_t channels_per_shard = tt::div_up(output_c, num_cores_c);
     uint32_t cps_mod_tile = channels_per_shard % tt::constants::TILE_WIDTH;
-    // For TILE output the shard width must be TILE_WIDTH-aligned regardless; for ROW_MAJOR
-    // we only round up to TILE_WIDTH when channels_per_shard is strictly partial (< FACE_WIDTH).
-    bool needs_tile_pad = !is_out_tiled && cps_mod_tile > 0 && cps_mod_tile < tt::constants::FACE_WIDTH;
+    // For TILE output the shard width must be TILE_WIDTH-aligned regardless; for ROW_MAJOR we
+    // only round up to TILE_WIDTH when the partial last tile is strictly less than one full face
+    // wide (cps_mod_tile < FACE_WIDTH) AND there is at least one preceding full tile per core
+    // (channels_per_shard > FACE_WIDTH). When the only tile per core is partial and fits in one
+    // face, the kernel packs just 1 face — so FACE_WIDTH alignment matches the kernel output and
+    // avoids creating per-shard internal padding that breaks downstream consumers (e.g.
+    // sharded_to_interleaved, slice_write).
+    bool needs_tile_pad = !is_out_tiled && cps_mod_tile > 0 && cps_mod_tile < tt::constants::FACE_WIDTH &&
+                          channels_per_shard > tt::constants::FACE_WIDTH;
     uint32_t base_alignment =
         (is_out_tiled || needs_tile_pad) ? tt::constants::TILE_WIDTH : tt::constants::TILE_WIDTH / 2;
     uint32_t output_c_padded = tt::round_up(output_c, num_cores_c * base_alignment);

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -152,10 +152,19 @@ FactoryParameters get_factory_parameters(
     uint32_t num_tilized_rows =
         kernel_size_hw <= tt::constants::FACE_WIDTH ? kernel_size_hw : tt::constants::TILE_HEIGHT;
     uint32_t in_ntiles_c = (uint32_t)std::ceil((float)in_channels / num_shards_c / tt::constants::TILE_WIDTH);
-    // For TILE_LAYOUT output, we need to align to TILE_WIDTH instead of FACE_WIDTH
-    uint32_t effective_tile_width_for_output =
-        (output_layout == Layout::TILE) ? tt::constants::TILE_WIDTH : tt::constants::FACE_WIDTH;
-    uint32_t out_ntiles_c = (uint32_t)std::ceil((float)in_channels / num_shards_c / effective_tile_width_for_output);
+    // Use ceiling division so WIDTH/BLOCK sharding with non-integer channels/core is handled
+    // correctly — avoids false partial-tile detection when floor(channels/cores) < FACE_WIDTH.
+    uint32_t channels_per_shard = tt::div_up(in_channels, num_shards_c);
+    // out_ntiles_c is kept at the FACE_WIDTH-aligned count (old formula) so it can be used for L1
+    // estimation (via calculate_L1_usage) without changing scheme-selection behaviour. The actual
+    // output CB page count is derived from output_shard_shape[1] / FACE_WIDTH in
+    // calculate_pool_cb_sizes, which correctly reflects the wider shard allocated for partial tiles.
+    uint32_t out_ntiles_c;
+    if (output_layout == Layout::TILE) {
+        out_ntiles_c = (uint32_t)std::ceil((float)channels_per_shard / tt::constants::TILE_WIDTH);
+    } else {
+        out_ntiles_c = (uint32_t)std::ceil((float)channels_per_shard / tt::constants::FACE_WIDTH);
+    }
 
     bool is_avg_pool = pool_type == Pool2DType::AVG_POOL2D;
     const bool last_tile_is_partial =
@@ -280,7 +289,10 @@ PoolCBSizes calculate_pool_cb_sizes(
     } else {
         sizes.out_cb_pagesize =
             std::min(static_cast<uint32_t>(tt::constants::FACE_WIDTH), output_shard_shape[1]) * params.nbytes;
-        sizes.out_cb_npages = output_shard_shape[0] * params.out_ntiles_c;
+        // Derive page count directly from the actual shard width so that CB size always matches
+        // the tensor buffer exactly — regardless of whether the shard was padded to TILE_WIDTH
+        // (partial last face) or FACE_WIDTH (all other cases).
+        sizes.out_cb_npages = output_shard_shape[0] * (output_shard_shape[1] / tt::constants::FACE_WIDTH);
     }
 
     // Output index CB (globally allocated, backed by output index tensor buffer)
@@ -400,8 +412,15 @@ std::optional<ParallelConfig> determine_pool_config_for_auto_shard(
 
     auto get_memconfig = [&](const ParallelConfig& parallel_config) {
         uint32_t nhw = batch_size * output_shape[1] * output_shape[2];
+        // Use FACE_WIDTH (TILE_WIDTH/2) alignment to match the actual shard formula for
+        // non-partial cases, so the L1 estimate stays consistent with the pre-partial-tile-fix
+        // behaviour and doesn't shift scheme selection for configs that were already working.
+        // For the actual output tensor the shard is widened to TILE_WIDTH when
+        // channels % TILE_WIDTH < FACE_WIDTH (generic_pools.cpp / pool_op.cpp), but that extra
+        // 32 bytes per row is small enough never to cause L1 overflow.
         uint32_t out_channel_padded = tt::round_up(
-            channels, conv::get_num_cores_channels_from_parallel_config(parallel_config) * tt::constants::TILE_WIDTH);
+            channels,
+            conv::get_num_cores_channels_from_parallel_config(parallel_config) * tt::constants::TILE_WIDTH / 2);
         return conv::create_sharded_memory_config_from_parallel_config(
             ttnn::Shape({1, 1, nhw, out_channel_padded}), parallel_config, tt::constants::TILE_HEIGHT);
     };


### PR DESCRIPTION
### Problem                                                                   
                                                                  
Pool2D's compute kernel previously had to reconfigure the packer mid-iteration whenever a per-core output tile was partial (channels_per_shard % TILE_WIDTH < FACE_WIDTH): full tiles emitted 2 faces, the last partial tile emitted 1 face. The mid-iter reconfiguration was undesirable (perf).

Additionally, when sharded_to_interleaved was used as a downstream tm op for a sharded input whose padded width exceeded its logical width, the writer's stick stride was sized off the destination's logical shape and overflowed adjacent sticks, corrupting data.                    

### Solution
#### 1. Always pack 2 faces in the pool output                
   
Compute and reader kernels emit 2 faces per output tile uniformly. Host correspondingly widens output_c_padded to TILE_WIDTH alignment when cps_mod_tile < FACE_WIDTH, and pool_utils.cpp derives out_cb_npages directly from output_shard_shape[1] / FACE_WIDTH so the CB matches the tensor buffer exactly. The cps_mod==FACE_WIDTH case (e.g. cps=16, 48, 80) keeps 1-face packing — no extra padding needed.

- compute_pool_2d.cpp, reader_mpwi.cpp: num_faces_in_last_output_tile = (... && in_c % TILE_WIDTH == FACE_WIDTH) ? 1 : 2.
- pool_op.cpp, generic_pools.cpp: out_c_padded rounds to num_cores_c * TILE_WIDTH when needed.                                                   
- pool_utils.cpp: out_cb_npages = output_shard_shape[0] * (output_shard_shape[1] / FACE_WIDTH); auto-shard L1 estimator keeps FACE_WIDTH alignment to preserve scheme selection.              
                                                                            
#### 2. ROW_MAJOR-only tile padding                            
   
TILE output must always align to TILE_WIDTH, so needs_tile_pad is now gated on !is_out_tiled in generic_pools.cpp.                    
                                                                            
#### 3. Propagate padded shape in sharded_to_interleaved 

Output TensorSpec is built via TensorLayout::fromPaddedShape(..., input.logical_shape(), input.padded_shape()) so the destination's stick stride matches the source's, preventing inter-stick overlap when the source has wider-than-logical sticks.                           

#### 4. Exception: single partial tile that fits in one face

When the only tile per core is partial and fits in one face (channels_per_shard ≤ FACE_WIDTH, e.g. channels=90, num_cores_c=6 → cps=15), widening the shard to 2 faces creates per-shard internal padding (15 valid + 17 pad). Downstream sharded_to_interleaved assumes each shard's output_unit_size is contiguous valid data and computes num_cores_unpadded = ceil(logical_row_bytes / shard_bytes) — with shard_width=32 the math drops cores 3..5 entirely, losing channels 45..89 and producing scrambled output (regression in test_max_pool2d_dram_slice for [1, 90, 900, 900, …, WIDTH_SHARDED]).

The fix: for this single-tile-fits-one-face case, keep FACE_WIDTH alignment on the host and have the kernel pack only 1 face. There's no mid-iter reconfiguration concern because there is no other tile in the iteration.

### Pipelines

- [x] [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/runs/25061109889)
- [x] [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/25061155172)
- [x] [Frequent models](https://github.com/tenstorrent/tt-metal/actions/runs/25061174372)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dstoiljkovic/pool_output_cb_expand)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dstoiljkovic/pool_output_cb_expand)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dstoiljkovic/pool_output_cb_expand)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dstoiljkovic/pool_output_cb_expand)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dstoiljkovic/pool_output_cb_expand)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dstoiljkovic/pool_output_cb_expand)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dstoiljkovic/pool_output_cb_expand)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dstoiljkovic/pool_output_cb_expand)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dstoiljkovic/pool_output_cb_expand)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dstoiljkovic/pool_output_cb_expand)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dstoiljkovic/pool_output_cb_expand)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dstoiljkovic/pool_output_cb_expand)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dstoiljkovic/pool_output_cb_expand)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dstoiljkovic/pool_output_cb_expand)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dstoiljkovic/pool_output_cb_expand)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dstoiljkovic/pool_output_cb_expand)