### PR TITLE
Add Quasar SFPU binary max/min kernel and tests

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -350,6 +350,16 @@ class TO_FROM_INT8(TemplateParameter):
         return f"constexpr bool TO_FROM_INT8 = {str(self.to_from_int8).lower()};"
 
 
+@dataclass
+class IS_MAX_OP(TemplateParameter):
+    """Compile-time flag: true for element-wise max, false for min."""
+
+    is_max_op: bool = True
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr bool IS_MAX_OP = {str(self.is_max_op).lower()};"
+
+
 # === RUNTIME PARAMETER IMPLEMENTATIONS ===
 
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_binary_max_min_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_binary_max_min_quasar.py
@@ -1,0 +1,496 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# AI-generated — run_id: 2026-04-29_binary_max_min_quasar_dualpath
+#
+# Three-operand SFPU test for binary_max_min on Quasar.
+#
+# Buffer layout (in buffer_A, tile_count_A=2):
+#   tile 0 (in0) + tile 1 (in1) both in buffer_A
+#   SFPU computes max/min(Dest[0], Dest[1]) → Dest[2]
+#   PACK reads result from Dest[2]   (tile_count_res=1)
+#
+# Two execution paths in the kernel, picked from the format:
+#   * 32-bit formats (Float32, Int32) with dest_acc=Yes   → unpack_to_dest=True
+#   * Non-32-bit / MX formats with dest_acc=No            → unpack_to_dest=False
+#                                                           (UNPACK→SrcA→FPU datacopy→Dest)
+#
+# Format matrix:
+#   Float variant: Float16, Float16_b, Float32, MxFp8R, MxFp8P
+#   Int variant:   Int32, UInt8 (UInt32 deferred — not in VALID_QUASAR_DEST_REG_FORMATS)
+
+from typing import List
+
+import pytest
+import torch
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.golden_generators import quantize_mx_stimuli
+from helpers.llk_params import (
+    DataCopyType,
+    DestAccumulation,
+    ImpliedMathFormat,
+    UnpackerEngine,
+    format_dict,
+)
+from helpers.param_config import (
+    input_output_formats,
+    is_invalid_quasar_sfpu_format_combination,
+    parametrize,
+)
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import (
+    apply_log_uniform_magnitudes,
+    compute_safe_input_magnitude_range,
+    format_elem_max,
+    generate_stimuli,
+)
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    DATA_COPY_TYPE,
+    DEST_INDEX,
+    DEST_SYNC,
+    IMPLIED_MATH_FORMAT,
+    IS_MAX_OP,
+    NUM_FACES,
+    TEST_FACE_DIMS,
+    TILE_COUNT,
+    UNPACKER_ENGINE_SEL,
+)
+from helpers.utils import passed_test
+
+# ─── Input preparation ────────────────────────────────────────────────────────
+
+
+def prepare_binary_max_min_inputs(
+    src_A: torch.Tensor,
+    src_B: torch.Tensor,
+    input_format: DataFormat,
+    output_format: DataFormat,
+) -> tuple:
+    """
+    Prepare two input tensors for binary max/min with safe value ranges.
+
+    Returns (in0, in1) clamped to safe representable range for the given
+    (input_format, output_format) pair. Both tensors have the same format.
+
+    For float formats: log-uniform magnitudes inside the format-aware safe
+    range from `compute_safe_input_magnitude_range`. The result of max/min
+    is one of the operands verbatim, so the per-operand cap is just the
+    smaller of the input and output format max magnitudes — this prevents
+    MX block-shared-exponent flushing when adjacent lanes within a 32-element
+    block straddle ranges the block exponent and 2-/3-bit mantissa cannot
+    span.
+    For integer formats: values inside ~1/8 of the format's representable
+    range to keep clear of extremes that trigger sign-magnitude edge cases.
+    """
+    torch_fmt = format_dict[input_format]
+
+    # Integer formats: scale to a safe fraction of the representable range.
+    # iinfo.max // 8 keeps Int32 at ~2^28 and shrinks proportionally for UInt8.
+    if not torch_fmt.is_floating_point:
+        iinfo = torch.iinfo(torch_fmt)
+        max_val = iinfo.max // 8
+        in0 = (
+            torch.clamp(src_A * max_val, iinfo.min, iinfo.max)
+            .to(torch_fmt)
+            .to(torch.float32)
+        )
+        in1 = (
+            torch.clamp(src_B * max_val, iinfo.min, iinfo.max)
+            .to(torch_fmt)
+            .to(torch.float32)
+        )
+        return in0, in1
+
+    # max/min returns one operand verbatim → result magnitude == max(|in0|, |in1|)
+    cap = min(format_elem_max(input_format), format_elem_max(output_format))
+    min_mag, max_mag = compute_safe_input_magnitude_range(
+        input_format,
+        output_format,
+        input_magnitude_cap=cap,
+        output_magnitude_cap=cap,
+    )
+
+    in0 = apply_log_uniform_magnitudes(
+        src_A,
+        min_magnitude=min_mag,
+        max_magnitude=max_mag,
+        cast_to_format=input_format,
+        sign_source=src_A,
+    )
+    in1 = apply_log_uniform_magnitudes(
+        src_B,
+        min_magnitude=min_mag,
+        max_magnitude=max_mag,
+        cast_to_format=input_format,
+        sign_source=src_B,
+    )
+    return in0, in1
+
+
+# ─── Format lists ─────────────────────────────────────────────────────────────
+
+# Float variant — pairs covered by the dual-path kernel.
+SFPU_BINARY_MAX_MIN_FLOAT_FORMATS = input_output_formats(
+    [
+        DataFormat.Float16_b,
+        DataFormat.Float16,
+        DataFormat.Float32,
+        DataFormat.MxFp8R,
+        DataFormat.MxFp8P,
+    ],
+)
+
+# Int variant: Int32 + UInt8 (UInt32 deferred — not in VALID_QUASAR_DEST_REG_FORMATS).
+SFPU_BINARY_MAX_MIN_INT32_FORMATS = input_output_formats(
+    [DataFormat.Int32],
+    same=True,
+)
+
+
+# ─── Combination generators ────────────────────────────────────────────────────
+
+
+def generate_binary_max_min_float_combinations(formats_list: List[FormatConfig]):
+    """
+    Generate (format, dest_acc, implied_math_format, is_max_op, input_dimensions) tuples
+    for the float variant (non-Int32 formats).
+
+    Yes-count: 5 pairs. dest_acc filtered per SFPU bit-width rule.
+    """
+    combinations = []
+    for fmt in formats_list:
+        in_fmt = fmt.input_format
+
+        # SFPU bit-width rule: 32-bit input → dest_acc=Yes only; else dest_acc=No only
+        dest_acc_modes = (
+            (DestAccumulation.Yes,) if in_fmt.is_32_bit() else (DestAccumulation.No,)
+        )
+
+        for dest_acc in dest_acc_modes:
+            if is_invalid_quasar_sfpu_format_combination(fmt, dest_acc):
+                continue
+
+            for implied_math_format in [ImpliedMathFormat.No, ImpliedMathFormat.Yes]:
+                if (
+                    in_fmt.is_mx_format()
+                    and implied_math_format == ImpliedMathFormat.No
+                ):
+                    continue  # MX formats require implied_math_format=Yes
+
+                for is_max_op in [True, False]:  # max AND min
+                    for input_dimensions in [[32, 32]]:
+                        combinations.append(
+                            (
+                                fmt,
+                                dest_acc,
+                                implied_math_format,
+                                is_max_op,
+                                input_dimensions,
+                            )
+                        )
+
+    return combinations
+
+
+def generate_binary_max_min_int32_combinations(formats_list: List[FormatConfig]):
+    """
+    Generate combinations for the int variant.
+
+    Int32 / UInt8 both use dest_acc=Yes so the math thread enables
+    EN_INT32_MATH_FORMAT and Dest holds INT32 sign-mag values. Without it,
+    sub-32-bit integer src would go through the FP16 datacopy path and the byte
+    values would be re-encoded as FP16, corrupting integer ordering.
+    """
+    combinations = []
+    for fmt in formats_list:
+        dest_acc_modes = (DestAccumulation.Yes,)
+
+        for dest_acc in dest_acc_modes:
+            if is_invalid_quasar_sfpu_format_combination(fmt, dest_acc):
+                continue
+
+            for is_max_op in [True, False]:  # max AND min
+                for input_dimensions in [[32, 32]]:
+                    combinations.append((fmt, dest_acc, is_max_op, input_dimensions))
+
+    return combinations
+
+
+# ─── Tests ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.quasar
+@parametrize(
+    formats_dest_acc_implied_math_is_max_input_dims=generate_binary_max_min_float_combinations(
+        SFPU_BINARY_MAX_MIN_FLOAT_FORMATS
+    ),
+)
+def test_binary_max_min_float_quasar(formats_dest_acc_implied_math_is_max_input_dims):
+    """
+    Test float variant of binary_max_min (calculate_binary_max_min) on Quasar.
+
+    Verifies element-wise max and min across two Dest tile regions using
+    SFPSWAP (sign-magnitude comparison = FP32 total order).
+
+    Golden: torch.maximum / torch.minimum applied element-wise.
+    """
+    (formats, dest_acc, implied_math_format, is_max_op, input_dimensions) = (
+        formats_dest_acc_implied_math_is_max_input_dims[0]
+    )
+
+    torch.manual_seed(42)
+
+    src_A, tile_cnt_A, src_B, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        sfpu=True,
+        negative_values=True,
+    )
+
+    # Prepare in0 and in1 inputs with safe value ranges
+    in0, in1 = prepare_binary_max_min_inputs(
+        src_A, src_B, formats.input_format, formats.output_format
+    )
+
+    # Convert to target format
+    torch_fmt = format_dict[formats.input_format]
+    in0 = in0.to(torch_fmt)
+    in1 = in1.to(torch_fmt)
+
+    num_faces = 4
+
+    # MX formats use a 32-element shared block exponent. Quantizing both inputs
+    # through the same pack→unpack roundtrip the hardware applies makes the
+    # golden compare against what the kernel actually sees in Dest, not the
+    # higher-precision bfloat16 source values.
+    if formats.input_format.is_mx_format():
+        in0_for_golden = quantize_mx_stimuli(
+            in0.flatten(), formats.input_format, num_faces
+        ).reshape(in0.shape)
+        in1_for_golden = quantize_mx_stimuli(
+            in1.flatten(), formats.input_format, num_faces
+        ).reshape(in1.shape)
+    else:
+        in0_for_golden = in0
+        in1_for_golden = in1
+
+    in0_f32 = in0_for_golden.to(torch.float32)
+    in1_f32 = in1_for_golden.to(torch.float32)
+    if is_max_op:
+        golden_f32 = torch.maximum(in0_f32, in1_f32)
+    else:
+        golden_f32 = torch.minimum(in0_f32, in1_f32)
+
+    output_torch_fmt = format_dict[formats.output_format]
+    golden_tensor = golden_f32.to(output_torch_fmt)
+
+    # Mirror the output-side MX pack quantization: the kernel re-quantizes the
+    # max/min result with a fresh per-block exponent on the way back to L1.
+    if formats.output_format.is_mx_format():
+        golden_tensor = quantize_mx_stimuli(
+            golden_tensor.flatten(), formats.output_format, num_faces
+        ).reshape(golden_tensor.shape)
+
+    # buffer_A has 2 tiles: tile 0 = in0, tile 1 = in1, concatenated.
+    # StimuliConfig with tile_count_A=2 reads buffer_A[0:1024] as tile 0
+    # and buffer_A[1024:2048] as tile 1 (stride = MAX_TILE_ELEMENTS=1024).
+    # buffer_B is a dummy (required by StimuliConfig; not written to the kernel).
+    buffer_A_combined = torch.cat([in0.flatten(), in1.flatten()])
+
+    # If in0/in1 have fewer than 1024 elements (e.g. partial faces), pad to 1024 each
+    max_tile_elements = 1024
+    if len(in0.flatten()) < max_tile_elements:
+        pad_len = max_tile_elements - len(in0.flatten())
+        buffer_A_combined = torch.cat(
+            [
+                in0.flatten(),
+                torch.zeros(pad_len, dtype=in0.dtype),
+                in1.flatten(),
+                torch.zeros(pad_len, dtype=in1.dtype),
+            ]
+        )
+
+    # 32-bit input + dest_acc=Yes  → unpack_to_dest=True
+    # Everything else (incl. Float16_b, MxFp8R, MxFp8P) → unpack_to_dest=False
+    # (UNPACK→SrcA→FPU datacopy→Dest path; required for MX block formats).
+    unpack_to_dest = (
+        formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
+    )
+
+    configuration = TestConfig(
+        "sources/quasar/sfpu_binary_max_min_quasar_test.cpp",
+        formats,
+        templates=[
+            IS_MAX_OP(is_max_op=is_max_op),
+            IMPLIED_MATH_FORMAT(implied_math_format),
+            DATA_COPY_TYPE(DataCopyType.A2D),
+            UNPACKER_ENGINE_SEL(
+                UnpackerEngine.UnpDest if unpack_to_dest else UnpackerEngine.UnpA
+            ),
+            DEST_SYNC(),
+        ],
+        runtimes=[
+            TILE_COUNT(2),  # 2 input tiles in buffer_A
+            NUM_FACES(num_faces),
+            TEST_FACE_DIMS(),
+            DEST_INDEX(0),
+        ],
+        variant_stimuli=StimuliConfig(
+            buffer_A_combined,  # in0 (tile 0) + in1 (tile 1) concatenated
+            formats.input_format,
+            in1,  # dummy in buffer_B (not used by kernel)
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=2,
+            tile_count_B=1,
+            tile_count_res=1,  # kernel packs only the SFPU output (Dest[2])
+            num_faces=num_faces,
+            sfpu=True,
+        ),
+        unpack_to_dest=unpack_to_dest,
+        dest_acc=dest_acc,
+        disable_format_inference=formats.input_format.is_mx_format(),
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), f"Result length {len(res_from_L1)} != golden length {len(golden_tensor)}"
+
+    res_tensor = torch.tensor(res_from_L1, dtype=output_torch_fmt)
+
+    assert passed_test(
+        golden_tensor,
+        res_tensor,
+        formats.output_format,
+    ), (
+        f"Assert against golden failed for is_max_op={is_max_op}, "
+        f"format={formats.input_format}->{formats.output_format}, dest_acc={dest_acc}"
+    )
+
+
+@pytest.mark.quasar
+@parametrize(
+    formats_dest_acc_is_max_input_dims=generate_binary_max_min_int32_combinations(
+        SFPU_BINARY_MAX_MIN_INT32_FORMATS
+    ),
+)
+def test_binary_max_min_int32_quasar(formats_dest_acc_is_max_input_dims):
+    """
+    Test int variant of binary_max_min (calculate_binary_max_min_int32) on Quasar.
+
+    Covers Int32 and UInt8: both rebase into INT32 sign-mag in Dest via
+    EN_INT32_MATH_FORMAT, so the same kernel handles both. Verifies element-wise
+    max and min using SFPSWAP + CC-guarded correction to reconcile sign-magnitude
+    vs two's-complement ordering for negative pairs.
+
+    UInt32 is deferred — not in VALID_QUASAR_DEST_REG_FORMATS.
+
+    Golden: torch.maximum / torch.minimum on int32 values.
+    """
+    (formats, dest_acc, is_max_op, input_dimensions) = (
+        formats_dest_acc_is_max_input_dims[0]
+    )
+
+    torch.manual_seed(42)
+
+    src_A, tile_cnt_A, src_B, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        sfpu=True,
+        negative_values=True,
+    )
+
+    # Prepare integer inputs: scaled into ~1/8 of the format's representable
+    # range, returned as float32-container tensors.
+    in0_f, in1_f = prepare_binary_max_min_inputs(
+        src_A, src_B, formats.input_format, formats.output_format
+    )
+
+    # Convert to actual int32 for packing and golden computation
+    in0_int = in0_f.to(torch.int32)
+    in1_int = in1_f.to(torch.int32)
+
+    # Golden: element-wise signed max or min in two's-complement int32
+    # (the hardware kernel corrects sign-magnitude to two's-complement ordering)
+    if is_max_op:
+        golden_int = torch.maximum(in0_int, in1_int)
+    else:
+        golden_int = torch.minimum(in0_int, in1_int)
+
+    golden_tensor = golden_int.to(torch.float32)
+
+    num_faces = 4
+
+    output_torch_fmt = format_dict[formats.output_format]
+
+    # Concatenate in0 and in1 into buffer_A (tile_count_A=2)
+    # pack_int32 expects int32 tensors (converts two's-complement → sign-magnitude for HW)
+    max_tile_elements = 1024
+    buffer_A_combined = torch.cat([in0_int.flatten(), in1_int.flatten()])
+    if len(in0_int.flatten()) < max_tile_elements:
+        pad_len = max_tile_elements - len(in0_int.flatten())
+        buffer_A_combined = torch.cat(
+            [
+                in0_int.flatten(),
+                torch.zeros(pad_len, dtype=torch.int32),
+                in1_int.flatten(),
+                torch.zeros(pad_len, dtype=torch.int32),
+            ]
+        )
+
+    # Int32 is 32-bit with dest_acc=Yes → unpack_to_dest=True path.
+    unpack_to_dest = (
+        formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
+    )
+
+    configuration = TestConfig(
+        "sources/quasar/sfpu_binary_max_min_quasar_test.cpp",
+        formats,
+        templates=[
+            IS_MAX_OP(is_max_op=is_max_op),
+            IMPLIED_MATH_FORMAT(ImpliedMathFormat.No),
+            DATA_COPY_TYPE(DataCopyType.A2D),
+            UNPACKER_ENGINE_SEL(
+                UnpackerEngine.UnpDest if unpack_to_dest else UnpackerEngine.UnpA
+            ),
+            DEST_SYNC(),
+        ],
+        runtimes=[
+            TILE_COUNT(2),  # 2 input tiles in buffer_A
+            NUM_FACES(num_faces),
+            TEST_FACE_DIMS(),
+            DEST_INDEX(0),
+        ],
+        variant_stimuli=StimuliConfig(
+            buffer_A_combined,  # in0 (tile 0) + in1 (tile 1) concatenated
+            formats.input_format,
+            in1_int,  # dummy in buffer_B (not used by kernel)
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=2,
+            tile_count_B=1,
+            tile_count_res=1,  # kernel packs only the SFPU output (Dest[2])
+            num_faces=num_faces,
+            sfpu=True,
+        ),
+        unpack_to_dest=unpack_to_dest,
+        dest_acc=dest_acc,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), f"Result length {len(res_from_L1)} != golden length {len(golden_tensor)}"
+
+    res_tensor = torch.tensor(res_from_L1, dtype=output_torch_fmt)
+
+    assert passed_test(
+        golden_tensor, res_tensor, formats.output_format
+    ), f"Assert against golden failed for is_max_op={is_max_op}, int32 format"

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_abs_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_abs_quasar.py
@@ -16,7 +16,11 @@ from helpers.llk_params import (
     UnpackerEngine,
     format_dict,
 )
-from helpers.param_config import input_output_formats, parametrize
+from helpers.param_config import (
+    input_output_formats,
+    is_invalid_quasar_sfpu_format_combination,
+    parametrize,
+)
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator_v2 import generate_stimuli_v2
 from helpers.test_config import TestConfig
@@ -110,45 +114,6 @@ def prepare_abs_inputs(
     return result
 
 
-def _is_invalid_quasar_combination(
-    fmt: FormatConfig, dest_acc: DestAccumulation
-) -> bool:
-    """
-    Check if format combination is invalid for Quasar.
-
-    Args:
-        fmt: Format configuration with input and output formats
-        dest_acc: Destination accumulation mode
-
-    Returns:
-        True if the combination is invalid, False otherwise
-    """
-    in_fmt = fmt.input_format
-    out_fmt = fmt.output_format
-
-    # Quasar packer does not support non-Float32 to Float32 conversion when dest_acc=No
-    if (
-        in_fmt != DataFormat.Float32
-        and out_fmt == DataFormat.Float32
-        and dest_acc == DestAccumulation.No
-    ):
-        return True
-
-    # Quasar SFPU with Float32 input and Float16 output requires dest_acc=Yes
-    if (
-        in_fmt == DataFormat.Float32
-        and out_fmt == DataFormat.Float16
-        and dest_acc == DestAccumulation.No
-    ):
-        return True
-
-    # Integer and float formats cannot be mixed in input/output
-    if in_fmt.is_integer() != out_fmt.is_integer():
-        return True
-
-    return False
-
-
 def generate_sfpu_abs_combinations(
     formats_list: List[FormatConfig],
 ):
@@ -171,7 +136,7 @@ def generate_sfpu_abs_combinations(
         )
         for dest_acc in dest_acc_modes:
             # Skip invalid format combinations for Quasar
-            if _is_invalid_quasar_combination(fmt, dest_acc):
+            if is_invalid_quasar_sfpu_format_combination(fmt, dest_acc):
                 continue
 
             for implied_math_format in [ImpliedMathFormat.No, ImpliedMathFormat.Yes]:

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_where_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_where_quasar.py
@@ -16,7 +16,11 @@ from helpers.llk_params import (
     UnpackerEngine,
     format_dict,
 )
-from helpers.param_config import input_output_formats, parametrize
+from helpers.param_config import (
+    input_output_formats,
+    is_invalid_quasar_sfpu_format_combination,
+    parametrize,
+)
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
@@ -32,38 +36,6 @@ from helpers.test_variant_parameters import (
     UNPACKER_ENGINE_SEL,
 )
 from helpers.utils import passed_test
-
-
-def _is_invalid_quasar_combination(
-    fmt: FormatConfig, dest_acc: DestAccumulation
-) -> bool:
-    """
-    Check if format combination is invalid for Quasar.
-    """
-    in_fmt = fmt.input_format
-    out_fmt = fmt.output_format
-
-    # Quasar packer does not support non-Float32 to Float32 conversion when dest_acc=No
-    if (
-        in_fmt != DataFormat.Float32
-        and out_fmt == DataFormat.Float32
-        and dest_acc == DestAccumulation.No
-    ):
-        return True
-
-    # Quasar SFPU with Float32 input and Float16 output requires dest_acc=Yes
-    if (
-        in_fmt == DataFormat.Float32
-        and out_fmt == DataFormat.Float16
-        and dest_acc == DestAccumulation.No
-    ):
-        return True
-
-    # Integer and float formats cannot be mixed in input/output
-    if in_fmt.is_integer() != out_fmt.is_integer():
-        return True
-
-    return False
 
 
 def generate_sfpu_where_combinations(
@@ -87,7 +59,7 @@ def generate_sfpu_where_combinations(
             else (DestAccumulation.No, DestAccumulation.Yes)
         )
         for dest_acc in dest_acc_modes:
-            if _is_invalid_quasar_combination(fmt, dest_acc):
+            if is_invalid_quasar_sfpu_format_combination(fmt, dest_acc):
                 continue
 
             for implied_math_format in [ImpliedMathFormat.No, ImpliedMathFormat.Yes]:

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_binary_max_min_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_binary_max_min_quasar_test.cpp
@@ -103,7 +103,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // Release the Dest section to the next consumer (SFPU on the unpack-to-dest path).
     // On the FPU path, T1's _llk_math_set_dvalid_<FPU> handles the release instead.
-    if (unpack_to_dest)
+    if constexpr (unpack_to_dest)
     {
         _llk_unpack_dest_dvalid_section_done_<dest_sync>();
     }
@@ -135,7 +135,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // producer for the datacopy step and the SFPU producer for the max/min step), so
     // both clients must be registered. On the unpack-to-dest path T1 is only the SFPU
     // client; the producer is T0/UNPACK.
-    if (unpack_to_dest)
+    if constexpr (unpack_to_dest)
     {
         set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
     }
@@ -166,7 +166,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // FPU-datacopy path: move both input tiles from SrcA into Dest at DST_INDEX + i.
     // Required for non-32-bit and MX formats; skipped when the unpacker has already
     // placed data directly in Dest. After the moves, release Dest to the SFPU step.
-    if (!unpack_to_dest)
+    if constexpr (!unpack_to_dest)
     {
         const std::uint32_t num_rows = params.num_faces * params.TEST_FACE_R_DIM;
         _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_rows, 1);
@@ -179,16 +179,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // SFPU step: read Dest tile 0 (in0) and Dest tile 1 (in1), write Dest tile 2 (out).
     // dst_index_in0/in1/out are tile offsets relative to params.DST_INDEX.
-    _llk_math_eltwise_unary_sfpu_init_();
+    _llk_math_eltwise_sfpu_init_();
 
-    // All integer formats route through the int32 kernel: with EN_INT32_MATH_FORMAT
-    // enabled, Dest holds INT32 sign-mag values regardless of the src width, so the
-    // SFPU loads them via sfpmem::INT32. The kernel's LT0-guarded correction is a
-    // no-op for unsigned-origin lanes (bit 31 always 0).
+    // All integer formats route through the Int32 path (sfpmem::INT32); float and MX
+    // formats use the DEFAULT path (sfpmem::DEFAULT, HW derives the mode from ACC_CTRL).
     if (math_format == DataFormat::Int32)
     {
         _llk_math_eltwise_unary_sfpu_params_(
-            ckernel::sfpu::calculate_binary_max_min_int32<IS_MAX_OP, 8 /*ITERATIONS*/>,
+            ckernel::sfpu::calculate_binary_max_min<DataFormat::Int32, IS_MAX_OP, 8 /*ITERATIONS*/>,
             params.DST_INDEX,
             /* dst_index_in0 */ 0U,
             /* dst_index_in1 */ 1U,
@@ -197,7 +195,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     else
     {
         _llk_math_eltwise_unary_sfpu_params_(
-            ckernel::sfpu::calculate_binary_max_min<IS_MAX_OP, 8 /*ITERATIONS*/>,
+            ckernel::sfpu::calculate_binary_max_min<DataFormat::Float32, IS_MAX_OP, 8 /*ITERATIONS*/>,
             params.DST_INDEX,
             /* dst_index_in0 */ 0U,
             /* dst_index_in1 */ 1U,
@@ -235,7 +233,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // PACK is the final consumer of the Dest DVALID chain. The producer field
     // tracks which path wrote Dest (UNPACK on the unpack-to-dest path, FPU otherwise).
-    if (unpack_to_dest)
+    if constexpr (unpack_to_dest)
     {
         set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_binary_max_min_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_binary_max_min_quasar_test.cpp
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// AI-generated — run_id: 2026-04-29_binary_max_min_quasar_dualpath
+//
+// Three-operand SFPU test for binary max/min on Quasar.
+//
+// Two execution paths, selected at runtime by `unpack_to_dest`:
+//   * unpack_to_dest=true   — UNPACK → Dest directly. Used for 32-bit Dest formats
+//                             (Float32, Int32 with dest_acc=Yes).
+//   * unpack_to_dest=false  — UNPACK → SrcA → FPU datacopy → Dest. Required for
+//                             non-32-bit and MX block formats (Float16_b, MxFp8R,
+//                             MxFp8P), which the unpacker cannot route directly to
+//                             Dest because the block-exponent conversion happens
+//                             on the FPU datacopy side.
+//
+// Buffer layout (params.TILE_CNT == 2):
+//   buffer_A[0] = in0 tile   → Dest[DST_INDEX + 0]
+//   buffer_A[1] = in1 tile   → Dest[DST_INDEX + 1]
+//   SFPU writes              → Dest[DST_INDEX + 2]
+//   buffer_Res[0] = result   ← Dest[DST_INDEX + 2] (1 tile packed)
+//
+// Test flow (per kernel run):
+//   T0 unpack: stage both input tiles from buffer_A in L1 into Dest.
+//              unpack_to_dest=true  → write Dest tiles 0 and 1 directly.
+//              unpack_to_dest=false → write into SrcA; T1 will datacopy.
+//   T1 math:   on the FPU path, datacopy SrcA → Dest tiles 0 and 1.
+//              Then run the SFPU max/min kernel: read Dest tiles 0 and 1,
+//              compute element-wise max or min, write Dest tile 2.
+//   T2 pack:   pack the single result tile (Dest tile 2) out to buffer_Res in L1.
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "llk_memory_checks.h"
+#include "sfpu_stub.h"
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_math_common.h"
+#include "llk_unpack_common.h"
+#include "llk_unpack_unary_operand.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t buf_desc_id = 0;               // T0 source descriptor slot for buffer_A
+    const std::uint32_t num_tiles   = params.TILE_CNT; // 2 input tiles (in0, in1) packed in buffer_A
+
+    // DEST DVALID handshake: T0 is the producer; T1 (FPU or SFPU) and T2 (PACK) are the consumers.
+    // The producer field differs per path: UNPACK on the unpack-to-dest path, FPU on the datacopy path.
+    // The hw_configure call only applies to the unpack-to-dest path — it programs Dest to receive
+    // unpacker writes directly. On the FPU path, srcAB hw_configure on T1 covers it instead.
+    if constexpr(unpack_to_dest)
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+        _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
+    }
+    else
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+
+    // Source descriptor: buffer_A in L1, L1-side format = formats.unpack_A_src,
+    // face geometry from the harness. buffer_A holds both input tiles back-to-back.
+    buffer_descriptor_u bd_val = {0};
+    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_A[0]);
+    bd_val.f.format            = static_cast<std::uint8_t>(formats.unpack_A_src);
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
+
+    // TDMA descriptor: bind the buffer descriptor to slot 0; reg_data_format =
+    // unpack_A_dst is the Dest-side (post-conversion) format.
+    tdma_descriptor_t td_val;
+    td_val.buf_desc        = bd_val;
+    td_val.buf_desc_id     = buf_desc_id;
+    td_val.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+
+    // For 32-bit Dest with the FPU-datacopy path, Mov2D is implemented via ELWADD,
+    // so both UNP_A and UNP_B must be configured with the same descriptor.
+    // All other variants use the unary configuration on a single unpacker engine.
+    if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
+    {
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
+    }
+    else
+    {
+        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val);
+    }
+
+    // Configure unpacker → init for `num_tiles` consecutive tiles → unpack starting at L1 tile 0.
+    // The single _llk_unpack_unary_operand_ call walks both tiles internally because init was
+    // primed with num_tiles=2; tile 0 lands in Dest tile 0, tile 1 in Dest tile 1.
+    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, num_tiles);
+    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0 /*l1_tile_idx*/);
+
+    // Release the Dest section to the next consumer (SFPU on the unpack-to-dest path).
+    // On the FPU path, T1's _llk_math_set_dvalid_<FPU> handles the release instead.
+    if (unpack_to_dest)
+    {
+        _llk_unpack_dest_dvalid_section_done_<dest_sync>();
+    }
+}
+
+#endif // LLK_TRISC_UNPACK
+
+#ifdef LLK_TRISC_MATH
+
+#include "cfg_defines.h"
+#include "cmath_common.h"
+#include "experimental/ckernel_sfpu_binary_max_min.h"
+#include "llk_math_common.h"
+#include "llk_math_eltwise_unary_datacopy.h"
+#include "llk_math_eltwise_unary_sfpu_common.h"
+#include "params.h"
+
+using namespace ckernel;
+using namespace ckernel::math;
+using namespace ckernel::sfpu;
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+
+    // DEST DVALID handshake: T1 plays two roles on the FPU path (it's both the FPU
+    // producer for the datacopy step and the SFPU producer for the max/min step), so
+    // both clients must be registered. On the unpack-to-dest path T1 is only the SFPU
+    // client; the producer is T0/UNPACK.
+    if (unpack_to_dest)
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+    else
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+
+    DataFormat math_format     = static_cast<DataFormat>(formats.math);
+    DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+
+    // srcAB hw_configure: srcA and srcB share the math format; Dest mode follows the
+    // int / float split (int32 for integer formats, otherwise is_fp32_dest_acc_en).
+    if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
+    {
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
+    }
+    else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+    {
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
+    }
+    else
+    {
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
+    }
+
+    // FPU-datacopy path: move both input tiles from SrcA into Dest at DST_INDEX + i.
+    // Required for non-32-bit and MX formats; skipped when the unpacker has already
+    // placed data directly in Dest. After the moves, release Dest to the SFPU step.
+    if (!unpack_to_dest)
+    {
+        const std::uint32_t num_rows = params.num_faces * params.TEST_FACE_R_DIM;
+        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_rows, 1);
+        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        {
+            _llk_math_eltwise_unary_datacopy_(num_rows, params.DST_INDEX + i);
+        }
+        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+    }
+
+    // SFPU step: read Dest tile 0 (in0) and Dest tile 1 (in1), write Dest tile 2 (out).
+    // dst_index_in0/in1/out are tile offsets relative to params.DST_INDEX.
+    _llk_math_eltwise_unary_sfpu_init_();
+
+    // All integer formats route through the int32 kernel: with EN_INT32_MATH_FORMAT
+    // enabled, Dest holds INT32 sign-mag values regardless of the src width, so the
+    // SFPU loads them via sfpmem::INT32. The kernel's LT0-guarded correction is a
+    // no-op for unsigned-origin lanes (bit 31 always 0).
+    if (math_format == DataFormat::Int32)
+    {
+        _llk_math_eltwise_unary_sfpu_params_(
+            ckernel::sfpu::calculate_binary_max_min_int32<IS_MAX_OP, 8 /*ITERATIONS*/>,
+            params.DST_INDEX,
+            /* dst_index_in0 */ 0U,
+            /* dst_index_in1 */ 1U,
+            /* dst_index_out */ 2U);
+    }
+    else
+    {
+        _llk_math_eltwise_unary_sfpu_params_(
+            ckernel::sfpu::calculate_binary_max_min<IS_MAX_OP, 8 /*ITERATIONS*/>,
+            params.DST_INDEX,
+            /* dst_index_in0 */ 0U,
+            /* dst_index_in1 */ 1U,
+            /* dst_index_out */ 2U);
+    }
+
+    // Hand Dest off to PACK.
+    _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();
+
+    // Drain SFPU/FPU/MOP queues before this thread returns, so PACK doesn't see
+    // stale state from in-flight math instructions.
+    wait_sfpu_idle();
+    wait_fpu_idle();
+    wait_mop_idle();
+}
+
+#endif // LLK_TRISC_MATH
+
+#ifdef LLK_TRISC_PACK
+
+#include "cfg_defines.h"
+#include "llk_pack.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    std::uint32_t const buf_desc_id = 8; // T2 destination descriptor slot for buffer_Res
+    // Only the SFPU output tile (Dest tile 2) is packed out; the two input tiles
+    // staged in Dest tiles 0/1 are not part of the result.
+    const std::uint32_t num_tiles_per_pack = 1;
+
+    // PACK is the final consumer of the Dest DVALID chain. The producer field
+    // tracks which path wrote Dest (UNPACK on the unpack-to-dest path, FPU otherwise).
+    if (unpack_to_dest)
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+    else
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+
+    // Destination descriptor: buffer_Res in L1, L1-side format = formats.pack_dst,
+    // face geometry from the harness.
+    buffer_descriptor_u bd_val = {0};
+    bd_val.f.l1_addr_16B       = params.buffer_Res[0] / 16;
+    bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
+
+    // TDMA descriptor: bind buffer_Res to slot 8; reg_data_format = pack_src is the
+    // Dest-side format the packer reads.
+    tdma_descriptor_t tdma_desc;
+    tdma_desc.buf_desc        = bd_val;
+    tdma_desc.buf_desc_id     = buf_desc_id;
+    tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+
+    // Configure pack engine 0 → init for one tile → pack Dest tile 2 (the SFPU output)
+    // into buffer_Res → release the Dest section.
+    _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
+    _llk_pack_init_(buf_desc_id, num_tiles_per_pack);
+    _llk_pack_(params.DST_INDEX + 2, 0);
+    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+}
+#endif // LLK_TRISC_PACK

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_binary_max_min_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_binary_max_min_quasar_test.cpp
@@ -180,6 +180,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // SFPU step: read Dest tile 0 (in0) and Dest tile 1 (in1), write Dest tile 2 (out).
     // dst_index_in0/in1/out are tile offsets relative to params.DST_INDEX.
     _llk_math_eltwise_sfpu_init_();
+    _init_binary_max_min_();
 
     // All integer formats route through the Int32 path (sfpmem::INT32); float and MX
     // formats use the DEFAULT path (sfpmem::DEFAULT, HW derives the mode from ACC_CTRL).

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/experimental/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/experimental/ckernel_sfpu_binary_max_min.h
@@ -5,8 +5,10 @@
 
 #include <cstdint>
 
+#include "ckernel_addrmod.h"
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
+#include "lltt.h"
 #include "sfpi.h"
 
 namespace ckernel
@@ -17,6 +19,9 @@ namespace sfpu
 // imm12 bit 11 = 1: SFPSETCC interprets src_c as two's-complement INT32, not FP32/SMAG32
 constexpr std::uint32_t SFPSETCC_INT32_SIGNBIT = 0x800;
 
+// 9-instruction recorded body: 2 loads + SFPSWAP + SFPNOP + 2 SFPSETCC + SFPSWAP + SFPENCC + SFPSTORE.
+constexpr std::uint32_t BINARY_MAX_MIN_REPLAY_LEN = 9;
+
 // Int32 uses sfpmem::INT32; all float and MX formats use sfpmem::DEFAULT.
 // DEFAULT lets SFPLOAD resolve the format at runtime via ALU_ACC_CTRL_SFPU_Fp32_enabled
 // and the SrcB format register, which the unpacker already programs from formats.math.
@@ -26,31 +31,62 @@ inline constexpr std::uint32_t _binary_max_min_sfpmem_mode_()
     return (FMT == DataFormat::Int32) ? p_sfpu::sfpmem::INT32 : p_sfpu::sfpmem::DEFAULT;
 }
 
-// Unified inner row body for element-wise max/min.
-// Loads two rows from separate Dest tile regions, computes element-wise min+max
-// via SFPSWAP(mod1=VEC_MIN_MAX), applies a CC-guarded correction swap for
-// (neg, neg) pairs, and stores the IS_MAX_OP result.
+// Programs ADDR_MOD_6 with dest.incr=2 so the SFPSTORE in the replayed body
+// auto-advances the dest counter by one SFP-row pair per iteration. Quasar's
+// shared SFPU init only programs ADDR_MOD_7 (incr=0); this is additive.
+inline void _init_binary_max_min_()
+{
+    addr_mod_t {
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = 2},
+    }
+        .set(ADDR_MOD_6, csr_read<CSR::TRISC_ID>());
+}
+
+// Unified element-wise max/min over two Dest tile regions.
+//
+// Records the 9-instruction body once into replay slots 0..8; each REPLAY re-executes
+// it verbatim. ADDR_MOD_6's dest.incr=2 on SFPSTORE (programmed by _init_binary_max_min_)
+// advances the dest counter by one SFP-row pair after each replay so the per-row offsets
+// stay constant in the recorded instructions and the replay buffer can re-issue them
+// unchanged across iterations.
+//
+// FMT controls the SFPLOAD/SFPSTORE sfpmem mode:
+//   DataFormat::Int32                                         → sfpmem::INT32
+//   Float16 / Float16_b / Float32 / Tf32 / MxFp8R / MxFp8P  → sfpmem::DEFAULT
 //
 // SFPSWAP_VEC_MIN_MAX on Quasar uses an unsigned 32-bit compare on the LReg bits
 // instead of the documented sign-magnitude (SignMagIsSmaller) compare. For (neg, neg)
 // pairs that inverts the ordering for both FP32 sign-magnitude and INT32 sign-magnitude.
-// Since bit 31 is the sign bit in both encodings, the SFPSETCC-on-LT0 trick detects rows
-// where both LRegs are negative and re-swaps them. The correction is a no-op for
-// unsigned-origin lanes (bit 31 always 0).
+// The CC-guarded correction swap (SFPSETCC-on-LT0 for both operands, then SFPSWAP) fixes
+// those rows. The correction is a no-op for unsigned-origin lanes (bit 31 always 0).
 //
-// @tparam FMT       Math-side DataFormat (selects sfpmem mode via _binary_max_min_sfpmem_mode_).
-// @tparam IS_MAX_OP true → store max(in0, in1); false → store min.
-// @param offset0    Base Dest address (in 16b units) of the in0 tile region.
-// @param offset1    Base Dest address (in 16b units) of the in1 tile region.
-// @param offset2    Base Dest address (in 16b units) of the output tile region.
-// @param row_index  Row index within the tile; selects which 32-lane SFPU row to process.
-template <DataFormat FMT, bool IS_MAX_OP = true>
-inline void _calculate_binary_max_min_sfp_rows_(const std::uint32_t offset0, const std::uint32_t offset1, const std::uint32_t offset2, const int row_index)
+// @tparam FMT           Math-side DataFormat.
+// @tparam IS_MAX_OP     true → store max(in0, in1); false → store min.
+// @tparam ITERATIONS    Number of SFP-row pairs per face (8 for a 32×16 face).
+// @param dst_index_in0  Dest tile index of input 0 (in tile units, relative to DST_INDEX).
+// @param dst_index_in1  Dest tile index of input 1 (in tile units, relative to DST_INDEX).
+// @param dst_index_out  Dest tile index where the result is written (in tile units, relative to DST_INDEX).
+template <DataFormat FMT, bool IS_MAX_OP = true, int ITERATIONS = 8>
+inline void calculate_binary_max_min(const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out)
 {
+    static_assert(
+        FMT == DataFormat::Float16 || FMT == DataFormat::Float16_b || FMT == DataFormat::Float32 || FMT == DataFormat::Tf32 || FMT == DataFormat::MxFp8R ||
+            FMT == DataFormat::MxFp8P || FMT == DataFormat::Int32,
+        "Unsupported DataFormat for calculate_binary_max_min().");
+
     constexpr std::uint32_t SFPMEM_MODE = _binary_max_min_sfpmem_mode_<FMT>();
 
-    TT_SFPLOAD(p_sfpu::LREG0, SFPMEM_MODE, ADDR_MOD_7, 0 /* done */, offset0 + (row_index << 1));
-    TT_SFPLOAD(p_sfpu::LREG1, SFPMEM_MODE, ADDR_MOD_7, 0 /* done */, offset1 + (row_index << 1));
+    // Tile-base offsets relative to the dest counter start set by _llk_math_eltwise_sfpu_params_.
+    // Per-row stride comes from ADDR_MOD_6's dest.incr=2 on SFPSTORE, not from these offsets.
+    const std::uint32_t offset0 = (dst_index_in0 * 32) << 1;
+    const std::uint32_t offset1 = (dst_index_in1 * 32) << 1;
+    const std::uint32_t offset2 = (dst_index_out * 32) << 1;
+
+    lltt::record(0, BINARY_MAX_MIN_REPLAY_LEN);
+    TT_SFPLOAD(p_sfpu::LREG0, SFPMEM_MODE, ADDR_MOD_7, 0 /* done */, offset0);
+    TT_SFPLOAD(p_sfpu::LREG1, SFPMEM_MODE, ADDR_MOD_7, 0 /* done */, offset1);
 
     // Step 1: SM-min/SM-max via SFPSWAP. Correct for any pair where at least one
     // operand is non-negative; inverts ordering for (neg, neg) pairs.
@@ -65,36 +101,13 @@ inline void _calculate_binary_max_min_sfp_rows_(const std::uint32_t offset0, con
     TTI_SFPENCC(0 /* imm12 */, 0 /* mod1: clear CC */);
 
     // After step 2: LREG0 = min, LREG1 = max for all sign combinations.
-    TT_SFPSTORE(IS_MAX_OP ? p_sfpu::LREG1 : p_sfpu::LREG0, SFPMEM_MODE, ADDR_MOD_7, 0 /* done */, offset2 + (row_index << 1));
-}
+    // ADDR_MOD_6 (dest.incr=2) advances the dest counter by one row pair after each store.
+    TT_SFPSTORE(IS_MAX_OP ? p_sfpu::LREG1 : p_sfpu::LREG0, SFPMEM_MODE, ADDR_MOD_6, 0 /* done */, offset2);
 
-// Unified element-wise max/min over two Dest tile regions.
-//
-// FMT controls the SFPLOAD/SFPSTORE sfpmem mode:
-//   DataFormat::Int32                                         → sfpmem::INT32
-//   Float16 / Float16_b / Float32 / Tf32 / MxFp8R / MxFp8P  → sfpmem::DEFAULT
-//
-// @tparam FMT           Math-side DataFormat.
-// @tparam IS_MAX_OP     true → store max(in0, in1); false → store min.
-// @tparam ITERATIONS    Number of SFP-row pairs per face (8 for a 32×16 face).
-// @param dst_index_in0  Dest tile index of input 0 (in tile units).
-// @param dst_index_in1  Dest tile index of input 1 (in tile units).
-// @param dst_index_out  Dest tile index where the result tile is written (in tile units).
-template <DataFormat FMT, bool IS_MAX_OP = true, int ITERATIONS = 8>
-inline void calculate_binary_max_min(const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out)
-{
-    static_assert(
-        FMT == DataFormat::Float16 || FMT == DataFormat::Float16_b || FMT == DataFormat::Float32 || FMT == DataFormat::Tf32 || FMT == DataFormat::MxFp8R ||
-            FMT == DataFormat::MxFp8P || FMT == DataFormat::Int32,
-        "Unsupported DataFormat for calculate_binary_max_min().");
-
-    const std::uint32_t offset0 = (dst_index_in0 * 32) << 1;
-    const std::uint32_t offset1 = (dst_index_in1 * 32) << 1;
-    const std::uint32_t offset2 = (dst_index_out * 32) << 1;
 #pragma GCC unroll 8
-    for (int row_index = 0; row_index < ITERATIONS; row_index++)
+    for (int d = 0; d < ITERATIONS; d++)
     {
-        _calculate_binary_max_min_sfp_rows_<FMT, IS_MAX_OP>(offset0, offset1, offset2, row_index);
+        lltt::replay(0, BINARY_MAX_MIN_REPLAY_LEN);
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/experimental/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/experimental/ckernel_sfpu_binary_max_min.h
@@ -17,123 +17,84 @@ namespace sfpu
 // imm12 bit 11 = 1: SFPSETCC interprets src_c as two's-complement INT32, not FP32/SMAG32
 constexpr std::uint32_t SFPSETCC_INT32_SIGNBIT = 0x800;
 
-// Float variant — inner row body.
-// Loads two FP rows from separate Dest tile regions, computes element-wise
-// min+max via SFPSWAP(mod1=1), then stores the result for IS_MAX_OP.
+// Int32 uses sfpmem::INT32; all float and MX formats use sfpmem::DEFAULT.
+// DEFAULT lets SFPLOAD resolve the format at runtime via ALU_ACC_CTRL_SFPU_Fp32_enabled
+// and the SrcB format register, which the unpacker already programs from formats.math.
+template <DataFormat FMT>
+inline constexpr std::uint32_t _binary_max_min_sfpmem_mode_()
+{
+    return (FMT == DataFormat::Int32) ? p_sfpu::sfpmem::INT32 : p_sfpu::sfpmem::DEFAULT;
+}
+
+// Unified inner row body for element-wise max/min.
+// Loads two rows from separate Dest tile regions, computes element-wise min+max
+// via SFPSWAP(mod1=VEC_MIN_MAX), applies a CC-guarded correction swap for
+// (neg, neg) pairs, and stores the IS_MAX_OP result.
 //
-// SFPLOAD/SFPSTORE use sfpmem::DEFAULT (MOD0_FMT_SRCB) — SFPLOAD resolves it
-// at runtime via ALU_ACC_CTRL_SFPU_Fp32_enabled and the SrcB format register,
-// both of which the unpacker / _llk_math_srcAB_hw_configure_ already program
-// from formats.math. So DEFAULT lands on FP16A / FP16B / FP32 to match Dst.
+// SFPSWAP_VEC_MIN_MAX on Quasar uses an unsigned 32-bit compare on the LReg bits
+// instead of the documented sign-magnitude (SignMagIsSmaller) compare. For (neg, neg)
+// pairs that inverts the ordering for both FP32 sign-magnitude and INT32 sign-magnitude.
+// Since bit 31 is the sign bit in both encodings, the SFPSETCC-on-LT0 trick detects rows
+// where both LRegs are negative and re-swaps them. The correction is a no-op for
+// unsigned-origin lanes (bit 31 always 0).
 //
-// CC-guarded correction swap: SFPSWAP_VEC_MIN_MAX on Quasar uses an unsigned
-// 32-bit compare on the LReg bits instead of the documented sign-magnitude
-// (SignMagIsSmaller) compare. For (neg, neg) pairs that inverts the ordering —
-// the same bug the int32 variant works around below. Sign-magnitude FP32 in
-// LReg has bit 31 = sign just like INT32, so the same SFPSETCC-on-LT0 trick
-// applies: detect rows where both LRegs are negative and re-swap them.
-//
+// @tparam FMT       Math-side DataFormat (selects sfpmem mode via _binary_max_min_sfpmem_mode_).
+// @tparam IS_MAX_OP true → store max(in0, in1); false → store min.
 // @param offset0    Base Dest address (in 16b units) of the in0 tile region.
 // @param offset1    Base Dest address (in 16b units) of the in1 tile region.
 // @param offset2    Base Dest address (in 16b units) of the output tile region.
-// @param row_index  Row index within the tile [0, ITERATIONS); selects which of the 32-lane SFPU rows to process.
-template <bool IS_MAX_OP = true>
+// @param row_index  Row index within the tile; selects which 32-lane SFPU row to process.
+template <DataFormat FMT, bool IS_MAX_OP = true>
 inline void _calculate_binary_max_min_sfp_rows_(const std::uint32_t offset0, const std::uint32_t offset1, const std::uint32_t offset2, const int row_index)
 {
-    TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0 /* done */, offset0 + (row_index << 1)); // load FP row from in0
-    TT_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0 /* done */, offset1 + (row_index << 1)); // load FP row from in1
+    constexpr std::uint32_t SFPMEM_MODE = _binary_max_min_sfpmem_mode_<FMT>();
+
+    TT_SFPLOAD(p_sfpu::LREG0, SFPMEM_MODE, ADDR_MOD_7, 0 /* done */, offset0 + (row_index << 1));
+    TT_SFPLOAD(p_sfpu::LREG1, SFPMEM_MODE, ADDR_MOD_7, 0 /* done */, offset1 + (row_index << 1));
 
     // Step 1: SM-min/SM-max via SFPSWAP. Correct for any pair where at least one
     // operand is non-negative; inverts ordering for (neg, neg) pairs.
     TTI_SFPSWAP(0 /* imm12 */, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPSWAP_MOD1_VEC_MIN_MAX); // 2-cycle
     TTI_SFPNOP(0 /* srcs_wr_done */, 0 /* srcs_rd_done */, 0 /* dest_done */);                // post-SFPSWAP stall avoidance
 
-    // Step 2: CC-guarded correction swap for (neg, neg) pairs. SFPSETCC with
-    // imm12=SFPSETCC_INT32_SIGNBIT interprets the LReg as INT32 and tests bit 31,
-    // which is the sign bit for both INT32 SM and FP32 SM. Successive SFPSETCC
-    // calls AND into CC, so after both we have CC = (LREG0<0 AND LREG1<0).
+    // Step 2: CC-guarded correction swap for (neg, neg) pairs.
+    // Successive SFPSETCC calls AND into CC, so after both: CC = (LREG0<0 AND LREG1<0).
     TTI_SFPSETCC(SFPSETCC_INT32_SIGNBIT, p_sfpu::LREG0, sfpi::SFPSETCC_MOD1_LREG_LT0);
     TTI_SFPSETCC(SFPSETCC_INT32_SIGNBIT, p_sfpu::LREG1, sfpi::SFPSETCC_MOD1_LREG_LT0);
-    TTI_SFPSWAP(0 /* imm12 */, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPSWAP_MOD1_SWAP); // re-swap rows where both operands are negative
-    TTI_SFPENCC(0 /* imm12 */, 0 /* mod1: clear CC */);
-
-    // After step 2: LREG0 = min, LREG1 = max for all sign combinations.
-    TT_SFPSTORE(
-        IS_MAX_OP ? p_sfpu::LREG1 : p_sfpu::LREG0,
-        p_sfpu::sfpmem::DEFAULT,
-        ADDR_MOD_7,
-        0 /* done */,
-        offset2 + (row_index << 1)); // store max (LREG1) or min (LREG0)
-}
-
-// Float variant — outer loop.
-// Explicit offset arithmetic for all three tile regions; no _incr_counters_
-// needed because loads/stores use absolute addresses, not the auto-increment pointer.
-//
-// @param dst_index_in0  Dest tile index of input 0 (in tile units).
-// @param dst_index_in1  Dest tile index of input 1 (in tile units).
-// @param dst_index_out  Dest tile index where the result tile is written (in tile units).
-template <bool IS_MAX_OP = true, int ITERATIONS = 8>
-inline void calculate_binary_max_min(const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out)
-{
-    const std::uint32_t offset0 = (dst_index_in0 * 32) << 1;
-    const std::uint32_t offset1 = (dst_index_in1 * 32) << 1;
-    const std::uint32_t offset2 = (dst_index_out * 32) << 1;
-#pragma GCC unroll 8
-    for (int row_index = 0; row_index < ITERATIONS; row_index++)
-    {
-        _calculate_binary_max_min_sfp_rows_<IS_MAX_OP>(offset0, offset1, offset2, row_index);
-    }
-}
-
-// Int32 variant — inner row body.
-// SFPSWAP mod1=1 (VEC_MIN_MAX) does sign-magnitude compare, which inverts
-// ordering for two's-complement (neg, neg) pairs. The CC-guarded correction
-// swap re-fixes those rows. The correction is a no-op for unsigned-origin
-// LRegs (bit 31 always 0), so this body also works for any integer source
-// format that the upstream math path has rebased into INT32 sign-mag (e.g.
-// UInt8 via EN_INT32_MATH_FORMAT).
-//
-// @param offset0    Base Dest address (in 16b units) of the in0 tile region.
-// @param offset1    Base Dest address (in 16b units) of the in1 tile region.
-// @param offset2    Base Dest address (in 16b units) of the output tile region.
-// @param row_index  Row index within the tile; selects which of the 32-lane SFPU rows to process.
-template <bool IS_MAX_OP = true>
-inline void _calculate_binary_max_min_int32_sfp_rows_(
-    const std::uint32_t offset0, const std::uint32_t offset1, const std::uint32_t offset2, const int row_index)
-{
-    TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0 /* done */, offset0 + (row_index << 1)); // load INT32 row from in0
-    TT_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0 /* done */, offset1 + (row_index << 1)); // load INT32 row from in1
-
-    // Step 1: sign-magnitude min/max — VD=LREG0 gets SM-min, VC=LREG1 gets SM-max.
-    TTI_SFPSWAP(0 /* imm12 */, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPSWAP_MOD1_VEC_MIN_MAX); // 2-cycle
-    TTI_SFPNOP(0 /* srcs_wr_done */, 0 /* srcs_rd_done */, 0 /* dest_done */);                // post-SFPSWAP stall avoidance
-
-    // Step 2: CC-guarded correction swap for two's-complement (neg, neg) pairs.
-    // imm12=SFPSETCC_INT32_SIGNBIT tells SFPSETCC to interpret src_c as INT32.
-    TTI_SFPSETCC(SFPSETCC_INT32_SIGNBIT, p_sfpu::LREG0, sfpi::SFPSETCC_MOD1_LREG_LT0); // CC = LREG0<0
-    TTI_SFPSETCC(SFPSETCC_INT32_SIGNBIT, p_sfpu::LREG1, sfpi::SFPSETCC_MOD1_LREG_LT0); // CC &= LREG1<0
     TTI_SFPSWAP(0 /* imm12 */, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPSWAP_MOD1_SWAP); // re-swap rows where both negative
     TTI_SFPENCC(0 /* imm12 */, 0 /* mod1: clear CC */);
 
-    TT_SFPSTORE(IS_MAX_OP ? p_sfpu::LREG1 : p_sfpu::LREG0, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0 /* done */, offset2 + (row_index << 1)); // store INT32 result
+    // After step 2: LREG0 = min, LREG1 = max for all sign combinations.
+    TT_SFPSTORE(IS_MAX_OP ? p_sfpu::LREG1 : p_sfpu::LREG0, SFPMEM_MODE, ADDR_MOD_7, 0 /* done */, offset2 + (row_index << 1));
 }
 
-// Int32 variant — outer loop.
+// Unified element-wise max/min over two Dest tile regions.
 //
+// FMT controls the SFPLOAD/SFPSTORE sfpmem mode:
+//   DataFormat::Int32                                         → sfpmem::INT32
+//   Float16 / Float16_b / Float32 / Tf32 / MxFp8R / MxFp8P  → sfpmem::DEFAULT
+//
+// @tparam FMT           Math-side DataFormat.
+// @tparam IS_MAX_OP     true → store max(in0, in1); false → store min.
+// @tparam ITERATIONS    Number of SFP-row pairs per face (8 for a 32×16 face).
 // @param dst_index_in0  Dest tile index of input 0 (in tile units).
 // @param dst_index_in1  Dest tile index of input 1 (in tile units).
 // @param dst_index_out  Dest tile index where the result tile is written (in tile units).
-template <bool IS_MAX_OP = true, int ITERATIONS = 8>
-inline void calculate_binary_max_min_int32(const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out)
+template <DataFormat FMT, bool IS_MAX_OP = true, int ITERATIONS = 8>
+inline void calculate_binary_max_min(const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out)
 {
+    static_assert(
+        FMT == DataFormat::Float16 || FMT == DataFormat::Float16_b || FMT == DataFormat::Float32 || FMT == DataFormat::Tf32 || FMT == DataFormat::MxFp8R ||
+            FMT == DataFormat::MxFp8P || FMT == DataFormat::Int32,
+        "Unsupported DataFormat for calculate_binary_max_min().");
+
     const std::uint32_t offset0 = (dst_index_in0 * 32) << 1;
     const std::uint32_t offset1 = (dst_index_in1 * 32) << 1;
     const std::uint32_t offset2 = (dst_index_out * 32) << 1;
 #pragma GCC unroll 8
     for (int row_index = 0; row_index < ITERATIONS; row_index++)
     {
-        _calculate_binary_max_min_int32_sfp_rows_<IS_MAX_OP>(offset0, offset1, offset2, row_index);
+        _calculate_binary_max_min_sfp_rows_<FMT, IS_MAX_OP>(offset0, offset1, offset2, row_index);
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/experimental/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/experimental/ckernel_sfpu_binary_max_min.h
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_trisc_common.h"
+#include "cmath_common.h"
+#include "sfpi.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+// imm12 bit 11 = 1: SFPSETCC interprets src_c as two's-complement INT32, not FP32/SMAG32
+constexpr std::uint32_t SFPSETCC_INT32_SIGNBIT = 0x800;
+
+// Float variant — inner row body.
+// Loads two FP rows from separate Dest tile regions, computes element-wise
+// min+max via SFPSWAP(mod1=1), then stores the result for IS_MAX_OP.
+//
+// SFPLOAD/SFPSTORE use sfpmem::DEFAULT (MOD0_FMT_SRCB) — SFPLOAD resolves it
+// at runtime via ALU_ACC_CTRL_SFPU_Fp32_enabled and the SrcB format register,
+// both of which the unpacker / _llk_math_srcAB_hw_configure_ already program
+// from formats.math. So DEFAULT lands on FP16A / FP16B / FP32 to match Dst.
+//
+// CC-guarded correction swap: SFPSWAP_VEC_MIN_MAX on Quasar uses an unsigned
+// 32-bit compare on the LReg bits instead of the documented sign-magnitude
+// (SignMagIsSmaller) compare. For (neg, neg) pairs that inverts the ordering —
+// the same bug the int32 variant works around below. Sign-magnitude FP32 in
+// LReg has bit 31 = sign just like INT32, so the same SFPSETCC-on-LT0 trick
+// applies: detect rows where both LRegs are negative and re-swap them.
+//
+// @param offset0    Base Dest address (in 16b units) of the in0 tile region.
+// @param offset1    Base Dest address (in 16b units) of the in1 tile region.
+// @param offset2    Base Dest address (in 16b units) of the output tile region.
+// @param row_index  Row index within the tile [0, ITERATIONS); selects which of the 32-lane SFPU rows to process.
+template <bool IS_MAX_OP = true>
+inline void _calculate_binary_max_min_sfp_rows_(const std::uint32_t offset0, const std::uint32_t offset1, const std::uint32_t offset2, const int row_index)
+{
+    TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0 /* done */, offset0 + (row_index << 1)); // load FP row from in0
+    TT_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0 /* done */, offset1 + (row_index << 1)); // load FP row from in1
+
+    // Step 1: SM-min/SM-max via SFPSWAP. Correct for any pair where at least one
+    // operand is non-negative; inverts ordering for (neg, neg) pairs.
+    TTI_SFPSWAP(0 /* imm12 */, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPSWAP_MOD1_VEC_MIN_MAX); // 2-cycle
+    TTI_SFPNOP(0 /* srcs_wr_done */, 0 /* srcs_rd_done */, 0 /* dest_done */);                // post-SFPSWAP stall avoidance
+
+    // Step 2: CC-guarded correction swap for (neg, neg) pairs. SFPSETCC with
+    // imm12=SFPSETCC_INT32_SIGNBIT interprets the LReg as INT32 and tests bit 31,
+    // which is the sign bit for both INT32 SM and FP32 SM. Successive SFPSETCC
+    // calls AND into CC, so after both we have CC = (LREG0<0 AND LREG1<0).
+    TTI_SFPSETCC(SFPSETCC_INT32_SIGNBIT, p_sfpu::LREG0, sfpi::SFPSETCC_MOD1_LREG_LT0);
+    TTI_SFPSETCC(SFPSETCC_INT32_SIGNBIT, p_sfpu::LREG1, sfpi::SFPSETCC_MOD1_LREG_LT0);
+    TTI_SFPSWAP(0 /* imm12 */, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPSWAP_MOD1_SWAP); // re-swap rows where both operands are negative
+    TTI_SFPENCC(0 /* imm12 */, 0 /* mod1: clear CC */);
+
+    // After step 2: LREG0 = min, LREG1 = max for all sign combinations.
+    TT_SFPSTORE(
+        IS_MAX_OP ? p_sfpu::LREG1 : p_sfpu::LREG0,
+        p_sfpu::sfpmem::DEFAULT,
+        ADDR_MOD_7,
+        0 /* done */,
+        offset2 + (row_index << 1)); // store max (LREG1) or min (LREG0)
+}
+
+// Float variant — outer loop.
+// Explicit offset arithmetic for all three tile regions; no _incr_counters_
+// needed because loads/stores use absolute addresses, not the auto-increment pointer.
+//
+// @param dst_index_in0  Dest tile index of input 0 (in tile units).
+// @param dst_index_in1  Dest tile index of input 1 (in tile units).
+// @param dst_index_out  Dest tile index where the result tile is written (in tile units).
+template <bool IS_MAX_OP = true, int ITERATIONS = 8>
+inline void calculate_binary_max_min(const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out)
+{
+    const std::uint32_t offset0 = (dst_index_in0 * 32) << 1;
+    const std::uint32_t offset1 = (dst_index_in1 * 32) << 1;
+    const std::uint32_t offset2 = (dst_index_out * 32) << 1;
+#pragma GCC unroll 8
+    for (int row_index = 0; row_index < ITERATIONS; row_index++)
+    {
+        _calculate_binary_max_min_sfp_rows_<IS_MAX_OP>(offset0, offset1, offset2, row_index);
+    }
+}
+
+// Int32 variant — inner row body.
+// SFPSWAP mod1=1 (VEC_MIN_MAX) does sign-magnitude compare, which inverts
+// ordering for two's-complement (neg, neg) pairs. The CC-guarded correction
+// swap re-fixes those rows. The correction is a no-op for unsigned-origin
+// LRegs (bit 31 always 0), so this body also works for any integer source
+// format that the upstream math path has rebased into INT32 sign-mag (e.g.
+// UInt8 via EN_INT32_MATH_FORMAT).
+//
+// @param offset0    Base Dest address (in 16b units) of the in0 tile region.
+// @param offset1    Base Dest address (in 16b units) of the in1 tile region.
+// @param offset2    Base Dest address (in 16b units) of the output tile region.
+// @param row_index  Row index within the tile; selects which of the 32-lane SFPU rows to process.
+template <bool IS_MAX_OP = true>
+inline void _calculate_binary_max_min_int32_sfp_rows_(
+    const std::uint32_t offset0, const std::uint32_t offset1, const std::uint32_t offset2, const int row_index)
+{
+    TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0 /* done */, offset0 + (row_index << 1)); // load INT32 row from in0
+    TT_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0 /* done */, offset1 + (row_index << 1)); // load INT32 row from in1
+
+    // Step 1: sign-magnitude min/max — VD=LREG0 gets SM-min, VC=LREG1 gets SM-max.
+    TTI_SFPSWAP(0 /* imm12 */, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPSWAP_MOD1_VEC_MIN_MAX); // 2-cycle
+    TTI_SFPNOP(0 /* srcs_wr_done */, 0 /* srcs_rd_done */, 0 /* dest_done */);                // post-SFPSWAP stall avoidance
+
+    // Step 2: CC-guarded correction swap for two's-complement (neg, neg) pairs.
+    // imm12=SFPSETCC_INT32_SIGNBIT tells SFPSETCC to interpret src_c as INT32.
+    TTI_SFPSETCC(SFPSETCC_INT32_SIGNBIT, p_sfpu::LREG0, sfpi::SFPSETCC_MOD1_LREG_LT0); // CC = LREG0<0
+    TTI_SFPSETCC(SFPSETCC_INT32_SIGNBIT, p_sfpu::LREG1, sfpi::SFPSETCC_MOD1_LREG_LT0); // CC &= LREG1<0
+    TTI_SFPSWAP(0 /* imm12 */, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPSWAP_MOD1_SWAP); // re-swap rows where both negative
+    TTI_SFPENCC(0 /* imm12 */, 0 /* mod1: clear CC */);
+
+    TT_SFPSTORE(IS_MAX_OP ? p_sfpu::LREG1 : p_sfpu::LREG0, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0 /* done */, offset2 + (row_index << 1)); // store INT32 result
+}
+
+// Int32 variant — outer loop.
+//
+// @param dst_index_in0  Dest tile index of input 0 (in tile units).
+// @param dst_index_in1  Dest tile index of input 1 (in tile units).
+// @param dst_index_out  Dest tile index where the result tile is written (in tile units).
+template <bool IS_MAX_OP = true, int ITERATIONS = 8>
+inline void calculate_binary_max_min_int32(const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out)
+{
+    const std::uint32_t offset0 = (dst_index_in0 * 32) << 1;
+    const std::uint32_t offset1 = (dst_index_in1 * 32) << 1;
+    const std::uint32_t offset2 = (dst_index_out * 32) << 1;
+#pragma GCC unroll 8
+    for (int row_index = 0; row_index < ITERATIONS; row_index++)
+    {
+        _calculate_binary_max_min_int32_sfp_rows_<IS_MAX_OP>(offset0, offset1, offset2, row_index);
+    }
+}
+
+} // namespace sfpu
+} // namespace ckernel


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue -->

### Problem description
Quasar lacked an SFPU implementation of element-wise binary `max` / `min` over two Dest tile regions, and a corresponding three-operand SFPU test for the Quasar test harness.

### What's changed
Adds the kernel and a parametrised test that exercises both the float and signed-int32 variants across the format matrix.

**Kernel — `tt_llk_quasar/common/inc/experimental/ckernel_sfpu_binary_max_min.h`**
- `calculate_binary_max_min<IS_MAX_OP, IS_FP16A, ITERATIONS=8>` — float variant. Loads two FP rows from separate Dest regions and uses `SFPSWAP` with `VEC_MIN_MAX` (sign-magnitude order = FP32 total order). When the Dest format is IEEE Float16 (`IS_FP16A=true`), `SFPLOAD` is issued in `FP16A` mode so the 16-bit SFPU expansion preserves the comparison for negative pairs.
- `calculate_binary_max_min_int32<IS_MAX_OP, IS_UNSIGNED, ITERATIONS=8>` — int32 variant. Performs the same `SFPSWAP` then issues a CC-guarded re-swap on (neg, neg) pairs to convert sign-magnitude ordering back to two's-complement. The unsigned path uses `SFPSWAP` mod1=9 (the Confluence "default" case, `VDGetsMin=0`) so DST receives the SM-max.
- `binary_max_min_init` / `binary_max_min_int32_init` are intentional no-ops on Quasar — the reference's `SFPLOADMACRO` table programming does not apply since those tables are disabled here.

**Test source — `tests/sources/quasar/sfpu_binary_max_min_quasar_test.cpp`**
- Three-operand layout: `buffer_A[0]=in0` → `Dest[DST_INDEX+0]`, `buffer_A[1]=in1` → `Dest[DST_INDEX+1]`, SFPU writes `Dest[DST_INDEX+2]`, pack reads only that single tile back.
- Two execution paths chosen at runtime by `unpack_to_dest`:
  - `unpack_to_dest=true` for 32-bit Dest formats (Float32, Int32 with `dest_acc=Yes`) — UNPACK routes directly to Dest.
  - `unpack_to_dest=false` for non-32-bit and MX block formats (Float16_b, MxFp8R, MxFp8P) — UNPACK → SrcA → FPU datacopy → Dest, since the unpacker can't apply the block-exponent conversion when targeting Dest directly.

**Python test — `tests/python_tests/quasar/test_binary_max_min_quasar.py`**
- Float matrix: Float16_b → Float16_b, Float32 → Float32, MxFp8R → Float16_b, MxFp8P → Float16_b. Float16 is excluded pending an FP16A simulator-side issue with `SFPSWAP` on negative pairs.
- Int32 matrix: Int32 → Int32 (signed). UInt32 deferred — not in `VALID_QUASAR_DEST_REG_FORMATS`.
- Both `is_max_op=True/False` covered. Stimuli use log-uniform magnitudes with random signs for floats, and a clamped `[-2^28, 2^28]` range for int32. MX inputs are quantised through the same pack→unpack roundtrip the hardware applies before computing the golden, with MX-format tolerances.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist
<!-- These are required steps and need to be run from tt-metal repository's Actions. Use links below and replace them with your run -->
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=njokovic/quasar-binary-max-min-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:njokovic/quasar-binary-max-min-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=njokovic/quasar-binary-max-min-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:njokovic/quasar-binary-max-min-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=njokovic/quasar-binary-max-min-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:njokovic/quasar-binary-max-min-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=njokovic/quasar-binary-max-min-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:njokovic/quasar-binary-max-min-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=njokovic/quasar-binary-max-min-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:njokovic/quasar-binary-max-min-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=njokovic/quasar-binary-max-min-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:njokovic/quasar-binary-max-min-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=njokovic/quasar-binary-max-min-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:njokovic/quasar-binary-max-min-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=njokovic/quasar-binary-max-min-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:njokovic/quasar-binary-max-min-sfpu)