### PR TITLE
use can_sample_on_device vllm contract

### DIFF
--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -3057,8 +3057,9 @@ class DeepseekGenerator(WarmupForwardMixin):
             return
 
         user_id = 0
+        original_sample_on_device = getattr(self, "sample_on_device", False)
         if sample_on_device is None or self.vllm_context:
-            sample_on_device_list = [False, True]
+            sample_on_device_list = [False, True] if can_sample_on_device else [False]
         else:
             sample_on_device_list = [sample_on_device]
 
@@ -3101,6 +3102,13 @@ class DeepseekGenerator(WarmupForwardMixin):
                     except Exception as e:
                         logger.warning(f"Failed to deallocate prefill logits: {e}")
 
+        if getattr(self, "sample_on_device", False) != original_sample_on_device:
+            # Warmup may initialize sampling internals; restore the caller's expected mode.
+            self._validate_and_initialize_sampling(
+                None,
+                original_sample_on_device,
+                enable_trace=enable_trace,
+            )
         # Warmup creates temporary page tables; clean them up to free memory.
         try:
             if self.page_tables_tt is not None:


### PR DESCRIPTION
## Summary
Fixes: https://github.com/tenstorrent/tt-metal/issues/43391

- align DeepSeek vLLM path with can_sample_on_device contract
- update generator behavior to match the vLLM sampling contract expectations
## Test plan
  - [x] Run `quad_teacher_forced`
  - [x] Run `dual_teacher_forced`
  - [x] Run `quad_demo`
  - [x] Run `dual_demo`
  - [x] Run `quad_demo_stress`

dual, quad demo o/p is good for 32upr and 8upr. stress test of quad also passed. (dual stress test not run)
TF demo acc summary:
```
+-------+------+----------------+----------------+
| Mesh  | UPR  | Top-1 Accuracy | Top-5 Accuracy |
+-------+------+----------------+----------------+
| Dual  | 8    | 89.8%          | 98.4%          |
| Dual  | 32   | 92.2%          | 96.9%          |
| Quad  | 8    | 83.6%          | 98.4%          |
| Quad  | 32   | 87.5%          | 99.2%          |
+-------+------+----------------+----------------+
```