### PR TITLE
[Fix] Defer creation of KernelCompileDescriptor in remote compile path

### DIFF
--- a/tt_metal/impl/jit_server/remote_compile_coordinator.cpp
+++ b/tt_metal/impl/jit_server/remote_compile_coordinator.cpp
@@ -37,21 +37,20 @@ RemoteCompileCoordinator::RemoteCompileCoordinator(
 
 RemoteCompileCoordinator::~RemoteCompileCoordinator() = default;
 
-void RemoteCompileCoordinator::submit(KernelCompileDescriptor descriptor) {
-    const std::size_t hash = descriptor.kernel_hash;
-
-    // Check the cross-invocation dedup cache.
+void RemoteCompileCoordinator::submit(
+    std::size_t kernel_hash, const std::function<KernelCompileDescriptor()>& make_descriptor) {
+    // Check the cross-invocation dedup cache before generating files for this hash.
     std::shared_future<void> existing_future;
     std::shared_ptr<std::promise<void>> new_promise;
     {
         std::lock_guard lock(s_dedup_mutex_);
-        auto it = s_dedup_cache_.find(hash);
+        auto it = s_dedup_cache_.find(kernel_hash);
         if (it != s_dedup_cache_.end()) {
             existing_future = it->second;
         } else {
             new_promise = std::make_shared<std::promise<void>>();
             existing_future = new_promise->get_future().share();
-            s_dedup_cache_[hash] = existing_future;
+            s_dedup_cache_[kernel_hash] = existing_future;
         }
     }
 
@@ -62,9 +61,10 @@ void RemoteCompileCoordinator::submit(KernelCompileDescriptor descriptor) {
     }
 
     // This kernel is new — assign endpoint and pipeline the send.
-    const std::size_t ep_idx = hash % endpoints_.size();
+    const std::size_t ep_idx = kernel_hash % endpoints_.size();
 
     try {
+        auto descriptor = make_descriptor();
         ensure_session(ep_idx);
         ensure_firmware_uploaded(ep_idx);
 
@@ -73,7 +73,7 @@ void RemoteCompileCoordinator::submit(KernelCompileDescriptor descriptor) {
     } catch (...) {
         {
             std::lock_guard lock(s_dedup_mutex_);
-            s_dedup_cache_.erase(hash);
+            s_dedup_cache_.erase(kernel_hash);
         }
         new_promise->set_exception(std::current_exception());
         throw;

--- a/tt_metal/impl/jit_server/remote_compile_coordinator.hpp
+++ b/tt_metal/impl/jit_server/remote_compile_coordinator.hpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <future>
 #include <memory>
 #include <mutex>
@@ -49,7 +50,8 @@ public:
     // Submit a kernel for remote compilation.
     // Deduplicates against prior submissions (even from previous batches in this process).
     // Sends the RPC immediately for new kernels; deduped kernels just record the future.
-    void submit(KernelCompileDescriptor descriptor);
+    // make_descriptor() is invoked only by the owning caller.
+    void submit(std::size_t kernel_hash, const std::function<KernelCompileDescriptor()>& make_descriptor);
 
     // Collect all outstanding RPC responses, write ELF blobs to disk,
     // and wait for any dedup'd kernels to complete.

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1974,9 +1974,10 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
             for (auto& [id, kernel] : kernels) {
                 validate_kernel_placement(force_slow_dispatch, kernel);
                 auto [build_options, kernel_hash] = prep_kernel(kernel);
-                generate_kernel_source_files(device, build_options, kernel);
-                auto desc = build_kernel_descriptor(device, kernel, build_options, kernel_hash);
-                coordinator.submit(std::move(desc));
+                coordinator.submit(kernel_hash, [&]() {
+                    generate_kernel_source_files(device, build_options, kernel);
+                    return build_kernel_descriptor(device, kernel, build_options, kernel_hash);
+                });
                 submitted_kernels.emplace_back(kernel, std::move(build_options));
             }
         }


### PR DESCRIPTION
### Summary
Only create the descriptor (along with the generated headers) when such kernel does not already exist in the global cache.  This avoids the unintentional effect that multiple threads compiling the same kernel can race on the generated files.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/distributed-compile-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/distributed-compile-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ruizhang/distributed-compile-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ruizhang/distributed-compile-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ruizhang/distributed-compile-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ruizhang/distributed-compile-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/distributed-compile-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/distributed-compile-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ruizhang/distributed-compile-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ruizhang/distributed-compile-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/distributed-compile-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/distributed-compile-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/distributed-compile-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/distributed-compile-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/distributed-compile-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/distributed-compile-fix)