### PR TITLE
Fix L2 nightly regression in tt-train moe tests

### DIFF
--- a/tt-train/sources/ttml/ttml/models/deepseek/moe.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/moe.py
@@ -175,7 +175,7 @@ class MoE(AbstractModuleBase):
                 [b, 1, s, self.n_limited_groups], ttnn.DataType.BFLOAT16, ttnn.ROW_MAJOR_LAYOUT, biased.device()
             )
             group_mask = ttnn.scatter(group_mask, -1, top_group_indices, group_src)
-            group_mask = ttnn.repeat(group_mask, ttnn.Shape([1, 1, 1, experts_per_group]))
+            group_mask = ttnn.repeat_interleave(group_mask, experts_per_group, dim=-1)
             group_mask = ttnn.to_layout(group_mask, ttnn.TILE_LAYOUT)
             neg_inf = ttnn.multiply(ttnn.subtract(group_mask, 1.0), 1e9)
             biased_masked = ttnn.add(biased, neg_inf)


### PR DESCRIPTION
### Summary

Fix group-expert mask expansion in MoE routing ( changed in #42859 ) that introduced a regression in tt-train tests: https://github.com/tenstorrent/tt-metal/actions/runs/25151578768/job/73723911943

The optimized routing built the group mask via `ttnn.scatter` (correct) followed by `ttnn.repeat` to expand each group's flag across its `experts_per_group` experts. 

Instead of repeating each element individually like `repeat_interleave`,  which produces `[g0, g0, g1, g1]`,  `ttnn.repeat` **tiles** the entire last dimension, producing `[g0, g1, g0, g1]`. 
Since experts are laid out contiguously by group (experts 0,1 → group 0; experts 2,3 → group 1), the tiled mask assigned each group's selection to the wrong experts.

Training loss was not visibly affected because the model adapts its weights to whichever routing it receives; the test caught it because it checks correctness deterministically with a fixed seed.

This PR replaces ttnn.repeat with ttnn.repeat_interleave (performance and loss remain comparable).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmaurice/fix-tt-train-moe-bug-repeat)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmaurice/fix-tt-train-moe-bug-repeat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmaurice/fix-tt-train-moe-bug-repeat)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmaurice/fix-tt-train-moe-bug-repeat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmaurice/fix-tt-train-moe-bug-repeat)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmaurice/fix-tt-train-moe-bug-repeat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmaurice/fix-tt-train-moe-bug-repeat)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmaurice/fix-tt-train-moe-bug-repeat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmaurice/fix-tt-train-moe-bug-repeat)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmaurice/fix-tt-train-moe-bug-repeat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmaurice/fix-tt-train-moe-bug-repeat)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmaurice/fix-tt-train-moe-bug-repeat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmaurice/fix-tt-train-moe-bug-repeat)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmaurice/fix-tt-train-moe-bug-repeat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmaurice/fix-tt-train-moe-bug-repeat)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmaurice/fix-tt-train-moe-bug-repeat)