### PR TITLE
[Bugfix]: Sort named CTAs before emitting to headergen

### DIFF
--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -156,11 +156,6 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
 // Also emits get_vararg() / get_common_vararg() helpers with the named-args offset baked
 // in, so that vararg indices in kernel code are stable across schema changes.
 //
-// The generated header itself is never hashed; the kernel cache key is derived in
-// Kernel::compute_hash() from the input data (kernel source, schema, CTA bindings, etc).
-// So we don't need to massage the generation order for hash stability — we just emit what
-// we're given.
-//
 // NOTE: This is only invoked for Metal 2.0 kernels created via the new host API.
 //       Legacy kernels do not get kernel_args_generated.h.
 void write_kernel_args_generated_header(const std::filesystem::path& out_dir, const JitBuildSettings& settings) {

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -171,8 +171,9 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
     const vector<string>& crta_names = settings.get_named_common_runtime_args();
 
     // Named CTAs come through the legacy unordered_map path (Kernel internal storage).
-    // The order in which we emit them doesn't matter: CTA values are baked into the header
-    // as independent constexpr constants; they don't affect RTA/CRTA byte offsets.
+    // The order in which we emit them DOES matter!
+    // We sort them to ensure the file output is deterministic for the JIT build cache
+    // (aka the on-disk per-object dephash cache)
     vector<pair<string, uint32_t>> cta_entries;
     settings.process_named_compile_time_args(
         [&cta_entries](const std::unordered_map<std::string, uint32_t>& named_args) {
@@ -180,6 +181,7 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
                 cta_entries.emplace_back(name, value);
             }
         });
+    sort(cta_entries.begin(), cta_entries.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
 
     ostringstream content;
     content << "// AUTO-GENERATED — do not edit.\n\n"


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/43206

### Summary
`write_kernel_args_generated_header `was iterating the named compile-time args directly out of an unordered_map, with a comment saying emission order didn't matter. 

That's true for the in-memory kernel cache (whose hash key in `Kernel::compute_hash()` already sorts the map), but it's not true for the on-disk per-object .dephash cache, which content-hashes generated headers. This could theoretically cause unnecessary recompiles.

Fix: sort the CTA entries by name before emisison. No functional change — only build-cache hit rate.

### Note

A _better_ fix would be to swap the `unordered_map` for a `map`. We've got several `unordered_map` types that get processed in headergen.... now we sort them all twice (once for the kernel cache, in `kernel.cpp`, and again in headergen). This is dumb. 

It's a small overhead though, and unfortunately the `unordered_map` is enshrined in the public API. This fix is nice and targeted, and it gets the job done.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/emit-CTAs-in-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/emit-CTAs-in-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/emit-CTAs-in-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/emit-CTAs-in-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/emit-CTAs-in-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/emit-CTAs-in-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/emit-CTAs-in-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/emit-CTAs-in-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/emit-CTAs-in-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/emit-CTAs-in-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/emit-CTAs-in-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/emit-CTAs-in-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/emit-CTAs-in-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/emit-CTAs-in-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/emit-CTAs-in-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/emit-CTAs-in-order)