### PR TITLE
Ring joint SDPA: mid-barrier on Q DRAM reads

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -1017,12 +1017,14 @@ void fetch_block(
     const uint32_t end_seq_tile,
     const uint32_t dst_addr,
     const uint32_t tile_bytes,
-    const bool transpose) {
+    const bool transpose,
+    const uint32_t barrier_threshold = 0) {
     const uint32_t src_rows = src_slice.get_d2_size();
     const uint32_t src_cols = src_slice.get_d3_size();
     uint32_t outer_ptr_stride = transpose ? tile_bytes : src_cols * tile_bytes;
     uint32_t inner_ptr_stride = transpose ? tile_bytes * src_rows : tile_bytes;
 
+    uint32_t barrier_count = 0;
     for (uint32_t row = 0; row < src_rows; ++row) {
         uint32_t write_ptr = dst_addr + row * outer_ptr_stride;
         for (uint32_t col = 0; col < src_cols; ++col) {
@@ -1035,6 +1037,10 @@ void fetch_block(
                 write_ptr);
 
             write_ptr += inner_ptr_stride;
+            if (barrier_threshold > 0 && ++barrier_count == barrier_threshold) {
+                noc_async_read_barrier();
+                barrier_count = 0;
+            }
         }
     }
     noc_async_read_barrier();
@@ -1047,10 +1053,12 @@ void read_block(
     const uint32_t end_seq_tile,
     const uint32_t cb_id,
     const uint32_t tile_bytes,
-    const bool transpose) {
+    const bool transpose,
+    const uint32_t barrier_threshold = 0) {
     const uint32_t num_tiles = src_slice.get_d2_size() * src_slice.get_d3_size();
     cb_reserve_back(cb_id, num_tiles);
-    fetch_block(cat_addr_generator, src_slice, end_seq_tile, get_write_ptr(cb_id), tile_bytes, transpose);
+    fetch_block(
+        cat_addr_generator, src_slice, end_seq_tile, get_write_ptr(cb_id), tile_bytes, transpose, barrier_threshold);
     cb_push_back(cb_id, num_tiles);
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -32,7 +32,7 @@ void kernel_main() {
     constexpr uint32_t is_causal = get_compile_time_arg_val(21);
     constexpr uint32_t is_balanced = get_compile_time_arg_val(22);
     constexpr bool use_zigzag_balancing = get_compile_time_arg_val(23) == 1;
-    constexpr uint32_t num_readers = get_compile_time_arg_val(25);
+    constexpr uint32_t num_q_readers = get_compile_time_arg_val(25);
 
     constexpr auto q_args = TensorAccessorArgs<26>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
@@ -137,7 +137,7 @@ void kernel_main() {
     constexpr uint32_t q_heads_per_k = NH / NHK;
 
     // Throttle Q DRAM reads so many readers don't saturate the NoC outstanding-read budget.
-    constexpr uint32_t q_barrier_threshold = get_barrier_read_threshold<q_tile_bytes, num_readers>();
+    constexpr uint32_t q_barrier_threshold = get_barrier_read_threshold<q_tile_bytes, num_q_readers>();
 
     const auto q_reader = TensorAccessor(q_args, q_addr);
     const auto local_k_reader = TensorAccessor(k_args, k_addr);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -32,8 +32,9 @@ void kernel_main() {
     constexpr uint32_t is_causal = get_compile_time_arg_val(21);
     constexpr uint32_t is_balanced = get_compile_time_arg_val(22);
     constexpr bool use_zigzag_balancing = get_compile_time_arg_val(23) == 1;
+    constexpr uint32_t num_readers = get_compile_time_arg_val(25);
 
-    constexpr auto q_args = TensorAccessorArgs<25>();
+    constexpr auto q_args = TensorAccessorArgs<26>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto gathered_k_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
@@ -134,6 +135,9 @@ void kernel_main() {
     constexpr uint32_t q_num_subblocks = Sq_chunk_t / qk_subblock_h;
     constexpr bool use_q_subblock_push = (q_num_subblocks > 1);
     constexpr uint32_t q_heads_per_k = NH / NHK;
+
+    // Throttle Q DRAM reads so many readers don't saturate the NoC outstanding-read budget.
+    constexpr uint32_t q_barrier_threshold = get_barrier_read_threshold<q_tile_bytes, num_readers>();
 
     const auto q_reader = TensorAccessor(q_args, q_addr);
     const auto local_k_reader = TensorAccessor(k_args, k_addr);
@@ -367,8 +371,8 @@ void kernel_main() {
                                 q_end_seq_tile,
                                 cb_q_in,
                                 q_tile_bytes,
-                                false /*transpose*/
-                            );
+                                false /*transpose*/,
+                                q_barrier_threshold);
                         }
                     } else {
                         read_block(
@@ -377,8 +381,8 @@ void kernel_main() {
                             q_end_seq_tile,
                             cb_q_in,
                             q_tile_bytes,
-                            false /*transpose*/
-                        );
+                            false /*transpose*/,
+                            q_barrier_threshold);
                     }
                     q_pushed = true;
                 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -417,6 +417,12 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     // Requires even num_q_chunks for symmetric light/heavy work distribution
     const bool enable_zigzag_balancing = args.is_balanced && args.is_causal && (num_q_chunks % 2 == 0);
 
+    // Cores actually issuing Q reads. When the flat q-chunk distribution is smaller
+    // than the grid the trailing cores get zero work; zigzag distributes pairs, so
+    // the unit count is total_pairs = all_heads_num_q_chunks / 2.
+    const uint32_t num_active_cores = enable_zigzag_balancing ? std::min(num_cores, all_heads_num_q_chunks / 2)
+                                                              : std::min(num_cores, all_heads_num_q_chunks);
+
     std::vector<uint32_t> reader_compile_time_args = {
         B,
         NH,
@@ -443,7 +449,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         args.is_balanced,
         static_cast<uint32_t>(enable_zigzag_balancing),
         static_cast<uint32_t>(use_streaming_compute),
-        num_cores,  // num_readers for get_barrier_read_threshold
+        num_active_cores,  // num_q_readers for get_barrier_read_threshold
     };
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -442,7 +442,9 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         args.is_causal,
         args.is_balanced,
         static_cast<uint32_t>(enable_zigzag_balancing),
-        static_cast<uint32_t>(use_streaming_compute)};
+        static_cast<uint32_t>(use_streaming_compute),
+        num_cores,  // num_readers for get_barrier_read_threshold
+    };
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args);


### PR DESCRIPTION
## Summary
Tightens the Q DRAM read throttling in the ring joint SDPA reader so many concurrent readers don't saturate the NoC outstanding-read budget. Adds an optional `barrier_threshold` to `fetch_block` / `read_block` and wires it into Q reads only (default off everywhere else).

## Problem
Before this change, Q reads in the reader issued a single `noc_async_read_barrier()` per Q-subblock fetch. For MLA that subblock is `DHt = 18` tiles per row — too large: when many cores read Q at the same q_chunk boundary, the in-flight read pool blew past what NoC can sustain and the exposed wallclock for Q DRAM reads dominated the hot path.

The mid-barrier issues an intermediate barrier every `barrier_threshold` tiles, with the threshold computed by `get_barrier_read_threshold<q_tile_bytes, num_readers>()`. K and V are unchanged (no observed contention there).

## Performance — `mla_100k`, q=160, k=320

Math util:

| HW / stack | Without mid-barrier | With mid-barrier | Δ |
|---|---|---|---|
| Quiet Box (BH 4-device single-ring), vanilla main | 41.5 % | 45.9 % | **+4.4 pp** |
| Quiet Box, full mcast stack (#42875) | 58.1 % | 58.5 % | +0.4 pp |
| Galaxy, full mcast stack (#42875) | 60.3 % | 61.0 % | +0.7 pp |

The gain is largest on vanilla main because K-chain mcast / streaming-compute optimizations from #42875 aren't present yet, so Q DRAM contention is the dominant exposed cost. Once #42875 lands, the mid-barrier still pulls a measurable +0.4–0.7 pp on top.

## Test plan

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-q-mid-barrier)](https://github.com/tenstorrent/tt-metal/actions/runs/25103833770)
- [x] [![Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-q-mid-barrier)](https://github.com/tenstorrent/tt-metal/actions/runs/25103842398) (sdpa only)
- [x] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-q-mid-barrier)](https://github.com/tenstorrent/tt-metal/actions/runs/25103835721)
- [x] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-q-mid-barrier)](https://github.com/tenstorrent/tt-metal/actions/runs/25154663020)
- [x] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-q-mid-barrier)](https://github.com/tenstorrent/tt-metal/actions/runs/25103838440)
- [x] [![(T3K) T3000 integration tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-q-mid-barrier)](https://github.com/tenstorrent/tt-metal/actions/runs/25103839758)
- [x] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-q-mid-barrier)](https://github.com/tenstorrent/tt-metal/actions/runs/25103841003)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-q-mid-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/ring-joint-sdpa-q-mid-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-q-mid-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/ring-joint-sdpa-q-mid-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-q-mid-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/ring-joint-sdpa-q-mid-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-q-mid-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/ring-joint-sdpa-q-mid-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-q-mid-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/ring-joint-sdpa-q-mid-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-q-mid-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/ring-joint-sdpa-q-mid-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-q-mid-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/ring-joint-sdpa-q-mid-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/ring-joint-sdpa-q-mid-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/ring-joint-sdpa-q-mid-barrier)