### PR TITLE
Pad vocab shards to power of two

### DIFF
--- a/models/demos/deepseek_v3/tests/test_sampling.py
+++ b/models/demos/deepseek_v3/tests/test_sampling.py
@@ -70,7 +70,7 @@ def _sample_device_tokens(mesh_device, ccl, args, torch_input, user_params):
 @pytest.mark.parametrize("device_params", [{"fabric_config": get_fabric_config()}], indirect=True)
 def test_deepseek_device_sampling_argmax_path(mesh_device, ccl, hf_config, device_params, sampling_params):
     vocab_size = int(hf_config.vocab_size)
-    args = make_deepseek_sampling_args(mesh_device, vocab_size=vocab_size)
+    args = make_deepseek_sampling_args(mesh_device, vocab_size=vocab_size, pad_logits_to_power_of_2=True)
     batch_size = USERS_PER_ROW * int(mesh_device.shape[0])
     seed = int(sampling_params.get("seed", 0))
     torch.manual_seed(seed)

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -461,7 +461,10 @@ class DeepseekGenerator(WarmupForwardMixin):
                 # create new sampling generator
                 enable_internal_trace_sampling = enable_trace
                 self.sampling_args = make_deepseek_sampling_args(
-                    self.mesh_device, self.hf_config.vocab_size, max_batch_size=self.batch_size_per_row
+                    self.mesh_device,
+                    self.hf_config.vocab_size,
+                    max_batch_size=self.batch_size_per_row,
+                    pad_logits_to_power_of_2=True,
                 )
                 self.sampling_generator = SamplingGenerator(
                     args=self.sampling_args,

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -55,6 +55,7 @@ class DeepseekSamplingArgs:
     sampling_dp: int
     cluster_shape: tuple[int, int]
     sampling_all_gather_axis: int = 1
+    pad_logits_to_power_of_2: bool = True
 
 
 ConfigDevice = ttnn.MeshDevice | MeshDeviceStub

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -102,6 +102,7 @@ def make_deepseek_sampling_args(
     max_top_k: int = MAX_TOP_K,
     max_batch_size: int = USERS_PER_ROW,
     sampling_all_gather_axis: int = 1,
+    pad_logits_to_power_of_2: bool = True,
 ) -> DeepseekSamplingArgs:
     cluster_shape = tuple(mesh_device.shape)
     sampling_dp = int(cluster_shape[0])  # one sampling group per row
@@ -117,6 +118,7 @@ def make_deepseek_sampling_args(
         sampling_dp=sampling_dp,
         cluster_shape=cluster_shape,
         sampling_all_gather_axis=sampling_all_gather_axis,
+        pad_logits_to_power_of_2=pad_logits_to_power_of_2,
     )
 
 


### PR DESCRIPTION
### Summary
Issue: https://github.com/tenstorrent/tt-metal/issues/43933


```

w/o opt
+-------------------------+------------+-----------------------------+-----------+
| Operation               | Core count | DEVICE KERNEL DURATION [ns] | us        |
+-------------------------+------------+-----------------------------+-----------+
| TypecastDeviceOperation |         70 |                       10381 |    10.381 |
| TopKDeviceOperation     |          1 |                     8995514 |  8995.514 |
| TypecastDeviceOperation |          8 |                        2499 |     2.499 |
| BinaryNgDeviceOperation |         70 |                        2993 |     2.993 |
| UntilizeDeviceOperation |          1 |                        8668 |     8.668 |
| ManualSeedDeviceOperation|        70 |                       25429 |    25.429 |
| SamplingDeviceOperation |         32 |                       68536 |    68.536 |
+-------------------------+------------+-----------------------------+-----------+
| Total                   |            |                     9114020 |  9114.020 |
+-------------------------+------------+-----------------------------+-----------+
with opt
+-------------------------+------------+-----------------------------+----------+
| Operation               | Core count | DEVICE KERNEL DURATION [ns] | us       |
+-------------------------+------------+-----------------------------+----------+
| TypecastDeviceOperation |         70 |                       10226 |   10.226 |
| PadDeviceOperation      |         70 |                       44813 |   44.813 |
| TopKDeviceOperation     |         33 |                      156793 |  156.793 |
| TypecastDeviceOperation |          8 |                        2527 |    2.527 |
| BinaryNgDeviceOperation |         70 |                        3040 |    3.040 |
| UntilizeDeviceOperation |          1 |                        8828 |    8.828 |
| ManualSeedDeviceOperation|        70 |                       25039 |   25.039 |
| SamplingDeviceOperation |         32 |                       68475 |   68.475 |
+-------------------------+------------+-----------------------------+----------+
| Total                   |            |                      319741 |  319.741 |
+-------------------------+------------+-----------------------------+----------+
```


## Test plan
      - [x] Run `quad_teacher_forced`
      - [x] Run `quad_demo`
      - [x] Run `quad_demo_stress`
      
TF demo
```
+-----------+-----+----------------+----------------+
| Host Mode | UPR | Top-1 Accuracy | Top-5 Accuracy |
+-----------+-----+----------------+----------------+
| Quad      | 8   | 86.7%          | 99.2%          |
| Quad      | 32  | 86.7%          | 99.2%          |
+-----------+-----+----------------+----------------+
```
