### PR TITLE
relax PGD tray requirements to get AUS colo quad functional in CI

### DIFF
--- a/tt_metal/fabric/physical_grouping_descriptor_matching.cpp
+++ b/tt_metal/fabric/physical_grouping_descriptor_matching.cpp
@@ -14,6 +14,7 @@
 #include <queue>
 #include <memory>
 #include <cctype>
+#include <cstdlib>
 #include <functional>
 #include <optional>
 #include <tt_stl/fmt.hpp>
@@ -971,8 +972,20 @@ MappingResult<uint32_t, AsicID> solve_for_one_grouping_to_psd(
         global_location_traits[asic_id] = asic_location;
     }
 
+    // When set to 1, do not require PGD (tray_id, asic_location) on logical nodes to match UMD-reported ASIC
+    // positions. Use only when slot counts already match but the labeled graph has no embedding (e.g. host / tray
+    // order differs from PGD row-major). Host-alignment constraints below still apply. Bring-up only.
+    const char* relax_env = std::getenv("TT_METAL_RELAX_PGD_SLOT_CONSTRAINTS");
+    const bool relax_pgd_slot_traits = (relax_env != nullptr && relax_env[0] == '1');
+    if (relax_pgd_slot_traits) {
+        log_warning(
+            tt::LogFabric,
+            "TT_METAL_RELAX_PGD_SLOT_CONSTRAINTS=1: skipping PGD tray / ASIC-location trait constraints for "
+            "PGD→PSD embedding");
+    }
+
     // Add trait constraints for tray_id and asic_location
-    if (!target_tray_traits.empty() && !global_tray_traits.empty()) {
+    if (!relax_pgd_slot_traits && !target_tray_traits.empty() && !global_tray_traits.empty()) {
         if (!constraints.add_required_trait_constraint<TrayID>(target_tray_traits, global_tray_traits)) {
             MappingResult<uint32_t, AsicID> failure;
             failure.success = false;
@@ -980,7 +993,7 @@ MappingResult<uint32_t, AsicID> solve_for_one_grouping_to_psd(
             return failure;
         }
     }
-    if (!target_location_traits.empty() && !global_location_traits.empty()) {
+    if (!relax_pgd_slot_traits && !target_location_traits.empty() && !global_location_traits.empty()) {
         if (!constraints.add_required_trait_constraint<ASICLocation>(target_location_traits, global_location_traits)) {
             MappingResult<uint32_t, AsicID> failure;
             failure.success = false;


### PR DESCRIPTION
### Summary
Some mismatch between PGD ask for tray / ASIC locations and PSD. Relaxing the requirements got CCL test passing + deepseek demo. This was a new WH quad galaxy being brought up. Wiring is completely correct verified in person + internal adjacency graph is producing expected output. I've attached the log to see all misconfigured tray / ASIC locations. For now, it may be helpful to allow devs to pass in env variable to bypass this strict requirement (so we have more machines in dev/CI). After this change, requirements can be relaxed using: `export TT_METAL_RELAX_PGD_SLOT_CONSTRAINTS=1`. 

Some interesting logs (potentially highlight trays misordered?)  
[psd_host_tray_loc_sorted_2x2_default.txt](https://github.com/user-attachments/files/27188949/psd_host_tray_loc_sorted_2x2_default.txt)
[psd_host_tray_loc_sorted_4x1.txt](https://github.com/user-attachments/files/27188950/psd_host_tray_loc_sorted_4x1.txt)


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=relax-pgd-tray-req)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:relax-pgd-tray-req)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=relax-pgd-tray-req)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:relax-pgd-tray-req)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=relax-pgd-tray-req)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:relax-pgd-tray-req)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=relax-pgd-tray-req)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:relax-pgd-tray-req)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=relax-pgd-tray-req)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:relax-pgd-tray-req)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=relax-pgd-tray-req)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:relax-pgd-tray-req)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=relax-pgd-tray-req)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:relax-pgd-tray-req)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=relax-pgd-tray-req)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:relax-pgd-tray-req)