### PR TITLE
Migrate rms_writer to dataflow_kernel_lib reduce scaler helpers

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/rms_test.py
+++ b/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/rms_test.py
@@ -7,7 +7,7 @@ import pytest
 from loguru import logger
 import ttnn
 import math
-from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc, get_atol_rtol_pcc
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 from tracy import signpost
 
@@ -838,6 +838,8 @@ def run_rms_fuse_impl_deepseek(
     residual_dtype=ttnn.bfloat16,
     layout=ttnn.TILE_LAYOUT,
     epsilon=1e-05,
+    atol_threshold=None,
+    rtol_threshold=None,
 ):
     ccl_sub_device_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(4, 7))})
     worker_sub_device = ttnn.SubDevice(
@@ -1017,6 +1019,19 @@ def run_rms_fuse_impl_deepseek(
         if not passing:
             mesh_device.reset_sub_device_stall_group()
         assert passing
+
+        if atol_threshold is not None or rtol_threshold is not None:
+            ref_lnorm_matched = ref_lnorm.type(tt_out_torch.dtype)
+            cal_atol, cal_rtol, _, _ = get_atol_rtol_pcc(tt_out_torch.float(), ref_lnorm_matched.float())
+            logger.info(f"iter {i}: ATOL={cal_atol:.6f} RTOL={cal_rtol:.6f}")
+            if (atol_threshold is not None and cal_atol > atol_threshold) or (
+                rtol_threshold is not None and cal_rtol > rtol_threshold
+            ):
+                mesh_device.reset_sub_device_stall_group()
+            if atol_threshold is not None:
+                assert cal_atol <= atol_threshold, f"ATOL {cal_atol} exceeds threshold {atol_threshold}"
+            if rtol_threshold is not None:
+                assert cal_rtol <= rtol_threshold, f"RTOL {cal_rtol} exceeds threshold {rtol_threshold}"
     mesh_device.reset_sub_device_stall_group()
 
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
@@ -1046,6 +1046,8 @@ def test_rms_fuse_n300(
 ):
     if mesh_device.get_num_devices() != 2:
         pytest.skip("Not N300 - this test targets 2-chip Wormhole")
+    atol_threshold = 1.0 if fused_add else 0.6
+    rtol_threshold = 20.0 if fused_add else 0.1
     run_rms_fuse_impl_deepseek(
         mesh_device,
         num_devices,
@@ -1061,6 +1063,8 @@ def test_rms_fuse_n300(
         num_iters=num_iters,
         input_dtype=input_dtype,
         residual_dtype=residual_dtype,
+        atol_threshold=atol_threshold,
+        rtol_threshold=rtol_threshold,
     )
 
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/compute/rms_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/compute/rms_compute.cpp
@@ -135,13 +135,13 @@ void kernel_main() {
 
     cb_reserve_back(cb_ex_partial2, 1);  // RMS E(x2) #Layernorm //E(x) and E(x^2)
 
-    reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_x2, cb_scaler, cb_ex_partial2);
+    reduce_init<PoolType::AVG, ReduceDim::REDUCE_ROW>(cb_x2, cb_scaler, cb_ex_partial2);
     index_h_offset = 0;
     tile_regs_acquire();
     for (uint32_t w = 0; w < num_reduce_tiles_per_block_h; w++) {
         // TODO(#38448): Temporary workaround pending further debug; do not copy this pattern elsewhere.
         tensix_sync();
-        reduce_tile<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_x2, cb_scaler, w + index_h_offset, scaler0, dst0);
+        reduce_tile<PoolType::AVG, ReduceDim::REDUCE_ROW>(cb_x2, cb_scaler, w + index_h_offset, scaler0, dst0);
     }
 
     tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
@@ -10,7 +10,7 @@
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
-#include "cpp/ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "reshard_writer.hpp"
 #include <cstdint>
@@ -57,14 +57,23 @@ void kernel_main() {
     const uint32_t mcast_dest_noc_start_y = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t mcast_dest_noc_end_x = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t mcast_dest_noc_end_y = get_arg_val<uint32_t>(arg_idx++);
-    const uint32_t scalar_w = get_arg_val<uint32_t>(arg_idx++);
-    wh_generate_reduce_scaler<true>(cb_in_2, scalar_w);
+    dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<
+        cb_in_2,
+        ckernel::PoolType::AVG,
+        ckernel::ReduceDim::REDUCE_ROW,
+        block_w * tt::constants::TILE_WIDTH,
+        /*compute_uses_reduce_tile=*/true>();
 
     if constexpr (is_all_to_all_worker) {
-        const uint32_t scalar_c = get_arg_val<uint32_t>(arg_idx++);
-        wh_generate_reduce_scaler<true>(cb_in_4, scalar_c);
-        const uint32_t post_scalar_c = get_arg_val<uint32_t>(base_post_rt + 0);
-        wh_generate_reduce_scaler<true>(post_cb_in_4, post_scalar_c);
+        const uint32_t scalar_c_bits = get_arg_val<uint32_t>(arg_idx++);
+        float scalar_c_f = __builtin_bit_cast(float, scalar_c_bits);
+        dataflow_kernel_lib::prepare_reduce_scaler<cb_in_4, ckernel::PoolType::AVG, ckernel::ReduceDim::REDUCE_ROW>(
+            scalar_c_f);
+        const uint32_t post_scalar_c_bits = get_arg_val<uint32_t>(base_post_rt + 0);
+        float post_scalar_c_f = __builtin_bit_cast(float, post_scalar_c_bits);
+        dataflow_kernel_lib::
+            prepare_reduce_scaler<post_cb_in_4, ckernel::PoolType::AVG, ckernel::ReduceDim::REDUCE_ROW>(
+                post_scalar_c_f);
     } else {
         arg_idx++;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_program_factory.cpp
@@ -23,6 +23,7 @@
 #include <type_traits>
 #include <ranges>
 #include <optional>
+#include <bit>
 
 using uint32_t = std::uint32_t;
 using namespace tt::constants;
@@ -199,7 +200,6 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
     uint32_t K = shape[-1];
     uint32_t Kt = K / TILE_WIDTH;
     // block
-    uint32_t block_w = block_wt * TILE_WIDTH;
     uint32_t num_blocks = 0;
 
     auto bbox = shard_spec.grid.bounding_box();
@@ -853,19 +853,12 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
     // Runtime Args
     std::vector<KernelHandle> writer_kernel_ids;
     writer_kernel_ids.reserve(cores.size());
-    float winv = 1.0f / block_w;           // bcast-w scaler
     float cinv_pre = (1.0f / num_blocks);  // bcast-cores scaler
     float cinv = (1.0f / num_distributed_devices);
     float cinv_one = 1.0f;  // bcast-cores scaler for all-to-all cores not on first row/col
-    auto bfloat_cinv_value = bfloat16(cinv);
-    auto bfloat_cinv_value_pre = bfloat16(cinv_pre);
-    uint32_t packed_cinv_value = pack_two_bfloat16_into_uint32({bfloat_cinv_value, bfloat_cinv_value});
-    uint32_t packed_cinv_value_pre = pack_two_bfloat16_into_uint32({bfloat_cinv_value_pre, bfloat_cinv_value_pre});
-
-    auto bfloat_cinv_value_one = bfloat16(cinv_one);
-    uint32_t packed_cinv_value_one = pack_two_bfloat16_into_uint32({bfloat_cinv_value_one, bfloat_cinv_value_one});
-    auto bfloat_winv_value = bfloat16(winv);
-    uint32_t packed_winv_value = pack_two_bfloat16_into_uint32({bfloat_winv_value, bfloat_winv_value});
+    uint32_t cinv_bits = std::bit_cast<uint32_t>(cinv);
+    uint32_t cinv_pre_bits = std::bit_cast<uint32_t>(cinv_pre);
+    uint32_t cinv_one_bits = std::bit_cast<uint32_t>(cinv_one);
     union {
         float f;
         uint32_t u;
@@ -1125,11 +1118,9 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
             writer_mcast_sender_args.push_back(mcast_end.x);
             writer_mcast_sender_args.push_back(mcast_end.y);
             if (use_two_stage_reduce && (!(width_index < 1))) {
-                writer_mcast_sender_args.push_back(packed_winv_value);
-                writer_mcast_sender_args.push_back(packed_cinv_value_one);
+                writer_mcast_sender_args.push_back(cinv_one_bits);
             } else {
-                writer_mcast_sender_args.push_back(packed_winv_value);
-                writer_mcast_sender_args.push_back(packed_cinv_value_pre);
+                writer_mcast_sender_args.push_back(cinv_pre_bits);
             }
             writer_mcast_sender_args.push_back(i);  // Core ID to limit number of cores to do all gather on
             writer_mcast_sender_args.insert(
@@ -1138,12 +1129,12 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
             std::vector<uint32_t> writer_mcast_post_sender_args;
             if (use_two_stage_reduce) {
                 if (width_index < 1) {
-                    writer_mcast_post_sender_args.push_back(packed_cinv_value);
+                    writer_mcast_post_sender_args.push_back(cinv_bits);
                 } else {
-                    writer_mcast_post_sender_args.push_back(packed_cinv_value_one);
+                    writer_mcast_post_sender_args.push_back(cinv_one_bits);
                 }
             } else {
-                writer_mcast_post_sender_args.push_back(packed_cinv_value);
+                writer_mcast_post_sender_args.push_back(cinv_bits);
             }
             writer_mcast_post_sender_args.push_back(e.u);
             writer_mcast_post_sender_args.push_back(gamma_dram_addr);
@@ -1175,14 +1166,13 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
             writer_mcast_receiver_args.push_back(mcast_start.y);
             writer_mcast_receiver_args.push_back(mcast_end.x);
             writer_mcast_receiver_args.push_back(mcast_end.y);
-            writer_mcast_receiver_args.push_back(packed_winv_value);
-            writer_mcast_receiver_args.push_back(packed_cinv_value_pre);
+            writer_mcast_receiver_args.push_back(cinv_pre_bits);
             writer_mcast_receiver_args.push_back(i);  // Core ID to limit number of cores to do all gather on
             writer_mcast_receiver_args.insert(
                 writer_mcast_receiver_args.end(), all_gather_rts.begin(), all_gather_rts.end());
             writer_mcast_receiver_args.at(0) = writer_mcast_receiver_args.size();
             std::vector<uint32_t> writer_mcast_post_receiver_args;
-            writer_mcast_post_receiver_args.push_back(packed_cinv_value);
+            writer_mcast_post_receiver_args.push_back(cinv_bits);
             writer_mcast_post_receiver_args.push_back(e.u);
             writer_mcast_post_receiver_args.push_back(gamma_dram_addr);
             writer_mcast_post_receiver_args.push_back(gamma_tile_start_id);
@@ -1270,14 +1260,14 @@ void RMSAllGatherMeshWorkloadFactory::override_runtime_arguments(
 
             if (writer_kernel_id == shared_vars.writer_mcast_sender_kernels_id) {
                 auto& runtime_args = writer_sender_args_by_core[core.x][core.y];
-                runtime_args[8] = operation_attributes.semaphore.address();
-                runtime_args[10] = stats_tensor.value().buffer()->address();
+                runtime_args[7] = operation_attributes.semaphore.address();
+                runtime_args[9] = stats_tensor.value().buffer()->address();
                 // runtime_args[0] holds the start of the post arguments, apply that offset
                 runtime_args[runtime_args[0] + 2] = gamma_address;
             } else if (writer_kernel_id == shared_vars.writer_mcast_receiver_kernels_id) {
                 auto& runtime_args = writer_receiver_args_by_core[core.x][core.y];
-                runtime_args[8] = operation_attributes.semaphore.address();
-                runtime_args[10] = stats_tensor.value().buffer()->address();
+                runtime_args[7] = operation_attributes.semaphore.address();
+                runtime_args[9] = stats_tensor.value().buffer()->address();
                 runtime_args[runtime_args[0] + 2] = gamma_address;
             }
         }


### PR DESCRIPTION
### Summary
Continuation of [#43230](https://github.com/tenstorrent/tt-metal/pull/43230). That PR fixed the immediate hang in `compute_kernel_lib::reduce`; this one finishes the migration on the **dataflow side** by replacing the legacy `wh_generate_reduce_scaler` calls in `rms_writer.cpp` with the new `dataflow_kernel_lib` helpers and switching the scaler wire format to plain `float` bits.

### Changes

**Kernel (`rms_writer.cpp`)**
- `wh_generate_reduce_scaler(cb_in_2, …)` → `dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<cb_in_2, AVG, REDUCE_ROW, block_w*TILE_WIDTH, /*compute_uses_reduce_tile=*/true>()`. The reduce factor is now a compile-time template arg, so the runtime `scalar_w` slot goes away.
- `wh_generate_reduce_scaler(cb_in_4, …)` and same for `post_cb_in_4` → `dataflow_kernel_lib::prepare_reduce_scaler<…, AVG, REDUCE_ROW>(scalar_f)`. These run on all-to-all workers only and need a per-program runtime scaler (`cinv` / `cinv_pre`), so they stay runtime — but with float bits instead of packed bf16.

**Compute (`rms_compute.cpp`)**
- First reduce flipped from `PoolType::SUM` → `PoolType::AVG` to match the AVG scaler now produced by `calculate_and_prepare_reduce_scaler`. Numerically identical (same 1/N factor), just consistent naming.

**Host (`rms_allgather_program_factory.cpp`)**
- Drop the now-dead `winv` RT slot (formerly slot 5 / 6 of writer RT args).
- Replace `pack_two_bfloat16_into_uint32` of `cinv` / `cinv_pre` / `cinv_one` with `std::bit_cast<uint32_t>(float)` — the kernel reads the bits and `__builtin_bit_cast`s them back to `float`.
- Realign `override_runtime_arguments` to the new layout: `runtime_args[8]` → `runtime_args[7]` (`out_ready_sem_bank_addr`), `runtime_args[10]` → `runtime_args[9]` (`tensor_address0`). This was the bug that initially caused a hang when removing the deprecated slot — the override was silently corrupting `out_ready_sem_wait_value` with the semaphore address, so the i=0 sender's `noc_semaphore_wait` waited forever.

**Test (`test_rms_fuse_n300` / `run_rms_fuse_impl_deepseek`)**
- `run_rms_fuse_impl_deepseek` now accepts optional `atol_threshold` / `rtol_threshold`; assert is gated per-arg so passing only one (or neither) still works.
- `test_rms_fuse_n300` picks per-`fused_add` thresholds:
  - `fused_add=False`: `atol=0.6`, `rtol=0.1`
  - `fused_add=True`: `atol=1.0`, `rtol=20`

  The looser RTOL on the fused-add path is **not** caused by this migration — the pre-helpers baseline (legacy kernels calling `reduce_init` / `reduce_tile` directly without the helper layer) shows the same RTOL distribution. A handful of reference values land near zero in this configuration, blowing up the relative error denominator. PCC stays > 0.999 and ATOL ≤ 1 in both forms.

### CI Status

The `-ci` branch ([`sjovic/rms-reader-migration-ci`](https://github.com/tenstorrent/tt-metal/tree/sjovic/rms-reader-migration-ci)) has this PR's commit plus the two L2-nightly workflow fixes from #43230 so that `test_rms_fuse_n300` actually executes on the N300 nightly runner.

- **L2 nightly** (N300, group 1 — `data_movement`): [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sjovic/rms-reader-migration-ci)](https://github.com/tenstorrent/tt-metal/actions/runs/25065783522)
- **Sanity tests** (this branch): [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sjovic/rms-reader-migration)](https://github.com/tenstorrent/tt-metal/actions/runs/25065807548)
- **All Model Tests** (Llama 3.3-70B decode path through `fused_rms_minimal`): [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sjovic/rms-reader-migration-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sjovic/rms-reader-migration-ci)

### Test plan
- [x] `test_rms_fuse_n300` passes both parametrizations locally with the new ATOL/RTOL asserts (`fused_add=False`: ATOL ≤ 0.38, RTOL ≤ 0.07; `fused_add=True`: ATOL ≤ 0.94, RTOL ≤ 17)
- [x] Sanity run dispatched: https://github.com/tenstorrent/tt-metal/actions/runs/25065807548
- [x] L2 nightly dispatched on `-ci` branch with `additional_test_categories=data_movement`: https://github.com/tenstorrent/tt-metal/actions/runs/25065783522
- [ ] All-model-tests pass on `-ci` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)