### PR TITLE
Fix DeepSeekV3 B1 teacher forcing accuracy script

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -5,8 +5,6 @@
 from __future__ import annotations
 
 import argparse
-import contextlib
-import os
 import sys
 import time
 from pathlib import Path
@@ -16,59 +14,10 @@ from loguru import logger
 from transformers import AutoTokenizer
 
 import ttnn
-from conftest import bh_2d_mesh_device_context
+from models.demos.deepseek_v3_b1.demo.mesh_device_context import open_mesh_device
 from models.demos.deepseek_v3_b1.demo.model_pipeline import ModelPipeline
-from models.demos.deepseek_v3_b1.demo.pipeline import create_fabric_router_config
 
 DEFAULT_TOKENIZER = "deepseek-ai/DeepSeek-R1-0528"
-
-
-def _fabric_config_for_num_procs(num_procs: int):
-    """Infer fabric config from process count: 4 → FABRIC_2D, 16 → FABRIC_2D_TORUS_Y."""
-    if num_procs == 4:
-        return ttnn.FabricConfig.FABRIC_2D
-    if num_procs == 16:
-        return ttnn.FabricConfig.FABRIC_2D_TORUS_Y
-    if num_procs == 64:
-        return ttnn.FabricConfig.FABRIC_2D_TORUS_Y
-    raise ValueError(f"Unsupported num_procs for fabric config: {num_procs} (expected 4, 16, or 64)")
-
-
-def _needs_extended_worker_l1(num_procs: int) -> bool:
-    """True for the one host that required extra L1 (``TT_MESH_ID`` from tt-run, or legacy global rank).
-
-    For 4×16 pod layouts, tt-run sets ``TT_MESH_ID=3`` on the mesh that replaced global rank 62.
-    With only mesh id, single-mesh 16-proc cannot be identified via env (all ranks share the same id),
-    so the rank fallback is used for 16 procs.
-    """
-    mid = os.environ.get("TT_MESH_ID")
-    if num_procs == 64:
-        return int(mid) == 62
-    if num_procs == 16:
-        return int(mid) == 14
-    return False
-
-
-@contextlib.contextmanager
-def open_mesh_device():
-    """Open mesh device using bh_2d_mesh_device_context (pod pipeline settings)."""
-    num_procs = int(ttnn.distributed_context_get_size())
-    worker_l1_size = 1499000 if _needs_extended_worker_l1(num_procs) else 1431568
-    if not os.environ.get("TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"):
-        os.environ["TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"] = "30000"
-    device_params = {
-        "fabric_config": _fabric_config_for_num_procs(num_procs),
-        "fabric_router_config": create_fabric_router_config(15232),
-        "worker_l1_size": worker_l1_size,
-    }
-    logger.info("Opening mesh device...")
-    with bh_2d_mesh_device_context(device_params) as mesh_device:
-        logger.info(
-            "Mesh device opened (id={}, shape={})",
-            mesh_device.get_system_mesh_id(),
-            mesh_device.shape,
-        )
-        yield mesh_device
 
 
 def create_parser() -> argparse.ArgumentParser:

--- a/models/demos/deepseek_v3_b1/demo/mesh_device_context.py
+++ b/models/demos/deepseek_v3_b1/demo/mesh_device_context.py
@@ -14,7 +14,7 @@ from conftest import bh_2d_mesh_device_context
 from models.demos.deepseek_v3_b1.demo.pipeline import create_fabric_router_config
 
 TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS_DEFAULT = "30000"
-FABRIC_ROUTER_ETH_PORT = 15232
+FABRIC_PACKET_SIZE_BYTES = 15232
 
 # TODO: Store these values inside the stages and fetch based on pipeline config
 DEFAULT_WORKER_L1_SIZE = 1431568
@@ -72,7 +72,7 @@ def open_mesh_device():
     worker_l1_size = _worker_l1_size_for_rank(num_procs=num_procs)
     device_params = {
         "fabric_config": _fabric_config_for_num_procs(num_procs),
-        "fabric_router_config": create_fabric_router_config(FABRIC_ROUTER_ETH_PORT),
+        "fabric_router_config": create_fabric_router_config(FABRIC_PACKET_SIZE_BYTES),
         "worker_l1_size": worker_l1_size,
     }
 

--- a/models/demos/deepseek_v3_b1/demo/mesh_device_context.py
+++ b/models/demos/deepseek_v3_b1/demo/mesh_device_context.py
@@ -14,20 +14,12 @@ from conftest import bh_2d_mesh_device_context
 from models.demos.deepseek_v3_b1.demo.pipeline import create_fabric_router_config
 
 TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS_DEFAULT = "30000"
-
-# Ethernet port used to initialize fabric router coordination.
 FABRIC_ROUTER_ETH_PORT = 15232
 
-# Default worker L1 size (bytes) for most ranks in pod pipeline demo runs.
+# TODO: Store these values inside the stages and fetch based on pipeline config
 DEFAULT_WORKER_L1_SIZE = 1431568
-
-# Larger worker L1 size (bytes) for LM-head/tail ranks that need extra L1.
 LM_HEAD_WORKER_L1_SIZE = 1499000
-
-# Mesh rank using LM-head/tail stage in 64-process topology.
 LM_HEAD_RANK_64_PROCS = 62
-
-# Mesh rank using LM-head/tail stage in 16-process topology.
 LM_HEAD_RANK_16_PROCS = 14
 
 

--- a/models/demos/deepseek_v3_b1/demo/mesh_device_context.py
+++ b/models/demos/deepseek_v3_b1/demo/mesh_device_context.py
@@ -32,11 +32,32 @@ def _fabric_config_for_num_procs(num_procs: int):
     raise ValueError(f"Unsupported num_procs for fabric config: {num_procs} (expected 4, 16, or 64)")
 
 
-def _worker_l1_size_for_rank(num_procs: int, my_rank: int) -> int:
+def _needs_extended_worker_l1(num_procs: int) -> bool:
+    """Return true when this worker must use the larger L1 budget.
+
+    TT_MESH_ID must be provided by launch tooling for 16/64-proc runs.
+    """
+    mesh_id = os.environ.get("TT_MESH_ID")
+    target_rank = None
+    if num_procs == 64:
+        target_rank = LM_HEAD_RANK_64_PROCS
+    elif num_procs == 16:
+        target_rank = LM_HEAD_RANK_16_PROCS
+    else:
+        return False
+
+    if mesh_id is None:
+        raise RuntimeError("TT_MESH_ID must be set for 16/64-process runs to select worker_l1_size")
+
+    try:
+        return int(mesh_id) == target_rank
+    except ValueError as exc:
+        raise RuntimeError(f"Invalid TT_MESH_ID={mesh_id!r}; expected an integer") from exc
+
+
+def _worker_l1_size_for_rank(num_procs: int) -> int:
     """Select worker L1 size for rank-specific LM-head memory requirements."""
-    if num_procs == 64 and my_rank == LM_HEAD_RANK_64_PROCS:
-        return LM_HEAD_WORKER_L1_SIZE
-    if num_procs == 16 and my_rank == LM_HEAD_RANK_16_PROCS:
+    if _needs_extended_worker_l1(num_procs=num_procs):
         return LM_HEAD_WORKER_L1_SIZE
     return DEFAULT_WORKER_L1_SIZE
 
@@ -47,9 +68,8 @@ def open_mesh_device():
     if not os.environ.get("TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"):
         os.environ["TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"] = TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS_DEFAULT
 
-    my_rank = int(ttnn.distributed_context_get_rank())
     num_procs = int(ttnn.distributed_context_get_size())
-    worker_l1_size = _worker_l1_size_for_rank(num_procs=num_procs, my_rank=my_rank)
+    worker_l1_size = _worker_l1_size_for_rank(num_procs=num_procs)
     device_params = {
         "fabric_config": _fabric_config_for_num_procs(num_procs),
         "fabric_router_config": create_fabric_router_config(FABRIC_ROUTER_ETH_PORT),

--- a/models/demos/deepseek_v3_b1/demo/mesh_device_context.py
+++ b/models/demos/deepseek_v3_b1/demo/mesh_device_context.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import contextlib
+import os
+
+from loguru import logger
+
+import ttnn
+from conftest import bh_2d_mesh_device_context
+from models.demos.deepseek_v3_b1.demo.pipeline import create_fabric_router_config
+
+TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS_DEFAULT = "30000"
+
+# Ethernet port used to initialize fabric router coordination.
+FABRIC_ROUTER_ETH_PORT = 15232
+
+# Default worker L1 size (bytes) for most ranks in pod pipeline demo runs.
+DEFAULT_WORKER_L1_SIZE = 1431568
+
+# Larger worker L1 size (bytes) for LM-head/tail ranks that need extra L1.
+LM_HEAD_WORKER_L1_SIZE = 1499000
+
+# Mesh rank using LM-head/tail stage in 64-process topology.
+LM_HEAD_RANK_64_PROCS = 62
+
+# Mesh rank using LM-head/tail stage in 16-process topology.
+LM_HEAD_RANK_16_PROCS = 14
+
+
+def _fabric_config_for_num_procs(num_procs: int):
+    """Infer fabric config from process count: 4 → FABRIC_2D, 16/64 → FABRIC_2D_TORUS_Y."""
+    if num_procs == 4:
+        return ttnn.FabricConfig.FABRIC_2D
+    if num_procs in (16, 64):
+        return ttnn.FabricConfig.FABRIC_2D_TORUS_Y
+    raise ValueError(f"Unsupported num_procs for fabric config: {num_procs} (expected 4, 16, or 64)")
+
+
+def _worker_l1_size_for_rank(num_procs: int, my_rank: int) -> int:
+    """Select worker L1 size for rank-specific LM-head memory requirements."""
+    if num_procs == 64 and my_rank == LM_HEAD_RANK_64_PROCS:
+        return LM_HEAD_WORKER_L1_SIZE
+    if num_procs == 16 and my_rank == LM_HEAD_RANK_16_PROCS:
+        return LM_HEAD_WORKER_L1_SIZE
+    return DEFAULT_WORKER_L1_SIZE
+
+
+@contextlib.contextmanager
+def open_mesh_device():
+    """Open mesh device for pod demos with shared fabric and worker L1 settings."""
+    if not os.environ.get("TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"):
+        os.environ["TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"] = TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS_DEFAULT
+
+    my_rank = int(ttnn.distributed_context_get_rank())
+    num_procs = int(ttnn.distributed_context_get_size())
+    worker_l1_size = _worker_l1_size_for_rank(num_procs=num_procs, my_rank=my_rank)
+    device_params = {
+        "fabric_config": _fabric_config_for_num_procs(num_procs),
+        "fabric_router_config": create_fabric_router_config(FABRIC_ROUTER_ETH_PORT),
+        "worker_l1_size": worker_l1_size,
+    }
+
+    logger.info("Opening mesh device...")
+    with bh_2d_mesh_device_context(device_params) as mesh_device:
+        logger.info(
+            "Mesh device opened (id={}, shape={})",
+            mesh_device.get_system_mesh_id(),
+            mesh_device.shape,
+        )
+        yield mesh_device

--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -10,7 +10,6 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-import torch
 from loguru import logger
 from transformers import AutoTokenizer
 
@@ -112,6 +111,7 @@ class ModelPipeline:
         self.pipeline.setup_and_run()
 
         self._page_size_datums = page_size_bytes(1) // TOKEN_ID_BYTES
+        self.position_id: int | None = None
         self.model: DeepSeekV3 | None = None
         if self.pipeline.my_stage_idx == 0:
             self.model = DeepSeekV3(
@@ -144,6 +144,7 @@ class ModelPipeline:
             for i in range(len(tokens))
         ]
         results = self.model.prefill(prompt_token_tensors)
+        self.position_id = len(tokens)
         logger.debug(f"Done prefilling with {len(tokens)} tokens.")
         return results
 
@@ -152,14 +153,20 @@ class ModelPipeline:
         if self.pipeline.my_stage_idx != 0:
             raise RuntimeError("decode_forward() should only be called on mesh id 0")
         assert self.model is not None
+        if self.position_id is None:
+            raise RuntimeError("decode_forward() requires prefill_forward() to be called first")
 
-        output = self.model.decode_step(
-            to_spec_input(input_token, user_id=0, position_id=self.position_id, page_size_datums=self._page_size_datums)
+        self.model.write_input(
+            input_token,
+            -1,
+            user_id=0,
+            position_id=self.position_id,
+            token_type=TokenType.BASE,
         )
+        result = self.model.read_result()
         self.position_id += 1
 
-        next_token_id = int(ttnn.to_torch(output).to(torch.int32)[0, 0].item())
-        return next_token_id
+        return result.token_0
 
     def _write_spec_pair(self, token_0: int, pos_0: int, token_1: int, pos_1: int, user_id: int = 0) -> None:
         """Write two tokens (base + speculation) into the pipeline."""

--- a/models/demos/deepseek_v3_b1/demo/teacher_forced.py
+++ b/models/demos/deepseek_v3_b1/demo/teacher_forced.py
@@ -7,9 +7,7 @@
 from __future__ import annotations
 
 import argparse
-import contextlib
 import json
-import os
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -19,9 +17,8 @@ from loguru import logger
 from transformers import AutoTokenizer
 
 import ttnn
-from conftest import bh_2d_mesh_device_context
+from models.demos.deepseek_v3_b1.demo.mesh_device_context import open_mesh_device
 from models.demos.deepseek_v3_b1.demo.model_pipeline import ModelPipeline
-from models.demos.deepseek_v3_b1.demo.pipeline import create_fabric_router_config
 
 DEFAULT_TOKENIZER = "deepseek-ai/DeepSeek-R1-0528"
 
@@ -146,7 +143,11 @@ def run_teacher_forced(
     per_position_match: list[bool] = []
     stopped_early_predicted_eos = False
 
-    pred = model_pipeline.prefill_forward(prompt_token_ids)
+    prefill_results = model_pipeline.prefill_forward(prompt_token_ids)
+    if not prefill_results:
+        raise RuntimeError("prefill_forward() returned no DecodeResults")
+
+    pred = prefill_results[0].token_0
     predicted_token_ids.append(pred)
     per_position_match.append(pred == effective_ref[0])
     if eos_token_id is not None and pred == eos_token_id:
@@ -185,38 +186,6 @@ def run_teacher_forced(
         per_chunk_accuracy=per_chunk,
         chunk_accuracy_token_size=chunk_sz,
     )
-
-
-def _fabric_config_for_num_procs(num_procs: int):
-    """Infer fabric config from process count: 4 → FABRIC_2D, 16 → FABRIC_2D_TORUS_Y."""
-    if num_procs == 4:
-        return ttnn.FabricConfig.FABRIC_2D
-    if num_procs == 16:
-        return ttnn.FabricConfig.FABRIC_2D_TORUS_Y
-    if num_procs == 64:
-        return ttnn.FabricConfig.FABRIC_2D_TORUS_Y
-    raise ValueError(f"Unsupported num_procs for fabric config: {num_procs} (expected 4, 16, or 64)")
-
-
-@contextlib.contextmanager
-def open_mesh_device():
-    """Open mesh device using bh_2d_mesh_device_context (pod pipeline settings)."""
-    if not os.environ.get("TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"):
-        os.environ["TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"] = "30000"
-    num_procs = int(ttnn.distributed_context_get_size())
-    device_params = {
-        "fabric_config": _fabric_config_for_num_procs(num_procs),
-        "fabric_router_config": create_fabric_router_config(15232),
-        "worker_l1_size": 1431568,
-    }
-    logger.info("Opening mesh device...")
-    with bh_2d_mesh_device_context(device_params) as mesh_device:
-        logger.info(
-            "Mesh device opened (id={}, shape={})",
-            mesh_device.get_system_mesh_id(),
-            mesh_device.shape,
-        )
-        yield mesh_device
 
 
 def create_parser() -> argparse.ArgumentParser:


### PR DESCRIPTION
### Summary

This pull request fixes the existing teacher forcing script to work correctly with the recent speculative decode improvements. 

It also commonizes the mesh device context setup and improves the model pipeline's decode logic.

### What's Changed

* Extracted all mesh device context logic (including environment variable setup, device parameters, and rank-specific L1 sizing) into a new module, `mesh_device_context.py`, with clear constants and helper functions for maintainability and reuse. The `open_mesh_device` context manager is now imported from this module in both `cli.py` and `teacher_forced.py`, replacing duplicated code. [[1]](diffhunk://#diff-7daacc00eb3437b677cbd265521d88bf250a47a601a3e0c72e04fadee4ab253eR1-R74) [[2]](diffhunk://#diff-b5a805c38bfaad6b32e44a92e79c50496b943dfca25d36fd011672e188257da2L19-L66) [[3]](diffhunk://#diff-4b1a32b98880e77549888d1d62e4a0d22d16dcb3eee16fe72536666c0522e754L22-L24) [[4]](diffhunk://#diff-b5a805c38bfaad6b32e44a92e79c50496b943dfca25d36fd011672e188257da2L8-L9) [[5]](diffhunk://#diff-4b1a32b98880e77549888d1d62e4a0d22d16dcb3eee16fe72536666c0522e754L10-L12) [[6]](diffhunk://#diff-4b1a32b98880e77549888d1d62e4a0d22d16dcb3eee16fe72536666c0522e754L190-L221)

* Refactored `ModelPipeline.decode_forward` to maintain and increment an internal `position_id` state, require `prefill_forward` to be called first, and use explicit `write_input`/`read_result` calls for decoding, improving correctness and clarity. [[1]](diffhunk://#diff-dee5e70b801c96fb26a6d0e98d534fb86d5ceb581b7233488bce4421fce1dbd7R114) [[2]](diffhunk://#diff-dee5e70b801c96fb26a6d0e98d534fb86d5ceb581b7233488bce4421fce1dbd7R147) [[3]](diffhunk://#diff-dee5e70b801c96fb26a6d0e98d534fb86d5ceb581b7233488bce4421fce1dbd7R156-R169)
* Updated `prefill_forward` to set the initial `position_id` after prefilling, ensuring correct sequence state for subsequent decoding.

* Updated `teacher_forced.py` to use the new `open_mesh_device` context and improved error handling for empty prefill results. [[1]](diffhunk://#diff-4b1a32b98880e77549888d1d62e4a0d22d16dcb3eee16fe72536666c0522e754L22-L24) [[2]](diffhunk://#diff-4b1a32b98880e77549888d1d62e4a0d22d16dcb3eee16fe72536666c0522e754L149-R150)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=esmal/fix-teacher-forcing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmal/fix-teacher-forcing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=esmal/fix-teacher-forcing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:esmal/fix-teacher-forcing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmal/fix-teacher-forcing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/fix-teacher-forcing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmal/fix-teacher-forcing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/fix-teacher-forcing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=esmal/fix-teacher-forcing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:esmal/fix-teacher-forcing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=esmal/fix-teacher-forcing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/fix-teacher-forcing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=esmal/fix-teacher-forcing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/fix-teacher-forcing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=esmal/fix-teacher-forcing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/fix-teacher-forcing)