### PR TITLE
ds_prefill(bincount data race)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py
@@ -191,3 +191,115 @@ def test_masked_bincount(
     )
     result.assert_passed("masked_bincount output does not match torch reference")
     logger.info("masked_bincount matches torch reference!")
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [
+        pytest.param(
+            (1, 1),
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 1), topology="linear"),
+            id="single",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+def test_masked_bincount_tree_reduction_race(mesh_device):
+    """
+    Stress test for tree-reduction race condition in masked_bincount.
+
+    Crafts workload skew to maximize out-of-order child completion in the
+    binary-tree gather phase: one core's shard targets present experts (slow,
+    many atomic increments) while all other cores target absent experts (fast,
+    zero increments). This creates a timing gap where deeper subtrees signal
+    the root's gather_sem before the slow leaf finishes, exposing data races
+    where a parent reads a child's incomplete histogram.
+    """
+    sp_dim = 4096
+    topk = 8
+    n_routed_experts = 256
+    num_cores = 64
+    rows_per_core = sp_dim // num_cores  # 64
+    num_iterations = 50
+
+    # Custom dispatch table: only experts 0-7 are "present" (chip_id=0),
+    # rest are absent (-1). Shape: (1, 256) for single dispatch group.
+    dispatch_table = torch.full((1, n_routed_experts), -1, dtype=torch.int32)
+    num_present = 8
+    for e in range(num_present):
+        dispatch_table[0, e] = 0
+
+    # Height-shard config matching the gate module pattern: 8x8 core grid
+    sharded_mem_config = ttnn.create_sharded_memory_config(
+        shape=(rows_per_core, topk),
+        core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))}),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    # Place dispatch table on device (static across iterations)
+    tt_dispatch_table = ttnn.from_torch(
+        dispatch_table,
+        device=mesh_device,
+        dtype=ttnn.int32,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device,
+            mesh_shape=mesh_device.shape,
+            dims=(None, 0),
+        ),
+    )
+
+    composer = get_ep_mesh_composer(mesh_device)
+    num_mismatches = 0
+
+    for iteration in range(num_iterations):
+        # Craft skewed indices:
+        # - Core 1 (rows 64-127): present experts 0..7 → many atomic increments (slow)
+        # - All other cores: absent experts 128..255 → zero increments (fast)
+        indices = torch.randint(128, n_routed_experts, (sp_dim, topk), dtype=torch.int32)
+        core1_start = 1 * rows_per_core
+        core1_end = 2 * rows_per_core
+        indices[core1_start:core1_end] = torch.randint(0, num_present, (rows_per_core, topk), dtype=torch.int32)
+
+        # Torch reference
+        reference = torch_masked_bincount(indices, dispatch_table[0], n_routed_experts)
+
+        # Place indices on device
+        tt_indices = ttnn.from_torch(
+            indices.to(torch.int16),
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_device.shape, dims=(0, None)),
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh_device,
+            dtype=ttnn.uint16,
+        )
+        tt_indices = ttnn.to_memory_config(tt_indices, sharded_mem_config)
+
+        # Run TTNN op
+        tt_hist = ttnn.experimental.deepseek_prefill.masked_bincount(
+            tt_indices, tt_dispatch_table, n_routed_experts, topk
+        )
+
+        # Read back and compare
+        tt_hist_4d = ttnn.unsqueeze_to_4D(tt_hist)
+        composed = ttnn.to_torch(tt_hist_4d, mesh_composer=composer).squeeze(2).to(torch.int32)
+        composed = composed[..., :n_routed_experts]
+        actual = composed.squeeze(0).squeeze(0)  # (n_routed_experts,)
+
+        if not torch.equal(actual, reference):
+            num_mismatches += 1
+            diff_mask = actual != reference
+            diff_indices = diff_mask.nonzero(as_tuple=True)[0]
+            logger.error(
+                f"Iteration {iteration}: MISMATCH at {len(diff_indices)} experts. "
+                f"First 5: {diff_indices[:5].tolist()}, "
+                f"actual={actual[diff_indices[:5]].tolist()}, "
+                f"expected={reference[diff_indices[:5]].tolist()}"
+            )
+
+    assert num_mismatches == 0, (
+        f"Tree-reduction race detected: {num_mismatches}/{num_iterations} iterations " f"produced incorrect histograms"
+    )
+    logger.info(f"All {num_iterations} iterations match torch reference (race test passed)")

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/kernels/reader_masked_bincount.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/kernels/reader_masked_bincount.cpp
@@ -146,9 +146,12 @@ void kernel_main() {
         uint32_t tmp_addr = get_write_ptr(cb_gather_tmp);
         volatile tt_l1_ptr uint32_t* local_hist = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_addr);
 
+        // Wait for ALL children to signal before reading any.
+        // A single gather_sem counter does not identify WHICH child signaled,
+        // so we must wait for all num_receive increments to guarantee every
+        // child's histogram is finalized before reading.
+        noc_semaphore_wait_min(gather_sem_ptr, num_receive);
         for (uint32_t level = 0; level < num_receive; level++) {
-            noc_semaphore_wait_min(gather_sem_ptr, level + 1);
-
             uint32_t child_noc_x = get_arg_val<uint32_t>(7 + level * 2);
             uint32_t child_noc_y = get_arg_val<uint32_t>(7 + level * 2 + 1);
 


### PR DESCRIPTION
## Summary
- Fix tree-reduction data race in `masked_bincount` kernel — the binary-tree gather phase shared a single `gather_sem` counter across all children but waited incrementally (`level+1`), allowing a parent to read a child's incomplete histogram if deeper subtrees finish before closer leaves
- Move `noc_semaphore_wait_min` before the read loop to wait for ALL children before reading any, since the counter cannot identify which child signaled
- Add `test_masked_bincount_tree_reduction_race` stress test that crafts workload skew (1 slow core vs 63 fast cores) to reliably reproduce the race (50/50 failures before fix, 0/50 after)

### Why the Stress Test Reproduces It 100%

With 64 cores and our crafted workload:
- **Core 1** (leaf, direct child of root): 512 atomic increments for present experts — slow
- **Cores 2-63**: zero increments (all absent experts) — fast

Core 32's entire subtree (32 cores, all fast) finishes and bubbles up to core 32, which signals core 0's `gather_sem`. Meanwhile core 1 is still counting. Core 0 sees `gather_sem >= 1`, reads core 1's partial histogram — guaranteed corruption every time.

## Test plan
- `/deepseek-pipelines` (all 4 CI workflows)

### DeepSeek Prefill CI
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mbezulj/2604_bincount_data_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:mbezulj/2604_bincount_data_race) Galaxy
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/2604_bincount_data_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mbezulj/2604_bincount_data_race) T3K
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=mbezulj/2604_bincount_data_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:mbezulj/2604_bincount_data_race) Single Card
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/2604_bincount_data_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/2604_bincount_data_race) Blackhole

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2604_bincount_data_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2604_bincount_data_race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/2604_bincount_data_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/2604_bincount_data_race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2604_bincount_data_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2604_bincount_data_race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2604_bincount_data_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2604_bincount_data_race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/2604_bincount_data_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/2604_bincount_data_race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2604_bincount_data_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2604_bincount_data_race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2604_bincount_data_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2604_bincount_data_race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2604_bincount_data_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2604_bincount_data_race)