### PR TITLE
Fix Quasar NOC multicast: write MCAST_DESTS register

### DIFF
--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc/noc_parameters.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc/noc_parameters.h
@@ -455,6 +455,10 @@
 #define NOC_XY_PCIE_ENCODING(x, y) \
     ((uint64_t(NOC_XY_ENCODING(x, y)) << (NOC_ADDR_LOCAL_BITS - NOC_COORD_REG_OFFSET)) | 0x1000000000000000)
 
+#define NOC_MULTICAST_ENCODING(x_start, y_start, x_end, y_end)                                                         \
+    ((((uint32_t)(x_start)) << (2 * NOC_ADDR_NODE_ID_BITS)) | (((uint32_t)(y_start)) << (3 * NOC_ADDR_NODE_ID_BITS)) | \
+     (((uint32_t)(x_end))) | (((uint32_t)(y_end)) << (NOC_ADDR_NODE_ID_BITS)))
+
 // Quasar firmware currently uses BH-style encoding (X,Y coords embedded at bits 36+).
 // NOC_LOCAL_ADDR extracts the local offset (bits 0-35) for memory bounds validation.
 //

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
@@ -439,6 +439,12 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write(
         (uint32_t)(dest_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
         cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_LEN_BYTES_REG_OFFSET / 8, len_bytes);
+    if (mcast) {
+        // HW needs MCAST_DESTS to match the number of cores in the (start,end) rectangle
+        // so it can track per-destination acks for the multicast.
+        __builtin_riscv_ttrocc_cmdbuf_wr_reg(
+            cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_MCAST_DESTS_REG_OFFSET / 8, num_dests);
+    }
     __builtin_riscv_ttrocc_cmdbuf_issue_trans(cmd_buf);
 
     if constexpr (update_counter) {
@@ -487,6 +493,12 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_loopback_src(
         (uint32_t)(dest_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
         cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_LEN_BYTES_REG_OFFSET / 8, len_bytes);
+    if (mcast) {
+        // HW needs MCAST_DESTS to match the number of cores in the (start,end) rectangle
+        // so it can track per-destination acks for the multicast.
+        __builtin_riscv_ttrocc_cmdbuf_wr_reg(
+            cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_MCAST_DESTS_REG_OFFSET / 8, num_dests);
+    }
     __builtin_riscv_ttrocc_cmdbuf_issue_trans(cmd_buf);
 
     if constexpr (noc_mode == DM_DEDICATED_NOC) {
@@ -653,6 +665,12 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_multicast(
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(
         TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_DEST_COORD_REG_OFFSET / 8,
         (uint32_t)(dest_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
+    if (mcast) {
+        // HW needs MCAST_DESTS to match the number of cores in the (start,end) rectangle
+        // so it can track per-destination acks for the multicast.
+        __builtin_riscv_ttrocc_scmdbuf_wr_reg(
+            TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_MCAST_DESTS_REG_OFFSET / 8, num_dests);
+    }
     __builtin_riscv_ttrocc_scmdbuf_issue_inline_trans(val);
 
     if (posted) {
@@ -732,6 +750,9 @@ inline __attribute__((always_inline)) void noc_fast_multicast_atomic_increment(
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_LEN_BYTES_REG_OFFSET / 8, at_len);
     __builtin_riscv_ttrocc_scmdbuf_wr_reg(
         TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_INLINE_DATA_REG_OFFSET / 8, (uint64_t)incr);
+    // HW needs MCAST_DESTS to match the number of cores in the (start,end) rectangle
+    // so it can track per-destination acks for the multicast atomic.
+    __builtin_riscv_ttrocc_scmdbuf_wr_reg(TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_MCAST_DESTS_REG_OFFSET / 8, num_dests);
     __builtin_riscv_ttrocc_scmdbuf_issue_trans();
 
     if (!posted) {


### PR DESCRIPTION
### Summary
The Quasar overlay HW tracks per-destination acks via the `MCAST_DESTS` register (offset `0x108`). All four V2 multicast paths in `noc_nonblocking_api_v2.h` previously omitted this register write, so HW didn't know how many acks to expect — leading to multicast hangs / incorrect ack counting. 

Also adds `NOC_MULTICAST_ENCODING(x_start, y_start, x_end, y_end)` to `quasar/noc_parameters.h` to match the BH/WH macro. The encoding is bit-identical to BH (same `NOC_ADDR_NODE_ID_BITS=6` and same `DEST_COORD` register layout: `end_x[5:0] | end_y[11:6] | start_x[17:12] | start_y[23:18]`).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vvukomanovic/quasar-mcast-dests-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vvukomanovic/quasar-mcast-dests-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vvukomanovic/quasar-mcast-dests-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vvukomanovic/quasar-mcast-dests-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vvukomanovic/quasar-mcast-dests-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vvukomanovic/quasar-mcast-dests-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/quasar-mcast-dests-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/quasar-mcast-dests-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vvukomanovic/quasar-mcast-dests-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vvukomanovic/quasar-mcast-dests-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/quasar-mcast-dests-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/quasar-mcast-dests-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/quasar-mcast-dests-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/quasar-mcast-dests-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/quasar-mcast-dests-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/quasar-mcast-dests-fix)