### PR TITLE
Fix binary sharded Sanity test fails due to infra update

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
+++ b/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
@@ -56,6 +56,11 @@ std::shared_ptr<Buffer> MakeDramBuffer(IDevice* device, uint32_t size = 2048) {
     return CreateBuffer(cfg);
 }
 
+std::shared_ptr<Buffer> MakeL1Buffer(IDevice* device, uint32_t size = 2048) {
+    InterleavedBufferConfig cfg{.device = device, .size = size, .page_size = size, .buffer_type = BufferType::L1};
+    return CreateBuffer(cfg);
+}
+
 // ============================================================================
 // SECTION 1: Pure unit tests — no device required
 // ============================================================================
@@ -323,6 +328,42 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyResolvedBindings_RepeatedApplic
     // Apply back to buf_a.
     apply_resolved_bindings(program, resolved, {buf_a.get()});
     EXPECT_EQ(GetRuntimeArgs(program, 0, {0, 0})[0], buf_a->address());
+}
+
+// Regression: a descriptor with sharded CB buffers but no emplace_runtime_args()
+// Buffer* calls must produce empty ResolvedBindings, so the adapter falls through
+// to the slow path.  Before the fix, CB-only bindings made empty() return false,
+// causing the fast path to activate for factories that never opted in.
+TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_CbOnlyBuffers_ReturnsEmpty) {
+    auto buf_dram = MakeDramBuffer(device());
+    auto buf_l1 = MakeL1Buffer(device());
+
+    KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
+    // Old-style: push buffer address as plain uint32_t (no Buffer* binding).
+    kd.runtime_args.emplace_back(CoreCoord{0, 0}, KernelDescriptor::CoreRuntimeArgs{buf_dram->address(), 42u});
+
+    ProgramDescriptor desc;
+    desc.kernels = {kd};
+
+    // Simulate a sharded CB: set .buffer on the CB descriptor (must be L1).
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2048,
+        .core_ranges = CoreRangeSet{CoreRange{{0, 0}}},
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = 0,
+            .data_format = tt::DataFormat::Float16_b,
+            .page_size = 2048,
+        }}},
+        .buffer = buf_l1.get(),
+    });
+
+    Program program{desc};
+    ResolvedBindings resolved = resolve_bindings(program, desc, {buf_l1.get()});
+
+    // No rt_arg bindings were declared, so both rt_args and cbs must be empty.
+    EXPECT_TRUE(resolved.rt_args.empty());
+    EXPECT_TRUE(resolved.cbs.empty());
+    EXPECT_TRUE(resolved.empty());
 }
 
 // resolve_bindings fires TT_FATAL when a binding buffer is not in tensor_buffers.

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -139,7 +139,9 @@ ResolvedBindings resolve_bindings(
     }
 
     // Only resolve CB bindings when the factory actually opted into the fast path
-    // by declaring at least one buffer binding via emplace_runtime_args().
+    // by declaring at least one runtime-arg buffer binding, whether via
+    // emplace_runtime_args() or emplace_common_runtime_args()
+    // (i.e. when !result.rt_args.empty()).
     // Without this guard, sharded operations that use the old API (passing
     // buffer->address() as uint32_t) would have non-empty resolved_bindings
     // due to CB entries alone, causing the adapter to take the fast path and

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -138,11 +138,19 @@ ResolvedBindings resolve_bindings(
         }
     }
 
-    auto program_cbs = program.circular_buffers();
-    for (uint32_t ci = 0; ci < static_cast<uint32_t>(desc.cbs.size()); ++ci) {
-        if (desc.cbs[ci].buffer) {
-            result.cbs.push_back(
-                {program_cbs[ci]->id(), find_idx(desc.cbs[ci].buffer, "cbs"), desc.cbs[ci].address_offset});
+    // Only resolve CB bindings when the factory actually opted into the fast path
+    // by declaring at least one buffer binding via emplace_runtime_args().
+    // Without this guard, sharded operations that use the old API (passing
+    // buffer->address() as uint32_t) would have non-empty resolved_bindings
+    // due to CB entries alone, causing the adapter to take the fast path and
+    // skip the full runtime-arg rebuild on cache hits.
+    if (!result.rt_args.empty()) {
+        auto program_cbs = program.circular_buffers();
+        for (uint32_t ci = 0; ci < static_cast<uint32_t>(desc.cbs.size()); ++ci) {
+            if (desc.cbs[ci].buffer) {
+                result.cbs.push_back(
+                    {program_cbs[ci]->id(), find_idx(desc.cbs[ci].buffer, "cbs"), desc.cbs[ci].address_offset});
+            }
         }
     }
 


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
PR https://github.com/tenstorrent/tt-metal/pull/42992 caused a failure in Sanity tests https://github.com/tenstorrent/tt-metal/actions/runs/25130858947
### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
**The problem:** `resolve_bindings()` unconditionally resolved CB bindings for any CBDescriptor with a non-null .buffer (i.e., any sharded CB). This made `ResolvedBindings::empty()` return false for sharded operations, causing the adapter to take the fast path on cache hits -- even for factories like binary_ng that never opted into the new API. The fast path only patches registered buffer positions and CB addresses, skipping the full runtime-arg rebuild. This left per-core runtime args (buffer addresses, packed scalars, tile offsets) stale from the initial cache-miss call.

**How it is fixed:** Wrap the CB binding resolution in if `(!result.rt_args.empty())`. CB bindings are only created when at least one kernel actually declared buffer bindings via `emplace_runtime_args()` with Buffer* args. Factories that haven't migrated produce a completely empty ResolvedBindings, so the adapter correctly falls through to the slow path (full descriptor rebuild + bulk copy).

**Note:** The fast path's contract is: on cache hits, only buffer addresses change; everything else is structurally identical. Binary_ng violates that assumption because the scalar values passed as runtime args, varies across cache hits. Until the fast-path API supports declaring non-buffer variable args (or binary_ng hashes the scalar to guarantee structural identity on cache hits which beats the purpose of runtime args), binary_ng must stay on the slow path.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kalaivani/resolve_bindings_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kalaivani/resolve_bindings_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kalaivani/resolve_bindings_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kalaivani/resolve_bindings_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kalaivani/resolve_bindings_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kalaivani/resolve_bindings_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kalaivani/resolve_bindings_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kalaivani/resolve_bindings_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kalaivani/resolve_bindings_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kalaivani/resolve_bindings_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kalaivani/resolve_bindings_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kalaivani/resolve_bindings_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kalaivani/resolve_bindings_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kalaivani/resolve_bindings_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kalaivani/resolve_bindings_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kalaivani/resolve_bindings_fix)