### PR TITLE
Fix ternaryOp program hash collision to account for logical dim when per-operand broadcasts are different but alias to same key

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_where.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_where.py
@@ -1075,3 +1075,79 @@ def test_where_ttt_int32_predicate_sub_core_grid(device, shape, sub_core_grid, c
     result = ttnn.to_torch(ttnn_result)
 
     assert torch_equal_nan(result, golden)
+
+
+# Program cache bug tests - ensure different broadcast configurations don't collide
+# Issue 43368: When padded shapes are identical but logical shapes differ (e.g., [1,1,32] vs [1,8,1]),
+# the program cache key must distinguish them to avoid using wrong kernel configuration.
+
+
+@pytest.mark.parametrize("variant", ["TTT", "TTS", "TST"])
+def test_where_program_cache_different_broadcast_shapes(device, variant):
+    """
+    Test that sequential where ops with same broadcast_type but different
+    per-operand broadcast configurations don't collide in program cache.
+    """
+    torch.manual_seed(42)
+
+    # First where: predicate broadcasts on rows (1x32 -> 4x32)
+    pred1 = torch.zeros(1, 1, 32, dtype=torch.bfloat16)
+    pred1[:, :, 16:] = 1.0
+
+    # Second where: predicate broadcasts on columns (8x1 -> 8x32)
+    pred2 = torch.zeros(1, 8, 1, dtype=torch.bfloat16)
+    pred2[:, 4:, :] = 1.0
+
+    if variant == "TTT":
+        true1 = torch.randn(1, 1, 1, dtype=torch.bfloat16)
+        false1 = torch.randn(1, 4, 32, dtype=torch.bfloat16)
+        true2 = torch.randn(1, 1, 1, dtype=torch.bfloat16)
+        false2 = torch.randn(1, 8, 32, dtype=torch.bfloat16)
+
+        expected1 = torch.where(pred1.bool().expand_as(false1), true1.expand_as(false1), false1)
+        expected2 = torch.where(pred2.bool().expand_as(false2), true2.expand_as(false2), false2)
+
+        pred1_ttnn = ttnn.from_torch(pred1, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+        true1_ttnn = ttnn.from_torch(true1, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+        false1_ttnn = ttnn.from_torch(false1, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+        result1 = ttnn.to_torch(ttnn.where(pred1_ttnn, true1_ttnn, false1_ttnn))
+
+        pred2_ttnn = ttnn.from_torch(pred2, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+        true2_ttnn = ttnn.from_torch(true2, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+        false2_ttnn = ttnn.from_torch(false2, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+        result2 = ttnn.to_torch(ttnn.where(pred2_ttnn, true2_ttnn, false2_ttnn))
+
+    elif variant == "TTS":
+        true1 = torch.randn(1, 4, 32, dtype=torch.bfloat16)
+        true2 = torch.randn(1, 8, 32, dtype=torch.bfloat16)
+        scalar_false = 0.0
+
+        expected1 = torch.where(pred1.bool().expand_as(true1), true1, torch.full_like(true1, scalar_false))
+        expected2 = torch.where(pred2.bool().expand_as(true2), true2, torch.full_like(true2, scalar_false))
+
+        pred1_ttnn = ttnn.from_torch(pred1, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+        true1_ttnn = ttnn.from_torch(true1, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+        result1 = ttnn.to_torch(ttnn.where(pred1_ttnn, true1_ttnn, scalar_false))
+
+        pred2_ttnn = ttnn.from_torch(pred2, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+        true2_ttnn = ttnn.from_torch(true2, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+        result2 = ttnn.to_torch(ttnn.where(pred2_ttnn, true2_ttnn, scalar_false))
+
+    elif variant == "TST":
+        false1 = torch.randn(1, 4, 32, dtype=torch.bfloat16)
+        false2 = torch.randn(1, 8, 32, dtype=torch.bfloat16)
+        scalar_true = 1.0
+
+        expected1 = torch.where(pred1.bool().expand_as(false1), torch.full_like(false1, scalar_true), false1)
+        expected2 = torch.where(pred2.bool().expand_as(false2), torch.full_like(false2, scalar_true), false2)
+
+        pred1_ttnn = ttnn.from_torch(pred1, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+        false1_ttnn = ttnn.from_torch(false1, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+        result1 = ttnn.to_torch(ttnn.where(pred1_ttnn, scalar_true, false1_ttnn))
+
+        pred2_ttnn = ttnn.from_torch(pred2, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+        false2_ttnn = ttnn.from_torch(false2, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+        result2 = ttnn.to_torch(ttnn.where(pred2_ttnn, scalar_true, false2_ttnn))
+
+    assert_with_pcc(expected1, result1, 0.9999)
+    assert_with_pcc(expected2, result2, 0.9999)

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
@@ -506,8 +506,22 @@ ttsl::hash::hash_t TernaryDeviceOperation::compute_program_hash(
 
         // Include true/false tensor volumes so "true broadcast, false full" and "true full, false
         // broadcast" get distinct cache keys (broadcast_type alone is the same for both).
+        // Also include H,W dimensions (last 2 dims) since they determine per-tensor broadcast
+        // configuration (SRC_BCAST_*, SRC_ROW_BCAST_*, SRC_SCALAR_*) in ROW_COL_BCAST kernels.
         const auto b_shape = input_b->padded_shape();
         const auto c_shape = input_c->padded_shape();
+
+        // Extract H,W dims (last 2 dimensions) for broadcast configuration differentiation
+        // Use logical_shape() since broadcast logic depends on logical dimensions, not padded
+        const auto& a_logical = input_a.logical_shape();
+        const auto& b_logical = input_b->logical_shape();
+        const auto& c_logical = input_c->logical_shape();
+        const uint32_t a_h = a_logical.rank() >= 2 ? a_logical[-2] : 1;
+        const uint32_t a_w = a_logical[-1];
+        const uint32_t b_h = b_logical.rank() >= 2 ? b_logical[-2] : 1;
+        const uint32_t b_w = b_logical[-1];
+        const uint32_t c_h = c_logical.rank() >= 2 ? c_logical[-2] : 1;
+        const uint32_t c_w = c_logical[-1];
 
         hash = tt::tt_metal::operation::hash_operation<TernaryDeviceOperation>(
             args,
@@ -520,6 +534,12 @@ ttsl::hash::hash_t TernaryDeviceOperation::compute_program_hash(
             a_shape.volume(),
             b_shape.volume(),
             c_shape.volume(),
+            a_h,
+            a_w,  // Predicate H,W
+            b_h,
+            b_w,  // True tensor H,W
+            c_h,
+            c_w,  // False tensor H,W
             shard_volumes);
 
     } else if (variant == TernaryVariant::TTS) {
@@ -529,6 +549,16 @@ ttsl::hash::hash_t TernaryDeviceOperation::compute_program_hash(
             input_a.tensor_spec(), input_b->tensor_spec(), std::nullopt, compute_output_specs(args, tensor_args));
 
         const auto b_shape = input_b->padded_shape();
+
+        // Include H,W dims for broadcast configuration differentiation
+        // Use logical_shape() since broadcast logic depends on logical dimensions, not padded
+        const auto& a_logical = input_a.logical_shape();
+        const auto& b_logical = input_b->logical_shape();
+        const uint32_t a_h = a_logical.rank() >= 2 ? a_logical[-2] : 1;
+        const uint32_t a_w = a_logical[-1];
+        const uint32_t b_h = b_logical.rank() >= 2 ? b_logical[-2] : 1;
+        const uint32_t b_w = b_logical[-1];
+
         hash = tt::tt_metal::operation::hash_operation<TernaryDeviceOperation>(
             args,
             input_a.dtype(),
@@ -537,6 +567,10 @@ ttsl::hash::hash_t TernaryDeviceOperation::compute_program_hash(
             input_b.value().memory_config(),
             a_shape.volume(),
             b_shape.volume(),
+            a_h,
+            a_w,
+            b_h,
+            b_w,
             shard_volumes);
     } else if (variant == TernaryVariant::TST) {
         TT_FATAL(is_device_tensor(*input_c), "Unexpected Tensor type {}", input_c->storage_type());
@@ -545,6 +579,16 @@ ttsl::hash::hash_t TernaryDeviceOperation::compute_program_hash(
             input_a.tensor_spec(), std::nullopt, input_c->tensor_spec(), compute_output_specs(args, tensor_args));
 
         const auto c_shape = input_c->padded_shape();
+
+        // Include H,W dims for broadcast configuration differentiation
+        // Use logical_shape() since broadcast logic depends on logical dimensions, not padded
+        const auto& a_logical = input_a.logical_shape();
+        const auto& c_logical = input_c->logical_shape();
+        const uint32_t a_h = a_logical.rank() >= 2 ? a_logical[-2] : 1;
+        const uint32_t a_w = a_logical[-1];
+        const uint32_t c_h = c_logical.rank() >= 2 ? c_logical[-2] : 1;
+        const uint32_t c_w = c_logical[-1];
+
         hash = tt::tt_metal::operation::hash_operation<TernaryDeviceOperation>(
             args,
             input_a.dtype(),
@@ -553,6 +597,10 @@ ttsl::hash::hash_t TernaryDeviceOperation::compute_program_hash(
             input_c.value().memory_config(),
             a_shape.volume(),
             c_shape.volume(),
+            a_h,
+            a_w,
+            c_h,
+            c_w,
             shard_volumes);
     }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
@@ -117,7 +117,6 @@ Tensor invoke_impl(
     Tensor condition = predicate;
     auto broadcast_type = ttnn::operations::ternary::get_broadcast_type(
         condition.logical_shape(), t_true.logical_shape(), t_false.logical_shape());
-
     bool typecast_needed = ternary_utils::typecast_predicate(predicate, t_true, t_false);
     if (typecast_needed) {
         condition = ttnn::typecast(predicate, t_true.dtype(), std::nullopt, std::nullopt, sub_core_grids);

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
@@ -117,6 +117,7 @@ Tensor invoke_impl(
     Tensor condition = predicate;
     auto broadcast_type = ttnn::operations::ternary::get_broadcast_type(
         condition.logical_shape(), t_true.logical_shape(), t_false.logical_shape());
+
     bool typecast_needed = ternary_utils::typecast_predicate(predicate, t_true, t_false);
     if (typecast_needed) {
         condition = ttnn::typecast(predicate, t_true.dtype(), std::nullopt, std::nullopt, sub_core_grids);


### PR DESCRIPTION
### Summary
Closes #43368
Related https://github.com/tenstorrent/tt-xla/issues/4418

When executing multiple ttnn.where ops in sequence with different per-operand broacasting, the wrong cached program gets used due to incorrect cache key generation.

For tiled tensors, which are padded to 32x32 in the back 2 dims, two tensors with different logical shapes could alias to the same padded shape. However, the logical shape determines which broadcasting kernel to use, so there is incompete information. 

eg. A=1x8x1, B=1x1x32 are both padded to 1x32x32, and could classify as the same overall ROW_COL_BCAST type, but if they are broadcast to C=1x4x32, A needs both row and column broadcast, while B needs only a row broadcast. 

### Notes for reviewers
This bug originated from forge DS4 bringup, where the lowering of a pattern of torch tensor slice + mutations turned into 4 ttnn.where ops, which required different per-operand broadcasting and corrupted the output. This failure went away when program cache was disabled and was eventually root caused to this program hash collision bug.

Added test `pytest -svv tests/ttnn/unit_tests/operations/eltwise/test_where.py::test_where_program_cache_different_broadcast_shapes`

More details in  https://github.com/tenstorrent/tt-xla/issues/4418

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jzx/repro_slice_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jzx/repro_slice_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jzx/repro_slice_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jzx/repro_slice_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jzx/repro_slice_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jzx/repro_slice_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jzx/repro_slice_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jzx/repro_slice_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jzx/repro_slice_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jzx/repro_slice_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jzx/repro_slice_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jzx/repro_slice_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jzx/repro_slice_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jzx/repro_slice_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jzx/repro_slice_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jzx/repro_slice_bug)