### PR TITLE
sdxl: bump L1_SMALL to 32000 after halo program cache split

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_common.py
@@ -20,9 +20,9 @@ from models.tt_dit.parallel.config import EncoderParallelConfig, ParallelFactor
 # For basic SDXL demo, L1 small size of 23000 is enough,
 # but for inpainting/img2img, we need larger L1 small due
 # to having an extra VAE encode call, which increases it.
-# For simplicity, increase both to 30800 as there's enough
+# For simplicity, increase both to 32000 as there's enough
 # space left in base variant as well.
-SDXL_L1_SMALL_SIZE = 30800
+SDXL_L1_SMALL_SIZE = 32000
 SDXL_L1_SMALL_SIZE_BH = 38000
 SDXL_CI_WEIGHTS_PATH = "/mnt/MLPerf/tt_dnn-models/hf_home"
 SDXL_FABRIC_CONFIG = ttnn.FabricConfig.FABRIC_1D


### PR DESCRIPTION
## Summary

- Bumps `SDXL_L1_SMALL_SIZE` from 30800 to 32000 to fix VAE-decoder OOM regression.
- Regression introduced by #43256 (`fix(conv): preserve fp32 magnitudes through halo's untilize`), which added `compute_kernel_config` to `HaloParams`. `HaloDeviceOperation` has no `compute_program_hash` override, so the default reflection-based hash now distinguishes by `fp32_dest_acc_en`. Symmetric UNet convs that share shapes but use different compute configs (e.g. `down_blocks.0` resnets NO_FP32 vs `up_blocks.2` resnets FP32) no longer share a halo cache entry. Each halo cache entry persistently holds 4 L1_SMALL config tensors (`padding_config_storage{0,1}`, `gather_config_storage{0,1}`), so the duplication pushes total L1_SMALL/bank past the 30800 B budget — VAE decoder fails with `Out of Memory: Not enough space to allocate 8192 B L1_SMALL buffer across 64 banks`.
- Measured peak L1_SMALL/bank for the failing test (img2img 1024x1024) = **31136 B**. 32000 leaves ~860 B headroom.

Failing job: https://github.com/tenstorrent/tt-metal/actions/runs/25127040476/job/73644323260
Triage: https://github.com/tenstorrent/tt-metal/actions/runs/25132892253

A proper fix in the halo subsystem (custom `compute_program_hash` keying only on `fp32_dest_acc_en`, since that is the only field affecting the untilize kernel format) is left as follow-up.

## Test plan

- [x] Local: `models/demos/stable_diffusion_xl_base/demo/demo_img2img.py -k "device_vae and device_encoders and with_trace and no_cfg_parallel and 1024x1024"` passes at 32000.
- [ ] CI: Single-card Demo tests (no perf), sdxl only — https://github.com/tenstorrent/tt-metal/actions/runs/25155263377

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/sdxl-bump-l1-small-after-halo-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/sdxl-bump-l1-small-after-halo-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/sdxl-bump-l1-small-after-halo-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/sdxl-bump-l1-small-after-halo-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/sdxl-bump-l1-small-after-halo-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/sdxl-bump-l1-small-after-halo-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/sdxl-bump-l1-small-after-halo-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/sdxl-bump-l1-small-after-halo-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/sdxl-bump-l1-small-after-halo-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/sdxl-bump-l1-small-after-halo-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/sdxl-bump-l1-small-after-halo-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/sdxl-bump-l1-small-after-halo-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/sdxl-bump-l1-small-after-halo-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/sdxl-bump-l1-small-after-halo-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/sdxl-bump-l1-small-after-halo-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/sdxl-bump-l1-small-after-halo-fix)