### PR TITLE
#41936: Fix unroll pragmas [FIX]

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
@@ -112,18 +112,18 @@ ALWI void piecewise_rational_eval_numer_denom(
     sfpi::vFloat denom = den_coeffs[DEN_DEGREE];
 
     if constexpr (NUM_DEGREE > DEN_DEGREE) {
-#pragma unroll
+#pragma GCC unroll 64
         for (int i = NUM_DEGREE - 1; i >= static_cast<int>(DEN_DEGREE); i--) {
             numer = numer * x + num_coeffs[i];
         }
     } else if constexpr (DEN_DEGREE > NUM_DEGREE) {
-#pragma unroll
+#pragma GCC unroll 64
         for (int i = DEN_DEGREE - 1; i >= static_cast<int>(NUM_DEGREE); i--) {
             denom = denom * x + den_coeffs[i];
         }
     }
 
-#pragma unroll
+#pragma GCC unroll 64
     for (int i = MIN_DEG - 1; i >= 0; i--) {
         numer = numer * x + num_coeffs[i];
         denom = denom * x + den_coeffs[i];
@@ -158,12 +158,12 @@ ALWI void piecewise_rational_eval_parity_numer_denom(
     sfpi::vFloat denom = den_coeffs[DEN_TOP];
 
     if constexpr (NUM_STEPS > DEN_STEPS) {
-#pragma unroll
+#pragma GCC unroll 64
         for (int k = 0; k < NUM_STEPS - DEN_STEPS; k++) {
             numer = numer * x2 + num_coeffs[NUM_TOP - 2 * (k + 1)];
         }
     } else if constexpr (DEN_STEPS > NUM_STEPS) {
-#pragma unroll
+#pragma GCC unroll 64
         for (int k = 0; k < DEN_STEPS - NUM_STEPS; k++) {
             denom = denom * x2 + den_coeffs[DEN_TOP - 2 * (k + 1)];
         }
@@ -173,7 +173,7 @@ ALWI void piecewise_rational_eval_parity_numer_denom(
     constexpr int NUM_POS = NUM_TOP - 2 * ((NUM_STEPS > DEN_STEPS) ? (NUM_STEPS - DEN_STEPS) : 0);
     constexpr int DEN_POS = DEN_TOP - 2 * ((DEN_STEPS > NUM_STEPS) ? (DEN_STEPS - NUM_STEPS) : 0);
 
-#pragma unroll
+#pragma GCC unroll 64
     for (int k = 1; k <= MIN_STEPS; k++) {
         numer = numer * x2 + num_coeffs[NUM_POS - 2 * k];
         denom = denom * x2 + den_coeffs[DEN_POS - 2 * k];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
@@ -112,18 +112,18 @@ ALWI void piecewise_rational_eval_numer_denom(
     sfpi::vFloat denom = den_coeffs[DEN_DEGREE];
 
     if constexpr (NUM_DEGREE > DEN_DEGREE) {
-#pragma unroll
+#pragma GCC unroll 64
         for (int i = NUM_DEGREE - 1; i >= static_cast<int>(DEN_DEGREE); i--) {
             numer = numer * x + num_coeffs[i];
         }
     } else if constexpr (DEN_DEGREE > NUM_DEGREE) {
-#pragma unroll
+#pragma GCC unroll 64
         for (int i = DEN_DEGREE - 1; i >= static_cast<int>(NUM_DEGREE); i--) {
             denom = denom * x + den_coeffs[i];
         }
     }
 
-#pragma unroll
+#pragma GCC unroll 64
     for (int i = MIN_DEG - 1; i >= 0; i--) {
         numer = numer * x + num_coeffs[i];
         denom = denom * x + den_coeffs[i];
@@ -158,12 +158,12 @@ ALWI void piecewise_rational_eval_parity_numer_denom(
     sfpi::vFloat denom = den_coeffs[DEN_TOP];
 
     if constexpr (NUM_STEPS > DEN_STEPS) {
-#pragma unroll
+#pragma GCC unroll 64
         for (int k = 0; k < NUM_STEPS - DEN_STEPS; k++) {
             numer = numer * x2 + num_coeffs[NUM_TOP - 2 * (k + 1)];
         }
     } else if constexpr (DEN_STEPS > NUM_STEPS) {
-#pragma unroll
+#pragma GCC unroll 64
         for (int k = 0; k < DEN_STEPS - NUM_STEPS; k++) {
             denom = denom * x2 + den_coeffs[DEN_TOP - 2 * (k + 1)];
         }
@@ -173,7 +173,7 @@ ALWI void piecewise_rational_eval_parity_numer_denom(
     constexpr int NUM_POS = NUM_TOP - 2 * ((NUM_STEPS > DEN_STEPS) ? (NUM_STEPS - DEN_STEPS) : 0);
     constexpr int DEN_POS = DEN_TOP - 2 * ((DEN_STEPS > NUM_STEPS) ? (DEN_STEPS - NUM_STEPS) : 0);
 
-#pragma unroll
+#pragma GCC unroll 64
     for (int k = 1; k <= MIN_STEPS; k++) {
         numer = numer * x2 + num_coeffs[NUM_POS - 2 * k];
         denom = denom * x2 + den_coeffs[DEN_POS - 2 * k];


### PR DESCRIPTION
### Summary
These pragmas are not recognized, so it was always relying on the compiler's heuristic, which happened to work.
The compiler never warned, because that warning was not enabled.
A compiler change caused some of these loops to no longer unroll

Perhaps we should add `-Wall` to the compilation options to catch this kind of thing?

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/digamma-41936)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/digamma-41936)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/digamma-41936)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/digamma-41936)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/digamma-41936)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/digamma-41936)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/digamma-41936)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/digamma-41936)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/digamma-41936)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/digamma-41936)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/digamma-41936)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/digamma-41936)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/digamma-41936)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/digamma-41936)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/digamma-41936)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/digamma-41936)