### PR TITLE
Added fatal in selective reduce combine PF to check if there are sufficient cores

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -82,15 +82,17 @@ auto launch_mux_workers(
     const uint32_t available_cores = mux_core_range_set.num_cores();
 
     // Validate sufficient cores exist before selection to prevent segfault in select_from_corerangeset
-    TT_FATAL(
-        needed_cores <= available_cores,
-        "Not enough mux cores! Needed: {} (num_links={} * neighbors.size()={}), Available: {}. "
-        "mux_core_range_set={}",
-        needed_cores,
-        num_links,
-        neighbors.size(),
-        available_cores,
-        mux_core_range_set.str());
+    if (needed_cores > 0) {
+        TT_FATAL(
+            needed_cores <= available_cores,
+            "Not enough mux cores! Needed: {} (num_links={} * neighbors.size()={}), Available: {}. "
+            "mux_core_range_set={}",
+            needed_cores,
+            num_links,
+            neighbors.size(),
+            available_cores,
+            mux_core_range_set.str());
+    }
 
     const auto needed_mux_core_range_set = select_from_corerangeset(mux_core_range_set, 0, needed_cores - 1);
     auto mux_kernel_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -77,8 +77,22 @@ auto launch_mux_workers(
             *occupied_l1_tensor_addr);
     }
 
-    const auto needed_mux_core_range_set =
-        select_from_corerangeset(mux_core_range_set, 0, num_links * neighbors.size() - 1);
+    // Calculate required vs available mux cores for fabric communication (one core per link per neighbor)
+    const uint32_t needed_cores = num_links * neighbors.size();
+    const uint32_t available_cores = mux_core_range_set.num_cores();
+
+    // Validate sufficient cores exist before selection to prevent segfault in select_from_corerangeset
+    TT_FATAL(
+        needed_cores <= available_cores,
+        "Not enough mux cores! Needed: {} (num_links={} * neighbors.size()={}), Available: {}. "
+        "mux_core_range_set={}",
+        needed_cores,
+        num_links,
+        neighbors.size(),
+        available_cores,
+        mux_core_range_set.str());
+
+    const auto needed_mux_core_range_set = select_from_corerangeset(mux_core_range_set, 0, needed_cores - 1);
     auto mux_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp",


### PR DESCRIPTION
### Summary

Recent changes in MoE caused my previous call to `ttnn.experimental.moe_compute` to result in a segmentation fault. Updated the selective reduce combine program factory to have a TT_FATAL checking the number of mux cores available, avoiding the seg fault and allowing for easier debugging. Previously:

My call to the op:
```
ttnn.experimental.moe_compute(
            tt_sparse,
            tt_indices,
            tt_scores,
            tt_expert_mapping,
            tt_w0_w1,
            tt_w2,
            layer_id=layer_id,
            output_height_shard_dim=output_height_shard_dim,
            output_width_shard_dim=output_width_shard_dim,
            cluster_axis=cluster_axis,
        )
```
Result (running a single galaxy test, testing the compute op):
```
Fatal Python error: Segmentation fault

Current thread 0x00007fba28c74740 (most recent call first):
  File "/localdev/smeydanshahi/tt-metal/ttnn/ttnn/decorators.py", line 473 in __call__
  File "/localdev/smeydanshahi/tt-metal/models/demos/deepseek_v3/tests/tg_moe_tests/individual_ops/test_compute_tg.py", line 328 in run_op
  File "/localdev/smeydanshahi/tt-metal/models/demos/deepseek_v3/tests/tg_moe_tests/individual_ops/test_compute_tg.py", line 369 in run_moe_compute_test
  File "/localdev/smeydanshahi/tt-metal/models/demos/deepseek_v3/tests/tg_moe_tests/individual_ops/test_compute_tg.py", line 467 in test_compute_correctness
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/_pytest/python.py", line 157 in pytest_pyfunc_call
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/_pytest/python.py", line 1671 in runtest
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/_pytest/runner.py", line 178 in pytest_runtest_call
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/_pytest/runner.py", line 246 in <lambda>
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/_pytest/runner.py", line 344 in from_call
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/_pytest/runner.py", line 245 in call_and_report
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/_pytest/runner.py", line 136 in runtestprotocol
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/_pytest/runner.py", line 117 in pytest_runtest_protocol
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/_pytest/main.py", line 367 in pytest_runtestloop
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/_pytest/main.py", line 343 in _main
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/_pytest/main.py", line 289 in wrap_session
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/_pytest/main.py", line 336 in pytest_cmdline_main
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/_pytest/config/__init__.py", line 175 in main
  File "/localdev/smeydanshahi/tt-metal/python_env/lib/python3.10/site-packages/_pytest/config/__init__.py", line 201 in console_main
  File "/localdev/smeydanshahi/tt-metal/python_env/bin/pytest", line 12 in <module>

Extension modules: markupsafe._speedups, zmq.backend.cython._zmq, tornado.speedups, msgpack._cmsgpack, psutil._psutil_linux, _brotli, backports.zstd._zstd, charset_normalizer.md, charset_normalizer.cd, simplejson._speedups, requests.packages.charset_normalizer.md, requests.packages.chardet.md, requests.packages.charset_normalizer.cd, requests.packages.chardet.cd, numpy.core._multiarray_umath, numpy.core._multiarray_tests, numpy.linalg._umath_linalg, numpy.fft._pocketfft_internal, numpy.random._common, numpy.random.bit_generator, numpy.random._bounded_integers, numpy.random._mt19937, numpy.random.mtrand, numpy.random._philox, numpy.random._pcg64, numpy.random._sfc64, numpy.random._generator, torch._C, torch._C._dynamo.autograd_compiler, torch._C._dynamo.eval_frame, torch._C._dynamo.guards, torch._C._dynamo.utils, torch._C._fft, torch._C._linalg, torch._C._nested, torch._C._nn, torch._C._sparse, torch._C._special, yaml._yaml, pyarrow.lib, pandas._libs.tslibs.ccalendar, pandas._libs.tslibs.np_datetime, pandas._libs.tslibs.dtypes, pandas._libs.tslibs.base, pandas._libs.tslibs.nattype, pandas._libs.tslibs.timezones, pandas._libs.tslibs.fields, pandas._libs.tslibs.timedeltas, pandas._libs.tslibs.tzconversion, pandas._libs.tslibs.timestamps, pandas._libs.properties, pandas._libs.tslibs.offsets, pandas._libs.tslibs.strptime, pandas._libs.tslibs.parsing, pandas._libs.tslibs.conversion, pandas._libs.tslibs.period, pandas._libs.tslibs.vectorized, pandas._libs.ops_dispatch, pandas._libs.missing, pandas._libs.hashtable, pandas._libs.algos, pandas._libs.interval, pandas._libs.lib, pyarrow._compute, pandas._libs.ops, pandas._libs.hashing, pandas._libs.arrays, pandas._libs.tslib, pandas._libs.sparse, pandas._libs.internals, pandas._libs.indexing, pandas._libs.index, pandas._libs.writers, pandas._libs.join, pandas._libs.window.aggregations, pandas._libs.window.indexers, pandas._libs.reshape, pandas._libs.groupby, pandas._libs.json, pandas._libs.parsers, pandas._libs.testing, PIL._imaging, kiwisolver._cext, scipy._lib._ccallback_c, scipy.sparse._sparsetools, _csparsetools, scipy.sparse._csparsetools, scipy.linalg._fblas, scipy.linalg._flapack, scipy.linalg.cython_lapack, scipy.linalg._cythonized_array_utils, scipy.linalg._solve_toeplitz, scipy.linalg._decomp_lu_cython, scipy.linalg._matfuncs_sqrtm_triu, scipy.linalg._matfuncs_expm, scipy.linalg._linalg_pythran, scipy.linalg.cython_blas, scipy.linalg._decomp_update, scipy.sparse.linalg._dsolve._superlu, scipy.sparse.linalg._eigen.arpack._arpack, scipy.sparse.linalg._propack._spropack, scipy.sparse.linalg._propack._dpropack, scipy.sparse.linalg._propack._cpropack, scipy.sparse.linalg._propack._zpropack, scipy.sparse.csgraph._tools, scipy.sparse.csgraph._shortest_path, scipy.sparse.csgraph._traversal, scipy.sparse.csgraph._min_spanning_tree, scipy.sparse.csgraph._flow, scipy.sparse.csgraph._matching, scipy.sparse.csgraph._reordering, scipy.spatial._ckdtree, scipy._lib.messagestream, scipy.spatial._qhull, scipy.spatial._voronoi, scipy.spatial._distance_wrap, scipy.spatial._hausdorff, scipy.special._ufuncs_cxx, scipy.special._ufuncs, scipy.special._specfun, scipy.special._comb, scipy.special._ellip_harm_2, scipy.spatial.transform._rotation, scipy.optimize._group_columns, scipy.optimize._trlib._trlib, scipy.optimize._lbfgsb, _moduleTNC, scipy.optimize._moduleTNC, scipy.optimize._cobyla, scipy.optimize._slsqp, scipy.optimize._minpack, scipy.optimize._lsq.givens_elimination, scipy.optimize._zeros, scipy.optimize._cython_nnls, scipy._lib._uarray._uarray, scipy.linalg._decomp_interpolative, scipy.optimize._bglu_dense, scipy.optimize._lsap, scipy.optimize._direct, scipy.integrate._odepack, scipy.integrate._quadpack, scipy.integrate._vode, scipy.integrate._dop, scipy.integrate._lsoda, scipy.interpolate._fitpack, scipy.interpolate._dfitpack, scipy.interpolate._dierckx, scipy.interpolate._ppoly, scipy.interpolate._interpnd, scipy.interpolate._rbfinterp_pythran, scipy.interpolate._rgi_cython, scipy.interpolate._bspl, scipy.special.cython_special, scipy.stats._stats, scipy.stats._sobol, scipy.stats._qmc_cy, scipy.stats._biasedurn, scipy.stats._stats_pythran, scipy.stats._levy_stable.levyst, scipy.stats._ansari_swilk_statistics, scipy.stats._mvn, scipy.stats._rcont.rcont, scipy.ndimage._nd_image, scipy.ndimage._rank_filter_1d, _ni_label, scipy.ndimage._ni_label, scipy.cluster._vq, scipy.cluster._hierarchy, scipy.cluster._optimal_leaf_ordering, PIL._imagingft, regex._regex, sklearn.__check_build._check_build, _cyutility, sklearn._cyutility, sklearn.utils._isfinite, sklearn.utils.sparsefuncs_fast, sklearn.utils.murmurhash, sklearn.utils._openmp_helpers, sklearn.metrics.cluster._expected_mutual_info_fast, sklearn.preprocessing._csr_polynomial_expansion, sklearn.preprocessing._target_encoder_fast, sklearn.metrics._dist_metrics, sklearn.metrics._pairwise_distances_reduction._datasets_pair, sklearn.utils._cython_blas, sklearn.metrics._pairwise_distances_reduction._base, sklearn.metrics._pairwise_distances_reduction._middle_term_computer, sklearn.utils._heap, sklearn.utils._sorting, sklearn.metrics._pairwise_distances_reduction._argkmin, sklearn.metrics._pairwise_distances_reduction._argkmin_classmode, sklearn.utils._vector_sentinel, sklearn.metrics._pairwise_distances_reduction._radius_neighbors, sklearn.metrics._pairwise_distances_reduction._radius_neighbors_classmode, sklearn.metrics._pairwise_fast (total: 194)
Segmentation fault (core dumped)
```
This same call, with the updated code in this PR:
```
TT_FATAL @ ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp:93: 

needed_cores <= available_cores
E               info:
E               Not enough mux cores! Needed: 8 (num_links=4 * neighbors.size()=2), Available: 0. mux_core_range_set={}
```

The following call to MoE however avoids both and works as desired (again, running a single galaxy test, testing the compute op):
```
combine_mux_cores = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 1), ttnn.CoreCoord(3, 3))])

...

ttnn.experimental.moe_compute(
            tt_sparse,
            tt_indices,
            tt_scores,
            tt_expert_mapping,
            tt_w0_w1,
            tt_w2,
            layer_id=layer_id,
            output_height_shard_dim=output_height_shard_dim,
            output_width_shard_dim=output_width_shard_dim,
            cluster_axis=cluster_axis,
            mux_core_range_set=combine_mux_cores, # <- update
        )
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=smeydanshahiTT/selective-reduce-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:smeydanshahiTT/selective-reduce-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=smeydanshahiTT/selective-reduce-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:smeydanshahiTT/selective-reduce-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=smeydanshahiTT/selective-reduce-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:smeydanshahiTT/selective-reduce-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=smeydanshahiTT/selective-reduce-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:smeydanshahiTT/selective-reduce-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=smeydanshahiTT/selective-reduce-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:smeydanshahiTT/selective-reduce-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=smeydanshahiTT/selective-reduce-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:smeydanshahiTT/selective-reduce-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=smeydanshahiTT/selective-reduce-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:smeydanshahiTT/selective-reduce-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=smeydanshahiTT/selective-reduce-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:smeydanshahiTT/selective-reduce-fatal)