### PR TITLE
Standardizing Eth Coords for Blitz Pipeline

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -1342,6 +1342,17 @@ void validate_sp5_blitz_decode_pipeline_stages(
             << coord_str(s.entry_node_coord);
     }
 
+    // 1b. Entry and exit on different columns: for 2D meshes coord[1] is the LINE axis (second MGD dim, width 2 in
+    // blitz decode 4x2); endpoints must not share the same column.
+    for (std::size_t i = 0; i < stages.size(); i++) {
+        const auto& s = stages[i];
+        EXPECT_NE(s.entry_node_coord[1], s.exit_node_coord[1])
+            << "Stage [" << i << "] (stage_index=" << s.stage_index
+            << ") entry and exit must use different mesh "
+               "columns (coord[1]): entry "
+            << coord_str(s.entry_node_coord) << " exit " << coord_str(s.exit_node_coord);
+    }
+
     // 2. No coord is reused across stages
     std::set<std::pair<std::size_t, std::pair<uint32_t, uint32_t>>> used_coords;
     for (std::size_t i = 0; i < stages.size(); i++) {

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -1343,9 +1343,23 @@ void validate_sp5_blitz_decode_pipeline_stages(
     }
 
     // 1b. Entry and exit on different columns: for 2D meshes coord[1] is the LINE axis (second MGD dim, width 2 in
-    // blitz decode 4x2); endpoints must not share the same column.
-    for (std::size_t i = 0; i < stages.size(); i++) {
+    // blitz decode 4x2); endpoints must not share the same column. Skip when an adjacent hop in the ring is
+    // intra-mesh (previous stage shares stage_index with this stage, or this stage shares stage_index with next):
+    // that leg completes on one logical mesh while the next hop stays on the same mesh (typical mesh-0 bookends),
+    // where LINE separation may be infeasible given hop/unclaimed constraints.
+    const std::size_t num_stages = stages.size();
+    for (std::size_t i = 0; i < num_stages; i++) {
         const auto& s = stages[i];
+        if (s.entry_node_coord.dims() < 2) {
+            continue;
+        }
+        const std::size_t prev_i = (i + num_stages - 1) % num_stages;
+        const std::size_t next_i = (i + 1) % num_stages;
+        const bool incoming_intra_mesh = stages[prev_i].stage_index == s.stage_index;
+        const bool outgoing_intra_mesh = s.stage_index == stages[next_i].stage_index;
+        if (incoming_intra_mesh || outgoing_intra_mesh) {
+            continue;
+        }
         EXPECT_NE(s.entry_node_coord[1], s.exit_node_coord[1])
             << "Stage [" << i << "] (stage_index=" << s.stage_index
             << ") entry and exit must use different mesh "
@@ -2195,33 +2209,51 @@ TEST_F(ControlPlaneFixture, TestBlitzDecodePipelineBuilder) {
 
     for (std::size_t si = 0; si < stages.size(); si++) {
         const auto& s = stages[si];
+        MeshId stage_mesh_id{static_cast<uint32_t>(s.stage_index)};
+        const FabricNodeId entry_fn(stage_mesh_id, mesh_graph.coordinate_to_chip(stage_mesh_id, s.entry_node_coord));
+        const FabricNodeId exit_fn(stage_mesh_id, mesh_graph.coordinate_to_chip(stage_mesh_id, s.exit_node_coord));
+
         fmt::print(
-            "stage{}: MeshCoordinate([{}, {}]) -> MeshCoordinate([{}, {}])\n",
+            "stage{}: stage_index={} entry_mesh_coord=[{}, {}] exit_mesh_coord=[{}, {}]\n",
             si,
+            s.stage_index,
             s.entry_node_coord[0],
             s.entry_node_coord[1],
             s.exit_node_coord[0],
             s.exit_node_coord[1]);
 
-        MeshId stage_mesh_id{static_cast<uint32_t>(s.stage_index)};
-        FabricNodeId entry_fn(stage_mesh_id, mesh_graph.coordinate_to_chip(stage_mesh_id, s.entry_node_coord));
-        FabricNodeId exit_fn(stage_mesh_id, mesh_graph.coordinate_to_chip(stage_mesh_id, s.exit_node_coord));
-
-        auto print_endpoint = [&](const FabricNodeId& fn, std::string_view label) {
+        auto print_endpoint = [&](std::string_view label, const MeshCoordinate& coord, const FabricNodeId& fn) {
             const std::string hostname = topology_mapper.get_hostname_for_fabric_node_id(fn);
             tt::tt_metal::TrayID tray_id = topology_mapper.get_tray_id_for_fabric_node_id(fn);
             tt::tt_metal::ASICLocation asic_location = topology_mapper.get_asic_location_for_fabric_node_id(fn);
             fmt::print(
-                "             {:9} hostname={} mesh_id={} tray_id={} asic_location={}\n",
+                "             {:9} mesh_coord=[{}, {}] fabric_node={} chip_id={} hostname={} mesh_id={} tray_id={} "
+                "asic_location={}\n",
                 label,
+                coord[0],
+                coord[1],
+                fn,
+                fn.chip_id,
                 hostname,
                 *fn.mesh_id,
                 *tray_id,
                 *asic_location);
         };
 
-        print_endpoint(entry_fn, "entry");
-        print_endpoint(exit_fn, "exit");
+        for (const auto& [label, coord, fn] :
+             {std::tuple<std::string_view, const MeshCoordinate&, const FabricNodeId&>{
+                  "entry", s.entry_node_coord, entry_fn},
+              {"exit", s.exit_node_coord, exit_fn}}) {
+            print_endpoint(label, coord, fn);
+        }
+
+        for (const auto& coord : mesh_graph.get_coord_range(stage_mesh_id)) {
+            if (coord == s.entry_node_coord || coord == s.exit_node_coord) {
+                continue;
+            }
+            const FabricNodeId fn(stage_mesh_id, mesh_graph.coordinate_to_chip(stage_mesh_id, coord));
+            print_endpoint("other", coord, fn);
+        }
     }
 
     validate_sp5_blitz_decode_pipeline_stages(control_plane, mesh_graph, mesh_ids, stages);

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -2180,6 +2180,39 @@ TEST_F(ControlPlaneFixture, TestBlitzDecodePipelineBuilder) {
          fn_to_coord(hops[num_meshes - 1].second),
          fn_to_coord(*loopback_exit_fn)});
 
+    const auto& topology_mapper = control_plane.get_topology_mapper();
+
+    for (std::size_t si = 0; si < stages.size(); si++) {
+        const auto& s = stages[si];
+        fmt::print(
+            "stage{}: MeshCoordinate([{}, {}]) -> MeshCoordinate([{}, {}])\n",
+            si,
+            s.entry_node_coord[0],
+            s.entry_node_coord[1],
+            s.exit_node_coord[0],
+            s.exit_node_coord[1]);
+
+        MeshId stage_mesh_id{static_cast<uint32_t>(s.stage_index)};
+        FabricNodeId entry_fn(stage_mesh_id, mesh_graph.coordinate_to_chip(stage_mesh_id, s.entry_node_coord));
+        FabricNodeId exit_fn(stage_mesh_id, mesh_graph.coordinate_to_chip(stage_mesh_id, s.exit_node_coord));
+
+        auto print_endpoint = [&](const FabricNodeId& fn, std::string_view label) {
+            const std::string hostname = topology_mapper.get_hostname_for_fabric_node_id(fn);
+            tt::tt_metal::TrayID tray_id = topology_mapper.get_tray_id_for_fabric_node_id(fn);
+            tt::tt_metal::ASICLocation asic_location = topology_mapper.get_asic_location_for_fabric_node_id(fn);
+            fmt::print(
+                "             {:9} hostname={} mesh_id={} tray_id={} asic_location={}\n",
+                label,
+                hostname,
+                *fn.mesh_id,
+                *tray_id,
+                *asic_location);
+        };
+
+        print_endpoint(entry_fn, "entry");
+        print_endpoint(exit_fn, "exit");
+    }
+
     validate_sp5_blitz_decode_pipeline_stages(control_plane, mesh_graph, mesh_ids, stages);
 }
 }  // namespace tt::tt_fabric::fabric_router_tests

--- a/tests/tt_metal/tt_fabric/golden_mapping_files/TestBHBlitzPipelineControlPlaneInit.yaml
+++ b/tests/tt_metal/tt_fabric/golden_mapping_files/TestBHBlitzPipelineControlPlaneInit.yaml
@@ -1,6 +1,618 @@
 asic_to_fabric_node_mapping:
   hostnames:
-    - hostname: 77d7cab2c197_0
+    - hostname: bh-glx-d04u02_0
+      mesh:
+        - mesh: 0
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 4
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 5
+              asic_id: 13348207248864415022
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 4
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 6
+              asic_id: 15734880723707946971
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 4
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 7
+              asic_id: 8459214721518564018
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 2
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 2
+              asic_id: 11801811412077560056
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 2
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 3
+              asic_id: 3691193096475209730
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 2
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 0
+              asic_id: 7684193079530792198
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 4
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 4
+              asic_id: 6627942144498420210
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 2
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 1
+              asic_id: 17295445229584620239
+    - hostname: bh-glx-d04u02_1
+      mesh:
+        - mesh: 1
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 4
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 1
+                chip_id: 5
+              asic_id: 6667095843572744785
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 4
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 1
+                chip_id: 6
+              asic_id: 11532499453081554079
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 4
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 1
+                chip_id: 7
+              asic_id: 18230463828552923623
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 2
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 1
+                chip_id: 2
+              asic_id: 5900074705319235799
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 2
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 1
+                chip_id: 3
+              asic_id: 11552056456286007868
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 2
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 1
+                chip_id: 0
+              asic_id: 8824147760529779932
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 4
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 1
+                chip_id: 4
+              asic_id: 5384180571585442648
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 2
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 1
+                chip_id: 1
+              asic_id: 16239237960952268849
+    - hostname: bh-glx-d04u02_10
+      mesh:
+        - mesh: 10
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 3
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 10
+                chip_id: 5
+              asic_id: 15028277671089687679
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 3
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 10
+                chip_id: 4
+              asic_id: 490339120626624879
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 3
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 10
+                chip_id: 7
+              asic_id: 13554297662260329756
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 3
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 10
+                chip_id: 6
+              asic_id: 14311095770108850986
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 1
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 10
+                chip_id: 3
+              asic_id: 10373009090463745106
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 1
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 10
+                chip_id: 2
+              asic_id: 7363775967540815515
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 1
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 10
+                chip_id: 1
+              asic_id: 8333899770744178642
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 1
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 10
+                chip_id: 0
+              asic_id: 4507153461113912361
+    - hostname: bh-glx-d04u02_11
+      mesh:
+        - mesh: 11
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 3
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 11
+                chip_id: 5
+              asic_id: 16592426178382485898
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 3
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 11
+                chip_id: 4
+              asic_id: 1152519795419237283
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 3
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 11
+                chip_id: 7
+              asic_id: 10513025765667202223
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 3
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 11
+                chip_id: 6
+              asic_id: 16989811402505437015
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 1
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 11
+                chip_id: 3
+              asic_id: 12855042880113048241
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 1
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 11
+                chip_id: 2
+              asic_id: 14273644944194117697
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 1
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 11
+                chip_id: 1
+              asic_id: 1122929848304643086
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 1
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 11
+                chip_id: 0
+              asic_id: 1698379830945815222
+    - hostname: bh-glx-d04u02_12
+      mesh:
+        - mesh: 12
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 4
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 12
+                chip_id: 5
+              asic_id: 11170837389934420258
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 4
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 12
+                chip_id: 6
+              asic_id: 13901658579026200376
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 4
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 12
+                chip_id: 7
+              asic_id: 10281883754685884980
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 2
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 12
+                chip_id: 2
+              asic_id: 5283700036842571129
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 2
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 12
+                chip_id: 3
+              asic_id: 7244256233350479197
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 2
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 12
+                chip_id: 0
+              asic_id: 1711960767933893786
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 4
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 12
+                chip_id: 4
+              asic_id: 9782458049578365927
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 2
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 12
+                chip_id: 1
+              asic_id: 15789888100861342469
+    - hostname: bh-glx-d04u02_13
+      mesh:
+        - mesh: 13
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 4
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 13
+                chip_id: 5
+              asic_id: 10484192742045754714
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 4
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 13
+                chip_id: 6
+              asic_id: 9345077999720262911
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 4
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 13
+                chip_id: 7
+              asic_id: 5259191034484665665
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 2
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 13
+                chip_id: 2
+              asic_id: 8802944617032836961
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 2
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 13
+                chip_id: 3
+              asic_id: 11247066650344368739
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 2
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 13
+                chip_id: 0
+              asic_id: 4258405893141475105
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 4
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 13
+                chip_id: 4
+              asic_id: 1410485883483512149
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 2
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 13
+                chip_id: 1
+              asic_id: 5678075323302001739
+    - hostname: bh-glx-d04u02_14
+      mesh:
+        - mesh: 14
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 3
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 14
+                chip_id: 5
+              asic_id: 3968902519925589972
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 3
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 14
+                chip_id: 4
+              asic_id: 18052773039961638338
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 3
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 14
+                chip_id: 7
+              asic_id: 6212024873067932086
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 3
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 14
+                chip_id: 6
+              asic_id: 14575018962128314899
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 1
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 14
+                chip_id: 3
+              asic_id: 10910141774173013073
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 1
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 14
+                chip_id: 2
+              asic_id: 4222914636247972723
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 1
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 14
+                chip_id: 1
+              asic_id: 13735617268803161823
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 1
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 14
+                chip_id: 0
+              asic_id: 17286228301501471304
+    - hostname: bh-glx-d04u02_15
+      mesh:
+        - mesh: 15
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 3
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 15
+                chip_id: 5
+              asic_id: 7988267450959457112
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 3
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 15
+                chip_id: 4
+              asic_id: 4275221169066566369
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 3
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 15
+                chip_id: 7
+              asic_id: 15546336940494616930
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 3
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 15
+                chip_id: 6
+              asic_id: 10743403487993730303
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 1
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 15
+                chip_id: 3
+              asic_id: 16078939182355445674
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 1
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 15
+                chip_id: 2
+              asic_id: 15010405134732781592
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 1
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 15
+                chip_id: 1
+              asic_id: 16811904067669907300
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 1
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 15
+                chip_id: 0
+              asic_id: 14359329708194393833
+    - hostname: bh-glx-d04u02_16
+      mesh:
+        - mesh: 16
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 4
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 16
+                chip_id: 5
+              asic_id: 11008787649806112536
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 4
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 16
+                chip_id: 6
+              asic_id: 1835151488866750695
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 4
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 16
+                chip_id: 7
+              asic_id: 11342067109236038482
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 2
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 16
+                chip_id: 2
+              asic_id: 1738102908796741959
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 2
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 16
+                chip_id: 3
+              asic_id: 7654775542189005910
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 2
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 16
+                chip_id: 0
+              asic_id: 7385599590380007687
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 4
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 16
+                chip_id: 4
+              asic_id: 1457509588724881939
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 2
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 16
+                chip_id: 1
+              asic_id: 5670778640144730146
+    - hostname: bh-glx-d04u02_17
       mesh:
         - mesh: 17
         - chips:
@@ -10,7 +622,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 17
-                chip_id: 4
+                chip_id: 5
               asic_id: 5435895895851207090
             - umd_chip_id: 1
               asic_position:
@@ -18,7 +630,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 17
-                chip_id: 6
+                chip_id: 4
               asic_id: 17683882158469668041
             - umd_chip_id: 2
               asic_position:
@@ -26,7 +638,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 17
-                chip_id: 2
+                chip_id: 7
               asic_id: 13596355956366853135
             - umd_chip_id: 3
               asic_position:
@@ -34,7 +646,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 17
-                chip_id: 0
+                chip_id: 6
               asic_id: 1651479517195975047
             - umd_chip_id: 4
               asic_position:
@@ -42,7 +654,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 17
-                chip_id: 5
+                chip_id: 3
               asic_id: 15423346608836745269
             - umd_chip_id: 5
               asic_position:
@@ -50,7 +662,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 17
-                chip_id: 7
+                chip_id: 2
               asic_id: 6773113568477272611
             - umd_chip_id: 6
               asic_position:
@@ -58,7 +670,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 17
-                chip_id: 3
+                chip_id: 1
               asic_id: 6858121661148188017
             - umd_chip_id: 7
               asic_position:
@@ -66,9 +678,9 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 17
-                chip_id: 1
+                chip_id: 0
               asic_id: 11121008009203562503
-    - hostname: 77d7cab2c197_1
+    - hostname: bh-glx-d04u02_18
       mesh:
         - mesh: 18
         - chips:
@@ -78,7 +690,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 18
-                chip_id: 6
+                chip_id: 5
               asic_id: 4619804671104165380
             - umd_chip_id: 1
               asic_position:
@@ -94,7 +706,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 18
-                chip_id: 0
+                chip_id: 7
               asic_id: 638397933911492781
             - umd_chip_id: 3
               asic_position:
@@ -102,7 +714,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 18
-                chip_id: 2
+                chip_id: 6
               asic_id: 2960825176032752273
             - umd_chip_id: 4
               asic_position:
@@ -110,7 +722,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 18
-                chip_id: 7
+                chip_id: 3
               asic_id: 17080729120545267017
             - umd_chip_id: 5
               asic_position:
@@ -118,7 +730,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 18
-                chip_id: 5
+                chip_id: 2
               asic_id: 14574350795437573159
             - umd_chip_id: 6
               asic_position:
@@ -134,689 +746,9 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 18
-                chip_id: 3
+                chip_id: 0
               asic_id: 18133340747597335132
-    - hostname: 77d7cab2c197_10
-      mesh:
-        - mesh: 14
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 3
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 14
-                chip_id: 0
-              asic_id: 3968902519925589972
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 3
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 14
-                chip_id: 6
-              asic_id: 18052773039961638338
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 3
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 14
-                chip_id: 1
-              asic_id: 6212024873067932086
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 3
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 14
-                chip_id: 7
-              asic_id: 14575018962128314899
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 1
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 14
-                chip_id: 2
-              asic_id: 10910141774173013073
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 1
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 14
-                chip_id: 4
-              asic_id: 4222914636247972723
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 1
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 14
-                chip_id: 3
-              asic_id: 13735617268803161823
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 1
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 14
-                chip_id: 5
-              asic_id: 17286228301501471304
-    - hostname: 77d7cab2c197_11
-      mesh:
-        - mesh: 15
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 3
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 15
-                chip_id: 1
-              asic_id: 7988267450959457112
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 3
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 15
-                chip_id: 0
-              asic_id: 4275221169066566369
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 3
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 15
-                chip_id: 3
-              asic_id: 15546336940494616930
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 3
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 15
-                chip_id: 2
-              asic_id: 10743403487993730303
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 1
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 15
-                chip_id: 7
-              asic_id: 16078939182355445674
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 1
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 15
-                chip_id: 6
-              asic_id: 15010405134732781592
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 1
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 15
-                chip_id: 5
-              asic_id: 16811904067669907300
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 1
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 15
-                chip_id: 4
-              asic_id: 14359329708194393833
-    - hostname: 77d7cab2c197_12
-      mesh:
-        - mesh: 4
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 4
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 4
-                chip_id: 1
-              asic_id: 6147713026362583004
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 4
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 4
-                chip_id: 2
-              asic_id: 12742186552163519901
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 4
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 4
-                chip_id: 0
-              asic_id: 1555815135633529513
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 2
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 4
-                chip_id: 5
-              asic_id: 9945840191581498569
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 2
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 4
-                chip_id: 7
-              asic_id: 9212806413261532482
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 2
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 4
-                chip_id: 4
-              asic_id: 7792959593985457581
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 4
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 4
-                chip_id: 3
-              asic_id: 2066747577509330035
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 2
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 4
-                chip_id: 6
-              asic_id: 13978077132572061600
-    - hostname: 77d7cab2c197_13
-      mesh:
-        - mesh: 5
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 4
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 5
-                chip_id: 4
-              asic_id: 17555829263203515246
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 4
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 5
-                chip_id: 7
-              asic_id: 10177024979229371154
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 4
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 5
-                chip_id: 6
-              asic_id: 13583439453767105397
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 2
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 5
-                chip_id: 3
-              asic_id: 10777488287282745292
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 2
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 5
-                chip_id: 2
-              asic_id: 10512870474042245169
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 2
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 5
-                chip_id: 1
-              asic_id: 8047778188575483887
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 4
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 5
-                chip_id: 5
-              asic_id: 10707433961261572697
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 2
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 5
-                chip_id: 0
-              asic_id: 1413410126679786690
-    - hostname: 77d7cab2c197_14
-      mesh:
-        - mesh: 6
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 3
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 6
-                chip_id: 6
-              asic_id: 18080982798508798832
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 3
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 6
-                chip_id: 0
-              asic_id: 626378700953115018
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 3
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 6
-                chip_id: 4
-              asic_id: 1747925788690200476
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 3
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 6
-                chip_id: 2
-              asic_id: 17319816454865850103
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 1
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 6
-                chip_id: 7
-              asic_id: 7174908135961423575
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 1
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 6
-                chip_id: 1
-              asic_id: 5772162951286734139
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 1
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 6
-                chip_id: 5
-              asic_id: 5840552128677601515
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 1
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 6
-                chip_id: 3
-              asic_id: 1240772167817611177
-    - hostname: 77d7cab2c197_15
-      mesh:
-        - mesh: 7
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 3
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 7
-                chip_id: 5
-              asic_id: 4587022518239692243
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 3
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 7
-                chip_id: 7
-              asic_id: 8745192001000318591
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 3
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 7
-                chip_id: 3
-              asic_id: 4392901209748127239
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 3
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 7
-                chip_id: 1
-              asic_id: 2605124421700375183
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 1
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 7
-                chip_id: 4
-              asic_id: 2425244126903214195
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 1
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 7
-                chip_id: 6
-              asic_id: 8916047439899456342
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 1
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 7
-                chip_id: 2
-              asic_id: 5260463295801319822
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 1
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 7
-                chip_id: 0
-              asic_id: 1466404354324792723
-    - hostname: 77d7cab2c197_16
-      mesh:
-        - mesh: 2
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 3
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 2
-                chip_id: 4
-              asic_id: 12060143095851202463
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 3
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 2
-                chip_id: 5
-              asic_id: 5000502086494109111
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 3
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 2
-                chip_id: 2
-              asic_id: 13973844372361264859
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 3
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 2
-                chip_id: 3
-              asic_id: 4868087456632261339
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 1
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 2
-                chip_id: 6
-              asic_id: 17262612186027163055
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 1
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 2
-                chip_id: 7
-              asic_id: 17201545820656445838
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 1
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 2
-                chip_id: 0
-              asic_id: 2284216125494013829
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 1
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 2
-                chip_id: 1
-              asic_id: 7705623201083719757
-    - hostname: 77d7cab2c197_17
-      mesh:
-        - mesh: 3
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 3
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 3
-                chip_id: 7
-              asic_id: 5254355237445041429
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 3
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 3
-                chip_id: 5
-              asic_id: 7161520843382460030
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 3
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 3
-                chip_id: 1
-              asic_id: 7822284952778057744
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 3
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 3
-                chip_id: 3
-              asic_id: 17799625212526150802
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 1
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 3
-                chip_id: 6
-              asic_id: 11769974876999127205
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 1
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 3
-                chip_id: 4
-              asic_id: 10169626425803233861
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 1
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 3
-                chip_id: 0
-              asic_id: 2758778762024106202
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 1
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 3
-                chip_id: 2
-              asic_id: 11254796596262279600
-    - hostname: 77d7cab2c197_18
-      mesh:
-        - mesh: 26
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 4
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 26
-                chip_id: 0
-              asic_id: 3682501398682376800
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 4
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 26
-                chip_id: 3
-              asic_id: 14658439907945146832
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 4
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 26
-                chip_id: 1
-              asic_id: 6130568186214017661
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 2
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 26
-                chip_id: 4
-              asic_id: 7643164980090023156
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 2
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 26
-                chip_id: 6
-              asic_id: 12460998733291048056
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 2
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 26
-                chip_id: 5
-              asic_id: 8773927515307786381
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 4
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 26
-                chip_id: 2
-              asic_id: 11760348432535030656
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 2
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 26
-                chip_id: 7
-              asic_id: 12492018707679192901
-    - hostname: 77d7cab2c197_19
-      mesh:
-        - mesh: 27
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 4
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 27
-                chip_id: 4
-              asic_id: 9826912081925935097
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 4
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 27
-                chip_id: 0
-              asic_id: 89316163026801103
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 4
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 27
-                chip_id: 6
-              asic_id: 15117412552324233424
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 2
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 27
-                chip_id: 3
-              asic_id: 15817418711322796708
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 2
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 27
-                chip_id: 5
-              asic_id: 3610897483260372681
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 2
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 27
-                chip_id: 1
-              asic_id: 9807815481303003444
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 4
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 27
-                chip_id: 2
-              asic_id: 12533426408746737476
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 2
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 27
-                chip_id: 7
-              asic_id: 12230073045238709244
-    - hostname: 77d7cab2c197_2
+    - hostname: bh-glx-d04u02_19
       mesh:
         - mesh: 19
         - chips:
@@ -826,7 +758,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 19
-                chip_id: 2
+                chip_id: 5
               asic_id: 17425826376848863834
             - umd_chip_id: 1
               asic_position:
@@ -834,7 +766,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 19
-                chip_id: 5
+                chip_id: 6
               asic_id: 13357716912541410186
             - umd_chip_id: 2
               asic_position:
@@ -842,7 +774,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 19
-                chip_id: 3
+                chip_id: 7
               asic_id: 7225245871838120217
             - umd_chip_id: 3
               asic_position:
@@ -850,7 +782,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 19
-                chip_id: 6
+                chip_id: 2
               asic_id: 18371256341237133519
             - umd_chip_id: 4
               asic_position:
@@ -858,7 +790,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 19
-                chip_id: 0
+                chip_id: 3
               asic_id: 6893319623116258730
             - umd_chip_id: 5
               asic_position:
@@ -866,7 +798,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 19
-                chip_id: 7
+                chip_id: 0
               asic_id: 9619322145853147279
             - umd_chip_id: 6
               asic_position:
@@ -884,7 +816,619 @@ asic_to_fabric_node_mapping:
                 mesh_id: 19
                 chip_id: 1
               asic_id: 9394870631221255312
-    - hostname: 77d7cab2c197_20
+    - hostname: bh-glx-d04u02_2
+      mesh:
+        - mesh: 2
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 3
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 2
+                chip_id: 5
+              asic_id: 12060143095851202463
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 3
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 2
+                chip_id: 4
+              asic_id: 5000502086494109111
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 3
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 2
+                chip_id: 7
+              asic_id: 13973844372361264859
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 3
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 2
+                chip_id: 6
+              asic_id: 4868087456632261339
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 1
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 2
+                chip_id: 3
+              asic_id: 17262612186027163055
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 1
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 2
+                chip_id: 2
+              asic_id: 17201545820656445838
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 1
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 2
+                chip_id: 1
+              asic_id: 2284216125494013829
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 1
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 2
+                chip_id: 0
+              asic_id: 7705623201083719757
+    - hostname: bh-glx-d04u02_20
+      mesh:
+        - mesh: 20
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 3
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 20
+                chip_id: 5
+              asic_id: 2842730311413033310
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 3
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 20
+                chip_id: 4
+              asic_id: 8444718494735347137
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 3
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 20
+                chip_id: 7
+              asic_id: 6641505709787200841
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 3
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 20
+                chip_id: 6
+              asic_id: 16860668890732972878
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 1
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 20
+                chip_id: 3
+              asic_id: 17554315731734223271
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 1
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 20
+                chip_id: 2
+              asic_id: 4556906345409755907
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 1
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 20
+                chip_id: 1
+              asic_id: 10641817919599683445
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 1
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 20
+                chip_id: 0
+              asic_id: 16753619853266968757
+    - hostname: bh-glx-d04u02_21
+      mesh:
+        - mesh: 21
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 3
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 21
+                chip_id: 5
+              asic_id: 8745719324908990193
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 3
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 21
+                chip_id: 4
+              asic_id: 12100547585034739379
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 3
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 21
+                chip_id: 7
+              asic_id: 17708240353977058438
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 3
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 21
+                chip_id: 6
+              asic_id: 17890258228802474127
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 1
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 21
+                chip_id: 3
+              asic_id: 7782087637162326179
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 1
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 21
+                chip_id: 2
+              asic_id: 16838654027923135830
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 1
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 21
+                chip_id: 1
+              asic_id: 4424366875635182953
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 1
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 21
+                chip_id: 0
+              asic_id: 7680107641566339825
+    - hostname: bh-glx-d04u02_22
+      mesh:
+        - mesh: 22
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 4
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 22
+                chip_id: 5
+              asic_id: 1536575218408937423
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 4
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 22
+                chip_id: 6
+              asic_id: 9480156280076631936
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 4
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 22
+                chip_id: 7
+              asic_id: 1078046135936462905
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 2
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 22
+                chip_id: 2
+              asic_id: 11942989571667069359
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 2
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 22
+                chip_id: 3
+              asic_id: 18173260730337322466
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 2
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 22
+                chip_id: 0
+              asic_id: 10811337254943637169
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 4
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 22
+                chip_id: 4
+              asic_id: 16509905763059000389
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 2
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 22
+                chip_id: 1
+              asic_id: 10067926037207310381
+    - hostname: bh-glx-d04u02_23
+      mesh:
+        - mesh: 23
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 4
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 23
+                chip_id: 5
+              asic_id: 10632926958766895977
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 4
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 23
+                chip_id: 6
+              asic_id: 4258304747927159645
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 4
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 23
+                chip_id: 7
+              asic_id: 5537830311541086885
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 2
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 23
+                chip_id: 2
+              asic_id: 11555989227393923057
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 2
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 23
+                chip_id: 3
+              asic_id: 7630134765035361838
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 2
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 23
+                chip_id: 0
+              asic_id: 4320113989807287967
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 4
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 23
+                chip_id: 4
+              asic_id: 14686161163199692436
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 2
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 23
+                chip_id: 1
+              asic_id: 15476266450711875340
+    - hostname: bh-glx-d04u02_24
+      mesh:
+        - mesh: 24
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 3
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 24
+                chip_id: 5
+              asic_id: 6906402073766592788
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 3
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 24
+                chip_id: 4
+              asic_id: 11945313263496900508
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 3
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 24
+                chip_id: 7
+              asic_id: 7051187655003936214
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 3
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 24
+                chip_id: 6
+              asic_id: 4901815699300951927
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 1
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 24
+                chip_id: 3
+              asic_id: 875601291695488544
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 1
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 24
+                chip_id: 2
+              asic_id: 10123102260497779113
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 1
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 24
+                chip_id: 1
+              asic_id: 2076990354253056348
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 1
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 24
+                chip_id: 0
+              asic_id: 11336884375678284840
+    - hostname: bh-glx-d04u02_25
+      mesh:
+        - mesh: 25
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 3
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 25
+                chip_id: 5
+              asic_id: 12392838017438723449
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 3
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 25
+                chip_id: 4
+              asic_id: 9793884830778632903
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 3
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 25
+                chip_id: 7
+              asic_id: 13718757109550908782
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 3
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 25
+                chip_id: 6
+              asic_id: 17819179437855475114
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 1
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 25
+                chip_id: 3
+              asic_id: 1272377275952210331
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 1
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 25
+                chip_id: 2
+              asic_id: 10679541815659398960
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 1
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 25
+                chip_id: 1
+              asic_id: 3086486670370602735
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 1
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 25
+                chip_id: 0
+              asic_id: 10145009310774598967
+    - hostname: bh-glx-d04u02_26
+      mesh:
+        - mesh: 26
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 4
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 26
+                chip_id: 5
+              asic_id: 3682501398682376800
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 4
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 26
+                chip_id: 6
+              asic_id: 14658439907945146832
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 4
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 26
+                chip_id: 7
+              asic_id: 6130568186214017661
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 2
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 26
+                chip_id: 2
+              asic_id: 7643164980090023156
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 2
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 26
+                chip_id: 3
+              asic_id: 12460998733291048056
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 2
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 26
+                chip_id: 0
+              asic_id: 8773927515307786381
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 4
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 26
+                chip_id: 4
+              asic_id: 11760348432535030656
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 2
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 26
+                chip_id: 1
+              asic_id: 12492018707679192901
+    - hostname: bh-glx-d04u02_27
+      mesh:
+        - mesh: 27
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 4
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 27
+                chip_id: 5
+              asic_id: 9826912081925935097
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 4
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 27
+                chip_id: 6
+              asic_id: 89316163026801103
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 4
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 27
+                chip_id: 7
+              asic_id: 15117412552324233424
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 2
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 27
+                chip_id: 2
+              asic_id: 15817418711322796708
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 2
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 27
+                chip_id: 3
+              asic_id: 3610897483260372681
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 2
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 27
+                chip_id: 0
+              asic_id: 9807815481303003444
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 4
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 27
+                chip_id: 4
+              asic_id: 12533426408746737476
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 2
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 27
+                chip_id: 1
+              asic_id: 12230073045238709244
+    - hostname: bh-glx-d04u02_28
       mesh:
         - mesh: 28
         - chips:
@@ -894,7 +1438,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 28
-                chip_id: 6
+                chip_id: 5
               asic_id: 16696018284483091843
             - umd_chip_id: 1
               asic_position:
@@ -902,7 +1446,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 28
-                chip_id: 0
+                chip_id: 4
               asic_id: 5049303072872419337
             - umd_chip_id: 2
               asic_position:
@@ -918,7 +1462,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 28
-                chip_id: 1
+                chip_id: 6
               asic_id: 11860423120223002955
             - umd_chip_id: 4
               asic_position:
@@ -926,7 +1470,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 28
-                chip_id: 4
+                chip_id: 3
               asic_id: 16101783422121042934
             - umd_chip_id: 5
               asic_position:
@@ -942,7 +1486,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 28
-                chip_id: 5
+                chip_id: 1
               asic_id: 12257734435621845493
             - umd_chip_id: 7
               asic_position:
@@ -950,9 +1494,9 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 28
-                chip_id: 3
+                chip_id: 0
               asic_id: 10858281385197882208
-    - hostname: 77d7cab2c197_21
+    - hostname: bh-glx-d04u02_29
       mesh:
         - mesh: 29
         - chips:
@@ -962,7 +1506,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 29
-                chip_id: 1
+                chip_id: 5
               asic_id: 3289894051591875356
             - umd_chip_id: 1
               asic_position:
@@ -970,7 +1514,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 29
-                chip_id: 7
+                chip_id: 4
               asic_id: 18392514324793660933
             - umd_chip_id: 2
               asic_position:
@@ -978,7 +1522,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 29
-                chip_id: 0
+                chip_id: 7
               asic_id: 1284405276360325565
             - umd_chip_id: 3
               asic_position:
@@ -1002,7 +1546,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 29
-                chip_id: 5
+                chip_id: 2
               asic_id: 6500788168482162414
             - umd_chip_id: 6
               asic_position:
@@ -1010,7 +1554,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 29
-                chip_id: 2
+                chip_id: 1
               asic_id: 9820198870331054471
             - umd_chip_id: 7
               asic_position:
@@ -1018,9 +1562,77 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 29
-                chip_id: 4
+                chip_id: 0
               asic_id: 10272368071379752254
-    - hostname: 77d7cab2c197_22
+    - hostname: bh-glx-d04u02_3
+      mesh:
+        - mesh: 3
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 3
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 3
+                chip_id: 5
+              asic_id: 5254355237445041429
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 3
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 3
+                chip_id: 4
+              asic_id: 7161520843382460030
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 3
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 3
+                chip_id: 7
+              asic_id: 7822284952778057744
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 3
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 3
+                chip_id: 6
+              asic_id: 17799625212526150802
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 1
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 3
+                chip_id: 3
+              asic_id: 11769974876999127205
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 1
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 3
+                chip_id: 2
+              asic_id: 10169626425803233861
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 1
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 3
+                chip_id: 1
+              asic_id: 2758778762024106202
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 1
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 3
+                chip_id: 0
+              asic_id: 11254796596262279600
+    - hostname: bh-glx-d04u02_30
       mesh:
         - mesh: 30
         - chips:
@@ -1030,7 +1642,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 30
-                chip_id: 4
+                chip_id: 5
               asic_id: 8185381716445776373
             - umd_chip_id: 1
               asic_position:
@@ -1038,7 +1650,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 30
-                chip_id: 0
+                chip_id: 6
               asic_id: 3808097669020956459
             - umd_chip_id: 2
               asic_position:
@@ -1046,7 +1658,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 30
-                chip_id: 6
+                chip_id: 7
               asic_id: 15926689925871286225
             - umd_chip_id: 3
               asic_position:
@@ -1054,7 +1666,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 30
-                chip_id: 3
+                chip_id: 2
               asic_id: 7211508056133702926
             - umd_chip_id: 4
               asic_position:
@@ -1062,7 +1674,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 30
-                chip_id: 5
+                chip_id: 3
               asic_id: 18111331784109153546
             - umd_chip_id: 5
               asic_position:
@@ -1070,7 +1682,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 30
-                chip_id: 1
+                chip_id: 0
               asic_id: 10057554315176554942
             - umd_chip_id: 6
               asic_position:
@@ -1078,7 +1690,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 30
-                chip_id: 2
+                chip_id: 4
               asic_id: 13256897718572470644
             - umd_chip_id: 7
               asic_position:
@@ -1086,9 +1698,9 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 30
-                chip_id: 7
+                chip_id: 1
               asic_id: 8673356211640278479
-    - hostname: 77d7cab2c197_23
+    - hostname: bh-glx-d04u02_31
       mesh:
         - mesh: 31
         - chips:
@@ -1098,7 +1710,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 31
-                chip_id: 7
+                chip_id: 5
               asic_id: 4532564537696114167
             - umd_chip_id: 1
               asic_position:
@@ -1106,7 +1718,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 31
-                chip_id: 0
+                chip_id: 6
               asic_id: 371892772031324679
             - umd_chip_id: 2
               asic_position:
@@ -1114,7 +1726,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 31
-                chip_id: 1
+                chip_id: 7
               asic_id: 9273713651241478914
             - umd_chip_id: 3
               asic_position:
@@ -1122,7 +1734,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 31
-                chip_id: 4
+                chip_id: 2
               asic_id: 6687819789687867691
             - umd_chip_id: 4
               asic_position:
@@ -1130,7 +1742,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 31
-                chip_id: 5
+                chip_id: 3
               asic_id: 9161003039013231953
             - umd_chip_id: 5
               asic_position:
@@ -1138,7 +1750,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 31
-                chip_id: 2
+                chip_id: 0
               asic_id: 11491997635029857223
             - umd_chip_id: 6
               asic_position:
@@ -1146,7 +1758,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 31
-                chip_id: 6
+                chip_id: 4
               asic_id: 17150374640803244457
             - umd_chip_id: 7
               asic_position:
@@ -1154,9 +1766,9 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 31
-                chip_id: 3
+                chip_id: 1
               asic_id: 4094776836739217219
-    - hostname: 77d7cab2c197_24
+    - hostname: bh-glx-d04u02_32
       mesh:
         - mesh: 32
         - chips:
@@ -1182,7 +1794,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 32
-                chip_id: 3
+                chip_id: 7
               asic_id: 17473543753791420106
             - umd_chip_id: 3
               asic_position:
@@ -1190,7 +1802,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 32
-                chip_id: 2
+                chip_id: 6
               asic_id: 8966694117796549890
             - umd_chip_id: 4
               asic_position:
@@ -1198,7 +1810,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 32
-                chip_id: 7
+                chip_id: 3
               asic_id: 8736203068076780792
             - umd_chip_id: 5
               asic_position:
@@ -1206,7 +1818,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 32
-                chip_id: 6
+                chip_id: 2
               asic_id: 18436077643646566507
             - umd_chip_id: 6
               asic_position:
@@ -1224,7 +1836,7 @@ asic_to_fabric_node_mapping:
                 mesh_id: 32
                 chip_id: 0
               asic_id: 2094951566635963727
-    - hostname: 77d7cab2c197_25
+    - hostname: bh-glx-d04u02_33
       mesh:
         - mesh: 33
         - chips:
@@ -1234,7 +1846,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 33
-                chip_id: 4
+                chip_id: 5
               asic_id: 13001783099147672284
             - umd_chip_id: 1
               asic_position:
@@ -1242,7 +1854,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 33
-                chip_id: 5
+                chip_id: 4
               asic_id: 3351865386869683306
             - umd_chip_id: 2
               asic_position:
@@ -1250,7 +1862,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 33
-                chip_id: 2
+                chip_id: 7
               asic_id: 12275854552662172944
             - umd_chip_id: 3
               asic_position:
@@ -1258,7 +1870,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 33
-                chip_id: 3
+                chip_id: 6
               asic_id: 15069257097787302865
             - umd_chip_id: 4
               asic_position:
@@ -1266,7 +1878,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 33
-                chip_id: 6
+                chip_id: 3
               asic_id: 16160466471288472744
             - umd_chip_id: 5
               asic_position:
@@ -1274,7 +1886,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 33
-                chip_id: 7
+                chip_id: 2
               asic_id: 7290938089592508694
             - umd_chip_id: 6
               asic_position:
@@ -1282,7 +1894,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 33
-                chip_id: 0
+                chip_id: 1
               asic_id: 2467241052041208
             - umd_chip_id: 7
               asic_position:
@@ -1290,485 +1902,9 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 33
-                chip_id: 1
+                chip_id: 0
               asic_id: 3868341087315840210
-    - hostname: 77d7cab2c197_26
-      mesh:
-        - mesh: 22
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 4
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 22
-                chip_id: 1
-              asic_id: 1536575218408937423
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 4
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 22
-                chip_id: 2
-              asic_id: 9480156280076631936
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 4
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 22
-                chip_id: 0
-              asic_id: 1078046135936462905
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 2
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 22
-                chip_id: 5
-              asic_id: 11942989571667069359
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 2
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 22
-                chip_id: 7
-              asic_id: 18173260730337322466
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 2
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 22
-                chip_id: 4
-              asic_id: 10811337254943637169
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 4
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 22
-                chip_id: 3
-              asic_id: 16509905763059000389
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 2
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 22
-                chip_id: 6
-              asic_id: 10067926037207310381
-    - hostname: 77d7cab2c197_27
-      mesh:
-        - mesh: 23
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 4
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 23
-                chip_id: 4
-              asic_id: 10632926958766895977
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 4
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 23
-                chip_id: 0
-              asic_id: 4258304747927159645
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 4
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 23
-                chip_id: 2
-              asic_id: 5537830311541086885
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 2
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 23
-                chip_id: 7
-              asic_id: 11555989227393923057
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 2
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 23
-                chip_id: 5
-              asic_id: 7630134765035361838
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 2
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 23
-                chip_id: 1
-              asic_id: 4320113989807287967
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 4
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 23
-                chip_id: 6
-              asic_id: 14686161163199692436
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 2
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 23
-                chip_id: 3
-              asic_id: 15476266450711875340
-    - hostname: 77d7cab2c197_28
-      mesh:
-        - mesh: 24
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 3
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 24
-                chip_id: 2
-              asic_id: 6906402073766592788
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 3
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 24
-                chip_id: 4
-              asic_id: 11945313263496900508
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 3
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 24
-                chip_id: 3
-              asic_id: 7051187655003936214
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 3
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 24
-                chip_id: 5
-              asic_id: 4901815699300951927
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 1
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 24
-                chip_id: 0
-              asic_id: 875601291695488544
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 1
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 24
-                chip_id: 6
-              asic_id: 10123102260497779113
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 1
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 24
-                chip_id: 1
-              asic_id: 2076990354253056348
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 1
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 24
-                chip_id: 7
-              asic_id: 11336884375678284840
-    - hostname: 77d7cab2c197_29
-      mesh:
-        - mesh: 25
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 3
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 25
-                chip_id: 6
-              asic_id: 12392838017438723449
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 3
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 25
-                chip_id: 4
-              asic_id: 9793884830778632903
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 3
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 25
-                chip_id: 7
-              asic_id: 13718757109550908782
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 3
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 25
-                chip_id: 5
-              asic_id: 17819179437855475114
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 1
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 25
-                chip_id: 0
-              asic_id: 1272377275952210331
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 1
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 25
-                chip_id: 2
-              asic_id: 10679541815659398960
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 1
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 25
-                chip_id: 1
-              asic_id: 3086486670370602735
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 1
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 25
-                chip_id: 3
-              asic_id: 10145009310774598967
-    - hostname: 77d7cab2c197_3
-      mesh:
-        - mesh: 16
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 4
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 16
-                chip_id: 6
-              asic_id: 11008787649806112536
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 4
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 16
-                chip_id: 2
-              asic_id: 1835151488866750695
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 4
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 16
-                chip_id: 4
-              asic_id: 11342067109236038482
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 2
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 16
-                chip_id: 1
-              asic_id: 1738102908796741959
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 2
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 16
-                chip_id: 7
-              asic_id: 7654775542189005910
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 2
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 16
-                chip_id: 3
-              asic_id: 7385599590380007687
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 4
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 16
-                chip_id: 0
-              asic_id: 1457509588724881939
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 2
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 16
-                chip_id: 5
-              asic_id: 5670778640144730146
-    - hostname: 77d7cab2c197_30
-      mesh:
-        - mesh: 20
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 3
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 20
-                chip_id: 0
-              asic_id: 2842730311413033310
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 3
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 20
-                chip_id: 2
-              asic_id: 8444718494735347137
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 3
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 20
-                chip_id: 1
-              asic_id: 6641505709787200841
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 3
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 20
-                chip_id: 3
-              asic_id: 16860668890732972878
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 1
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 20
-                chip_id: 6
-              asic_id: 17554315731734223271
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 1
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 20
-                chip_id: 4
-              asic_id: 4556906345409755907
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 1
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 20
-                chip_id: 7
-              asic_id: 10641817919599683445
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 1
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 20
-                chip_id: 5
-              asic_id: 16753619853266968757
-    - hostname: 77d7cab2c197_31
-      mesh:
-        - mesh: 21
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 3
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 21
-                chip_id: 4
-              asic_id: 8745719324908990193
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 3
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 21
-                chip_id: 5
-              asic_id: 12100547585034739379
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 3
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 21
-                chip_id: 6
-              asic_id: 17708240353977058438
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 3
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 21
-                chip_id: 7
-              asic_id: 17890258228802474127
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 1
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 21
-                chip_id: 2
-              asic_id: 7782087637162326179
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 1
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 21
-                chip_id: 3
-              asic_id: 16838654027923135830
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 1
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 21
-                chip_id: 0
-              asic_id: 4424366875635182953
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 1
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 21
-                chip_id: 1
-              asic_id: 7680107641566339825
-    - hostname: 77d7cab2c197_32
+    - hostname: bh-glx-d04u02_34
       mesh:
         - mesh: 34
         - chips:
@@ -1778,7 +1914,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 34
-                chip_id: 6
+                chip_id: 5
               asic_id: 12064810096940975009
             - umd_chip_id: 1
               asic_position:
@@ -1786,7 +1922,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 34
-                chip_id: 5
+                chip_id: 6
               asic_id: 2991544777588037107
             - umd_chip_id: 2
               asic_position:
@@ -1794,7 +1930,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 34
-                chip_id: 4
+                chip_id: 7
               asic_id: 10616734480909497223
             - umd_chip_id: 3
               asic_position:
@@ -1802,7 +1938,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 34
-                chip_id: 1
+                chip_id: 2
               asic_id: 8892358611227294380
             - umd_chip_id: 4
               asic_position:
@@ -1810,7 +1946,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 34
-                chip_id: 0
+                chip_id: 3
               asic_id: 1308562032372554992
             - umd_chip_id: 5
               asic_position:
@@ -1818,7 +1954,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 34
-                chip_id: 3
+                chip_id: 0
               asic_id: 18312295675560723286
             - umd_chip_id: 6
               asic_position:
@@ -1826,7 +1962,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 34
-                chip_id: 7
+                chip_id: 4
               asic_id: 4467939314084149303
             - umd_chip_id: 7
               asic_position:
@@ -1834,9 +1970,689 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 34
-                chip_id: 2
+                chip_id: 1
               asic_id: 11881887861193807234
-    - hostname: 77d7cab2c197_33
+    - hostname: bh-glx-d04u02_35
+      mesh:
+        - mesh: 35
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 3
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 35
+                chip_id: 5
+              asic_id: 15769276473807194899
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 3
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 35
+                chip_id: 4
+              asic_id: 7266940715099405514
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 3
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 35
+                chip_id: 7
+              asic_id: 526158955621198538
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 3
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 35
+                chip_id: 6
+              asic_id: 17311861584942216916
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 1
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 35
+                chip_id: 3
+              asic_id: 8084626692990689633
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 1
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 35
+                chip_id: 2
+              asic_id: 890321020828740093
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 1
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 35
+                chip_id: 1
+              asic_id: 12735388180647696997
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 1
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 35
+                chip_id: 0
+              asic_id: 3795650484393163876
+    - hostname: bh-glx-d04u02_36
+      mesh:
+        - mesh: 36
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 4
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 36
+                chip_id: 5
+              asic_id: 9093680903433213156
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 4
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 36
+                chip_id: 6
+              asic_id: 3987029371762093487
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 4
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 36
+                chip_id: 7
+              asic_id: 15924280082353661037
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 2
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 36
+                chip_id: 2
+              asic_id: 107758125611043101
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 2
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 36
+                chip_id: 3
+              asic_id: 1629699181206337760
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 2
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 36
+                chip_id: 0
+              asic_id: 14380527000930691623
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 4
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 36
+                chip_id: 4
+              asic_id: 17379335532730750137
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 2
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 36
+                chip_id: 1
+              asic_id: 18251489318244579981
+    - hostname: bh-glx-d04u02_37
+      mesh:
+        - mesh: 37
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 4
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 37
+                chip_id: 5
+              asic_id: 12966347750871724641
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 4
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 37
+                chip_id: 6
+              asic_id: 17136169789437991096
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 4
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 37
+                chip_id: 7
+              asic_id: 7944663697380482723
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 2
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 37
+                chip_id: 2
+              asic_id: 14500311465688926495
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 2
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 37
+                chip_id: 3
+              asic_id: 8109917399857023846
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 2
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 37
+                chip_id: 0
+              asic_id: 7930106402435840711
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 4
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 37
+                chip_id: 4
+              asic_id: 2545411250791794144
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 2
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 37
+                chip_id: 1
+              asic_id: 426337650959028430
+    - hostname: bh-glx-d04u02_38
+      mesh:
+        - mesh: 38
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 3
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 38
+                chip_id: 5
+              asic_id: 7619199387253569311
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 3
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 38
+                chip_id: 4
+              asic_id: 1291542933758784109
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 3
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 38
+                chip_id: 7
+              asic_id: 1350142134585656580
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 3
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 38
+                chip_id: 6
+              asic_id: 7704844523296742395
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 1
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 38
+                chip_id: 3
+              asic_id: 9804540789678569610
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 1
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 38
+                chip_id: 2
+              asic_id: 11963410648939273357
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 1
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 38
+                chip_id: 1
+              asic_id: 18333255811685529797
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 1
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 38
+                chip_id: 0
+              asic_id: 9418732762146702091
+    - hostname: bh-glx-d04u02_39
+      mesh:
+        - mesh: 39
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 3
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 39
+                chip_id: 5
+              asic_id: 3509405147933189096
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 3
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 39
+                chip_id: 4
+              asic_id: 3650792362704566843
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 3
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 39
+                chip_id: 7
+              asic_id: 15912961644730419228
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 3
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 39
+                chip_id: 6
+              asic_id: 5952787987249728030
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 1
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 39
+                chip_id: 3
+              asic_id: 5887444308137117967
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 1
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 39
+                chip_id: 2
+              asic_id: 17902919209385098159
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 1
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 39
+                chip_id: 1
+              asic_id: 1079118396370025951
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 1
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 39
+                chip_id: 0
+              asic_id: 13286783246641959229
+    - hostname: bh-glx-d04u02_4
+      mesh:
+        - mesh: 4
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 4
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 4
+                chip_id: 5
+              asic_id: 6147713026362583004
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 4
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 4
+                chip_id: 6
+              asic_id: 12742186552163519901
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 4
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 4
+                chip_id: 7
+              asic_id: 1555815135633529513
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 2
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 4
+                chip_id: 2
+              asic_id: 9945840191581498569
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 2
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 4
+                chip_id: 3
+              asic_id: 9212806413261532482
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 2
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 4
+                chip_id: 0
+              asic_id: 7792959593985457581
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 4
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 4
+                chip_id: 4
+              asic_id: 2066747577509330035
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 2
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 4
+                chip_id: 1
+              asic_id: 13978077132572061600
+    - hostname: bh-glx-d04u02_40
+      mesh:
+        - mesh: 40
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 4
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 40
+                chip_id: 5
+              asic_id: 5308752956021557080
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 4
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 40
+                chip_id: 6
+              asic_id: 3057414301055217449
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 4
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 40
+                chip_id: 7
+              asic_id: 15259890567635697565
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 2
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 40
+                chip_id: 2
+              asic_id: 12304035593804427903
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 2
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 40
+                chip_id: 3
+              asic_id: 16712011927668772093
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 2
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 40
+                chip_id: 0
+              asic_id: 219421723272504649
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 4
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 40
+                chip_id: 4
+              asic_id: 7691515768967032364
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 2
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 40
+                chip_id: 1
+              asic_id: 14491595713301183834
+    - hostname: bh-glx-d04u02_41
+      mesh:
+        - mesh: 41
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 4
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 41
+                chip_id: 5
+              asic_id: 9960702364312382776
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 4
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 41
+                chip_id: 6
+              asic_id: 5230955422975078278
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 4
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 41
+                chip_id: 7
+              asic_id: 17511333351633864414
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 2
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 41
+                chip_id: 2
+              asic_id: 16054581901615393636
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 2
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 41
+                chip_id: 3
+              asic_id: 2106351074855704247
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 2
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 41
+                chip_id: 0
+              asic_id: 6807132636891109783
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 4
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 41
+                chip_id: 4
+              asic_id: 10383300135110988229
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 2
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 41
+                chip_id: 1
+              asic_id: 5501257575933533068
+    - hostname: bh-glx-d04u02_42
+      mesh:
+        - mesh: 42
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 3
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 42
+                chip_id: 5
+              asic_id: 177127060856827182
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 3
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 42
+                chip_id: 4
+              asic_id: 10115007130382413457
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 3
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 42
+                chip_id: 7
+              asic_id: 7492453979027389469
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 3
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 42
+                chip_id: 6
+              asic_id: 6454264650870853669
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 1
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 42
+                chip_id: 3
+              asic_id: 8487967722812761660
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 1
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 42
+                chip_id: 2
+              asic_id: 8664474434288397985
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 1
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 42
+                chip_id: 1
+              asic_id: 338893184642266230
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 1
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 42
+                chip_id: 0
+              asic_id: 1870569292920138712
+    - hostname: bh-glx-d04u02_43
+      mesh:
+        - mesh: 43
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 3
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 43
+                chip_id: 5
+              asic_id: 16001306078687353122
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 3
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 43
+                chip_id: 4
+              asic_id: 17185980413693085733
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 3
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 43
+                chip_id: 7
+              asic_id: 1847638098113896109
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 3
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 43
+                chip_id: 6
+              asic_id: 18381562812321460677
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 1
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 43
+                chip_id: 3
+              asic_id: 6372326649848205422
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 1
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 43
+                chip_id: 2
+              asic_id: 2889583347849322957
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 1
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 43
+                chip_id: 1
+              asic_id: 13362963824298813426
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 1
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 43
+                chip_id: 0
+              asic_id: 7608801860044290962
+    - hostname: bh-glx-d04u02_44
       mesh:
         - mesh: 44
         - chips:
@@ -1862,7 +2678,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 44
-                chip_id: 4
+                chip_id: 7
               asic_id: 11888806785086543223
             - umd_chip_id: 3
               asic_position:
@@ -1870,7 +2686,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 44
-                chip_id: 1
+                chip_id: 2
               asic_id: 4111358061326282727
             - umd_chip_id: 4
               asic_position:
@@ -1894,7 +2710,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 44
-                chip_id: 7
+                chip_id: 4
               asic_id: 14072157649377832527
             - umd_chip_id: 7
               asic_position:
@@ -1902,9 +2718,9 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 44
-                chip_id: 2
+                chip_id: 1
               asic_id: 5752721107569782278
-    - hostname: 77d7cab2c197_34
+    - hostname: bh-glx-d04u02_45
       mesh:
         - mesh: 45
         - chips:
@@ -1914,7 +2730,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 45
-                chip_id: 4
+                chip_id: 5
               asic_id: 13649860546650296281
             - umd_chip_id: 1
               asic_position:
@@ -1922,7 +2738,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 45
-                chip_id: 3
+                chip_id: 6
               asic_id: 3563193742383953893
             - umd_chip_id: 2
               asic_position:
@@ -1930,7 +2746,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 45
-                chip_id: 2
+                chip_id: 7
               asic_id: 13045821867031346337
             - umd_chip_id: 3
               asic_position:
@@ -1938,7 +2754,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 45
-                chip_id: 7
+                chip_id: 2
               asic_id: 3379169373064289140
             - umd_chip_id: 4
               asic_position:
@@ -1946,7 +2762,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 45
-                chip_id: 6
+                chip_id: 3
               asic_id: 17109240272006859197
             - umd_chip_id: 5
               asic_position:
@@ -1954,7 +2770,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 45
-                chip_id: 1
+                chip_id: 0
               asic_id: 3141259074763952680
             - umd_chip_id: 6
               asic_position:
@@ -1962,7 +2778,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 45
-                chip_id: 5
+                chip_id: 4
               asic_id: 6432315237702789523
             - umd_chip_id: 7
               asic_position:
@@ -1970,9 +2786,9 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 45
-                chip_id: 0
+                chip_id: 1
               asic_id: 2093868012525681382
-    - hostname: 77d7cab2c197_35
+    - hostname: bh-glx-d04u02_46
       mesh:
         - mesh: 46
         - chips:
@@ -1982,7 +2798,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 46
-                chip_id: 0
+                chip_id: 5
               asic_id: 1486480469639335971
             - umd_chip_id: 1
               asic_position:
@@ -1990,7 +2806,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 46
-                chip_id: 2
+                chip_id: 4
               asic_id: 13824826965310899590
             - umd_chip_id: 2
               asic_position:
@@ -1998,7 +2814,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 46
-                chip_id: 6
+                chip_id: 7
               asic_id: 15231050360131519342
             - umd_chip_id: 3
               asic_position:
@@ -2006,7 +2822,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 46
-                chip_id: 4
+                chip_id: 6
               asic_id: 14318926476223009264
             - umd_chip_id: 4
               asic_position:
@@ -2014,7 +2830,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 46
-                chip_id: 1
+                chip_id: 3
               asic_id: 7767975433654103127
             - umd_chip_id: 5
               asic_position:
@@ -2022,7 +2838,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 46
-                chip_id: 3
+                chip_id: 2
               asic_id: 7846046859762530191
             - umd_chip_id: 6
               asic_position:
@@ -2030,7 +2846,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 46
-                chip_id: 7
+                chip_id: 1
               asic_id: 12064997755891517751
             - umd_chip_id: 7
               asic_position:
@@ -2038,9 +2854,9 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 46
-                chip_id: 5
+                chip_id: 0
               asic_id: 17491092328372421324
-    - hostname: 77d7cab2c197_36
+    - hostname: bh-glx-d04u02_47
       mesh:
         - mesh: 47
         - chips:
@@ -2050,7 +2866,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 47
-                chip_id: 0
+                chip_id: 5
               asic_id: 1709608851489938881
             - umd_chip_id: 1
               asic_position:
@@ -2058,7 +2874,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 47
-                chip_id: 1
+                chip_id: 4
               asic_id: 3463605596171063760
             - umd_chip_id: 2
               asic_position:
@@ -2066,7 +2882,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 47
-                chip_id: 6
+                chip_id: 7
               asic_id: 16509867213574936524
             - umd_chip_id: 3
               asic_position:
@@ -2074,7 +2890,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 47
-                chip_id: 7
+                chip_id: 6
               asic_id: 4211242328685544013
             - umd_chip_id: 4
               asic_position:
@@ -2082,7 +2898,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 47
-                chip_id: 2
+                chip_id: 3
               asic_id: 12128072968699407205
             - umd_chip_id: 5
               asic_position:
@@ -2090,7 +2906,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 47
-                chip_id: 3
+                chip_id: 2
               asic_id: 17242810096593771213
             - umd_chip_id: 6
               asic_position:
@@ -2098,7 +2914,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 47
-                chip_id: 4
+                chip_id: 1
               asic_id: 10408644701869850374
             - umd_chip_id: 7
               asic_position:
@@ -2106,213 +2922,213 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 47
-                chip_id: 5
+                chip_id: 0
               asic_id: 17352350493115727449
-    - hostname: 77d7cab2c197_37
+    - hostname: bh-glx-d04u02_5
       mesh:
-        - mesh: 0
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 4
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 2
-              asic_id: 13348207248864415022
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 4
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 5
-              asic_id: 15734880723707946971
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 4
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 4
-              asic_id: 8459214721518564018
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 2
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 1
-              asic_id: 11801811412077560056
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 2
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 0
-              asic_id: 3691193096475209730
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 2
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 7
-              asic_id: 7684193079530792198
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 4
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 3
-              asic_id: 6627942144498420210
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 2
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 6
-              asic_id: 17295445229584620239
-    - hostname: 77d7cab2c197_38
-      mesh:
-        - mesh: 1
+        - mesh: 5
         - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 4
                 asic_location: 7
               fabric_node_id:
-                mesh_id: 1
-                chip_id: 2
-              asic_id: 6667095843572744785
+                mesh_id: 5
+                chip_id: 5
+              asic_id: 17555829263203515246
             - umd_chip_id: 1
               asic_position:
                 tray_id: 4
                 asic_location: 4
               fabric_node_id:
-                mesh_id: 1
+                mesh_id: 5
                 chip_id: 6
-              asic_id: 11532499453081554079
+              asic_id: 10177024979229371154
             - umd_chip_id: 2
               asic_position:
                 tray_id: 4
                 asic_location: 3
               fabric_node_id:
-                mesh_id: 1
-                chip_id: 4
-              asic_id: 18230463828552923623
+                mesh_id: 5
+                chip_id: 7
+              asic_id: 13583439453767105397
             - umd_chip_id: 3
               asic_position:
                 tray_id: 2
                 asic_location: 8
               fabric_node_id:
-                mesh_id: 1
-                chip_id: 1
-              asic_id: 5900074705319235799
+                mesh_id: 5
+                chip_id: 2
+              asic_id: 10777488287282745292
             - umd_chip_id: 4
               asic_position:
                 tray_id: 2
                 asic_location: 7
               fabric_node_id:
-                mesh_id: 1
+                mesh_id: 5
                 chip_id: 3
-              asic_id: 11552056456286007868
+              asic_id: 10512870474042245169
             - umd_chip_id: 5
               asic_position:
                 tray_id: 2
                 asic_location: 4
               fabric_node_id:
-                mesh_id: 1
-                chip_id: 7
-              asic_id: 8824147760529779932
+                mesh_id: 5
+                chip_id: 0
+              asic_id: 8047778188575483887
             - umd_chip_id: 6
               asic_position:
                 tray_id: 4
                 asic_location: 8
               fabric_node_id:
-                mesh_id: 1
-                chip_id: 0
-              asic_id: 5384180571585442648
+                mesh_id: 5
+                chip_id: 4
+              asic_id: 10707433961261572697
             - umd_chip_id: 7
               asic_position:
                 tray_id: 2
                 asic_location: 3
               fabric_node_id:
-                mesh_id: 1
-                chip_id: 5
-              asic_id: 16239237960952268849
-    - hostname: 77d7cab2c197_39
+                mesh_id: 5
+                chip_id: 1
+              asic_id: 1413410126679786690
+    - hostname: bh-glx-d04u02_6
       mesh:
-        - mesh: 35
+        - mesh: 6
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 3
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 6
+                chip_id: 5
+              asic_id: 18080982798508798832
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 3
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 6
+                chip_id: 4
+              asic_id: 626378700953115018
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 3
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 6
+                chip_id: 7
+              asic_id: 1747925788690200476
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 3
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 6
+                chip_id: 6
+              asic_id: 17319816454865850103
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 1
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 6
+                chip_id: 3
+              asic_id: 7174908135961423575
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 1
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 6
+                chip_id: 2
+              asic_id: 5772162951286734139
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 1
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 6
+                chip_id: 1
+              asic_id: 5840552128677601515
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 1
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 6
+                chip_id: 0
+              asic_id: 1240772167817611177
+    - hostname: bh-glx-d04u02_7
+      mesh:
+        - mesh: 7
         - chips:
             - umd_chip_id: 0
               asic_position:
                 tray_id: 3
                 asic_location: 6
               fabric_node_id:
-                mesh_id: 35
-                chip_id: 2
-              asic_id: 15769276473807194899
+                mesh_id: 7
+                chip_id: 5
+              asic_id: 4587022518239692243
             - umd_chip_id: 1
               asic_position:
                 tray_id: 3
                 asic_location: 5
               fabric_node_id:
-                mesh_id: 35
+                mesh_id: 7
                 chip_id: 4
-              asic_id: 7266940715099405514
+              asic_id: 8745192001000318591
             - umd_chip_id: 2
               asic_position:
                 tray_id: 3
                 asic_location: 2
               fabric_node_id:
-                mesh_id: 35
-                chip_id: 0
-              asic_id: 526158955621198538
+                mesh_id: 7
+                chip_id: 7
+              asic_id: 4392901209748127239
             - umd_chip_id: 3
               asic_position:
                 tray_id: 3
                 asic_location: 1
               fabric_node_id:
-                mesh_id: 35
+                mesh_id: 7
                 chip_id: 6
-              asic_id: 17311861584942216916
+              asic_id: 2605124421700375183
             - umd_chip_id: 4
               asic_position:
                 tray_id: 1
                 asic_location: 6
               fabric_node_id:
-                mesh_id: 35
+                mesh_id: 7
                 chip_id: 3
-              asic_id: 8084626692990689633
+              asic_id: 2425244126903214195
             - umd_chip_id: 5
               asic_position:
                 tray_id: 1
                 asic_location: 5
               fabric_node_id:
-                mesh_id: 35
-                chip_id: 5
-              asic_id: 890321020828740093
+                mesh_id: 7
+                chip_id: 2
+              asic_id: 8916047439899456342
             - umd_chip_id: 6
               asic_position:
                 tray_id: 1
                 asic_location: 2
               fabric_node_id:
-                mesh_id: 35
+                mesh_id: 7
                 chip_id: 1
-              asic_id: 12735388180647696997
+              asic_id: 5260463295801319822
             - umd_chip_id: 7
               asic_position:
                 tray_id: 1
                 asic_location: 1
               fabric_node_id:
-                mesh_id: 35
-                chip_id: 7
-              asic_id: 3795650484393163876
-    - hostname: 77d7cab2c197_4
+                mesh_id: 7
+                chip_id: 0
+              asic_id: 1466404354324792723
+    - hostname: bh-glx-d04u02_8
       mesh:
         - mesh: 8
         - chips:
@@ -2322,7 +3138,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 8
-                chip_id: 7
+                chip_id: 5
               asic_id: 7244132655203577012
             - umd_chip_id: 1
               asic_position:
@@ -2330,7 +3146,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 8
-                chip_id: 3
+                chip_id: 6
               asic_id: 11583796653499992490
             - umd_chip_id: 2
               asic_position:
@@ -2338,7 +3154,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 8
-                chip_id: 5
+                chip_id: 7
               asic_id: 7236211689352678335
             - umd_chip_id: 3
               asic_position:
@@ -2346,7 +3162,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 8
-                chip_id: 0
+                chip_id: 2
               asic_id: 4383431266423279978
             - umd_chip_id: 4
               asic_position:
@@ -2354,7 +3170,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 8
-                chip_id: 6
+                chip_id: 3
               asic_id: 17733453004311735718
             - umd_chip_id: 5
               asic_position:
@@ -2362,7 +3178,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 8
-                chip_id: 2
+                chip_id: 0
               asic_id: 16788321376567380816
             - umd_chip_id: 6
               asic_position:
@@ -2370,7 +3186,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 8
-                chip_id: 1
+                chip_id: 4
               asic_id: 6850213778642228121
             - umd_chip_id: 7
               asic_position:
@@ -2378,553 +3194,9 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 8
-                chip_id: 4
+                chip_id: 1
               asic_id: 15143113916809024295
-    - hostname: 77d7cab2c197_40
-      mesh:
-        - mesh: 40
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 4
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 40
-                chip_id: 5
-              asic_id: 5308752956021557080
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 4
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 40
-                chip_id: 1
-              asic_id: 3057414301055217449
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 4
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 40
-                chip_id: 7
-              asic_id: 15259890567635697565
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 2
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 40
-                chip_id: 2
-              asic_id: 12304035593804427903
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 2
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 40
-                chip_id: 4
-              asic_id: 16712011927668772093
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 2
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 40
-                chip_id: 0
-              asic_id: 219421723272504649
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 4
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 40
-                chip_id: 3
-              asic_id: 7691515768967032364
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 2
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 40
-                chip_id: 6
-              asic_id: 14491595713301183834
-    - hostname: 77d7cab2c197_41
-      mesh:
-        - mesh: 41
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 4
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 41
-                chip_id: 2
-              asic_id: 9960702364312382776
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 4
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 41
-                chip_id: 5
-              asic_id: 5230955422975078278
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 4
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 41
-                chip_id: 3
-              asic_id: 17511333351633864414
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 2
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 41
-                chip_id: 6
-              asic_id: 16054581901615393636
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 2
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 41
-                chip_id: 0
-              asic_id: 2106351074855704247
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 2
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 41
-                chip_id: 7
-              asic_id: 6807132636891109783
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 4
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 41
-                chip_id: 4
-              asic_id: 10383300135110988229
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 2
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 41
-                chip_id: 1
-              asic_id: 5501257575933533068
-    - hostname: 77d7cab2c197_42
-      mesh:
-        - mesh: 42
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 3
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 42
-                chip_id: 0
-              asic_id: 177127060856827182
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 3
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 42
-                chip_id: 6
-              asic_id: 10115007130382413457
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 3
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 42
-                chip_id: 1
-              asic_id: 7492453979027389469
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 3
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 42
-                chip_id: 7
-              asic_id: 6454264650870853669
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 1
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 42
-                chip_id: 2
-              asic_id: 8487967722812761660
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 1
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 42
-                chip_id: 4
-              asic_id: 8664474434288397985
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 1
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 42
-                chip_id: 3
-              asic_id: 338893184642266230
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 1
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 42
-                chip_id: 5
-              asic_id: 1870569292920138712
-    - hostname: 77d7cab2c197_43
-      mesh:
-        - mesh: 43
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 3
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 43
-                chip_id: 2
-              asic_id: 16001306078687353122
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 3
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 43
-                chip_id: 4
-              asic_id: 17185980413693085733
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 3
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 43
-                chip_id: 0
-              asic_id: 1847638098113896109
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 3
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 43
-                chip_id: 6
-              asic_id: 18381562812321460677
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 1
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 43
-                chip_id: 3
-              asic_id: 6372326649848205422
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 1
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 43
-                chip_id: 5
-              asic_id: 2889583347849322957
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 1
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 43
-                chip_id: 1
-              asic_id: 13362963824298813426
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 1
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 43
-                chip_id: 7
-              asic_id: 7608801860044290962
-    - hostname: 77d7cab2c197_44
-      mesh:
-        - mesh: 36
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 4
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 36
-                chip_id: 7
-              asic_id: 9093680903433213156
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 4
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 36
-                chip_id: 4
-              asic_id: 3987029371762093487
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 4
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 36
-                chip_id: 5
-              asic_id: 15924280082353661037
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 2
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 36
-                chip_id: 0
-              asic_id: 107758125611043101
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 2
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 36
-                chip_id: 1
-              asic_id: 1629699181206337760
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 2
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 36
-                chip_id: 2
-              asic_id: 14380527000930691623
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 4
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 36
-                chip_id: 6
-              asic_id: 17379335532730750137
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 2
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 36
-                chip_id: 3
-              asic_id: 18251489318244579981
-    - hostname: 77d7cab2c197_45
-      mesh:
-        - mesh: 37
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 4
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 37
-                chip_id: 4
-              asic_id: 12966347750871724641
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 4
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 37
-                chip_id: 3
-              asic_id: 17136169789437991096
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 4
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 37
-                chip_id: 2
-              asic_id: 7944663697380482723
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 2
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 37
-                chip_id: 7
-              asic_id: 14500311465688926495
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 2
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 37
-                chip_id: 6
-              asic_id: 8109917399857023846
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 2
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 37
-                chip_id: 1
-              asic_id: 7930106402435840711
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 4
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 37
-                chip_id: 5
-              asic_id: 2545411250791794144
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 2
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 37
-                chip_id: 0
-              asic_id: 426337650959028430
-    - hostname: 77d7cab2c197_46
-      mesh:
-        - mesh: 38
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 3
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 38
-                chip_id: 1
-              asic_id: 7619199387253569311
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 3
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 38
-                chip_id: 0
-              asic_id: 1291542933758784109
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 3
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 38
-                chip_id: 3
-              asic_id: 1350142134585656580
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 3
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 38
-                chip_id: 2
-              asic_id: 7704844523296742395
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 1
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 38
-                chip_id: 7
-              asic_id: 9804540789678569610
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 1
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 38
-                chip_id: 6
-              asic_id: 11963410648939273357
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 1
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 38
-                chip_id: 5
-              asic_id: 18333255811685529797
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 1
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 38
-                chip_id: 4
-              asic_id: 9418732762146702091
-    - hostname: 77d7cab2c197_47
-      mesh:
-        - mesh: 39
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 3
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 39
-                chip_id: 7
-              asic_id: 3509405147933189096
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 3
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 39
-                chip_id: 5
-              asic_id: 3650792362704566843
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 3
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 39
-                chip_id: 6
-              asic_id: 15912961644730419228
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 3
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 39
-                chip_id: 4
-              asic_id: 5952787987249728030
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 1
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 39
-                chip_id: 1
-              asic_id: 5887444308137117967
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 1
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 39
-                chip_id: 3
-              asic_id: 17902919209385098159
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 1
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 39
-                chip_id: 0
-              asic_id: 1079118396370025951
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 1
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 39
-                chip_id: 2
-              asic_id: 13286783246641959229
-    - hostname: 77d7cab2c197_5
+    - hostname: bh-glx-d04u02_9
       mesh:
         - mesh: 9
         - chips:
@@ -2942,7 +3214,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 9
-                chip_id: 2
+                chip_id: 6
               asic_id: 8175519286034729980
             - umd_chip_id: 2
               asic_position:
@@ -2950,7 +3222,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 9
-                chip_id: 3
+                chip_id: 7
               asic_id: 10617099334128963764
             - umd_chip_id: 3
               asic_position:
@@ -2958,7 +3230,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 9
-                chip_id: 6
+                chip_id: 2
               asic_id: 8359103845802229818
             - umd_chip_id: 4
               asic_position:
@@ -2966,7 +3238,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 9
-                chip_id: 7
+                chip_id: 3
               asic_id: 16473617610994745236
             - umd_chip_id: 5
               asic_position:
@@ -2992,275 +3264,3 @@ asic_to_fabric_node_mapping:
                 mesh_id: 9
                 chip_id: 1
               asic_id: 6259708900162877457
-    - hostname: 77d7cab2c197_6
-      mesh:
-        - mesh: 10
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 3
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 10
-                chip_id: 6
-              asic_id: 15028277671089687679
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 3
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 10
-                chip_id: 0
-              asic_id: 490339120626624879
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 3
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 10
-                chip_id: 4
-              asic_id: 13554297662260329756
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 3
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 10
-                chip_id: 2
-              asic_id: 14311095770108850986
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 1
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 10
-                chip_id: 7
-              asic_id: 10373009090463745106
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 1
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 10
-                chip_id: 1
-              asic_id: 7363775967540815515
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 1
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 10
-                chip_id: 5
-              asic_id: 8333899770744178642
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 1
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 10
-                chip_id: 3
-              asic_id: 4507153461113912361
-    - hostname: 77d7cab2c197_7
-      mesh:
-        - mesh: 11
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 3
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 11
-                chip_id: 4
-              asic_id: 16592426178382485898
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 3
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 11
-                chip_id: 5
-              asic_id: 1152519795419237283
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 3
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 11
-                chip_id: 2
-              asic_id: 10513025765667202223
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 3
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 11
-                chip_id: 3
-              asic_id: 16989811402505437015
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 1
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 11
-                chip_id: 6
-              asic_id: 12855042880113048241
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 1
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 11
-                chip_id: 7
-              asic_id: 14273644944194117697
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 1
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 11
-                chip_id: 0
-              asic_id: 1122929848304643086
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 1
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 11
-                chip_id: 1
-              asic_id: 1698379830945815222
-    - hostname: 77d7cab2c197_8
-      mesh:
-        - mesh: 12
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 4
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 12
-                chip_id: 5
-              asic_id: 11170837389934420258
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 4
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 12
-                chip_id: 2
-              asic_id: 13901658579026200376
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 4
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 12
-                chip_id: 4
-              asic_id: 10281883754685884980
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 2
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 12
-                chip_id: 1
-              asic_id: 5283700036842571129
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 2
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 12
-                chip_id: 7
-              asic_id: 7244256233350479197
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 2
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 12
-                chip_id: 0
-              asic_id: 1711960767933893786
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 4
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 12
-                chip_id: 3
-              asic_id: 9782458049578365927
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 2
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 12
-                chip_id: 6
-              asic_id: 15789888100861342469
-    - hostname: 77d7cab2c197_9
-      mesh:
-        - mesh: 13
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 4
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 13
-                chip_id: 6
-              asic_id: 10484192742045754714
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 4
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 13
-                chip_id: 2
-              asic_id: 9345077999720262911
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 4
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 13
-                chip_id: 4
-              asic_id: 5259191034484665665
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 2
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 13
-                chip_id: 1
-              asic_id: 8802944617032836961
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 2
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 13
-                chip_id: 7
-              asic_id: 11247066650344368739
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 2
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 13
-                chip_id: 3
-              asic_id: 4258405893141475105
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 4
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 13
-                chip_id: 0
-              asic_id: 1410485883483512149
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 2
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 13
-                chip_id: 5
-              asic_id: 5678075323302001739

--- a/tests/tt_metal/tt_fabric/golden_mapping_files/TestQuadGalaxyControlPlaneInit.yaml
+++ b/tests/tt_metal/tt_fabric/golden_mapping_files/TestQuadGalaxyControlPlaneInit.yaml
@@ -6,271 +6,11 @@ asic_to_fabric_node_mapping:
         - chips:
             - umd_chip_id: 0
               asic_position:
-                tray_id: 3
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 7
-              asic_id: 87028777098424372
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 1
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 119
-              asic_id: 87028777098424392
-            - umd_chip_id: 2
-              asic_position:
                 tray_id: 2
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 116
-              asic_id: 87028777098424398
-            - umd_chip_id: 3
-              asic_position:
-                tray_id: 4
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 4
-              asic_id: 87028789983326288
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 3
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 23
-              asic_id: 159086371136352308
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 1
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 103
-              asic_id: 159086371136352328
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 2
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 100
-              asic_id: 159086371136352334
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 4
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 20
-              asic_id: 159086384021254224
-            - umd_chip_id: 8
-              asic_position:
-                tray_id: 3
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 39
-              asic_id: 231143965174280244
-            - umd_chip_id: 9
-              asic_position:
-                tray_id: 1
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 87
-              asic_id: 231143965174280264
-            - umd_chip_id: 10
-              asic_position:
-                tray_id: 2
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 84
-              asic_id: 231143965174280270
-            - umd_chip_id: 11
-              asic_position:
-                tray_id: 4
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 36
-              asic_id: 231143978059182160
-            - umd_chip_id: 12
-              asic_position:
-                tray_id: 3
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 55
-              asic_id: 303201559212208180
-            - umd_chip_id: 13
-              asic_position:
-                tray_id: 1
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 71
-              asic_id: 303201559212208200
-            - umd_chip_id: 14
-              asic_position:
-                tray_id: 2
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 68
-              asic_id: 303201559212208206
-            - umd_chip_id: 15
-              asic_position:
-                tray_id: 4
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 52
-              asic_id: 303201572097110096
-            - umd_chip_id: 16
-              asic_position:
-                tray_id: 3
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 6
-              asic_id: 375259153250136116
-            - umd_chip_id: 17
-              asic_position:
-                tray_id: 1
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 118
-              asic_id: 375259153250136136
-            - umd_chip_id: 18
-              asic_position:
-                tray_id: 2
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 117
-              asic_id: 375259153250136142
-            - umd_chip_id: 19
-              asic_position:
-                tray_id: 4
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 5
-              asic_id: 375259166135038032
-            - umd_chip_id: 20
-              asic_position:
-                tray_id: 3
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 22
-              asic_id: 447316747288064052
-            - umd_chip_id: 21
-              asic_position:
-                tray_id: 1
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 102
-              asic_id: 447316747288064072
-            - umd_chip_id: 22
-              asic_position:
-                tray_id: 2
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 101
-              asic_id: 447316747288064078
-            - umd_chip_id: 23
-              asic_position:
-                tray_id: 4
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 21
-              asic_id: 447316760172965968
-            - umd_chip_id: 24
-              asic_position:
-                tray_id: 3
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 38
-              asic_id: 519374341325991988
-            - umd_chip_id: 25
-              asic_position:
-                tray_id: 1
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 86
-              asic_id: 519374341325992008
-            - umd_chip_id: 26
-              asic_position:
-                tray_id: 2
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 85
-              asic_id: 519374341325992014
-            - umd_chip_id: 27
-              asic_position:
-                tray_id: 4
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 37
-              asic_id: 519374354210893904
-            - umd_chip_id: 28
-              asic_position:
-                tray_id: 3
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 54
-              asic_id: 591431935363919924
-            - umd_chip_id: 29
-              asic_position:
-                tray_id: 1
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 70
-              asic_id: 591431935363919944
-            - umd_chip_id: 30
-              asic_position:
-                tray_id: 2
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 69
-              asic_id: 591431935363919950
-            - umd_chip_id: 31
-              asic_position:
-                tray_id: 4
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 53
-              asic_id: 591431948248821840
-    - hostname: slurm-login_1
-      mesh:
-        - mesh: 0
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 2
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 112
+                chip_id: 0
               asic_id: 87028755623587893
             - umd_chip_id: 1
               asic_position:
@@ -278,7 +18,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 3
+                chip_id: 115
               asic_id: 87028768508489781
             - umd_chip_id: 2
               asic_position:
@@ -286,7 +26,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 115
+                chip_id: 3
               asic_id: 87028768508489794
             - umd_chip_id: 3
               asic_position:
@@ -294,7 +34,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 0
+                chip_id: 112
               asic_id: 87028789983326265
             - umd_chip_id: 4
               asic_position:
@@ -302,7 +42,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 96
+                chip_id: 16
               asic_id: 159086349661515829
             - umd_chip_id: 5
               asic_position:
@@ -310,7 +50,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 19
+                chip_id: 99
               asic_id: 159086362546417717
             - umd_chip_id: 6
               asic_position:
@@ -318,7 +58,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 99
+                chip_id: 19
               asic_id: 159086362546417730
             - umd_chip_id: 7
               asic_position:
@@ -326,7 +66,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 16
+                chip_id: 96
               asic_id: 159086384021254201
             - umd_chip_id: 8
               asic_position:
@@ -334,7 +74,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 80
+                chip_id: 32
               asic_id: 231143943699443765
             - umd_chip_id: 9
               asic_position:
@@ -342,7 +82,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 35
+                chip_id: 83
               asic_id: 231143956584345653
             - umd_chip_id: 10
               asic_position:
@@ -350,7 +90,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 83
+                chip_id: 35
               asic_id: 231143956584345666
             - umd_chip_id: 11
               asic_position:
@@ -358,7 +98,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 32
+                chip_id: 80
               asic_id: 231143978059182137
             - umd_chip_id: 12
               asic_position:
@@ -366,7 +106,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 64
+                chip_id: 48
               asic_id: 303201537737371701
             - umd_chip_id: 13
               asic_position:
@@ -374,7 +114,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 51
+                chip_id: 67
               asic_id: 303201550622273589
             - umd_chip_id: 14
               asic_position:
@@ -382,7 +122,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 67
+                chip_id: 51
               asic_id: 303201550622273602
             - umd_chip_id: 15
               asic_position:
@@ -390,7 +130,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 48
+                chip_id: 64
               asic_id: 303201572097110073
             - umd_chip_id: 16
               asic_position:
@@ -398,7 +138,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 113
+                chip_id: 1
               asic_id: 375259131775299637
             - umd_chip_id: 17
               asic_position:
@@ -406,7 +146,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 2
+                chip_id: 114
               asic_id: 375259144660201525
             - umd_chip_id: 18
               asic_position:
@@ -414,7 +154,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 114
+                chip_id: 2
               asic_id: 375259144660201538
             - umd_chip_id: 19
               asic_position:
@@ -422,7 +162,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 1
+                chip_id: 113
               asic_id: 375259166135038009
             - umd_chip_id: 20
               asic_position:
@@ -430,7 +170,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 97
+                chip_id: 17
               asic_id: 447316725813227573
             - umd_chip_id: 21
               asic_position:
@@ -438,7 +178,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 18
+                chip_id: 98
               asic_id: 447316738698129461
             - umd_chip_id: 22
               asic_position:
@@ -446,7 +186,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 98
+                chip_id: 18
               asic_id: 447316738698129474
             - umd_chip_id: 23
               asic_position:
@@ -454,7 +194,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 17
+                chip_id: 97
               asic_id: 447316760172965945
             - umd_chip_id: 24
               asic_position:
@@ -462,7 +202,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 81
+                chip_id: 33
               asic_id: 519374319851155509
             - umd_chip_id: 25
               asic_position:
@@ -470,7 +210,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 34
+                chip_id: 82
               asic_id: 519374332736057397
             - umd_chip_id: 26
               asic_position:
@@ -478,7 +218,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 82
+                chip_id: 34
               asic_id: 519374332736057410
             - umd_chip_id: 27
               asic_position:
@@ -486,7 +226,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 33
+                chip_id: 81
               asic_id: 519374354210893881
             - umd_chip_id: 28
               asic_position:
@@ -494,7 +234,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 65
+                chip_id: 49
               asic_id: 591431913889083445
             - umd_chip_id: 29
               asic_position:
@@ -502,7 +242,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 50
+                chip_id: 66
               asic_id: 591431926773985333
             - umd_chip_id: 30
               asic_position:
@@ -510,7 +250,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 66
+                chip_id: 50
               asic_id: 591431926773985346
             - umd_chip_id: 31
               asic_position:
@@ -518,279 +258,279 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 49
+                chip_id: 65
               asic_id: 591431948248821817
+    - hostname: slurm-login_1
+      mesh:
+        - mesh: 0
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 3
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 119
+              asic_id: 87028777098424372
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 1
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 7
+              asic_id: 87028777098424392
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 2
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 4
+              asic_id: 87028777098424398
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 4
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 116
+              asic_id: 87028789983326288
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 3
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 103
+              asic_id: 159086371136352308
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 1
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 23
+              asic_id: 159086371136352328
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 2
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 20
+              asic_id: 159086371136352334
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 4
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 100
+              asic_id: 159086384021254224
+            - umd_chip_id: 8
+              asic_position:
+                tray_id: 3
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 87
+              asic_id: 231143965174280244
+            - umd_chip_id: 9
+              asic_position:
+                tray_id: 1
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 39
+              asic_id: 231143965174280264
+            - umd_chip_id: 10
+              asic_position:
+                tray_id: 2
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 36
+              asic_id: 231143965174280270
+            - umd_chip_id: 11
+              asic_position:
+                tray_id: 4
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 84
+              asic_id: 231143978059182160
+            - umd_chip_id: 12
+              asic_position:
+                tray_id: 3
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 71
+              asic_id: 303201559212208180
+            - umd_chip_id: 13
+              asic_position:
+                tray_id: 1
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 55
+              asic_id: 303201559212208200
+            - umd_chip_id: 14
+              asic_position:
+                tray_id: 2
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 52
+              asic_id: 303201559212208206
+            - umd_chip_id: 15
+              asic_position:
+                tray_id: 4
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 68
+              asic_id: 303201572097110096
+            - umd_chip_id: 16
+              asic_position:
+                tray_id: 3
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 118
+              asic_id: 375259153250136116
+            - umd_chip_id: 17
+              asic_position:
+                tray_id: 1
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 6
+              asic_id: 375259153250136136
+            - umd_chip_id: 18
+              asic_position:
+                tray_id: 2
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 5
+              asic_id: 375259153250136142
+            - umd_chip_id: 19
+              asic_position:
+                tray_id: 4
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 117
+              asic_id: 375259166135038032
+            - umd_chip_id: 20
+              asic_position:
+                tray_id: 3
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 102
+              asic_id: 447316747288064052
+            - umd_chip_id: 21
+              asic_position:
+                tray_id: 1
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 22
+              asic_id: 447316747288064072
+            - umd_chip_id: 22
+              asic_position:
+                tray_id: 2
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 21
+              asic_id: 447316747288064078
+            - umd_chip_id: 23
+              asic_position:
+                tray_id: 4
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 101
+              asic_id: 447316760172965968
+            - umd_chip_id: 24
+              asic_position:
+                tray_id: 3
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 86
+              asic_id: 519374341325991988
+            - umd_chip_id: 25
+              asic_position:
+                tray_id: 1
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 38
+              asic_id: 519374341325992008
+            - umd_chip_id: 26
+              asic_position:
+                tray_id: 2
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 37
+              asic_id: 519374341325992014
+            - umd_chip_id: 27
+              asic_position:
+                tray_id: 4
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 85
+              asic_id: 519374354210893904
+            - umd_chip_id: 28
+              asic_position:
+                tray_id: 3
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 70
+              asic_id: 591431935363919924
+            - umd_chip_id: 29
+              asic_position:
+                tray_id: 1
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 54
+              asic_id: 591431935363919944
+            - umd_chip_id: 30
+              asic_position:
+                tray_id: 2
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 53
+              asic_id: 591431935363919950
+            - umd_chip_id: 31
+              asic_position:
+                tray_id: 4
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 69
+              asic_id: 591431948248821840
     - hostname: slurm-login_2
       mesh:
         - mesh: 0
         - chips:
             - umd_chip_id: 0
               asic_position:
-                tray_id: 4
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 12
-              asic_id: 87028789983326519
-            - umd_chip_id: 1
-              asic_position:
-                tray_id: 3
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 15
-              asic_id: 87028789983326529
-            - umd_chip_id: 2
-              asic_position:
-                tray_id: 1
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 127
-              asic_id: 87028789983326547
-            - umd_chip_id: 3
-              asic_position:
                 tray_id: 2
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 124
-              asic_id: 87028789983326550
-            - umd_chip_id: 4
-              asic_position:
-                tray_id: 4
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 28
-              asic_id: 159086384021254455
-            - umd_chip_id: 5
-              asic_position:
-                tray_id: 3
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 31
-              asic_id: 159086384021254465
-            - umd_chip_id: 6
-              asic_position:
-                tray_id: 1
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 111
-              asic_id: 159086384021254483
-            - umd_chip_id: 7
-              asic_position:
-                tray_id: 2
-                asic_location: 2
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 108
-              asic_id: 159086384021254486
-            - umd_chip_id: 8
-              asic_position:
-                tray_id: 4
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 44
-              asic_id: 231143978059182391
-            - umd_chip_id: 9
-              asic_position:
-                tray_id: 3
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 47
-              asic_id: 231143978059182401
-            - umd_chip_id: 10
-              asic_position:
-                tray_id: 1
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 95
-              asic_id: 231143978059182419
-            - umd_chip_id: 11
-              asic_position:
-                tray_id: 2
-                asic_location: 3
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 92
-              asic_id: 231143978059182422
-            - umd_chip_id: 12
-              asic_position:
-                tray_id: 4
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 60
-              asic_id: 303201572097110327
-            - umd_chip_id: 13
-              asic_position:
-                tray_id: 3
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 63
-              asic_id: 303201572097110337
-            - umd_chip_id: 14
-              asic_position:
-                tray_id: 1
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 79
-              asic_id: 303201572097110355
-            - umd_chip_id: 15
-              asic_position:
-                tray_id: 2
-                asic_location: 4
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 76
-              asic_id: 303201572097110358
-            - umd_chip_id: 16
-              asic_position:
-                tray_id: 4
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 13
-              asic_id: 375259166135038263
-            - umd_chip_id: 17
-              asic_position:
-                tray_id: 3
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 14
-              asic_id: 375259166135038273
-            - umd_chip_id: 18
-              asic_position:
-                tray_id: 1
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 126
-              asic_id: 375259166135038291
-            - umd_chip_id: 19
-              asic_position:
-                tray_id: 2
-                asic_location: 5
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 125
-              asic_id: 375259166135038294
-            - umd_chip_id: 20
-              asic_position:
-                tray_id: 4
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 29
-              asic_id: 447316760172966199
-            - umd_chip_id: 21
-              asic_position:
-                tray_id: 3
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 30
-              asic_id: 447316760172966209
-            - umd_chip_id: 22
-              asic_position:
-                tray_id: 1
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 110
-              asic_id: 447316760172966227
-            - umd_chip_id: 23
-              asic_position:
-                tray_id: 2
-                asic_location: 6
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 109
-              asic_id: 447316760172966230
-            - umd_chip_id: 24
-              asic_position:
-                tray_id: 4
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 45
-              asic_id: 519374354210894135
-            - umd_chip_id: 25
-              asic_position:
-                tray_id: 3
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 46
-              asic_id: 519374354210894145
-            - umd_chip_id: 26
-              asic_position:
-                tray_id: 1
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 94
-              asic_id: 519374354210894163
-            - umd_chip_id: 27
-              asic_position:
-                tray_id: 2
-                asic_location: 7
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 93
-              asic_id: 519374354210894166
-            - umd_chip_id: 28
-              asic_position:
-                tray_id: 4
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 61
-              asic_id: 591431948248822071
-            - umd_chip_id: 29
-              asic_position:
-                tray_id: 3
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 62
-              asic_id: 591431948248822081
-            - umd_chip_id: 30
-              asic_position:
-                tray_id: 1
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 78
-              asic_id: 591431948248822099
-            - umd_chip_id: 31
-              asic_position:
-                tray_id: 2
-                asic_location: 8
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 77
-              asic_id: 591431948248822102
-    - hostname: slurm-login_3
-      mesh:
-        - mesh: 0
-        - chips:
-            - umd_chip_id: 0
-              asic_position:
-                tray_id: 2
-                asic_location: 1
-              fabric_node_id:
-                mesh_id: 0
-                chip_id: 120
+                chip_id: 8
               asic_id: 87028789983326263
             - umd_chip_id: 1
               asic_position:
@@ -798,7 +538,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 123
+                chip_id: 11
               asic_id: 87028789983326292
             - umd_chip_id: 2
               asic_position:
@@ -806,7 +546,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 8
+                chip_id: 120
               asic_id: 87028789983326521
             - umd_chip_id: 3
               asic_position:
@@ -814,7 +554,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 11
+                chip_id: 123
               asic_id: 87028789983326768
             - umd_chip_id: 4
               asic_position:
@@ -822,7 +562,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 104
+                chip_id: 24
               asic_id: 159086384021254199
             - umd_chip_id: 5
               asic_position:
@@ -830,7 +570,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 107
+                chip_id: 27
               asic_id: 159086384021254228
             - umd_chip_id: 6
               asic_position:
@@ -838,7 +578,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 24
+                chip_id: 104
               asic_id: 159086384021254457
             - umd_chip_id: 7
               asic_position:
@@ -846,7 +586,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 27
+                chip_id: 107
               asic_id: 159086384021254704
             - umd_chip_id: 8
               asic_position:
@@ -854,7 +594,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 88
+                chip_id: 40
               asic_id: 231143978059182135
             - umd_chip_id: 9
               asic_position:
@@ -862,7 +602,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 91
+                chip_id: 43
               asic_id: 231143978059182164
             - umd_chip_id: 10
               asic_position:
@@ -870,7 +610,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 40
+                chip_id: 88
               asic_id: 231143978059182393
             - umd_chip_id: 11
               asic_position:
@@ -878,7 +618,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 43
+                chip_id: 91
               asic_id: 231143978059182640
             - umd_chip_id: 12
               asic_position:
@@ -886,7 +626,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 72
+                chip_id: 56
               asic_id: 303201572097110071
             - umd_chip_id: 13
               asic_position:
@@ -894,7 +634,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 75
+                chip_id: 59
               asic_id: 303201572097110100
             - umd_chip_id: 14
               asic_position:
@@ -902,7 +642,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 56
+                chip_id: 72
               asic_id: 303201572097110329
             - umd_chip_id: 15
               asic_position:
@@ -910,7 +650,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 59
+                chip_id: 75
               asic_id: 303201572097110576
             - umd_chip_id: 16
               asic_position:
@@ -918,7 +658,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 121
+                chip_id: 9
               asic_id: 375259166135038007
             - umd_chip_id: 17
               asic_position:
@@ -926,7 +666,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 122
+                chip_id: 10
               asic_id: 375259166135038036
             - umd_chip_id: 18
               asic_position:
@@ -934,7 +674,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 9
+                chip_id: 121
               asic_id: 375259166135038265
             - umd_chip_id: 19
               asic_position:
@@ -942,7 +682,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 10
+                chip_id: 122
               asic_id: 375259166135038512
             - umd_chip_id: 20
               asic_position:
@@ -950,7 +690,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 105
+                chip_id: 25
               asic_id: 447316760172965943
             - umd_chip_id: 21
               asic_position:
@@ -958,7 +698,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 106
+                chip_id: 26
               asic_id: 447316760172965972
             - umd_chip_id: 22
               asic_position:
@@ -966,7 +706,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 25
+                chip_id: 105
               asic_id: 447316760172966201
             - umd_chip_id: 23
               asic_position:
@@ -974,7 +714,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 26
+                chip_id: 106
               asic_id: 447316760172966448
             - umd_chip_id: 24
               asic_position:
@@ -982,7 +722,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 89
+                chip_id: 41
               asic_id: 519374354210893879
             - umd_chip_id: 25
               asic_position:
@@ -990,7 +730,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 90
+                chip_id: 42
               asic_id: 519374354210893908
             - umd_chip_id: 26
               asic_position:
@@ -998,7 +738,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 41
+                chip_id: 89
               asic_id: 519374354210894137
             - umd_chip_id: 27
               asic_position:
@@ -1006,7 +746,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 42
+                chip_id: 90
               asic_id: 519374354210894384
             - umd_chip_id: 28
               asic_position:
@@ -1014,7 +754,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 73
+                chip_id: 57
               asic_id: 591431948248821815
             - umd_chip_id: 29
               asic_position:
@@ -1022,7 +762,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 74
+                chip_id: 58
               asic_id: 591431948248821844
             - umd_chip_id: 30
               asic_position:
@@ -1030,7 +770,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 57
+                chip_id: 73
               asic_id: 591431948248822073
             - umd_chip_id: 31
               asic_position:
@@ -1038,5 +778,265 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 58
+                chip_id: 74
               asic_id: 591431948248822320
+    - hostname: slurm-login_3
+      mesh:
+        - mesh: 0
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 4
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 124
+              asic_id: 87028789983326519
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 3
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 127
+              asic_id: 87028789983326529
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 1
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 15
+              asic_id: 87028789983326547
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 2
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 12
+              asic_id: 87028789983326550
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 4
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 108
+              asic_id: 159086384021254455
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 3
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 111
+              asic_id: 159086384021254465
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 1
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 31
+              asic_id: 159086384021254483
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 2
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 28
+              asic_id: 159086384021254486
+            - umd_chip_id: 8
+              asic_position:
+                tray_id: 4
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 92
+              asic_id: 231143978059182391
+            - umd_chip_id: 9
+              asic_position:
+                tray_id: 3
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 95
+              asic_id: 231143978059182401
+            - umd_chip_id: 10
+              asic_position:
+                tray_id: 1
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 47
+              asic_id: 231143978059182419
+            - umd_chip_id: 11
+              asic_position:
+                tray_id: 2
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 44
+              asic_id: 231143978059182422
+            - umd_chip_id: 12
+              asic_position:
+                tray_id: 4
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 76
+              asic_id: 303201572097110327
+            - umd_chip_id: 13
+              asic_position:
+                tray_id: 3
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 79
+              asic_id: 303201572097110337
+            - umd_chip_id: 14
+              asic_position:
+                tray_id: 1
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 63
+              asic_id: 303201572097110355
+            - umd_chip_id: 15
+              asic_position:
+                tray_id: 2
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 60
+              asic_id: 303201572097110358
+            - umd_chip_id: 16
+              asic_position:
+                tray_id: 4
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 125
+              asic_id: 375259166135038263
+            - umd_chip_id: 17
+              asic_position:
+                tray_id: 3
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 126
+              asic_id: 375259166135038273
+            - umd_chip_id: 18
+              asic_position:
+                tray_id: 1
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 14
+              asic_id: 375259166135038291
+            - umd_chip_id: 19
+              asic_position:
+                tray_id: 2
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 13
+              asic_id: 375259166135038294
+            - umd_chip_id: 20
+              asic_position:
+                tray_id: 4
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 109
+              asic_id: 447316760172966199
+            - umd_chip_id: 21
+              asic_position:
+                tray_id: 3
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 110
+              asic_id: 447316760172966209
+            - umd_chip_id: 22
+              asic_position:
+                tray_id: 1
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 30
+              asic_id: 447316760172966227
+            - umd_chip_id: 23
+              asic_position:
+                tray_id: 2
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 29
+              asic_id: 447316760172966230
+            - umd_chip_id: 24
+              asic_position:
+                tray_id: 4
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 93
+              asic_id: 519374354210894135
+            - umd_chip_id: 25
+              asic_position:
+                tray_id: 3
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 94
+              asic_id: 519374354210894145
+            - umd_chip_id: 26
+              asic_position:
+                tray_id: 1
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 46
+              asic_id: 519374354210894163
+            - umd_chip_id: 27
+              asic_position:
+                tray_id: 2
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 45
+              asic_id: 519374354210894166
+            - umd_chip_id: 28
+              asic_position:
+                tray_id: 4
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 77
+              asic_id: 591431948248822071
+            - umd_chip_id: 29
+              asic_position:
+                tray_id: 3
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 78
+              asic_id: 591431948248822081
+            - umd_chip_id: 30
+              asic_position:
+                tray_id: 1
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 62
+              asic_id: 591431948248822099
+            - umd_chip_id: 31
+              asic_position:
+                tray_id: 2
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 61
+              asic_id: 591431948248822102

--- a/tests/tt_metal/tt_fabric/golden_mapping_files/TestQuadGalaxyControlPlaneInit.yaml
+++ b/tests/tt_metal/tt_fabric/golden_mapping_files/TestQuadGalaxyControlPlaneInit.yaml
@@ -1,6 +1,6 @@
 asic_to_fabric_node_mapping:
   hostnames:
-    - hostname: slurm-login_0
+    - hostname: bh-glx-d04u02_0
       mesh:
         - mesh: 0
         - chips:
@@ -10,7 +10,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 0
+                chip_id: 112
               asic_id: 87028755623587893
             - umd_chip_id: 1
               asic_position:
@@ -18,7 +18,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 115
+                chip_id: 3
               asic_id: 87028768508489781
             - umd_chip_id: 2
               asic_position:
@@ -26,7 +26,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 3
+                chip_id: 115
               asic_id: 87028768508489794
             - umd_chip_id: 3
               asic_position:
@@ -34,7 +34,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 112
+                chip_id: 0
               asic_id: 87028789983326265
             - umd_chip_id: 4
               asic_position:
@@ -42,7 +42,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 16
+                chip_id: 96
               asic_id: 159086349661515829
             - umd_chip_id: 5
               asic_position:
@@ -50,7 +50,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 99
+                chip_id: 19
               asic_id: 159086362546417717
             - umd_chip_id: 6
               asic_position:
@@ -58,7 +58,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 19
+                chip_id: 99
               asic_id: 159086362546417730
             - umd_chip_id: 7
               asic_position:
@@ -66,7 +66,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 96
+                chip_id: 16
               asic_id: 159086384021254201
             - umd_chip_id: 8
               asic_position:
@@ -74,7 +74,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 32
+                chip_id: 80
               asic_id: 231143943699443765
             - umd_chip_id: 9
               asic_position:
@@ -82,7 +82,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 83
+                chip_id: 35
               asic_id: 231143956584345653
             - umd_chip_id: 10
               asic_position:
@@ -90,7 +90,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 35
+                chip_id: 83
               asic_id: 231143956584345666
             - umd_chip_id: 11
               asic_position:
@@ -98,7 +98,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 80
+                chip_id: 32
               asic_id: 231143978059182137
             - umd_chip_id: 12
               asic_position:
@@ -106,7 +106,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 48
+                chip_id: 64
               asic_id: 303201537737371701
             - umd_chip_id: 13
               asic_position:
@@ -114,7 +114,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 67
+                chip_id: 51
               asic_id: 303201550622273589
             - umd_chip_id: 14
               asic_position:
@@ -122,7 +122,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 51
+                chip_id: 67
               asic_id: 303201550622273602
             - umd_chip_id: 15
               asic_position:
@@ -130,7 +130,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 64
+                chip_id: 48
               asic_id: 303201572097110073
             - umd_chip_id: 16
               asic_position:
@@ -138,7 +138,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 1
+                chip_id: 113
               asic_id: 375259131775299637
             - umd_chip_id: 17
               asic_position:
@@ -146,7 +146,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 114
+                chip_id: 2
               asic_id: 375259144660201525
             - umd_chip_id: 18
               asic_position:
@@ -154,7 +154,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 2
+                chip_id: 114
               asic_id: 375259144660201538
             - umd_chip_id: 19
               asic_position:
@@ -162,7 +162,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 113
+                chip_id: 1
               asic_id: 375259166135038009
             - umd_chip_id: 20
               asic_position:
@@ -170,7 +170,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 17
+                chip_id: 97
               asic_id: 447316725813227573
             - umd_chip_id: 21
               asic_position:
@@ -178,7 +178,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 98
+                chip_id: 18
               asic_id: 447316738698129461
             - umd_chip_id: 22
               asic_position:
@@ -186,7 +186,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 18
+                chip_id: 98
               asic_id: 447316738698129474
             - umd_chip_id: 23
               asic_position:
@@ -194,7 +194,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 97
+                chip_id: 17
               asic_id: 447316760172965945
             - umd_chip_id: 24
               asic_position:
@@ -202,7 +202,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 33
+                chip_id: 81
               asic_id: 519374319851155509
             - umd_chip_id: 25
               asic_position:
@@ -210,7 +210,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 82
+                chip_id: 34
               asic_id: 519374332736057397
             - umd_chip_id: 26
               asic_position:
@@ -218,7 +218,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 34
+                chip_id: 82
               asic_id: 519374332736057410
             - umd_chip_id: 27
               asic_position:
@@ -226,7 +226,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 81
+                chip_id: 33
               asic_id: 519374354210893881
             - umd_chip_id: 28
               asic_position:
@@ -234,7 +234,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 49
+                chip_id: 65
               asic_id: 591431913889083445
             - umd_chip_id: 29
               asic_position:
@@ -242,7 +242,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 66
+                chip_id: 50
               asic_id: 591431926773985333
             - umd_chip_id: 30
               asic_position:
@@ -250,7 +250,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 50
+                chip_id: 66
               asic_id: 591431926773985346
             - umd_chip_id: 31
               asic_position:
@@ -258,9 +258,9 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 65
+                chip_id: 49
               asic_id: 591431948248821817
-    - hostname: slurm-login_1
+    - hostname: bh-glx-d04u02_1
       mesh:
         - mesh: 0
         - chips:
@@ -270,7 +270,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 119
+                chip_id: 7
               asic_id: 87028777098424372
             - umd_chip_id: 1
               asic_position:
@@ -278,7 +278,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 7
+                chip_id: 119
               asic_id: 87028777098424392
             - umd_chip_id: 2
               asic_position:
@@ -286,7 +286,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 4
+                chip_id: 116
               asic_id: 87028777098424398
             - umd_chip_id: 3
               asic_position:
@@ -294,7 +294,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 116
+                chip_id: 4
               asic_id: 87028789983326288
             - umd_chip_id: 4
               asic_position:
@@ -302,7 +302,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 103
+                chip_id: 23
               asic_id: 159086371136352308
             - umd_chip_id: 5
               asic_position:
@@ -310,7 +310,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 23
+                chip_id: 103
               asic_id: 159086371136352328
             - umd_chip_id: 6
               asic_position:
@@ -318,7 +318,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 20
+                chip_id: 100
               asic_id: 159086371136352334
             - umd_chip_id: 7
               asic_position:
@@ -326,7 +326,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 100
+                chip_id: 20
               asic_id: 159086384021254224
             - umd_chip_id: 8
               asic_position:
@@ -334,7 +334,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 87
+                chip_id: 39
               asic_id: 231143965174280244
             - umd_chip_id: 9
               asic_position:
@@ -342,7 +342,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 39
+                chip_id: 87
               asic_id: 231143965174280264
             - umd_chip_id: 10
               asic_position:
@@ -350,7 +350,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 36
+                chip_id: 84
               asic_id: 231143965174280270
             - umd_chip_id: 11
               asic_position:
@@ -358,7 +358,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 84
+                chip_id: 36
               asic_id: 231143978059182160
             - umd_chip_id: 12
               asic_position:
@@ -366,7 +366,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 71
+                chip_id: 55
               asic_id: 303201559212208180
             - umd_chip_id: 13
               asic_position:
@@ -374,7 +374,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 55
+                chip_id: 71
               asic_id: 303201559212208200
             - umd_chip_id: 14
               asic_position:
@@ -382,7 +382,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 52
+                chip_id: 68
               asic_id: 303201559212208206
             - umd_chip_id: 15
               asic_position:
@@ -390,7 +390,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 68
+                chip_id: 52
               asic_id: 303201572097110096
             - umd_chip_id: 16
               asic_position:
@@ -398,7 +398,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 118
+                chip_id: 6
               asic_id: 375259153250136116
             - umd_chip_id: 17
               asic_position:
@@ -406,7 +406,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 6
+                chip_id: 118
               asic_id: 375259153250136136
             - umd_chip_id: 18
               asic_position:
@@ -414,7 +414,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 5
+                chip_id: 117
               asic_id: 375259153250136142
             - umd_chip_id: 19
               asic_position:
@@ -422,7 +422,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 117
+                chip_id: 5
               asic_id: 375259166135038032
             - umd_chip_id: 20
               asic_position:
@@ -430,7 +430,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 102
+                chip_id: 22
               asic_id: 447316747288064052
             - umd_chip_id: 21
               asic_position:
@@ -438,7 +438,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 22
+                chip_id: 102
               asic_id: 447316747288064072
             - umd_chip_id: 22
               asic_position:
@@ -446,7 +446,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 21
+                chip_id: 101
               asic_id: 447316747288064078
             - umd_chip_id: 23
               asic_position:
@@ -454,7 +454,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 101
+                chip_id: 21
               asic_id: 447316760172965968
             - umd_chip_id: 24
               asic_position:
@@ -462,7 +462,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 86
+                chip_id: 38
               asic_id: 519374341325991988
             - umd_chip_id: 25
               asic_position:
@@ -470,7 +470,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 38
+                chip_id: 86
               asic_id: 519374341325992008
             - umd_chip_id: 26
               asic_position:
@@ -478,7 +478,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 37
+                chip_id: 85
               asic_id: 519374341325992014
             - umd_chip_id: 27
               asic_position:
@@ -486,7 +486,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 85
+                chip_id: 37
               asic_id: 519374354210893904
             - umd_chip_id: 28
               asic_position:
@@ -494,7 +494,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 70
+                chip_id: 54
               asic_id: 591431935363919924
             - umd_chip_id: 29
               asic_position:
@@ -502,7 +502,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 54
+                chip_id: 70
               asic_id: 591431935363919944
             - umd_chip_id: 30
               asic_position:
@@ -510,7 +510,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 53
+                chip_id: 69
               asic_id: 591431935363919950
             - umd_chip_id: 31
               asic_position:
@@ -518,9 +518,9 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 69
+                chip_id: 53
               asic_id: 591431948248821840
-    - hostname: slurm-login_2
+    - hostname: bh-glx-d04u02_2
       mesh:
         - mesh: 0
         - chips:
@@ -530,7 +530,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 8
+                chip_id: 120
               asic_id: 87028789983326263
             - umd_chip_id: 1
               asic_position:
@@ -538,7 +538,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 11
+                chip_id: 123
               asic_id: 87028789983326292
             - umd_chip_id: 2
               asic_position:
@@ -546,7 +546,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 120
+                chip_id: 8
               asic_id: 87028789983326521
             - umd_chip_id: 3
               asic_position:
@@ -554,7 +554,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 123
+                chip_id: 11
               asic_id: 87028789983326768
             - umd_chip_id: 4
               asic_position:
@@ -562,7 +562,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 24
+                chip_id: 104
               asic_id: 159086384021254199
             - umd_chip_id: 5
               asic_position:
@@ -570,7 +570,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 27
+                chip_id: 107
               asic_id: 159086384021254228
             - umd_chip_id: 6
               asic_position:
@@ -578,7 +578,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 104
+                chip_id: 24
               asic_id: 159086384021254457
             - umd_chip_id: 7
               asic_position:
@@ -586,7 +586,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 107
+                chip_id: 27
               asic_id: 159086384021254704
             - umd_chip_id: 8
               asic_position:
@@ -594,7 +594,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 40
+                chip_id: 88
               asic_id: 231143978059182135
             - umd_chip_id: 9
               asic_position:
@@ -602,7 +602,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 43
+                chip_id: 91
               asic_id: 231143978059182164
             - umd_chip_id: 10
               asic_position:
@@ -610,7 +610,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 88
+                chip_id: 40
               asic_id: 231143978059182393
             - umd_chip_id: 11
               asic_position:
@@ -618,7 +618,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 91
+                chip_id: 43
               asic_id: 231143978059182640
             - umd_chip_id: 12
               asic_position:
@@ -626,7 +626,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 56
+                chip_id: 72
               asic_id: 303201572097110071
             - umd_chip_id: 13
               asic_position:
@@ -634,7 +634,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 59
+                chip_id: 75
               asic_id: 303201572097110100
             - umd_chip_id: 14
               asic_position:
@@ -642,7 +642,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 72
+                chip_id: 56
               asic_id: 303201572097110329
             - umd_chip_id: 15
               asic_position:
@@ -650,7 +650,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 75
+                chip_id: 59
               asic_id: 303201572097110576
             - umd_chip_id: 16
               asic_position:
@@ -658,7 +658,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 9
+                chip_id: 121
               asic_id: 375259166135038007
             - umd_chip_id: 17
               asic_position:
@@ -666,7 +666,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 10
+                chip_id: 122
               asic_id: 375259166135038036
             - umd_chip_id: 18
               asic_position:
@@ -674,7 +674,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 121
+                chip_id: 9
               asic_id: 375259166135038265
             - umd_chip_id: 19
               asic_position:
@@ -682,7 +682,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 122
+                chip_id: 10
               asic_id: 375259166135038512
             - umd_chip_id: 20
               asic_position:
@@ -690,7 +690,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 25
+                chip_id: 105
               asic_id: 447316760172965943
             - umd_chip_id: 21
               asic_position:
@@ -698,7 +698,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 26
+                chip_id: 106
               asic_id: 447316760172965972
             - umd_chip_id: 22
               asic_position:
@@ -706,7 +706,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 105
+                chip_id: 25
               asic_id: 447316760172966201
             - umd_chip_id: 23
               asic_position:
@@ -714,7 +714,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 106
+                chip_id: 26
               asic_id: 447316760172966448
             - umd_chip_id: 24
               asic_position:
@@ -722,7 +722,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 41
+                chip_id: 89
               asic_id: 519374354210893879
             - umd_chip_id: 25
               asic_position:
@@ -730,7 +730,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 42
+                chip_id: 90
               asic_id: 519374354210893908
             - umd_chip_id: 26
               asic_position:
@@ -738,7 +738,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 89
+                chip_id: 41
               asic_id: 519374354210894137
             - umd_chip_id: 27
               asic_position:
@@ -746,7 +746,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 90
+                chip_id: 42
               asic_id: 519374354210894384
             - umd_chip_id: 28
               asic_position:
@@ -754,7 +754,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 57
+                chip_id: 73
               asic_id: 591431948248821815
             - umd_chip_id: 29
               asic_position:
@@ -762,7 +762,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 58
+                chip_id: 74
               asic_id: 591431948248821844
             - umd_chip_id: 30
               asic_position:
@@ -770,7 +770,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 73
+                chip_id: 57
               asic_id: 591431948248822073
             - umd_chip_id: 31
               asic_position:
@@ -778,9 +778,9 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 74
+                chip_id: 58
               asic_id: 591431948248822320
-    - hostname: slurm-login_3
+    - hostname: bh-glx-d04u02_3
       mesh:
         - mesh: 0
         - chips:
@@ -790,7 +790,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 124
+                chip_id: 12
               asic_id: 87028789983326519
             - umd_chip_id: 1
               asic_position:
@@ -798,7 +798,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 127
+                chip_id: 15
               asic_id: 87028789983326529
             - umd_chip_id: 2
               asic_position:
@@ -806,7 +806,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 15
+                chip_id: 127
               asic_id: 87028789983326547
             - umd_chip_id: 3
               asic_position:
@@ -814,7 +814,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 1
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 12
+                chip_id: 124
               asic_id: 87028789983326550
             - umd_chip_id: 4
               asic_position:
@@ -822,7 +822,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 108
+                chip_id: 28
               asic_id: 159086384021254455
             - umd_chip_id: 5
               asic_position:
@@ -830,7 +830,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 111
+                chip_id: 31
               asic_id: 159086384021254465
             - umd_chip_id: 6
               asic_position:
@@ -838,7 +838,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 31
+                chip_id: 111
               asic_id: 159086384021254483
             - umd_chip_id: 7
               asic_position:
@@ -846,7 +846,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 2
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 28
+                chip_id: 108
               asic_id: 159086384021254486
             - umd_chip_id: 8
               asic_position:
@@ -854,7 +854,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 92
+                chip_id: 44
               asic_id: 231143978059182391
             - umd_chip_id: 9
               asic_position:
@@ -862,7 +862,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 95
+                chip_id: 47
               asic_id: 231143978059182401
             - umd_chip_id: 10
               asic_position:
@@ -870,7 +870,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 47
+                chip_id: 95
               asic_id: 231143978059182419
             - umd_chip_id: 11
               asic_position:
@@ -878,7 +878,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 3
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 44
+                chip_id: 92
               asic_id: 231143978059182422
             - umd_chip_id: 12
               asic_position:
@@ -886,7 +886,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 76
+                chip_id: 60
               asic_id: 303201572097110327
             - umd_chip_id: 13
               asic_position:
@@ -894,7 +894,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 79
+                chip_id: 63
               asic_id: 303201572097110337
             - umd_chip_id: 14
               asic_position:
@@ -902,7 +902,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 63
+                chip_id: 79
               asic_id: 303201572097110355
             - umd_chip_id: 15
               asic_position:
@@ -910,7 +910,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 4
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 60
+                chip_id: 76
               asic_id: 303201572097110358
             - umd_chip_id: 16
               asic_position:
@@ -918,7 +918,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 125
+                chip_id: 13
               asic_id: 375259166135038263
             - umd_chip_id: 17
               asic_position:
@@ -926,7 +926,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 126
+                chip_id: 14
               asic_id: 375259166135038273
             - umd_chip_id: 18
               asic_position:
@@ -934,7 +934,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 14
+                chip_id: 126
               asic_id: 375259166135038291
             - umd_chip_id: 19
               asic_position:
@@ -942,7 +942,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 5
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 13
+                chip_id: 125
               asic_id: 375259166135038294
             - umd_chip_id: 20
               asic_position:
@@ -950,7 +950,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 109
+                chip_id: 29
               asic_id: 447316760172966199
             - umd_chip_id: 21
               asic_position:
@@ -958,7 +958,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 110
+                chip_id: 30
               asic_id: 447316760172966209
             - umd_chip_id: 22
               asic_position:
@@ -966,7 +966,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 30
+                chip_id: 110
               asic_id: 447316760172966227
             - umd_chip_id: 23
               asic_position:
@@ -974,7 +974,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 6
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 29
+                chip_id: 109
               asic_id: 447316760172966230
             - umd_chip_id: 24
               asic_position:
@@ -982,7 +982,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 93
+                chip_id: 45
               asic_id: 519374354210894135
             - umd_chip_id: 25
               asic_position:
@@ -990,7 +990,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 94
+                chip_id: 46
               asic_id: 519374354210894145
             - umd_chip_id: 26
               asic_position:
@@ -998,7 +998,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 46
+                chip_id: 94
               asic_id: 519374354210894163
             - umd_chip_id: 27
               asic_position:
@@ -1006,7 +1006,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 7
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 45
+                chip_id: 93
               asic_id: 519374354210894166
             - umd_chip_id: 28
               asic_position:
@@ -1014,7 +1014,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 77
+                chip_id: 61
               asic_id: 591431948248822071
             - umd_chip_id: 29
               asic_position:
@@ -1022,7 +1022,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 78
+                chip_id: 62
               asic_id: 591431948248822081
             - umd_chip_id: 30
               asic_position:
@@ -1030,7 +1030,7 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 62
+                chip_id: 78
               asic_id: 591431948248822099
             - umd_chip_id: 31
               asic_position:
@@ -1038,5 +1038,5 @@ asic_to_fabric_node_mapping:
                 asic_location: 8
               fabric_node_id:
                 mesh_id: 0
-                chip_id: 61
+                chip_id: 77
               asic_id: 591431948248822102

--- a/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
+++ b/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
@@ -416,6 +416,22 @@ void validate_pipeline(const std::vector<BlitzDecodePipelineStage>& stages, bool
             coord_str(s.entry_node_coord));
     }
 
+    // 1b. Entry and exit on different mesh columns (coord[1]) when coordinates are 2D: coord[1] is the LINE axis
+    // (second MGD dim, e.g. width 2 in blitz decode 4x2). Skip for 1D meshes (no coord[1]).
+    for (std::size_t i = 0; i < check_distinct_until; i++) {
+        const auto& s = stages[i];
+        if (s.entry_node_coord.dims() < 2) {
+            continue;
+        }
+        TT_FATAL(
+            s.entry_node_coord[1] != s.exit_node_coord[1],
+            "Stage [{}] (stage_index={}) entry and exit must use different mesh columns (coord[1]): entry {} exit {}",
+            i,
+            s.stage_index,
+            coord_str(s.entry_node_coord),
+            coord_str(s.exit_node_coord));
+    }
+
     // 2. No coord is reused across stages (no overlapping nodes).
     // Skip the last stage's exit when !initialize_loopback — it has no downstream exit.
     std::set<std::pair<std::size_t, std::pair<uint32_t, uint32_t>>> used_coords;

--- a/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
+++ b/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
@@ -417,10 +417,20 @@ void validate_pipeline(const std::vector<BlitzDecodePipelineStage>& stages, bool
     }
 
     // 1b. Entry and exit on different mesh columns (coord[1]) when coordinates are 2D: coord[1] is the LINE axis
-    // (second MGD dim, e.g. width 2 in blitz decode 4x2). Skip for 1D meshes (no coord[1]).
+    // (second MGD dim, e.g. width 2 in blitz decode 4x2). Skip for 1D meshes (no coord[1]). Skip when an adjacent
+    // hop in the ring is intra-mesh (same stage_index as previous or next stage): LINE-axis separation may be
+    // infeasible for those legs while still satisfying hop and unclaimed-node constraints.
+    const std::size_t n = stages.size();
     for (std::size_t i = 0; i < check_distinct_until; i++) {
         const auto& s = stages[i];
         if (s.entry_node_coord.dims() < 2) {
+            continue;
+        }
+        const std::size_t prev_i = (i + n - 1) % n;
+        const std::size_t next_i = (i + 1) % n;
+        const bool incoming_intra_mesh = stages[prev_i].stage_index == s.stage_index;
+        const bool outgoing_intra_mesh = s.stage_index == stages[next_i].stage_index;
+        if (incoming_intra_mesh || outgoing_intra_mesh) {
             continue;
         }
         TT_FATAL(

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -116,6 +116,40 @@ std::vector<std::pair<FabricNodeId, std::vector<AsicPosition>>> get_galaxy_fixed
     return fixed_asic_position_pinnings;
 }
 
+// Blitz decode pipeline: octet mesh (4x2 device topology, 8 chips) ASIC-position pinnings for chips 0, 3, and 7 on
+// Blackhole Galaxy (QSFP / tray layout vs logical mesh). Only used when cluster is Blackhole Galaxy and the mesh
+// shape matches decode MGDs (dims [4,2]).
+std::vector<std::pair<FabricNodeId, std::vector<AsicPosition>>>
+get_blitz_decode_pipeline_asic_position_pinnings_for_mesh(MeshId mesh_id, const MeshShape& mesh_shape) {
+    std::vector<std::pair<FabricNodeId, std::vector<AsicPosition>>> fixed_asic_position_pinnings;
+    if (mesh_shape.mesh_size() != 8 || mesh_shape[0] != 4 || mesh_shape[1] != 2) {
+        return fixed_asic_position_pinnings;
+    }
+
+    std::vector<AsicPosition> node0_positions;
+    node0_positions.emplace_back(AsicPosition{1, 1});
+    node0_positions.emplace_back(AsicPosition{1, 3});
+    node0_positions.emplace_back(AsicPosition{2, 4});
+    node0_positions.emplace_back(AsicPosition{2, 2});
+
+    std::vector<AsicPosition> node3_positions;
+    node3_positions.emplace_back(AsicPosition{3, 1});
+    node3_positions.emplace_back(AsicPosition{3, 3});
+    node3_positions.emplace_back(AsicPosition{4, 4});
+    node3_positions.emplace_back(AsicPosition{4, 2});
+
+    std::vector<AsicPosition> node7_positions;
+    node7_positions.emplace_back(AsicPosition{3, 2});
+    node7_positions.emplace_back(AsicPosition{3, 4});
+    node7_positions.emplace_back(AsicPosition{4, 3});
+    node7_positions.emplace_back(AsicPosition{4, 1});
+
+    fixed_asic_position_pinnings.emplace_back(FabricNodeId{mesh_id, 0}, std::move(node0_positions));
+    fixed_asic_position_pinnings.emplace_back(FabricNodeId{mesh_id, 6}, std::move(node3_positions));
+    fixed_asic_position_pinnings.emplace_back(FabricNodeId{mesh_id, 7}, std::move(node7_positions));
+    return fixed_asic_position_pinnings;
+}
+
 template <typename CONNECTIVITY_MAP_T>
 void build_golden_link_counts(
     CONNECTIVITY_MAP_T const& golden_connectivity_map,
@@ -496,8 +530,12 @@ void ControlPlane::init_control_plane(
                 const bool is_1d = mesh_shape[0] == 1 || mesh_shape[1] == 1;
                 const size_t mesh_chip_count = mesh_shape.mesh_size();
 
-                // Only apply galaxy pinnings if mesh has multiple of 32 chips and is not 1D
-                if (!is_1d && mesh_chip_count % 32 == 0) {
+                if (cluster.get_cluster_type() == tt::tt_metal::ClusterType::BLACKHOLE_GALAXY && !is_1d &&
+                    mesh_chip_count == 8 && mesh_shape[0] == 4 && mesh_shape[1] == 2) {
+                    auto mesh_pinnings = get_blitz_decode_pipeline_asic_position_pinnings_for_mesh(mesh_id, mesh_shape);
+                    fixed_asic_position_pinnings.insert(
+                        fixed_asic_position_pinnings.end(), mesh_pinnings.begin(), mesh_pinnings.end());
+                } else if (!is_1d && mesh_chip_count % 32 == 0) {
                     auto mesh_pinnings =
                         get_galaxy_fixed_asic_position_pinnings_for_mesh(mesh_id, mesh_shape, world_size == 1);
                     fixed_asic_position_pinnings.insert(
@@ -606,8 +644,12 @@ void ControlPlane::init_control_plane_auto_discovery() {
             const bool is_1d = mesh_shape[0] == 1 || mesh_shape[1] == 1;
             const size_t mesh_chip_count = mesh_shape.mesh_size();
 
-            // Only apply galaxy pinnings if mesh has multiple of 32 chips and is not 1D
-            if (!is_1d && mesh_chip_count % 32 == 0) {
+            if (cluster.get_cluster_type() == tt::tt_metal::ClusterType::BLACKHOLE_GALAXY && !is_1d &&
+                mesh_chip_count == 8 && mesh_shape[0] == 4 && mesh_shape[1] == 2) {
+                auto mesh_pinnings = get_blitz_decode_pipeline_asic_position_pinnings_for_mesh(mesh_id, mesh_shape);
+                fixed_asic_position_pinnings.insert(
+                    fixed_asic_position_pinnings.end(), mesh_pinnings.begin(), mesh_pinnings.end());
+            } else if (!is_1d && mesh_chip_count % 32 == 0) {
                 auto mesh_pinnings =
                     get_galaxy_fixed_asic_position_pinnings_for_mesh(mesh_id, mesh_shape, world_size == 1);
                 fixed_asic_position_pinnings.insert(

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -116,9 +116,9 @@ std::vector<std::pair<FabricNodeId, std::vector<AsicPosition>>> get_galaxy_fixed
     return fixed_asic_position_pinnings;
 }
 
-// Blitz decode pipeline: octet mesh (4x2 device topology, 8 chips) ASIC-position pinnings for chips 0, 3, and 7 on
-// Blackhole Galaxy (QSFP / tray layout vs logical mesh). Only used when cluster is Blackhole Galaxy and the mesh
-// shape matches decode MGDs (dims [4,2]).
+// Blitz decode pipeline: octet mesh (4x2 device topology, 8 chips) ASIC-position pinnings for chips 0, 1, 2, 5,
+// 6, and 7 on Blackhole Galaxy (QSFP / tray layout vs logical mesh). Only used when cluster is Blackhole Galaxy
+// and the mesh shape matches decode MGDs (dims [4,2]).
 std::vector<std::pair<FabricNodeId, std::vector<AsicPosition>>>
 get_blitz_decode_pipeline_asic_position_pinnings_for_mesh(MeshId mesh_id, const MeshShape& mesh_shape) {
     std::vector<std::pair<FabricNodeId, std::vector<AsicPosition>>> fixed_asic_position_pinnings;

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -129,23 +129,32 @@ get_blitz_decode_pipeline_asic_position_pinnings_for_mesh(MeshId mesh_id, const 
     std::vector<AsicPosition> node0_positions;
     node0_positions.emplace_back(AsicPosition{1, 1});
     node0_positions.emplace_back(AsicPosition{1, 3});
-    node0_positions.emplace_back(AsicPosition{2, 4});
-    node0_positions.emplace_back(AsicPosition{2, 2});
 
-    std::vector<AsicPosition> node3_positions;
-    node3_positions.emplace_back(AsicPosition{3, 1});
-    node3_positions.emplace_back(AsicPosition{3, 3});
-    node3_positions.emplace_back(AsicPosition{4, 4});
-    node3_positions.emplace_back(AsicPosition{4, 2});
+    std::vector<AsicPosition> node1_positions;
+    node1_positions.emplace_back(AsicPosition{1, 2});
+    node1_positions.emplace_back(AsicPosition{1, 4});
+
+    std::vector<AsicPosition> node2_positions;
+    node2_positions.emplace_back(AsicPosition{1, 5});
+    node2_positions.emplace_back(AsicPosition{1, 7});
+
+    std::vector<AsicPosition> node5_positions;
+    node5_positions.emplace_back(AsicPosition{4, 5});
+    node5_positions.emplace_back(AsicPosition{4, 7});
+
+    std::vector<AsicPosition> node6_positions;
+    node6_positions.emplace_back(AsicPosition{4, 2});
+    node6_positions.emplace_back(AsicPosition{4, 4});
 
     std::vector<AsicPosition> node7_positions;
-    node7_positions.emplace_back(AsicPosition{3, 2});
-    node7_positions.emplace_back(AsicPosition{3, 4});
-    node7_positions.emplace_back(AsicPosition{4, 3});
     node7_positions.emplace_back(AsicPosition{4, 1});
+    node7_positions.emplace_back(AsicPosition{4, 3});
 
     fixed_asic_position_pinnings.emplace_back(FabricNodeId{mesh_id, 0}, std::move(node0_positions));
-    fixed_asic_position_pinnings.emplace_back(FabricNodeId{mesh_id, 6}, std::move(node3_positions));
+    fixed_asic_position_pinnings.emplace_back(FabricNodeId{mesh_id, 1}, std::move(node1_positions));
+    fixed_asic_position_pinnings.emplace_back(FabricNodeId{mesh_id, 2}, std::move(node2_positions));
+    fixed_asic_position_pinnings.emplace_back(FabricNodeId{mesh_id, 5}, std::move(node5_positions));
+    fixed_asic_position_pinnings.emplace_back(FabricNodeId{mesh_id, 6}, std::move(node6_positions));
     fixed_asic_position_pinnings.emplace_back(FabricNodeId{mesh_id, 7}, std::move(node7_positions));
     return fixed_asic_position_pinnings;
 }

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -1795,10 +1795,10 @@ void add_pinning_constraints(
         for (const auto& position : positions) {
             auto it = asic_positions_to_asic_ids.find(position);
             if (it == asic_positions_to_asic_ids.end()) {
-                log_critical(
+                log_warning(
                     tt::LogFabric,
                     "Pinned ASIC position (tray_id: {}, asic_location: {}) to fabric node id (mesh_id: {}, chip_id: "
-                    "{}) from MGD not found in physical topology",
+                    "{}) from MGD not found in physical topology; skipping this pin",
                     position.first.get(),
                     position.second.get(),
                     fabric_node.mesh_id.get(),
@@ -1818,7 +1818,12 @@ void add_pinning_constraints(
             }
         }
     }
-    TT_FATAL(success, "Failed to add pinning constraints");
+    if (!success) {
+        log_warning(
+            tt::LogFabric,
+            "Some pinning constraints were skipped because the ASIC (tray, location) was absent from the physical "
+            "mesh; topology mapping proceeds without those pins");
+    }
 }
 
 // Parallel physical inter-mesh edges from one exit ASIC to a destination mesh (each edge is one link / channel).

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -1818,6 +1818,8 @@ void add_pinning_constraints(
             }
         }
     }
+    // TODO: Would like to communicate this to the caller so they can fail the mapping if any pinnings are skipped.
+    // https://github.com/tenstorrent/tt-metal/issues/43451
     if (!success) {
         log_warning(
             tt::LogFabric,


### PR DESCRIPTION
# Blitz decode on Blackhole Galaxy: fixed ASIC pinnings and validation

## Summary

Improves **topology mapping** and **pipeline validation** for **Blitz-style decode** on **Blackhole Galaxy UBB** when each logical mesh is an **8-chip, 4×2** layout (non-1D). The goal is to align logical fabric node IDs with the **physical tray / ASIC locations** used on Galaxy SKUs, without hard-failing when the mesh graph pins a location that is absent in the current PSD (e.g. mock or partial systems).

This pinning guarantees that all meshes have a consistent Coordinate system of:
```
00 10 20 30
01 11 21 31
```

## Control plane: Blitz decode ASIC-position pinnings

- Adds **`get_blitz_decode_pipeline_asic_position_pinnings_for_mesh`**, which returns candidate `(tray_id, asic_location)` sets per **fabric chip** for the octet layout (`mesh_size == 8`, shape **`[4, 2]`**).
- Current chips covered: **0, 1, 2, 5, 6, 7** (each with a small list of allowed tray/location pairs appropriate for Galaxy cabling vs. the decode MGD).
- Applied during **`ControlPlane::init_control_plane`** and **`init_control_plane_auto_discovery`** when:
  - cluster is **`is_ubb_galaxy()`**,
  - **`ClusterType::BLACKHOLE_GALAXY`**,
  - mesh is **not** 1D,
  - mesh shape matches **4×2** and **8** devices.
- This path is **in addition to** the existing **32-chip** Galaxy corner-pinning path (`get_galaxy_fixed_asic_position_pinnings_for_mesh`) for larger meshes.

## Topology mapper: resilient MGD pinnings

- **`add_pinning_constraints`**: if an MGD-specified ASIC position has **no matching ASIC in the physical topology**, the mapper now **logs a warning and skips that pin** instead of fatally aborting. A **single summary warning** is emitted if any pin was skipped.

## Blitz decode pipeline validation

- **`validate_pipeline`** in **`blitz_decode_pipeline.cpp`**: for stages where entry/exit coordinates are **2D**, asserts **entry and exit differ on `coord[1]`** (LINE / second MGD dimension, e.g. width **2** on 4×2 decode meshes). Skips this check when **`dims() < 2`** (1D coordinates). Uses the same **loopback / no-loopback** bounds as the existing “distinct entry/exit” check.

## Fabric router tests (SP5)

- **`validate_sp5_blitz_decode_pipeline_stages`**: adds **`EXPECT_NE(entry[1], exit[1])`** per stage so tests match the production pipeline column invariant.

## How to verify

- Run **fabric / routing-table** coverage that builds Blitz decode on BH Galaxy 4×2 MGDs (including **`test_routing_tables`** SP5 Blitz path where applicable).
- On systems where MGD pins don’t exist physically, confirm **warnings** appear and mapping **continues** instead of **`TT_FATAL`**.

---

*Remove or relocate this file after opening the PR if you prefer not to keep PR drafts in-repo.*

### DeepSeek Blitz Decode CI

Dispatched the DeepSeek B1 Decode (Blitz pipeline) test group from the **"(Release) Model Status for Console Deployment"** workflow (`.github/workflows/demo-sp-release.yaml`, `test-group=deepseek_decode`, SKUs `bh_p300,bh_galaxy`) against this branch:

- DeepSeek Decode (Blitz, BH Galaxy): https://github.com/tenstorrent/tt-metal/actions/runs/26829440869 (commit `80c8e13`)

### Local SP1 run (Blackhole Galaxy, 4×32 single pod) — commit `80c8e13`

Because the dispatched CI wasn't exercising this path, ran the DeepSeek B1 **SP1** demo locally on a reserved 4-galaxy Blackhole quad (`BH_GALAXY_REV_AB`, hosts `bh-glx-d07u02/08,d08u02/08`) via SLURM, built from this branch, launched with **ttrun auto-allocation** mode:

```
tt-run --tcp-interface ens5f0np0 \
  --mesh-graph-descriptor models/demos/deepseek_v3_b1/scaleout_configs/blitz_decode_single_pod_mesh_graph_descriptor.textproto \
  --hosts <quad> --force-rediscovery \
  python3 -m models.demos.deepseek_v3_b1.demo.cli --max-new-tokens 4096 --no-stop-at-eos --weights real \
    --cache-path /mnt/models/deepseek-ai/cache-2026-03-22 --model-path /mnt/models/deepseek-ai/DeepSeek-R1-0528-dequantized
```

Result:
- ✅ Cluster reset + validation healthy (`recover.sh --config 4x32`)
- ✅ ttrun Phase 1 `generate_rank_bindings` discovered the device map (auto-handles galaxy rev)
- ✅ **Topology mapping / control-plane init succeeded** — all **16 ranks** opened the mesh device, compiled kernels, loaded weights, and entered compute. This exercises and validates this PR's eth-coord / non-1D 4×2 BH-galaxy topology-mapping path through model execution.
- ❌ Blocked **downstream** at the `lm_head_sampling` stage: `TT_FATAL: No available semaphore ID for buffer index semaphore` (`tt_metal/fabric/fabric.cpp:192`), via `micro_ops/ccl_broadcast` (rank 14) — fabric semaphore-ID exhaustion, separate from this PR's mapping changes. (Note: the committed `rev_c_*` single-pod rank bindings are rev-c-specific and do **not** map on rev_AB hardware — must use ttrun auto mode / `--mesh-graph-descriptor` there.)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ridvan/socket-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ridvan/socket-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ridvan/socket-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ridvan/socket-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ridvan/socket-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ridvan/socket-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ridvan/socket-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ridvan/socket-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ridvan/socket-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ridvan/socket-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ridvan/socket-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ridvan/socket-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ridvan/socket-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ridvan/socket-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ridvan/socket-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ridvan/socket-issue)

