### PR TITLE
Support running Fast Dispatch on TTSim 

### DIFF
--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -668,7 +668,7 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
             ctx.get_cluster().read_core(&fence, sizeof(uint32_t), this->prefetcher_cores[cq_id], prefetch_q_rd_ptr);
             this->prefetch_q_dev_fences[cq_id] = fence;
             // Yield to clock the simulator when running on TTSim; no-op on real hardware.
-            ctx.get_cluster().yield(this->device_id);
+            ctx.get_cluster().advance_device_execution(this->device_id);
         };
 
         // Condition to check if should continue waiting
@@ -720,7 +720,7 @@ uint32_t SystemMemoryManager::completion_queue_wait_front(
         write_ptr = write_ptr_and_toggle & 0x7fffffff;
         write_toggle = write_ptr_and_toggle >> 31;
         // Yield to clock the simulator when running on TTSim; no-op on real hardware.
-        tt::tt_metal::MetalContext::instance(this->context_id).get_cluster().yield(this->device_id);
+        tt::tt_metal::MetalContext::instance(this->context_id).get_cluster().advance_device_execution(this->device_id);
     };
 
     // Condition to check if the operation should continue

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -717,6 +717,7 @@ uint32_t SystemMemoryManager::completion_queue_wait_front(
         write_ptr_and_toggle = get_cq_completion_wr_ptr<true>(this->device_id, cq_id, this->cq_size);
         write_ptr = write_ptr_and_toggle & 0x7fffffff;
         write_toggle = write_ptr_and_toggle >> 31;
+        tt::tt_metal::MetalContext::instance(this->context_id).get_cluster().yield(this->device_id);
     };
 
     // Condition to check if the operation should continue

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -667,6 +667,8 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
         auto fetch_operation_body = [&]() {
             ctx.get_cluster().read_core(&fence, sizeof(uint32_t), this->prefetcher_cores[cq_id], prefetch_q_rd_ptr);
             this->prefetch_q_dev_fences[cq_id] = fence;
+            // Yield to clock the simulator when running on TTSim; no-op on real hardware.
+            ctx.get_cluster().yield(this->device_id);
         };
 
         // Condition to check if should continue waiting
@@ -717,6 +719,7 @@ uint32_t SystemMemoryManager::completion_queue_wait_front(
         write_ptr_and_toggle = get_cq_completion_wr_ptr<true>(this->device_id, cq_id, this->cq_size);
         write_ptr = write_ptr_and_toggle & 0x7fffffff;
         write_toggle = write_ptr_and_toggle >> 31;
+        // Yield to clock the simulator when running on TTSim; no-op on real hardware.
         tt::tt_metal::MetalContext::instance(this->context_id).get_cluster().yield(this->device_id);
     };
 

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -87,8 +87,7 @@ void configure_static_tlbs(
         device_driver.configure_tlb(mmio_device_id, core, get_static_tlb_size(), address, tt::umd::tlb_data::Strict);
     }
 
-    if (arch == tt::ARCH::BLACKHOLE) {
-        // Setup static 4GB tlbs for DRAM cores.
+    if (arch == tt::ARCH::BLACKHOLE && sdesc.get_num_dram_channels() == blackhole::NUM_DRAM_CHANNELS) {
         uint32_t dram_addr = 0;
         for (std::uint32_t dram_channel = 0; dram_channel < blackhole::NUM_DRAM_CHANNELS; dram_channel++) {
             tt::umd::CoreCoord dram_core =

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -398,7 +398,7 @@ void Cluster::open_driver(const bool& /*skip_driver_allocs*/) {
             mock_cluster_desc = get_mock_cluster_desc(rtoptions_);
             device_driver = std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{
                 .chip_type = tt::umd::ChipType::SIMULATION,
-                .num_host_mem_ch_per_mmio_device = 4,
+                .num_host_mem_ch_per_mmio_device = 1,
                 .sdesc_path = sdesc_path,
                 .cluster_descriptor = mock_cluster_desc.get(),
                 .simulator_directory = rtoptions_.get_simulator_path(),
@@ -406,7 +406,7 @@ void Cluster::open_driver(const bool& /*skip_driver_allocs*/) {
         } else {
             device_driver = std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{
                 .chip_type = tt::umd::ChipType::SIMULATION,
-                .num_host_mem_ch_per_mmio_device = 4,
+                .num_host_mem_ch_per_mmio_device = 1,
                 .target_devices = {0},
                 .simulator_directory = rtoptions_.get_simulator_path(),
             });

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -474,8 +474,7 @@ void Cluster::start_driver(umd::DeviceParams& device_params) const {
     // May block waiting for other processes to release the device.
     this->driver_->start_device(device_params);
 
-    if ((this->target_type_ == TargetDevice::Silicon || this->target_type_ == TargetDevice::Simulator ) &&
-        device_params.init_device) {
+    if ((this->target_type_ == TargetDevice::Silicon || this->target_type_ == TargetDevice::Simulator) && device_params.init_device) {
         // Configure TLBs on all MMIO devices in parallel
         std::vector<std::shared_future<void>> futures;
         const auto& mmio_device_ids = driver_->get_target_mmio_device_ids();

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -971,9 +971,7 @@ void Cluster::read_sysmem(
     this->driver_->read_from_sysmem(vec, addr, channel & HOST_MEM_CHANNELS_MASK, size_in_bytes, src_device_id);
 }
 
-void Cluster::yield(ChipId device_id) const {
-    this->driver_->yield(device_id);
-}
+void Cluster::advance_device_execution(ChipId device_id) const { this->driver_->advance_device_execution(device_id); }
 
 std::unique_ptr<tt::umd::SysmemBuffer> Cluster::allocate_sysmem_buffer(
     ChipId device_id, size_t sysmem_buffer_size, bool map_to_noc) const {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -398,6 +398,7 @@ void Cluster::open_driver(const bool& /*skip_driver_allocs*/) {
             mock_cluster_desc = get_mock_cluster_desc(rtoptions_);
             device_driver = std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{
                 .chip_type = tt::umd::ChipType::SIMULATION,
+                .num_host_mem_ch_per_mmio_device = 4,
                 .sdesc_path = sdesc_path,
                 .cluster_descriptor = mock_cluster_desc.get(),
                 .simulator_directory = rtoptions_.get_simulator_path(),
@@ -405,6 +406,7 @@ void Cluster::open_driver(const bool& /*skip_driver_allocs*/) {
         } else {
             device_driver = std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{
                 .chip_type = tt::umd::ChipType::SIMULATION,
+                .num_host_mem_ch_per_mmio_device = 4,
                 .target_devices = {0},
                 .simulator_directory = rtoptions_.get_simulator_path(),
             });
@@ -472,8 +474,7 @@ void Cluster::start_driver(umd::DeviceParams& device_params) const {
     // May block waiting for other processes to release the device.
     this->driver_->start_device(device_params);
 
-    if ((this->target_type_ == TargetDevice::Silicon ||
-         (this->target_type_ == TargetDevice::Simulator && this->arch_ == tt::ARCH::QUASAR)) &&
+    if ((this->target_type_ == TargetDevice::Silicon || this->target_type_ == TargetDevice::Simulator ) &&
         device_params.init_device) {
         // Configure TLBs on all MMIO devices in parallel
         std::vector<std::shared_future<void>> futures;
@@ -969,6 +970,10 @@ void Cluster::read_sysmem(
     void* vec, uint32_t size_in_bytes, uint64_t addr, ChipId src_device_id, uint16_t channel) const {
     TT_ASSERT(this->cluster_desc_->is_chip_mmio_capable(src_device_id));
     this->driver_->read_from_sysmem(vec, addr, channel & HOST_MEM_CHANNELS_MASK, size_in_bytes, src_device_id);
+}
+
+void Cluster::yield(ChipId device_id) const {
+    this->driver_->yield(device_id);
 }
 
 std::unique_ptr<tt::umd::SysmemBuffer> Cluster::allocate_sysmem_buffer(

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -241,6 +241,8 @@ public:
         const void* vec, uint32_t size_in_bytes, uint64_t addr, ChipId src_device_id, uint16_t channel) const;
     void read_sysmem(void* vec, uint32_t size_in_bytes, uint64_t addr, ChipId src_device_id, uint16_t channel) const;
 
+    void yield(ChipId device_id) const;
+
     // System memory buffer allocation methods
     std::unique_ptr<tt::umd::SysmemBuffer> allocate_sysmem_buffer(
         ChipId device_id, size_t sysmem_buffer_size, bool map_to_noc = false) const;

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -241,7 +241,7 @@ public:
         const void* vec, uint32_t size_in_bytes, uint64_t addr, ChipId src_device_id, uint16_t channel) const;
     void read_sysmem(void* vec, uint32_t size_in_bytes, uint64_t addr, ChipId src_device_id, uint16_t channel) const;
 
-    void yield(ChipId device_id) const;
+    void advance_device_execution(ChipId device_id) const;
 
     // System memory buffer allocation methods
     std::unique_ptr<tt::umd::SysmemBuffer> allocate_sysmem_buffer(


### PR DESCRIPTION
### Summary

Enables Fast Dispatch to run on TTSim. The dispatch host code spins in tight busy-wait loops on
prefetch/completion queue pointers; on a simulator, the device only advances when host hands control back,
so without explicitly advancing device execution the simulator never makes progress and the host hangs.
This PR threads an `advance_device_execution()` call through `tt::Cluster` to UMD's driver and calls it
from the two busy-wait sites in `SystemMemoryManager`. It also fixes simulator-side initialization so TLB
setup and sysmem channel sizing work for the `SIMULATION` chip type.

### Notes for reviewers

- `tt_metal/llrt/tt_cluster.{cpp,hpp}`: new `Cluster::advance_device_execution(device_id)` is a thin pass-through
  to `umd::Cluster::advance_device_execution`. On silicon UMD's implementation is a no-op, so this is free for
  the hardware path.
- `tt_metal/llrt/tt_cluster.cpp`:
  - The `TargetDevice::Silicon &&` guard around TLB configuration in `start_driver` is removed so the
    simulator path also runs TLB config when `init_device` is set. Worth a careful look — please confirm there's
    nothing silicon-specific inside that loop that would misbehave on the simulator.
  - `num_host_mem_ch_per_mmio_device = 1` is set for both simulator open paths (mock-cluster-desc and
    target-devices). Matches the "one sysmem page" constraint of the simulator.
- `tt_metal/impl/dispatch/system_memory_manager.cpp`: `cluster.advance_device_execution()` is now called inside
  the busy-wait bodies of `wait_for_fetch_q_space` (in `fetch_queue_reserve_back`) and
  `completion_queue_wait_front`. Each call site has a comment explaining the TTSim rationale.
- UMD submodule bump is required — it brings in the `advance_device_execution()` API on `umd::Cluster`
  (renamed from the earlier `yield()` API).
- No CI coverage for FD-on-TTSim yet, so this was validated locally on the simulator (no longer
  hangs/segfaults). Silicon paths are unchanged behaviorally — `advance_device_execution()` is a no-op there.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjanevski/fast_dispatch_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjanevski/fast_dispatch_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjanevski/fast_dispatch_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjanevski/fast_dispatch_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjanevski/fast_dispatch_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjanevski/fast_dispatch_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjanevski/fast_dispatch_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjanevski/fast_dispatch_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjanevski/fast_dispatch_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjanevski/fast_dispatch_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjanevski/fast_dispatch_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjanevski/fast_dispatch_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjanevski/fast_dispatch_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjanevski/fast_dispatch_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjanevski/fast_dispatch_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjanevski/fast_dispatch_test)