### PR TITLE
[SpecDecode] [V3] add host FSM logic tests for spec decode

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -237,7 +237,7 @@ class ModelPipeline:
 
             # logger.debug("Got MD from Device: ")
             # logger.debug(f"Token 0 Pos: {result.token_0_pos}, Token 1 Pos: {result.token_1_pos}")
-            # logger.debug(f"Token 0 Type: {result.token_0_type}, Token 1 Type: {result.token_1_type}")
+            # logger.debug(f"Token Type: {result.token_type}")
             # logger.debug(
             #     f"Token 0: {tokenizer.decode([result.token_0], skip_special_tokens=False)}, Token 1: {tokenizer.decode([result.token_1], skip_special_tokens=False)}"
             # )
@@ -249,7 +249,7 @@ class ModelPipeline:
                 num_emits += 1
                 # logger.debug("Prefill done")
             else:
-                if result.token_0_type == TokenType.BASE:
+                if result.token_type == TokenType.BASE:
                     # On acceptance, we check that the base token matches the first token of the last unverified spec token
                     if result.token_0 == unverified_spec_tokens[-1]:
                         verified_spec_tokens.append(unverified_spec_tokens.pop())
@@ -269,7 +269,7 @@ class ModelPipeline:
                         num_emits += 1
                         signal_to_exit = is_eos(result.token_0) or len(generated_tokens) >= max_new_tokens
 
-                if result.token_0_type == TokenType.SPEC:
+                if result.token_type == TokenType.SPEC:
                     # If we have a verified spec token it means we have an acceptance case, remove it and emit the token
                     if verified_spec_tokens:
                         verified_spec_tokens.pop()
@@ -303,6 +303,13 @@ class ModelPipeline:
         while num_reads < num_writes:
             self.model.read_result()
             num_reads += 1
+
+        accepted_spec_tokens = base_accept
+        rejected_spec_tokens = base_reject
+        self.last_inference_stats = {
+            "num_accepts": accepted_spec_tokens,
+            "num_rejects": rejected_spec_tokens,
+        }
 
         end_time = time.time()
         logger.debug(f"Time taken: {end_time - start_time} seconds")

--- a/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/kernels/lm_head_sampling_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/kernels/lm_head_sampling_kernel.cpp
@@ -640,32 +640,28 @@ void kernel_main() {
             mcast;
 
     uint32_t iteration_count = 0;
-    constexpr uint32_t TOKEN_TYPE_BASE = 0;
-    constexpr uint32_t TOKEN_TYPE_SPEC = 1;
-
 #if defined(COMPILE_FOR_BRISC)
     // Pack up to 2 tokens into a single TOKEN_META page (64 bytes) in the given CB.
-    // Layout: [num_tokens, tok0_id, tok0_type, tok0_pos, tok1_id, tok1_type, tok1_pos, ...]
+    // Layout: [token_type, tok0_id, tok0_pos, tok1_id, tok1_pos, slot_id, token_id, position_id, ...]
     auto write_token_metadata_to_socket_cb = [](uint32_t cb,
+                                                uint32_t token_type,
                                                 uint32_t tok0_id,
-                                                uint32_t tok0_type,
                                                 uint32_t tok0_pos,
                                                 uint32_t tok1_id = 0,
-                                                uint32_t tok1_type = 0,
                                                 uint32_t tok1_pos = 0,
                                                 uint32_t input_pos_id = 0,
                                                 uint32_t slot_id = 0) {
         cb_reserve_back(cb, 1);
         volatile tt_l1_ptr uint32_t* page = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb));
-        page[0] = tok0_id;
-        page[1] = tok0_type;
+        page[0] = token_type;
+        page[1] = tok0_id;
         page[2] = tok0_pos;
         page[3] = tok1_id;
-        page[4] = tok1_type;
-        page[5] = tok1_pos;
-        page[6] = slot_id;
-        page[7] = 0; // input token id
-        page[8] = input_pos_id;
+        page[4] = tok1_pos;
+        page[5] = slot_id;
+        page[6] = 0;  // input token id
+        page[7] = input_pos_id;
+        page[8] = 0;  // prefill token id
         cb_push_back(cb, 1);
     };
 #endif
@@ -1029,7 +1025,7 @@ void kernel_main() {
 
             // Write token metadata to gather destination CB
             invalidate_l1_cache();
-            uint32_t base_token_type = metadata_ptr->tok0_type;
+            uint32_t token_type = metadata_ptr->token_type;
             uint32_t base_token_pos = metadata_ptr->position_id;
             uint32_t input_pos_id = metadata_ptr->tok0_pos + 1;
             uint32_t slot_id = metadata_ptr->slot_id;
@@ -1044,7 +1040,7 @@ void kernel_main() {
             cb_wait_front(argmax_socket_cb, 1);
             uint32_t base_token_id = *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(argmax_socket_cb));
             write_token_metadata_to_socket_cb(
-                eh_gather_dst_cb, base_token_id, base_token_type, base_token_pos, 0, 0, 0, input_pos_id, slot_id);
+                eh_gather_dst_cb, token_type, base_token_id, base_token_pos, 0, 0, input_pos_id, slot_id);
             cb_pop_front(argmax_socket_cb, 1);
         }
 #endif
@@ -1060,7 +1056,7 @@ void kernel_main() {
     // writes a TOKEN_META page with both tokens back to CB 6.
     //
     // Metadata layout from base stage (at metadata_output_l1_addr):
-    //   [0] = num_tokens, [1] = tok0_id, [2] = tok0_type, [3] = tok0_pos, ...
+    //   [0] = token_type, [1] = tok0_id, [2] = tok0_pos, [3] = tok1_id, [4] = tok1_pos, ...
     // ========================================================================
     auto update_speculative_state = [&]() {
 #if defined(COMPILE_FOR_BRISC)
@@ -1085,10 +1081,9 @@ void kernel_main() {
                 reinterpret_cast<volatile tt_l1_ptr deepseek_b1_ops::DeepseekMetadata*>(metadata_output_l1_addr);
             invalidate_l1_cache();
             uint32_t base_token_id = metadata_ptr->tok0_id;
-            uint32_t base_token_type = metadata_ptr->tok0_type;
+            uint32_t token_type = metadata_ptr->token_type;
             uint32_t base_token_pos = metadata_ptr->tok0_pos + 1;
             uint32_t slot_id = metadata_ptr->slot_id;
-            uint32_t spec_token_type = TOKEN_TYPE_SPEC;
             uint32_t spec_token_pos = metadata_ptr->tok0_pos + 2;
             uint32_t input_pos_id = metadata_ptr->position_id;
             cb_pop_front(argmax_socket_cb, 1);
@@ -1096,11 +1091,10 @@ void kernel_main() {
             // Push the base and speculative tokens to the argmax socket CB that will be written to the socket later
             write_token_metadata_to_socket_cb(
                 argmax_socket_cb,
+                token_type,
                 base_token_id,
-                base_token_type,
                 base_token_pos,
                 spec_token_id,
-                spec_token_type,
                 spec_token_pos,
                 input_pos_id,
                 slot_id);

--- a/models/demos/deepseek_v3_b1/metadata/metadata.hpp
+++ b/models/demos/deepseek_v3_b1/metadata/metadata.hpp
@@ -11,11 +11,10 @@ namespace deepseek_b1_ops {
 
 struct DeepseekMetadata {
     // Output fields
+    uint32_t token_type;
     uint32_t tok0_id;
-    uint32_t tok0_type;
     uint32_t tok0_pos;
     uint32_t tok1_id;
-    uint32_t tok1_type;
     uint32_t tok1_pos;
     // Input fields
     uint32_t slot_id;

--- a/models/demos/deepseek_v3_b1/metadata/metadata.py
+++ b/models/demos/deepseek_v3_b1/metadata/metadata.py
@@ -13,11 +13,10 @@ import ttnn
 class DeepseekMetadata:
     FIELD_SIZE_BYTES = 4  # Each field is uint32_t
 
+    token_type: int = 0
     tok0_id: int = 0
-    tok0_type: int = 0
     tok0_pos: int = 0
     tok1_id: int = 0
-    tok1_type: int = 0
     tok1_pos: int = 0
     slot_id: int = 0
     token_id: int = 0

--- a/models/demos/deepseek_v3_b1/model.py
+++ b/models/demos/deepseek_v3_b1/model.py
@@ -50,22 +50,21 @@ PCIE_PAGE_ALIGNMENT_BYTES: int = 64
 class OutputField:
     """uint32 indices within the 16-word output page."""
 
-    TOKEN_0 = 0
-    TOKEN_0_TYPE = 1
+    TOKEN_TYPE = 0
+    TOKEN_0 = 1
     TOKEN_0_POS = 2
     TOKEN_1 = 3
-    TOKEN_1_TYPE = 4
-    TOKEN_1_POS = 5
+    TOKEN_1_POS = 4
 
 
 class InputField:
     """uint32 indices within the 16-word input page."""
 
-    TOKEN_TYPE = 1
-    USER_ID = 6
-    TOKEN_ID = 7
-    POSITION_ID = 8
-    PREFILL_TOKEN_ID = 9
+    TOKEN_TYPE = 0
+    USER_ID = 5
+    TOKEN_ID = 6
+    POSITION_ID = 7
+    PREFILL_TOKEN_ID = 8
     TOKEN0_POSITION_ID = 2
 
 
@@ -79,10 +78,9 @@ class DecodeResult:
     """Parsed output page from the pipeline."""
 
     token_0: int
-    token_0_type: int
+    token_type: int
     token_0_pos: int
     token_1: int | None = None
-    token_1_type: int | None = None
     token_1_pos: int | None = None
     slot_id: int | None = None
 
@@ -92,10 +90,9 @@ def parse_output_page(output_buffer: ttnn.Tensor) -> DecodeResult:
     raw = ttnn.to_torch(output_buffer).to(torch.int32).flatten()
     return DecodeResult(
         token_0=int(raw[OutputField.TOKEN_0].item()),
-        token_0_type=int(raw[OutputField.TOKEN_0_TYPE].item()),
+        token_type=int(raw[OutputField.TOKEN_TYPE].item()),
         token_0_pos=int(raw[OutputField.TOKEN_0_POS].item()),
         token_1=int(raw[OutputField.TOKEN_1].item()),
-        token_1_type=int(raw[OutputField.TOKEN_1_TYPE].item()),
         token_1_pos=int(raw[OutputField.TOKEN_1_POS].item()),
         slot_id=int(raw[InputField.USER_ID].item()),
     )

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/reference_data/reference_trace_spec_decode_128_tokens.json
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/reference_data/reference_trace_spec_decode_128_tokens.json
@@ -1,0 +1,2690 @@
+{
+  "schema_version": 1,
+  "name": "spec_decode_host_fsm_case",
+  "metadata": {
+    "num_accepts": 62,
+    "num_rejects": 4
+  },
+  "params": {
+    "prompt_token_ids": [
+      0,
+      128803,
+      21750,
+      260,
+      3107,
+      15255,
+      2019,
+      396,
+      10340,
+      270,
+      48941,
+      26509,
+      1167,
+      16,
+      128804
+    ],
+    "max_new_tokens": 128,
+    "eos_token_id": 1
+  },
+  "device_to_host": {
+    "prefill_results": [
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 128798,
+          "pos": 15
+        },
+        "token_1": {
+          "token_id": 201,
+          "pos": 16
+        }
+      }
+    ],
+    "read_results": [
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 201,
+          "pos": 16
+        },
+        "token_1": {
+          "token_id": 2581,
+          "pos": 17
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 2581,
+          "pos": 17
+        },
+        "token_1": {
+          "token_id": 477,
+          "pos": 18
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 477,
+          "pos": 18
+        },
+        "token_1": {
+          "token_id": 2887,
+          "pos": 19
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 2887,
+          "pos": 19
+        },
+        "token_1": {
+          "token_id": 304,
+          "pos": 20
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 304,
+          "pos": 20
+        },
+        "token_1": {
+          "token_id": 5085,
+          "pos": 21
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 5085,
+          "pos": 21
+        },
+        "token_1": {
+          "token_id": 260,
+          "pos": 22
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 260,
+          "pos": 22
+        },
+        "token_1": {
+          "token_id": 2019,
+          "pos": 23
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 2019,
+          "pos": 23
+        },
+        "token_1": {
+          "token_id": 396,
+          "pos": 24
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 396,
+          "pos": 24
+        },
+        "token_1": {
+          "token_id": 10340,
+          "pos": 25
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 10340,
+          "pos": 25
+        },
+        "token_1": {
+          "token_id": 270,
+          "pos": 26
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 270,
+          "pos": 26
+        },
+        "token_1": {
+          "token_id": 48941,
+          "pos": 27
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 48941,
+          "pos": 27
+        },
+        "token_1": {
+          "token_id": 26509,
+          "pos": 28
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 26509,
+          "pos": 28
+        },
+        "token_1": {
+          "token_id": 1167,
+          "pos": 29
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 1167,
+          "pos": 29
+        },
+        "token_1": {
+          "token_id": 603,
+          "pos": 30
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 603,
+          "pos": 30
+        },
+        "token_1": {
+          "token_id": 455,
+          "pos": 31
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 455,
+          "pos": 31
+        },
+        "token_1": {
+          "token_id": 26509,
+          "pos": 32
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 26509,
+          "pos": 32
+        },
+        "token_1": {
+          "token_id": 8205,
+          "pos": 33
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 8205,
+          "pos": 33
+        },
+        "token_1": {
+          "token_id": 344,
+          "pos": 34
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 344,
+          "pos": 34
+        },
+        "token_1": {
+          "token_id": 6428,
+          "pos": 35
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 6428,
+          "pos": 35
+        },
+        "token_1": {
+          "token_id": 412,
+          "pos": 36
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 412,
+          "pos": 36
+        },
+        "token_1": {
+          "token_id": 1137,
+          "pos": 37
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 1137,
+          "pos": 37
+        },
+        "token_1": {
+          "token_id": 262,
+          "pos": 38
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 262,
+          "pos": 38
+        },
+        "token_1": {
+          "token_id": 447,
+          "pos": 39
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 447,
+          "pos": 39
+        },
+        "token_1": {
+          "token_id": 10,
+          "pos": 40
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 10,
+          "pos": 40
+        },
+        "token_1": {
+          "token_id": 18,
+          "pos": 41
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 18,
+          "pos": 41
+        },
+        "token_1": {
+          "token_id": 11,
+          "pos": 42
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 11,
+          "pos": 42
+        },
+        "token_1": {
+          "token_id": 438,
+          "pos": 43
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 438,
+          "pos": 43
+        },
+        "token_1": {
+          "token_id": 223,
+          "pos": 44
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 223,
+          "pos": 44
+        },
+        "token_1": {
+          "token_id": 18,
+          "pos": 45
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 18,
+          "pos": 45
+        },
+        "token_1": {
+          "token_id": 201,
+          "pos": 46
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 201,
+          "pos": 46
+        },
+        "token_1": {
+          "token_id": 262,
+          "pos": 47
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 262,
+          "pos": 47
+        },
+        "token_1": {
+          "token_id": 447,
+          "pos": 48
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 447,
+          "pos": 48
+        },
+        "token_1": {
+          "token_id": 10,
+          "pos": 49
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 10,
+          "pos": 49
+        },
+        "token_1": {
+          "token_id": 19,
+          "pos": 50
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 19,
+          "pos": 50
+        },
+        "token_1": {
+          "token_id": 11,
+          "pos": 51
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 11,
+          "pos": 51
+        },
+        "token_1": {
+          "token_id": 438,
+          "pos": 52
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 438,
+          "pos": 52
+        },
+        "token_1": {
+          "token_id": 223,
+          "pos": 53
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 223,
+          "pos": 53
+        },
+        "token_1": {
+          "token_id": 19,
+          "pos": 54
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 19,
+          "pos": 54
+        },
+        "token_1": {
+          "token_id": 201,
+          "pos": 55
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 201,
+          "pos": 55
+        },
+        "token_1": {
+          "token_id": 262,
+          "pos": 56
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 262,
+          "pos": 56
+        },
+        "token_1": {
+          "token_id": 447,
+          "pos": 57
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 447,
+          "pos": 57
+        },
+        "token_1": {
+          "token_id": 3913,
+          "pos": 58
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 3913,
+          "pos": 58
+        },
+        "token_1": {
+          "token_id": 11,
+          "pos": 59
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 11,
+          "pos": 59
+        },
+        "token_1": {
+          "token_id": 438,
+          "pos": 60
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 438,
+          "pos": 60
+        },
+        "token_1": {
+          "token_id": 447,
+          "pos": 61
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 447,
+          "pos": 61
+        },
+        "token_1": {
+          "token_id": 3913,
+          "pos": 62
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 3913,
+          "pos": 62
+        },
+        "token_1": {
+          "token_id": 15,
+          "pos": 63
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 15,
+          "pos": 63
+        },
+        "token_1": {
+          "token_id": 19,
+          "pos": 64
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 19,
+          "pos": 64
+        },
+        "token_1": {
+          "token_id": 11,
+          "pos": 65
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 11,
+          "pos": 65
+        },
+        "token_1": {
+          "token_id": 940,
+          "pos": 66
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 940,
+          "pos": 66
+        },
+        "token_1": {
+          "token_id": 447,
+          "pos": 67
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 447,
+          "pos": 67
+        },
+        "token_1": {
+          "token_id": 3913,
+          "pos": 68
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 3913,
+          "pos": 68
+        },
+        "token_1": {
+          "token_id": 15,
+          "pos": 69
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 15,
+          "pos": 69
+        },
+        "token_1": {
+          "token_id": 20,
+          "pos": 70
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 20,
+          "pos": 70
+        },
+        "token_1": {
+          "token_id": 11,
+          "pos": 71
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 11,
+          "pos": 71
+        },
+        "token_1": {
+          "token_id": 362,
+          "pos": 72
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 362,
+          "pos": 72
+        },
+        "token_1": {
+          "token_id": 313,
+          "pos": 73
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 313,
+          "pos": 73
+        },
+        "token_1": {
+          "token_id": 1955,
+          "pos": 74
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 1955,
+          "pos": 74
+        },
+        "token_1": {
+          "token_id": 223,
+          "pos": 75
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 223,
+          "pos": 75
+        },
+        "token_1": {
+          "token_id": 19,
+          "pos": 76
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 19,
+          "pos": 76
+        },
+        "token_1": {
+          "token_id": 271,
+          "pos": 77
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 271,
+          "pos": 77
+        },
+        "token_1": {
+          "token_id": 1350,
+          "pos": 78
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 1350,
+          "pos": 78
+        },
+        "token_1": {
+          "token_id": 588,
+          "pos": 79
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 588,
+          "pos": 79
+        },
+        "token_1": {
+          "token_id": 1347,
+          "pos": 80
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 1347,
+          "pos": 80
+        },
+        "token_1": {
+          "token_id": 411,
+          "pos": 81
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 411,
+          "pos": 81
+        },
+        "token_1": {
+          "token_id": 58112,
+          "pos": 82
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 58112,
+          "pos": 82
+        },
+        "token_1": {
+          "token_id": 4090,
+          "pos": 83
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 4090,
+          "pos": 83
+        },
+        "token_1": {
+          "token_id": 304,
+          "pos": 84
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 362,
+          "pos": 84
+        },
+        "token_1": {
+          "token_id": 9062,
+          "pos": 85
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 9062,
+          "pos": 85
+        },
+        "token_1": {
+          "token_id": 343,
+          "pos": 86
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 9062,
+          "pos": 85
+        },
+        "token_1": {
+          "token_id": 343,
+          "pos": 86
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 343,
+          "pos": 86
+        },
+        "token_1": {
+          "token_id": 49,
+          "pos": 87
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 1495,
+          "pos": 87
+        },
+        "token_1": {
+          "token_id": 5789,
+          "pos": 88
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 5789,
+          "pos": 88
+        },
+        "token_1": {
+          "token_id": 270,
+          "pos": 89
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 5789,
+          "pos": 88
+        },
+        "token_1": {
+          "token_id": 270,
+          "pos": 89
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 270,
+          "pos": 89
+        },
+        "token_1": {
+          "token_id": 78157,
+          "pos": 90
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 33732,
+          "pos": 90
+        },
+        "token_1": {
+          "token_id": 1014,
+          "pos": 91
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 1014,
+          "pos": 91
+        },
+        "token_1": {
+          "token_id": 294,
+          "pos": 92
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 1014,
+          "pos": 91
+        },
+        "token_1": {
+          "token_id": 294,
+          "pos": 92
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 294,
+          "pos": 92
+        },
+        "token_1": {
+          "token_id": 78157,
+          "pos": 93
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 78157,
+          "pos": 93
+        },
+        "token_1": {
+          "token_id": 2503,
+          "pos": 94
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 2503,
+          "pos": 94
+        },
+        "token_1": {
+          "token_id": 50363,
+          "pos": 95
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 50363,
+          "pos": 95
+        },
+        "token_1": {
+          "token_id": 1878,
+          "pos": 96
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 1878,
+          "pos": 96
+        },
+        "token_1": {
+          "token_id": 5772,
+          "pos": 97
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 5772,
+          "pos": 97
+        },
+        "token_1": {
+          "token_id": 3211,
+          "pos": 98
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 3211,
+          "pos": 98
+        },
+        "token_1": {
+          "token_id": 14,
+          "pos": 99
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 14,
+          "pos": 99
+        },
+        "token_1": {
+          "token_id": 7155,
+          "pos": 100
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 7155,
+          "pos": 100
+        },
+        "token_1": {
+          "token_id": 396,
+          "pos": 101
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 396,
+          "pos": 101
+        },
+        "token_1": {
+          "token_id": 270,
+          "pos": 102
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 270,
+          "pos": 102
+        },
+        "token_1": {
+          "token_id": 3295,
+          "pos": 103
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 3295,
+          "pos": 103
+        },
+        "token_1": {
+          "token_id": 4230,
+          "pos": 104
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 4230,
+          "pos": 104
+        },
+        "token_1": {
+          "token_id": 582,
+          "pos": 105
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 582,
+          "pos": 105
+        },
+        "token_1": {
+          "token_id": 31150,
+          "pos": 106
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 31150,
+          "pos": 106
+        },
+        "token_1": {
+          "token_id": 1760,
+          "pos": 107
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 1760,
+          "pos": 107
+        },
+        "token_1": {
+          "token_id": 832,
+          "pos": 108
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 832,
+          "pos": 108
+        },
+        "token_1": {
+          "token_id": 579,
+          "pos": 109
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 579,
+          "pos": 109
+        },
+        "token_1": {
+          "token_id": 2786,
+          "pos": 110
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 2786,
+          "pos": 110
+        },
+        "token_1": {
+          "token_id": 990,
+          "pos": 111
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 990,
+          "pos": 111
+        },
+        "token_1": {
+          "token_id": 2255,
+          "pos": 112
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 2255,
+          "pos": 112
+        },
+        "token_1": {
+          "token_id": 260,
+          "pos": 113
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 260,
+          "pos": 113
+        },
+        "token_1": {
+          "token_id": 4654,
+          "pos": 114
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 4654,
+          "pos": 114
+        },
+        "token_1": {
+          "token_id": 50494,
+          "pos": 115
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 50494,
+          "pos": 115
+        },
+        "token_1": {
+          "token_id": 4630,
+          "pos": 116
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 4630,
+          "pos": 116
+        },
+        "token_1": {
+          "token_id": 855,
+          "pos": 117
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 855,
+          "pos": 117
+        },
+        "token_1": {
+          "token_id": 313,
+          "pos": 118
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 313,
+          "pos": 118
+        },
+        "token_1": {
+          "token_id": 344,
+          "pos": 119
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 344,
+          "pos": 119
+        },
+        "token_1": {
+          "token_id": 2395,
+          "pos": 120
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 2395,
+          "pos": 120
+        },
+        "token_1": {
+          "token_id": 603,
+          "pos": 121
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 2755,
+          "pos": 121
+        },
+        "token_1": {
+          "token_id": 2275,
+          "pos": 122
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 2275,
+          "pos": 122
+        },
+        "token_1": {
+          "token_id": 270,
+          "pos": 123
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 2275,
+          "pos": 122
+        },
+        "token_1": {
+          "token_id": 270,
+          "pos": 123
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 270,
+          "pos": 123
+        },
+        "token_1": {
+          "token_id": 3295,
+          "pos": 124
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 3295,
+          "pos": 124
+        },
+        "token_1": {
+          "token_id": 5354,
+          "pos": 125
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 5354,
+          "pos": 125
+        },
+        "token_1": {
+          "token_id": 1664,
+          "pos": 126
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 1664,
+          "pos": 126
+        },
+        "token_1": {
+          "token_id": 23708,
+          "pos": 127
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 23708,
+          "pos": 127
+        },
+        "token_1": {
+          "token_id": 270,
+          "pos": 128
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 270,
+          "pos": 128
+        },
+        "token_1": {
+          "token_id": 3291,
+          "pos": 129
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 3291,
+          "pos": 129
+        },
+        "token_1": {
+          "token_id": 294,
+          "pos": 130
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 294,
+          "pos": 130
+        },
+        "token_1": {
+          "token_id": 313,
+          "pos": 131
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 313,
+          "pos": 131
+        },
+        "token_1": {
+          "token_id": 14,
+          "pos": 132
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 14,
+          "pos": 132
+        },
+        "token_1": {
+          "token_id": 832,
+          "pos": 133
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 832,
+          "pos": 133
+        },
+        "token_1": {
+          "token_id": 579,
+          "pos": 134
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 579,
+          "pos": 134
+        },
+        "token_1": {
+          "token_id": 1531,
+          "pos": 135
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 1531,
+          "pos": 135
+        },
+        "token_1": {
+          "token_id": 366,
+          "pos": 136
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 366,
+          "pos": 136
+        },
+        "token_1": {
+          "token_id": 8281,
+          "pos": 137
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 8281,
+          "pos": 137
+        },
+        "token_1": {
+          "token_id": 339,
+          "pos": 138
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 339,
+          "pos": 138
+        },
+        "token_1": {
+          "token_id": 4480,
+          "pos": 139
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 4480,
+          "pos": 139
+        },
+        "token_1": {
+          "token_id": 734,
+          "pos": 140
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 734,
+          "pos": 140
+        },
+        "token_1": {
+          "token_id": 696,
+          "pos": 141
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 696,
+          "pos": 141
+        },
+        "token_1": {
+          "token_id": 58112,
+          "pos": 142
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 58112,
+          "pos": 142
+        },
+        "token_1": {
+          "token_id": 362,
+          "pos": 143
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 362,
+          "pos": 143
+        },
+        "token_1": {
+          "token_id": 2993,
+          "pos": 144
+        }
+      }
+    ]
+  },
+  "expected_host": {
+    "generated_tokens": [
+      128798,
+      201,
+      2581,
+      477,
+      2887,
+      304,
+      5085,
+      260,
+      2019,
+      396,
+      10340,
+      270,
+      48941,
+      26509,
+      1167,
+      603,
+      455,
+      26509,
+      8205,
+      344,
+      6428,
+      412,
+      1137,
+      262,
+      447,
+      10,
+      18,
+      11,
+      438,
+      223,
+      18,
+      201,
+      262,
+      447,
+      10,
+      19,
+      11,
+      438,
+      223,
+      19,
+      201,
+      262,
+      447,
+      3913,
+      11,
+      438,
+      447,
+      3913,
+      15,
+      19,
+      11,
+      940,
+      447,
+      3913,
+      15,
+      20,
+      11,
+      362,
+      313,
+      1955,
+      223,
+      19,
+      271,
+      1350,
+      588,
+      1347,
+      411,
+      58112,
+      4090,
+      362,
+      9062,
+      343,
+      1495,
+      5789,
+      270,
+      33732,
+      1014,
+      294,
+      78157,
+      2503,
+      50363,
+      1878,
+      5772,
+      3211,
+      14,
+      7155,
+      396,
+      270,
+      3295,
+      4230,
+      582,
+      31150,
+      1760,
+      832,
+      579,
+      2786,
+      990,
+      2255,
+      260,
+      4654,
+      50494,
+      4630,
+      855,
+      313,
+      344,
+      2395,
+      2755,
+      2275,
+      270,
+      3295,
+      5354,
+      1664,
+      23708,
+      270,
+      3291,
+      294,
+      313,
+      14,
+      832,
+      579,
+      1531,
+      366,
+      8281,
+      339,
+      4480,
+      734,
+      696,
+      58112
+    ],
+    "writes": [
+      {
+        "token_id": 128798,
+        "type": "BASE",
+        "pos": 15,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 201,
+        "type": "SPEC",
+        "pos": 16,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2581,
+        "type": "BASE",
+        "pos": 17,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 477,
+        "type": "SPEC",
+        "pos": 18,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2887,
+        "type": "BASE",
+        "pos": 19,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 304,
+        "type": "SPEC",
+        "pos": 20,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 5085,
+        "type": "BASE",
+        "pos": 21,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 260,
+        "type": "SPEC",
+        "pos": 22,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2019,
+        "type": "BASE",
+        "pos": 23,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 396,
+        "type": "SPEC",
+        "pos": 24,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 10340,
+        "type": "BASE",
+        "pos": 25,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 270,
+        "type": "SPEC",
+        "pos": 26,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 48941,
+        "type": "BASE",
+        "pos": 27,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 26509,
+        "type": "SPEC",
+        "pos": 28,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1167,
+        "type": "BASE",
+        "pos": 29,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 603,
+        "type": "SPEC",
+        "pos": 30,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 455,
+        "type": "BASE",
+        "pos": 31,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 26509,
+        "type": "SPEC",
+        "pos": 32,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 8205,
+        "type": "BASE",
+        "pos": 33,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 344,
+        "type": "SPEC",
+        "pos": 34,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 6428,
+        "type": "BASE",
+        "pos": 35,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 412,
+        "type": "SPEC",
+        "pos": 36,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1137,
+        "type": "BASE",
+        "pos": 37,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 262,
+        "type": "SPEC",
+        "pos": 38,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 447,
+        "type": "BASE",
+        "pos": 39,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 10,
+        "type": "SPEC",
+        "pos": 40,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 18,
+        "type": "BASE",
+        "pos": 41,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 11,
+        "type": "SPEC",
+        "pos": 42,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 438,
+        "type": "BASE",
+        "pos": 43,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 223,
+        "type": "SPEC",
+        "pos": 44,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 18,
+        "type": "BASE",
+        "pos": 45,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 201,
+        "type": "SPEC",
+        "pos": 46,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 262,
+        "type": "BASE",
+        "pos": 47,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 447,
+        "type": "SPEC",
+        "pos": 48,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 10,
+        "type": "BASE",
+        "pos": 49,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 19,
+        "type": "SPEC",
+        "pos": 50,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 11,
+        "type": "BASE",
+        "pos": 51,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 438,
+        "type": "SPEC",
+        "pos": 52,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 223,
+        "type": "BASE",
+        "pos": 53,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 19,
+        "type": "SPEC",
+        "pos": 54,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 201,
+        "type": "BASE",
+        "pos": 55,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 262,
+        "type": "SPEC",
+        "pos": 56,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 447,
+        "type": "BASE",
+        "pos": 57,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 3913,
+        "type": "SPEC",
+        "pos": 58,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 11,
+        "type": "BASE",
+        "pos": 59,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 438,
+        "type": "SPEC",
+        "pos": 60,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 447,
+        "type": "BASE",
+        "pos": 61,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 3913,
+        "type": "SPEC",
+        "pos": 62,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 15,
+        "type": "BASE",
+        "pos": 63,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 19,
+        "type": "SPEC",
+        "pos": 64,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 11,
+        "type": "BASE",
+        "pos": 65,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 940,
+        "type": "SPEC",
+        "pos": 66,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 447,
+        "type": "BASE",
+        "pos": 67,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 3913,
+        "type": "SPEC",
+        "pos": 68,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 15,
+        "type": "BASE",
+        "pos": 69,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 20,
+        "type": "SPEC",
+        "pos": 70,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 11,
+        "type": "BASE",
+        "pos": 71,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 362,
+        "type": "SPEC",
+        "pos": 72,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 313,
+        "type": "BASE",
+        "pos": 73,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1955,
+        "type": "SPEC",
+        "pos": 74,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 223,
+        "type": "BASE",
+        "pos": 75,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 19,
+        "type": "SPEC",
+        "pos": 76,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 271,
+        "type": "BASE",
+        "pos": 77,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1350,
+        "type": "SPEC",
+        "pos": 78,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 588,
+        "type": "BASE",
+        "pos": 79,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1347,
+        "type": "SPEC",
+        "pos": 80,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 411,
+        "type": "BASE",
+        "pos": 81,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 58112,
+        "type": "SPEC",
+        "pos": 82,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 4090,
+        "type": "BASE",
+        "pos": 83,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 304,
+        "type": "SPEC",
+        "pos": 84,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 362,
+        "type": "BASE",
+        "pos": 84,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 9062,
+        "type": "SPEC",
+        "pos": 85,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 343,
+        "type": "BASE",
+        "pos": 86,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 49,
+        "type": "SPEC",
+        "pos": 87,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1495,
+        "type": "BASE",
+        "pos": 87,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 5789,
+        "type": "SPEC",
+        "pos": 88,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 270,
+        "type": "BASE",
+        "pos": 89,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 78157,
+        "type": "SPEC",
+        "pos": 90,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 33732,
+        "type": "BASE",
+        "pos": 90,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1014,
+        "type": "SPEC",
+        "pos": 91,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 294,
+        "type": "BASE",
+        "pos": 92,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 78157,
+        "type": "SPEC",
+        "pos": 93,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2503,
+        "type": "BASE",
+        "pos": 94,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 50363,
+        "type": "SPEC",
+        "pos": 95,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1878,
+        "type": "BASE",
+        "pos": 96,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 5772,
+        "type": "SPEC",
+        "pos": 97,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 3211,
+        "type": "BASE",
+        "pos": 98,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 14,
+        "type": "SPEC",
+        "pos": 99,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 7155,
+        "type": "BASE",
+        "pos": 100,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 396,
+        "type": "SPEC",
+        "pos": 101,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 270,
+        "type": "BASE",
+        "pos": 102,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 3295,
+        "type": "SPEC",
+        "pos": 103,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 4230,
+        "type": "BASE",
+        "pos": 104,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 582,
+        "type": "SPEC",
+        "pos": 105,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 31150,
+        "type": "BASE",
+        "pos": 106,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1760,
+        "type": "SPEC",
+        "pos": 107,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 832,
+        "type": "BASE",
+        "pos": 108,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 579,
+        "type": "SPEC",
+        "pos": 109,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2786,
+        "type": "BASE",
+        "pos": 110,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 990,
+        "type": "SPEC",
+        "pos": 111,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2255,
+        "type": "BASE",
+        "pos": 112,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 260,
+        "type": "SPEC",
+        "pos": 113,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 4654,
+        "type": "BASE",
+        "pos": 114,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 50494,
+        "type": "SPEC",
+        "pos": 115,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 4630,
+        "type": "BASE",
+        "pos": 116,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 855,
+        "type": "SPEC",
+        "pos": 117,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 313,
+        "type": "BASE",
+        "pos": 118,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 344,
+        "type": "SPEC",
+        "pos": 119,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2395,
+        "type": "BASE",
+        "pos": 120,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 603,
+        "type": "SPEC",
+        "pos": 121,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2755,
+        "type": "BASE",
+        "pos": 121,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2275,
+        "type": "SPEC",
+        "pos": 122,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 270,
+        "type": "BASE",
+        "pos": 123,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 3295,
+        "type": "SPEC",
+        "pos": 124,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 5354,
+        "type": "BASE",
+        "pos": 125,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1664,
+        "type": "SPEC",
+        "pos": 126,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 23708,
+        "type": "BASE",
+        "pos": 127,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 270,
+        "type": "SPEC",
+        "pos": 128,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 3291,
+        "type": "BASE",
+        "pos": 129,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 294,
+        "type": "SPEC",
+        "pos": 130,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 313,
+        "type": "BASE",
+        "pos": 131,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 14,
+        "type": "SPEC",
+        "pos": 132,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 832,
+        "type": "BASE",
+        "pos": 133,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 579,
+        "type": "SPEC",
+        "pos": 134,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1531,
+        "type": "BASE",
+        "pos": 135,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 366,
+        "type": "SPEC",
+        "pos": 136,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 8281,
+        "type": "BASE",
+        "pos": 137,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 339,
+        "type": "SPEC",
+        "pos": 138,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 4480,
+        "type": "BASE",
+        "pos": 139,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 734,
+        "type": "SPEC",
+        "pos": 140,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 696,
+        "type": "BASE",
+        "pos": 141,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 58112,
+        "type": "SPEC",
+        "pos": 142,
+        "user_id": 0,
+        "prefill_id": -1
+      }
+    ],
+    "read_count": 132
+  }
+}

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/reference_data/reference_trace_spec_decode_128_tokens_prompt2.json
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/reference_data/reference_trace_spec_decode_128_tokens_prompt2.json
@@ -1,0 +1,2775 @@
+{
+  "schema_version": 1,
+  "name": "spec_decode_host_fsm_case",
+  "metadata": {
+    "num_accepts": 60,
+    "num_rejects": 8
+  },
+  "params": {
+    "prompt_token_ids": [
+      0,
+      128803,
+      65106,
+      270,
+      6672,
+      6461,
+      23916,
+      8947,
+      14,
+      2622,
+      3939,
+      436,
+      344,
+      832,
+      2239,
+      305,
+      1205,
+      1482,
+      2915,
+      78740,
+      943,
+      436,
+      16,
+      128804
+    ],
+    "max_new_tokens": 128,
+    "eos_token_id": 1
+  },
+  "device_to_host": {
+    "prefill_results": [
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 128798,
+          "pos": 24
+        },
+        "token_1": {
+          "token_id": 201,
+          "pos": 25
+        }
+      }
+    ],
+    "read_results": [
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 201,
+          "pos": 25
+        },
+        "token_1": {
+          "token_id": 33001,
+          "pos": 26
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 33001,
+          "pos": 26
+        },
+        "token_1": {
+          "token_id": 14,
+          "pos": 27
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 14,
+          "pos": 27
+        },
+        "token_1": {
+          "token_id": 270,
+          "pos": 28
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 270,
+          "pos": 28
+        },
+        "token_1": {
+          "token_id": 3967,
+          "pos": 29
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 3967,
+          "pos": 29
+        },
+        "token_1": {
+          "token_id": 10059,
+          "pos": 30
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 10059,
+          "pos": 30
+        },
+        "token_1": {
+          "token_id": 260,
+          "pos": 31
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 260,
+          "pos": 31
+        },
+        "token_1": {
+          "token_id": 4521,
+          "pos": 32
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 4521,
+          "pos": 32
+        },
+        "token_1": {
+          "token_id": 11394,
+          "pos": 33
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 11394,
+          "pos": 33
+        },
+        "token_1": {
+          "token_id": 294,
+          "pos": 34
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 294,
+          "pos": 34
+        },
+        "token_1": {
+          "token_id": 270,
+          "pos": 35
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 270,
+          "pos": 35
+        },
+        "token_1": {
+          "token_id": 10252,
+          "pos": 36
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 10252,
+          "pos": 36
+        },
+        "token_1": {
+          "token_id": 55840,
+          "pos": 37
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 55840,
+          "pos": 37
+        },
+        "token_1": {
+          "token_id": 26364,
+          "pos": 38
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 26364,
+          "pos": 38
+        },
+        "token_1": {
+          "token_id": 343,
+          "pos": 39
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 343,
+          "pos": 39
+        },
+        "token_1": {
+          "token_id": 8272,
+          "pos": 40
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 8272,
+          "pos": 40
+        },
+        "token_1": {
+          "token_id": 54,
+          "pos": 41
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 54,
+          "pos": 41
+        },
+        "token_1": {
+          "token_id": 754,
+          "pos": 42
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 754,
+          "pos": 42
+        },
+        "token_1": {
+          "token_id": 1009,
+          "pos": 43
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 1009,
+          "pos": 43
+        },
+        "token_1": {
+          "token_id": 7176,
+          "pos": 44
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 7176,
+          "pos": 44
+        },
+        "token_1": {
+          "token_id": 14,
+          "pos": 45
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 14,
+          "pos": 45
+        },
+        "token_1": {
+          "token_id": 305,
+          "pos": 46
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 305,
+          "pos": 46
+        },
+        "token_1": {
+          "token_id": 2953,
+          "pos": 47
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 2953,
+          "pos": 47
+        },
+        "token_1": {
+          "token_id": 99378,
+          "pos": 48
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 99378,
+          "pos": 48
+        },
+        "token_1": {
+          "token_id": 16,
+          "pos": 49
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 16,
+          "pos": 49
+        },
+        "token_1": {
+          "token_id": 4480,
+          "pos": 50
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 4480,
+          "pos": 50
+        },
+        "token_1": {
+          "token_id": 678,
+          "pos": 51
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 678,
+          "pos": 51
+        },
+        "token_1": {
+          "token_id": 1904,
+          "pos": 52
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 1904,
+          "pos": 52
+        },
+        "token_1": {
+          "token_id": 513,
+          "pos": 53
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 513,
+          "pos": 53
+        },
+        "token_1": {
+          "token_id": 96703,
+          "pos": 54
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 96703,
+          "pos": 54
+        },
+        "token_1": {
+          "token_id": 1205,
+          "pos": 55
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 1205,
+          "pos": 55
+        },
+        "token_1": {
+          "token_id": 270,
+          "pos": 56
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 270,
+          "pos": 56
+        },
+        "token_1": {
+          "token_id": 15449,
+          "pos": 57
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 15449,
+          "pos": 57
+        },
+        "token_1": {
+          "token_id": 54,
+          "pos": 58
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 54,
+          "pos": 58
+        },
+        "token_1": {
+          "token_id": 5756,
+          "pos": 59
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 5756,
+          "pos": 59
+        },
+        "token_1": {
+          "token_id": 16,
+          "pos": 60
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 16,
+          "pos": 60
+        },
+        "token_1": {
+          "token_id": 983,
+          "pos": 61
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 983,
+          "pos": 61
+        },
+        "token_1": {
+          "token_id": 734,
+          "pos": 62
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 734,
+          "pos": 62
+        },
+        "token_1": {
+          "token_id": 943,
+          "pos": 63
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 943,
+          "pos": 63
+        },
+        "token_1": {
+          "token_id": 270,
+          "pos": 64
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 270,
+          "pos": 64
+        },
+        "token_1": {
+          "token_id": 6380,
+          "pos": 65
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 6380,
+          "pos": 65
+        },
+        "token_1": {
+          "token_id": 294,
+          "pos": 66
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 294,
+          "pos": 66
+        },
+        "token_1": {
+          "token_id": 6810,
+          "pos": 67
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 6810,
+          "pos": 67
+        },
+        "token_1": {
+          "token_id": 3189,
+          "pos": 68
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 3189,
+          "pos": 68
+        },
+        "token_1": {
+          "token_id": 32634,
+          "pos": 69
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 32634,
+          "pos": 69
+        },
+        "token_1": {
+          "token_id": 260,
+          "pos": 70
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 260,
+          "pos": 70
+        },
+        "token_1": {
+          "token_id": 5374,
+          "pos": 71
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 5374,
+          "pos": 71
+        },
+        "token_1": {
+          "token_id": 6380,
+          "pos": 72
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 6380,
+          "pos": 72
+        },
+        "token_1": {
+          "token_id": 412,
+          "pos": 73
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 412,
+          "pos": 73
+        },
+        "token_1": {
+          "token_id": 6810,
+          "pos": 74
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 6810,
+          "pos": 74
+        },
+        "token_1": {
+          "token_id": 3701,
+          "pos": 75
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 3701,
+          "pos": 75
+        },
+        "token_1": {
+          "token_id": 9347,
+          "pos": 76
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 9347,
+          "pos": 76
+        },
+        "token_1": {
+          "token_id": 14,
+          "pos": 77
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 14,
+          "pos": 77
+        },
+        "token_1": {
+          "token_id": 17883,
+          "pos": 78
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 17883,
+          "pos": 78
+        },
+        "token_1": {
+          "token_id": 294,
+          "pos": 79
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 294,
+          "pos": 79
+        },
+        "token_1": {
+          "token_id": 270,
+          "pos": 80
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 270,
+          "pos": 80
+        },
+        "token_1": {
+          "token_id": 5185,
+          "pos": 81
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 5185,
+          "pos": 81
+        },
+        "token_1": {
+          "token_id": 734,
+          "pos": 82
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 734,
+          "pos": 82
+        },
+        "token_1": {
+          "token_id": 6380,
+          "pos": 83
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 6380,
+          "pos": 83
+        },
+        "token_1": {
+          "token_id": 16,
+          "pos": 84
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 16,
+          "pos": 84
+        },
+        "token_1": {
+          "token_id": 1004,
+          "pos": 85
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 2275,
+          "pos": 85
+        },
+        "token_1": {
+          "token_id": 3939,
+          "pos": 86
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 3939,
+          "pos": 86
+        },
+        "token_1": {
+          "token_id": 344,
+          "pos": 87
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 3939,
+          "pos": 86
+        },
+        "token_1": {
+          "token_id": 344,
+          "pos": 87
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 344,
+          "pos": 87
+        },
+        "token_1": {
+          "token_id": 396,
+          "pos": 88
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 396,
+          "pos": 88
+        },
+        "token_1": {
+          "token_id": 2239,
+          "pos": 89
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 2239,
+          "pos": 89
+        },
+        "token_1": {
+          "token_id": 1240,
+          "pos": 90
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 33,
+          "pos": 90
+        },
+        "token_1": {
+          "token_id": 17519,
+          "pos": 91
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 17519,
+          "pos": 91
+        },
+        "token_1": {
+          "token_id": 270,
+          "pos": 92
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 17519,
+          "pos": 91
+        },
+        "token_1": {
+          "token_id": 270,
+          "pos": 92
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 270,
+          "pos": 92
+        },
+        "token_1": {
+          "token_id": 3967,
+          "pos": 93
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 3967,
+          "pos": 93
+        },
+        "token_1": {
+          "token_id": 4086,
+          "pos": 94
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 4086,
+          "pos": 94
+        },
+        "token_1": {
+          "token_id": 566,
+          "pos": 95
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 566,
+          "pos": 95
+        },
+        "token_1": {
+          "token_id": 362,
+          "pos": 96
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 362,
+          "pos": 96
+        },
+        "token_1": {
+          "token_id": 260,
+          "pos": 97
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 260,
+          "pos": 97
+        },
+        "token_1": {
+          "token_id": 38701,
+          "pos": 98
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 38701,
+          "pos": 98
+        },
+        "token_1": {
+          "token_id": 1312,
+          "pos": 99
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 1312,
+          "pos": 99
+        },
+        "token_1": {
+          "token_id": 469,
+          "pos": 100
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 469,
+          "pos": 100
+        },
+        "token_1": {
+          "token_id": 260,
+          "pos": 101
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 2041,
+          "pos": 101
+        },
+        "token_1": {
+          "token_id": 27609,
+          "pos": 102
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 27609,
+          "pos": 102
+        },
+        "token_1": {
+          "token_id": 4762,
+          "pos": 103
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 27609,
+          "pos": 102
+        },
+        "token_1": {
+          "token_id": 4762,
+          "pos": 103
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 4762,
+          "pos": 103
+        },
+        "token_1": {
+          "token_id": 16,
+          "pos": 104
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 16,
+          "pos": 104
+        },
+        "token_1": {
+          "token_id": 2359,
+          "pos": 105
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 2359,
+          "pos": 105
+        },
+        "token_1": {
+          "token_id": 2786,
+          "pos": 106
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 2786,
+          "pos": 106
+        },
+        "token_1": {
+          "token_id": 366,
+          "pos": 107
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 366,
+          "pos": 107
+        },
+        "token_1": {
+          "token_id": 260,
+          "pos": 108
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 260,
+          "pos": 108
+        },
+        "token_1": {
+          "token_id": 5347,
+          "pos": 109
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 5347,
+          "pos": 109
+        },
+        "token_1": {
+          "token_id": 469,
+          "pos": 110
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 469,
+          "pos": 110
+        },
+        "token_1": {
+          "token_id": 260,
+          "pos": 111
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 260,
+          "pos": 111
+        },
+        "token_1": {
+          "token_id": 6687,
+          "pos": 112
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 6687,
+          "pos": 112
+        },
+        "token_1": {
+          "token_id": 4735,
+          "pos": 113
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 4735,
+          "pos": 113
+        },
+        "token_1": {
+          "token_id": 304,
+          "pos": 114
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 304,
+          "pos": 114
+        },
+        "token_1": {
+          "token_id": 7263,
+          "pos": 115
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 7263,
+          "pos": 115
+        },
+        "token_1": {
+          "token_id": 566,
+          "pos": 116
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 38701,
+          "pos": 116
+        },
+        "token_1": {
+          "token_id": 339,
+          "pos": 117
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 295,
+          "pos": 117
+        },
+        "token_1": {
+          "token_id": 786,
+          "pos": 118
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 295,
+          "pos": 117
+        },
+        "token_1": {
+          "token_id": 786,
+          "pos": 118
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 786,
+          "pos": 118
+        },
+        "token_1": {
+          "token_id": 1116,
+          "pos": 119
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 786,
+          "pos": 118
+        },
+        "token_1": {
+          "token_id": 1116,
+          "pos": 119
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 1116,
+          "pos": 119
+        },
+        "token_1": {
+          "token_id": 339,
+          "pos": 120
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 339,
+          "pos": 120
+        },
+        "token_1": {
+          "token_id": 671,
+          "pos": 121
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 671,
+          "pos": 121
+        },
+        "token_1": {
+          "token_id": 3967,
+          "pos": 122
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 3967,
+          "pos": 122
+        },
+        "token_1": {
+          "token_id": 43375,
+          "pos": 123
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 43375,
+          "pos": 123
+        },
+        "token_1": {
+          "token_id": 582,
+          "pos": 124
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 582,
+          "pos": 124
+        },
+        "token_1": {
+          "token_id": 44029,
+          "pos": 125
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 44029,
+          "pos": 125
+        },
+        "token_1": {
+          "token_id": 436,
+          "pos": 126
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 436,
+          "pos": 126
+        },
+        "token_1": {
+          "token_id": 344,
+          "pos": 127
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 344,
+          "pos": 127
+        },
+        "token_1": {
+          "token_id": 832,
+          "pos": 128
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 832,
+          "pos": 128
+        },
+        "token_1": {
+          "token_id": 2239,
+          "pos": 129
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 2239,
+          "pos": 129
+        },
+        "token_1": {
+          "token_id": 2148,
+          "pos": 130
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 2148,
+          "pos": 130
+        },
+        "token_1": {
+          "token_id": 342,
+          "pos": 131
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 342,
+          "pos": 131
+        },
+        "token_1": {
+          "token_id": 1531,
+          "pos": 132
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 1531,
+          "pos": 132
+        },
+        "token_1": {
+          "token_id": 11217,
+          "pos": 133
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 11217,
+          "pos": 133
+        },
+        "token_1": {
+          "token_id": 3077,
+          "pos": 134
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 10200,
+          "pos": 134
+        },
+        "token_1": {
+          "token_id": 6532,
+          "pos": 135
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 6532,
+          "pos": 135
+        },
+        "token_1": {
+          "token_id": 1277,
+          "pos": 136
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 6532,
+          "pos": 135
+        },
+        "token_1": {
+          "token_id": 1277,
+          "pos": 136
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 1277,
+          "pos": 136
+        },
+        "token_1": {
+          "token_id": 295,
+          "pos": 137
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 16915,
+          "pos": 137
+        },
+        "token_1": {
+          "token_id": 8273,
+          "pos": 138
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 8273,
+          "pos": 138
+        },
+        "token_1": {
+          "token_id": 14,
+          "pos": 139
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 8273,
+          "pos": 138
+        },
+        "token_1": {
+          "token_id": 14,
+          "pos": 139
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 14,
+          "pos": 139
+        },
+        "token_1": {
+          "token_id": 11198,
+          "pos": 140
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 11198,
+          "pos": 140
+        },
+        "token_1": {
+          "token_id": 22650,
+          "pos": 141
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 22650,
+          "pos": 141
+        },
+        "token_1": {
+          "token_id": 14,
+          "pos": 142
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 14,
+          "pos": 142
+        },
+        "token_1": {
+          "token_id": 4474,
+          "pos": 143
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 4474,
+          "pos": 143
+        },
+        "token_1": {
+          "token_id": 2703,
+          "pos": 144
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 2703,
+          "pos": 144
+        },
+        "token_1": {
+          "token_id": 16,
+          "pos": 145
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 16,
+          "pos": 145
+        },
+        "token_1": {
+          "token_id": 15728,
+          "pos": 146
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 3109,
+          "pos": 146
+        },
+        "token_1": {
+          "token_id": 477,
+          "pos": 147
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 477,
+          "pos": 147
+        },
+        "token_1": {
+          "token_id": 4501,
+          "pos": 148
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 477,
+          "pos": 147
+        },
+        "token_1": {
+          "token_id": 4501,
+          "pos": 148
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 4501,
+          "pos": 148
+        },
+        "token_1": {
+          "token_id": 1479,
+          "pos": 149
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 1479,
+          "pos": 149
+        },
+        "token_1": {
+          "token_id": 15449,
+          "pos": 150
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 15449,
+          "pos": 150
+        },
+        "token_1": {
+          "token_id": 54,
+          "pos": 151
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 54,
+          "pos": 151
+        },
+        "token_1": {
+          "token_id": 344,
+          "pos": 152
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 344,
+          "pos": 152
+        },
+        "token_1": {
+          "token_id": 59972,
+          "pos": 153
+        }
+      }
+    ]
+  },
+  "expected_host": {
+    "generated_tokens": [
+      128798,
+      201,
+      33001,
+      14,
+      270,
+      3967,
+      10059,
+      260,
+      4521,
+      11394,
+      294,
+      270,
+      10252,
+      55840,
+      26364,
+      343,
+      8272,
+      54,
+      754,
+      1009,
+      7176,
+      14,
+      305,
+      2953,
+      99378,
+      16,
+      4480,
+      678,
+      1904,
+      513,
+      96703,
+      1205,
+      270,
+      15449,
+      54,
+      5756,
+      16,
+      983,
+      734,
+      943,
+      270,
+      6380,
+      294,
+      6810,
+      3189,
+      32634,
+      260,
+      5374,
+      6380,
+      412,
+      6810,
+      3701,
+      9347,
+      14,
+      17883,
+      294,
+      270,
+      5185,
+      734,
+      6380,
+      16,
+      2275,
+      3939,
+      344,
+      396,
+      2239,
+      33,
+      17519,
+      270,
+      3967,
+      4086,
+      566,
+      362,
+      260,
+      38701,
+      1312,
+      469,
+      2041,
+      27609,
+      4762,
+      16,
+      2359,
+      2786,
+      366,
+      260,
+      5347,
+      469,
+      260,
+      6687,
+      4735,
+      304,
+      7263,
+      38701,
+      295,
+      786,
+      1116,
+      339,
+      671,
+      3967,
+      43375,
+      582,
+      44029,
+      436,
+      344,
+      832,
+      2239,
+      2148,
+      342,
+      1531,
+      11217,
+      10200,
+      6532,
+      1277,
+      16915,
+      8273,
+      14,
+      11198,
+      22650,
+      14,
+      4474,
+      2703,
+      16,
+      3109,
+      477,
+      4501,
+      1479,
+      15449,
+      54
+    ],
+    "writes": [
+      {
+        "token_id": 128798,
+        "type": "BASE",
+        "pos": 24,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 201,
+        "type": "SPEC",
+        "pos": 25,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 33001,
+        "type": "BASE",
+        "pos": 26,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 14,
+        "type": "SPEC",
+        "pos": 27,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 270,
+        "type": "BASE",
+        "pos": 28,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 3967,
+        "type": "SPEC",
+        "pos": 29,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 10059,
+        "type": "BASE",
+        "pos": 30,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 260,
+        "type": "SPEC",
+        "pos": 31,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 4521,
+        "type": "BASE",
+        "pos": 32,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 11394,
+        "type": "SPEC",
+        "pos": 33,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 294,
+        "type": "BASE",
+        "pos": 34,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 270,
+        "type": "SPEC",
+        "pos": 35,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 10252,
+        "type": "BASE",
+        "pos": 36,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 55840,
+        "type": "SPEC",
+        "pos": 37,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 26364,
+        "type": "BASE",
+        "pos": 38,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 343,
+        "type": "SPEC",
+        "pos": 39,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 8272,
+        "type": "BASE",
+        "pos": 40,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 54,
+        "type": "SPEC",
+        "pos": 41,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 754,
+        "type": "BASE",
+        "pos": 42,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1009,
+        "type": "SPEC",
+        "pos": 43,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 7176,
+        "type": "BASE",
+        "pos": 44,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 14,
+        "type": "SPEC",
+        "pos": 45,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 305,
+        "type": "BASE",
+        "pos": 46,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2953,
+        "type": "SPEC",
+        "pos": 47,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 99378,
+        "type": "BASE",
+        "pos": 48,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 16,
+        "type": "SPEC",
+        "pos": 49,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 4480,
+        "type": "BASE",
+        "pos": 50,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 678,
+        "type": "SPEC",
+        "pos": 51,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1904,
+        "type": "BASE",
+        "pos": 52,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 513,
+        "type": "SPEC",
+        "pos": 53,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 96703,
+        "type": "BASE",
+        "pos": 54,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1205,
+        "type": "SPEC",
+        "pos": 55,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 270,
+        "type": "BASE",
+        "pos": 56,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 15449,
+        "type": "SPEC",
+        "pos": 57,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 54,
+        "type": "BASE",
+        "pos": 58,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 5756,
+        "type": "SPEC",
+        "pos": 59,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 16,
+        "type": "BASE",
+        "pos": 60,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 983,
+        "type": "SPEC",
+        "pos": 61,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 734,
+        "type": "BASE",
+        "pos": 62,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 943,
+        "type": "SPEC",
+        "pos": 63,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 270,
+        "type": "BASE",
+        "pos": 64,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 6380,
+        "type": "SPEC",
+        "pos": 65,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 294,
+        "type": "BASE",
+        "pos": 66,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 6810,
+        "type": "SPEC",
+        "pos": 67,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 3189,
+        "type": "BASE",
+        "pos": 68,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 32634,
+        "type": "SPEC",
+        "pos": 69,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 260,
+        "type": "BASE",
+        "pos": 70,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 5374,
+        "type": "SPEC",
+        "pos": 71,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 6380,
+        "type": "BASE",
+        "pos": 72,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 412,
+        "type": "SPEC",
+        "pos": 73,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 6810,
+        "type": "BASE",
+        "pos": 74,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 3701,
+        "type": "SPEC",
+        "pos": 75,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 9347,
+        "type": "BASE",
+        "pos": 76,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 14,
+        "type": "SPEC",
+        "pos": 77,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 17883,
+        "type": "BASE",
+        "pos": 78,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 294,
+        "type": "SPEC",
+        "pos": 79,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 270,
+        "type": "BASE",
+        "pos": 80,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 5185,
+        "type": "SPEC",
+        "pos": 81,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 734,
+        "type": "BASE",
+        "pos": 82,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 6380,
+        "type": "SPEC",
+        "pos": 83,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 16,
+        "type": "BASE",
+        "pos": 84,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1004,
+        "type": "SPEC",
+        "pos": 85,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2275,
+        "type": "BASE",
+        "pos": 85,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 3939,
+        "type": "SPEC",
+        "pos": 86,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 344,
+        "type": "BASE",
+        "pos": 87,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 396,
+        "type": "SPEC",
+        "pos": 88,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2239,
+        "type": "BASE",
+        "pos": 89,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1240,
+        "type": "SPEC",
+        "pos": 90,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 33,
+        "type": "BASE",
+        "pos": 90,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 17519,
+        "type": "SPEC",
+        "pos": 91,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 270,
+        "type": "BASE",
+        "pos": 92,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 3967,
+        "type": "SPEC",
+        "pos": 93,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 4086,
+        "type": "BASE",
+        "pos": 94,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 566,
+        "type": "SPEC",
+        "pos": 95,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 362,
+        "type": "BASE",
+        "pos": 96,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 260,
+        "type": "SPEC",
+        "pos": 97,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 38701,
+        "type": "BASE",
+        "pos": 98,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1312,
+        "type": "SPEC",
+        "pos": 99,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 469,
+        "type": "BASE",
+        "pos": 100,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 260,
+        "type": "SPEC",
+        "pos": 101,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2041,
+        "type": "BASE",
+        "pos": 101,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 27609,
+        "type": "SPEC",
+        "pos": 102,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 4762,
+        "type": "BASE",
+        "pos": 103,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 16,
+        "type": "SPEC",
+        "pos": 104,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2359,
+        "type": "BASE",
+        "pos": 105,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2786,
+        "type": "SPEC",
+        "pos": 106,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 366,
+        "type": "BASE",
+        "pos": 107,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 260,
+        "type": "SPEC",
+        "pos": 108,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 5347,
+        "type": "BASE",
+        "pos": 109,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 469,
+        "type": "SPEC",
+        "pos": 110,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 260,
+        "type": "BASE",
+        "pos": 111,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 6687,
+        "type": "SPEC",
+        "pos": 112,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 4735,
+        "type": "BASE",
+        "pos": 113,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 304,
+        "type": "SPEC",
+        "pos": 114,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 7263,
+        "type": "BASE",
+        "pos": 115,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 566,
+        "type": "SPEC",
+        "pos": 116,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 38701,
+        "type": "BASE",
+        "pos": 116,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 339,
+        "type": "SPEC",
+        "pos": 117,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 295,
+        "type": "BASE",
+        "pos": 117,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 786,
+        "type": "SPEC",
+        "pos": 118,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1116,
+        "type": "BASE",
+        "pos": 119,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 339,
+        "type": "SPEC",
+        "pos": 120,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 671,
+        "type": "BASE",
+        "pos": 121,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 3967,
+        "type": "SPEC",
+        "pos": 122,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 43375,
+        "type": "BASE",
+        "pos": 123,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 582,
+        "type": "SPEC",
+        "pos": 124,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 44029,
+        "type": "BASE",
+        "pos": 125,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 436,
+        "type": "SPEC",
+        "pos": 126,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 344,
+        "type": "BASE",
+        "pos": 127,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 832,
+        "type": "SPEC",
+        "pos": 128,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2239,
+        "type": "BASE",
+        "pos": 129,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2148,
+        "type": "SPEC",
+        "pos": 130,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 342,
+        "type": "BASE",
+        "pos": 131,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1531,
+        "type": "SPEC",
+        "pos": 132,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 11217,
+        "type": "BASE",
+        "pos": 133,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 3077,
+        "type": "SPEC",
+        "pos": 134,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 10200,
+        "type": "BASE",
+        "pos": 134,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 6532,
+        "type": "SPEC",
+        "pos": 135,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1277,
+        "type": "BASE",
+        "pos": 136,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 295,
+        "type": "SPEC",
+        "pos": 137,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 16915,
+        "type": "BASE",
+        "pos": 137,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 8273,
+        "type": "SPEC",
+        "pos": 138,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 14,
+        "type": "BASE",
+        "pos": 139,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 11198,
+        "type": "SPEC",
+        "pos": 140,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 22650,
+        "type": "BASE",
+        "pos": 141,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 14,
+        "type": "SPEC",
+        "pos": 142,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 4474,
+        "type": "BASE",
+        "pos": 143,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2703,
+        "type": "SPEC",
+        "pos": 144,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 16,
+        "type": "BASE",
+        "pos": 145,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 15728,
+        "type": "SPEC",
+        "pos": 146,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 3109,
+        "type": "BASE",
+        "pos": 146,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 477,
+        "type": "SPEC",
+        "pos": 147,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 4501,
+        "type": "BASE",
+        "pos": 148,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1479,
+        "type": "SPEC",
+        "pos": 149,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 15449,
+        "type": "BASE",
+        "pos": 150,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 54,
+        "type": "SPEC",
+        "pos": 151,
+        "user_id": 0,
+        "prefill_id": -1
+      }
+    ],
+    "read_count": 136
+  }
+}

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/reference_data/reference_trace_spec_decode_32_tokens.json
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/reference_data/reference_trace_spec_decode_32_tokens.json
@@ -1,0 +1,694 @@
+{
+  "schema_version": 1,
+  "name": "spec_decode_host_fsm_case",
+  "metadata": {
+    "num_accepts": 16,
+    "num_rejects": 0
+  },
+  "params": {
+    "prompt_token_ids": [
+      0,
+      128803,
+      21750,
+      260,
+      3107,
+      15255,
+      2019,
+      396,
+      10340,
+      270,
+      48941,
+      26509,
+      1167,
+      16,
+      128804
+    ],
+    "max_new_tokens": 32,
+    "eos_token_id": 1
+  },
+  "device_to_host": {
+    "prefill_results": [
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 128798,
+          "pos": 15
+        },
+        "token_1": {
+          "token_id": 201,
+          "pos": 16
+        }
+      }
+    ],
+    "read_results": [
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 201,
+          "pos": 16
+        },
+        "token_1": {
+          "token_id": 2581,
+          "pos": 17
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 2581,
+          "pos": 17
+        },
+        "token_1": {
+          "token_id": 477,
+          "pos": 18
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 477,
+          "pos": 18
+        },
+        "token_1": {
+          "token_id": 2887,
+          "pos": 19
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 2887,
+          "pos": 19
+        },
+        "token_1": {
+          "token_id": 304,
+          "pos": 20
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 304,
+          "pos": 20
+        },
+        "token_1": {
+          "token_id": 5085,
+          "pos": 21
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 5085,
+          "pos": 21
+        },
+        "token_1": {
+          "token_id": 260,
+          "pos": 22
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 260,
+          "pos": 22
+        },
+        "token_1": {
+          "token_id": 2019,
+          "pos": 23
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 2019,
+          "pos": 23
+        },
+        "token_1": {
+          "token_id": 396,
+          "pos": 24
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 396,
+          "pos": 24
+        },
+        "token_1": {
+          "token_id": 10340,
+          "pos": 25
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 10340,
+          "pos": 25
+        },
+        "token_1": {
+          "token_id": 270,
+          "pos": 26
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 270,
+          "pos": 26
+        },
+        "token_1": {
+          "token_id": 48941,
+          "pos": 27
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 48941,
+          "pos": 27
+        },
+        "token_1": {
+          "token_id": 26509,
+          "pos": 28
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 26509,
+          "pos": 28
+        },
+        "token_1": {
+          "token_id": 1167,
+          "pos": 29
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 1167,
+          "pos": 29
+        },
+        "token_1": {
+          "token_id": 603,
+          "pos": 30
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 603,
+          "pos": 30
+        },
+        "token_1": {
+          "token_id": 455,
+          "pos": 31
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 455,
+          "pos": 31
+        },
+        "token_1": {
+          "token_id": 26509,
+          "pos": 32
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 26509,
+          "pos": 32
+        },
+        "token_1": {
+          "token_id": 8205,
+          "pos": 33
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 8205,
+          "pos": 33
+        },
+        "token_1": {
+          "token_id": 344,
+          "pos": 34
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 344,
+          "pos": 34
+        },
+        "token_1": {
+          "token_id": 6428,
+          "pos": 35
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 6428,
+          "pos": 35
+        },
+        "token_1": {
+          "token_id": 412,
+          "pos": 36
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 412,
+          "pos": 36
+        },
+        "token_1": {
+          "token_id": 1137,
+          "pos": 37
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 1137,
+          "pos": 37
+        },
+        "token_1": {
+          "token_id": 262,
+          "pos": 38
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 262,
+          "pos": 38
+        },
+        "token_1": {
+          "token_id": 447,
+          "pos": 39
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 447,
+          "pos": 39
+        },
+        "token_1": {
+          "token_id": 10,
+          "pos": 40
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 10,
+          "pos": 40
+        },
+        "token_1": {
+          "token_id": 18,
+          "pos": 41
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 18,
+          "pos": 41
+        },
+        "token_1": {
+          "token_id": 11,
+          "pos": 42
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 11,
+          "pos": 42
+        },
+        "token_1": {
+          "token_id": 438,
+          "pos": 43
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 438,
+          "pos": 43
+        },
+        "token_1": {
+          "token_id": 223,
+          "pos": 44
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 223,
+          "pos": 44
+        },
+        "token_1": {
+          "token_id": 18,
+          "pos": 45
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 18,
+          "pos": 45
+        },
+        "token_1": {
+          "token_id": 201,
+          "pos": 46
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 201,
+          "pos": 46
+        },
+        "token_1": {
+          "token_id": 262,
+          "pos": 47
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 262,
+          "pos": 47
+        },
+        "token_1": {
+          "token_id": 447,
+          "pos": 48
+        }
+      }
+    ]
+  },
+  "expected_host": {
+    "generated_tokens": [
+      128798,
+      201,
+      2581,
+      477,
+      2887,
+      304,
+      5085,
+      260,
+      2019,
+      396,
+      10340,
+      270,
+      48941,
+      26509,
+      1167,
+      603,
+      455,
+      26509,
+      8205,
+      344,
+      6428,
+      412,
+      1137,
+      262,
+      447,
+      10,
+      18,
+      11,
+      438,
+      223,
+      18,
+      201
+    ],
+    "writes": [
+      {
+        "token_id": 128798,
+        "type": "BASE",
+        "pos": 15,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 201,
+        "type": "SPEC",
+        "pos": 16,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2581,
+        "type": "BASE",
+        "pos": 17,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 477,
+        "type": "SPEC",
+        "pos": 18,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2887,
+        "type": "BASE",
+        "pos": 19,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 304,
+        "type": "SPEC",
+        "pos": 20,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 5085,
+        "type": "BASE",
+        "pos": 21,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 260,
+        "type": "SPEC",
+        "pos": 22,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2019,
+        "type": "BASE",
+        "pos": 23,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 396,
+        "type": "SPEC",
+        "pos": 24,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 10340,
+        "type": "BASE",
+        "pos": 25,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 270,
+        "type": "SPEC",
+        "pos": 26,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 48941,
+        "type": "BASE",
+        "pos": 27,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 26509,
+        "type": "SPEC",
+        "pos": 28,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1167,
+        "type": "BASE",
+        "pos": 29,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 603,
+        "type": "SPEC",
+        "pos": 30,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 455,
+        "type": "BASE",
+        "pos": 31,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 26509,
+        "type": "SPEC",
+        "pos": 32,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 8205,
+        "type": "BASE",
+        "pos": 33,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 344,
+        "type": "SPEC",
+        "pos": 34,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 6428,
+        "type": "BASE",
+        "pos": 35,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 412,
+        "type": "SPEC",
+        "pos": 36,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 1137,
+        "type": "BASE",
+        "pos": 37,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 262,
+        "type": "SPEC",
+        "pos": 38,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 447,
+        "type": "BASE",
+        "pos": 39,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 10,
+        "type": "SPEC",
+        "pos": 40,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 18,
+        "type": "BASE",
+        "pos": 41,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 11,
+        "type": "SPEC",
+        "pos": 42,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 438,
+        "type": "BASE",
+        "pos": 43,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 223,
+        "type": "SPEC",
+        "pos": 44,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 18,
+        "type": "BASE",
+        "pos": 45,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 201,
+        "type": "SPEC",
+        "pos": 46,
+        "user_id": 0,
+        "prefill_id": -1
+      }
+    ],
+    "read_count": 32
+  }
+}

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/reference_data/reference_trace_spec_decode_5_tokens.json
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/reference_data/reference_trace_spec_decode_5_tokens.json
@@ -1,0 +1,135 @@
+{
+  "schema_version": 1,
+  "name": "spec_decode_host_fsm_case",
+  "metadata": {
+    "num_accepts": 2,
+    "num_rejects": 0
+  },
+  "params": {
+    "prompt_token_ids": [
+      0,
+      128803,
+      21750,
+      260,
+      3107,
+      15255,
+      2019,
+      396,
+      10340,
+      270,
+      48941,
+      26509,
+      1167,
+      16,
+      128804
+    ],
+    "max_new_tokens": 5,
+    "eos_token_id": 1
+  },
+  "device_to_host": {
+    "prefill_results": [
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 128798,
+          "pos": 15
+        },
+        "token_1": {
+          "token_id": 201,
+          "pos": 16
+        }
+      }
+    ],
+    "read_results": [
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 201,
+          "pos": 16
+        },
+        "token_1": {
+          "token_id": 2581,
+          "pos": 17
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 2581,
+          "pos": 17
+        },
+        "token_1": {
+          "token_id": 477,
+          "pos": 18
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "BASE",
+        "token_0": {
+          "token_id": 477,
+          "pos": 18
+        },
+        "token_1": {
+          "token_id": 2887,
+          "pos": 19
+        }
+      },
+      {
+        "user_id": 0,
+        "type": "SPEC",
+        "token_0": {
+          "token_id": 2887,
+          "pos": 19
+        },
+        "token_1": {
+          "token_id": 304,
+          "pos": 20
+        }
+      }
+    ]
+  },
+  "expected_host": {
+    "generated_tokens": [
+      128798,
+      201,
+      2581,
+      477,
+      2887
+    ],
+    "writes": [
+      {
+        "token_id": 128798,
+        "type": "BASE",
+        "pos": 15,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 201,
+        "type": "SPEC",
+        "pos": 16,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 2581,
+        "type": "BASE",
+        "pos": 17,
+        "user_id": 0,
+        "prefill_id": -1
+      },
+      {
+        "token_id": 477,
+        "type": "SPEC",
+        "pos": 18,
+        "user_id": 0,
+        "prefill_id": -1
+      }
+    ],
+    "read_count": 4
+  }
+}

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_bcast_moe_reduce_pipeline.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_bcast_moe_reduce_pipeline.py
@@ -371,7 +371,7 @@ def test_bcast_moe_reduce_pipeline(
     if is_stage0:
         token_size_datums = token_size_bytes // dtype_size(ttnn.uint32)
         torch_token = torch.zeros(1, token_size_datums, dtype=torch.uint32)
-        torch_token[0, 0] = token_id
+        torch_token[0, 6] = token_id
         token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
         pipeline_block.write_token(token_tensor)
         logger.info(f"[rank=0] token {token_id} injected")
@@ -915,7 +915,7 @@ def test_persistent_mode_pipeline(
             for iteration in range(iterations):
                 print(f"[rank={my_mesh_id}] iteration {iteration} start")
                 torch_token = torch.zeros(1, token_size_datums, dtype=torch.uint32)
-                torch_token[0, 0] = iteration
+                torch_token[0, 6] = iteration
                 token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
 
                 d2h_output_tensor = ttnn.from_torch(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_broadcast_rms.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_broadcast_rms.py
@@ -223,7 +223,7 @@ def test_broadcast_rms_fused(
     if use_socket:
         token_size_datums = token_page_size // 4
         torch_token = torch.zeros(1, token_size_datums, dtype=torch.uint32)
-        torch_token[0, 0] = 0
+        torch_token[0, 6] = 0
         token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
         h2d_socket.write_tensor(token_tensor)
         host_io.terminate(False)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_broadcast_rms_single_device.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_broadcast_rms_single_device.py
@@ -201,7 +201,7 @@ def test_broadcast_rms_single_device(
     if use_socket:
         token_size_datums = token_page_size // 4
         torch_token = torch.zeros(1, token_size_datums, dtype=torch.uint32)
-        torch_token[0, 0] = 0
+        torch_token[0, 6] = 0
         token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
         h2d_socket.write_tensor(token_tensor)
         host_io.terminate(False)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_broadcast_rms_two_stage_pipeline.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_broadcast_rms_two_stage_pipeline.py
@@ -192,7 +192,7 @@ def test_broadcast_rms_two_stage_pipeline(mesh_device, vocab_size, embedding_dim
     if is_stage0:
         token_size_datums = token_size_bytes // dtype_size(ttnn.uint32)
         torch_token = torch.zeros(1, token_size_datums, dtype=torch.uint32)
-        torch_token[0, 0] = token_id
+        torch_token[0, 6] = token_id
         token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
         pipeline_block.write_token(token_tensor)
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
@@ -164,9 +164,9 @@ def test_host_io_loopback_with_embedding(
     logger.info(f"Testing embedding with vocab size {vocab_size} over H2D → D2H loopback")
 
     for token_id in range(vocab_size):
-        # Write 64-byte packet with token ID as first uint32, rest zeros
+        # Write 64-byte metadata packet with token ID at word 6, rest zeros.
         torch_input = torch.zeros(1, token_size_datums, dtype=token_dtype)
-        torch_input[0, 0] = token_id
+        torch_input[0, 6] = token_id
         input_tensor = ttnn.from_torch(
             torch_input, dtype=ttnn_dtype_from_torch_dtype(token_dtype), layout=ttnn.ROW_MAJOR_LAYOUT
         )
@@ -594,9 +594,9 @@ def test_multi_stage_pipeline_loopback_with_embedding(
     logger.info(f"Testing embedding with vocab size {vocab_size} over multi-stage pipeline")
 
     for token_id in range(vocab_size):
-        # Write 64-byte packet with token ID as first uint32, rest zeros
+        # Write 64-byte metadata packet with token ID at word 6, rest zeros.
         torch_input = torch.zeros(1, token_size_datums, dtype=token_dtype)
-        torch_input[0, 0] = token_id
+        torch_input[0, 6] = token_id
         input_tensor = ttnn.from_torch(
             torch_input, dtype=ttnn_dtype_from_torch_dtype(token_dtype), layout=ttnn.ROW_MAJOR_LAYOUT
         )

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_lm_head_sampling.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_lm_head_sampling.py
@@ -1295,13 +1295,12 @@ def _create_reference_spec_decode_pipeline_configuration(
 def _parse_token_meta_page(raw: torch.Tensor) -> dict[str, int]:
     raw = raw.to(torch.uint32).flatten()
     return {
-        "num_tokens": int(raw[0].item()),
+        "token_type": int(raw[0].item()),
         "tok0_id": int(raw[1].item()),
-        "tok0_type": int(raw[2].item()),
-        "tok0_pos": int(raw[3].item()),
-        "tok1_id": int(raw[4].item()),
-        "tok1_type": int(raw[5].item()),
-        "tok1_pos": int(raw[6].item()),
+        "tok0_pos": int(raw[2].item()),
+        "tok1_id": int(raw[3].item()),
+        "tok1_pos": int(raw[4].item()),
+        "slot_id": int(raw[5].item()),
     }
 
 
@@ -1556,7 +1555,7 @@ def _compute_reference_payload_mtp_metrics_ttnn(
 
         for row_idx in range(total_rows):
             torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
-            torch_token[0, 0] = row_idx
+            torch_token[0, 6] = row_idx
             token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
             output_tensor = ttnn.from_torch(
                 torch.zeros(1, token_meta_words, dtype=torch.uint32),
@@ -4430,7 +4429,7 @@ def test_pipline_block_4stage_galaxy_1_iteration(mesh_device, use_fp32, device_p
 
         if pipeline.my_mesh_id == 0:
             torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
-            torch_token[0, 0] = 0
+            torch_token[0, 6] = 0
             token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
             output_tensor = ttnn.from_torch(
                 torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32),
@@ -4501,7 +4500,7 @@ def test_persistent_mode(mesh_device, use_fp32, device_params):
         for iteration in range(iterations):
             logger.info(f"Writing token for iteration {iteration}")
             torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
-            torch_token[0, 0] = iteration
+            torch_token[0, 6] = iteration
             token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
             output_tensor = ttnn.from_torch(
                 torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32),
@@ -4549,9 +4548,8 @@ def test_persistent_mode_mtp(mesh_device, use_fp32):
     own LM head + argmax, then outputs a TOKEN_META page (64 bytes) back to P1.
 
     TOKEN_META page layout (uint32 words):
-      [0] num_tokens  (0=stale, 1=accept, 2=reject)
-      [1] tok0_id     [2] tok0_type (0=BASE,1=SPEC)  [3] tok0_pos
-      [4] tok1_id     [5] tok1_type                   [6] tok1_pos
+      [0] token_type  [1] tok0_id  [2] tok0_pos
+      [3] tok1_id     [4] tok1_pos                    [5] slot_id
     """
     if not is_slow_dispatch():
         pytest.skip("Skipping test in fast dispatch mode")
@@ -4600,7 +4598,7 @@ def test_persistent_mode_mtp(mesh_device, use_fp32):
             for iteration in range(iterations):
                 logger.debug(f"[TEST P{pid}] iter {iteration} write_token")
                 torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
-                torch_token[0, 0] = iteration
+                torch_token[0, 6] = iteration
                 token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
                 output_tensor = ttnn.from_torch(
                     torch.zeros(1, token_meta_words, dtype=torch.uint32),
@@ -4613,13 +4611,11 @@ def test_persistent_mode_mtp(mesh_device, use_fp32):
                 logger.debug(f"[TEST P{pid}] iter {iteration} to_torch")
                 raw = ttnn.to_torch(output_tensor).to(torch.uint32).flatten()
 
-                num_tokens = raw[0].item()
+                token_type = raw[0].item()
                 tok0_id = raw[1].item()
-                tok0_type = raw[2].item()
-                tok0_pos = raw[3].item()
-                tok1_id = raw[4].item()
-                tok1_type = raw[5].item()
-                tok1_pos = raw[6].item()
+                tok0_pos = raw[2].item()
+                tok1_id = raw[3].item()
+                tok1_pos = raw[4].item()
 
                 if run_golden:
                     expected_base, expected_spec = golden[iteration]
@@ -4630,8 +4626,8 @@ def test_persistent_mode_mtp(mesh_device, use_fp32):
                 type_name = {0: "BASE", 1: "SPEC"}
                 logger.debug(
                     f"[TEST P{pid}] iter {iteration} "
-                    f"ntok={num_tokens} t0={tok0_id}/{type_name.get(tok0_type,'?')} "
-                    f"t1={tok1_id}/{type_name.get(tok1_type,'?')} ",
+                    f"t0={tok0_id}/{type_name.get(token_type,'?')} "
+                    f"t1={tok1_id} ",
                     f"t0 pos={tok0_pos} t1 pos={tok1_pos} ",
                     f"golden base token={expected_base} golden spec token={expected_spec}",
                 )
@@ -4716,7 +4712,7 @@ def test_persistent_mode_real_weights(mesh_device, use_fp32, hf_model_path, hf_s
             in_tok = int(input_token_ids[iteration].item())
             logger.info(f"Writing token for iteration {iteration} (in_tok={in_tok})")
             torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
-            torch_token[0, 0] = in_tok
+            torch_token[0, 6] = in_tok
             token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
             output_tensor = ttnn.from_torch(
                 torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32),
@@ -4815,7 +4811,7 @@ def test_persistent_mode_pod(mesh_device, use_fp32, device_params):
     if pipeline.my_mesh_id == 0:
         for iteration in range(iterations):
             torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
-            torch_token[0, 0] = iteration
+            torch_token[0, 6] = iteration
             token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
             output_tensor = ttnn.from_torch(
                 torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32),
@@ -4863,9 +4859,8 @@ def test_persistent_mode_spec_decode(mesh_device, use_fp32):
     own LM head + argmax, then outputs a TOKEN_META page (64 bytes) back to P1.
 
     TOKEN_META page layout (uint32 words):
-      [0] num_tokens  (0=stale, 1=accept, 2=reject)
-      [1] tok0_id     [2] tok0_type (0=BASE,1=SPEC)  [3] tok0_pos
-      [4] tok1_id     [5] tok1_type                   [6] tok1_pos
+      [0] token_type  [1] tok0_id  [2] tok0_pos
+      [3] tok1_id     [4] tok1_pos                    [5] slot_id
     """
     if not is_slow_dispatch():
         pytest.skip("Skipping test in fast dispatch mode")
@@ -4919,19 +4914,19 @@ def test_persistent_mode_spec_decode(mesh_device, use_fp32):
                 logger.debug(f"[TEST] skipping golden computation")
 
             tok0_id = 0
-            tok0_type = 0
+            token_type = 0
             tok0_pos = 0
             tok1_id = 0
-            tok1_type = 0
             tok1_pos = 0
 
             for iteration in range(iterations):
                 logger.debug(f"[TEST P{pid}] iter {iteration} write_token")
                 torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
-                torch_token[0, 6] = slot_id
+                torch_token[0, 2] = iteration
+                torch_token[0, 5] = slot_id
+                torch_token[0, 6] = iteration
                 torch_token[0, 7] = iteration
                 torch_token[0, 8] = iteration
-                torch_token[0, 9] = iteration
                 token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
                 output_tensor = ttnn.from_torch(
                     torch.zeros(1, token_meta_words, dtype=torch.uint32),
@@ -4944,12 +4939,11 @@ def test_persistent_mode_spec_decode(mesh_device, use_fp32):
                 logger.debug(f"[TEST P{pid}] iter {iteration} to_torch")
                 raw = ttnn.to_torch(output_tensor).to(torch.uint32).flatten()
 
-                tok0_id = raw[0].item()
-                tok0_type = raw[1].item()
+                token_type = raw[0].item()
+                tok0_id = raw[1].item()
                 tok0_pos = raw[2].item()
                 tok1_id = raw[3].item()
-                tok1_type = raw[4].item()
-                tok1_pos = raw[5].item()
+                tok1_pos = raw[4].item()
 
                 if run_golden:
                     expected_base, expected_spec = golden[iteration]
@@ -4960,8 +4954,8 @@ def test_persistent_mode_spec_decode(mesh_device, use_fp32):
                 type_name = {0: "BASE", 1: "SPEC"}
                 logger.debug(
                     f"[TEST P{pid}] iter {iteration} "
-                    f"t0={tok0_id}/{type_name.get(tok0_type,'?')} "
-                    f"t1={tok1_id}/{type_name.get(tok1_type,'?')} ",
+                    f"t0={tok0_id}/{type_name.get(token_type,'?')} "
+                    f"t1={tok1_id} ",
                     f"t0 pos={tok0_pos} t1 pos={tok1_pos} ",
                     f"golden base token={expected_base} golden spec token={expected_spec}",
                 )

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_15_stages.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_15_stages.py
@@ -356,7 +356,7 @@ def test_moe_15_stages(mesh_device, vocab_size, embedding_dim, token_id, device_
     if is_stage0:
         token_size_datums = token_size_bytes // dtype_size(ttnn.uint32)
         torch_token = torch.zeros(1, token_size_datums, dtype=torch.uint32)
-        torch_token[0, 0] = token_id
+        torch_token[0, 6] = token_id
         token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
         pipeline_block.write_token(token_tensor)
         logger.info(f"[rank=0] token {token_id} injected")
@@ -775,7 +775,7 @@ def test_persistent_moe_15_stages(
             token_size_datums = token_size_bytes // dtype_size(ttnn.uint32)
             num_elements = embedding_size_bytes // 2
             torch_token = torch.zeros(1, token_size_datums, dtype=torch.uint32)
-            torch_token[0, 0] = 0
+            torch_token[0, 6] = 0
             token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
             start_time = time.time()
             for iteration in range(iterations):
@@ -1163,7 +1163,7 @@ def test_persistent_moe_multi_token(
             token_size_datums = token_size_bytes // dtype_size(ttnn.uint32)
             num_elements = embedding_size_bytes // 2
             torch_token = torch.zeros(1, token_size_datums, dtype=torch.uint32)
-            torch_token[0, 0] = 0
+            torch_token[0, 6] = 0
             token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
             start_time = time.time()
             num_tokens_in_flight = 64

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_multi_host_pipeline.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_multi_host_pipeline.py
@@ -410,7 +410,7 @@ def test_multi_host_loopback_pipeline_with_embedding(
 
         for token_id in range(vocab_size):
             torch_input = torch.zeros(1, token_size_datums, dtype=token_dtype)
-            torch_input[0, 7] = token_id
+            torch_input[0, 6] = token_id
             input_tensor = ttnn.from_torch(
                 torch_input, dtype=ttnn_dtype_from_torch_dtype(token_dtype), layout=ttnn.ROW_MAJOR_LAYOUT
             )
@@ -562,7 +562,7 @@ def test_pipeline_block(mesh_device, vocab_size, embedding_dim, token_fifo_size,
 
         for token_id in range(vocab_size):
             torch_input = torch.zeros(1, token_size_datums, dtype=token_dtype)
-            torch_input[0, 7] = token_id
+            torch_input[0, 6] = token_id
             input_tensor = ttnn.from_torch(
                 torch_input, dtype=ttnn_dtype_from_torch_dtype(token_dtype), layout=ttnn.ROW_MAJOR_LAYOUT
             )
@@ -686,7 +686,7 @@ def test_pipeline_block_no_loopback(mesh_device, vocab_size, embedding_dim, toke
 
         for token_id in range(vocab_size):
             torch_input = torch.zeros(1, token_size_datums, dtype=token_dtype)
-            torch_input[0, 7] = token_id
+            torch_input[0, 6] = token_id
             input_tensor = ttnn.from_torch(
                 torch_input, dtype=ttnn_dtype_from_torch_dtype(token_dtype), layout=ttnn.ROW_MAJOR_LAYOUT
             )
@@ -816,7 +816,7 @@ def test_pipeline_block_host_loopback(mesh_device, vocab_size, embedding_dim, to
 
         for token_id in range(vocab_size):
             torch_input = torch.zeros(1, token_size_datums, dtype=token_dtype)
-            torch_input[0, 7] = token_id
+            torch_input[0, 6] = token_id
             input_tensor = ttnn.from_torch(
                 torch_input, dtype=ttnn_dtype_from_torch_dtype(token_dtype), layout=ttnn.ROW_MAJOR_LAYOUT
             )
@@ -1262,7 +1262,7 @@ def test_passthrough_pipeline_block(mesh_device):
 
             for token_id in range(vocab_size):
                 torch_input = torch.zeros(1, token_size_datums, dtype=token_dtype)
-                torch_input[0, 7] = token_id
+                torch_input[0, 6] = token_id
                 input_tensor = ttnn.from_torch(
                     torch_input, dtype=ttnn_dtype_from_torch_dtype(token_dtype), layout=ttnn.ROW_MAJOR_LAYOUT
                 )
@@ -1332,7 +1332,7 @@ def test_single_galaxy_deepseek_pipeline(mesh_device, use_fp32, device_params):
 
         if pipeline.my_mesh_id == 0:
             torch_token = torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32)
-            torch_token[0, 0] = 0
+            torch_token[0, 6] = 0
             token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
             output_tensor = ttnn.from_torch(
                 torch.zeros(1, TOKEN_PAGE_SIZE_BYTES // 4, dtype=torch.uint32),

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_run_inference.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_run_inference.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from models.demos.deepseek_v3_b1.demo import model_pipeline as model_pipeline_module
+from models.demos.deepseek_v3_b1.demo.model_pipeline import ModelPipeline
+from models.demos.deepseek_v3_b1.model import DecodeResult, TokenType
+
+RUN_INFERENCE_TRACE_ENV = "DEEPSEEK_V3_B1_RUN_INFERENCE_TRACE"
+
+TOKEN_TYPE_BY_NAME = {
+    "BASE": TokenType.BASE,
+    "SPEC": TokenType.SPEC,
+}
+TOKEN_TYPE_NAME_BY_VALUE = {value: name for name, value in TOKEN_TYPE_BY_NAME.items()}
+
+
+class _TraceBackedModel:
+    def __init__(self, read_results: list[DecodeResult]) -> None:
+        self._read_results = list(read_results)
+        self.read_count = 0
+        self.writes = []
+
+    def read_result(self) -> DecodeResult:
+        if not self._read_results:
+            pytest.fail("run_inference attempted to read more device packets than the trace provides")
+        self.read_count += 1
+        return self._read_results.pop(0)
+
+    def write_input(
+        self, token_id: int, prefill_token_id: int, user_id: int, position_id: int, token_type: int
+    ) -> None:
+        self.writes.append(
+            {
+                "token_id": int(token_id),
+                "type": TOKEN_TYPE_NAME_BY_VALUE[int(token_type)],
+                "pos": int(position_id),
+                "user_id": int(user_id),
+                "prefill_id": int(prefill_token_id),
+            }
+        )
+
+    def assert_fully_consumed(self) -> None:
+        assert not self._read_results, f"Trace has {len(self._read_results)} unread device packet(s)"
+
+
+def _require_keys(value: dict, keys: tuple[str, ...], context: str) -> None:
+    missing = [key for key in keys if key not in value]
+    assert not missing, f"{context} missing required key(s): {missing}"
+
+
+def _require_exact_keys(value: dict, keys: tuple[str, ...], context: str) -> None:
+    _require_keys(value, keys, context)
+    extra = sorted(set(value) - set(keys))
+    assert not extra, f"{context} has unexpected key(s): {extra}"
+
+
+def _validate_token(token: dict, context: str) -> None:
+    _require_exact_keys(token, ("token_id", "pos"), context)
+
+
+def _validate_packet(packet: dict, context: str) -> None:
+    _require_exact_keys(packet, ("user_id", "type", "token_0", "token_1"), context)
+    assert packet["type"] in TOKEN_TYPE_BY_NAME, f"{context}.type must be BASE or SPEC, got {packet['type']!r}"
+    _validate_token(packet["token_0"], f"{context}.token_0")
+    _validate_token(packet["token_1"], f"{context}.token_1")
+
+
+def _validate_expected_write(write: dict, context: str) -> None:
+    _require_exact_keys(write, ("token_id", "type", "pos", "user_id", "prefill_id"), context)
+    assert write["type"] in TOKEN_TYPE_BY_NAME, f"{context}.type must be BASE or SPEC, got {write['type']!r}"
+
+
+def _validate_metadata(metadata: dict, context: str) -> None:
+    _require_exact_keys(metadata, ("num_accepts", "num_rejects"), context)
+    assert isinstance(metadata["num_accepts"], int), f"{context}.num_accepts must be an integer"
+    assert isinstance(metadata["num_rejects"], int), f"{context}.num_rejects must be an integer"
+
+
+def _normalize_expected_write(write: dict) -> dict:
+    return {
+        "token_id": int(write["token_id"]),
+        "type": write["type"],
+        "pos": int(write["pos"]),
+        "user_id": int(write["user_id"]),
+        "prefill_id": int(write["prefill_id"]),
+    }
+
+
+def _load_trace(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as trace_file:
+        trace = json.load(trace_file)
+
+    _require_exact_keys(
+        trace, ("schema_version", "name", "params", "device_to_host", "expected_host", "metadata"), str(path)
+    )
+    assert trace["schema_version"] == 1, f"{path} has unsupported schema_version={trace['schema_version']!r}"
+
+    _require_exact_keys(trace["params"], ("prompt_token_ids", "max_new_tokens", "eos_token_id"), f"{path}.params")
+    _require_exact_keys(trace["device_to_host"], ("prefill_results", "read_results"), f"{path}.device_to_host")
+    _require_exact_keys(trace["expected_host"], ("generated_tokens", "writes", "read_count"), f"{path}.expected_host")
+    _validate_metadata(trace["metadata"], f"{path}.metadata")
+
+    for packet_idx, packet in enumerate(trace["device_to_host"]["prefill_results"]):
+        _validate_packet(packet, f"{path}.device_to_host.prefill_results[{packet_idx}]")
+    for packet_idx, packet in enumerate(trace["device_to_host"]["read_results"]):
+        _validate_packet(packet, f"{path}.device_to_host.read_results[{packet_idx}]")
+    for write_idx, write in enumerate(trace["expected_host"]["writes"]):
+        _validate_expected_write(write, f"{path}.expected_host.writes[{write_idx}]")
+
+    return trace
+
+
+def _packet_to_decode_result(packet: dict) -> DecodeResult:
+    token_0 = packet["token_0"]
+    token_1 = packet["token_1"]
+    return DecodeResult(
+        token_0=int(token_0["token_id"]),
+        token_type=TOKEN_TYPE_BY_NAME[packet["type"]],
+        token_0_pos=int(token_0["pos"]),
+        token_1=int(token_1["token_id"]),
+        token_1_pos=int(token_1["pos"]),
+        slot_id=int(packet["user_id"]),
+    )
+
+
+def _make_trace_backed_pipeline(trace: dict) -> tuple[ModelPipeline, _TraceBackedModel]:
+    prefill_results = [_packet_to_decode_result(packet) for packet in trace["device_to_host"]["prefill_results"]]
+    read_results = [_packet_to_decode_result(packet) for packet in trace["device_to_host"]["read_results"]]
+
+    fake_model = _TraceBackedModel(read_results)
+    pipeline = ModelPipeline.__new__(ModelPipeline)
+    pipeline.pipeline = SimpleNamespace(my_stage_idx=0)
+    pipeline.model = fake_model
+
+    def prefill_forward(prompt_token_ids: list[int]) -> list[DecodeResult]:
+        assert prompt_token_ids == trace["params"]["prompt_token_ids"]
+        return list(prefill_results)
+
+    pipeline.prefill_forward = prefill_forward
+    return pipeline, fake_model
+
+
+@pytest.fixture
+def run_inference_trace_path() -> Path:
+    raw_path = os.getenv(RUN_INFERENCE_TRACE_ENV)
+    if raw_path is None or not raw_path.strip():
+        pytest.skip(f"Set {RUN_INFERENCE_TRACE_ENV}=/path/to/reference_trace.json to run this host-side replay test")
+
+    trace_path = Path(raw_path.strip()).expanduser().resolve()
+    if not trace_path.is_file():
+        pytest.fail(f"{RUN_INFERENCE_TRACE_ENV} does not point to a file: {trace_path}")
+    return trace_path
+
+
+def test_run_inference_replays_spec_decode_trace(run_inference_trace_path: Path, monkeypatch):
+    trace_path = run_inference_trace_path
+    trace = _load_trace(trace_path)
+    pipeline, fake_model = _make_trace_backed_pipeline(trace)
+    emitted_tokens = []
+
+    monkeypatch.setattr(
+        model_pipeline_module.AutoTokenizer,
+        "from_pretrained",
+        lambda *args, **kwargs: SimpleNamespace(decode=lambda token_ids, **decode_kwargs: str(token_ids)),
+    )
+
+    generated_tokens = pipeline.run_inference(
+        trace["params"]["prompt_token_ids"],
+        trace["params"]["max_new_tokens"],
+        on_token=emitted_tokens.append,
+        eos_token_id=trace["params"]["eos_token_id"],
+        return_generated_tokens=True,
+    )
+
+    fake_model.assert_fully_consumed()
+    assert generated_tokens == trace["expected_host"]["generated_tokens"]
+    assert emitted_tokens == trace["expected_host"]["generated_tokens"]
+    assert fake_model.writes == [_normalize_expected_write(write) for write in trace["expected_host"]["writes"]]
+    assert fake_model.read_count == trace["expected_host"]["read_count"]
+    assert pipeline.last_inference_stats["num_accepts"] == trace["metadata"]["num_accepts"]
+    assert pipeline.last_inference_stats["num_rejects"] == trace["metadata"]["num_rejects"]


### PR DESCRIPTION
### Summary
Adds a host-side logic test for run_inference in pipeline_manager. The code tests the accept/reject logic including packet writing to the device pipeline based on reference i/o data from GPU traces to verify correct host-side behaviour. I also updated metadata, see note below

### Notes for reviewers
I updated metadata slightly to keep the type per packet and not per output token since this is how it was used anyway and also logically correct. For that I had to update some tests etc. to index correctly into the input token id. Please review if there's any issues with this.
