### PR TITLE
fix(ccl): default fp32_dest_acc_en=true for fp32 reduce_scatter

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -79,6 +79,18 @@ ttnn::Tensor reduce_scatter_minimal_async(
         }
     }
 
+    // For fp32 inputs without an explicit compute_kernel_config, enable fp32 dest accumulation
+    // so the line_reduction sum runs at fp32 precision in dst (Tf32 unpack-dst). Without this,
+    // the JIT data-format selection picks a 7-bit-mantissa dst, silently truncating the
+    // cross-device sum.
+    auto resolved_compute_kernel_config = compute_kernel_config;
+    if (!resolved_compute_kernel_config.has_value() && input_tensor.dtype() == DataType::FLOAT32) {
+        resolved_compute_kernel_config = ttnn::DeviceComputeKernelConfig{
+            .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
+            .fp32_dest_acc_en = true,
+        };
+    }
+
     // Call the prim operation
     auto result = ttnn::prim::reduce_scatter_minimal_async(
         input_tensor,
@@ -98,7 +110,7 @@ ttnn::Tensor reduce_scatter_minimal_async(
         chunks_per_sync,
         num_workers_per_link,
         num_buffers_per_channel,
-        compute_kernel_config);
+        resolved_compute_kernel_config);
 
     // Return the output tensor (index 1, intermediate is at index 0)
     return result.at(1);


### PR DESCRIPTION
## Summary

Auto-promote `fp32_dest_acc_en=true` in `ttnn::experimental::reduce_scatter_minimal_async` when the input is `FLOAT32` and no `compute_kernel_config` is supplied. Mirrors the per-dtype promotion already done by the unary/binary eltwise primitives (`ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp:27-28`, `element_wise_multi_core_program_factory.cpp:184-186`).

Fixes the precision regression in `models/tt_dit/tests/unit/test_embeddings.py::test_wan_time_text_image_embedding[t3k-1-512-4096]` (RMSE 0.6% → 0.4%, threshold 0.5%).

## When the regression appeared

| Run | Commit | Status |
|-----|--------|--------|
| Last pass | [25104224639](https://github.com/tenstorrent/tt-metal/actions/runs/25104224639/job/73562110294) — `d9515c53` | ✅ |
| First fail | [25109298720](https://github.com/tenstorrent/tt-metal/actions/runs/25109298720/job/73580088264) — `41ab472a` | ❌ |
| Second fail | [25115944341](https://github.com/tenstorrent/tt-metal/actions/runs/25115944341/job/73604531978) — `9d4e0b04` | ❌ |

Auto-triage flagged commit [`2f9afc85`](https://github.com/tenstorrent/tt-metal/commit/2f9afc85848de4cd281c8b8bb552d87b9f19e4a9) (PR #43229 / #43256, "fix(conv): preserve fp32 magnitudes through halo's untilize") with confidence 96. Verified manually: that commit changed `tt_metal/jit_build/data_format.cpp::get_data_exp_precision` to return `ExpPrecision::B` (instead of `A`) when all CBs are Float32. In `genfiles.cpp:462-468`, that flips the conditional unpack-dst format from `Float16` → `Float16_b` for any kernel that runs with `fp32_dest_acc_en=false` and all-fp32 CBs.

The flip from FP16 (10-bit mantissa, 5-bit exponent) to BF16 (7-bit mantissa, 8-bit exponent) was the intent for the conv halo path — the wider exponent fixes the magnitude saturation in [#43229](https://github.com/tenstorrent/tt-metal/issues/43229). But the change was global, so any other op that landed on the conditional branch silently lost 3 bits of mantissa precision.

## Why `reduce_scatter` specifically

The WAN test path goes through `RowParallelLinear` → `CCLManager.reduce_scatter` → `ttnn::experimental::reduce_scatter_minimal_async`, which calls into a `line_reduction` compute kernel that sums fp32 partials across 4 devices. None of the surrounding ops regressed:

- `Linear` / `RowParallelLinear` / `ColParallelLinear` already pass `fp32_dest_acc_en=true` explicitly (`models/tt_dit/layers/linear.py:49,142,299`) — matmuls stay on Tf32.
- `ttnn.silu` / `cos` / `sin` self-promote on fp32 input via `unary.cpp:27-28` — Tf32.
- `ttnn.multiply` self-promotes via `element_wise_multi_core_program_factory.cpp:184-186` — Tf32.

`reduce_scatter_minimal_async` does **not** self-promote. Its program factory reads `fp32_dest_acc_en = ttnn::get_fp32_dest_acc_en(compute_kernel_config)` (`reduce_scatter_minimal_async_program.cpp:1102`), which returns `false` when no config is supplied (`compute_kernel_config.cpp:69-74`). So the `line_reduction` kernel ran with `fp32_dest_acc_en=false` and all-fp32 CBs — exactly the case the `data_format.cpp` change flipped to BF16.

### Diagnostic confirmation

Added temporary `std::cerr` logging in `genfiles.cpp` printing kernel name + buf_dataformat_arr + resolved unpack-dst for any kernel with fp32 in its CBs, then ran the failing test. The only **compute** kernel in the WAN path with `fp32_dest_acc_en=false` and all-fp32 CBs that resolved to `Float16_b` was:

```
[FP32_DBG] kernel='line_reduction/...' fp32_dest_acc_en=0 exp_prec=B unpack_dst=5 (Float16_b) all_fp32=1
```

All other compute kernels (`compute/*`, `eltwise_*`, `tilize*`, `tilize_wh`, `eltwise_typecast`) had `fp32_dest_acc_en=1` and resolved to `Tf32`. Data-movement kernels (`dm_*`, `reader_*`, `writer_*`) also showed `Float16_b` resolution but have no math pipeline so the format is irrelevant.

## The fix

```cpp
auto resolved_compute_kernel_config = compute_kernel_config;
if (!resolved_compute_kernel_config.has_value() && input_tensor.dtype() == DataType::FLOAT32) {
    resolved_compute_kernel_config = ttnn::DeviceComputeKernelConfig{
        .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
        .fp32_dest_acc_en = true,
    };
}
```

`HiFi4` matches the existing per-op default when no config is supplied (`reduce_scatter_minimal_async_program.cpp:1103-1105`) so math_fidelity is unchanged. `fp32_dest_acc_en=true` makes the line-reduction sum land on `Tf32` unpack-dst (10-bit mantissa, full fp32 exponent) — the format was always intended for fp32 paths.

This change also implicitly covers `all_reduce_async`'s reduce-scatter+all-gather code path, which calls `ttnn::experimental::reduce_scatter_minimal_async` without a compute config (`all_reduce_async.cpp:243`).

User-supplied configs are untouched.

## Test plan

- [x] Reproduce on local t3k: `pytest 'models/tt_dit/tests/unit/test_embeddings.py::test_wan_time_text_image_embedding[wormhole_b0-device_params0-t3k-1-512-4096]'` — fails at RMSE 0.6%.
- [x] Apply fix, rebuild release, re-run — passes at RMSE 0.4% (PCC 99.9999%).
- [ ] Full T3K unit suite via `(T3K) T3000 unit tests` workflow with `model=dits` (triggered separately on this branch).
- [ ] T3K perf / integration smoke (other CCL fp32 paths).

## Follow-ups (not in this PR)

- The same pattern should likely be applied to other CCL ops with compute kernels (`all_reduce`, `reduce_to_root`, etc.) — only `reduce_scatter_minimal_async` had a confirmed regressing test, so I scoped narrowly.
- The composite_reduce_scatter early-out at `reduce_scatter_minimal_async.cpp:52-65` doesn't take a `compute_kernel_config` and would still hit the same bug if its reduction kernel runs all-fp32 CBs without dest acc. Worth verifying separately.
- The global `data_format.cpp` change in #43229/#43256 remains a foot-gun for any future op that runs on fp32 without opting into `fp32_dest_acc_en`. Consider adding a CI gate that flunks on all-fp32 + `fp32_dest_acc_en=false` so this kind of silent precision drop fails loudly at codegen time rather than at downstream RMSE checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-fp32-reduce-scatter-precision)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-fp32-reduce-scatter-precision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-fp32-reduce-scatter-precision)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-fp32-reduce-scatter-precision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/fix-fp32-reduce-scatter-precision)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/fix-fp32-reduce-scatter-precision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-fp32-reduce-scatter-precision)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-fp32-reduce-scatter-precision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-fp32-reduce-scatter-precision)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-fp32-reduce-scatter-precision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-fp32-reduce-scatter-precision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-fp32-reduce-scatter-precision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-fp32-reduce-scatter-precision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-fp32-reduce-scatter-precision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-fp32-reduce-scatter-precision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-fp32-reduce-scatter-precision)