### PR TITLE
[tt-triage] Refactor script execution

### DIFF
--- a/tools/triage/run_checks.py
+++ b/tools/triage/run_checks.py
@@ -126,7 +126,7 @@ def get_devices(
     else:
         device_ids = [int(id) for id in devices]
 
-    return [context.devices[id] for id in device_ids if id in context.devices]
+    return [context.devices[id] for id in device_ids]
 
 
 def _convert_to_on_chip_coordinates(

--- a/tools/triage/run_checks.py
+++ b/tools/triage/run_checks.py
@@ -42,6 +42,7 @@ from triage import (
     log_warning_risc,
     create_progress,
     log_check,
+    TTTriageSkipped,
 )
 from triage_session import get_triage_session
 from ttexalens.context import Context
@@ -49,7 +50,6 @@ from ttexalens.device import Device
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.umd_device import TimeoutDeviceRegisterError
 from ttexalens.hardware.risc_debug import RiscHaltError
-import utils
 from metal_device_id_mapping import run as get_metal_device_id_mapping, MetalDeviceIdMapping
 
 script_config = ScriptConfig(
@@ -110,34 +110,23 @@ class PerCoreCheckResult(PerBlockCheckResult):
 
 def get_devices(
     devices: list[str],
-    inspector_data: InspectorData | None,
+    inspector_data: InspectorData,
     metal_device_id_mapping: MetalDeviceIdMapping,
     context: Context,
 ) -> list[Device]:
     if len(devices) == 1 and devices[0].lower() == "in_use":
-        if inspector_data is not None:
-            metal_device_ids = list(inspector_data.getDevicesInUse().metalDeviceIds)
-
-            if len(metal_device_ids) == 0:
-                utils.WARN(
-                    f"  No devices in use found in inspector data. Switching to use all available devices. If you are using ttnn check if you have enabled program cache."
-                )
-                device_ids = [int(id) for id in context.devices.keys()]
-            else:
-                device_ids = [
-                    metal_device_id_mapping.get_device_id(metal_device_id)
-                    for metal_device_id in metal_device_ids
-                    if metal_device_id_mapping.get_device_id(metal_device_id) is not None
-                ]
-        else:
-            utils.WARN(f"  Using all available devices.")
-            device_ids = [int(id) for id in context.devices.keys()]
+        metal_device_ids = list(inspector_data.getDevicesInUse().metalDeviceIds)
+        device_ids = [
+            metal_device_id_mapping.get_device_id(metal_device_id)
+            for metal_device_id in metal_device_ids
+            if metal_device_id_mapping.get_device_id(metal_device_id) is not None
+        ]
     elif len(devices) == 1 and devices[0].lower() == "all":
         device_ids = [int(id) for id in context.devices.keys()]
     else:
         device_ids = [int(id) for id in devices]
 
-    return [context.devices[id] for id in device_ids]
+    return [context.devices[id] for id in device_ids if id in context.devices]
 
 
 def _convert_to_on_chip_coordinates(
@@ -162,8 +151,10 @@ def get_block_locations(
     inspector_data: InspectorData,
     metal_device_id_mapping: MetalDeviceIdMapping,
 ) -> dict[Device, dict[BlockType, list[OnChipCoordinate]]]:
-    device_map = _make_device_map(devices)
     block_locations: dict[Device, dict[BlockType, list[OnChipCoordinate]]] = defaultdict(dict)
+    if not devices:
+        return block_locations
+    device_map = _make_device_map(devices)
     chip_blocks_list = inspector_data.getBlocksByType().chips
 
     for i in range(len(chip_blocks_list)):
@@ -390,6 +381,14 @@ def run(args, context: Context):
     inspector_data = get_inspector_data(args, context)
     metal_device_id_mapping = get_metal_device_id_mapping(args, context)
     devices = get_devices(devices_to_check, inspector_data, metal_device_id_mapping, context)
+    if not devices:
+        raise TTTriageSkipped(
+            "No active devices in metal process; nothing to triage - no scripts requiring metal devices will be executed.\n"
+            "       Likely causes: device init (e.g. FW-init) failed before any device was registered with the runtime, "
+            "the process never opened a device or the workload closed all devices before triage attached.\n"
+            "       Pass --dev=all to inspect every visible chip anyway (unsafe in multi-process/TT_METAL_VISIBLE_DEVICES setups)."
+        )
+
     block_locations = get_block_locations(devices, inspector_data, metal_device_id_mapping)
     return RunChecks(devices, block_locations, metal_device_id_mapping)
 

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -487,12 +487,11 @@ def log_warning_risc(risc_name: str, location: OnChipCoordinate, message: str) -
     log_warning_location(location, f"{risc_name}: {message}")
 
 
-def serialize_result(script: TriageScript | None, result, execution_time: str = ""):
+def serialize_result(script: TriageScript, result, execution_time: str = ""):
     from dataclasses import fields, is_dataclass
 
-    if script is not None:
-        print()
-        utils.INFO(f"{script.name}{execution_time}:")
+    print()
+    utils.INFO(f"{script.name}{execution_time}:")
 
     global FAILURE_CHECKS, FAILURE_CHECKS_LOCK, WARNING_CHECKS, WARNING_CHECKS_LOCK
     with FAILURE_CHECKS_LOCK:
@@ -501,16 +500,15 @@ def serialize_result(script: TriageScript | None, result, execution_time: str = 
     with WARNING_CHECKS_LOCK:
         warnings = WARNING_CHECKS
         WARNING_CHECKS = []
-    if script is not None and script.skipped:
+    if script.skipped:
         utils.INFO(f"  skipped: {script.status_message}")
         return
     if result is None:
-        script_failed = script is not None and script.failed
-        if len(failures) > 0 or script_failed:
+        if len(failures) > 0 or script.failed:
             utils.ERROR("  fail")
             for failure in failures:
                 utils.ERROR(f"    {failure}")
-            if script_failed:
+            if script.failed:
                 utils.ERROR(f"    {script.status_message}")
 
                 import textwrap
@@ -761,10 +759,9 @@ def run_script(
 
     result = manager.execute_script(script_path, args, context)
 
-    script = manager.scripts.get(script_path)
     if return_result:
         return result
-    serialize_result(script, result)
+    serialize_result(manager.scripts[script_path], result)
 
     if force_exit:
         # Remove nanobind leak check to avoid false positives on exit

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -103,6 +103,20 @@ def _raise_open_file_limit(desired: int = 65536) -> None:
         )
 
 
+class TTTriageError(Exception):
+    """Base class for TT Triage errors."""
+
+    pass
+
+
+class TTTriageSkipped(Exception):
+    """Raised by a script's run() to signal it has nothing to do."""
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
 class ScriptPriority(Enum):
     LOW = 0
     MEDIUM = 1
@@ -755,20 +769,6 @@ def run_script(
     if force_exit:
         # Remove nanobind leak check to avoid false positives on exit
         os._exit(0)
-
-
-class TTTriageError(Exception):
-    """Base class for TT Triage errors."""
-
-    pass
-
-
-class TTTriageSkipped(Exception):
-    """Raised by a script's run() to signal it has nothing to do."""
-
-    def __init__(self, reason: str):
-        super().__init__(reason)
-        self.reason = reason
 
 
 def main():

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -769,8 +769,6 @@ def run_script(
 
 
 def main():
-    from triage_script_manager import TriageScriptManager
-
     triage_start = time()
 
     # Parse only tt-triage script arguments first to initialize logging and console
@@ -780,6 +778,8 @@ def main():
     my_name = os.path.splitext(os.path.basename(__file__))[0]
     if my_name not in sys.modules:
         sys.modules[my_name] = sys.modules["__main__"]
+
+    from triage_script_manager import TriageScriptManager
 
     application_path = os.path.abspath(os.path.dirname(__file__))
     manager = TriageScriptManager()

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -40,9 +40,7 @@ Owner:
 """
 
 # Check if tt-exalens is installed
-from collections import defaultdict
 from enum import Enum
-import heapq
 import inspect
 import os
 import shutil
@@ -70,9 +68,7 @@ except ImportError as e:
     exit(1)
 
 # Import necessary libraries
-from copy import deepcopy
 from dataclasses import dataclass, field
-import importlib
 import importlib.metadata as importlib_metadata
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn, TimeRemainingColumn, BarColumn, TextColumn
@@ -83,7 +79,7 @@ from ttexalens.device import Device
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.elf import ElfVariable
 from ttexalens.umd_device import TimeoutDeviceRegisterError
-from typing import Any, Callable, Iterable, TypeVar
+from typing import Any, Callable, Iterable, Literal, TypeAlias, TypeVar
 from types import ModuleType
 
 
@@ -221,6 +217,9 @@ def get_verbose_level() -> int:
     return _verbose_level
 
 
+TriageStatus: TypeAlias = Literal["pending", "passed", "failed", "skipped"]
+
+
 @dataclass
 class TriageScript:
     name: str
@@ -230,169 +229,50 @@ class TriageScript:
     run_method: Callable[..., Any]
     documentation: str
     depends: list["TriageScript"] = field(default_factory=list)
-    failed: bool = False
-    failure_message: str | None = None
+    status: TriageStatus = "pending"
+    status_message: str | None = None
+
+    @property
+    def failed(self) -> bool:
+        return self.status == "failed"
+
+    @property
+    def skipped(self) -> bool:
+        return self.status == "skipped"
 
     def run(self, args: ScriptArguments, context: Context, log_error: bool = True) -> Any:
         try:
             result = self.run_method(args=args, context=context)
             if self.config.data_provider and result is None:
                 if log_error:
-                    self.failed = True
-                    self.failure_message = "Data provider script did not return any data."
+                    self.status = "failed"
+                    self.status_message = "Data provider script did not return any data."
                 else:
                     raise TTTriageError("Data provider script did not return any data.")
             return result
         except TimeoutDeviceRegisterError:
             raise
+        except TTTriageSkipped as e:
+            if log_error:
+                self.status = "skipped"
+                self.status_message = e.reason
+                return None
+            else:
+                raise
         except ValueError as e:
             if log_error:
-                self.failed = True
-                self.failure_message = f"{e}"
+                self.status = "failed"
+                self.status_message = f"{e}"
                 return None
             else:
                 raise
         except Exception as e:
             if log_error:
-                self.failed = True
-                self.failure_message = traceback.format_exc()
+                self.status = "failed"
+                self.status_message = traceback.format_exc()
                 return None
             else:
                 raise
-
-    @staticmethod
-    def load(script_path: str) -> "TriageScript":
-        script_path = os.path.abspath(script_path)
-        base_path = os.path.dirname(script_path)
-        appended = False
-        if not base_path in sys.path:
-            sys.path.append(base_path)
-            appended = True
-        try:
-            script_name = os.path.splitext(os.path.basename(script_path))[0]
-            script_module = importlib.import_module(script_name)
-
-            # Check if script has a configuration
-            script_config: ScriptConfig = script_module.script_config
-            if script_config is None:
-                # This script does not have a configuration, which means it is not tt-triage script, skipping...
-                raise ValueError(f"Script {script_path} does not have script_config.")
-
-            # Check if script has a docstring and an owner
-            if not script_module.__doc__:
-                raise ValueError(f"Script {script_path} must have a docstring, see relevant scripts for examples.\n")
-
-            if not re.search(r"^Owner:\s*\S+", script_module.__doc__, re.MULTILINE):
-                raise ValueError(
-                    f"Script {script_path} docstring must include an 'Owner:' field with the corresponding owner of the script.\n"
-                )
-
-            # Check if script has a run method with two arguments (args and context)
-            run_method = script_module.run if hasattr(script_module, "run") and callable(script_module.run) else None
-            if run_method is not None:
-                signature = inspect.signature(run_method)
-                if (
-                    len(signature.parameters) != 2
-                    or "args" not in signature.parameters
-                    or "context" not in signature.parameters
-                ):
-                    run_method = None
-            if run_method is None:
-                raise ValueError(
-                    f"Script {script_path} does not have a valid run method with two arguments (args, context)."
-                )
-
-            triage_script = TriageScript(
-                name=os.path.basename(script_path),
-                path=script_path,
-                config=deepcopy(script_config),
-                module=script_module,
-                run_method=run_method,
-                documentation=script_module.__doc__,
-            )
-
-            if triage_script.config.depends is None:
-                # If script does not have dependencies, set it to empty list
-                triage_script.config.depends = []
-            else:
-                triage_script.config.depends = [
-                    dep if isinstance(dep, str) and dep.endswith(".py") else f"{dep}.py"
-                    for dep in triage_script.config.depends
-                ]
-                triage_script.config.depends = [os.path.join(base_path, dep) for dep in triage_script.config.depends]
-
-            return triage_script
-        finally:
-            if appended:
-                sys.path.remove(base_path)
-
-    @staticmethod
-    def load_all(script_path: str) -> dict[str, "TriageScript"]:
-        scripts: dict[str, TriageScript] = {}
-        loading: list[str] = []
-        script = TriageScript.load(script_path)
-        scripts[script_path] = script
-
-        # Load all dependencies
-        loading.extend(script.config.depends)
-        while len(loading) > 0:
-            loading_script = loading.pop(0)
-            if loading_script not in scripts:
-                script = TriageScript.load(loading_script)
-                scripts[loading_script] = script
-                loading.extend(script.config.depends)
-
-        # Update dependencies in scripts
-        for script in scripts.values():
-            for dep in script.config.depends:
-                assert dep in scripts, f"Dependency {dep} for script {script.name} not found."
-                script.depends.append(scripts[dep])
-        return scripts
-
-
-def resolve_execution_order(scripts: dict[str, TriageScript]) -> list[TriageScript]:
-    # Build script dependents graph and script missing dependencies map
-    script_dependents = defaultdict(list)  # dep_path -> list of scripts depending on it
-    script_missing_dependencies = defaultdict(int)  # script_path -> number of unmet dependencies
-
-    for path, script in scripts.items():
-        script_missing_dependencies[path] = len(script.config.depends)
-        for dep in script.config.depends:
-            script_dependents[dep].append(path)
-
-    # Min-heap for runnable scripts: (-priority, script name, script object)
-    # Negative priority because heapq is a min-heap
-    heap = []
-
-    # Initialize heap with scripts with in-degree 0 (no unmet dependencies)
-    for path, script in scripts.items():
-        if script_missing_dependencies[path] == 0:
-            heapq.heappush(heap, (-script.config.priority.value, path, script))
-
-    result = []
-
-    while heap:
-        # Pop the highest priority ready script
-        _, path, script = heapq.heappop(heap)
-        result.append(script)
-
-        # Decrease in-degree of dependent scripts
-        for dep_path in script_dependents[path]:
-            script_missing_dependencies[dep_path] -= 1
-            if script_missing_dependencies[dep_path] == 0:
-                dep_script = scripts[dep_path]
-                heapq.heappush(heap, (-dep_script.config.priority.value, dep_path, dep_script))
-
-    # If some scripts remain with non-zero in-degree, we have a cycle
-    if len(result) != len(scripts):
-        remaining_scripts = set(scripts.keys()) - {s.config.name for s in result}
-        raise ValueError(
-            f"Bad dependency detected in scripts: {', '.join(remaining_scripts)}\n"
-            f"  Circular dependency, dependency on disabled or non-existing script is not allowed.\n"
-            f"  Please check if all dependencies are met and scripts are enabled."
-        )
-
-    return result
 
 
 # Purposely uninitialized global console object to ensure proper initialization only once later
@@ -607,13 +487,16 @@ def serialize_result(script: TriageScript | None, result, execution_time: str = 
     with WARNING_CHECKS_LOCK:
         warnings = WARNING_CHECKS
         WARNING_CHECKS = []
+    if script is not None and script.skipped:
+        utils.INFO(f"  skipped: {script.status_message}")
+        return
     if result is None:
         if len(failures) > 0 or script.failed:
             utils.ERROR("  fail")
             for failure in failures:
                 utils.ERROR(f"    {failure}")
             if script.failed:
-                utils.ERROR(f"    {script.failure_message}")
+                utils.ERROR(f"    {script.status_message}")
 
                 import textwrap
 
@@ -849,31 +732,21 @@ def run_script(
         if not os.path.exists(script_path):
             raise FileNotFoundError(f"Script {script_path} does not exist.")
 
-    # Load script and its dependencies
-    scripts = TriageScript.load_all(script_path)
+    from triage_script_manager import TriageScriptManager
 
-    # Find execution order of scripts
-    script_queue = resolve_execution_order(scripts)
+    manager = TriageScriptManager()
+    manager.load_script_with_dependencies(script_path)
+    manager.resolve_dependencies(missing_dep_marks_as_failed=False)
 
-    # Parse arguments
     if args is None:
-        args = parse_arguments(scripts, script_path, argv)
-
-    # Initialize context if not provided
+        args = parse_arguments(manager.scripts, script_path, argv)
     if context is None:
         _enforce_dependencies(args)
         context = _init_ttexalens(args)
 
-    # Run scripts in order
-    result: Any = None
-    for script in script_queue:
-        if not all(not dep.failed for dep in script.depends):
-            raise TTTriageError(f"{script.name}: Cannot run script due to failed dependencies.")
-        else:
-            result = script.run(args=args, context=context, log_error=False)
-            if script.config.data_provider and result is None:
-                raise TTTriageError(f"{script.name}: Data provider script did not return any data.")
-    script = scripts[script_path] if script_path in scripts else None
+    result = manager.execute_subgraph(args, context)
+
+    script = manager.scripts.get(script_path)
     if return_result:
         return result
     serialize_result(script, result)
@@ -889,129 +762,66 @@ class TTTriageError(Exception):
     pass
 
 
-def _build_triage_summary(script_queue: list[TriageScript]) -> str:
-    summary_lines = []
-    for script in script_queue:
-        if script.failed:
-            summary_lines.append(f"{script.name}: FAIL - {script.failure_message or 'unknown error'}")
-        elif not script.config.data_provider:
-            summary_lines.append(f"{script.name}: pass")
-    return "\n".join(summary_lines) if summary_lines else "No triage scripts executed."
+class TTTriageSkipped(Exception):
+    """Raised by a script's run() to signal it has nothing to do."""
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
 
 
 def main():
+    from triage_script_manager import TriageScriptManager
+
     triage_start = time()
 
     # Parse only tt-triage script arguments first to initialize logging and console
     parse_arguments(only_triage_script_args=True)
-
-    # Enumerate all scripts in application directory
-    application_path = os.path.abspath(os.path.dirname(__file__))
-    script_files = [f for f in os.listdir(application_path) if f.endswith(".py") and f != os.path.basename(__file__)]
 
     # To avoid multiple imports of this script, we add it to sys.modules
     my_name = os.path.splitext(os.path.basename(__file__))[0]
     if my_name not in sys.modules:
         sys.modules[my_name] = sys.modules["__main__"]
 
-    # Load tt-triage scripts
-    # TODO: do we need to check for subdirectories?
-    scripts: dict[str, TriageScript] = {}
-    base_path = application_path
-    for script in script_files:
-        script_path = os.path.join(base_path, script)
-        try:
-            triage_script = TriageScript.load(script_path)
-            if triage_script.config.disabled:
-                utils.DEBUG(f"Script {script_path} is disabled, skipping...")
-                continue
-        except Exception as e:
-            utils.DEBUG(f"Failed to load script {script_path}: {e}")
-            continue
-        scripts[script_path] = triage_script
+    application_path = os.path.abspath(os.path.dirname(__file__))
+    manager = TriageScriptManager()
+    manager.load_application_scripts(application_path)
+    manager.resolve_dependencies()
 
-    # Resolve dependencies
-    for script in scripts.values():
-        for dep in script.config.depends:
-            if dep in scripts:
-                script.depends.append(scripts[dep])
-            else:
-                utils.ERROR(f"Dependency {dep} for script {script.name} not found.")
-                script.failed = True
-                script.failure_message = f"Dependency {dep} not found."
-
-    # Find dependency graph of script execution
-    script_queue = resolve_execution_order(scripts)
-
-    # Parse common command line arguments
-    args = parse_arguments(scripts)
-
-    # Enforce debugger dependencies, then initialize
+    args = parse_arguments(manager.scripts)
     _enforce_dependencies(args)
     context = _init_ttexalens(args)
 
-    with create_progress() as progress:
-        scripts_task = progress.add_task("Script execution", total=len(script_queue))
+    if args["--run"] is not None and (len(args["--run"]) != 1 or args["--run"][0] != "all"):
+        with create_progress() as progress:
+            run_task = progress.add_task("Script execution", total=len(args["--run"]))
+            try:
+                for script_name in args["--run"]:
+                    progress.update(run_task, description=f"Running {script_name}")
+                    run_script(script_name, args, context)
+                    progress.advance(run_task)
+            finally:
+                progress.remove_task(run_task)
+    else:
+        triage_init_end = time()
+        if args["--print-script-times"]:
+            utils.INFO(f"Triage initialization time: {triage_init_end - triage_start:.2f}s")
 
-        # Check if we should run specific scripts
-        if args["--run"] is not None and (len(args["--run"]) != 1 or args["--run"][0] != "all"):
-            progress.update(scripts_task, total=len(args["--run"]))
-            for script_name in args["--run"]:
-                progress.update(scripts_task, description=f"Running {script_name}")
-                run_script(script_name, args, context)
-                progress.advance(scripts_task)
-        else:
-            # Execute all scripts
-            triage_init_end = time()
-            if args["--print-script-times"]:
-                utils.INFO(f"Triage initialization time: {triage_init_end - triage_start:.2f}s")
-            total_time = triage_init_end - triage_start
-            serialization_time = 0.0
-            progress.update(scripts_task, total=len(script_queue))
-            for script in script_queue:
-                progress.update(scripts_task, description=f"Running {script.name}")
-                if not all(not dep.failed for dep in script.depends):
-                    utils.INFO(f"{script.name}:")
-                    utils.WARN(f"  Cannot run script due to failed dependencies.")
-                    script.failed = True
-                    script.failure_message = "Cannot run script due to failed dependencies."
-                else:
-                    start_time = time()
-                    result = script.run(args=args, context=context)
-                    end_time = time()
-                    total_time += end_time - start_time
-                    execution_time = f" [{end_time - start_time:.2f}s]" if args["--print-script-times"] else ""
-                    if script.config.data_provider:
-                        if result is None:
-                            print()
-                            utils.INFO(f"{script.name}{execution_time}:")
-                            if script.failure_message is not None:
-                                utils.ERROR(f"  Data provider script failed: {script.failure_message}")
-                            else:
-                                utils.ERROR(f"  Data provider script did not return any data.")
-                        elif execution_time:
-                            print()
-                            utils.INFO(f"{script.name}{execution_time}:")
-                            utils.INFO("  pass")
-                    else:
-                        start_time = time()
-                        serialize_result(script, result, execution_time)
-                        end_time = time()
-                        total_time += end_time - start_time
-                        serialization_time += end_time - start_time
-                progress.advance(scripts_task)
-            if args["--print-script-times"]:
-                print()
-                utils.INFO(f"Total serialization time: {serialization_time:.2f}s")
-                utils.INFO(f"Total execution time: {total_time:.2f}s")
-        progress.remove_task(scripts_task)
+        run_total, serialization_total = manager.execute_all(
+            args, context, print_script_times=bool(args["--print-script-times"])
+        )
+
+        if args["--print-script-times"]:
+            print()
+            utils.INFO(f"Total serialization time: {serialization_total:.2f}s")
+            utils.INFO(f"Total execution time: {(triage_init_end - triage_start) + run_total:.2f}s")
 
     triage_summary_path = args["--triage-summary-path"]
     if triage_summary_path:
         try:
             os.makedirs(os.path.dirname(triage_summary_path), exist_ok=True)
             with open(triage_summary_path, "w") as f:
-                f.write(_build_triage_summary(script_queue))
+                f.write(manager.build_summary())
             utils.INFO(f"Triage summary written to {triage_summary_path}")
         except Exception as e:
             utils.WARN(f"Failed to write triage summary: {e}")

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -491,11 +491,12 @@ def serialize_result(script: TriageScript | None, result, execution_time: str = 
         utils.INFO(f"  skipped: {script.status_message}")
         return
     if result is None:
-        if len(failures) > 0 or script.failed:
+        script_failed = script is not None and script.failed
+        if len(failures) > 0 or script_failed:
             utils.ERROR("  fail")
             for failure in failures:
                 utils.ERROR(f"    {failure}")
-            if script.failed:
+            if script_failed:
                 utils.ERROR(f"    {script.status_message}")
 
                 import textwrap
@@ -736,7 +737,7 @@ def run_script(
 
     manager = TriageScriptManager()
     manager.load_script_with_dependencies(script_path)
-    manager.resolve_dependencies(missing_dep_marks_as_failed=False)
+    manager.resolve_dependencies()
 
     if args is None:
         args = parse_arguments(manager.scripts, script_path, argv)
@@ -744,7 +745,7 @@ def run_script(
         _enforce_dependencies(args)
         context = _init_ttexalens(args)
 
-    result = manager.execute_subgraph(args, context)
+    result = manager.execute_script(script_path, args, context)
 
     script = manager.scripts.get(script_path)
     if return_result:

--- a/tools/triage/triage_script_manager.py
+++ b/tools/triage/triage_script_manager.py
@@ -46,7 +46,7 @@ class TriageScriptManager:
         for script_file in script_files:
             script_path = os.path.join(application_path, script_file)
             try:
-                triage_script = self._load_script(script_path)
+                triage_script = _load_script(script_path)
                 if triage_script.config.disabled:
                     utils.DEBUG(f"Script {script_path} is disabled, skipping...")
                     continue
@@ -59,79 +59,14 @@ class TriageScriptManager:
         """Load one script plus its transitive deps via BFS. Used by run_script()."""
         script_path = os.path.abspath(script_path)
         loading: list[str] = []
-        self.scripts[script_path] = self._load_script(script_path)
+        self.scripts[script_path] = _load_script(script_path)
         loading.extend(self.scripts[script_path].config.depends)
         while loading:
             dep_path = loading.pop(0)
             if dep_path in self.scripts:
                 continue
-            self.scripts[dep_path] = self._load_script(dep_path)
+            self.scripts[dep_path] = _load_script(dep_path)
             loading.extend(self.scripts[dep_path].config.depends)
-
-    @staticmethod
-    def _load_script(script_path: str) -> TriageScript:
-        """Import a single script module and construct a TriageScript from it.
-        Validates that the module has script_config, an Owner: tag, and run(args, context)."""
-        script_path = os.path.abspath(script_path)
-        base_path = os.path.dirname(script_path)
-        appended = False
-        if base_path not in sys.path:
-            sys.path.append(base_path)
-            appended = True
-        try:
-            script_name = os.path.splitext(os.path.basename(script_path))[0]
-            script_module = importlib.import_module(script_name)
-
-            script_config: ScriptConfig = script_module.script_config
-            if script_config is None:
-                raise ValueError(f"Script {script_path} does not have script_config.")
-
-            if not script_module.__doc__:
-                raise ValueError(f"Script {script_path} must have a docstring, see relevant scripts for examples.\n")
-
-            if not re.search(r"^Owner:\s*\S+", script_module.__doc__, re.MULTILINE):
-                raise ValueError(
-                    f"Script {script_path} docstring must include an 'Owner:' field with the corresponding owner of the script.\n"
-                )
-
-            run_method = script_module.run if hasattr(script_module, "run") and callable(script_module.run) else None
-            if run_method is not None:
-                signature = inspect.signature(run_method)
-                if (
-                    len(signature.parameters) != 2
-                    or "args" not in signature.parameters
-                    or "context" not in signature.parameters
-                ):
-                    run_method = None
-            if run_method is None:
-                raise ValueError(
-                    f"Script {script_path} does not have a valid run method with two arguments (args, context)."
-                )
-
-            triage_script = TriageScript(
-                name=os.path.basename(script_path),
-                path=script_path,
-                config=deepcopy(script_config),
-                module=script_module,
-                run_method=run_method,
-                documentation=script_module.__doc__,
-            )
-
-            # Normalize string `depends` entries to absolute file paths so the
-            # registry keying lines up with what _load_script returns.
-            if triage_script.config.depends is None:
-                triage_script.config.depends = []
-            else:
-                triage_script.config.depends = [
-                    dep if isinstance(dep, str) and dep.endswith(".py") else f"{dep}.py"
-                    for dep in triage_script.config.depends
-                ]
-                triage_script.config.depends = [os.path.join(base_path, dep) for dep in triage_script.config.depends]
-
-            return triage_script
-        finally:
-            if appended:
-                sys.path.remove(base_path)
 
     def resolve_dependencies(self) -> None:
         """Wire up `depends=[...]` refs and topo-sort into script_queue.
@@ -173,7 +108,8 @@ class TriageScriptManager:
                 for script in self.script_queue:
                     progress.update(scripts_task, description=f"Running {script.name}")
 
-                    if self._propagate_skip_or_fail(script):
+                    if _propagate_skip(script):
+                        serialize_result(script, None)
                         progress.advance(scripts_task)
                         continue
 
@@ -183,11 +119,7 @@ class TriageScriptManager:
                     total_time += end_time - start_time
                     execution_time = f" [{end_time - start_time:.2f}s]" if print_script_times else ""
 
-                    if script.skipped:
-                        print()
-                        utils.INFO(f"{script.name}{execution_time}:")
-                        utils.INFO(f"  skipped: {script.status_message}")
-                    elif script.config.data_provider:
+                    if script.config.data_provider and not script.skipped:
                         if result is None:
                             print()
                             utils.INFO(f"{script.name}{execution_time}:")
@@ -218,23 +150,18 @@ class TriageScriptManager:
         args: ScriptArguments,
         context: Context,
     ) -> Any:
-        """Run the loaded subgraph with log_error=False (raises on failure).
-        Returns the result of `script_path` specifically -- not the last script in
-        topological order, even though those happen to coincide today."""
+        """Run the loaded subgraph for an explicit `--run X`.
+        Deps run with log_error=True so their failures/skips are captured and can cascade
+        cleanly to the target. The target itself runs with log_error=False so its own
+        failure raises rather than being silently swallowed."""
+        target_path = os.path.abspath(script_path)
         results: dict[str, Any] = {}
         for script in self.script_queue:
-            if self._propagate_skip_in_subgraph(script):
+            if _propagate_skip(script, raise_on_failed_dep=True):
                 results[script.path] = None
                 continue
-            if not all(not dep.failed for dep in script.depends):
-                raise TTTriageError(f"{script.name}: Cannot run script due to failed dependencies.")
-            result = script.run(args=args, context=context, log_error=False)
-            results[script.path] = result
-            if script.skipped:
-                continue
-            if script.config.data_provider and result is None:
-                raise TTTriageError(f"{script.name}: Data provider script did not return any data.")
-        return results.get(os.path.abspath(script_path))
+            results[script.path] = script.run(args=args, context=context, log_error=script.path != target_path)
+        return results.get(target_path)
 
     def build_summary(self) -> str:
         """One line per script: FAIL, SKIP, or pass (data providers' pass status is omitted)."""
@@ -248,30 +175,91 @@ class TriageScriptManager:
                 lines.append(f"{script.name}: pass")
         return "\n".join(lines) if lines else "No triage scripts executed."
 
-    def _propagate_skip_or_fail(self, script: TriageScript) -> bool:
-        """Mark `script` skipped/failed if any dep was. Skip wins over fail.
-        Returns True when the script should not be invoked. Used by execute_all."""
-        skipped_dep = next((dep for dep in script.depends if dep.skipped), None)
-        if skipped_dep is not None:
-            script.status = "skipped"
-            script.status_message = f"dependency '{skipped_dep.name}' was skipped"
-            return True
-        if not all(not dep.failed for dep in script.depends):
-            utils.INFO(f"{script.name}:")
-            utils.WARN(f"  Cannot run script due to failed dependencies.")
-            script.status = "failed"
-            script.status_message = "Cannot run script due to failed dependencies."
-            return True
-        return False
 
-    def _propagate_skip_in_subgraph(self, script: TriageScript) -> bool:
-        """Skip-only propagation for execute_subgraph (which raises on fail elsewhere)."""
-        skipped_dep = next((dep for dep in script.depends if dep.skipped), None)
-        if skipped_dep is not None:
-            script.status = "skipped"
-            script.status_message = f"dependency '{skipped_dep.name}' was skipped"
-            return True
-        return False
+def _propagate_skip(script: TriageScript, raise_on_failed_dep: bool = False) -> bool:
+    """If any dep was skipped, cascade as skip on `script`.
+    If a dep failed: raise TTTriageError when `raise_on_failed_dep` is set (so an explicit
+    `--run X` surfaces the dep failure loudly), otherwise cascade as skip.
+    Returns True when the script should not be invoked."""
+    skipped_dep = next((dep for dep in script.depends if dep.skipped), None)
+    if skipped_dep is not None:
+        script.status = "skipped"
+        script.status_message = f"dependency '{skipped_dep.name}' was skipped"
+        return True
+    failed_dep = next((dep for dep in script.depends if dep.failed), None)
+    if failed_dep is not None:
+        if raise_on_failed_dep:
+            detail = f":\n{failed_dep.status_message}" if failed_dep.status_message else "."
+            raise TTTriageError(f"{script.name}: Cannot run script; dependency '{failed_dep.name}' failed{detail}")
+        script.status = "skipped"
+        script.status_message = f"dependency '{failed_dep.name}' failed"
+        return True
+    return False
+
+
+def _load_script(script_path: str) -> TriageScript:
+    """Import a single script module and construct a TriageScript from it.
+    Validates that the module has script_config, an Owner: tag, and run(args, context)."""
+    script_path = os.path.abspath(script_path)
+    base_path = os.path.dirname(script_path)
+    appended = False
+    if base_path not in sys.path:
+        sys.path.append(base_path)
+        appended = True
+    try:
+        script_name = os.path.splitext(os.path.basename(script_path))[0]
+        script_module = importlib.import_module(script_name)
+
+        script_config: ScriptConfig = script_module.script_config
+        if script_config is None:
+            raise ValueError(f"Script {script_path} does not have script_config.")
+
+        if not script_module.__doc__:
+            raise ValueError(f"Script {script_path} must have a docstring, see relevant scripts for examples.\n")
+
+        if not re.search(r"^Owner:\s*\S+", script_module.__doc__, re.MULTILINE):
+            raise ValueError(
+                f"Script {script_path} docstring must include an 'Owner:' field with the corresponding owner of the script.\n"
+            )
+
+        run_method = script_module.run if hasattr(script_module, "run") and callable(script_module.run) else None
+        if run_method is not None:
+            signature = inspect.signature(run_method)
+            if (
+                len(signature.parameters) != 2
+                or "args" not in signature.parameters
+                or "context" not in signature.parameters
+            ):
+                run_method = None
+        if run_method is None:
+            raise ValueError(
+                f"Script {script_path} does not have a valid run method with two arguments (args, context)."
+            )
+
+        triage_script = TriageScript(
+            name=os.path.basename(script_path),
+            path=script_path,
+            config=deepcopy(script_config),
+            module=script_module,
+            run_method=run_method,
+            documentation=script_module.__doc__,
+        )
+
+        # Normalize string `depends` entries to absolute file paths so the
+        # registry keying lines up with what _load_script returns.
+        if triage_script.config.depends is None:
+            triage_script.config.depends = []
+        else:
+            triage_script.config.depends = [
+                dep if isinstance(dep, str) and dep.endswith(".py") else f"{dep}.py"
+                for dep in triage_script.config.depends
+            ]
+            triage_script.config.depends = [os.path.join(base_path, dep) for dep in triage_script.config.depends]
+
+        return triage_script
+    finally:
+        if appended:
+            sys.path.remove(base_path)
 
 
 def _resolve_execution_order(scripts: dict[str, TriageScript]) -> list[TriageScript]:

--- a/tools/triage/triage_script_manager.py
+++ b/tools/triage/triage_script_manager.py
@@ -151,17 +151,16 @@ class TriageScriptManager:
         context: Context,
     ) -> Any:
         """Run the loaded subgraph for an explicit `--run X`.
-        Deps run with log_error=True so their failures/skips are captured and can cascade
-        cleanly to the target. The target itself runs with log_error=False so its own
-        failure raises rather than being silently swallowed."""
-        target_path = os.path.abspath(script_path)
+        Failures and skips are captured into each script's status so the caller can route
+        them through serialize_result uniformly. Failed deps still raise TTTriageError
+        so the cascade surfaces loudly under --run, rather than silently skipping."""
         results: dict[str, Any] = {}
         for script in self.script_queue:
             if _propagate_skip(script, raise_on_failed_dep=True):
                 results[script.path] = None
                 continue
-            results[script.path] = script.run(args=args, context=context, log_error=script.path != target_path)
-        return results.get(target_path)
+            results[script.path] = script.run(args=args, context=context)
+        return results.get(os.path.abspath(script_path))
 
     def build_summary(self) -> str:
         """One line per script: FAIL, SKIP, or pass (data providers' pass status is omitted)."""

--- a/tools/triage/triage_script_manager.py
+++ b/tools/triage/triage_script_manager.py
@@ -134,13 +134,8 @@ class TriageScriptManager:
                 sys.path.remove(base_path)
 
     def resolve_dependencies(self) -> None:
-        """Build the DAG and topo-sort into script_queue.
-        Scripts whose declared deps aren't in the registry are dropped (with a clear log
-        line) so they never enter the queue. Drops cascade: if A depends on B and B was
-        dropped, A is dropped too. By the time this returns, every script in script_queue
-        has all its deps wired up; failed/skipped are reserved for runtime outcomes."""
-        # Iteratively drop scripts whose deps cannot be resolved, until stable.
-        # Drops cascade: dropping A causes scripts that depended on A to drop too.
+        """Wire up `depends=[...]` refs and topo-sort into script_queue.
+        Scripts with unresolvable deps are dropped (cascading) before the queue is built."""
         while True:
             missing_by_path: dict[str, list[str]] = {}
             for path, script in self.scripts.items():

--- a/tools/triage/triage_script_manager.py
+++ b/tools/triage/triage_script_manager.py
@@ -133,17 +133,32 @@ class TriageScriptManager:
             if appended:
                 sys.path.remove(base_path)
 
-    def resolve_dependencies(self, missing_dep_marks_as_failed: bool = True) -> None:
-        """Wire up `depends=[...]` strings to TriageScript refs, then topo-sort into script_queue.
-        With missing_dep_marks_as_failed=True, unresolved deps mark the script failed instead of raising."""
+    def resolve_dependencies(self) -> None:
+        """Build the DAG and topo-sort into script_queue.
+        Scripts whose declared deps aren't in the registry are dropped (with a clear log
+        line) so they never enter the queue. Drops cascade: if A depends on B and B was
+        dropped, A is dropped too. By the time this returns, every script in script_queue
+        has all its deps wired up; failed/skipped are reserved for runtime outcomes."""
+        # Iteratively drop scripts whose deps cannot be resolved, until stable.
+        # Drops cascade: dropping A causes scripts that depended on A to drop too.
+        while True:
+            missing_by_path: dict[str, list[str]] = {}
+            for path, script in self.scripts.items():
+                unresolved = [dep for dep in script.config.depends if dep not in self.scripts]
+                if unresolved:
+                    missing_by_path[path] = unresolved
+            if not missing_by_path:
+                break
+            for path, unresolved in missing_by_path.items():
+                script = self.scripts[path]
+                missing = ", ".join(os.path.basename(d) for d in unresolved)
+                utils.ERROR(f"Dropping '{script.name}': missing dependencies: {missing}")
+                del self.scripts[path]
+
+        # Every surviving script has all its deps in the registry; wire them up.
         for script in self.scripts.values():
-            for dep_name in script.config.depends:
-                if dep_name in self.scripts:
-                    script.depends.append(self.scripts[dep_name])
-                elif missing_dep_marks_as_failed:
-                    utils.ERROR(f"Dependency {dep_name} for script {script.name} not found.")
-                    script.status = "failed"
-                    script.status_message = f"Dependency {dep_name} not found."
+            script.depends = [self.scripts[dep] for dep in script.config.depends]
+
         self.script_queue = _resolve_execution_order(self.scripts)
 
     def execute_all(
@@ -202,25 +217,29 @@ class TriageScriptManager:
 
         return total_time, serialization_time
 
-    def execute_subgraph(
+    def execute_script(
         self,
+        script_path: str,
         args: ScriptArguments,
         context: Context,
     ) -> Any:
-        """Run the loaded scripts with log_error=False (raises on failure).
-        Used by run_script(); returns the result of the last script in the queue."""
-        result: Any = None
+        """Run the loaded subgraph with log_error=False (raises on failure).
+        Returns the result of `script_path` specifically -- not the last script in
+        topological order, even though those happen to coincide today."""
+        results: dict[str, Any] = {}
         for script in self.script_queue:
             if self._propagate_skip_in_subgraph(script):
+                results[script.path] = None
                 continue
             if not all(not dep.failed for dep in script.depends):
                 raise TTTriageError(f"{script.name}: Cannot run script due to failed dependencies.")
             result = script.run(args=args, context=context, log_error=False)
+            results[script.path] = result
             if script.skipped:
                 continue
             if script.config.data_provider and result is None:
                 raise TTTriageError(f"{script.name}: Data provider script did not return any data.")
-        return result
+        return results.get(os.path.abspath(script_path))
 
     def build_summary(self) -> str:
         """One line per script: FAIL, SKIP, or pass (data providers' pass status is omitted)."""
@@ -286,7 +305,7 @@ def _resolve_execution_order(scripts: dict[str, TriageScript]) -> list[TriageScr
                 heapq.heappush(heap, (-dep_script.config.priority.value, dep_path, dep_script))
 
     if len(result) != len(scripts):
-        remaining = set(scripts.keys()) - {s.config.name for s in result}
+        remaining = set(scripts.keys()) - {s.path for s in result}
         raise ValueError(
             f"Bad dependency detected in scripts: {', '.join(remaining)}\n"
             f"  Circular dependency, dependency on disabled or non-existing script is not allowed.\n"

--- a/tools/triage/triage_script_manager.py
+++ b/tools/triage/triage_script_manager.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from collections import defaultdict
+from copy import deepcopy
+import heapq
+import importlib
+import inspect
+import os
+import re
+import sys
+from time import time
+from typing import Any
+
+import utils
+from triage import (
+    ScriptArguments,
+    ScriptConfig,
+    TriageScript,
+    TTTriageError,
+    create_progress,
+    serialize_result,
+)
+from ttexalens.context import Context
+
+
+class TriageScriptManager:
+    """Owns script discovery, dep resolution, execution, and reporting for one triage run."""
+
+    def __init__(self) -> None:
+        # Script registry keyed by absolute path. Populated by load_*().
+        self.scripts: dict[str, TriageScript] = {}
+        # Topologically ordered execution queue. Populated by resolve_dependencies().
+        self.script_queue: list[TriageScript] = []
+
+    def load_application_scripts(self, application_path: str) -> None:
+        """Discover triage scripts by enumerating .py files in the directory.
+        Disabled or invalid scripts are silently dropped."""
+        own_basename = "triage.py"  # the entrypoint's loader, not a triage script itself
+        manager_basename = os.path.basename(__file__)
+        script_files = [
+            f for f in os.listdir(application_path) if f.endswith(".py") and f != own_basename and f != manager_basename
+        ]
+        for script_file in script_files:
+            script_path = os.path.join(application_path, script_file)
+            try:
+                triage_script = self._load_script(script_path)
+                if triage_script.config.disabled:
+                    utils.DEBUG(f"Script {script_path} is disabled, skipping...")
+                    continue
+            except Exception as e:
+                utils.DEBUG(f"Failed to load script {script_path}: {e}")
+                continue
+            self.scripts[script_path] = triage_script
+
+    def load_script_with_dependencies(self, script_path: str) -> None:
+        """Load one script plus its transitive deps via BFS. Used by run_script()."""
+        script_path = os.path.abspath(script_path)
+        loading: list[str] = []
+        self.scripts[script_path] = self._load_script(script_path)
+        loading.extend(self.scripts[script_path].config.depends)
+        while loading:
+            dep_path = loading.pop(0)
+            if dep_path in self.scripts:
+                continue
+            self.scripts[dep_path] = self._load_script(dep_path)
+            loading.extend(self.scripts[dep_path].config.depends)
+
+    @staticmethod
+    def _load_script(script_path: str) -> TriageScript:
+        """Import a single script module and construct a TriageScript from it.
+        Validates that the module has script_config, an Owner: tag, and run(args, context)."""
+        script_path = os.path.abspath(script_path)
+        base_path = os.path.dirname(script_path)
+        appended = False
+        if base_path not in sys.path:
+            sys.path.append(base_path)
+            appended = True
+        try:
+            script_name = os.path.splitext(os.path.basename(script_path))[0]
+            script_module = importlib.import_module(script_name)
+
+            script_config: ScriptConfig = script_module.script_config
+            if script_config is None:
+                raise ValueError(f"Script {script_path} does not have script_config.")
+
+            if not script_module.__doc__:
+                raise ValueError(f"Script {script_path} must have a docstring, see relevant scripts for examples.\n")
+
+            if not re.search(r"^Owner:\s*\S+", script_module.__doc__, re.MULTILINE):
+                raise ValueError(
+                    f"Script {script_path} docstring must include an 'Owner:' field with the corresponding owner of the script.\n"
+                )
+
+            run_method = script_module.run if hasattr(script_module, "run") and callable(script_module.run) else None
+            if run_method is not None:
+                signature = inspect.signature(run_method)
+                if (
+                    len(signature.parameters) != 2
+                    or "args" not in signature.parameters
+                    or "context" not in signature.parameters
+                ):
+                    run_method = None
+            if run_method is None:
+                raise ValueError(
+                    f"Script {script_path} does not have a valid run method with two arguments (args, context)."
+                )
+
+            triage_script = TriageScript(
+                name=os.path.basename(script_path),
+                path=script_path,
+                config=deepcopy(script_config),
+                module=script_module,
+                run_method=run_method,
+                documentation=script_module.__doc__,
+            )
+
+            # Normalize string `depends` entries to absolute file paths so the
+            # registry keying lines up with what _load_script returns.
+            if triage_script.config.depends is None:
+                triage_script.config.depends = []
+            else:
+                triage_script.config.depends = [
+                    dep if isinstance(dep, str) and dep.endswith(".py") else f"{dep}.py"
+                    for dep in triage_script.config.depends
+                ]
+                triage_script.config.depends = [os.path.join(base_path, dep) for dep in triage_script.config.depends]
+
+            return triage_script
+        finally:
+            if appended:
+                sys.path.remove(base_path)
+
+    def resolve_dependencies(self, missing_dep_marks_as_failed: bool = True) -> None:
+        """Wire up `depends=[...]` strings to TriageScript refs, then topo-sort into script_queue.
+        With missing_dep_marks_as_failed=True, unresolved deps mark the script failed instead of raising."""
+        for script in self.scripts.values():
+            for dep_name in script.config.depends:
+                if dep_name in self.scripts:
+                    script.depends.append(self.scripts[dep_name])
+                elif missing_dep_marks_as_failed:
+                    utils.ERROR(f"Dependency {dep_name} for script {script.name} not found.")
+                    script.status = "failed"
+                    script.status_message = f"Dependency {dep_name} not found."
+        self.script_queue = _resolve_execution_order(self.scripts)
+
+    def execute_all(
+        self,
+        args: ScriptArguments,
+        context: Context,
+        print_script_times: bool = False,
+    ) -> tuple[float, float]:
+        """Run every script in topological order with skip/fail propagation.
+        Returns (total_time, serialization_time) for printing if --print-script-times is on."""
+        total_time = 0.0
+        serialization_time = 0.0
+
+        with create_progress() as progress:
+            scripts_task = progress.add_task("Script execution", total=len(self.script_queue))
+            try:
+                for script in self.script_queue:
+                    progress.update(scripts_task, description=f"Running {script.name}")
+
+                    if self._propagate_skip_or_fail(script):
+                        progress.advance(scripts_task)
+                        continue
+
+                    start_time = time()
+                    result = script.run(args=args, context=context)
+                    end_time = time()
+                    total_time += end_time - start_time
+                    execution_time = f" [{end_time - start_time:.2f}s]" if print_script_times else ""
+
+                    if script.skipped:
+                        print()
+                        utils.INFO(f"{script.name}{execution_time}:")
+                        utils.INFO(f"  skipped: {script.status_message}")
+                    elif script.config.data_provider:
+                        if result is None:
+                            print()
+                            utils.INFO(f"{script.name}{execution_time}:")
+                            if script.status_message is not None:
+                                utils.ERROR(f"  Data provider script failed: {script.status_message}")
+                            else:
+                                utils.ERROR(f"  Data provider script did not return any data.")
+                        elif execution_time:
+                            print()
+                            utils.INFO(f"{script.name}{execution_time}:")
+                            utils.INFO("  pass")
+                    else:
+                        ser_start = time()
+                        serialize_result(script, result, execution_time)
+                        ser_end = time()
+                        total_time += ser_end - ser_start
+                        serialization_time += ser_end - ser_start
+
+                    progress.advance(scripts_task)
+            finally:
+                progress.remove_task(scripts_task)
+
+        return total_time, serialization_time
+
+    def execute_subgraph(
+        self,
+        args: ScriptArguments,
+        context: Context,
+    ) -> Any:
+        """Run the loaded scripts with log_error=False (raises on failure).
+        Used by run_script(); returns the result of the last script in the queue."""
+        result: Any = None
+        for script in self.script_queue:
+            if self._propagate_skip_in_subgraph(script):
+                continue
+            if not all(not dep.failed for dep in script.depends):
+                raise TTTriageError(f"{script.name}: Cannot run script due to failed dependencies.")
+            result = script.run(args=args, context=context, log_error=False)
+            if script.skipped:
+                continue
+            if script.config.data_provider and result is None:
+                raise TTTriageError(f"{script.name}: Data provider script did not return any data.")
+        return result
+
+    def build_summary(self) -> str:
+        """One line per script: FAIL, SKIP, or pass (data providers' pass status is omitted)."""
+        lines = []
+        for script in self.script_queue:
+            if script.failed:
+                lines.append(f"{script.name}: FAIL - {script.status_message or 'unknown error'}")
+            elif script.skipped:
+                lines.append(f"{script.name}: SKIP - {script.status_message or 'no reason given'}")
+            elif not script.config.data_provider:
+                lines.append(f"{script.name}: pass")
+        return "\n".join(lines) if lines else "No triage scripts executed."
+
+    def _propagate_skip_or_fail(self, script: TriageScript) -> bool:
+        """Mark `script` skipped/failed if any dep was. Skip wins over fail.
+        Returns True when the script should not be invoked. Used by execute_all."""
+        skipped_dep = next((dep for dep in script.depends if dep.skipped), None)
+        if skipped_dep is not None:
+            script.status = "skipped"
+            script.status_message = f"dependency '{skipped_dep.name}' was skipped"
+            return True
+        if not all(not dep.failed for dep in script.depends):
+            utils.INFO(f"{script.name}:")
+            utils.WARN(f"  Cannot run script due to failed dependencies.")
+            script.status = "failed"
+            script.status_message = "Cannot run script due to failed dependencies."
+            return True
+        return False
+
+    def _propagate_skip_in_subgraph(self, script: TriageScript) -> bool:
+        """Skip-only propagation for execute_subgraph (which raises on fail elsewhere)."""
+        skipped_dep = next((dep for dep in script.depends if dep.skipped), None)
+        if skipped_dep is not None:
+            script.status = "skipped"
+            script.status_message = f"dependency '{skipped_dep.name}' was skipped"
+            return True
+        return False
+
+
+def _resolve_execution_order(scripts: dict[str, TriageScript]) -> list[TriageScript]:
+    """Topological sort with ScriptPriority as the tiebreaker (HIGH first)."""
+    script_dependents: dict[str, list[str]] = defaultdict(list)
+    script_missing_dependencies: dict[str, int] = defaultdict(int)
+
+    for path, script in scripts.items():
+        script_missing_dependencies[path] = len(script.config.depends)
+        for dep in script.config.depends:
+            script_dependents[dep].append(path)
+
+    heap: list[tuple[int, str, TriageScript]] = []
+    for path, script in scripts.items():
+        if script_missing_dependencies[path] == 0:
+            heapq.heappush(heap, (-script.config.priority.value, path, script))
+
+    result: list[TriageScript] = []
+    while heap:
+        _, path, script = heapq.heappop(heap)
+        result.append(script)
+        for dep_path in script_dependents[path]:
+            script_missing_dependencies[dep_path] -= 1
+            if script_missing_dependencies[dep_path] == 0:
+                dep_script = scripts[dep_path]
+                heapq.heappush(heap, (-dep_script.config.priority.value, dep_path, dep_script))
+
+    if len(result) != len(scripts):
+        remaining = set(scripts.keys()) - {s.config.name for s in result}
+        raise ValueError(
+            f"Bad dependency detected in scripts: {', '.join(remaining)}\n"
+            f"  Circular dependency, dependency on disabled or non-existing script is not allowed.\n"
+            f"  Please check if all dependencies are met and scripts are enabled."
+        )
+    return result


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Closes https://github.com/tenstorrent/tt-exalens/issues/965
This PR addresses a couple of things:
1. Triage.py is bloated with code, all script execution, order and load logic is moved and trimmed into a separate "script manager", no changing in functionality
2. Adds ability for scripts to get skipped with useful user output
3. Scripts that fail/skip now propagate that to their dependencies with nice message to the user.
4. When inspector does not have any devices, run checks will skip and no scripts requiring devices will be executed  

Here's the table showing differences from original:
### `triage` (full sweep)

| Scenario | Original | This PR |
|---|---|---|
| Script `S` fails (raises exception) | `S:` then `fail` block: failures + traceback + docstring | _unchanged_ |
| Script `S` raises `TTTriageSkipped(reason)` | _Did not exist_ — would have been treated as a generic failure | `S:` then `  skipped: {reason}` |
| Dependent `D` of failed `S` | `D:` then `WARN: Cannot run script due to failed dependencies.` Marked **failed**, no `serialize_result` call. | `D:` then `  skipped: dependency 'S' failed`. Marked **skipped**, routed through `serialize_result`. |
| Dependent `D` of skipped `S` | _Did not exist_ | `D:` then `  skipped: dependency 'S' was skipped` |

### `triage --run X` (or `python <triage_script>.py`)

| Scenario | Original | This PR |
|---|---|---|
| Target `X` passes | normal table output | _unchanged_ |
| Target `X` fails | Raw Python traceback (target ran with `log_error=False`) | `X:` then `fail` block: failures + traceback + docstring. **Cleaner output.** |
| Target `X` raises `TTTriageSkipped(reason)` | _Did not exist_ — would have surfaced as a raw Python traceback | `X:` then `  skipped: {reason}` |
| Dep `Y` fails | Raw Python traceback of `Y`'s exception (`Y` re-raised under `log_error=False`) | Python traceback for `TTTriageError("X: Cannot run script; dependency 'Y' failed:\n<Y's traceback>")`. `Y`'s traceback is preserved inside the message. |
| Dep `Y` raises `TTTriageSkipped(reason)` | _Did not exist_ — would have surfaced as a raw Python traceback | `X:` then `  skipped: dependency 'Y' was skipped` |

### Summary file (`--triage-summary-path`)

| Scenario | Original | This PR |
|---|---|---|
| Script `S` failed | `S: FAIL - {message}` | _unchanged_ |
| Script `S` skipped | _Did not exist_ | `S: SKIP - {reason}` |
| Dependent `D` of failed `S` | `D: FAIL - Cannot run script due to failed dependencies.` | `D: SKIP - dependency 'S' failed` |
| Dependent `D` of skipped `S` | _Did not exist_ | `D: SKIP - dependency 'S' was skipped` |

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezic/triage-script-manager)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezic/triage-script-manager)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=onenezic/triage-script-manager)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:onenezic/triage-script-manager)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=onenezic/triage-script-manager)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:onenezic/triage-script-manager)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezic/triage-script-manager)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezic/triage-script-manager)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=onenezic/triage-script-manager)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:onenezic/triage-script-manager)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezic/triage-script-manager)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezic/triage-script-manager)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezic/triage-script-manager)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezic/triage-script-manager)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezic/triage-script-manager)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezic/triage-script-manager)