### PR TITLE
[skip ci] Update merge_cluster_configs.py to enable merging multi-cluster files

### DIFF
--- a/tools/scaleout/cabling_generator/cabling_descriptor_analysis.py
+++ b/tools/scaleout/cabling_generator/cabling_descriptor_analysis.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""
+Script to identify and report on clusters in a cabling_descriptor.textproto file.
+A cluster is defined here as a group of nodes that are connected through one or more connections.
+
+USAGE:
+    Basic usage (human-readable output):
+        python3 cabling_descriptor_analysis.py <path_to_cabling_descriptor.textproto>
+
+    Verbose output (shows all connections):
+        python3 cabling_descriptor_analysis.py -v <path_to_cabling_descriptor.textproto>
+        python3 cabling_descriptor_analysis.py --verbose <path_to_cabling_descriptor.textproto>
+
+    JSON output (for use in other scripts):
+        python3 cabling_descriptor_analysis.py --json <path_to_cabling_descriptor.textproto>
+
+    JSON format:
+        {
+          "total_clusters": 5,
+          "total_hosts": 20,
+          "total_connections": 240,
+          "clusters": [
+            {
+              "cluster_id": 1,
+              "num_hosts": 4,
+              "num_connections": 48,
+              "hostnames": ["node1", "node2", "node3", "node4"]
+            },
+            ...
+          ]
+        }
+"""
+
+import argparse
+import json
+import re
+from collections import defaultdict
+from typing import Set, Dict, List, Tuple
+
+
+class UnionFind:
+    """Union-Find data structure for finding connected components."""
+
+    def __init__(self, nodes: List[str]):
+        self.parent = {node: node for node in nodes}
+        self.rank = {node: 0 for node in nodes}
+
+    def find(self, node: str) -> str:
+        """Find the root parent of a node with path compression."""
+        if self.parent[node] != node:
+            self.parent[node] = self.find(self.parent[node])
+        return self.parent[node]
+
+    def union(self, node1: str, node2: str) -> None:
+        """Union two nodes by rank."""
+        root1 = self.find(node1)
+        root2 = self.find(node2)
+
+        if root1 != root2:
+            if self.rank[root1] < self.rank[root2]:
+                self.parent[root1] = root2
+            elif self.rank[root1] > self.rank[root2]:
+                self.parent[root2] = root1
+            else:
+                self.parent[root2] = root1
+                self.rank[root1] += 1
+
+    def get_components(self) -> Dict[str, Set[str]]:
+        """Get all connected components grouped by their root."""
+        components = defaultdict(set)
+        for node in self.parent:
+            root = self.find(node)
+            components[root].add(node)
+        return components
+
+
+def parse_cabling_descriptor(filepath: str) -> Tuple[Set[str], List[Tuple[str, str]], List[Dict]]:
+    """
+    Parse a cabling_descriptor.textproto file and extract nodes and connections.
+
+    Returns:
+        Tuple of (set of node names, list of connection tuples, list of detailed connections)
+    """
+    nodes = set()
+    connections = []
+    detailed_connections = []
+
+    with open(filepath, "r") as f:
+        content = f.read()
+
+    # Extract node names from children blocks
+    children_pattern = r'children\s*\{\s*name:\s*"([^"]+)"'
+    for match in re.finditer(children_pattern, content):
+        node_name = match.group(1)
+        nodes.add(node_name)
+
+    # Extract connections from internal_connections with full details
+    # Pattern to match: connections { port_a { path: "node" tray_id: X port_id: Y } port_b { path: "node" tray_id: X port_id: Y } }
+    connection_pattern = r'connections\s*\{\s*port_a\s*\{\s*path:\s*"([^"]+)"\s*tray_id:\s*(\d+)\s*port_id:\s*(\d+)\s*\}\s*port_b\s*\{\s*path:\s*"([^"]+)"\s*tray_id:\s*(\d+)\s*port_id:\s*(\d+)\s*\}\s*\}'
+
+    for match in re.finditer(connection_pattern, content):
+        node_a = match.group(1)
+        tray_a = int(match.group(2))
+        port_a = int(match.group(3))
+        node_b = match.group(4)
+        tray_b = int(match.group(5))
+        port_b = int(match.group(6))
+
+        connections.append((node_a, node_b))
+        detailed_connections.append(
+            {"node_a": node_a, "tray_a": tray_a, "port_a": port_a, "node_b": node_b, "tray_b": tray_b, "port_b": port_b}
+        )
+
+    return nodes, connections, detailed_connections
+
+
+def analyze_clusters(
+    nodes: Set[str], connections: List[Tuple[str, str]], detailed_connections: List[Dict]
+) -> List[Dict]:
+    """
+    Analyze the graph to find clusters and their properties.
+
+    Args:
+        nodes: Set of all node names
+        connections: List of (node_a, node_b) tuples
+        detailed_connections: List of dicts with full connection details (tray_id, port_id)
+
+    Returns:
+        List of dictionaries containing cluster information
+    """
+    if not nodes:
+        return []
+
+    # Build Union-Find structure
+    uf = UnionFind(list(nodes))
+
+    # Union all connected nodes
+    for node_a, node_b in connections:
+        if node_a in nodes and node_b in nodes:
+            uf.union(node_a, node_b)
+
+    # Get connected components
+    components = uf.get_components()
+
+    # Build cluster information
+    clusters = []
+    for cluster_nodes in components.values():
+        # Count connections within this cluster
+        cluster_connections = []
+        cluster_detailed_connections = []
+        for idx, (node_a, node_b) in enumerate(connections):
+            if node_a in cluster_nodes and node_b in cluster_nodes:
+                cluster_connections.append((node_a, node_b))
+                cluster_detailed_connections.append(detailed_connections[idx])
+
+        cluster_info = {
+            "nodes": sorted(cluster_nodes),
+            "num_hosts": len(cluster_nodes),
+            "num_connections": len(cluster_connections),
+            "connections": cluster_connections,
+            "detailed_connections": cluster_detailed_connections,
+        }
+        clusters.append(cluster_info)
+
+    # Sort clusters by size (descending) for better readability
+    clusters.sort(key=lambda x: x["num_hosts"], reverse=True)
+
+    return clusters
+
+
+def print_cluster_report(clusters: List[Dict], verbose: bool = False) -> None:
+    """Print a formatted report of the clusters."""
+
+    print(f"\n{'='*80}")
+    print(f"CLUSTER ANALYSIS REPORT")
+    print(f"{'='*80}")
+    print(f"\nTotal clusters found: {len(clusters)}")
+    print(f"Total hosts across all clusters: {sum(c['num_hosts'] for c in clusters)}")
+    print(f"Total connections: {sum(c['num_connections'] for c in clusters)}")
+
+    for idx, cluster in enumerate(clusters, 1):
+        # Determine cluster type for descriptive naming
+        num_hosts = cluster["num_hosts"]
+
+        if num_hosts == 4:
+            cluster_type = "QUAD"
+        elif num_hosts % 4 == 0:
+            # Multiple of 4 nodes = multiple QUADs, call it SC#
+            num_quads = num_hosts // 4
+            cluster_type = f"SC{num_quads}"
+        else:
+            cluster_type = "CLUSTER"
+
+        print(f"\n{'-'*80}")
+        print(f"{cluster_type} #{idx}")
+        print(f"{'-'*80}")
+        print(f"Number of hosts: {cluster['num_hosts']}")
+        print(f"Number of connections: {cluster['num_connections']}")
+        print(f"\nHostnames:")
+        for node in cluster["nodes"]:
+            print(f"  - {node}")
+
+        # Count connections between each pair of nodes
+        connection_counts = defaultdict(int)
+        for node_a, node_b in cluster["connections"]:
+            # Normalize the pair so (A, B) and (B, A) are treated the same
+            pair = tuple(sorted([node_a, node_b]))
+            connection_counts[pair] += 1
+
+        # Display connection counts between nodes
+        if connection_counts:
+            print(f"\nConnection counts between nodes:")
+            # Sort by node pairs for consistent output
+            for (node_a, node_b), count in sorted(connection_counts.items()):
+                print(f"  {node_a} <-> {node_b}: {count} connection(s)")
+
+        if verbose and cluster["detailed_connections"]:
+            print(f"\nDetailed connections:")
+            for conn in cluster["detailed_connections"]:
+                print(
+                    f"  {conn['node_a']} [tray {conn['tray_a']}, port {conn['port_a']}] <-> {conn['node_b']} [tray {conn['tray_b']}, port {conn['port_b']}]"
+                )
+
+    print(f"\n{'='*80}\n")
+
+
+def print_json_output(clusters: List[Dict]) -> None:
+    """Print cluster information in JSON format for programmatic consumption."""
+    output = {
+        "total_clusters": len(clusters),
+        "total_hosts": sum(c["num_hosts"] for c in clusters),
+        "total_connections": sum(c["num_connections"] for c in clusters),
+        "clusters": [],
+    }
+
+    for idx, cluster in enumerate(clusters, 1):
+        cluster_info = {
+            "cluster_id": idx,
+            "num_hosts": cluster["num_hosts"],
+            "num_connections": cluster["num_connections"],
+            "hostnames": cluster["nodes"],
+        }
+        output["clusters"].append(cluster_info)
+
+    print(json.dumps(output, indent=2))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Analyze cabling_descriptor.textproto to identify clusters of connected nodes.",
+        epilog="""
+examples:
+  # Basic human-readable output
+  %(prog)s /path/to/cabling_descriptor.textproto
+
+  # Verbose output with connection details
+  %(prog)s -v /path/to/cabling_descriptor.textproto
+
+  # JSON output for use in other scripts
+  %(prog)s --json /path/to/cabling_descriptor.textproto
+
+  # Use with jq to extract hostnames
+  %(prog)s --json file.textproto | jq '.clusters[].hostnames'
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("filepath", help="Path to the cabling_descriptor.textproto file")
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Show detailed connection information for each cluster"
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Output results in JSON format for programmatic consumption"
+    )
+
+    args = parser.parse_args()
+
+    try:
+        # Parse the file
+        if not args.json:
+            print(f"Reading cabling descriptor from: {args.filepath}")
+        nodes, connections, detailed_connections = parse_cabling_descriptor(args.filepath)
+
+        if not args.json:
+            print(f"Found {len(nodes)} nodes and {len(connections)} connections")
+
+        # Analyze clusters
+        clusters = analyze_clusters(nodes, connections, detailed_connections)
+
+        # Print report in requested format
+        if args.json:
+            print_json_output(clusters)
+        else:
+            print_cluster_report(clusters, verbose=args.verbose)
+
+    except FileNotFoundError:
+        print(f"Error: File not found: {args.filepath}")
+        return 1
+    except Exception as e:
+        print(f"Error: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/tools/scaleout/cabling_generator/cabling_descriptor_analysis.py
+++ b/tools/scaleout/cabling_generator/cabling_descriptor_analysis.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
 """
 Script to identify and report on clusters in a cabling_descriptor.textproto file.
 A cluster is defined here as a group of nodes that are connected through one or more connections.

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -312,7 +312,7 @@ void validate_and_merge_node_templates(
     const std::unordered_map<std::string, Node>& other_node_desc_name_to_node,
     const std::string& existing_source_file,
     const std::string& new_source_file) {
-    // Forward pass: validate/merge templates that exist in both
+    // Forward pass: validate/merge templates that exist in both, add new ones
     for (const auto& [node_desc_name, other_template] : other_node_desc_name_to_node) {
         if (this_node_desc_name_to_node.contains(node_desc_name)) {
             // Template exists in both - validate it matches
@@ -321,36 +321,24 @@ void validate_and_merge_node_templates(
             validate_inter_board_connections(
                 this_template, other_template, node_desc_name, existing_source_file, new_source_file);
         } else {
-            // Template missing in 'this' - try torus-compatible merge or throw error
+            // Template missing in 'this' - try torus-compatible merge, otherwise add as new
             bool merged = try_merge_torus_compatible_template(
                 this_node_desc_name_to_node, node_desc_name, other_template, existing_source_file, new_source_file);
 
             if (!merged) {
-                throw std::runtime_error(fmt::format(
-                    "Node template '{}' exists in {} but not in {} - structural mismatch",
+                // Add the new template (allows merging clusters with different node types)
+                log_info(
+                    tt::LogDistributed,
+                    "Adding node template '{}' from {} to merged configuration",
                     node_desc_name,
-                    get_source_description(new_source_file),
-                    get_source_description(existing_source_file)));
+                    get_source_description(new_source_file));
+                this_node_desc_name_to_node[node_desc_name] = other_template;
             }
         }
     }
 
-    // Backward pass: check for templates in 'this' that don't exist in 'other'
-    for (const auto& [node_desc_name, this_template] : this_node_desc_name_to_node) {
-        if (!other_node_desc_name_to_node.contains(node_desc_name)) {
-            // Check if this is a torus type that can be merged with another torus variant
-            bool found_compatible =
-                find_torus_compatible_template(other_node_desc_name_to_node, node_desc_name).has_value();
-
-            if (!found_compatible) {
-                throw std::runtime_error(fmt::format(
-                    "Node template '{}' exists in {} but not in {} - structural mismatch",
-                    node_desc_name,
-                    get_source_description(existing_source_file),
-                    get_source_description(new_source_file)));
-            }
-        }
-    }
+    // Backward pass: templates in 'this' but not in 'other' are fine - they're kept as-is
+    // Different clusters can have different node types
 }
 
 // Find node descriptor by name - search inline first, then fallback to file
@@ -476,6 +464,7 @@ Node build_node(
         throw std::runtime_error("Node descriptor " + node_descriptor_name + " missing motherboard");
     }
     template_node.motherboard = node_descriptor.motherboard();
+    template_node.node_descriptor_name = node_descriptor_name;  // Store original template name
 
     // Create boards with internal connections marked (using cached boards)
     for (const auto& board_item : node_descriptor.boards().board()) {
@@ -602,21 +591,6 @@ std::unique_ptr<ResolvedGraphInstance> build_graph_instance_impl(
             HostId host_id = HostId(child_mapping.host_id());
             const std::string& node_descriptor_name = child_def.node_ref().node_descriptor();
 
-            // Validate deployment node type if deployment descriptor is provided
-            if (deployment_descriptor != nullptr) {
-                if (*host_id < deployment_descriptor->hosts().size()) {
-                    const auto& deployment_host = deployment_descriptor->hosts()[*host_id];
-                    if (!deployment_host.node_type().empty() && deployment_host.node_type() != node_descriptor_name) {
-                        throw std::runtime_error(
-                            "Node type mismatch for host " + deployment_host.host() + " (host_id " +
-                            std::to_string(*host_id) + "): deployment specifies '" + deployment_host.node_type() +
-                            "' but cluster configuration expects '" + node_descriptor_name + "'");
-                    }
-                } else {
-                    throw std::runtime_error("Host ID " + std::to_string(*host_id) + " not found in deployment");
-                }
-            }
-
             // Find node descriptor and build node
             resolved->nodes[child_name] = build_node(node_descriptor_name, host_id, cluster_descriptor, node_templates);
             resolved->children_order.emplace_back(child_name, true);
@@ -679,13 +653,12 @@ void populate_deployment_hosts(
     const tt::scaleout_tools::deployment::proto::DeploymentDescriptor& deployment_descriptor,
     const std::unordered_map<std::string, Node>& node_templates,
     std::vector<Host>& deployment_hosts) {
-    // Store deployment hosts
+    // Store deployment hosts - skip those whose node_type isn't in current templates
+    // (happens during merge when deployment contains multiple clusters)
     deployment_hosts.reserve(deployment_descriptor.hosts().size());
     for (const auto& proto_host : deployment_descriptor.hosts()) {
         if (!node_templates.contains(proto_host.node_type())) {
-            throw std::runtime_error(
-                "Node type '" + proto_host.node_type() + "' from deployment descriptor host '" + proto_host.host() +
-                "' not found in cluster descriptor templates");
+            continue;  // Skip - will be populated from other cabling files
         }
         deployment_hosts.emplace_back(Host{
             .hostname = proto_host.host(),
@@ -937,6 +910,7 @@ static Node create_base_node_from_template(
     // (template only has ports marked as used for inter-board connections from node descriptor)
     Node base_node = template_node;
     base_node.host_id = source_node.host_id;
+    base_node.node_descriptor_name = source_node.node_descriptor_name;  // Preserve original template name
     // Copy inter_board_connections from source (they may have been merged from multiple files)
     base_node.inter_board_connections = source_node.inter_board_connections;
     // Re-mark ports as used for the merged inter-board connections
@@ -979,6 +953,20 @@ static void merge_resolved_graph_instances(
                         source_node.host_id.get(),
                         get_source_description(new_source_file)));
                 }
+
+                // Validate node types match for duplicate nodes
+                if (!target.nodes[name].node_descriptor_name.empty() && !source_node.node_descriptor_name.empty() &&
+                    target.nodes[name].node_descriptor_name != source_node.node_descriptor_name) {
+                    throw std::runtime_error(fmt::format(
+                        "Node '{}' has conflicting node types: '{}' in {} vs '{}' in {} "
+                        "(same hostname cannot have different node types across cabling descriptors)",
+                        name,
+                        target.nodes[name].node_descriptor_name,
+                        get_source_description(existing_source_file),
+                        source_node.node_descriptor_name,
+                        get_source_description(new_source_file)));
+                }
+
                 // Validate inter_board_connections match or are torus-compatible
                 // For torus-compatible nodes, we merge the connections
                 // For non-torus nodes, we only merge internal_connections, not inter_board_connections
@@ -1317,15 +1305,12 @@ static void resolved_graph_to_protobuf(
         child->set_name(name);
         auto* node_ref = child->mutable_node_ref();
 
-        auto template_key = find_template_key_for_node(node, node_templates);
-        if (!template_key) {
-            throw std::runtime_error(fmt::format(
-                "Could not find node descriptor for node '{}' with motherboard '{}' and {} boards",
-                name,
-                node.motherboard,
-                node.boards.size()));
+        // Use the stored node_descriptor_name instead of finding by structure
+        if (node.node_descriptor_name.empty()) {
+            throw std::runtime_error(
+                fmt::format("Node '{}' missing node_descriptor_name - should have been set during construction", name));
         }
-        node_ref->set_node_descriptor(*template_key);
+        node_ref->set_node_descriptor(node.node_descriptor_name);
     }
 
     // Add internal_connections

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -301,8 +301,9 @@ bool try_merge_torus_compatible_template(
 
     merge_inter_board_connections(this_node_desc_name_to_node[*compatible_desc_name], missing_template);
 
-    // Add the missing template as an alias
+    // Add the missing template as an alias (copy compatible template but preserve alias name)
     this_node_desc_name_to_node[missing_node_desc_name] = this_node_desc_name_to_node[*compatible_desc_name];
+    this_node_desc_name_to_node[missing_node_desc_name].node_descriptor_name = missing_node_desc_name;
 
     return true;
 }
@@ -403,6 +404,7 @@ Node build_node(
     if (it != node_templates.end()) {
         Node node = it->second;  // Copy template
         node.host_id = host_id;
+        node.node_descriptor_name = node_descriptor_name;  // Preserve original descriptor name
         return node;
     }
 
@@ -560,7 +562,7 @@ HostId resolve_path_from_proto(
 std::unique_ptr<ResolvedGraphInstance> build_graph_instance_impl(
     const tt::scaleout_tools::cabling_generator::proto::GraphInstance& graph_instance,
     const tt::scaleout_tools::cabling_generator::proto::ClusterDescriptor& cluster_descriptor,
-    const tt::scaleout_tools::deployment::proto::DeploymentDescriptor* deployment_descriptor,
+    [[maybe_unused]] const tt::scaleout_tools::deployment::proto::DeploymentDescriptor* deployment_descriptor,
     const std::string& instance_name,
     std::unordered_map<std::string, Node>& node_templates) {
     auto resolved = std::make_unique<ResolvedGraphInstance>();

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -92,6 +92,7 @@ struct Node {
     std::string motherboard;
     std::map<TrayId, Board> boards;
     HostId host_id{0};
+    std::string node_descriptor_name;  // Track original template name (e.g., BH_GALAXY_REV_AB)
 
     // Board-to-board connections within this node: PortType -> [(tray_id, port_id) <-> (tray_id, port_id)]
     using BoardEndpoint = std::pair<TrayId, PortId>;

--- a/tools/scaleout/cabling_generator/merge_cluster_configs.py
+++ b/tools/scaleout/cabling_generator/merge_cluster_configs.py
@@ -127,16 +127,26 @@ def count_nodes(deployment_path):
 def validate_cluster_node_types(cabling_path, deployment_path):
     """
     Validate that:
-    1. All hosts within each cluster have the same node_type (deployment descriptor)
+    1. Cabling and deployment descriptors have exactly the same set of hosts
     2. Each host's node_descriptor (cabling) matches its node_type (deployment)
-    Uses cabling_descriptor_analysis.py to identify clusters.
+    3. All hosts within each cluster have the same node_type (deployment descriptor)
+
+    Uses cabling_descriptor_analysis.py to identify clusters via connectivity analysis.
+
+    Exits with non-zero status if:
+    - Analysis script is missing
+    - Analysis script fails to run
+    - Hosts exist in one descriptor but not the other
+    - Host types mismatch between descriptors
+    - Cluster has mixed node types
     """
     script_dir = Path(__file__).resolve().parent
     analysis_script = script_dir / "cabling_descriptor_analysis.py"
 
     if not analysis_script.exists():
-        print(f"Warning: Cluster analysis script not found at {analysis_script}, skipping validation", file=sys.stderr)
-        return
+        print(f"Error: Cluster analysis script not found at {analysis_script}", file=sys.stderr)
+        print("This script is required for validation. Cannot proceed.", file=sys.stderr)
+        sys.exit(1)
 
     # Run cluster analysis to get cluster information
     try:
@@ -145,11 +155,17 @@ def validate_cluster_node_types(cabling_path, deployment_path):
         )
         cluster_data = json.loads(result.stdout)
     except subprocess.CalledProcessError as e:
-        print(f"Warning: Failed to run cluster analysis: {e}", file=sys.stderr)
-        return
+        print(f"Error: Failed to run cluster analysis script", file=sys.stderr)
+        print(f"Command failed with exit code {e.returncode}", file=sys.stderr)
+        if e.stderr:
+            print(f"stderr: {e.stderr}", file=sys.stderr)
+        if e.stdout:
+            print(f"stdout: {e.stdout}", file=sys.stderr)
+        sys.exit(1)
     except json.JSONDecodeError as e:
-        print(f"Warning: Failed to parse cluster analysis JSON: {e}", file=sys.stderr)
-        return
+        print(f"Error: Failed to parse cluster analysis JSON output: {e}", file=sys.stderr)
+        print(f"Output was: {result.stdout[:500]}", file=sys.stderr)
+        sys.exit(1)
 
     # Parse deployment descriptor to build hostname -> node_type mapping
     hostname_to_node_type = {}
@@ -191,20 +207,44 @@ def validate_cluster_node_types(cabling_path, deployment_path):
 
     # Check 1: Cabling descriptor matches deployment descriptor for each host
     print("  Checking cabling descriptor vs deployment descriptor...")
-    cabling_deployment_mismatches = []
-    for hostname, node_descriptor in hostname_to_node_descriptor.items():
-        if hostname in hostname_to_node_type:
-            node_type = hostname_to_node_type[hostname]
-            if node_descriptor != node_type:
-                cabling_deployment_mismatches.append(
-                    f"    {hostname}: cabling has '{node_descriptor}' but deployment has '{node_type}'"
-                )
+    cabling_deployment_errors = []
 
-    if cabling_deployment_mismatches:
-        errors.append("\n  Cabling/Deployment mismatch errors:")
-        errors.extend(cabling_deployment_mismatches)
+    # Check: Hosts in cabling but missing from deployment
+    cabling_only_hosts = set(hostname_to_node_descriptor.keys()) - set(hostname_to_node_type.keys())
+    if cabling_only_hosts:
+        cabling_deployment_errors.append(f"\n    Hosts in cabling descriptor but missing from deployment descriptor:")
+        for hostname in sorted(cabling_only_hosts):
+            cabling_deployment_errors.append(
+                f"      {hostname} (node_descriptor: '{hostname_to_node_descriptor[hostname]}')"
+            )
+
+    # Check: Hosts in deployment but missing from cabling
+    deployment_only_hosts = set(hostname_to_node_type.keys()) - set(hostname_to_node_descriptor.keys())
+    if deployment_only_hosts:
+        cabling_deployment_errors.append(f"\n    Hosts in deployment descriptor but missing from cabling descriptor:")
+        for hostname in sorted(deployment_only_hosts):
+            cabling_deployment_errors.append(f"      {hostname} (node_type: '{hostname_to_node_type[hostname]}')")
+
+    # Check: Hosts in both descriptors but with mismatched types
+    type_mismatches = []
+    common_hosts = set(hostname_to_node_descriptor.keys()) & set(hostname_to_node_type.keys())
+    for hostname in sorted(common_hosts):
+        node_descriptor = hostname_to_node_descriptor[hostname]
+        node_type = hostname_to_node_type[hostname]
+        if node_descriptor != node_type:
+            type_mismatches.append(
+                f"      {hostname}: cabling has '{node_descriptor}' but deployment has '{node_type}'"
+            )
+
+    if type_mismatches:
+        cabling_deployment_errors.append(f"\n    Node type mismatches between cabling and deployment:")
+        cabling_deployment_errors.extend(type_mismatches)
+
+    if cabling_deployment_errors:
+        errors.append("\n  Cabling/Deployment consistency errors:")
+        errors.extend(cabling_deployment_errors)
     else:
-        print("    All hosts match between cabling and deployment ✓")
+        print(f"    All {len(common_hosts)} hosts match between cabling and deployment ✓")
 
     # Check 2: All hosts within each cluster have the same node type
     print(f"  Checking consistency across {cluster_data['total_clusters']} clusters...")

--- a/tools/scaleout/cabling_generator/merge_cluster_configs.py
+++ b/tools/scaleout/cabling_generator/merge_cluster_configs.py
@@ -29,6 +29,7 @@ Generates in output-dir:
 """
 
 import argparse
+import json
 import os
 import re
 import shutil
@@ -123,6 +124,125 @@ def count_nodes(deployment_path):
     return len(re.findall(pattern, content, re.MULTILINE))
 
 
+def validate_cluster_node_types(cabling_path, deployment_path):
+    """
+    Validate that:
+    1. All hosts within each cluster have the same node_type (deployment descriptor)
+    2. Each host's node_descriptor (cabling) matches its node_type (deployment)
+    Uses cabling_descriptor_analysis.py to identify clusters.
+    """
+    script_dir = Path(__file__).resolve().parent
+    analysis_script = script_dir / "cabling_descriptor_analysis.py"
+
+    if not analysis_script.exists():
+        print(f"Warning: Cluster analysis script not found at {analysis_script}, skipping validation", file=sys.stderr)
+        return
+
+    # Run cluster analysis to get cluster information
+    try:
+        result = subprocess.run(
+            ["python3", str(analysis_script), str(cabling_path), "--json"], capture_output=True, text=True, check=True
+        )
+        cluster_data = json.loads(result.stdout)
+    except subprocess.CalledProcessError as e:
+        print(f"Warning: Failed to run cluster analysis: {e}", file=sys.stderr)
+        return
+    except json.JSONDecodeError as e:
+        print(f"Warning: Failed to parse cluster analysis JSON: {e}", file=sys.stderr)
+        return
+
+    # Parse deployment descriptor to build hostname -> node_type mapping
+    hostname_to_node_type = {}
+    with open(deployment_path, "r") as f:
+        content = f.read()
+
+    # Extract host blocks using regex
+    host_pattern = r"hosts\s*\{([^}]+)\}"
+    for host_match in re.finditer(host_pattern, content):
+        host_block = host_match.group(1)
+
+        # Extract hostname and node_type from block
+        hostname_match = re.search(r'host:\s*"([^"]+)"', host_block)
+        node_type_match = re.search(r'node_type:\s*"([^"]+)"', host_block)
+
+        if hostname_match and node_type_match:
+            hostname_to_node_type[hostname_match.group(1)] = node_type_match.group(1)
+
+    # Parse cabling descriptor to build hostname -> node_descriptor mapping
+    hostname_to_node_descriptor = {}
+    with open(cabling_path, "r") as f:
+        content = f.read()
+
+    # Extract children blocks with name and node_descriptor
+    children_pattern = r"children\s*\{([^}]+)\}"
+    for child_match in re.finditer(children_pattern, content):
+        child_block = child_match.group(1)
+
+        # Extract name and node_descriptor from block
+        name_match = re.search(r'name:\s*"([^"]+)"', child_block)
+        descriptor_match = re.search(r'node_descriptor:\s*"([^"]+)"', child_block)
+
+        if name_match and descriptor_match:
+            hostname_to_node_descriptor[name_match.group(1)] = descriptor_match.group(1)
+
+    # Validate: 1) cabling vs deployment consistency, 2) cluster homogeneity
+    print(f"\nValidating node type consistency...")
+    errors = []
+
+    # Check 1: Cabling descriptor matches deployment descriptor for each host
+    print("  Checking cabling descriptor vs deployment descriptor...")
+    cabling_deployment_mismatches = []
+    for hostname, node_descriptor in hostname_to_node_descriptor.items():
+        if hostname in hostname_to_node_type:
+            node_type = hostname_to_node_type[hostname]
+            if node_descriptor != node_type:
+                cabling_deployment_mismatches.append(
+                    f"    {hostname}: cabling has '{node_descriptor}' but deployment has '{node_type}'"
+                )
+
+    if cabling_deployment_mismatches:
+        errors.append("\n  Cabling/Deployment mismatch errors:")
+        errors.extend(cabling_deployment_mismatches)
+    else:
+        print("    All hosts match between cabling and deployment ✓")
+
+    # Check 2: All hosts within each cluster have the same node type
+    print(f"  Checking consistency across {cluster_data['total_clusters']} clusters...")
+    for cluster in cluster_data["clusters"]:
+        cluster_id = cluster["cluster_id"]
+        hostnames = cluster["hostnames"]
+
+        # Get node types for all hosts in this cluster
+        node_types_in_cluster = {}
+        for hostname in hostnames:
+            if hostname in hostname_to_node_type:
+                node_type = hostname_to_node_type[hostname]
+                if node_type not in node_types_in_cluster:
+                    node_types_in_cluster[node_type] = []
+                node_types_in_cluster[node_type].append(hostname)
+
+        # Check if all hosts have the same node type
+        if len(node_types_in_cluster) > 1:
+            error_msg = f"\n  Cluster {cluster_id} has mixed node types:"
+            for node_type, hosts in sorted(node_types_in_cluster.items()):
+                error_msg += f"\n    {node_type}: {len(hosts)} hosts ({', '.join(hosts[:3])}"
+                if len(hosts) > 3:
+                    error_msg += f", ... and {len(hosts) - 3} more"
+                error_msg += ")"
+            errors.append(error_msg)
+        else:
+            node_type = list(node_types_in_cluster.keys())[0] if node_types_in_cluster else "unknown"
+            print(f"    Cluster {cluster_id}: {cluster['num_hosts']} hosts, all {node_type} ✓")
+
+    if errors:
+        print("\n❌ Validation failed with errors:", file=sys.stderr)
+        for error in errors:
+            print(error, file=sys.stderr)
+        sys.exit(1)
+
+    print("\n✅ All validation checks passed\n")
+
+
 def main():
     parser = argparse.ArgumentParser(description="Merge two cluster configurations.")
     parser.add_argument("--cabling1", required=True, help="First cabling_descriptor.textproto")
@@ -172,19 +292,32 @@ def main():
         else:
             shutil.copy(args.deployment1, merged_deployment)
 
-        merged_fsd = output_dir / "merged_fsd.textproto"
+        # Write merged files to temp directory first
+        merged_fsd_temp = temp_dir / "merged_fsd.textproto"
         generated_deployment_path = run_cabling_generator(
-            str(cabling_dir), str(merged_deployment), str(merged_fsd), args.build_dir
+            str(cabling_dir), str(merged_deployment), str(merged_fsd_temp), args.build_dir
         )
 
-        final_deployment = output_dir / "merged_deployment_descriptor.textproto"
+        final_deployment_temp = temp_dir / "final_deployment_descriptor.textproto"
         if generated_deployment_path is not None:
             # Use C++-generated deployment (one host per node in host_id order, no duplicates)
-            shutil.copy(generated_deployment_path, final_deployment)
+            shutil.copy(generated_deployment_path, final_deployment_temp)
         else:
-            shutil.copy(merged_deployment, final_deployment)
+            shutil.copy(merged_deployment, final_deployment_temp)
 
-        total_nodes = count_nodes(str(final_deployment))
+        # Validate node type consistency within each cluster before writing to output
+        merged_cabling_temp = temp_dir / "merged_cabling_descriptor.textproto"
+        if merged_cabling_temp.exists():
+            validate_cluster_node_types(merged_cabling_temp, final_deployment_temp)
+
+        # Validation passed - now copy files to output directory
+        shutil.copy(merged_fsd_temp, output_dir / "merged_fsd.textproto")
+        shutil.copy(final_deployment_temp, output_dir / "merged_deployment_descriptor.textproto")
+        if merged_cabling_temp.exists():
+            shutil.copy(merged_cabling_temp, output_dir / "merged_cabling_descriptor.textproto")
+
+        total_nodes = count_nodes(str(final_deployment_temp))
+        print(f"\n✅ Merge successful!")
         print(f"Merged {total_nodes} nodes")
         print(f"Output: {output_dir}")
 


### PR DESCRIPTION
### Issue
Ticket: [DCAMP-289](https://tenstorrent.atlassian.net/browse/DCAMP-289)

Merging global cabling descriptors containing multiple independent clusters with different node types (e.g., BH_GALAXY_REV_AB and BH_GALAXY_REV_C) failed due to validation logic assuming single-cluster files and host_id-based validation breaking on overlapping IDs

### Solution

Core Changes:

- Allow different node types across files (different clusters can have different hardware)
- Added node_descriptor_name field to preserve original template names through merge lifecycle
- Moved validation from construction-time to post-merge with cluster-aware checks
- New Tool - `cabling_descriptor_analysis.py`:
Added inspection utility for cabling descriptor files that identifies clusters using Union-Find algorithm on connection topology. Supports both human-readable and JSON output formats

New validation flow:
- Validates nodes described in cabling_descriptor match the deployment_descriptor
- Identify clusters using `cabling_descriptor_analysis.py` and validates node type consistency within each cluster
Safe Write: Only writes output files after successful validation

✅ Supports merging multiple independent clusters for datacenter-wide/global descriptors
✅ Different node types can coexist across file but not within same cluster
✅ Prevents silent type mismatches with explicit validation errors
✅ Clear user feedback with per-cluster validation reporting
✅ Standalone inspection tool for debugging and analysis
