### PR TITLE
gpt_oss/prefill: adapt to ds_prefill #41668 API changes

### DIFF
--- a/models/demos/gpt_oss/conftest.py
+++ b/models/demos/gpt_oss/conftest.py
@@ -20,8 +20,9 @@ def state_dict(request):
     model_path = os.getenv("HF_MODEL", None)
     if model_path is None or not load_model:
         return {}
-    else:
-        return ModelArgs.load_state_dict(model_path, dummy_weights=False)
+    num_layers_env = os.getenv("GPT_OSS_NUM_LAYERS")
+    num_layers = int(num_layers_env) if num_layers_env else None
+    return ModelArgs.load_state_dict(model_path, dummy_weights=False, num_layers=num_layers)
 
 
 @pytest.fixture

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -128,6 +128,7 @@ def prepare_gpt_oss_generator_args(
             paged_attention_config=paged_attention_config,
             dtype=ttnn.bfloat8_b,
             state_dict=state_dict,
+            num_layers=int(os.environ.get("GPT_OSS_NUM_LAYERS", 0)) or None,
             mesh_config=mesh_config,  # Pass mesh config for proper sharding
             users_row_sharded=users_row_sharded,
             use_throughput_experts=use_throughput,

--- a/models/demos/gpt_oss/tt/common.py
+++ b/models/demos/gpt_oss/tt/common.py
@@ -56,6 +56,7 @@ def create_tt_model(
             weights_path=gpt_oss_model_args.model_path,
             dummy_weights=gpt_oss_model_args.dummy_weights,
             convert_to_meta_format=True,
+            num_layers=num_layers,
         )
 
     # Create GPT-OSS model using transformer-compatible constructor

--- a/models/demos/gpt_oss/tt/experts_throughput/prefill.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/prefill.py
@@ -7,6 +7,7 @@ Uses GROUP-BASED dispatch table (standard ExpertMapping) with permuted
 ThroughputExpertWeights to match the dispatch's expert-to-device mapping.
 """
 
+import torch
 from loguru import logger
 
 import ttnn
@@ -70,6 +71,13 @@ class DeepSeekPrefillConfig:
         experts_per_chip = config.num_experts // (dispatch_group_size * num_dispatch_groups)
         self.experts_per_chip = experts_per_chip
         self.seq_len_per_chip = seq_len_per_chip
+        # Override capacity_factor to be at least experts_per_chip. We override the post-#41668
+        # dynamic per-expert offsets with FIXED-stride offsets (each expert at L * max_dispatched
+        # within its destination chip's flat buffer), which lets us reshape the dispatched buffer
+        # into the pre-#41668 EPC-batched 4D layout `[1, EPC, max_dispatched, H]` and run the
+        # original single batched-matmul FFN chain. That requires the buffer to fit
+        # EPC * max_dispatched rows -> `dispatch_buffer_capacity_factor >= experts_per_chip`.
+        capacity_factor = max(int(capacity_factor), experts_per_chip)
         self.capacity_factor = capacity_factor
 
         _, metadata_len, max_dispatch_buffer_token_size, max_dispatched = compute_constants(
@@ -78,7 +86,7 @@ class DeepSeekPrefillConfig:
             num_experts_per_tok=config.num_experts_per_tok,
             num_devices=dispatch_group_size * num_dispatch_groups,
             dispatch_group_size=dispatch_group_size,
-            dispatch_buffer_capacity_factor=int(capacity_factor),
+            dispatch_buffer_capacity_factor=capacity_factor,
         )
         self.metadata_len = metadata_len
         self.max_dispatched_tokens_per_expert = max_dispatched
@@ -114,6 +122,31 @@ class DeepSeekPrefillConfig:
         global_expert_idx_tt = ttnn.squeeze(global_expert_idx_tt, 0)
         global_expert_idx_tt = ttnn.squeeze(global_expert_idx_tt, 0)
         self.global_expert_idx_table = global_expert_idx_tt
+
+        # Build fixed-stride region offsets per expert. For each global expert id `e`, the value is
+        # `local_idx_of_e_on_its_destination_chip * max_dispatched`. With this layout, every chip's
+        # flat dispatch buffer is naturally segmented into EPC fixed-size regions, and we can
+        # reshape `[1, 1, EPC * max_dispatched, H]` -> `[1, EPC, max_dispatched, H]` for the
+        # pre-#41668 batched matmul chain (no per-expert extract/insert needed).
+        expert_id_table_torch = ExpertMapping.create_global_expert_idx_table(
+            experts_per_chip=experts_per_chip,
+            dispatch_group_size=dispatch_group_size,
+            num_dispatch_groups=num_dispatch_groups,
+        )  # shape (ndg, dgs, EPC) -> global expert id
+        fixed_region_offsets_torch = torch.zeros(1, config.num_experts, dtype=torch.int32)
+        for g in range(num_dispatch_groups):
+            for c in range(dispatch_group_size):
+                for L in range(experts_per_chip):
+                    e = int(expert_id_table_torch[g, c, L])
+                    fixed_region_offsets_torch[0, e] = L * max_dispatched
+        self.fixed_region_offsets_tt = ttnn.from_torch(
+            fixed_region_offsets_torch,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh_device,
+            dtype=ttnn.uint32,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
 
         self.dispatch_module = TtDispatchModule(
             mesh_device=mesh_device,
@@ -334,131 +367,81 @@ def _forward_prefill_deepseek_chunk(
     i_3d = ttnn.reshape(indices_rm, (1, pc.seq_len_per_chip, config.num_experts_per_tok))
 
     # Step 5: Dispatch
-    dispatched, metadata = pc.dispatch_module(x_3d, w_3d, i_3d, tt_offsets, pc.tt_dispatch_table)
+    #
+    # routing_setup produced `tt_offsets` and `expert_region_offsets` from a per-source-device
+    # cumsum that tightly packs each expert's region in the destination chip's flat buffer
+    # (region_offset[e] = sum of counts for prior experts). To restore the pre-#41668 layout
+    # where each local expert occupied a fixed slot of `max_dispatched` rows, we substitute
+    # FIXED-stride region offsets (`L * max_dispatched` for the L-th local expert on its
+    # destination chip) and re-derive the per-source dispatch offsets:
+    #   tt_offsets_dynamic = local_offset_per_source + region_offsets_dynamic
+    #   tt_offsets_fixed   = local_offset_per_source + region_offsets_fixed
+    #                      = tt_offsets_dynamic - region_offsets_dynamic + region_offsets_fixed
+    # `pc.fixed_region_offsets_tt` was precomputed at config init.
+    local_offsets = ttnn.subtract(tt_offsets, expert_region_offsets)
+    ttnn.deallocate(tt_offsets)
+    ttnn.deallocate(expert_region_offsets)
+    tt_offsets_fixed = ttnn.add(local_offsets, pc.fixed_region_offsets_tt)
+    ttnn.deallocate(local_offsets)
+
+    dispatched, metadata = pc.dispatch_module(x_3d, w_3d, i_3d, tt_offsets_fixed, pc.tt_dispatch_table)
     # Dispatch done — x/scores/indices no longer needed
     if x_full_is_new:
         ttnn.deallocate(x_full)
     ttnn.deallocate(scores_rm)
     ttnn.deallocate(indices_rm)
-    ttnn.deallocate(tt_offsets)
+    ttnn.deallocate(tt_offsets_fixed)
 
-    # Step 6: Per-expert FFN using extract/insert (post-#41668)
+    # Step 6: Reshape flat dispatched buffer to EPC-batched and run pre-#41668 batched FFN.
     #
-    # The dispatched buffer is now flat [1, 1, max_dispatch_buffer_token_size, H]
-    # with each expert's tokens stored at a TILE-aligned offset given by
-    # expert_region_offsets, packed dynamically. The old single-batched-matmul
-    # pattern over EPC=4 expert weights doesn't apply — we mirror DeepSeek's
-    # TtRoutedExpert: extract per-expert tokens, run FFN on them, insert back.
-    #
-    # extract / insert require 2D BFLOAT8_B TILE inputs, so we flatten the
-    # leading [1, 1] dims and typecast once into the loop and once back out.
+    # With fixed-stride layout the buffer is `[1, 1, EPC * max_dispatched, H]`, expert L's
+    # rows at flat positions `[L * max_dispatched, (L+1) * max_dispatched)`. Reshape to
+    # `[1, EPC, max_dispatched, H]` and the original single batched-matmul-over-EPC chain
+    # works unchanged.
     H = config.hidden_size
     I = config.intermediate_size
     max_per_expert = pc.max_dispatched_tokens_per_expert
+    EPC = pc.experts_per_chip
 
     memory_config = ttnn.DRAM_MEMORY_CONFIG
 
-    buf = ttnn.squeeze(dispatched, dim=0)  # [1, max_buffer, H] or [max_buffer, H]
-    if len(buf.shape) >= 3:
-        buf = ttnn.squeeze(buf, dim=0)  # [max_buffer, H]
+    buf = ttnn.squeeze(dispatched, dim=0)  # [1, EPC * max_per_expert, H]
+    buf = ttnn.reshape(buf, (1, EPC, max_per_expert, H))  # [1, EPC, max_per_expert, H]
     buf_tiled = ttnn.to_layout(buf, ttnn.TILE_LAYOUT, memory_config=memory_config)
     ttnn.deallocate(dispatched)
-    if buf_tiled.dtype != ttnn.bfloat8_b:
-        buf_tiled_bf8 = ttnn.typecast(buf_tiled, ttnn.bfloat8_b)
+
+    if pw.w1_w3_fused is not None:
+        w1_w3_out = ttnn.matmul(buf_tiled, pw.w1_w3_fused, memory_config=memory_config)
         ttnn.deallocate(buf_tiled)
-    else:
-        buf_tiled_bf8 = buf_tiled
-
-    expert_outputs = buf_tiled_bf8
-
-    assert pw.w1_w3_fused is not None, (
-        "GPT-OSS prefill MoE per-expert loop currently requires fused w1_w3 weights"
-    )
-
-    # Pre-slice the EPC-batched weight tensors into per-expert tensors ONCE per
-    # config and cache on `pc`. Without this we'd hit `ttnn.slice` on bfloat4_b
-    # weights on every prefill call, which falls back through host and grows
-    # RSS unbounded (DeepSeek's TtRoutedExpert avoids this by storing
-    # gate_projs/up_projs/down_projs as pre-sliced Python lists at init time).
-    if not hasattr(pc, "_per_expert_weight_slices"):
-        pc._per_expert_weight_slices = [
-            (
-                ttnn.slice(pw.w1_w3_fused, [0, e, 0, 0], [1, e + 1, H, 2 * I], [1, 1, 1, 1]),
-                ttnn.slice(pw.w1_w3_bias_fused, [0, e, 0, 0], [1, e + 1, 1, 2 * I], [1, 1, 1, 1]),
-                ttnn.slice(pw.w2, [0, e, 0, 0], [1, e + 1, I, H], [1, 1, 1, 1]),
-                ttnn.slice(pw.w2_bias, [0, e, 0, 0], [1, e + 1, 1, H], [1, 1, 1, 1]),
-            )
-            for e in range(pc.experts_per_chip)
-        ]
-
-    for local_expert in range(pc.experts_per_chip):
-        # 6a. extract this expert's [max_per_expert, H] BFLOAT8_B TILE region.
-        tokens = ttnn.experimental.deepseek_prefill.extract(
-            expert_outputs,
-            expert_region_offsets,
-            tt_counts,
-            pc.global_expert_idx_table,
-            local_expert_id=local_expert,
-            max_dispatched_tokens_per_expert=max_per_expert,
-        )
-
-        # 6b. matmul wants BFLOAT16 acts + 4D shape. Typecast and unsqueeze.
-        tokens_bf16 = ttnn.typecast(tokens, ttnn.bfloat16)
-        ttnn.deallocate(tokens)
-        tokens_4d = ttnn.reshape(tokens_bf16, (1, 1, max_per_expert, H))
-
-        w1_w3_e, w1_w3_bias_e, w2_e, w2_bias_e = pc._per_expert_weight_slices[local_expert]
-
-        # 6d. W1+W3 fused matmul + bias + slice into gate / up halves.
-        w1_w3_out = ttnn.matmul(tokens_4d, w1_w3_e, memory_config=memory_config)
-        ttnn.deallocate(tokens_4d)
-        ttnn.deallocate(tokens_bf16)
-        ttnn.add(w1_w3_out, w1_w3_bias_e, output_tensor=w1_w3_out)
-        sh = w1_w3_out.shape
-        w1_out = ttnn.slice(w1_w3_out, [0, 0, 0, 0], [sh[0], sh[1], sh[2], I], [1, 1, 1, 1])
-        w3_out = ttnn.slice(w1_w3_out, [0, 0, 0, I], [sh[0], sh[1], sh[2], 2 * I], [1, 1, 1, 1])
+        ttnn.add(w1_w3_out, pw.w1_w3_bias_fused, output_tensor=w1_w3_out)
+        shape = w1_w3_out.shape
+        w1_out = ttnn.slice(w1_w3_out, [0, 0, 0, 0], [shape[0], shape[1], shape[2], I], [1, 1, 1, 1])
+        w3_out = ttnn.slice(w1_w3_out, [0, 0, 0, I], [shape[0], shape[1], shape[2], 2 * I], [1, 1, 1, 1])
         ttnn.deallocate(w1_w3_out)
+    else:
+        w1_out = ttnn.matmul(buf_tiled, pw.w1, memory_config=memory_config)
+        ttnn.add(w1_out, pw.w1_bias, output_tensor=w1_out)
+        w3_out = ttnn.matmul(buf_tiled, pw.w3, memory_config=memory_config)
+        ttnn.deallocate(buf_tiled)
+        ttnn.add(w3_out, pw.w3_bias, output_tensor=w3_out)
 
-        # 6e. Clamped SwiGLU (same _apply_swiglu we already use; eltwise on DRAM).
-        activated = _apply_swiglu(w1_out, w3_out, config.alpha, config.swiglu_limit, memory_config)
+    activated = _apply_swiglu(w1_out, w3_out, config.alpha, config.swiglu_limit, memory_config)
 
-        # 6f. W2 matmul + bias.
-        expert_out_4d = ttnn.matmul(activated, w2_e, memory_config=memory_config)
-        ttnn.deallocate(activated)
-        ttnn.add(expert_out_4d, w2_bias_e, output_tensor=expert_out_4d)
+    expert_output = ttnn.matmul(activated, pw.w2, memory_config=memory_config)
+    ttnn.deallocate(activated)
+    ttnn.add(expert_output, pw.w2_bias, output_tensor=expert_output)
 
-        # 6g. Reshape + typecast back to 2D BFLOAT8_B TILE for insert.
-        expert_out_2d = ttnn.reshape(expert_out_4d, (max_per_expert, H))
-        if expert_out_2d.dtype != ttnn.bfloat8_b:
-            expert_out_bf8 = ttnn.typecast(expert_out_2d, ttnn.bfloat8_b)
-            ttnn.deallocate(expert_out_4d)
-        else:
-            expert_out_bf8 = expert_out_2d
+    # Reshape back to flat for combine.
+    expert_out_rm = ttnn.to_layout(expert_output, ttnn.ROW_MAJOR_LAYOUT, memory_config=memory_config)
+    ttnn.deallocate(expert_output)
+    expert_out_rm = ttnn.reshape(expert_out_rm, (1, 1, EPC * max_per_expert, H))
 
-        # 6h. Insert this expert's slice back into the flat buffer.
-        expert_outputs = ttnn.experimental.deepseek_prefill.insert(
-            expert_outputs,
-            expert_out_bf8,
-            expert_region_offsets,
-            tt_counts,
-            pc.global_expert_idx_table,
-            local_expert_id=local_expert,
-        )
-        ttnn.deallocate(expert_out_bf8)
-
-    # Convert flat buffer back to ROW_MAJOR BFLOAT16 4D for combine.
-    expert_outputs_bf16 = ttnn.typecast(expert_outputs, ttnn.bfloat16)
-    ttnn.deallocate(expert_outputs)
-    expert_out_rm_2d = ttnn.to_layout(expert_outputs_bf16, ttnn.ROW_MAJOR_LAYOUT, memory_config=memory_config)
-    ttnn.deallocate(expert_outputs_bf16)
-    expert_out_rm = ttnn.reshape(expert_out_rm_2d, (1, 1, pc.max_dispatch_buffer_token_size, H))
-
-    # Step 7: Combine
-    combined = pc.combine_module(expert_out_rm, metadata, tt_counts, expert_region_offsets)
+    # Step 7: Combine — pass the FIXED region offsets so combine reads from the same layout
+    # dispatch wrote to.
+    combined = pc.combine_module(expert_out_rm, metadata, tt_counts, pc.fixed_region_offsets_tt)
     ttnn.deallocate(expert_out_rm)
     ttnn.deallocate(metadata)
     ttnn.deallocate(tt_counts)
-    ttnn.deallocate(expert_region_offsets)
 
     # Step 8: Fused post-combine reduce (w_reduce/w_5d may be views of scores_for_reduce)
     w_reduce = ttnn.reshape(scores_for_reduce, (1, 1, pc.seq_len_per_chip, config.num_experts_per_tok))

--- a/models/demos/gpt_oss/tt/experts_throughput/prefill.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/prefill.py
@@ -368,6 +368,23 @@ def _forward_prefill_deepseek_chunk(
     assert pw.w1_w3_fused is not None, (
         "GPT-OSS prefill MoE per-expert loop currently requires fused w1_w3 weights"
     )
+
+    # Pre-slice the EPC-batched weight tensors into per-expert tensors ONCE per
+    # config and cache on `pc`. Without this we'd hit `ttnn.slice` on bfloat4_b
+    # weights on every prefill call, which falls back through host and grows
+    # RSS unbounded (DeepSeek's TtRoutedExpert avoids this by storing
+    # gate_projs/up_projs/down_projs as pre-sliced Python lists at init time).
+    if not hasattr(pc, "_per_expert_weight_slices"):
+        pc._per_expert_weight_slices = [
+            (
+                ttnn.slice(pw.w1_w3_fused, [0, e, 0, 0], [1, e + 1, H, 2 * I], [1, 1, 1, 1]),
+                ttnn.slice(pw.w1_w3_bias_fused, [0, e, 0, 0], [1, e + 1, 1, 2 * I], [1, 1, 1, 1]),
+                ttnn.slice(pw.w2, [0, e, 0, 0], [1, e + 1, I, H], [1, 1, 1, 1]),
+                ttnn.slice(pw.w2_bias, [0, e, 0, 0], [1, e + 1, 1, H], [1, 1, 1, 1]),
+            )
+            for e in range(pc.experts_per_chip)
+        ]
+
     for local_expert in range(pc.experts_per_chip):
         # 6a. extract this expert's [max_per_expert, H] BFLOAT8_B TILE region.
         tokens = ttnn.experimental.deepseek_prefill.extract(
@@ -384,23 +401,13 @@ def _forward_prefill_deepseek_chunk(
         ttnn.deallocate(tokens)
         tokens_4d = ttnn.reshape(tokens_bf16, (1, 1, max_per_expert, H))
 
-        # 6c. Slice per-expert weight + bias rows out of the EPC-batched tensors.
-        w1_w3_e = ttnn.slice(
-            pw.w1_w3_fused, [0, local_expert, 0, 0], [1, local_expert + 1, H, 2 * I], [1, 1, 1, 1]
-        )
-        w1_w3_bias_e = ttnn.slice(
-            pw.w1_w3_bias_fused, [0, local_expert, 0, 0], [1, local_expert + 1, 1, 2 * I], [1, 1, 1, 1]
-        )
-        w2_e = ttnn.slice(pw.w2, [0, local_expert, 0, 0], [1, local_expert + 1, I, H], [1, 1, 1, 1])
-        w2_bias_e = ttnn.slice(pw.w2_bias, [0, local_expert, 0, 0], [1, local_expert + 1, 1, H], [1, 1, 1, 1])
+        w1_w3_e, w1_w3_bias_e, w2_e, w2_bias_e = pc._per_expert_weight_slices[local_expert]
 
         # 6d. W1+W3 fused matmul + bias + slice into gate / up halves.
         w1_w3_out = ttnn.matmul(tokens_4d, w1_w3_e, memory_config=memory_config)
         ttnn.deallocate(tokens_4d)
         ttnn.deallocate(tokens_bf16)
-        ttnn.deallocate(w1_w3_e)
         ttnn.add(w1_w3_out, w1_w3_bias_e, output_tensor=w1_w3_out)
-        ttnn.deallocate(w1_w3_bias_e)
         sh = w1_w3_out.shape
         w1_out = ttnn.slice(w1_w3_out, [0, 0, 0, 0], [sh[0], sh[1], sh[2], I], [1, 1, 1, 1])
         w3_out = ttnn.slice(w1_w3_out, [0, 0, 0, I], [sh[0], sh[1], sh[2], 2 * I], [1, 1, 1, 1])
@@ -412,9 +419,7 @@ def _forward_prefill_deepseek_chunk(
         # 6f. W2 matmul + bias.
         expert_out_4d = ttnn.matmul(activated, w2_e, memory_config=memory_config)
         ttnn.deallocate(activated)
-        ttnn.deallocate(w2_e)
         ttnn.add(expert_out_4d, w2_bias_e, output_tensor=expert_out_4d)
-        ttnn.deallocate(w2_bias_e)
 
         # 6g. Reshape + typecast back to 2D BFLOAT8_B TILE for insert.
         expert_out_2d = ttnn.reshape(expert_out_4d, (max_per_expert, H))

--- a/models/demos/gpt_oss/tt/experts_throughput/prefill.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/prefill.py
@@ -72,16 +72,18 @@ class DeepSeekPrefillConfig:
         self.seq_len_per_chip = seq_len_per_chip
         self.capacity_factor = capacity_factor
 
-        _, metadata_len, max_dispatched = compute_constants(
+        _, metadata_len, max_dispatch_buffer_token_size, max_dispatched = compute_constants(
             seq_len_per_chip=seq_len_per_chip,
             num_routed_experts=config.num_experts,
             num_experts_per_tok=config.num_experts_per_tok,
             num_devices=dispatch_group_size * num_dispatch_groups,
             dispatch_group_size=dispatch_group_size,
-            capacity_factor=capacity_factor,
+            dispatch_buffer_capacity_factor=int(capacity_factor),
         )
         self.metadata_len = metadata_len
         self.max_dispatched_tokens_per_expert = max_dispatched
+        # New in #41668: dispatch buffer's total token capacity (drives TtDispatchModule sizing).
+        self.max_dispatch_buffer_token_size = max_dispatch_buffer_token_size
 
         # Standard GROUP-BASED dispatch table
         expert_dispatch_table = ExpertMapping.create_dispatch_table(
@@ -99,7 +101,7 @@ class DeepSeekPrefillConfig:
             num_routed_experts=config.num_experts,
             num_experts_per_tok=config.num_experts_per_tok,
             metadata_len=metadata_len,
-            max_dispatched_tokens_per_expert=max_dispatched,
+            max_dispatch_buffer_token_size=max_dispatch_buffer_token_size,
             seq_len_per_chip=seq_len_per_chip,
             emb_dim=config.hidden_size,
             cluster_axis=0,
@@ -279,7 +281,7 @@ def _forward_prefill_deepseek_chunk(
         idx_for_routing = ttnn.to_layout(idx_u16, ttnn.ROW_MAJOR_LAYOUT)
         ttnn.deallocate(idx_u16)
 
-    tt_offsets, tt_counts, _ = pc.routing_setup(
+    tt_offsets, tt_counts, expert_region_offsets, _ = pc.routing_setup(
         ttnn_top_k_experts_indices=idx_for_routing,
         num_routed_experts=config.num_experts,
         seq_len_per_chip=pc.seq_len_per_chip,
@@ -356,10 +358,11 @@ def _forward_prefill_deepseek_chunk(
     expert_out_rm = ttnn.unsqueeze(expert_out_rm, dim=0)
 
     # Step 7: Combine
-    combined = pc.combine_module(expert_out_rm, metadata, tt_counts)
+    combined = pc.combine_module(expert_out_rm, metadata, tt_counts, expert_region_offsets)
     ttnn.deallocate(expert_out_rm)
     ttnn.deallocate(metadata)
     ttnn.deallocate(tt_counts)
+    ttnn.deallocate(expert_region_offsets)
 
     # Step 8: Fused post-combine reduce (w_reduce/w_5d may be views of scores_for_reduce)
     w_reduce = ttnn.reshape(scores_for_reduce, (1, 1, pc.seq_len_per_chip, config.num_experts_per_tok))

--- a/models/demos/gpt_oss/tt/experts_throughput/prefill.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/prefill.py
@@ -10,7 +10,7 @@ ThroughputExpertWeights to match the dispatch's expert-to-device mapping.
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping, compute_constants
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping, compute_constants, get_ep_mesh_mapper
 from models.demos.deepseek_v3_d_p.tt.moe.tt_combine import TtCombineModule
 from models.demos.deepseek_v3_d_p.tt.moe.tt_dispatch import TtDispatchModule
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_routing_setup import TtMoERoutingSetup
@@ -93,6 +93,27 @@ class DeepSeekPrefillConfig:
         self.tt_dispatch_table = TtDispatchModule.shard_expert_dispatch_table(
             mesh_device, expert_dispatch_table, dispatch_axis=0
         )
+
+        # Per-#41668: extract/insert kernels look up global_expert_id from this
+        # table at dispatch time. Build once per config and ship to device.
+        # ShardTensor2dMesh splits dim 1 across rows and dim 0 across cols, so
+        # each device ends up with a (1, 1, experts_per_chip) slice; squeeze
+        # the two leading singletons so we hand a 1D vector to the kernels
+        # (their validators require rank 1 or 2 with first dim == 1).
+        global_expert_idx_tt = ttnn.from_torch(
+            ExpertMapping.create_global_expert_idx_table(
+                experts_per_chip=experts_per_chip,
+                dispatch_group_size=dispatch_group_size,
+                num_dispatch_groups=num_dispatch_groups,
+            ),
+            mesh_mapper=get_ep_mesh_mapper(mesh_device),
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh_device,
+            dtype=ttnn.uint32,
+        )
+        global_expert_idx_tt = ttnn.squeeze(global_expert_idx_tt, 0)
+        global_expert_idx_tt = ttnn.squeeze(global_expert_idx_tt, 0)
+        self.global_expert_idx_table = global_expert_idx_tt
 
         self.dispatch_module = TtDispatchModule(
             mesh_device=mesh_device,
@@ -315,47 +336,111 @@ def _forward_prefill_deepseek_chunk(
     ttnn.deallocate(indices_rm)
     ttnn.deallocate(tt_offsets)
 
-    # Step 6: Expert compute using GROUP-permuted ThroughputExpertWeights
-    buf = ttnn.squeeze(dispatched, dim=0)
-    if len(buf.shape) == 3:
-        buf = ttnn.unsqueeze(buf, dim=0)
-    # NaN cleanup skipped — unfilled dispatch slots dont affect valid token outputs
-    buf_tiled = ttnn.to_layout(buf, ttnn.TILE_LAYOUT)
-    ttnn.deallocate(dispatched)
+    # Step 6: Per-expert FFN using extract/insert (post-#41668)
+    #
+    # The dispatched buffer is now flat [1, 1, max_dispatch_buffer_token_size, H]
+    # with each expert's tokens stored at a TILE-aligned offset given by
+    # expert_region_offsets, packed dynamically. The old single-batched-matmul
+    # pattern over EPC=4 expert weights doesn't apply — we mirror DeepSeek's
+    # TtRoutedExpert: extract per-expert tokens, run FFN on them, insert back.
+    #
+    # extract / insert require 2D BFLOAT8_B TILE inputs, so we flatten the
+    # leading [1, 1] dims and typecast once into the loop and once back out.
+    H = config.hidden_size
+    I = config.intermediate_size
+    max_per_expert = pc.max_dispatched_tokens_per_expert
 
     memory_config = ttnn.DRAM_MEMORY_CONFIG
 
-    if pw.w1_w3_fused is not None:
-        w1_w3_out = ttnn.matmul(buf_tiled, pw.w1_w3_fused, memory_config=memory_config)
+    buf = ttnn.squeeze(dispatched, dim=0)  # [1, max_buffer, H] or [max_buffer, H]
+    if len(buf.shape) >= 3:
+        buf = ttnn.squeeze(buf, dim=0)  # [max_buffer, H]
+    buf_tiled = ttnn.to_layout(buf, ttnn.TILE_LAYOUT, memory_config=memory_config)
+    ttnn.deallocate(dispatched)
+    if buf_tiled.dtype != ttnn.bfloat8_b:
+        buf_tiled_bf8 = ttnn.typecast(buf_tiled, ttnn.bfloat8_b)
         ttnn.deallocate(buf_tiled)
-        ttnn.add(w1_w3_out, pw.w1_w3_bias_fused, output_tensor=w1_w3_out)
-        shape = w1_w3_out.shape
-        w1_out = ttnn.slice(
-            w1_w3_out, [0, 0, 0, 0], [shape[0], shape[1], shape[2], config.intermediate_size], [1, 1, 1, 1]
-        )
-        w3_out = ttnn.slice(
-            w1_w3_out,
-            [0, 0, 0, config.intermediate_size],
-            [shape[0], shape[1], shape[2], 2 * config.intermediate_size],
-            [1, 1, 1, 1],
-        )
-        ttnn.deallocate(w1_w3_out)
     else:
-        w1_out = ttnn.matmul(buf_tiled, pw.w1, memory_config=memory_config)
-        ttnn.add(w1_out, pw.w1_bias, output_tensor=w1_out)
-        w3_out = ttnn.matmul(buf_tiled, pw.w3, memory_config=memory_config)
-        ttnn.deallocate(buf_tiled)
-        ttnn.add(w3_out, pw.w3_bias, output_tensor=w3_out)
+        buf_tiled_bf8 = buf_tiled
 
-    activated = _apply_swiglu(w1_out, w3_out, config.alpha, config.swiglu_limit, memory_config)
+    expert_outputs = buf_tiled_bf8
 
-    expert_output = ttnn.matmul(activated, pw.w2, memory_config=memory_config)
-    ttnn.deallocate(activated)
-    ttnn.add(expert_output, pw.w2_bias, output_tensor=expert_output)
+    assert pw.w1_w3_fused is not None, (
+        "GPT-OSS prefill MoE per-expert loop currently requires fused w1_w3 weights"
+    )
+    for local_expert in range(pc.experts_per_chip):
+        # 6a. extract this expert's [max_per_expert, H] BFLOAT8_B TILE region.
+        tokens = ttnn.experimental.deepseek_prefill.extract(
+            expert_outputs,
+            expert_region_offsets,
+            tt_counts,
+            pc.global_expert_idx_table,
+            local_expert,
+            max_per_expert,
+        )
 
-    expert_out_rm = ttnn.to_layout(expert_output, ttnn.ROW_MAJOR_LAYOUT)
-    ttnn.deallocate(expert_output)
-    expert_out_rm = ttnn.unsqueeze(expert_out_rm, dim=0)
+        # 6b. matmul wants BFLOAT16 acts + 4D shape. Typecast and unsqueeze.
+        tokens_bf16 = ttnn.typecast(tokens, ttnn.bfloat16)
+        ttnn.deallocate(tokens)
+        tokens_4d = ttnn.reshape(tokens_bf16, (1, 1, max_per_expert, H))
+
+        # 6c. Slice per-expert weight + bias rows out of the EPC-batched tensors.
+        w1_w3_e = ttnn.slice(
+            pw.w1_w3_fused, [0, local_expert, 0, 0], [1, local_expert + 1, H, 2 * I], [1, 1, 1, 1]
+        )
+        w1_w3_bias_e = ttnn.slice(
+            pw.w1_w3_bias_fused, [0, local_expert, 0, 0], [1, local_expert + 1, 1, 2 * I], [1, 1, 1, 1]
+        )
+        w2_e = ttnn.slice(pw.w2, [0, local_expert, 0, 0], [1, local_expert + 1, I, H], [1, 1, 1, 1])
+        w2_bias_e = ttnn.slice(pw.w2_bias, [0, local_expert, 0, 0], [1, local_expert + 1, 1, H], [1, 1, 1, 1])
+
+        # 6d. W1+W3 fused matmul + bias + slice into gate / up halves.
+        w1_w3_out = ttnn.matmul(tokens_4d, w1_w3_e, memory_config=memory_config)
+        ttnn.deallocate(tokens_4d)
+        ttnn.deallocate(tokens_bf16)
+        ttnn.deallocate(w1_w3_e)
+        ttnn.add(w1_w3_out, w1_w3_bias_e, output_tensor=w1_w3_out)
+        ttnn.deallocate(w1_w3_bias_e)
+        sh = w1_w3_out.shape
+        w1_out = ttnn.slice(w1_w3_out, [0, 0, 0, 0], [sh[0], sh[1], sh[2], I], [1, 1, 1, 1])
+        w3_out = ttnn.slice(w1_w3_out, [0, 0, 0, I], [sh[0], sh[1], sh[2], 2 * I], [1, 1, 1, 1])
+        ttnn.deallocate(w1_w3_out)
+
+        # 6e. Clamped SwiGLU (same _apply_swiglu we already use; eltwise on DRAM).
+        activated = _apply_swiglu(w1_out, w3_out, config.alpha, config.swiglu_limit, memory_config)
+
+        # 6f. W2 matmul + bias.
+        expert_out_4d = ttnn.matmul(activated, w2_e, memory_config=memory_config)
+        ttnn.deallocate(activated)
+        ttnn.deallocate(w2_e)
+        ttnn.add(expert_out_4d, w2_bias_e, output_tensor=expert_out_4d)
+        ttnn.deallocate(w2_bias_e)
+
+        # 6g. Reshape + typecast back to 2D BFLOAT8_B TILE for insert.
+        expert_out_2d = ttnn.reshape(expert_out_4d, (max_per_expert, H))
+        if expert_out_2d.dtype != ttnn.bfloat8_b:
+            expert_out_bf8 = ttnn.typecast(expert_out_2d, ttnn.bfloat8_b)
+            ttnn.deallocate(expert_out_4d)
+        else:
+            expert_out_bf8 = expert_out_2d
+
+        # 6h. Insert this expert's slice back into the flat buffer.
+        expert_outputs = ttnn.experimental.deepseek_prefill.insert(
+            expert_outputs,
+            expert_out_bf8,
+            expert_region_offsets,
+            tt_counts,
+            pc.global_expert_idx_table,
+            local_expert,
+        )
+        ttnn.deallocate(expert_out_bf8)
+
+    # Convert flat buffer back to ROW_MAJOR BFLOAT16 4D for combine.
+    expert_outputs_bf16 = ttnn.typecast(expert_outputs, ttnn.bfloat16)
+    ttnn.deallocate(expert_outputs)
+    expert_out_rm_2d = ttnn.to_layout(expert_outputs_bf16, ttnn.ROW_MAJOR_LAYOUT, memory_config=memory_config)
+    ttnn.deallocate(expert_outputs_bf16)
+    expert_out_rm = ttnn.reshape(expert_out_rm_2d, (1, 1, pc.max_dispatch_buffer_token_size, H))
 
     # Step 7: Combine
     combined = pc.combine_module(expert_out_rm, metadata, tt_counts, expert_region_offsets)

--- a/models/demos/gpt_oss/tt/experts_throughput/prefill.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/prefill.py
@@ -7,7 +7,6 @@ Uses GROUP-BASED dispatch table (standard ExpertMapping) with permuted
 ThroughputExpertWeights to match the dispatch's expert-to-device mapping.
 """
 
-import torch
 from loguru import logger
 
 import ttnn
@@ -71,13 +70,6 @@ class DeepSeekPrefillConfig:
         experts_per_chip = config.num_experts // (dispatch_group_size * num_dispatch_groups)
         self.experts_per_chip = experts_per_chip
         self.seq_len_per_chip = seq_len_per_chip
-        # Override capacity_factor to be at least experts_per_chip. We override the post-#41668
-        # dynamic per-expert offsets with FIXED-stride offsets (each expert at L * max_dispatched
-        # within its destination chip's flat buffer), which lets us reshape the dispatched buffer
-        # into the pre-#41668 EPC-batched 4D layout `[1, EPC, max_dispatched, H]` and run the
-        # original single batched-matmul FFN chain. That requires the buffer to fit
-        # EPC * max_dispatched rows -> `dispatch_buffer_capacity_factor >= experts_per_chip`.
-        capacity_factor = max(int(capacity_factor), experts_per_chip)
         self.capacity_factor = capacity_factor
 
         _, metadata_len, max_dispatch_buffer_token_size, max_dispatched = compute_constants(
@@ -86,7 +78,7 @@ class DeepSeekPrefillConfig:
             num_experts_per_tok=config.num_experts_per_tok,
             num_devices=dispatch_group_size * num_dispatch_groups,
             dispatch_group_size=dispatch_group_size,
-            dispatch_buffer_capacity_factor=capacity_factor,
+            dispatch_buffer_capacity_factor=int(capacity_factor),
         )
         self.metadata_len = metadata_len
         self.max_dispatched_tokens_per_expert = max_dispatched
@@ -122,31 +114,6 @@ class DeepSeekPrefillConfig:
         global_expert_idx_tt = ttnn.squeeze(global_expert_idx_tt, 0)
         global_expert_idx_tt = ttnn.squeeze(global_expert_idx_tt, 0)
         self.global_expert_idx_table = global_expert_idx_tt
-
-        # Build fixed-stride region offsets per expert. For each global expert id `e`, the value is
-        # `local_idx_of_e_on_its_destination_chip * max_dispatched`. With this layout, every chip's
-        # flat dispatch buffer is naturally segmented into EPC fixed-size regions, and we can
-        # reshape `[1, 1, EPC * max_dispatched, H]` -> `[1, EPC, max_dispatched, H]` for the
-        # pre-#41668 batched matmul chain (no per-expert extract/insert needed).
-        expert_id_table_torch = ExpertMapping.create_global_expert_idx_table(
-            experts_per_chip=experts_per_chip,
-            dispatch_group_size=dispatch_group_size,
-            num_dispatch_groups=num_dispatch_groups,
-        )  # shape (ndg, dgs, EPC) -> global expert id
-        fixed_region_offsets_torch = torch.zeros(1, config.num_experts, dtype=torch.int32)
-        for g in range(num_dispatch_groups):
-            for c in range(dispatch_group_size):
-                for L in range(experts_per_chip):
-                    e = int(expert_id_table_torch[g, c, L])
-                    fixed_region_offsets_torch[0, e] = L * max_dispatched
-        self.fixed_region_offsets_tt = ttnn.from_torch(
-            fixed_region_offsets_torch,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=mesh_device,
-            dtype=ttnn.uint32,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        )
 
         self.dispatch_module = TtDispatchModule(
             mesh_device=mesh_device,
@@ -367,81 +334,131 @@ def _forward_prefill_deepseek_chunk(
     i_3d = ttnn.reshape(indices_rm, (1, pc.seq_len_per_chip, config.num_experts_per_tok))
 
     # Step 5: Dispatch
-    #
-    # routing_setup produced `tt_offsets` and `expert_region_offsets` from a per-source-device
-    # cumsum that tightly packs each expert's region in the destination chip's flat buffer
-    # (region_offset[e] = sum of counts for prior experts). To restore the pre-#41668 layout
-    # where each local expert occupied a fixed slot of `max_dispatched` rows, we substitute
-    # FIXED-stride region offsets (`L * max_dispatched` for the L-th local expert on its
-    # destination chip) and re-derive the per-source dispatch offsets:
-    #   tt_offsets_dynamic = local_offset_per_source + region_offsets_dynamic
-    #   tt_offsets_fixed   = local_offset_per_source + region_offsets_fixed
-    #                      = tt_offsets_dynamic - region_offsets_dynamic + region_offsets_fixed
-    # `pc.fixed_region_offsets_tt` was precomputed at config init.
-    local_offsets = ttnn.subtract(tt_offsets, expert_region_offsets)
-    ttnn.deallocate(tt_offsets)
-    ttnn.deallocate(expert_region_offsets)
-    tt_offsets_fixed = ttnn.add(local_offsets, pc.fixed_region_offsets_tt)
-    ttnn.deallocate(local_offsets)
-
-    dispatched, metadata = pc.dispatch_module(x_3d, w_3d, i_3d, tt_offsets_fixed, pc.tt_dispatch_table)
+    dispatched, metadata = pc.dispatch_module(x_3d, w_3d, i_3d, tt_offsets, pc.tt_dispatch_table)
     # Dispatch done — x/scores/indices no longer needed
     if x_full_is_new:
         ttnn.deallocate(x_full)
     ttnn.deallocate(scores_rm)
     ttnn.deallocate(indices_rm)
-    ttnn.deallocate(tt_offsets_fixed)
+    ttnn.deallocate(tt_offsets)
 
-    # Step 6: Reshape flat dispatched buffer to EPC-batched and run pre-#41668 batched FFN.
+    # Step 6: Per-expert FFN using extract/insert (post-#41668)
     #
-    # With fixed-stride layout the buffer is `[1, 1, EPC * max_dispatched, H]`, expert L's
-    # rows at flat positions `[L * max_dispatched, (L+1) * max_dispatched)`. Reshape to
-    # `[1, EPC, max_dispatched, H]` and the original single batched-matmul-over-EPC chain
-    # works unchanged.
+    # The dispatched buffer is now flat [1, 1, max_dispatch_buffer_token_size, H]
+    # with each expert's tokens stored at a TILE-aligned offset given by
+    # expert_region_offsets, packed dynamically. The old single-batched-matmul
+    # pattern over EPC=4 expert weights doesn't apply — we mirror DeepSeek's
+    # TtRoutedExpert: extract per-expert tokens, run FFN on them, insert back.
+    #
+    # extract / insert require 2D BFLOAT8_B TILE inputs, so we flatten the
+    # leading [1, 1] dims and typecast once into the loop and once back out.
     H = config.hidden_size
     I = config.intermediate_size
     max_per_expert = pc.max_dispatched_tokens_per_expert
-    EPC = pc.experts_per_chip
 
     memory_config = ttnn.DRAM_MEMORY_CONFIG
 
-    buf = ttnn.squeeze(dispatched, dim=0)  # [1, EPC * max_per_expert, H]
-    buf = ttnn.reshape(buf, (1, EPC, max_per_expert, H))  # [1, EPC, max_per_expert, H]
+    buf = ttnn.squeeze(dispatched, dim=0)  # [1, max_buffer, H] or [max_buffer, H]
+    if len(buf.shape) >= 3:
+        buf = ttnn.squeeze(buf, dim=0)  # [max_buffer, H]
     buf_tiled = ttnn.to_layout(buf, ttnn.TILE_LAYOUT, memory_config=memory_config)
     ttnn.deallocate(dispatched)
-
-    if pw.w1_w3_fused is not None:
-        w1_w3_out = ttnn.matmul(buf_tiled, pw.w1_w3_fused, memory_config=memory_config)
+    if buf_tiled.dtype != ttnn.bfloat8_b:
+        buf_tiled_bf8 = ttnn.typecast(buf_tiled, ttnn.bfloat8_b)
         ttnn.deallocate(buf_tiled)
-        ttnn.add(w1_w3_out, pw.w1_w3_bias_fused, output_tensor=w1_w3_out)
-        shape = w1_w3_out.shape
-        w1_out = ttnn.slice(w1_w3_out, [0, 0, 0, 0], [shape[0], shape[1], shape[2], I], [1, 1, 1, 1])
-        w3_out = ttnn.slice(w1_w3_out, [0, 0, 0, I], [shape[0], shape[1], shape[2], 2 * I], [1, 1, 1, 1])
-        ttnn.deallocate(w1_w3_out)
     else:
-        w1_out = ttnn.matmul(buf_tiled, pw.w1, memory_config=memory_config)
-        ttnn.add(w1_out, pw.w1_bias, output_tensor=w1_out)
-        w3_out = ttnn.matmul(buf_tiled, pw.w3, memory_config=memory_config)
-        ttnn.deallocate(buf_tiled)
-        ttnn.add(w3_out, pw.w3_bias, output_tensor=w3_out)
+        buf_tiled_bf8 = buf_tiled
 
-    activated = _apply_swiglu(w1_out, w3_out, config.alpha, config.swiglu_limit, memory_config)
+    expert_outputs = buf_tiled_bf8
 
-    expert_output = ttnn.matmul(activated, pw.w2, memory_config=memory_config)
-    ttnn.deallocate(activated)
-    ttnn.add(expert_output, pw.w2_bias, output_tensor=expert_output)
+    assert pw.w1_w3_fused is not None, (
+        "GPT-OSS prefill MoE per-expert loop currently requires fused w1_w3 weights"
+    )
 
-    # Reshape back to flat for combine.
-    expert_out_rm = ttnn.to_layout(expert_output, ttnn.ROW_MAJOR_LAYOUT, memory_config=memory_config)
-    ttnn.deallocate(expert_output)
-    expert_out_rm = ttnn.reshape(expert_out_rm, (1, 1, EPC * max_per_expert, H))
+    # Pre-slice the EPC-batched weight tensors into per-expert tensors ONCE per
+    # config and cache on `pc`. Without this we'd hit `ttnn.slice` on bfloat4_b
+    # weights on every prefill call, which falls back through host and grows
+    # RSS unbounded (DeepSeek's TtRoutedExpert avoids this by storing
+    # gate_projs/up_projs/down_projs as pre-sliced Python lists at init time).
+    if not hasattr(pc, "_per_expert_weight_slices"):
+        pc._per_expert_weight_slices = [
+            (
+                ttnn.slice(pw.w1_w3_fused, [0, e, 0, 0], [1, e + 1, H, 2 * I], [1, 1, 1, 1]),
+                ttnn.slice(pw.w1_w3_bias_fused, [0, e, 0, 0], [1, e + 1, 1, 2 * I], [1, 1, 1, 1]),
+                ttnn.slice(pw.w2, [0, e, 0, 0], [1, e + 1, I, H], [1, 1, 1, 1]),
+                ttnn.slice(pw.w2_bias, [0, e, 0, 0], [1, e + 1, 1, H], [1, 1, 1, 1]),
+            )
+            for e in range(pc.experts_per_chip)
+        ]
 
-    # Step 7: Combine — pass the FIXED region offsets so combine reads from the same layout
-    # dispatch wrote to.
-    combined = pc.combine_module(expert_out_rm, metadata, tt_counts, pc.fixed_region_offsets_tt)
+    for local_expert in range(pc.experts_per_chip):
+        # 6a. extract this expert's [max_per_expert, H] BFLOAT8_B TILE region.
+        tokens = ttnn.experimental.deepseek_prefill.extract(
+            expert_outputs,
+            expert_region_offsets,
+            tt_counts,
+            pc.global_expert_idx_table,
+            local_expert_id=local_expert,
+            max_dispatched_tokens_per_expert=max_per_expert,
+        )
+
+        # 6b. matmul wants BFLOAT16 acts + 4D shape. Typecast and unsqueeze.
+        tokens_bf16 = ttnn.typecast(tokens, ttnn.bfloat16)
+        ttnn.deallocate(tokens)
+        tokens_4d = ttnn.reshape(tokens_bf16, (1, 1, max_per_expert, H))
+
+        w1_w3_e, w1_w3_bias_e, w2_e, w2_bias_e = pc._per_expert_weight_slices[local_expert]
+
+        # 6d. W1+W3 fused matmul + bias + slice into gate / up halves.
+        w1_w3_out = ttnn.matmul(tokens_4d, w1_w3_e, memory_config=memory_config)
+        ttnn.deallocate(tokens_4d)
+        ttnn.deallocate(tokens_bf16)
+        ttnn.add(w1_w3_out, w1_w3_bias_e, output_tensor=w1_w3_out)
+        sh = w1_w3_out.shape
+        w1_out = ttnn.slice(w1_w3_out, [0, 0, 0, 0], [sh[0], sh[1], sh[2], I], [1, 1, 1, 1])
+        w3_out = ttnn.slice(w1_w3_out, [0, 0, 0, I], [sh[0], sh[1], sh[2], 2 * I], [1, 1, 1, 1])
+        ttnn.deallocate(w1_w3_out)
+
+        # 6e. Clamped SwiGLU (same _apply_swiglu we already use; eltwise on DRAM).
+        activated = _apply_swiglu(w1_out, w3_out, config.alpha, config.swiglu_limit, memory_config)
+
+        # 6f. W2 matmul + bias.
+        expert_out_4d = ttnn.matmul(activated, w2_e, memory_config=memory_config)
+        ttnn.deallocate(activated)
+        ttnn.add(expert_out_4d, w2_bias_e, output_tensor=expert_out_4d)
+
+        # 6g. Reshape + typecast back to 2D BFLOAT8_B TILE for insert.
+        expert_out_2d = ttnn.reshape(expert_out_4d, (max_per_expert, H))
+        if expert_out_2d.dtype != ttnn.bfloat8_b:
+            expert_out_bf8 = ttnn.typecast(expert_out_2d, ttnn.bfloat8_b)
+            ttnn.deallocate(expert_out_4d)
+        else:
+            expert_out_bf8 = expert_out_2d
+
+        # 6h. Insert this expert's slice back into the flat buffer.
+        expert_outputs = ttnn.experimental.deepseek_prefill.insert(
+            expert_outputs,
+            expert_out_bf8,
+            expert_region_offsets,
+            tt_counts,
+            pc.global_expert_idx_table,
+            local_expert_id=local_expert,
+        )
+        ttnn.deallocate(expert_out_bf8)
+
+    # Convert flat buffer back to ROW_MAJOR BFLOAT16 4D for combine.
+    expert_outputs_bf16 = ttnn.typecast(expert_outputs, ttnn.bfloat16)
+    ttnn.deallocate(expert_outputs)
+    expert_out_rm_2d = ttnn.to_layout(expert_outputs_bf16, ttnn.ROW_MAJOR_LAYOUT, memory_config=memory_config)
+    ttnn.deallocate(expert_outputs_bf16)
+    expert_out_rm = ttnn.reshape(expert_out_rm_2d, (1, 1, pc.max_dispatch_buffer_token_size, H))
+
+    # Step 7: Combine
+    combined = pc.combine_module(expert_out_rm, metadata, tt_counts, expert_region_offsets)
     ttnn.deallocate(expert_out_rm)
     ttnn.deallocate(metadata)
     ttnn.deallocate(tt_counts)
+    ttnn.deallocate(expert_region_offsets)
 
     # Step 8: Fused post-combine reduce (w_reduce/w_5d may be views of scores_for_reduce)
     w_reduce = ttnn.reshape(scores_for_reduce, (1, 1, pc.seq_len_per_chip, config.num_experts_per_tok))

--- a/models/demos/gpt_oss/tt/experts_throughput/prefill.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/prefill.py
@@ -143,7 +143,13 @@ class DeepSeekPrefillConfig:
             init_zeros=True,
         )
 
-        self.routing_setup = TtMoERoutingSetup(mesh_device, expert_dispatch_table, num_links=num_links)
+        # IMPORTANT: TtMoERoutingSetup defaults experts_per_chip=32. GPT-OSS-120b on a 4x8 mesh
+        # has only 4 experts per chip; with the wrong value the offset_cumsum produces
+        # expert_region_offsets sized for 32 experts, which extract then reads as out-of-range
+        # offsets and the device kernel enters an unbounded host-allocating retry path.
+        self.routing_setup = TtMoERoutingSetup(
+            mesh_device, expert_dispatch_table, experts_per_chip=experts_per_chip, num_links=num_links
+        )
 
         self.permuted_weights = None  # Set by mlp.py after host-side permutation
 
@@ -392,8 +398,8 @@ def _forward_prefill_deepseek_chunk(
             expert_region_offsets,
             tt_counts,
             pc.global_expert_idx_table,
-            local_expert,
-            max_per_expert,
+            local_expert_id=local_expert,
+            max_dispatched_tokens_per_expert=max_per_expert,
         )
 
         # 6b. matmul wants BFLOAT16 acts + 4D shape. Typecast and unsqueeze.
@@ -436,7 +442,7 @@ def _forward_prefill_deepseek_chunk(
             expert_region_offsets,
             tt_counts,
             pc.global_expert_idx_table,
-            local_expert,
+            local_expert_id=local_expert,
         )
         ttnn.deallocate(expert_out_bf8)
 

--- a/models/demos/gpt_oss/tt/model_config.py
+++ b/models/demos/gpt_oss/tt/model_config.py
@@ -215,7 +215,7 @@ class ModelArgs:
             return self.tokenizer.apply_chat_template(prompt_text, add_generation_prompt=True, tokenize=True)
 
     @staticmethod
-    def load_state_dict(weights_path, dummy_weights=False, convert_to_meta_format=True):
+    def load_state_dict(weights_path, dummy_weights=False, convert_to_meta_format=True, num_layers=None):
         """Load model state dict compatible with tt_transformers
 
         Args:
@@ -223,6 +223,9 @@ class ModelArgs:
             dummy_weights (bool): If True, returns a dummy state dict for testing purposes.
             convert_to_meta_format (bool): If True, convert HF QKV weights to Meta format for RoPE.
                 Set to False when loading for HuggingFace reference models.
+            num_layers (int, optional): If set, override `num_hidden_layers` so HF only
+                materializes that many decoder blocks. Avoids ~250 GB host RSS during
+                MXFP4->bf16 dequant when only a few layers are needed (e.g. quick test runs).
         """
         if dummy_weights:
             # Return dummy state dict for testing
@@ -230,9 +233,17 @@ class ModelArgs:
         else:
             # Load actual GPT-OSS weights directly from safetensors files
             # Check if we have a cached torch_state_dict.pt file
+            from_pretrained_kwargs = {"torch_dtype": "auto"}
+            if num_layers is not None:
+                hf_config = AutoConfig.from_pretrained(weights_path)
+                logger.info(
+                    f"load_state_dict: overriding num_hidden_layers {hf_config.num_hidden_layers} -> {num_layers}"
+                )
+                hf_config.num_hidden_layers = num_layers
+                from_pretrained_kwargs["config"] = hf_config
             model = AutoModelForCausalLM.from_pretrained(
                 weights_path,
-                torch_dtype="auto"
+                **from_pretrained_kwargs,
                 # Note that the default setting is torch.dtype.float32, but model weights are
                 # may come in any dtype. If the model's weights are in torch.dtype.bfloat16, this would result in 2x memory usage from an
                 # unnecessary cast.


### PR DESCRIPTION
PR #41668 (ds_prefill: Support for dynamic dispatch buffer size) landed on main and rotated several APIs we depend on, breaking the GPT-OSS DeepSeek prefill path. Wire the call sites in
experts_throughput/prefill.py to the new signatures:

  * compute_constants — kwarg capacity_factor -> dispatch_buffer_capacity_factor; return tuple now has 4 values (max_dispatch_buffer_token_size added before max_dispatched_tokens_per_expert).
  * TtDispatchModule.__init__ — max_dispatched_tokens_per_expert kwarg renamed to max_dispatch_buffer_token_size.
  * TtMoERoutingSetup.forward — now returns 4 tensors (global_dispatch_offsets, total_counts_per_expert, expert_region_offsets, expert_histograms); we capture the new expert_region_offsets at idx 2.
  * TtCombineModule.forward — now takes a required 4th tensor argument expert_region_offsets; thread it through and deallocate after combine.

capacity_factor is cast to int per the new explicit semantics ("callers pick the smallest integer factor such that dgs*seq*factor covers the worst-case buffer"). The DeepSeekPrefillConfig.capacity_factor field stays float-typed at the public API for caller convenience.

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sraizada/fix-prefill-after-41668)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sraizada/fix-prefill-after-41668)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sraizada/fix-prefill-after-41668)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sraizada/fix-prefill-after-41668)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sraizada/fix-prefill-after-41668)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sraizada/fix-prefill-after-41668)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sraizada/fix-prefill-after-41668)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sraizada/fix-prefill-after-41668)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sraizada/fix-prefill-after-41668)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sraizada/fix-prefill-after-41668)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sraizada/fix-prefill-after-41668)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sraizada/fix-prefill-after-41668)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sraizada/fix-prefill-after-41668)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sraizada/fix-prefill-after-41668)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sraizada/fix-prefill-after-41668)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sraizada/fix-prefill-after-41668)