### PR TITLE
Column Wise Pipeline Stage Sync for Blitz

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/column_wise_pipeline_stage_sync/kernels/column_wise_pipeline_stage_sync_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/column_wise_pipeline_stage_sync/kernels/column_wise_pipeline_stage_sync_kernel.cpp
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unified PipelineStageSync Kernel.
+ *
+ * Uses the unified PipelineStageSync op from unified_kernels/pipeline_stage_sync.hpp
+ */
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+#include "../../../unified_kernels/pipeline_stage_sync.hpp"
+
+void kernel_main() {
+    using PipelineStageSync = deepseek_b1_ops::PipelineStageSync;
+
+#if defined(COMPILE_FOR_NCRISC)
+    // Reader CTArgs
+    using CTArgs = PipelineStageSync::ReaderCTArgs<
+        get_named_compile_time_arg_val("run_stalling_logic_on_ncrisc"),
+        get_named_compile_time_arg_val("run_signalling_logic_on_ncrisc"),
+        get_named_compile_time_arg_val("is_intermediate_signaller"),
+        get_named_compile_time_arg_val("is_signalling_to_intermediate_signaller"),
+        get_named_compile_time_arg_val("signalling_core_noc_x_addr"),
+        get_named_compile_time_arg_val("signalling_core_noc_y_addr"),
+        get_named_compile_time_arg_val("stalling_core_noc_x_addr"),
+        get_named_compile_time_arg_val("stalling_core_noc_y_addr"),
+        get_named_compile_time_arg_val("semaphore_l1_addr"),
+        get_named_compile_time_arg_val("fabric_arg_base")>;
+
+    // Reader runtime args
+    PipelineStageSync::ReaderArgs rt_args = {};
+
+#elif defined(COMPILE_FOR_BRISC)
+    // Writer CTArgs
+    using CTArgs = PipelineStageSync::WriterCTArgs<
+        get_named_compile_time_arg_val("run_stalling_logic_on_brisc"),
+        get_named_compile_time_arg_val("run_signalling_logic_on_brisc"),
+        get_named_compile_time_arg_val("is_intermediate_signaller"),
+        get_named_compile_time_arg_val("is_signalling_to_intermediate_signaller"),
+        get_named_compile_time_arg_val("signalling_core_noc_x_addr"),
+        get_named_compile_time_arg_val("signalling_core_noc_y_addr"),
+        get_named_compile_time_arg_val("stalling_core_noc_x_addr"),
+        get_named_compile_time_arg_val("stalling_core_noc_y_addr"),
+        get_named_compile_time_arg_val("semaphore_l1_addr"),
+        get_named_compile_time_arg_val("fabric_arg_base")>;
+
+    // Writer runtime args
+    PipelineStageSync::WriterArgs rt_args = {};
+
+#elif defined(COMPILE_FOR_TRISC)
+    // Compute CTArgs
+    using CTArgs = PipelineStageSync::ComputeCTArgs;
+
+    // Compute runtime args
+    PipelineStageSync::ComputeArgs rt_args = {};
+#endif
+
+    // Execute the op (looped for testing iteration correctness)
+    constexpr uint32_t num_iterations = get_named_compile_time_arg_val("num_iterations");
+    PipelineStageSync::Op<CTArgs> op;
+    for (uint32_t iteration = 0; iteration < num_iterations; ++iteration) {
+        op(rt_args);
+    }
+}

--- a/models/demos/deepseek_v3_b1/micro_ops/column_wise_pipeline_stage_sync/kernels/column_wise_pipeline_stage_sync_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/column_wise_pipeline_stage_sync/kernels/column_wise_pipeline_stage_sync_kernel.cpp
@@ -3,63 +3,59 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Unified PipelineStageSync Kernel.
+ * Unified ColumnWisePipelineStageSync Kernel.
  *
- * Uses the unified PipelineStageSync op from unified_kernels/pipeline_stage_sync.hpp
+ * Uses the unified ColumnWisePipelineStageSync op from unified_kernels/column_wise_pipeline_stage_sync.hpp
  */
 
 #include "../../../unified_kernels/kernel_op_api.hpp"
 #include "../../../unified_kernels/kernel_utils.hpp"
-#include "../../../unified_kernels/pipeline_stage_sync.hpp"
+#include "../../../unified_kernels/column_wise_pipeline_stage_sync.hpp"
 
 void kernel_main() {
-    using PipelineStageSync = deepseek_b1_ops::PipelineStageSync;
+    using ColumnWisePipelineStageSync = deepseek_b1_ops::ColumnWisePipelineStageSync;
 
 #if defined(COMPILE_FOR_NCRISC)
     // Reader CTArgs
-    using CTArgs = PipelineStageSync::ReaderCTArgs<
-        get_named_compile_time_arg_val("run_stalling_logic_on_ncrisc"),
-        get_named_compile_time_arg_val("run_signalling_logic_on_ncrisc"),
-        get_named_compile_time_arg_val("is_intermediate_signaller"),
-        get_named_compile_time_arg_val("is_signalling_to_intermediate_signaller"),
-        get_named_compile_time_arg_val("signalling_core_noc_x_addr"),
-        get_named_compile_time_arg_val("signalling_core_noc_y_addr"),
-        get_named_compile_time_arg_val("stalling_core_noc_x_addr"),
-        get_named_compile_time_arg_val("stalling_core_noc_y_addr"),
-        get_named_compile_time_arg_val("semaphore_l1_addr"),
+    using CTArgs = ColumnWisePipelineStageSync::ReaderCTArgs<
+        get_named_compile_time_arg_val("run_entry_device_logic_on_ncrisc"),
+        get_named_compile_time_arg_val("run_exit_device_logic_on_ncrisc"),
+        get_named_compile_time_arg_val("entry_device_core_noc_x_addr"),
+        get_named_compile_time_arg_val("entry_device_core_noc_y_addr"),
+        get_named_compile_time_arg_val("r1_semaphore_l1_addr"),
+        get_named_compile_time_arg_val("r2_semaphore_l1_addr"),
+        get_named_compile_time_arg_val("r3_semaphore_l1_addr"),
         get_named_compile_time_arg_val("fabric_arg_base")>;
 
     // Reader runtime args
-    PipelineStageSync::ReaderArgs rt_args = {};
+    ColumnWisePipelineStageSync::ReaderArgs rt_args = {};
 
 #elif defined(COMPILE_FOR_BRISC)
     // Writer CTArgs
-    using CTArgs = PipelineStageSync::WriterCTArgs<
-        get_named_compile_time_arg_val("run_stalling_logic_on_brisc"),
-        get_named_compile_time_arg_val("run_signalling_logic_on_brisc"),
-        get_named_compile_time_arg_val("is_intermediate_signaller"),
-        get_named_compile_time_arg_val("is_signalling_to_intermediate_signaller"),
-        get_named_compile_time_arg_val("signalling_core_noc_x_addr"),
-        get_named_compile_time_arg_val("signalling_core_noc_y_addr"),
-        get_named_compile_time_arg_val("stalling_core_noc_x_addr"),
-        get_named_compile_time_arg_val("stalling_core_noc_y_addr"),
-        get_named_compile_time_arg_val("semaphore_l1_addr"),
+    using CTArgs = ColumnWisePipelineStageSync::WriterCTArgs<
+        get_named_compile_time_arg_val("run_entry_device_logic_on_brisc"),
+        get_named_compile_time_arg_val("run_exit_device_logic_on_brisc"),
+        get_named_compile_time_arg_val("entry_device_core_noc_x_addr"),
+        get_named_compile_time_arg_val("entry_device_core_noc_y_addr"),
+        get_named_compile_time_arg_val("r1_semaphore_l1_addr"),
+        get_named_compile_time_arg_val("r2_semaphore_l1_addr"),
+        get_named_compile_time_arg_val("r3_semaphore_l1_addr"),
         get_named_compile_time_arg_val("fabric_arg_base")>;
 
     // Writer runtime args
-    PipelineStageSync::WriterArgs rt_args = {};
+    ColumnWisePipelineStageSync::WriterArgs rt_args = {};
 
 #elif defined(COMPILE_FOR_TRISC)
     // Compute CTArgs
-    using CTArgs = PipelineStageSync::ComputeCTArgs;
+    using CTArgs = ColumnWisePipelineStageSync::ComputeCTArgs;
 
     // Compute runtime args
-    PipelineStageSync::ComputeArgs rt_args = {};
+    ColumnWisePipelineStageSync::ComputeArgs rt_args = {};
 #endif
 
     // Execute the op (looped for testing iteration correctness)
     constexpr uint32_t num_iterations = get_named_compile_time_arg_val("num_iterations");
-    PipelineStageSync::Op<CTArgs> op;
+    ColumnWisePipelineStageSync::Op<CTArgs> op;
     for (uint32_t iteration = 0; iteration < num_iterations; ++iteration) {
         op(rt_args);
     }

--- a/models/demos/deepseek_v3_b1/micro_ops/column_wise_pipeline_stage_sync/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/column_wise_pipeline_stage_sync/op.py
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+PipelineStageSync Operation using ttnn.generic_op
+
+This module implements a multi-device synchronization on an arbitrary mesh.
+
+"""
+
+
+import ttnn
+from models.demos.deepseek_v3_b1.unified_kernel_descriptor import PerCoreCompileTimeDescriptor, UnifiedKernelDescriptor
+
+
+def build_signalling_path(src_device_mesh_coord, dst_device_mesh_coord, mesh_rows, mesh_cols):
+    src_row, src_col = src_device_mesh_coord[0], src_device_mesh_coord[1]
+    dst_row, dst_col = dst_device_mesh_coord[0], dst_device_mesh_coord[1]
+
+    path = [ttnn.MeshCoordinate(src_row, src_col)]
+    current_row, current_col = src_row, src_col
+
+    # traverse across rows first (wrap around present)
+    positive_row_distance = (dst_row - src_row) % mesh_rows
+    negative_row_distance = (src_row - dst_row) % mesh_rows
+
+    if positive_row_distance <= negative_row_distance:
+        row_step = 1
+        row_num_hops = positive_row_distance
+    else:
+        row_step = -1
+        row_num_hops = negative_row_distance
+
+    for _ in range(row_num_hops):
+        current_row = (current_row + row_step) % mesh_rows
+        path.append(ttnn.MeshCoordinate(current_row, current_col))
+
+    # traverse across cols second (wrap around not present)
+    while current_col != dst_col:
+        current_col += 1 if dst_col > current_col else -1
+        path.append(ttnn.MeshCoordinate(current_row, current_col))
+
+    # signalling and intermediate signalling sets
+    signalling_devices = set(path[0:-1])
+    intermediate_signalling_devices = set(path[1:-1])
+
+    # build signalling device to target device mapping
+    signaller_device_mapping = {}
+    for i in range(len(path) - 1):
+        signaller_device_mapping[path[i]] = path[i + 1]
+
+    return signalling_devices, intermediate_signalling_devices, signaller_device_mapping
+
+
+class PipelineStageSync:
+    """
+    Multi-device PipelineStageSync implementation using ttnn.generic_op.
+    """
+
+    @staticmethod
+    def golden() -> None:
+        # NOTE: micro op is purely for synchronization, no associated golden
+        return
+
+    @staticmethod
+    def op(
+        pseudo_input_tensor: ttnn.Tensor,
+        pseudo_output_tensor: ttnn.Tensor,
+        mesh_device: ttnn.MeshDevice,
+        semaphore,
+        src_device_mesh_coord: ttnn.MeshCoordinate,
+        signalling_core: ttnn.CoreCoord,
+        run_signalling_kernel_on_ncrisc: bool,
+        dst_device_mesh_coord: ttnn.MeshCoordinate,
+        stalling_core: ttnn.CoreCoord,
+        run_stalling_kernel_on_ncrisc: bool,
+        num_iterations: int = 1,
+    ) -> None:
+        """
+        Execute PipelineStageSync using generic_op.
+
+        Args:
+            mesh_device: mesh_device micro op operates on
+            semaphore: global semaphore used in op
+            src_device_mesh_coord: src mesh coordinate
+            signalling_core: core that signalling logic is executed on
+            run_signalling_kernel_on_ncrisc: whether to run the signalling kernel on ncrisc or brisc
+            dst_device_mesh_coord: dst mesh coordinate
+            stalling_core: core that stalling logic is executed on
+            run_stalling_kernel_on_ncrisc: whether to run the stalling kernel on ncrisc or brisc
+            num_iterations: Number of iterations to run inside the kernel
+
+        Returns:
+            None
+        """
+
+        # mesh details
+        mesh_shape = mesh_device.shape
+        mesh_rows = mesh_shape[0]
+        mesh_cols = mesh_shape[1]
+
+        # create mesh program descriptor
+        mesh_program_descriptor = ttnn.MeshProgramDescriptor()
+
+        # kernel path
+        kernel_path = "models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/kernels/pipeline_stage_sync_kernel.cpp"
+
+        if src_device_mesh_coord == dst_device_mesh_coord:
+            raise ValueError("src and dst device cannot be the same")
+
+        # cores
+        if stalling_core == signalling_core:
+            all_cores_core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(stalling_core, stalling_core)])
+        else:
+            all_cores_core_range_set = ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(stalling_core, stalling_core),
+                    ttnn.CoreRange(signalling_core, signalling_core),
+                ]
+            )
+
+        signalling_core_phys = mesh_device.worker_core_from_logical_core(signalling_core)
+        signalling_core_noc_x_addr = signalling_core_phys.x
+        signalling_core_noc_y_addr = signalling_core_phys.y
+
+        stalling_core_phys = mesh_device.worker_core_from_logical_core(stalling_core)
+        stalling_core_noc_x_addr = stalling_core_phys.x
+        stalling_core_noc_y_addr = stalling_core_phys.y
+
+        # semaphores
+        semaphore_l1_addr = ttnn.get_global_semaphore_address(semaphore)
+
+        # construct path
+        signalling_devices, intermediate_signalling_devices, signaller_device_mapping = build_signalling_path(
+            src_device_mesh_coord, dst_device_mesh_coord, mesh_rows, mesh_cols
+        )
+
+        for row in range(mesh_rows):
+            for col in range(mesh_cols):
+                mesh_coord = ttnn.MeshCoordinate(row, col)
+                target_device = signaller_device_mapping.get(mesh_coord, None)
+
+                # === Compile-time args ===
+
+                # Reader (NCRISC) and Writer (BRISC) compile-time args
+                is_intermediate_signaller = mesh_coord in intermediate_signalling_devices
+                is_signalling_to_intermediate_signaller = (
+                    mesh_coord in signalling_devices and target_device in intermediate_signalling_devices
+                )
+
+                fabric_arg_base = 0
+                reader_named_ct_args = [
+                    ("is_intermediate_signaller", is_intermediate_signaller),
+                    ("is_signalling_to_intermediate_signaller", is_signalling_to_intermediate_signaller),
+                    ("signalling_core_noc_x_addr", signalling_core_noc_x_addr),
+                    ("signalling_core_noc_y_addr", signalling_core_noc_y_addr),
+                    ("stalling_core_noc_x_addr", stalling_core_noc_x_addr),
+                    ("stalling_core_noc_y_addr", stalling_core_noc_y_addr),
+                    ("semaphore_l1_addr", semaphore_l1_addr),
+                    ("fabric_arg_base", fabric_arg_base),
+                    ("num_iterations", num_iterations),
+                ]
+                writer_named_ct_args = reader_named_ct_args
+                compute_name_ct_args = [("num_iterations", num_iterations)]
+
+                # === Unified Kernel Descriptor ===
+
+                # select risc for signalling cores
+                if mesh_coord in signalling_devices:
+                    if run_signalling_kernel_on_ncrisc:
+                        run_signalling_logic_on_ncrisc = True
+                        run_signalling_logic_on_brisc = False
+                    else:
+                        run_signalling_logic_on_ncrisc = False
+                        run_signalling_logic_on_brisc = True
+                else:
+                    run_signalling_logic_on_ncrisc = False
+                    run_signalling_logic_on_brisc = False
+
+                # select risc for stalling cores
+                if mesh_coord == dst_device_mesh_coord:
+                    if run_stalling_kernel_on_ncrisc:
+                        run_stalling_logic_on_ncrisc = True
+                        run_stalling_logic_on_brisc = False
+                    else:
+                        run_stalling_logic_on_ncrisc = False
+                        run_stalling_logic_on_brisc = True
+                else:
+                    run_stalling_logic_on_ncrisc = False
+                    run_stalling_logic_on_brisc = False
+
+                unified_kernel = UnifiedKernelDescriptor(
+                    kernel_source=kernel_path,
+                    core_ranges=all_cores_core_range_set,
+                    ncrisc_named_compile_time_args=reader_named_ct_args,
+                    trisc_named_compile_time_args=compute_name_ct_args,
+                    brisc_named_compile_time_args=writer_named_ct_args,
+                    ncrisc_common_runtime_args=[],
+                    brisc_common_runtime_args=[],
+                    per_core_compile_time_descriptors=[
+                        PerCoreCompileTimeDescriptor(
+                            named_compile_time_arg="run_signalling_logic_on_ncrisc",
+                            core_values=[(signalling_core, run_signalling_logic_on_ncrisc)],
+                            other_value=0,
+                        ),
+                        PerCoreCompileTimeDescriptor(
+                            named_compile_time_arg="run_signalling_logic_on_brisc",
+                            core_values=[(signalling_core, run_signalling_logic_on_brisc)],
+                            other_value=0,
+                        ),
+                        PerCoreCompileTimeDescriptor(
+                            named_compile_time_arg="run_stalling_logic_on_ncrisc",
+                            core_values=[(stalling_core, run_stalling_logic_on_ncrisc)],
+                            other_value=0,
+                        ),
+                        PerCoreCompileTimeDescriptor(
+                            named_compile_time_arg="run_stalling_logic_on_brisc",
+                            core_values=[(stalling_core, run_stalling_logic_on_brisc)],
+                            other_value=0,
+                        ),
+                    ],
+                )
+
+                kernel_result = unified_kernel.get_kernel_descriptors()
+
+                program = ttnn.ProgramDescriptor(
+                    kernels=kernel_result.kernels,
+                    semaphores=[],
+                    cbs=[],
+                )
+
+                # Setup fabric
+                if mesh_coord in signalling_devices:
+                    if run_signalling_kernel_on_ncrisc:
+                        kernel_idx = kernel_result.get_group_by_arg(
+                            "run_signalling_logic_on_ncrisc", 1
+                        ).ncrisc_kernel_index
+                    else:
+                        kernel_idx = kernel_result.get_group_by_arg(
+                            "run_signalling_logic_on_brisc", 1
+                        ).brisc_kernel_index
+                    program.kernels[kernel_idx].runtime_args[signalling_core.x][signalling_core.y] = []
+                    per_core_rt_args_ref = program.kernels[kernel_idx].runtime_args[signalling_core.x][
+                        signalling_core.y
+                    ]
+
+                    fabric_src_node_id = mesh_device.get_fabric_node_id(mesh_coord)
+                    fabric_dst_node_id = mesh_device.get_fabric_node_id(target_device)
+
+                    link_index = 0
+                    fabric_args = ttnn.setup_routing_plane_connection(
+                        fabric_src_node_id,
+                        [fabric_dst_node_id],
+                        [link_index],
+                        program,
+                        kernel_idx,
+                        signalling_core,
+                    )
+                    per_core_rt_args_ref.extend(fabric_args)
+
+                mesh_program_descriptor[ttnn.MeshCoordinateRange(mesh_coord, mesh_coord)] = program
+
+        # Execute pipeline_stage_sync operation
+        ttnn.generic_op([pseudo_input_tensor, pseudo_output_tensor], mesh_program_descriptor)

--- a/models/demos/deepseek_v3_b1/micro_ops/column_wise_pipeline_stage_sync/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/column_wise_pipeline_stage_sync/op.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
-
+#
 # SPDX-License-Identifier: Apache-2.0
 
 """
-PipelineStageSync Operation using ttnn.generic_op
+ColumnWisePipelineStageSync Operation using ttnn.generic_op
 
 This module implements a multi-device synchronization on an arbitrary mesh.
 
@@ -14,48 +14,9 @@ import ttnn
 from models.demos.deepseek_v3_b1.unified_kernel_descriptor import PerCoreCompileTimeDescriptor, UnifiedKernelDescriptor
 
 
-def build_signalling_path(src_device_mesh_coord, dst_device_mesh_coord, mesh_rows, mesh_cols):
-    src_row, src_col = src_device_mesh_coord[0], src_device_mesh_coord[1]
-    dst_row, dst_col = dst_device_mesh_coord[0], dst_device_mesh_coord[1]
-
-    path = [ttnn.MeshCoordinate(src_row, src_col)]
-    current_row, current_col = src_row, src_col
-
-    # traverse across rows first (wrap around present)
-    positive_row_distance = (dst_row - src_row) % mesh_rows
-    negative_row_distance = (src_row - dst_row) % mesh_rows
-
-    if positive_row_distance <= negative_row_distance:
-        row_step = 1
-        row_num_hops = positive_row_distance
-    else:
-        row_step = -1
-        row_num_hops = negative_row_distance
-
-    for _ in range(row_num_hops):
-        current_row = (current_row + row_step) % mesh_rows
-        path.append(ttnn.MeshCoordinate(current_row, current_col))
-
-    # traverse across cols second (wrap around not present)
-    while current_col != dst_col:
-        current_col += 1 if dst_col > current_col else -1
-        path.append(ttnn.MeshCoordinate(current_row, current_col))
-
-    # signalling and intermediate signalling sets
-    signalling_devices = set(path[0:-1])
-    intermediate_signalling_devices = set(path[1:-1])
-
-    # build signalling device to target device mapping
-    signaller_device_mapping = {}
-    for i in range(len(path) - 1):
-        signaller_device_mapping[path[i]] = path[i + 1]
-
-    return signalling_devices, intermediate_signalling_devices, signaller_device_mapping
-
-
-class PipelineStageSync:
+class ColumnWisePipelineStageSync:
     """
-    Multi-device PipelineStageSync implementation using ttnn.generic_op.
+    Multi-device ColumnWisePipelineStageSync implementation using ttnn.generic_op.
     """
 
     @staticmethod
@@ -68,32 +29,24 @@ class PipelineStageSync:
         pseudo_input_tensor: ttnn.Tensor,
         pseudo_output_tensor: ttnn.Tensor,
         mesh_device: ttnn.MeshDevice,
-        semaphore,
-        src_device_mesh_coord: ttnn.MeshCoordinate,
-        signalling_core: ttnn.CoreCoord,
-        run_signalling_kernel_on_ncrisc: bool,
-        dst_device_mesh_coord: ttnn.MeshCoordinate,
-        stalling_core: ttnn.CoreCoord,
-        run_stalling_kernel_on_ncrisc: bool,
+        semaphores: list,
+        entry_device_mesh_col: int,
+        exit_device_mesh_col: int,
+        entry_device_core_coord: ttnn.CoreCoord,
+        run_entry_device_logic_on_ncrsic: bool,
+        exit_device_core_coord: ttnn.CoreCoord,
+        run_exit_device_logic_on_ncrsic: bool,
         num_iterations: int = 1,
     ) -> None:
         """
         Execute PipelineStageSync using generic_op.
 
-        Args:
-            mesh_device: mesh_device micro op operates on
-            semaphore: global semaphore used in op
-            src_device_mesh_coord: src mesh coordinate
-            signalling_core: core that signalling logic is executed on
-            run_signalling_kernel_on_ncrisc: whether to run the signalling kernel on ncrisc or brisc
-            dst_device_mesh_coord: dst mesh coordinate
-            stalling_core: core that stalling logic is executed on
-            run_stalling_kernel_on_ncrisc: whether to run the stalling kernel on ncrisc or brisc
-            num_iterations: Number of iterations to run inside the kernel
-
         Returns:
             None
         """
+
+        if entry_device_mesh_col == exit_device_mesh_col:
+            raise ValueError("entry and exit mesh columns cannot be the same")
 
         # mesh details
         mesh_shape = mesh_device.shape
@@ -104,92 +57,79 @@ class PipelineStageSync:
         mesh_program_descriptor = ttnn.MeshProgramDescriptor()
 
         # kernel path
-        kernel_path = "models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/kernels/pipeline_stage_sync_kernel.cpp"
-
-        if src_device_mesh_coord == dst_device_mesh_coord:
-            raise ValueError("src and dst device cannot be the same")
+        kernel_path = "models/demos/deepseek_v3_b1/micro_ops/column_wise_pipeline_stage_sync/kernels/column_wise_pipeline_stage_sync_kernel.cpp"
 
         # cores
-        if stalling_core == signalling_core:
-            all_cores_core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(stalling_core, stalling_core)])
+        if entry_device_core_coord == exit_device_core_coord:
+            all_cores_core_range_set = ttnn.CoreRangeSet(
+                [ttnn.CoreRange(entry_device_core_coord, entry_device_core_coord)]
+            )
         else:
             all_cores_core_range_set = ttnn.CoreRangeSet(
                 [
-                    ttnn.CoreRange(stalling_core, stalling_core),
-                    ttnn.CoreRange(signalling_core, signalling_core),
+                    ttnn.CoreRange(entry_device_core_coord, entry_device_core_coord),
+                    ttnn.CoreRange(exit_device_core_coord, exit_device_core_coord),
                 ]
             )
 
-        signalling_core_phys = mesh_device.worker_core_from_logical_core(signalling_core)
-        signalling_core_noc_x_addr = signalling_core_phys.x
-        signalling_core_noc_y_addr = signalling_core_phys.y
-
-        stalling_core_phys = mesh_device.worker_core_from_logical_core(stalling_core)
-        stalling_core_noc_x_addr = stalling_core_phys.x
-        stalling_core_noc_y_addr = stalling_core_phys.y
+        entry_device_core_phys = mesh_device.worker_core_from_logical_core(entry_device_core_coord)
+        entry_device_core_noc_x_addr = entry_device_core_phys.x
+        entry_device_core_noc_y_addr = entry_device_core_phys.y
 
         # semaphores
-        semaphore_l1_addr = ttnn.get_global_semaphore_address(semaphore)
+        if len(semaphores) != 3:
+            raise ValueError("requires 3 semaphores")
+        r1_semaphore_l1_addr = ttnn.get_global_semaphore_address(semaphores[0])
+        r2_semaphore_l1_addr = ttnn.get_global_semaphore_address(semaphores[1])
+        r3_semaphore_l1_addr = ttnn.get_global_semaphore_address(semaphores[2])
 
-        # construct path
-        signalling_devices, intermediate_signalling_devices, signaller_device_mapping = build_signalling_path(
-            src_device_mesh_coord, dst_device_mesh_coord, mesh_rows, mesh_cols
-        )
+        # device loop
+        for mesh_row in range(mesh_rows):
+            for mesh_col in range(mesh_cols):
+                mesh_coord = ttnn.MeshCoordinate(mesh_row, mesh_col)
 
-        for row in range(mesh_rows):
-            for col in range(mesh_cols):
-                mesh_coord = ttnn.MeshCoordinate(row, col)
-                target_device = signaller_device_mapping.get(mesh_coord, None)
+                is_entry_device = mesh_col == entry_device_mesh_col
+                is_exit_device = mesh_col == exit_device_mesh_col
 
                 # === Compile-time args ===
 
                 # Reader (NCRISC) and Writer (BRISC) compile-time args
-                is_intermediate_signaller = mesh_coord in intermediate_signalling_devices
-                is_signalling_to_intermediate_signaller = (
-                    mesh_coord in signalling_devices and target_device in intermediate_signalling_devices
-                )
-
                 fabric_arg_base = 0
                 reader_named_ct_args = [
-                    ("is_intermediate_signaller", is_intermediate_signaller),
-                    ("is_signalling_to_intermediate_signaller", is_signalling_to_intermediate_signaller),
-                    ("signalling_core_noc_x_addr", signalling_core_noc_x_addr),
-                    ("signalling_core_noc_y_addr", signalling_core_noc_y_addr),
-                    ("stalling_core_noc_x_addr", stalling_core_noc_x_addr),
-                    ("stalling_core_noc_y_addr", stalling_core_noc_y_addr),
-                    ("semaphore_l1_addr", semaphore_l1_addr),
+                    ("entry_device_core_noc_x_addr", entry_device_core_noc_x_addr),
+                    ("entry_device_core_noc_y_addr", entry_device_core_noc_y_addr),
+                    ("r1_semaphore_l1_addr", r1_semaphore_l1_addr),
+                    ("r2_semaphore_l1_addr", r2_semaphore_l1_addr),
+                    ("r3_semaphore_l1_addr", r3_semaphore_l1_addr),
                     ("fabric_arg_base", fabric_arg_base),
                     ("num_iterations", num_iterations),
                 ]
                 writer_named_ct_args = reader_named_ct_args
                 compute_name_ct_args = [("num_iterations", num_iterations)]
 
+                # select risc for entry and exit device cores
+                if is_entry_device:
+                    if run_entry_device_logic_on_ncrsic:
+                        run_entry_device_logic_on_ncrisc = True
+                        run_entry_device_logic_on_brisc = False
+                    else:
+                        run_entry_device_logic_on_ncrisc = False
+                        run_entry_device_logic_on_brisc = True
+
+                    run_exit_device_logic_on_ncrisc = False
+                    run_exit_device_logic_on_brisc = False
+                else:
+                    if run_exit_device_logic_on_ncrsic:
+                        run_exit_device_logic_on_ncrisc = True
+                        run_exit_device_logic_on_brisc = False
+                    else:
+                        run_exit_device_logic_on_ncrisc = False
+                        run_exit_device_logic_on_brisc = True
+
+                    run_entry_device_logic_on_ncrisc = False
+                    run_entry_device_logic_on_brisc = False
+
                 # === Unified Kernel Descriptor ===
-
-                # select risc for signalling cores
-                if mesh_coord in signalling_devices:
-                    if run_signalling_kernel_on_ncrisc:
-                        run_signalling_logic_on_ncrisc = True
-                        run_signalling_logic_on_brisc = False
-                    else:
-                        run_signalling_logic_on_ncrisc = False
-                        run_signalling_logic_on_brisc = True
-                else:
-                    run_signalling_logic_on_ncrisc = False
-                    run_signalling_logic_on_brisc = False
-
-                # select risc for stalling cores
-                if mesh_coord == dst_device_mesh_coord:
-                    if run_stalling_kernel_on_ncrisc:
-                        run_stalling_logic_on_ncrisc = True
-                        run_stalling_logic_on_brisc = False
-                    else:
-                        run_stalling_logic_on_ncrisc = False
-                        run_stalling_logic_on_brisc = True
-                else:
-                    run_stalling_logic_on_ncrisc = False
-                    run_stalling_logic_on_brisc = False
-
                 unified_kernel = UnifiedKernelDescriptor(
                     kernel_source=kernel_path,
                     core_ranges=all_cores_core_range_set,
@@ -200,23 +140,23 @@ class PipelineStageSync:
                     brisc_common_runtime_args=[],
                     per_core_compile_time_descriptors=[
                         PerCoreCompileTimeDescriptor(
-                            named_compile_time_arg="run_signalling_logic_on_ncrisc",
-                            core_values=[(signalling_core, run_signalling_logic_on_ncrisc)],
+                            named_compile_time_arg="run_entry_device_logic_on_ncrisc",
+                            core_values=[(entry_device_core_coord, run_entry_device_logic_on_ncrisc)],
                             other_value=0,
                         ),
                         PerCoreCompileTimeDescriptor(
-                            named_compile_time_arg="run_signalling_logic_on_brisc",
-                            core_values=[(signalling_core, run_signalling_logic_on_brisc)],
+                            named_compile_time_arg="run_entry_device_logic_on_brisc",
+                            core_values=[(entry_device_core_coord, run_entry_device_logic_on_brisc)],
                             other_value=0,
                         ),
                         PerCoreCompileTimeDescriptor(
-                            named_compile_time_arg="run_stalling_logic_on_ncrisc",
-                            core_values=[(stalling_core, run_stalling_logic_on_ncrisc)],
+                            named_compile_time_arg="run_exit_device_logic_on_ncrisc",
+                            core_values=[(exit_device_core_coord, run_exit_device_logic_on_ncrisc)],
                             other_value=0,
                         ),
                         PerCoreCompileTimeDescriptor(
-                            named_compile_time_arg="run_stalling_logic_on_brisc",
-                            core_values=[(stalling_core, run_stalling_logic_on_brisc)],
+                            named_compile_time_arg="run_exit_device_logic_on_brisc",
+                            core_values=[(exit_device_core_coord, run_exit_device_logic_on_brisc)],
                             other_value=0,
                         ),
                     ],
@@ -231,22 +171,57 @@ class PipelineStageSync:
                 )
 
                 # Setup fabric
-                if mesh_coord in signalling_devices:
-                    if run_signalling_kernel_on_ncrisc:
+                if is_entry_device:
+                    if run_entry_device_logic_on_ncrisc:
                         kernel_idx = kernel_result.get_group_by_arg(
-                            "run_signalling_logic_on_ncrisc", 1
+                            "run_entry_device_logic_on_ncrisc", 1
                         ).ncrisc_kernel_index
                     else:
                         kernel_idx = kernel_result.get_group_by_arg(
-                            "run_signalling_logic_on_brisc", 1
+                            "run_entry_device_logic_on_brisc", 1
                         ).brisc_kernel_index
-                    program.kernels[kernel_idx].runtime_args[signalling_core.x][signalling_core.y] = []
-                    per_core_rt_args_ref = program.kernels[kernel_idx].runtime_args[signalling_core.x][
-                        signalling_core.y
+                    program.kernels[kernel_idx].runtime_args[entry_device_core_coord.x][entry_device_core_coord.y] = []
+                    per_core_rt_args_ref = program.kernels[kernel_idx].runtime_args[entry_device_core_coord.x][
+                        entry_device_core_coord.y
                     ]
 
                     fabric_src_node_id = mesh_device.get_fabric_node_id(mesh_coord)
-                    fabric_dst_node_id = mesh_device.get_fabric_node_id(target_device)
+                    fabric_dst_node_one_id = mesh_device.get_fabric_node_id(
+                        ttnn.MeshCoordinate((mesh_row - 1) % mesh_rows, mesh_col)
+                    )
+                    fabric_dst_node_two_id = mesh_device.get_fabric_node_id(
+                        ttnn.MeshCoordinate((mesh_row + 1) % mesh_rows, mesh_col)
+                    )
+
+                    link_index = 0
+                    fabric_args = ttnn.setup_routing_plane_connection(
+                        fabric_src_node_id,
+                        [fabric_dst_node_one_id, fabric_dst_node_two_id],
+                        [link_index, link_index],
+                        program,
+                        kernel_idx,
+                        exit_device_core_coord,
+                    )
+                    per_core_rt_args_ref.extend(fabric_args)
+
+                else:
+                    if run_exit_device_logic_on_ncrisc:
+                        kernel_idx = kernel_result.get_group_by_arg(
+                            "run_exit_device_logic_on_ncrisc", 1
+                        ).ncrisc_kernel_index
+                    else:
+                        kernel_idx = kernel_result.get_group_by_arg(
+                            "run_exit_device_logic_on_brisc", 1
+                        ).brisc_kernel_index
+                    program.kernels[kernel_idx].runtime_args[exit_device_core_coord.x][exit_device_core_coord.y] = []
+                    per_core_rt_args_ref = program.kernels[kernel_idx].runtime_args[exit_device_core_coord.x][
+                        exit_device_core_coord.y
+                    ]
+
+                    fabric_src_node_id = mesh_device.get_fabric_node_id(mesh_coord)
+                    fabric_dst_node_id = mesh_device.get_fabric_node_id(
+                        ttnn.MeshCoordinate(mesh_row, (mesh_col + 1) % mesh_cols)
+                    )
 
                     link_index = 0
                     fabric_args = ttnn.setup_routing_plane_connection(
@@ -255,7 +230,7 @@ class PipelineStageSync:
                         [link_index],
                         program,
                         kernel_idx,
-                        signalling_core,
+                        exit_device_core_coord,
                     )
                     per_core_rt_args_ref.extend(fabric_args)
 

--- a/models/demos/deepseek_v3_b1/micro_ops/column_wise_pipeline_stage_sync/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/column_wise_pipeline_stage_sync/op.py
@@ -39,7 +39,7 @@ class ColumnWisePipelineStageSync:
         num_iterations: int = 1,
     ) -> None:
         """
-        Execute PipelineStageSync using generic_op.
+        Execute ColumnWisePipelineStageSync using generic_op.
 
         Returns:
             None

--- a/models/demos/deepseek_v3_b1/micro_ops/column_wise_pipeline_stage_sync/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/column_wise_pipeline_stage_sync/op.py
@@ -47,6 +47,8 @@ class ColumnWisePipelineStageSync:
 
         if entry_device_mesh_col == exit_device_mesh_col:
             raise ValueError("entry and exit mesh columns cannot be the same")
+        if entry_device_mesh_col >= 2 or exit_device_mesh_col >= 2:
+            raise ValueError("requires operating on a 2 column mesh")
 
         # mesh details
         mesh_shape = mesh_device.shape

--- a/models/demos/deepseek_v3_b1/micro_ops/column_wise_pipeline_stage_sync/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/column_wise_pipeline_stage_sync/op.py
@@ -33,9 +33,9 @@ class ColumnWisePipelineStageSync:
         entry_device_mesh_col: int,
         exit_device_mesh_col: int,
         entry_device_core_coord: ttnn.CoreCoord,
-        run_entry_device_logic_on_ncrsic: bool,
+        run_entry_device_logic_on_ncrisc: bool,
         exit_device_core_coord: ttnn.CoreCoord,
-        run_exit_device_logic_on_ncrsic: bool,
+        run_exit_device_logic_on_ncrisc: bool,
         num_iterations: int = 1,
     ) -> None:
         """
@@ -47,13 +47,14 @@ class ColumnWisePipelineStageSync:
 
         if entry_device_mesh_col == exit_device_mesh_col:
             raise ValueError("entry and exit mesh columns cannot be the same")
-        if entry_device_mesh_col >= 2 or exit_device_mesh_col >= 2:
-            raise ValueError("requires operating on a 2 column mesh")
 
         # mesh details
         mesh_shape = mesh_device.shape
         mesh_rows = mesh_shape[0]
         mesh_cols = mesh_shape[1]
+
+        if mesh_cols != 2 or entry_device_mesh_col >= 2 or exit_device_mesh_col >= 2:
+            raise ValueError("requires operating on a 2 column mesh")
 
         # create mesh program descriptor
         mesh_program_descriptor = ttnn.MeshProgramDescriptor()
@@ -110,7 +111,7 @@ class ColumnWisePipelineStageSync:
 
                 # select risc for entry and exit device cores
                 if is_entry_device:
-                    if run_entry_device_logic_on_ncrsic:
+                    if run_entry_device_logic_on_ncrisc:
                         run_entry_device_logic_on_ncrisc = True
                         run_entry_device_logic_on_brisc = False
                     else:
@@ -120,7 +121,7 @@ class ColumnWisePipelineStageSync:
                     run_exit_device_logic_on_ncrisc = False
                     run_exit_device_logic_on_brisc = False
                 else:
-                    if run_exit_device_logic_on_ncrsic:
+                    if run_exit_device_logic_on_ncrisc:
                         run_exit_device_logic_on_ncrisc = True
                         run_exit_device_logic_on_brisc = False
                     else:
@@ -201,7 +202,7 @@ class ColumnWisePipelineStageSync:
                         [link_index, link_index],
                         program,
                         kernel_idx,
-                        exit_device_core_coord,
+                        entry_device_core_coord,
                     )
                     per_core_rt_args_ref.extend(fabric_args)
 

--- a/models/demos/deepseek_v3_b1/micro_ops/column_wise_pipeline_stage_sync/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/column_wise_pipeline_stage_sync/op.py
@@ -91,7 +91,6 @@ class ColumnWisePipelineStageSync:
                 mesh_coord = ttnn.MeshCoordinate(mesh_row, mesh_col)
 
                 is_entry_device = mesh_col == entry_device_mesh_col
-                is_exit_device = mesh_col == exit_device_mesh_col
 
                 # === Compile-time args ===
 

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_stage_sync/op.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
-
+#
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_column_wise_pipeline_stage_sync.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_column_wise_pipeline_stage_sync.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for PipelineStageSync operation.
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import skip_for_wormhole_b0
+from models.demos.deepseek_v3_b1.micro_ops.pipeline_stage_sync.op import PipelineStageSync
+
+
+@skip_for_wormhole_b0("This test is for blackhole")
+@pytest.mark.parametrize(
+    "src_device_mesh_coord, signalling_core, run_signalling_kernel_on_ncrisc, dst_device_mesh_coord, stalling_core, run_stalling_kernel_on_ncrisc",
+    [
+        (
+            ttnn.MeshCoordinate((0, 0)),
+            ttnn.CoreCoord(0, 0),
+            True,
+            ttnn.MeshCoordinate((1, 1)),
+            ttnn.CoreCoord(1, 1),
+            False,
+        ),  # nc signaller, b staller
+        (
+            ttnn.MeshCoordinate((0, 0)),
+            ttnn.CoreCoord(0, 0),
+            False,
+            ttnn.MeshCoordinate((1, 1)),
+            ttnn.CoreCoord(1, 1),
+            True,
+        ),  # b signaller, nc staller
+        (
+            ttnn.MeshCoordinate((0, 0)),
+            ttnn.CoreCoord(0, 0),
+            True,
+            ttnn.MeshCoordinate((1, 1)),
+            ttnn.CoreCoord(1, 1),
+            True,
+        ),  # nc signaller, nc staller
+        (
+            ttnn.MeshCoordinate((0, 0)),
+            ttnn.CoreCoord(0, 0),
+            False,
+            ttnn.MeshCoordinate((1, 1)),
+            ttnn.CoreCoord(1, 1),
+            False,
+        ),  # b signaller, b staller
+        (
+            ttnn.MeshCoordinate((0, 0)),
+            ttnn.CoreCoord(0, 0),
+            True,
+            ttnn.MeshCoordinate((1, 1)),
+            ttnn.CoreCoord(0, 0),
+            False,
+        ),  # same core, different risc
+        (
+            ttnn.MeshCoordinate((0, 0)),
+            ttnn.CoreCoord(0, 0),
+            True,
+            ttnn.MeshCoordinate((1, 1)),
+            ttnn.CoreCoord(0, 0),
+            True,
+        ),  # same core, same risc
+        (
+            ttnn.MeshCoordinate((0, 0)),
+            ttnn.CoreCoord(0, 0),
+            True,
+            ttnn.MeshCoordinate((2, 1)),
+            ttnn.CoreCoord(1, 1),
+            False,
+        ),  # multiple intermediate, first col to second col
+        (
+            ttnn.MeshCoordinate((2, 0)),
+            ttnn.CoreCoord(0, 0),
+            True,
+            ttnn.MeshCoordinate((0, 1)),
+            ttnn.CoreCoord(1, 1),
+            False,
+        ),  # multiple intermediate, second col to first col
+        (
+            ttnn.MeshCoordinate((3, 0)),
+            ttnn.CoreCoord(0, 0),
+            True,
+            ttnn.MeshCoordinate((0, 0)),
+            ttnn.CoreCoord(1, 1),
+            False,
+        ),  # wrap around
+        (
+            ttnn.MeshCoordinate((1, 0)),
+            ttnn.CoreCoord(0, 0),
+            True,
+            ttnn.MeshCoordinate((0, 0)),
+            ttnn.CoreCoord(1, 1),
+            False,
+        ),  # backwards across rows
+        (
+            ttnn.MeshCoordinate((0, 0)),
+            ttnn.CoreCoord(0, 0),
+            True,
+            ttnn.MeshCoordinate((0, 1)),
+            ttnn.CoreCoord(1, 1),
+            False,
+        ),  # just col traversal, left to right
+        (
+            ttnn.MeshCoordinate((0, 1)),
+            ttnn.CoreCoord(0, 0),
+            True,
+            ttnn.MeshCoordinate((0, 0)),
+            ttnn.CoreCoord(1, 1),
+            False,
+        ),  # just col traversal, right to left
+    ],
+)
+@pytest.mark.parametrize("num_iterations", [50])
+@pytest.mark.parametrize("num_devices", [8])
+@pytest.mark.parametrize(
+    "device_params",
+    [({"fabric_config": ttnn.FabricConfig.FABRIC_2D})],
+    indirect=["device_params"],
+)
+def test_pipeline_stage_sync_2d(
+    bh_2d_mesh_device,
+    src_device_mesh_coord,
+    signalling_core,
+    run_signalling_kernel_on_ncrisc,
+    dst_device_mesh_coord,
+    stalling_core,
+    run_stalling_kernel_on_ncrisc,
+    num_iterations,
+    num_devices,
+):
+    """Test pipeline_stage_sync with 2D fabric."""
+    # Validate mesh size
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
+        pytest.skip("Test requires more devices than are available on this platform")
+
+    submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+
+    logger.info(f"=== Testing pipeline_stage_sync (num_iterations={num_iterations}) ===")
+
+    # Pseudo input/output tensors
+    pseudo_input_tensor = ttnn.from_torch(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        device=submesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+        mesh_mapper=ttnn.create_mesh_mapper(
+            submesh_device,
+            ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementReplicate()], submesh_device.shape),
+        ),
+    )
+    pseudo_output_tensor = ttnn.from_torch(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        device=submesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+        mesh_mapper=ttnn.create_mesh_mapper(
+            submesh_device,
+            ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementReplicate()], submesh_device.shape),
+        ),
+    )
+
+    compute_grid_size = submesh_device.compute_with_storage_grid_size()
+    num_cores = compute_grid_size.x * compute_grid_size.y
+    available_cores = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, row_wise=True)
+    semaphore = ttnn.create_global_semaphore(submesh_device, available_cores, 0)
+
+    # Run pipeline_stage_sync with looping inside the kernel
+    ttnn.synchronize_device(submesh_device)
+    PipelineStageSync.op(
+        pseudo_input_tensor=pseudo_input_tensor,
+        pseudo_output_tensor=pseudo_output_tensor,
+        mesh_device=submesh_device,
+        semaphore=semaphore,
+        src_device_mesh_coord=src_device_mesh_coord,
+        signalling_core=signalling_core,
+        run_signalling_kernel_on_ncrisc=run_signalling_kernel_on_ncrisc,
+        dst_device_mesh_coord=dst_device_mesh_coord,
+        stalling_core=stalling_core,
+        run_stalling_kernel_on_ncrisc=run_stalling_kernel_on_ncrisc,
+        num_iterations=num_iterations,
+    )
+    ttnn.synchronize_device(submesh_device)
+
+    logger.info("Test passed!")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_column_wise_pipeline_stage_sync.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_column_wise_pipeline_stage_sync.py
@@ -121,7 +121,7 @@ from models.demos.deepseek_v3_b1.micro_ops.pipeline_stage_sync.op import Pipelin
 @pytest.mark.parametrize("num_devices", [8])
 @pytest.mark.parametrize(
     "device_params",
-    [({"fabric_config": ttnn.FabricConfig.FABRIC_2D})],
+    [({"fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X})],
     indirect=["device_params"],
 )
 def test_pipeline_stage_sync_2d(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_column_wise_pipeline_stage_sync.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_column_wise_pipeline_stage_sync.py
@@ -12,111 +12,15 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import skip_for_wormhole_b0
-from models.demos.deepseek_v3_b1.micro_ops.pipeline_stage_sync.op import PipelineStageSync
+from models.demos.deepseek_v3_b1.micro_ops.column_wise_pipeline_stage_sync.op import ColumnWisePipelineStageSync
 
 
 @skip_for_wormhole_b0("This test is for blackhole")
-@pytest.mark.parametrize(
-    "src_device_mesh_coord, signalling_core, run_signalling_kernel_on_ncrisc, dst_device_mesh_coord, stalling_core, run_stalling_kernel_on_ncrisc",
-    [
-        (
-            ttnn.MeshCoordinate((0, 0)),
-            ttnn.CoreCoord(0, 0),
-            True,
-            ttnn.MeshCoordinate((1, 1)),
-            ttnn.CoreCoord(1, 1),
-            False,
-        ),  # nc signaller, b staller
-        (
-            ttnn.MeshCoordinate((0, 0)),
-            ttnn.CoreCoord(0, 0),
-            False,
-            ttnn.MeshCoordinate((1, 1)),
-            ttnn.CoreCoord(1, 1),
-            True,
-        ),  # b signaller, nc staller
-        (
-            ttnn.MeshCoordinate((0, 0)),
-            ttnn.CoreCoord(0, 0),
-            True,
-            ttnn.MeshCoordinate((1, 1)),
-            ttnn.CoreCoord(1, 1),
-            True,
-        ),  # nc signaller, nc staller
-        (
-            ttnn.MeshCoordinate((0, 0)),
-            ttnn.CoreCoord(0, 0),
-            False,
-            ttnn.MeshCoordinate((1, 1)),
-            ttnn.CoreCoord(1, 1),
-            False,
-        ),  # b signaller, b staller
-        (
-            ttnn.MeshCoordinate((0, 0)),
-            ttnn.CoreCoord(0, 0),
-            True,
-            ttnn.MeshCoordinate((1, 1)),
-            ttnn.CoreCoord(0, 0),
-            False,
-        ),  # same core, different risc
-        (
-            ttnn.MeshCoordinate((0, 0)),
-            ttnn.CoreCoord(0, 0),
-            True,
-            ttnn.MeshCoordinate((1, 1)),
-            ttnn.CoreCoord(0, 0),
-            True,
-        ),  # same core, same risc
-        (
-            ttnn.MeshCoordinate((0, 0)),
-            ttnn.CoreCoord(0, 0),
-            True,
-            ttnn.MeshCoordinate((2, 1)),
-            ttnn.CoreCoord(1, 1),
-            False,
-        ),  # multiple intermediate, first col to second col
-        (
-            ttnn.MeshCoordinate((2, 0)),
-            ttnn.CoreCoord(0, 0),
-            True,
-            ttnn.MeshCoordinate((0, 1)),
-            ttnn.CoreCoord(1, 1),
-            False,
-        ),  # multiple intermediate, second col to first col
-        (
-            ttnn.MeshCoordinate((3, 0)),
-            ttnn.CoreCoord(0, 0),
-            True,
-            ttnn.MeshCoordinate((0, 0)),
-            ttnn.CoreCoord(1, 1),
-            False,
-        ),  # wrap around
-        (
-            ttnn.MeshCoordinate((1, 0)),
-            ttnn.CoreCoord(0, 0),
-            True,
-            ttnn.MeshCoordinate((0, 0)),
-            ttnn.CoreCoord(1, 1),
-            False,
-        ),  # backwards across rows
-        (
-            ttnn.MeshCoordinate((0, 0)),
-            ttnn.CoreCoord(0, 0),
-            True,
-            ttnn.MeshCoordinate((0, 1)),
-            ttnn.CoreCoord(1, 1),
-            False,
-        ),  # just col traversal, left to right
-        (
-            ttnn.MeshCoordinate((0, 1)),
-            ttnn.CoreCoord(0, 0),
-            True,
-            ttnn.MeshCoordinate((0, 0)),
-            ttnn.CoreCoord(1, 1),
-            False,
-        ),  # just col traversal, right to left
-    ],
-)
+@pytest.mark.parametrize("entry_device_mesh_col, exit_device_mesh_col", [(0, 1), (1, 0)])
+@pytest.mark.parametrize("entry_device_core_coord", [ttnn.CoreCoord(1, 1), ttnn.CoreCoord(12, 9)])
+@pytest.mark.parametrize("run_entry_device_logic_on_ncrsic", [True, False])
+@pytest.mark.parametrize("exit_device_core_coord", [ttnn.CoreCoord(1, 1), ttnn.CoreCoord(12, 9)])
+@pytest.mark.parametrize("run_exit_device_logic_on_ncrsic", [True, False])
 @pytest.mark.parametrize("num_iterations", [50])
 @pytest.mark.parametrize("num_devices", [8])
 @pytest.mark.parametrize(
@@ -126,12 +30,12 @@ from models.demos.deepseek_v3_b1.micro_ops.pipeline_stage_sync.op import Pipelin
 )
 def test_pipeline_stage_sync_2d(
     bh_2d_mesh_device,
-    src_device_mesh_coord,
-    signalling_core,
-    run_signalling_kernel_on_ncrisc,
-    dst_device_mesh_coord,
-    stalling_core,
-    run_stalling_kernel_on_ncrisc,
+    entry_device_mesh_col,
+    exit_device_mesh_col,
+    entry_device_core_coord,
+    run_entry_device_logic_on_ncrsic,
+    exit_device_core_coord,
+    run_exit_device_logic_on_ncrsic,
     num_iterations,
     num_devices,
 ):
@@ -142,7 +46,7 @@ def test_pipeline_stage_sync_2d(
 
     submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
 
-    logger.info(f"=== Testing pipeline_stage_sync (num_iterations={num_iterations}) ===")
+    logger.info(f"=== Testing column_wise_pipeline_stage_sync (num_iterations={num_iterations}) ===")
 
     # Pseudo input/output tensors
     pseudo_input_tensor = ttnn.from_torch(
@@ -171,21 +75,21 @@ def test_pipeline_stage_sync_2d(
     compute_grid_size = submesh_device.compute_with_storage_grid_size()
     num_cores = compute_grid_size.x * compute_grid_size.y
     available_cores = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, row_wise=True)
-    semaphore = ttnn.create_global_semaphore(submesh_device, available_cores, 0)
+    semaphores = [ttnn.create_global_semaphore(submesh_device, available_cores, 0) for _ in range(3)]
 
     # Run pipeline_stage_sync with looping inside the kernel
     ttnn.synchronize_device(submesh_device)
-    PipelineStageSync.op(
+    ColumnWisePipelineStageSync.op(
         pseudo_input_tensor=pseudo_input_tensor,
         pseudo_output_tensor=pseudo_output_tensor,
         mesh_device=submesh_device,
-        semaphore=semaphore,
-        src_device_mesh_coord=src_device_mesh_coord,
-        signalling_core=signalling_core,
-        run_signalling_kernel_on_ncrisc=run_signalling_kernel_on_ncrisc,
-        dst_device_mesh_coord=dst_device_mesh_coord,
-        stalling_core=stalling_core,
-        run_stalling_kernel_on_ncrisc=run_stalling_kernel_on_ncrisc,
+        semaphores=semaphores,
+        entry_device_mesh_col=entry_device_mesh_col,
+        exit_device_mesh_col=exit_device_mesh_col,
+        entry_device_core_coord=entry_device_core_coord,
+        run_entry_device_logic_on_ncrsic=run_entry_device_logic_on_ncrsic,
+        exit_device_core_coord=exit_device_core_coord,
+        run_exit_device_logic_on_ncrsic=run_exit_device_logic_on_ncrsic,
         num_iterations=num_iterations,
     )
     ttnn.synchronize_device(submesh_device)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_column_wise_pipeline_stage_sync.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_column_wise_pipeline_stage_sync.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Unit tests for PipelineStageSync operation.
+Unit tests for ColumnWisePipelineStageSync operation.
 """
 
 import pytest
@@ -18,9 +18,9 @@ from models.demos.deepseek_v3_b1.micro_ops.column_wise_pipeline_stage_sync.op im
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize("entry_device_mesh_col, exit_device_mesh_col", [(0, 1), (1, 0)])
 @pytest.mark.parametrize("entry_device_core_coord", [ttnn.CoreCoord(1, 1), ttnn.CoreCoord(12, 9)])
-@pytest.mark.parametrize("run_entry_device_logic_on_ncrsic", [True, False])
+@pytest.mark.parametrize("run_entry_device_logic_on_ncrisc", [True, False])
 @pytest.mark.parametrize("exit_device_core_coord", [ttnn.CoreCoord(1, 1), ttnn.CoreCoord(12, 9)])
-@pytest.mark.parametrize("run_exit_device_logic_on_ncrsic", [True, False])
+@pytest.mark.parametrize("run_exit_device_logic_on_ncrisc", [True, False])
 @pytest.mark.parametrize("num_iterations", [50])
 @pytest.mark.parametrize("num_devices", [8])
 @pytest.mark.parametrize(
@@ -28,14 +28,14 @@ from models.demos.deepseek_v3_b1.micro_ops.column_wise_pipeline_stage_sync.op im
     [({"fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X})],
     indirect=["device_params"],
 )
-def test_pipeline_stage_sync_2d(
+def test_column_wise_pipeline_stage_sync_2d(
     bh_2d_mesh_device,
     entry_device_mesh_col,
     exit_device_mesh_col,
     entry_device_core_coord,
-    run_entry_device_logic_on_ncrsic,
+    run_entry_device_logic_on_ncrisc,
     exit_device_core_coord,
-    run_exit_device_logic_on_ncrsic,
+    run_exit_device_logic_on_ncrisc,
     num_iterations,
     num_devices,
 ):
@@ -87,9 +87,9 @@ def test_pipeline_stage_sync_2d(
         entry_device_mesh_col=entry_device_mesh_col,
         exit_device_mesh_col=exit_device_mesh_col,
         entry_device_core_coord=entry_device_core_coord,
-        run_entry_device_logic_on_ncrsic=run_entry_device_logic_on_ncrsic,
+        run_entry_device_logic_on_ncrisc=run_entry_device_logic_on_ncrisc,
         exit_device_core_coord=exit_device_core_coord,
-        run_exit_device_logic_on_ncrsic=run_exit_device_logic_on_ncrsic,
+        run_exit_device_logic_on_ncrisc=run_exit_device_logic_on_ncrisc,
         num_iterations=num_iterations,
     )
     ttnn.synchronize_device(submesh_device)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pipeline_stage_sync.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pipeline_stage_sync.py
@@ -121,7 +121,7 @@ from models.demos.deepseek_v3_b1.micro_ops.pipeline_stage_sync.op import Pipelin
 @pytest.mark.parametrize("num_devices", [8])
 @pytest.mark.parametrize(
     "device_params",
-    [({"fabric_config": ttnn.FabricConfig.FABRIC_2D})],
+    [({"fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X})],
     indirect=["device_params"],
 )
 def test_pipeline_stage_sync_2d(

--- a/models/demos/deepseek_v3_b1/unified_kernels/column_wise_pipeline_stage_sync.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/column_wise_pipeline_stage_sync.hpp
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "kernel_op_api.hpp"
+#include "kernel_utils.hpp"
+
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt_metal/fabric/hw/inc/linear/api.h"
+
+using namespace tt::tt_fabric::linear::experimental;
+
+#endif
+
+namespace deepseek_b1_ops {
+
+struct PipelineStageSync {
+    // ========================================================================
+    // Compile-time args structs
+    // ========================================================================
+
+    // Reader CTArgs (NCRISC)
+    template <
+        uint32_t runStallingLogicOnNCRISC,
+        uint32_t runSignallingLogicOnNCRISC,
+        uint32_t isIntermediateSignaller,
+        uint32_t isSignallingToIntermediateSignaller,
+        uint32_t signallingCoreNocXAddr,
+        uint32_t signallingCoreNocYAddr,
+        uint32_t stallingCoreNocXAddr,
+        uint32_t stallingCoreNocYAddr,
+        uint32_t semaphoreL1Addr,
+        uint32_t fabricArgBase>
+    struct ReaderCTArgs {
+        static constexpr bool run_stalling_logic_on_ncrisc = runStallingLogicOnNCRISC == 1;
+        static constexpr bool run_signalling_logic_on_ncrisc = runSignallingLogicOnNCRISC == 1;
+        static constexpr bool is_intermediate_signaller = isIntermediateSignaller == 1;
+        static constexpr bool is_signalling_to_intermediate_signaller = isSignallingToIntermediateSignaller == 1;
+        static constexpr uint32_t signalling_core_noc_x_addr = signallingCoreNocXAddr;
+        static constexpr uint32_t signalling_core_noc_y_addr = signallingCoreNocYAddr;
+        static constexpr uint32_t stalling_core_noc_x_addr = stallingCoreNocXAddr;
+        static constexpr uint32_t stalling_core_noc_y_addr = stallingCoreNocYAddr;
+        static constexpr uint32_t semaphore_l1_addr = semaphoreL1Addr;
+        static constexpr uint32_t fabric_arg_base = fabricArgBase;
+    };
+
+    // Compute CTArgs (no-op) (TRISC)
+    struct ComputeCTArgs {};
+
+    // Writer CTArgs (BRISC)
+    template <
+        uint32_t runStallingLogicOnBRISC,
+        uint32_t runSignallingLogicOnBRISC,
+        uint32_t isIntermediateSignaller,
+        uint32_t isSignallingToIntermediateSignaller,
+        uint32_t signallingCoreNocXAddr,
+        uint32_t signallingCoreNocYAddr,
+        uint32_t stallingCoreNocXAddr,
+        uint32_t stallingCoreNocYAddr,
+        uint32_t semaphoreL1Addr,
+        uint32_t fabricArgBase>
+    struct WriterCTArgs {
+        static constexpr bool run_stalling_logic_on_brisc = runStallingLogicOnBRISC == 1;
+        static constexpr bool run_signalling_logic_on_brisc = runSignallingLogicOnBRISC == 1;
+        static constexpr bool is_intermediate_signaller = isIntermediateSignaller == 1;
+        static constexpr bool is_signalling_to_intermediate_signaller = isSignallingToIntermediateSignaller == 1;
+        static constexpr uint32_t signalling_core_noc_x_addr = signallingCoreNocXAddr;
+        static constexpr uint32_t signalling_core_noc_y_addr = signallingCoreNocYAddr;
+        static constexpr uint32_t stalling_core_noc_x_addr = stallingCoreNocXAddr;
+        static constexpr uint32_t stalling_core_noc_y_addr = stallingCoreNocYAddr;
+        static constexpr uint32_t semaphore_l1_addr = semaphoreL1Addr;
+        static constexpr uint32_t fabric_arg_base = fabricArgBase;
+    };
+
+    // ========================================================================
+    // Runtime args structs
+    // ========================================================================
+
+    // NCRISC reader args
+    struct ReaderArgs {};
+
+    // TRISC compute args (no-op)
+    struct ComputeArgs {};
+
+    // BRISC writer args
+    struct WriterArgs {};
+
+    // Select args type based on current RISC
+    using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
+
+    // ========================================================================
+    // Op
+    // ========================================================================
+    template <typename CTArgs>
+    class Op {
+    public:
+        void operator()(const RTArgs& args) { impl(args); }
+
+    private:
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
+        static FORCE_INLINE void stalling_impl(uint32_t semaphore_l1_addr) {
+            /*
+             * - Wait min as multiple signals may have been received before testing semaphore value
+             * - Decrement by one (instead of set to 0), so further signals aren't erased
+             * - Invalidate cache to ensure value is decremented before proceeding (to prevent wrap around reading same
+             * value)
+             */
+            auto semaphore_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_l1_addr);
+            noc_semaphore_wait_min(semaphore_l1_ptr, 1);
+            unified_kernels::semaphore_dec(semaphore_l1_ptr);
+            invalidate_l1_cache();
+        }
+
+        static FORCE_INLINE void signalling_impl(
+            bool is_intermediate_signaller,
+            bool is_signalling_to_intermediate_signaller,
+            uint32_t signalling_core_noc_x_addr,
+            uint32_t signalling_core_noc_y_addr,
+            uint32_t stalling_core_noc_x_addr,
+            uint32_t stalling_core_noc_y_addr,
+            uint32_t semaphore_l1_addr,
+            size_t fabric_arg_base) {
+            // Remote semaphore noc address
+            uint64_t remote_semaphore_noc_addr;
+            if (is_signalling_to_intermediate_signaller) {
+                remote_semaphore_noc_addr =
+                    get_noc_addr(signalling_core_noc_x_addr, signalling_core_noc_y_addr, semaphore_l1_addr);
+            } else {
+                remote_semaphore_noc_addr =
+                    get_noc_addr(stalling_core_noc_x_addr, stalling_core_noc_y_addr, semaphore_l1_addr);
+            }
+
+            // Setup fabric while waiting for signal (speeds things up for intermediate signallers)
+            constexpr uint32_t num_connections = 1;
+            tt::tt_fabric::RoutingPlaneConnectionManager fabric_connection;
+            open_connections(fabric_connection, num_connections, fabric_arg_base);
+
+            PacketHeaderPool::reset();
+            auto* packet_header_ptr = PacketHeaderPool::allocate_header(1);
+            fabric_set_unicast_route(fabric_connection, packet_header_ptr, 0);
+
+            constexpr uint32_t num_hops = 1;
+            packet_header_ptr->to_chip_unicast(num_hops);
+            packet_header_ptr->to_noc_unicast_atomic_inc(
+                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{remote_semaphore_noc_addr, 1});
+
+            // Wait for signal (if intermediate signaller)
+            if (is_intermediate_signaller) {
+                auto semaphore_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_l1_addr);
+                noc_semaphore_wait_min(semaphore_l1_ptr, 1);
+                unified_kernels::semaphore_dec(semaphore_l1_ptr);
+                invalidate_l1_cache();
+            }
+
+            // Send semaphore increment over fabric
+            auto& connection = fabric_connection.get(0).sender;
+            connection.wait_for_empty_write_slot();
+            connection.send_payload_flush_blocking_from_address(
+                (uint32_t)packet_header_ptr, sizeof(PACKET_HEADER_TYPE));
+            close_connections(fabric_connection);
+            noc_async_write_barrier();
+        }
+#endif
+
+        void impl([[maybe_unused]] const RTArgs& args) {
+#if defined(COMPILE_FOR_NCRISC)
+            // ================================================================
+            // NCRISC (Reader)
+            // ================================================================
+            if constexpr (CTArgs::run_stalling_logic_on_ncrisc) {
+                stalling_impl(CTArgs::semaphore_l1_addr);
+            } else if constexpr (CTArgs::run_signalling_logic_on_ncrisc) {
+                signalling_impl(
+                    CTArgs::is_intermediate_signaller,
+                    CTArgs::is_signalling_to_intermediate_signaller,
+                    CTArgs::signalling_core_noc_x_addr,
+                    CTArgs::signalling_core_noc_y_addr,
+                    CTArgs::stalling_core_noc_x_addr,
+                    CTArgs::stalling_core_noc_y_addr,
+                    CTArgs::semaphore_l1_addr,
+                    CTArgs::fabric_arg_base);
+            }
+
+#elif defined(COMPILE_FOR_TRISC)
+            // ================================================================
+            // TRISC - No-op
+            // ================================================================
+
+#elif defined(COMPILE_FOR_BRISC)
+            // ================================================================
+            // BRISC (Writer)
+            // ================================================================
+            if constexpr (CTArgs::run_stalling_logic_on_brisc) {
+                stalling_impl(CTArgs::semaphore_l1_addr);
+            } else if constexpr (CTArgs::run_signalling_logic_on_brisc) {
+                signalling_impl(
+                    CTArgs::is_intermediate_signaller,
+                    CTArgs::is_signalling_to_intermediate_signaller,
+                    CTArgs::signalling_core_noc_x_addr,
+                    CTArgs::signalling_core_noc_y_addr,
+                    CTArgs::stalling_core_noc_x_addr,
+                    CTArgs::stalling_core_noc_y_addr,
+                    CTArgs::semaphore_l1_addr,
+                    CTArgs::fabric_arg_base);
+            }
+#endif
+        }
+    };
+
+};  // struct PipelineStageSync
+
+}  // namespace deepseek_b1_ops

--- a/models/demos/deepseek_v3_b1/unified_kernels/column_wise_pipeline_stage_sync.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/column_wise_pipeline_stage_sync.hpp
@@ -19,33 +19,29 @@ using namespace tt::tt_fabric::linear::experimental;
 
 namespace deepseek_b1_ops {
 
-struct PipelineStageSync {
+struct ColumnWisePipelineStageSync {
     // ========================================================================
     // Compile-time args structs
     // ========================================================================
 
     // Reader CTArgs (NCRISC)
     template <
-        uint32_t runStallingLogicOnNCRISC,
-        uint32_t runSignallingLogicOnNCRISC,
-        uint32_t isIntermediateSignaller,
-        uint32_t isSignallingToIntermediateSignaller,
-        uint32_t signallingCoreNocXAddr,
-        uint32_t signallingCoreNocYAddr,
-        uint32_t stallingCoreNocXAddr,
-        uint32_t stallingCoreNocYAddr,
-        uint32_t semaphoreL1Addr,
+        uint32_t runEntryDeviceLogicOnNCRISC,
+        uint32_t runExitDeviceLogicOnNCRISC,
+        uint32_t entryDeviceCoreNocXAddr,
+        uint32_t entryDeviceCoreNocYAddr,
+        uint32_t r1SemaphoreL1Addr,
+        uint32_t r2SemaphoreL1Addr,
+        uint32_t r3SemaphoreL1Addr,
         uint32_t fabricArgBase>
     struct ReaderCTArgs {
-        static constexpr bool run_stalling_logic_on_ncrisc = runStallingLogicOnNCRISC == 1;
-        static constexpr bool run_signalling_logic_on_ncrisc = runSignallingLogicOnNCRISC == 1;
-        static constexpr bool is_intermediate_signaller = isIntermediateSignaller == 1;
-        static constexpr bool is_signalling_to_intermediate_signaller = isSignallingToIntermediateSignaller == 1;
-        static constexpr uint32_t signalling_core_noc_x_addr = signallingCoreNocXAddr;
-        static constexpr uint32_t signalling_core_noc_y_addr = signallingCoreNocYAddr;
-        static constexpr uint32_t stalling_core_noc_x_addr = stallingCoreNocXAddr;
-        static constexpr uint32_t stalling_core_noc_y_addr = stallingCoreNocYAddr;
-        static constexpr uint32_t semaphore_l1_addr = semaphoreL1Addr;
+        static constexpr bool run_entry_device_logic_on_ncrisc = runEntryDeviceLogicOnNCRISC == 1;
+        static constexpr bool run_exit_device_logic_on_ncrisc = runExitDeviceLogicOnNCRISC == 1;
+        static constexpr uint32_t entry_device_core_noc_x_addr = entryDeviceCoreNocXAddr;
+        static constexpr uint32_t entry_device_core_noc_y_addr = entryDeviceCoreNocYAddr;
+        static constexpr uint32_t r1_semaphore_l1_addr = r1SemaphoreL1Addr;
+        static constexpr uint32_t r2_semaphore_l1_addr = r2SemaphoreL1Addr;
+        static constexpr uint32_t r3_semaphore_l1_addr = r2SemaphoreL1Addr;
         static constexpr uint32_t fabric_arg_base = fabricArgBase;
     };
 
@@ -54,26 +50,22 @@ struct PipelineStageSync {
 
     // Writer CTArgs (BRISC)
     template <
-        uint32_t runStallingLogicOnBRISC,
-        uint32_t runSignallingLogicOnBRISC,
-        uint32_t isIntermediateSignaller,
-        uint32_t isSignallingToIntermediateSignaller,
-        uint32_t signallingCoreNocXAddr,
-        uint32_t signallingCoreNocYAddr,
-        uint32_t stallingCoreNocXAddr,
-        uint32_t stallingCoreNocYAddr,
-        uint32_t semaphoreL1Addr,
+        uint32_t runEntryDeviceLogicOnBRISC,
+        uint32_t runExitDeviceLogicOnBRISC,
+        uint32_t entryDeviceCoreNocXAddr,
+        uint32_t entryDeviceCoreNocYAddr,
+        uint32_t r1SemaphoreL1Addr,
+        uint32_t r2SemaphoreL1Addr,
+        uint32_t r3SemaphoreL1Addr,
         uint32_t fabricArgBase>
     struct WriterCTArgs {
-        static constexpr bool run_stalling_logic_on_brisc = runStallingLogicOnBRISC == 1;
-        static constexpr bool run_signalling_logic_on_brisc = runSignallingLogicOnBRISC == 1;
-        static constexpr bool is_intermediate_signaller = isIntermediateSignaller == 1;
-        static constexpr bool is_signalling_to_intermediate_signaller = isSignallingToIntermediateSignaller == 1;
-        static constexpr uint32_t signalling_core_noc_x_addr = signallingCoreNocXAddr;
-        static constexpr uint32_t signalling_core_noc_y_addr = signallingCoreNocYAddr;
-        static constexpr uint32_t stalling_core_noc_x_addr = stallingCoreNocXAddr;
-        static constexpr uint32_t stalling_core_noc_y_addr = stallingCoreNocYAddr;
-        static constexpr uint32_t semaphore_l1_addr = semaphoreL1Addr;
+        static constexpr bool run_entry_device_logic_on_brisc = runEntryDeviceLogicOnBRISC == 1;
+        static constexpr bool run_exit_device_logic_on_brisc = runExitDeviceLogicOnBRISC == 1;
+        static constexpr uint32_t entry_device_core_noc_x_addr = entryDeviceCoreNocXAddr;
+        static constexpr uint32_t entry_device_core_noc_y_addr = entryDeviceCoreNocYAddr;
+        static constexpr uint32_t r1_semaphore_l1_addr = r1SemaphoreL1Addr;
+        static constexpr uint32_t r2_semaphore_l1_addr = r2SemaphoreL1Addr;
+        static constexpr uint32_t r3_semaphore_l1_addr = r2SemaphoreL1Addr;
         static constexpr uint32_t fabric_arg_base = fabricArgBase;
     };
 
@@ -103,65 +95,108 @@ struct PipelineStageSync {
 
     private:
 #if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
-        static FORCE_INLINE void stalling_impl(uint32_t semaphore_l1_addr) {
-            /*
-             * - Wait min as multiple signals may have been received before testing semaphore value
-             * - Decrement by one (instead of set to 0), so further signals aren't erased
-             * - Invalidate cache to ensure value is decremented before proceeding (to prevent wrap around reading same
-             * value)
-             */
-            auto semaphore_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_l1_addr);
-            noc_semaphore_wait_min(semaphore_l1_ptr, 1);
-            unified_kernels::semaphore_dec(semaphore_l1_ptr);
+        static FORCE_INLINE void entry_device_impl(
+            uint32_t entry_device_core_noc_x_addr,
+            uint32_t entry_device_core_noc_y_addr,
+            uint32_t r1_semaphore_l1_addr,
+            uint32_t r2_semaphore_l1_addr,
+            uint32_t r3_semaphore_l1_addr,
+            size_t fabric_arg_base) {
+            auto r1_semaphore_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(r1_semaphore_l1_addr);
+            auto r2_semaphore_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(r2_semaphore_l1_addr);
+            auto r3_semaphore_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(r3_semaphore_l1_addr);
+
+            uint64_t r2_semaphore_noc_addr =
+                get_noc_addr(entry_device_core_noc_x_addr, entry_device_core_noc_y_addr, r2_semaphore_l1_addr);
+            uint64_t r3_semaphore_noc_addr =
+                get_noc_addr(entry_device_core_noc_x_addr, entry_device_core_noc_y_addr, r3_semaphore_l1_addr);
+
+            constexpr uint32_t slot_a = 0;
+            constexpr uint32_t slot_b = 1;
+            constexpr uint32_t num_connections = 2;
+            tt::tt_fabric::RoutingPlaneConnectionManager fabric_connection;
+            open_connections(fabric_connection, num_connections, fabric_arg_base);
+
+            PacketHeaderPool::reset();
+            auto* packet_header_a_ptr = PacketHeaderPool::allocate_header(1);
+            auto* packet_header_b_ptr = PacketHeaderPool::allocate_header(1);
+
+            fabric_set_unicast_route(fabric_connection, packet_header_a_ptr, slot_a);
+            fabric_set_unicast_route(fabric_connection, packet_header_b_ptr, slot_b);
+
+            auto& sender_a = fabric_connection.get(slot_a).sender;
+            auto& sender_b = fabric_connection.get(slot_b).sender;
+
+            packet_header_a_ptr->to_noc_unicast_atomic_inc(
+                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{r2_semaphore_noc_addr, 1});
+            packet_header_b_ptr->to_noc_unicast_atomic_inc(
+                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{r2_semaphore_noc_addr, 1});
+
+            // TODO: (GR) change to single semaphore with bits
+
+            // == Round 1
+            noc_semaphore_wait_min(r1_semaphore_l1_ptr, 1);
+            unified_kernels::semaphore_dec(r1_semaphore_l1_ptr);
+
+            // propagate to both neighbours
+            sender_a.wait_for_empty_write_slot();
+            sender_a.send_payload_flush_blocking_from_address(
+                (uint32_t)packet_header_a_ptr, sizeof(PACKET_HEADER_TYPE));
+
+            sender_b.wait_for_empty_write_slot();
+            sender_b.send_payload_flush_blocking_from_address(
+                (uint32_t)packet_header_b_ptr, sizeof(PACKET_HEADER_TYPE));
+
+            // == Round 2
+            noc_semaphore_wait_min(r2_semaphore_l1_ptr, 1);
+            unified_kernels::semaphore_dec(r2_semaphore_l1_ptr);
+
+            // propagate to just left neighbour
+            packet_header_a_ptr->to_noc_unicast_atomic_inc(
+                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{r3_semaphore_noc_addr, 1});
+            sender_a.wait_for_empty_write_slot();
+            sender_a.send_payload_flush_blocking_from_address(
+                (uint32_t)packet_header_a_ptr, sizeof(PACKET_HEADER_TYPE));
+
+            // == Round 3
+            noc_semaphore_wait_min(r3_semaphore_l1_ptr, 1);
+            unified_kernels::semaphore_dec(r3_semaphore_l1_ptr);
+
+            // == Shutdown
+            close_connections(fabric_connection);
+            noc_async_write_barrier();
             invalidate_l1_cache();
+            // TODO: (GR)
+            // NOTE: don't need fabric barrier after on these devices, since executes on same core/risc as bcast
+
+            // TODO: (GR) confirm this
+            // NOTE: don't need a fabric barrier on the other devices either, since they have to be done
+            // in order for next stage to start
         }
 
-        static FORCE_INLINE void signalling_impl(
-            bool is_intermediate_signaller,
-            bool is_signalling_to_intermediate_signaller,
-            uint32_t signalling_core_noc_x_addr,
-            uint32_t signalling_core_noc_y_addr,
-            uint32_t stalling_core_noc_x_addr,
-            uint32_t stalling_core_noc_y_addr,
-            uint32_t semaphore_l1_addr,
+        static FORCE_INLINE void exit_device_impl(
+            uint32_t entry_device_core_noc_x_addr,
+            uint32_t entry_device_core_noc_y_addr,
+            uint32_t r1_semaphore_l1_addr,
             size_t fabric_arg_base) {
-            // Remote semaphore noc address
-            uint64_t remote_semaphore_noc_addr;
-            if (is_signalling_to_intermediate_signaller) {
-                remote_semaphore_noc_addr =
-                    get_noc_addr(signalling_core_noc_x_addr, signalling_core_noc_y_addr, semaphore_l1_addr);
-            } else {
-                remote_semaphore_noc_addr =
-                    get_noc_addr(stalling_core_noc_x_addr, stalling_core_noc_y_addr, semaphore_l1_addr);
-            }
+            uint64_t r1_semaphore_noc_addr =
+                get_noc_addr(entry_device_core_noc_x_addr, entry_device_core_noc_y_addr, r1_semaphore_l1_addr);
 
-            // Setup fabric while waiting for signal (speeds things up for intermediate signallers)
+            constexpr uint32_t slot = 0;
             constexpr uint32_t num_connections = 1;
             tt::tt_fabric::RoutingPlaneConnectionManager fabric_connection;
             open_connections(fabric_connection, num_connections, fabric_arg_base);
 
             PacketHeaderPool::reset();
             auto* packet_header_ptr = PacketHeaderPool::allocate_header(1);
-            fabric_set_unicast_route(fabric_connection, packet_header_ptr, 0);
+            fabric_set_unicast_route(fabric_connection, packet_header_ptr, slot);
+            auto& sender = fabric_connection.get(slot).sender;
 
-            constexpr uint32_t num_hops = 1;
-            packet_header_ptr->to_chip_unicast(num_hops);
             packet_header_ptr->to_noc_unicast_atomic_inc(
-                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{remote_semaphore_noc_addr, 1});
+                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{r1_semaphore_noc_addr, 1});
+            sender.wait_for_empty_write_slot();
+            sender.send_payload_flush_blocking_from_address((uint32_t)packet_header_ptr, sizeof(PACKET_HEADER_TYPE));
 
-            // Wait for signal (if intermediate signaller)
-            if (is_intermediate_signaller) {
-                auto semaphore_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_l1_addr);
-                noc_semaphore_wait_min(semaphore_l1_ptr, 1);
-                unified_kernels::semaphore_dec(semaphore_l1_ptr);
-                invalidate_l1_cache();
-            }
-
-            // Send semaphore increment over fabric
-            auto& connection = fabric_connection.get(0).sender;
-            connection.wait_for_empty_write_slot();
-            connection.send_payload_flush_blocking_from_address(
-                (uint32_t)packet_header_ptr, sizeof(PACKET_HEADER_TYPE));
             close_connections(fabric_connection);
             noc_async_write_barrier();
         }
@@ -172,17 +207,19 @@ struct PipelineStageSync {
             // ================================================================
             // NCRISC (Reader)
             // ================================================================
-            if constexpr (CTArgs::run_stalling_logic_on_ncrisc) {
-                stalling_impl(CTArgs::semaphore_l1_addr);
-            } else if constexpr (CTArgs::run_signalling_logic_on_ncrisc) {
-                signalling_impl(
-                    CTArgs::is_intermediate_signaller,
-                    CTArgs::is_signalling_to_intermediate_signaller,
-                    CTArgs::signalling_core_noc_x_addr,
-                    CTArgs::signalling_core_noc_y_addr,
-                    CTArgs::stalling_core_noc_x_addr,
-                    CTArgs::stalling_core_noc_y_addr,
-                    CTArgs::semaphore_l1_addr,
+            if constexpr (CTArgs::run_entry_device_logic_on_ncrisc) {
+                entry_device_impl(
+                    CTArgs::entry_device_core_noc_x_addr,
+                    CTArgs::entry_device_core_noc_y_addr,
+                    CTArgs::r1_semaphore_l1_addr,
+                    CTArgs::r2_semaphore_l1_addr,
+                    CTArgs::r3_semaphore_l1_addr,
+                    CTArgs::fabric_arg_base);
+            } else if constexpr (CTArgs::run_exit_device_logic_on_ncrisc) {
+                exit_device_impl(
+                    CTArgs::entry_device_core_noc_x_addr,
+                    CTArgs::entry_device_core_noc_y_addr,
+                    CTArgs::r1_semaphore_l1_addr,
                     CTArgs::fabric_arg_base);
             }
 
@@ -195,23 +232,25 @@ struct PipelineStageSync {
             // ================================================================
             // BRISC (Writer)
             // ================================================================
-            if constexpr (CTArgs::run_stalling_logic_on_brisc) {
-                stalling_impl(CTArgs::semaphore_l1_addr);
-            } else if constexpr (CTArgs::run_signalling_logic_on_brisc) {
-                signalling_impl(
-                    CTArgs::is_intermediate_signaller,
-                    CTArgs::is_signalling_to_intermediate_signaller,
-                    CTArgs::signalling_core_noc_x_addr,
-                    CTArgs::signalling_core_noc_y_addr,
-                    CTArgs::stalling_core_noc_x_addr,
-                    CTArgs::stalling_core_noc_y_addr,
-                    CTArgs::semaphore_l1_addr,
+            if constexpr (CTArgs::run_entry_device_logic_on_brisc) {
+                entry_device_impl(
+                    CTArgs::entry_device_core_noc_x_addr,
+                    CTArgs::entry_device_core_noc_y_addr,
+                    CTArgs::r1_semaphore_l1_addr,
+                    CTArgs::r2_semaphore_l1_addr,
+                    CTArgs::r3_semaphore_l1_addr,
+                    CTArgs::fabric_arg_base);
+            } else if constexpr (CTArgs::run_exit_device_logic_on_brisc) {
+                exit_device_impl(
+                    CTArgs::entry_device_core_noc_x_addr,
+                    CTArgs::entry_device_core_noc_y_addr,
+                    CTArgs::r1_semaphore_l1_addr,
                     CTArgs::fabric_arg_base);
             }
 #endif
         }
     };
 
-};  // struct PipelineStageSync
+};  // struct ColumnWisePipelineStageSync
 
 }  // namespace deepseek_b1_ops

--- a/models/demos/deepseek_v3_b1/unified_kernels/column_wise_pipeline_stage_sync.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/column_wise_pipeline_stage_sync.hpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/models/demos/deepseek_v3_b1/unified_kernels/column_wise_pipeline_stage_sync.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/column_wise_pipeline_stage_sync.hpp
@@ -42,7 +42,7 @@ struct ColumnWisePipelineStageSync {
         static constexpr uint32_t entry_device_core_noc_y_addr = entryDeviceCoreNocYAddr;
         static constexpr uint32_t r1_semaphore_l1_addr = r1SemaphoreL1Addr;
         static constexpr uint32_t r2_semaphore_l1_addr = r2SemaphoreL1Addr;
-        static constexpr uint32_t r3_semaphore_l1_addr = r2SemaphoreL1Addr;
+        static constexpr uint32_t r3_semaphore_l1_addr = r3SemaphoreL1Addr;
         static constexpr uint32_t fabric_arg_base = fabricArgBase;
     };
 
@@ -66,7 +66,7 @@ struct ColumnWisePipelineStageSync {
         static constexpr uint32_t entry_device_core_noc_y_addr = entryDeviceCoreNocYAddr;
         static constexpr uint32_t r1_semaphore_l1_addr = r1SemaphoreL1Addr;
         static constexpr uint32_t r2_semaphore_l1_addr = r2SemaphoreL1Addr;
-        static constexpr uint32_t r3_semaphore_l1_addr = r2SemaphoreL1Addr;
+        static constexpr uint32_t r3_semaphore_l1_addr = r3SemaphoreL1Addr;
         static constexpr uint32_t fabric_arg_base = fabricArgBase;
     };
 
@@ -149,7 +149,7 @@ struct ColumnWisePipelineStageSync {
                 (uint32_t)packet_header_b_ptr, sizeof(PACKET_HEADER_TYPE));
 
             // == Round 2
-            noc_semaphore_wait_min(r2_semaphore_l1_ptr, 1);
+            noc_semaphore_wait_min(r2_semaphore_l1_ptr, 2);
             unified_kernels::semaphore_dec(r2_semaphore_l1_ptr);
 
             // propagate to just left neighbour

--- a/models/demos/deepseek_v3_b1/unified_kernels/column_wise_pipeline_stage_sync.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/column_wise_pipeline_stage_sync.hpp
@@ -103,6 +103,8 @@ struct ColumnWisePipelineStageSync {
             uint32_t r2_semaphore_l1_addr,
             uint32_t r3_semaphore_l1_addr,
             size_t fabric_arg_base) {
+            // TODO: (GR) need fabric barrier between reduce_to_all fabric cores and this
+
             auto r1_semaphore_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(r1_semaphore_l1_addr);
             auto r2_semaphore_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(r2_semaphore_l1_addr);
             auto r3_semaphore_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(r3_semaphore_l1_addr);
@@ -132,8 +134,6 @@ struct ColumnWisePipelineStageSync {
                 tt::tt_fabric::NocUnicastAtomicIncCommandHeader{r2_semaphore_noc_addr, 1});
             packet_header_b_ptr->to_noc_unicast_atomic_inc(
                 tt::tt_fabric::NocUnicastAtomicIncCommandHeader{r2_semaphore_noc_addr, 1});
-
-            // TODO: (GR) change to single semaphore with bits
 
             // == Round 1
             noc_semaphore_wait_min(r1_semaphore_l1_ptr, 1);
@@ -167,12 +167,8 @@ struct ColumnWisePipelineStageSync {
             close_connections(fabric_connection);
             noc_async_write_barrier();
             invalidate_l1_cache();
-            // TODO: (GR)
-            // NOTE: don't need fabric barrier after on these devices, since executes on same core/risc as bcast
 
-            // TODO: (GR) confirm this
-            // NOTE: don't need a fabric barrier on the other devices either, since they have to be done
-            // in order for next stage to start
+            // TODO: (GR) assuming this executes on broadcast core and risc, don't need fabric barrier
         }
 
         static FORCE_INLINE void exit_device_impl(
@@ -180,6 +176,8 @@ struct ColumnWisePipelineStageSync {
             uint32_t entry_device_core_noc_y_addr,
             uint32_t r1_semaphore_l1_addr,
             size_t fabric_arg_base) {
+            // TODO: (GR) need fabric barrier between reduce_to_all fabric cores and this
+
             uint64_t r1_semaphore_noc_addr =
                 get_noc_addr(entry_device_core_noc_x_addr, entry_device_core_noc_y_addr, r1_semaphore_l1_addr);
 
@@ -200,6 +198,8 @@ struct ColumnWisePipelineStageSync {
 
             close_connections(fabric_connection);
             noc_async_write_barrier();
+
+            // TODO: (GR) need fabric barrier between this and first CCL
         }
 #endif
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/column_wise_pipeline_stage_sync.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/column_wise_pipeline_stage_sync.hpp
@@ -103,8 +103,6 @@ struct ColumnWisePipelineStageSync {
             uint32_t r2_semaphore_l1_addr,
             uint32_t r3_semaphore_l1_addr,
             size_t fabric_arg_base) {
-            // TODO: (GR) need fabric barrier between reduce_to_all fabric cores and this
-
             auto r1_semaphore_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(r1_semaphore_l1_addr);
             auto r2_semaphore_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(r2_semaphore_l1_addr);
             auto r3_semaphore_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(r3_semaphore_l1_addr);
@@ -167,8 +165,6 @@ struct ColumnWisePipelineStageSync {
             close_connections(fabric_connection);
             noc_async_write_barrier();
             invalidate_l1_cache();
-
-            // TODO: (GR) assuming this executes on broadcast core and risc, don't need fabric barrier
         }
 
         static FORCE_INLINE void exit_device_impl(
@@ -176,8 +172,6 @@ struct ColumnWisePipelineStageSync {
             uint32_t entry_device_core_noc_y_addr,
             uint32_t r1_semaphore_l1_addr,
             size_t fabric_arg_base) {
-            // TODO: (GR) need fabric barrier between reduce_to_all fabric cores and this
-
             uint64_t r1_semaphore_noc_addr =
                 get_noc_addr(entry_device_core_noc_x_addr, entry_device_core_noc_y_addr, r1_semaphore_l1_addr);
 
@@ -198,8 +192,6 @@ struct ColumnWisePipelineStageSync {
 
             close_connections(fabric_connection);
             noc_async_write_barrier();
-
-            // TODO: (GR) need fabric barrier between this and first CCL
         }
 #endif
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/column_wise_pipeline_stage_sync.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/column_wise_pipeline_stage_sync.hpp
@@ -149,6 +149,7 @@ struct ColumnWisePipelineStageSync {
             // == Round 2
             noc_semaphore_wait_min(r2_semaphore_l1_ptr, 2);
             unified_kernels::semaphore_dec(r2_semaphore_l1_ptr);
+            unified_kernels::semaphore_dec(r2_semaphore_l1_ptr);
 
             // propagate to just left neighbour
             packet_header_a_ptr->to_noc_unicast_atomic_inc(

--- a/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
@@ -138,8 +138,7 @@ struct PipelineStageSync {
             PacketHeaderPool::reset();
             auto* packet_header_ptr = PacketHeaderPool::allocate_header(1);
             fabric_set_unicast_route(fabric_connection, packet_header_ptr, slot);
-            packet_header_ptr->to_noc_unicast_atomic_inc(
-                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{remote_semaphore_noc_addr, 1});
+            auto& sender = fabric_connection.get(slot).sender;
 
             // Wait for signal (if intermediate signaller)
             if (is_intermediate_signaller) {
@@ -150,7 +149,8 @@ struct PipelineStageSync {
             }
 
             // Send semaphore increment over fabric
-            auto& sender = fabric_connection.get(slot).sender;
+            packet_header_ptr->to_noc_unicast_atomic_inc(
+                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{remote_semaphore_noc_addr, 1});
             sender.wait_for_empty_write_slot();
             sender.send_payload_flush_blocking_from_address((uint32_t)packet_header_ptr, sizeof(PACKET_HEADER_TYPE));
             close_connections(fabric_connection);

--- a/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/pipeline_stage_sync.hpp
@@ -104,12 +104,6 @@ struct PipelineStageSync {
     private:
 #if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
         static FORCE_INLINE void stalling_impl(uint32_t semaphore_l1_addr) {
-            /*
-             * - Wait min as multiple signals may have been received before testing semaphore value
-             * - Decrement by one (instead of set to 0), so further signals aren't erased
-             * - Invalidate cache to ensure value is decremented before proceeding (to prevent wrap around reading same
-             * value)
-             */
             auto semaphore_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_l1_addr);
             noc_semaphore_wait_min(semaphore_l1_ptr, 1);
             unified_kernels::semaphore_dec(semaphore_l1_ptr);
@@ -136,16 +130,14 @@ struct PipelineStageSync {
             }
 
             // Setup fabric while waiting for signal (speeds things up for intermediate signallers)
+            constexpr uint32_t slot = 0;
             constexpr uint32_t num_connections = 1;
             tt::tt_fabric::RoutingPlaneConnectionManager fabric_connection;
             open_connections(fabric_connection, num_connections, fabric_arg_base);
 
             PacketHeaderPool::reset();
             auto* packet_header_ptr = PacketHeaderPool::allocate_header(1);
-            fabric_set_unicast_route(fabric_connection, packet_header_ptr, 0);
-
-            constexpr uint32_t num_hops = 1;
-            packet_header_ptr->to_chip_unicast(num_hops);
+            fabric_set_unicast_route(fabric_connection, packet_header_ptr, slot);
             packet_header_ptr->to_noc_unicast_atomic_inc(
                 tt::tt_fabric::NocUnicastAtomicIncCommandHeader{remote_semaphore_noc_addr, 1});
 
@@ -158,10 +150,9 @@ struct PipelineStageSync {
             }
 
             // Send semaphore increment over fabric
-            auto& connection = fabric_connection.get(0).sender;
-            connection.wait_for_empty_write_slot();
-            connection.send_payload_flush_blocking_from_address(
-                (uint32_t)packet_header_ptr, sizeof(PACKET_HEADER_TYPE));
+            auto& sender = fabric_connection.get(slot).sender;
+            sender.wait_for_empty_write_slot();
+            sender.send_payload_flush_blocking_from_address((uint32_t)packet_header_ptr, sizeof(PACKET_HEADER_TYPE));
             close_connections(fabric_connection);
             noc_async_write_barrier();
         }


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
- New synchronization micro-op for handling new socket strategy for decoder stage, where the 4 devices on column 0 are entry devices and the 4 devices on column 1 are exit devices
  - Previously we just had a single entry device and single exit device
- So the 4 entry devices need to wait until the 4 exit devices are all complete
  - Token has to be sent to next stage (work split between 4 exit devices), before new token can be released into current stage (work split between 4 entry devices)
- This micro-op facilitates the synchronization described above

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
- Not integrated into the model yet, will do so when required
- Can't be integrated until decoder logic for the 4 entry device 4 exit device logic is complete (ex: reduce to one essentially needs to be changed to a reduce to all)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=grechsteiner/pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:grechsteiner/pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=grechsteiner/pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:grechsteiner/pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=grechsteiner/pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:grechsteiner/pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=grechsteiner/pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:grechsteiner/pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=grechsteiner/pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:grechsteiner/pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=grechsteiner/pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:grechsteiner/pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=grechsteiner/pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:grechsteiner/pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=grechsteiner/pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:grechsteiner/pipeline)