### PR TITLE
Fix fast_reduce_nc for the test_sum_8d_tensor_dims fails when dim_8 > 8

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -164,7 +164,6 @@ def test_prod(device, input_shape, dim, keepdim, force_implicit_pad, dtype):
     )
 
 
-# TODO: add few more shapes, once issue #42500 is solved
 @pytest.mark.parametrize("dim_1", [1])
 @pytest.mark.parametrize("dim_2", [2])
 @pytest.mark.parametrize("dim_3", [3])
@@ -172,7 +171,7 @@ def test_prod(device, input_shape, dim, keepdim, force_implicit_pad, dtype):
 @pytest.mark.parametrize("dim_5", [4])
 @pytest.mark.parametrize("dim_6", [6])
 @pytest.mark.parametrize("dim_7", [7])
-@pytest.mark.parametrize("dim_8", [8])
+@pytest.mark.parametrize("dim_8", [8, 32, 63])
 @pytest.mark.parametrize("dim", [[3, 7]])
 @pytest.mark.parametrize("keepdim", [True, False])
 def test_sum_8d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim_7, dim_8, dim, keepdim):

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
@@ -15,11 +15,15 @@ void FastReduceNCDeviceOperation::validate_on_program_cache_miss(
     const auto& input = tensor_args.input;
     const auto& preallocated_output = tensor_args.preallocated_output;
 
-    // validate tensor
-    operations::check_tensor(input, "FastReduceNC", "input", {DataType::BFLOAT16, DataType::BFLOAT8_B});
+    // FLOAT32 is allowed so multi-stage Sum chains can carry FP32 between stages.
+    operations::check_tensor(
+        input, "FastReduceNC", "input", {DataType::BFLOAT16, DataType::BFLOAT8_B, DataType::FLOAT32});
     if (preallocated_output.has_value()) {
         operations::check_tensor(
-            preallocated_output.value(), "FastReduceNC", "output", {DataType::BFLOAT16, DataType::BFLOAT8_B});
+            preallocated_output.value(),
+            "FastReduceNC",
+            "output",
+            {DataType::BFLOAT16, DataType::BFLOAT8_B, DataType::FLOAT32});
     }
 
     // validate input dim
@@ -44,9 +48,10 @@ TensorSpec FastReduceNCDeviceOperation::compute_output_specs(
     auto output_shape = input_shape;
     // last 2-dim
     output_shape[args.dim] = 1;
+    const auto output_dtype = args.output_dtype.value_or(input.dtype());
     return TensorSpec(
         output_shape,
-        operations::TensorLayout(input.dtype(), operations::PageConfig(Layout::TILE), args.output_mem_config));
+        operations::TensorLayout(output_dtype, operations::PageConfig(Layout::TILE), args.output_mem_config));
 }
 
 Tensor FastReduceNCDeviceOperation::create_output_tensors(
@@ -68,14 +73,16 @@ Tensor fast_reduce_nc(
     const std::optional<const Tensor>& output,
     const MemoryConfig& output_mem_config,
     const DeviceComputeKernelConfig& compute_kernel_config,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<DataType>& output_dtype) {
     using OperationType = ttnn::experimental::prim::FastReduceNCDeviceOperation;
 
     auto operation_attributes = OperationType::operation_attributes_t{
         .dim = dim,
         .output_mem_config = output_mem_config,
         .compute_kernel_config = compute_kernel_config,
-        .sub_core_grids = sub_core_grids};
+        .sub_core_grids = sub_core_grids,
+        .output_dtype = output_dtype};
     auto tensor_args = OperationType::tensor_args_t{.input = input, .preallocated_output = output};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.hpp
@@ -36,6 +36,7 @@ Tensor fast_reduce_nc(
     const std::optional<const Tensor>& output,
     const MemoryConfig& output_mem_config,
     const DeviceComputeKernelConfig& compute_kernel_config,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<DataType>& output_dtype = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation_types.hpp
@@ -15,6 +15,8 @@ struct FastReduceNCParams {
     const tt::tt_metal::MemoryConfig output_mem_config;
     const ttnn::DeviceComputeKernelConfig compute_kernel_config;
     const std::optional<tt::tt_metal::CoreRangeSet> sub_core_grids;
+    // When set, packer writes this dtype instead of input.dtype() (used by the Sum precision chain).
+    const std::optional<tt::tt_metal::DataType> output_dtype;
 };
 
 struct FastReduceNCInputs {

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
@@ -62,8 +62,11 @@ FastReduceNCProgramFactory::cached_program_t FastReduceNCProgramFactory::create(
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
     ////////////////////////////////////////////////////////////////////////////
-    const auto cb_data_format = datatype_to_dataformat_converter(tensor_return_value.dtype());
-    const auto single_tile_size = tt::tile_size(cb_data_format);
+    // Input and output CBs may differ when the Sum precision chain requests FP32 packing.
+    const auto input_data_format = datatype_to_dataformat_converter(tensor_args.input.dtype());
+    const auto input_tile_size = tt::tile_size(input_data_format);
+    const auto output_data_format = datatype_to_dataformat_converter(tensor_return_value.dtype());
+    const auto output_tile_size = tt::tile_size(output_data_format);
     const auto cb_1_data_format = datatype_to_dataformat_converter(DataType::BFLOAT16);
     const auto cb_1_tile_size = tt::tile_size(cb_1_data_format);
 
@@ -141,15 +144,15 @@ FastReduceNCProgramFactory::cached_program_t FastReduceNCProgramFactory::create(
     num_cols_per_core_group_1 *= shard_factor;
     num_cols_per_core_group_2 *= shard_factor;
 
-    const auto intermed_cb_data_format = (fp32_dest_acc_en) ? tt::DataFormat::Float32 : cb_data_format;
-    const auto intermed_cb_single_tile_size = (fp32_dest_acc_en) ? single_tile_size * 2 : single_tile_size;
+    const auto intermed_cb_data_format = (fp32_dest_acc_en) ? tt::DataFormat::Float32 : output_data_format;
+    const auto intermed_cb_single_tile_size = tt::tile_size(intermed_cb_data_format);
 
     ////////////////////////////////////////////////////////////////////////////
     //                         CircularBuffer Setup
     ////////////////////////////////////////////////////////////////////////////
     tt_metal::CircularBufferConfig cb_scr0_config =
-        tt_metal::CircularBufferConfig(in0_t * single_tile_size, {{CBIndex::c_0, cb_data_format}})
-            .set_page_size(CBIndex::c_0, single_tile_size);
+        tt_metal::CircularBufferConfig(in0_t * input_tile_size, {{CBIndex::c_0, input_data_format}})
+            .set_page_size(CBIndex::c_0, input_tile_size);
     tt_metal::CreateCircularBuffer(program, all_cores, cb_scr0_config);
 
     tt_metal::CircularBufferConfig cb_scr1_config =
@@ -164,8 +167,8 @@ FastReduceNCProgramFactory::cached_program_t FastReduceNCProgramFactory::create(
     tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed0_config);
 
     tt_metal::CircularBufferConfig cb_output_config =
-        tt_metal::CircularBufferConfig(out0_t * single_tile_size, {{CBIndex::c_16, cb_data_format}})
-            .set_page_size(CBIndex::c_16, single_tile_size);
+        tt_metal::CircularBufferConfig(out0_t * output_tile_size, {{CBIndex::c_16, output_data_format}})
+            .set_page_size(CBIndex::c_16, output_tile_size);
     tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
 
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.cpp
@@ -17,7 +17,9 @@ ttnn::Tensor fast_reduce_nc(
     const std::optional<const Tensor>& output,
     const ttnn::MemoryConfig& memory_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
-    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids) {
+    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::DataType>& output_dtype,
+    bool fp32_intermediate_stages) {
     TT_FATAL(
         input.storage_type() == StorageType::DEVICE,
         "Input tensor storage type must be DEVICE but got {}",
@@ -31,14 +33,23 @@ ttnn::Tensor fast_reduce_nc(
     ttnn::SmallVector<int32_t> sorted_dims(dims.begin(), dims.end());
     std::sort(sorted_dims.begin(), sorted_dims.end());
 
+    const std::optional<tt::tt_metal::DataType> intermediate_dtype =
+        fp32_intermediate_stages ? std::optional<tt::tt_metal::DataType>{tt::tt_metal::DataType::FLOAT32}
+                                 : std::nullopt;
     auto temp_input = input;
     for (uint32_t i = dims.size() - 1; i > 0; i--) {
         auto temp_output = ttnn::prim::fast_reduce_nc(
-            temp_input, sorted_dims[i], std::nullopt, memory_config, kernel_config_val, sub_core_grids);
+            temp_input,
+            sorted_dims[i],
+            std::nullopt,
+            memory_config,
+            kernel_config_val,
+            sub_core_grids,
+            intermediate_dtype);
         temp_input = temp_output;
     }
     return ttnn::prim::fast_reduce_nc(
-        temp_input, sorted_dims.front(), output, memory_config, kernel_config_val, sub_core_grids);
+        temp_input, sorted_dims.front(), output, memory_config, kernel_config_val, sub_core_grids, output_dtype);
 }
 
 }  // namespace ttnn::experimental::reduction

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.hpp
@@ -10,12 +10,16 @@
 
 namespace ttnn::experimental::reduction {
 
+// `output_dtype` sets the dtype produced by the final prim::fast_reduce_nc stage;
+// `fp32_intermediate_stages` keeps non-final stages in FLOAT32 to avoid double-rounding.
 ttnn::Tensor fast_reduce_nc(
     const ttnn::Tensor& input,
     ttsl::Span<const int32_t> dims,
     const std::optional<const Tensor>& output,
     const ttnn::MemoryConfig& memory_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
-    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt);
+    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::DataType>& output_dtype = std::nullopt,
+    bool fp32_intermediate_stages = false);
 
 }  // namespace ttnn::experimental::reduction

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -128,14 +128,20 @@ Tensor reduce(
     // However, sqrt of a negative number is NaN, so negative scalers
     // must take the two-step W-then-H path where the scaler is applied once.
     if (is_multicore_hw || (reduce_dim == tt::tt_metal::ReduceOpDim::HW && reduce_scaler < 0)) {
-        // Multi-core HW reduction: first reduce W, then reduce H on the result
+        // Multi-core HW reduction: first reduce W, then reduce H on the result.
+        // For the Sum chain's terminal fp32->bf16 stage, keep W in fp32 so only H packs to bf16.
+        const auto out_final = output_dtype.value_or(input_tensor.dtype());
+        const bool keep_w_fp32 = output_dtype.has_value() && out_final == tt::tt_metal::DataType::BFLOAT16 &&
+                                 tilized_input.dtype() == tt::tt_metal::DataType::FLOAT32;
+        const auto out_w = keep_w_fp32 ? tt::tt_metal::DataType::FLOAT32 : out_final;
+
         const Tensor output_tensor = ttnn::prim::reduce(
             tilized_input,
             reduce_math,
             tt::tt_metal::ReduceOpDim::W,
             1.0f,
             output_mem_config,
-            output_dtype.value_or(input_tensor.dtype()),
+            out_w,
             config,
             sub_core_grids,
             negate,
@@ -147,7 +153,7 @@ Tensor reduce(
             tt::tt_metal::ReduceOpDim::H,
             reduce_scaler,
             output_mem_config,
-            output_dtype.value_or(input_tensor.dtype()),
+            out_final,
             config,
             sub_core_grids,
             negate,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -130,10 +130,10 @@ Tensor reduce(
     if (is_multicore_hw || (reduce_dim == tt::tt_metal::ReduceOpDim::HW && reduce_scaler < 0)) {
         // Multi-core HW reduction: first reduce W, then reduce H on the result.
         // For the Sum chain's terminal fp32->bf16 stage, keep W in fp32 so only H packs to bf16.
-        const auto out_final = output_dtype.value_or(input_tensor.dtype());
-        const bool keep_w_fp32 = output_dtype.has_value() && out_final == tt::tt_metal::DataType::BFLOAT16 &&
+        const auto out_final_dtype = output_dtype.value_or(input_tensor.dtype());
+        const bool keep_w_fp32 = output_dtype.has_value() && out_final_dtype == tt::tt_metal::DataType::BFLOAT16 &&
                                  tilized_input.dtype() == tt::tt_metal::DataType::FLOAT32;
-        const auto out_w = keep_w_fp32 ? tt::tt_metal::DataType::FLOAT32 : out_final;
+        const auto out_w_dtype = keep_w_fp32 ? tt::tt_metal::DataType::FLOAT32 : out_final_dtype;
 
         const Tensor output_tensor = ttnn::prim::reduce(
             tilized_input,
@@ -141,7 +141,7 @@ Tensor reduce(
             tt::tt_metal::ReduceOpDim::W,
             1.0f,
             output_mem_config,
-            out_w,
+            out_w_dtype,
             config,
             sub_core_grids,
             negate,
@@ -153,7 +153,7 @@ Tensor reduce(
             tt::tt_metal::ReduceOpDim::H,
             reduce_scaler,
             output_mem_config,
-            out_final,
+            out_final_dtype,
             config,
             sub_core_grids,
             negate,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -114,7 +114,11 @@ static Tensor reduce_impl(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     float scalar,
     const ttnn::SmallVector<int>& non_height_width_dims,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    // Sum precision chain: when active, intermediate stages stay FP32 and only
+    // the stage with is_last_in_chain=true packs the final bf16 result.
+    bool chain_active = false,
+    bool is_last_in_chain = false) {
     auto input_shape = input_tensor_arg.logical_shape();
     auto rank = input_shape.rank();
     auto memory_config = memory_config_arg.value_or(input_tensor_arg.memory_config());
@@ -161,6 +165,8 @@ static Tensor reduce_impl(
                         output_tensor = ttnn::transpose(output_tensor, i_dim, -2, memory_config, pad_value);
                         reduce_dim = rank - 2;
                     }
+                    // Only the smallest-axis sub-step ends the chain; earlier sub-steps stay in fp32.
+                    const bool sub_is_last = chain_active && is_last_in_chain && (i_dim == min_reduce_axis);
                     if (use_reduce_type) {
                         output_tensor = reduce_impl<reduce_type>(
                             output_tensor,
@@ -170,7 +176,9 @@ static Tensor reduce_impl(
                             compute_kernel_config,
                             effective_scalar,
                             non_height_width_dims,
-                            sub_core_grids);
+                            sub_core_grids,
+                            chain_active,
+                            sub_is_last);
                     } else {
                         output_tensor = reduce_impl<reduction_common::ReduceType::Sum>(
                             output_tensor,
@@ -180,7 +188,9 @@ static Tensor reduce_impl(
                             compute_kernel_config,
                             effective_scalar,
                             non_height_width_dims,
-                            sub_core_grids);
+                            sub_core_grids,
+                            chain_active,
+                            sub_is_last);
                     }
                     if (transpose) {
                         output_tensor = ttnn::transpose(output_tensor, i_dim, -2, memory_config, pad_value);
@@ -226,13 +236,19 @@ static Tensor reduce_impl(
                                          : input_tensor_arg;
 
         if constexpr (reduce_type == reduction_common::ReduceType::Sum) {
+            // In the chain, pack FP32 except on the last stage where we pack bf16.
+            std::optional<tt::tt_metal::DataType> sum_output_dtype;
+            if (chain_active) {
+                sum_output_dtype =
+                    is_last_in_chain ? tt::tt_metal::DataType::BFLOAT16 : tt::tt_metal::DataType::FLOAT32;
+            }
             output_tensor = ttnn::operations::reduction::generic::detail::reduce(
                 input_tensor,
                 tt::tt_metal::ReduceOpMath::SUM,
                 reduce_op_dim,
                 scalar,
                 memory_config,
-                std::nullopt,
+                sum_output_dtype,
                 compute_kernel_config,
                 sub_core_grids);
         } else if constexpr (reduce_type == reduction_common::ReduceType::Mean) {
@@ -486,7 +502,9 @@ Tensor non_height_width_reduce(
     ttnn::SmallVector<int> dims,
     const std::optional<MemoryConfig>& memory_config_arg,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<DataType>& output_dtype = std::nullopt,
+    bool fp32_intermediate_stages = false) {
     auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
     const auto& input_shape = input_tensor.logical_shape();
     // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
@@ -507,7 +525,14 @@ Tensor non_height_width_reduce(
             tensor_to_reduce, padded_shape, 0.0f, memory_config, std::nullopt, /*use_multicore=*/true, sub_core_grids);
     }
     Tensor output_tensor = ttnn::experimental::reduction::fast_reduce_nc(
-        tensor_to_reduce, dims, /*output=*/std::nullopt, memory_config, config, sub_core_grids);
+        tensor_to_reduce,
+        dims,
+        /*output=*/std::nullopt,
+        memory_config,
+        config,
+        sub_core_grids,
+        output_dtype,
+        fp32_intermediate_stages);
     auto [start, end, step] = get_slice_parameters(input_shape, output_tensor.logical_shape());
     output_tensor = ttnn::slice(output_tensor, start, end, step);
     return output_tensor;
@@ -548,6 +573,14 @@ Tensor reduce(
     bool is_tiled = input_tensor_arg.layout() == TILE_LAYOUT;
     auto input_tensor = is_tiled ? ttnn::fill_implicit_tile_padding(input_tensor_arg, pad_value) : input_tensor_arg;
 
+    // bf16 multi-axis Sum precision chain: carry FP32 between stages and pack bf16
+    // only on the final stage. Skipped for full-tensor reductions (dim covers every
+    // axis) since torch's bf16 reference is itself accumulated in bf16, so the
+    // legacy path already matches it there.
+    const bool chain_active = reduce_type == reduction_common::ReduceType::Sum && dim.size() > 1 &&
+                              input_tensor.dtype() == DataType::BFLOAT16 &&
+                              dim.size() < static_cast<size_t>(input_tensor.logical_shape().rank());
+
     // fast_reduce_nc ignores `scalar` so it can't be used when scalar != 1.0f.
     if (call_fast_nc<reduce_type>(input_tensor.dtype()) && scalar == 1.0f) {
         auto dims = split_height_width_dims(dim, input_tensor);
@@ -569,8 +602,22 @@ Tensor reduce(
                 return reduction_common::zero_volume_reduce<reduce_type>(input_tensor_arg, dim, keepdim, memory_config);
             }
 
+            // Final fast_nc stage packs bf16 only when no H/W stage follows; inner
+            // stages stay FP32 (only relevant with multiple non-H/W axes).
+            std::optional<DataType> fast_nc_final_dtype;
+            bool fast_nc_intermediate_fp32 = false;
+            if (chain_active) {
+                fast_nc_final_dtype = height_width_dims.empty() ? DataType::BFLOAT16 : DataType::FLOAT32;
+                fast_nc_intermediate_fp32 = non_height_width_dims.size() > 1;
+            }
             input_tensor = non_height_width_reduce(
-                input_tensor, non_height_width_dims, memory_config_arg, compute_kernel_config, sub_core_grids);
+                input_tensor,
+                non_height_width_dims,
+                memory_config_arg,
+                compute_kernel_config,
+                sub_core_grids,
+                fast_nc_final_dtype,
+                fast_nc_intermediate_fp32);
 
             if (height_width_dims.empty()) {
                 return adjust_shape(
@@ -587,7 +634,9 @@ Tensor reduce(
         compute_kernel_config,
         scalar,
         non_height_width_dims,
-        sub_core_grids);
+        sub_core_grids,
+        /*chain_active=*/chain_active,
+        /*is_last_in_chain=*/chain_active);
 }
 
 Tensor pool_sum(


### PR DESCRIPTION
### Summary
Fixes `ttnn.sum` numerical mismatches against PyTorch for 8D `bfloat16` tensors when reducing over both a non-height/width axis and the width axis (e.g. `dim=[3, 7]`), especially when the reduction is large enough that `dim_8` is big (e.g. `32` or `63`). 
- Closes #42500


#### Root Cause
The failures were caused by a **precision loss issue in multi-stage reductions for `bfloat16` tensors**, not by incorrect reduction logic.

PyTorch’s bfloat16 sum behaves like: accumulate in higher precision (effectively float32), then round once to bfloat16 at the end. This minimizes rounding error.

But on the TTNN side:

The reduction path was split across **two device stages** depending on dimensions being reduced:

* **Non-H/W dimensions** (for example `dim=3`) were handled by `fast_reduce_nc` using the `reduce_nc` compute kernel.
* **H/W dimensions** (for example `dim=7`, width after layout mapping) were handled by the generic reduction path (`reduce.cpp` / `detail::reduce`).

Although each stage used **FP32 destination accumulation internally**, the intermediate output of Stage 1 still had to be written back to memory as **BF16 tiles**.

That means:

#### Stage 1

* Accumulate in FP32
* Store intermediate tensor as BF16
  → **First FP32 → BF16 rounding**

#### Stage 2

* Read already-rounded BF16 intermediate tensor
* Accumulate again in FP32
* Store final result as BF16
  → **Second FP32 → BF16 rounding**

#### Why This Caused Failures

This introduced **two BF16 rounding steps** in the reduction chain, whereas PyTorch effectively performs only **one final rounding**. For small reductions the difference stayed inside tolerances; for larger dim_8 it showed up as allclose failures (often with Frobenius/PCC still looking fine). So the failures were due to **extra intermediate quantization**, not incorrect summation order or functional errors.

Implicit padding was investigated and ruled out. The same failures occurred with and without padding enabled, confirming padding was unrelated.

### What's Changed

**Goal:** for multi‑axis BF16 `Sum`, keep full precision through every intermediate stage and cast to BF16 only once — at the very end.

For multi‑axis BF16 sum reductions:
- Every intermediate stage now carries its result in **FP32**.
- This includes the non‑H/W leg (`fast_reduce_nc`), the H/W leg (`reduce_impl` → `detail::reduce`), the multicore HW W→H two‑step, and the recursive ND axis loop.
- Only the **final** stage in the pipeline packs to BF16.
- This removes every redundant BF16 rounding event between stages.

#### Code Updates

- **`fast_reduce_nc`**: added optional `output_dtype` and `fp32_intermediate_stages` so the host wrapper can request FP32 carry between stages and the configured pack dtype on the last stage.
- **Device op**: `output_dtype` plumbed through `FastReduceNCParams`; validation accepts `FLOAT32` for input/preallocated output; `compute_output_specs` honors `output_dtype`.
- **Program factory**: decoupled input vs. output CB formats and tile sizes (BF16‑in / FP32‑out and FP32‑in / FP32‑out); intermediate accumulator CB tile size is derived from its actual format.
- **`reduce_op.cpp`**: in the multicore HW W→H two‑step, keep the W result in FP32 when terminating the chain so only H packs BF16.
- **`generic_reductions.cpp`**: introduced `chain_active` / `is_last_in_chain` flags on `reduce_impl` (defaulted `false` so other callers are unchanged); top‑level `reduce()` decides the chain policy and forwards `output_dtype` only where it actually affects packing. The chain engages for BF16 `Sum` with multiple reduction axes and is skipped for full‑tensor reductions (`dim` covers every axis), where torch's BF16 reference is itself BF16‑accumulated.
- **Tests**: re‑enabled larger `dim_8` cases (`32, 63`) in `test_sum_8d_tensor_dims` that previously failed; dropped the now‑stale TODO marker.

---

### Notes for reviewers

- The FP32 carry is applied **only** for BF16 `Sum` with `1 < dim.size() < rank`. Other reduction types (Mean / Min / Max / Var / Std / Prod), single‑axis Sum, non‑BF16 inputs, and full‑tensor reductions are bit‑for‑bit unchanged.
- The chain is **independent of `scalar`**: the existing `scalar == 1.0f` gate elsewhere only controls the `fast_reduce_nc` fast path (which has no scalar parameter), not the precision chain. `scalar != 1.0` cases still benefit via `reduce_impl`'s ND loop.
- Every new parameter defaults to `nullopt` / `false`, so call sites that don't go through `ttnn::reduce` (e.g. `std_var_impl`, `pool_sum`) compile and run unchanged.
- No kernel code was modified — only host‑side CB sizing/format declarations and orchestration. The compute kernel already supports mixed input/output dtypes via `reconfig_data_format` / `pack_reconfig_data_format`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/sudha-sum8d-fails)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/sudha-sum8d-fails)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/sudha-sum8d-fails)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/sudha-sum8d-fails)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/sudha-sum8d-fails)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/sudha-sum8d-fails)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/sudha-sum8d-fails)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/sudha-sum8d-fails)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/sudha-sum8d-fails)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/sudha-sum8d-fails)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/sudha-sum8d-fails)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-sum8d-fails)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/sudha-sum8d-fails)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-sum8d-fails)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/sudha-sum8d-fails)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-sum8d-fails)