### PR TITLE
ci: wire AI job/run summary into all-model-tests

### DIFF
--- a/.github/workflows/all-model-tests.yaml
+++ b/.github/workflows/all-model-tests.yaml
@@ -439,7 +439,7 @@ jobs:
         with:
           config: |
             {
-              "model": "anthropic/claude-sonnet-4-6",
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
               "workspace": "$GITHUB_WORKSPACE",
               "input_dir": "ai_job_summaries",
               "output_dir": "ai_run_summaries"

--- a/.github/workflows/all-model-tests.yaml
+++ b/.github/workflows/all-model-tests.yaml
@@ -387,3 +387,77 @@ jobs:
       tier: "3"
 
   # Note: Tier 3 sweep tests not yet defined — no sweep entries with tier 3 exist in models_sweep_tests.yaml
+
+  # ── AI run summary ────────────────────────────────────────────────
+  # Aggregates per-leg ai-job-summary artifacts into one run-level report.
+  ai-run-summary:
+    needs:
+      - t1-unit-tests
+      - t1-e2e-tests
+      - t1-sweep-tests
+      - t2-unit-tests
+      - t2-e2e-tests
+      - t2-sweep-tests
+      - t3-unit-tests
+      - t3-e2e-tests
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Aggregate child matrices and results
+        id: aggregate
+        env:
+          # toJSON(needs) gives one object keyed by child workflow name,
+          # each with `result` and `outputs.matrix`. Using it here keeps
+          # the aggregation data-driven — adding/removing a tier or
+          # test-type only requires updating the `needs:` list above.
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          # Union of every child's matrix output. Skipped children expose
+          # null or "" for outputs.matrix; both must be filtered before
+          # `fromjson` (which would otherwise throw).
+          EXPECTED=$(jq -cn --argjson n "$NEEDS" '
+            [$n[] | .outputs.matrix | select(. != null and . != "") | fromjson] | add // []')
+          echo "expected-jobs=$EXPECTED" >> "$GITHUB_OUTPUT"
+          echo "Merged $(echo "$EXPECTED" | jq 'length') expected legs"
+
+          # Most-severe-wins precedence: failure > cancelled > success > skipped.
+          RESULT=$(jq -rn --argjson n "$NEEDS" '
+            [$n[].result] as $r |
+            if   any($r[]; . == "failure")   then "failure"
+            elif any($r[]; . == "cancelled") then "cancelled"
+            elif any($r[]; . == "success")   then "success"
+            else                                  "skipped"
+            end')
+          echo "run-result=$RESULT" >> "$GITHUB_OUTPUT"
+          echo "Combined run-result: $RESULT"
+
+      - id: ai-run-summary
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/run@main
+        with:
+          config: |
+            {
+              "model": "anthropic/claude-sonnet-4-6",
+              "workspace": "$GITHUB_WORKSPACE",
+              "input_dir": "ai_job_summaries",
+              "output_dir": "ai_run_summaries"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          expected-jobs: ${{ steps.aggregate.outputs.expected-jobs }}
+          run-result: ${{ steps.aggregate.outputs.run-result }}
+
+      - name: Show report
+        if: always() && steps.ai-run-summary.outputs.report-file != ''
+        continue-on-error: true
+        shell: bash
+        env:
+          REPORT_FILE: ${{ steps.ai-run-summary.outputs.report-file }}
+        run: |
+          if [ -f "$REPORT_FILE" ]; then
+            cat "$REPORT_FILE"
+          else
+            echo "::warning::Report file not found: $REPORT_FILE"
+          fi

--- a/.github/workflows/all-model-tests.yaml
+++ b/.github/workflows/all-model-tests.yaml
@@ -458,6 +458,7 @@ jobs:
         run: |
           if [ -f "$REPORT_FILE" ]; then
             cat "$REPORT_FILE"
+            cat "$REPORT_FILE" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "::warning::Report file not found: $REPORT_FILE"
           fi

--- a/.github/workflows/models-e2e-tests-impl.yaml
+++ b/.github/workflows/models-e2e-tests-impl.yaml
@@ -183,7 +183,7 @@ jobs:
         with:
           config: |
             {
-              "model": "anthropic/claude-sonnet-4-6",
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
               "workspace": "$GITHUB_WORKSPACE/docker-job",
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries"

--- a/.github/workflows/models-e2e-tests-impl.yaml
+++ b/.github/workflows/models-e2e-tests-impl.yaml
@@ -28,6 +28,10 @@ on:
         required: true
         type: string
         description: "Model tier to filter tests (1, 2, or 3)"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)."
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 jobs:
   load-test-matrix:
@@ -123,8 +127,19 @@ jobs:
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
-          mkdir -p generated/test_reports
-          ${{ matrix.test-group.cmd }}
+          mkdir -p generated/test_reports generated/test_logs
+
+          # Mirror the matrix command's combined stdout+stderr to a per-leg
+          # log file so ai-summary can read it later. The brace group lets
+          # the cmd be multiple statements; PIPESTATUS forwards the real
+          # exit code that piping through tee would otherwise mask.
+          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' /' '__')
+          LOG_FILE="generated/test_logs/${SAFE_NAME}_${{ job.check_run_id }}.log"
+
+          {
+            ${{ matrix.test-group.cmd }}
+          } 2>&1 | tee "$LOG_FILE"
+          exit "${PIPESTATUS[0]}"
       - name: Save environment data
         id: save-environment-data
         if: ${{ !cancelled() }}
@@ -161,5 +176,20 @@ jobs:
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
         if: ${{ failure() }}
+      - name: 🤖 AI job summary
+        if: always() && !cancelled()
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "anthropic/claude-sonnet-4-6",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/models-sweep-tests-impl.yaml
+++ b/.github/workflows/models-sweep-tests-impl.yaml
@@ -155,7 +155,7 @@ jobs:
         with:
           config: |
             {
-              "model": "anthropic/claude-sonnet-4-6",
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
               "workspace": "$GITHUB_WORKSPACE/docker-job",
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries"

--- a/.github/workflows/models-sweep-tests-impl.yaml
+++ b/.github/workflows/models-sweep-tests-impl.yaml
@@ -28,6 +28,10 @@ on:
         required: true
         type: string
         description: "Model tier to filter tests (1, 2, or 3)"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)."
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 jobs:
   load-test-matrix:
@@ -123,8 +127,19 @@ jobs:
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
-          mkdir -p generated/test_reports
-          ${{ matrix.test-group.cmd }}
+          mkdir -p generated/test_reports generated/test_logs
+
+          # Mirror the matrix command's combined stdout+stderr to a per-leg
+          # log file so ai-summary can read it later. The brace group lets
+          # the cmd be multiple statements; PIPESTATUS forwards the real
+          # exit code that piping through tee would otherwise mask.
+          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' /' '__')
+          LOG_FILE="generated/test_logs/${SAFE_NAME}_${{ job.check_run_id }}.log"
+
+          {
+            ${{ matrix.test-group.cmd }}
+          } 2>&1 | tee "$LOG_FILE"
+          exit "${PIPESTATUS[0]}"
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
@@ -133,5 +148,20 @@ jobs:
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
         if: ${{ failure() }}
+      - name: 🤖 AI job summary
+        if: always() && !cancelled()
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "anthropic/claude-sonnet-4-6",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/models-unit-tests-impl.yaml
+++ b/.github/workflows/models-unit-tests-impl.yaml
@@ -155,7 +155,7 @@ jobs:
         with:
           config: |
             {
-              "model": "anthropic/claude-sonnet-4-6",
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
               "workspace": "$GITHUB_WORKSPACE/docker-job",
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries"

--- a/.github/workflows/models-unit-tests-impl.yaml
+++ b/.github/workflows/models-unit-tests-impl.yaml
@@ -28,6 +28,10 @@ on:
         required: true
         type: string
         description: "Model tier to filter tests (1, 2, or 3)"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)."
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 jobs:
   load-test-matrix:
@@ -123,8 +127,19 @@ jobs:
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
-          mkdir -p generated/test_reports
-          ${{ matrix.test-group.cmd }}
+          mkdir -p generated/test_reports generated/test_logs
+
+          # Mirror the matrix command's combined stdout+stderr to a per-leg
+          # log file so ai-summary can read it later. The brace group lets
+          # the cmd be multiple statements; PIPESTATUS forwards the real
+          # exit code that piping through tee would otherwise mask.
+          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' /' '__')
+          LOG_FILE="generated/test_logs/${SAFE_NAME}_${{ job.check_run_id }}.log"
+
+          {
+            ${{ matrix.test-group.cmd }}
+          } 2>&1 | tee "$LOG_FILE"
+          exit "${PIPESTATUS[0]}"
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
@@ -133,5 +148,20 @@ jobs:
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
         if: ${{ failure() }}
+      - name: 🤖 AI job summary
+        if: always() && !cancelled()
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "anthropic/claude-sonnet-4-6",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()


### PR DESCRIPTION
Wires the `AI summary` actions into vLLM nightly pipeline.

- Every failing leg gets a structured, LLM-classified root-cause summary
- Run-level aggregator rolls them up into a single report

Requires secrets: `TT_CHAT_API_KEY` and `TT_CHAT_URL`

Note:
Gymnastics is needed to list the expected jobs from composite matrices.
This is the only way to expose a failing runner and handle cancelled runs.

AI Job Summary example:
https://github.com/tenstorrent/tt-metal/actions/runs/25104898361/job/73564706480#step:20:178
AI Run Summary example:
https://github.com/tenstorrent/tt-metal/actions/runs/25104898361/job/73573972864#step:4:12

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ppetrovic/ai-summary-all-model-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ppetrovic/ai-summary-all-model-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ppetrovic/ai-summary-all-model-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ppetrovic/ai-summary-all-model-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ppetrovic/ai-summary-all-model-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ppetrovic/ai-summary-all-model-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ppetrovic/ai-summary-all-model-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ppetrovic/ai-summary-all-model-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ppetrovic/ai-summary-all-model-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ppetrovic/ai-summary-all-model-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ppetrovic/ai-summary-all-model-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ppetrovic/ai-summary-all-model-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ppetrovic/ai-summary-all-model-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ppetrovic/ai-summary-all-model-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ppetrovic/ai-summary-all-model-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ppetrovic/ai-summary-all-model-tests)