### PR TITLE
fix(transformer): default fp32_dest_acc_en=true for fp32 nlp_create_qkv_heads transpose

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_program_factory.cpp
@@ -157,12 +157,16 @@ CreateQKVHeadsProgramFactory::cached_program_t CreateQKVHeadsProgramFactory::cre
         std::vector<uint32_t> compute_args = {
             (std::uint32_t)block_ht * num_tiles_per_group[1] * groups_per_block,  // number of K tiles
         };
+        // For FLOAT32 input, enable fp32 dest accumulation so the JIT data-format selection
+        // resolves the unpack-dst CB to Tf32 (10-bit mantissa) instead of Float16_b (7-bit
+        // mantissa). Mirrors the per-dtype promotion in eltwise unary/binary primitives.
+        const bool fp32_dest_acc_en = input_tensor.dtype() == tt_metal::DataType::FLOAT32;
         compute_kernel_id = tt_metal::CreateKernel(
             program,
             "ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/kernels/"
             "compute/transpose_wh_sharded.cpp",
             all_cores,
-            tt_metal::ComputeConfig{.compile_args = compute_args});
+            tt_metal::ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_args});
     }
 
     uint32_t input_size = block_ht * block_wt * single_tile_size;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_program_factory.cpp
@@ -80,12 +80,16 @@ CreateQKVHeadsSeparateTensorsProgramFactory::cached_program_t CreateQKVHeadsSepa
         std::vector<uint32_t> compute_args = {
             (std::uint32_t)(per_core_k_tiles),  // number of K tiles
         };
+        // For FLOAT32 input, enable fp32 dest accumulation so the JIT data-format selection
+        // resolves the unpack-dst CB to Tf32 (10-bit mantissa) instead of Float16_b (7-bit
+        // mantissa). Mirrors the per-dtype promotion in eltwise unary/binary primitives.
+        const bool fp32_dest_acc_en = input_tensor_kv.dtype() == tt_metal::DataType::FLOAT32;
         tt_metal::CreateKernel(
             program,
             "ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/kernels/"
             "compute/transpose_wh_sharded.cpp",
             all_cores,
-            tt_metal::ComputeConfig{.compile_args = compute_args});
+            tt_metal::ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_args});
     }
 
     uint32_t q_size = per_core_q_tiles * single_tile_size;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
@@ -115,12 +115,17 @@ NlpCreateHeadsDeviceOperation::Interleaved::cached_program_t NlpCreateHeadsDevic
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
     if (transpose_k_heads) {
+        // For FLOAT32 input, enable fp32 dest accumulation so the JIT data-format selection
+        // resolves the unpack-dst CB to Tf32 (10-bit mantissa) instead of Float16_b (7-bit
+        // mantissa). Mirrors the per-dtype promotion in eltwise unary/binary primitives.
+        const bool fp32_dest_acc_en = input_tensor.dtype() == tt_metal::DataType::FLOAT32;
+
         std::vector<uint32_t> compute_args_core_group_1 = {num_blocks_per_core_group_1 * kv_num_tiles};
         tt_metal::CreateKernel(
             program,
             "ttnn/cpp/ttnn/kernel/compute/transpose_wh.cpp",
             core_group_1,
-            tt_metal::ComputeConfig{.compile_args = compute_args_core_group_1});
+            tt_metal::ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_args_core_group_1});
 
         if (core_group_2.num_cores() > 0) {
             std::vector<uint32_t> compute_args_core_group_2 = {num_blocks_per_core_group_2 * kv_num_tiles};
@@ -128,7 +133,8 @@ NlpCreateHeadsDeviceOperation::Interleaved::cached_program_t NlpCreateHeadsDevic
                 program,
                 "ttnn/cpp/ttnn/kernel/compute/transpose_wh.cpp",
                 core_group_2,
-                tt_metal::ComputeConfig{.compile_args = compute_args_core_group_2});
+                tt_metal::ComputeConfig{
+                    .fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_args_core_group_2});
         }
 
         reader_defines["TRANSPOSE_K_HEADS"] = "1";


### PR DESCRIPTION
## Summary

Auto-promote `fp32_dest_acc_en=true` in the `transpose_wh` / `transpose_wh_sharded` compute kernels created by three sibling QKV-heads ops when `transpose_k_heads=true` and input dtype is `FLOAT32`:

- `nlp_create_qkv_heads` (Interleaved factory)
- `create_qkv_heads` (sharded factory)
- `create_qkv_heads_from_separate_tensors` (sharded factory; preemptive — no parametrised fp32 test today, but shares the same `transpose_wh_sharded` kernel path)

Mirrors the per-dtype promotion already done by the unary/binary eltwise primitives and `reduce_scatter_minimal_async` (#43382).

Fixes the deterministic precision regressions flagged by [auto-triage](https://github.com/tenstorrent/tt-metal/actions/runs/25151607146) and the follow-up `runtime_fd_python_2` failure on this branch:

- `test_nlp_create_qkv_heads.py::test_nlp_create_qkv_heads_test[111-64-96-5-3-True-False-FLOAT32-in_DRAM-out_DRAM]`
- `test_create_qkv_heads.py::test_nlp_create_qkv_heads_test[7-224-8-8-64-7-8-True-FLOAT32-device_params0]`

Both regressed at commit `2f9afc85` (PR #43256).

## Root cause

Commit `2f9afc85` ("fix(conv): preserve fp32 magnitudes through halo's untilize", #43229 / #43256) changed `tt_metal/jit_build/data_format.cpp::get_data_exp_precision` to return `ExpPrecision::B` (instead of `A`) when all CBs are Float32. In `genfiles.cpp`, that flips the conditional unpack-dst format from `Float16` (5-bit exp, 10-bit mantissa) → `Float16_b` (8-bit exp, 7-bit mantissa) for any kernel running with `fp32_dest_acc_en=false` and all-fp32 CBs.

The wider exponent was the intent for the conv halo path (fixes #43229). But the change was global, so any other op that landed on the conditional branch silently lost 3 bits of mantissa precision.

## Why the QKV-heads ops specifically

When invoked with `transpose_k_heads=True` and `dtype=FLOAT32`:

1. The program factory creates a `transpose_wh` (or `transpose_wh_sharded`) compute kernel with a default `ComputeConfig{}` (no `fp32_dest_acc_en`).
2. All CBs for this kernel are `DataFormat::Float32`.
3. `check_consistent_format_across_buffers` skips Float32 → returns `Invalid`.
4. Post-#43229: `ExpPrecision::B` → `unpack_conditional_dst_format = Float16_b` → mantissa drops from 10 bits to 7 bits → PCC 0.99999 < 0.9999999 threshold.

Q and V heads were unaffected because they take a pure data-movement path (reader → writer, no compute kernel). The test PCC checks only failed on `passing_pcc_k`.

## The fix

```cpp
const bool fp32_dest_acc_en = input_tensor.dtype() == tt_metal::DataType::FLOAT32;
tt_metal::CreateKernel(
    program,
    ".../transpose_wh.cpp",
    cores,
    tt_metal::ComputeConfig{
        .fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_args});
```

`fp32_dest_acc_en=true` causes `get_operand_dst_format(icb)` to return `Tf32` for the JIT data-format selection — 10-bit mantissa, full fp32 exponent — restoring the pre-#43229 mantissa precision while preserving the conv exponent fix.

Bf16 / bf8 paths are untouched (the boolean evaluates to `false` for those dtypes, matching prior behaviour).

## Test plan

- [x] Reproduce on local N300:
  - `test_nlp_create_qkv_heads.py::...[111-64-96-5-3-True-False-FLOAT32-in_DRAM-out_DRAM]` — fails at K PCC.
  - `test_create_qkv_heads.py::...[7-224-8-8-64-7-8-True-FLOAT32-device_params0]` — fails at K PCC.
- [x] Apply fix, rebuild release, re-run:
  - First test passes (K PCC 0.9999999759).
  - Second test passes (K PCC 0.9999999761).
- [x] Full local suites:
  - `test_nlp_create_qkv_heads.py::test_nlp_create_qkv_heads_test` — 36/36 pass.
  - `test_create_qkv_heads.py` — 58/58 pass.
- [x] Full `runtime-integration-tests` workflow on this branch — first dispatch caught the second regression at commit `23448a4`: https://github.com/tenstorrent/tt-metal/actions/runs/25156663573
- [ ] Re-dispatched after second fix (commit `5788c7e`): https://github.com/tenstorrent/tt-metal/actions/runs/25168419047

## Follow-ups (not in this PR)

- These ops do not currently expose a `compute_kernel_config` parameter. Adding one (mirroring PR #43382's surface) would let advanced callers override; out of scope here since the auto-promotion is sufficient to close the regression.
- Other transformer ops with `transpose_wh` compute kernels that were not touched here: `nlp_create_qkv_heads_boltz`, `nlp_create_qkv_heads_vit`, `split_query_key_value_and_split_heads` (interleaved + sharded factories). Same pattern, no current CI failure — left for a separate PR if regressions surface.
- The Sharded factory in `nlp_create_qkv_heads` does not create a compute kernel — the dtype-conditional fix is only needed in the Interleaved factory there.
- The global `data_format.cpp` change in #43229/#43256 remains a foot-gun for any future op that runs on fp32 without opting into `fp32_dest_acc_en`. Consider a CI gate that flags all-fp32 + `fp32_dest_acc_en=false` so this kind of silent precision drop fails loudly at codegen time. (Same follow-up as #43382.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
