### PR TITLE
[tt-train] Fix OOM in to_numpy for model checkpointing

### DIFF
--- a/tt-train/sources/ttml/autograd/autocast_tensor.cpp
+++ b/tt-train/sources/ttml/autograd/autocast_tensor.cpp
@@ -4,6 +4,8 @@
 
 #include "autocast_tensor.hpp"
 
+#include <tt-logger/tt-logger.hpp>
+
 #include "core/tt_tensor_utils.hpp"
 
 namespace ttml::autograd {
@@ -37,6 +39,7 @@ bool AutocastTensor::has_full() const {
 }
 
 const tt::tt_metal::Tensor &AutocastTensor::get_tensor(PreferredPrecision preferred_precision, bool autocast) const {
+    TT_FATAL(has_half() || has_full(), "AutocastTensor has neither half nor full precision tensor initialized");
     // Non-float tensors (e.g. UINT32 embedding indices) are stored in the full-precision
     // slot and returned unchanged — they cannot be typecast to half/full float precision.
     if (has_full() && !is_float_dtype(m_full_precision_tensor.dtype())) {
@@ -44,11 +47,26 @@ const tt::tt_metal::Tensor &AutocastTensor::get_tensor(PreferredPrecision prefer
     }
 
     if (!autocast) {
-        TT_FATAL(has_half() || has_full(), "AutocastTensor has neither half nor full precision tensor initialized");
         if (preferred_precision == PreferredPrecision::HALF) {
-            return has_half() ? m_half_precision_tensor : m_full_precision_tensor;
+            if (!has_half()) {
+                log_warning(
+                    tt::LogAlways,
+                    "Requested half precision tensor but AutocastTensor has no half precision tensor initialized. "
+                    "Since autocast=false, returning full precision tensor instead. To create a half precision tensor, "
+                    "set autocast=true.");
+                return m_full_precision_tensor;
+            }
+            return m_half_precision_tensor;
         }
-        return has_full() ? m_full_precision_tensor : m_half_precision_tensor;
+        if (!has_full()) {
+            log_warning(
+                tt::LogAlways,
+                "Requested full precision tensor but AutocastTensor has no full precision tensor initialized. Since "
+                "autocast=false, returning half precision tensor instead. To create a full precision tensor, set "
+                "autocast=true.");
+            return m_half_precision_tensor;
+        }
+        return m_full_precision_tensor;
     }
 
     // TODO: Lazy precision caching can leave the FULL/FLOAT32 view stale

--- a/tt-train/sources/ttml/autograd/autocast_tensor.cpp
+++ b/tt-train/sources/ttml/autograd/autocast_tensor.cpp
@@ -36,11 +36,19 @@ bool AutocastTensor::has_full() const {
     return core::is_tensor_initialized(m_full_precision_tensor);
 }
 
-const tt::tt_metal::Tensor &AutocastTensor::get_tensor(PreferredPrecision preferred_precision) const {
+const tt::tt_metal::Tensor &AutocastTensor::get_tensor(PreferredPrecision preferred_precision, bool autocast) const {
     // Non-float tensors (e.g. UINT32 embedding indices) are stored in the full-precision
     // slot and returned unchanged — they cannot be typecast to half/full float precision.
     if (has_full() && !is_float_dtype(m_full_precision_tensor.dtype())) {
         return m_full_precision_tensor;
+    }
+
+    if (!autocast) {
+        TT_FATAL(has_half() || has_full(), "AutocastTensor has neither half nor full precision tensor initialized");
+        if (preferred_precision == PreferredPrecision::HALF) {
+            return has_half() ? m_half_precision_tensor : m_full_precision_tensor;
+        }
+        return has_full() ? m_full_precision_tensor : m_half_precision_tensor;
     }
 
     // TODO: Lazy precision caching can leave the FULL/FLOAT32 view stale

--- a/tt-train/sources/ttml/autograd/autocast_tensor.hpp
+++ b/tt-train/sources/ttml/autograd/autocast_tensor.hpp
@@ -26,7 +26,7 @@ public:
 
     void set_tensor(const tt::tt_metal::Tensor &tensor);
     [[nodiscard]] const tt::tt_metal::Tensor &get_tensor(
-        PreferredPrecision preferred_precision = PreferredPrecision::HALF) const;
+        PreferredPrecision preferred_precision = PreferredPrecision::HALF, bool autocast = true) const;
 
     [[nodiscard]] bool has_half() const;
     [[nodiscard]] bool has_full() const;

--- a/tt-train/sources/ttml/autograd/tensor.cpp
+++ b/tt-train/sources/ttml/autograd/tensor.cpp
@@ -136,8 +136,8 @@ void Tensor::set_requires_grad(bool requires_grad) {
     m_requires_grad = requires_grad;
 }
 
-const tt::tt_metal::Tensor& Tensor::get_value(PreferredPrecision preferred_precision) const {
-    return m_value.get_tensor(preferred_precision);
+const tt::tt_metal::Tensor& Tensor::get_value(PreferredPrecision preferred_precision, bool autocast) const {
+    return m_value.get_tensor(preferred_precision, autocast);
 }
 
 const tt::tt_metal::Tensor& Tensor::get_grad() const {

--- a/tt-train/sources/ttml/autograd/tensor.hpp
+++ b/tt-train/sources/ttml/autograd/tensor.hpp
@@ -36,7 +36,8 @@ public:
     void add_grad(const tt::tt_metal::Tensor &grad);
     void set_requires_grad(bool requires_grad);
 
-    const tt::tt_metal::Tensor &get_value(PreferredPrecision preferred_precision = PreferredPrecision::HALF) const;
+    const tt::tt_metal::Tensor &get_value(
+        PreferredPrecision preferred_precision = PreferredPrecision::HALF, bool autocast = true) const;
     const tt::tt_metal::Tensor &get_grad() const;
     tt::tt_metal::Tensor &get_grad();
     bool get_requires_grad() const;

--- a/tt-train/sources/ttml/nanobind/nb_autograd.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_autograd.cpp
@@ -143,12 +143,16 @@ void py_module(nb::module_& m) {
             "to_numpy",
             [](const Tensor& tensor,
                std::optional<tt::tt_metal::DataType> new_type,
-               ttnn::distributed::MeshToTensor* composer) {
-                return ttml::nanobind::util::make_numpy_tensor(
-                    tensor.get_value(PreferredPrecision::FULL), new_type, composer);
+               ttnn::distributed::MeshToTensor* composer,
+               bool prefer_half) {
+                // prefer_half=True reads bf16 storage directly, avoiding a device-side float32
+                // typecast and its persistent cache in AutocastTensor. Avoids OOM on checkpoint.
+                auto prec = prefer_half ? PreferredPrecision::HALF : PreferredPrecision::FULL;
+                return ttml::nanobind::util::make_numpy_tensor(tensor.get_value(prec), new_type, composer);
             },
             nb::arg("new_type") = std::nullopt,
             nb::arg("composer") = nullptr,
+            nb::arg("prefer_half") = false,
             "Construct a numpy tensor from a Tensor");
         py_tensor.def(
             "to_string",

--- a/tt-train/sources/ttml/nanobind/nb_autograd.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_autograd.cpp
@@ -85,6 +85,7 @@ void py_module(nb::module_& m) {
             "get_value",
             &Tensor::get_value,
             nb::arg("precision") = PreferredPrecision::HALF,
+            nb::arg("autocast") = true,
             "Get underlying tensor value");
         py_tensor.def("get_grad", nb::overload_cast<>(&Tensor::get_grad, nb::const_), "Get gradient");
         py_tensor.def("get_grad_rw", nb::overload_cast<>(&Tensor::get_grad), "Get/set gradient");
@@ -144,15 +145,18 @@ void py_module(nb::module_& m) {
             [](const Tensor& tensor,
                std::optional<tt::tt_metal::DataType> new_type,
                ttnn::distributed::MeshToTensor* composer,
-               bool prefer_half) {
-                // prefer_half=True reads bf16 storage directly, avoiding a device-side float32
-                // typecast and its persistent cache in AutocastTensor. Avoids OOM on checkpoint.
-                auto prec = prefer_half ? PreferredPrecision::HALF : PreferredPrecision::FULL;
-                return ttml::nanobind::util::make_numpy_tensor(tensor.get_value(prec), new_type, composer);
+               bool cast_on_device) {
+                // cast_on_device=False fetches the bf16 storage directly without triggering a
+                // device-side typecast or caching a float32 copy in AutocastTensor. Any dtype
+                // conversion is then done on the CPU via new_type. Use this for checkpointing
+                // bf16 models to avoid OOM from float32 copies of every parameter accumulating
+                // on device simultaneously. TT_FATAL if the requested precision is not cached.
+                return ttml::nanobind::util::make_numpy_tensor(
+                    tensor.get_value(PreferredPrecision::FULL, /*autocast=*/cast_on_device), new_type, composer);
             },
             nb::arg("new_type") = std::nullopt,
             nb::arg("composer") = nullptr,
-            nb::arg("prefer_half") = false,
+            nb::arg("cast_on_device") = true,
             "Construct a numpy tensor from a Tensor");
         py_tensor.def(
             "to_string",

--- a/tt-train/tests/python/test_autograd.py
+++ b/tt-train/tests/python/test_autograd.py
@@ -516,6 +516,42 @@ def test_numpy_autograd_conversion_expecting_runtime_error(tensor_data, numpy_ty
     )
 
 
+def test_to_numpy_prefer_half_returns_bfloat16_dtype():
+    # prefer_half=True should return an ml_dtypes.bfloat16 array, not float32.
+    numpy_tensor = np.array(default_tensor_data, dtype=ml_dtypes.bfloat16)
+    tensor = ttml.autograd.Tensor.from_numpy(numpy_tensor, new_type=ttnn.DataType.BFLOAT16)
+    result = tensor.to_numpy(prefer_half=True)
+    assert result.dtype == ml_dtypes.bfloat16, f"Expected ml_dtypes.bfloat16, got {result.dtype}"
+
+
+def test_to_numpy_prefer_half_matches_float32_path():
+    # prefer_half=True + .astype(float32) must be numerically identical to to_numpy(FLOAT32).
+    numpy_tensor = np.array(default_tensor_data, dtype=ml_dtypes.bfloat16)
+    tensor = ttml.autograd.Tensor.from_numpy(numpy_tensor, new_type=ttnn.DataType.BFLOAT16)
+    via_prefer_half = tensor.to_numpy(prefer_half=True).astype(np.float32)
+    via_float32 = tensor.to_numpy(ttnn.DataType.FLOAT32)
+    np.testing.assert_array_equal(via_prefer_half, via_float32)
+
+
+def test_to_numpy_prefer_half_with_new_type_float32():
+    # prefer_half=True + new_type=FLOAT32 is valid: bf16 is fetched from device (no AutocastTensor
+    # float32 cache created) and converted to float32 in C++ on the CPU side.
+    numpy_tensor = np.array(default_tensor_data, dtype=ml_dtypes.bfloat16)
+    tensor = ttml.autograd.Tensor.from_numpy(numpy_tensor, new_type=ttnn.DataType.BFLOAT16)
+    result = tensor.to_numpy(prefer_half=True, new_type=ttnn.DataType.FLOAT32)
+    assert result.dtype == np.float32
+    np.testing.assert_array_equal(result, tensor.to_numpy(ttnn.DataType.FLOAT32))
+
+
+def test_to_numpy_prefer_half_false_unchanged():
+    # prefer_half=False (default) must behave identically to the pre-existing default path.
+    numpy_tensor = np.array(default_tensor_data, dtype=ml_dtypes.bfloat16)
+    tensor = ttml.autograd.Tensor.from_numpy(numpy_tensor, new_type=ttnn.DataType.BFLOAT16)
+    default_result = tensor.to_numpy(ttnn.DataType.FLOAT32)
+    explicit_false_result = tensor.to_numpy(prefer_half=False, new_type=ttnn.DataType.FLOAT32)
+    np.testing.assert_array_equal(default_result, explicit_false_result)
+
+
 def make_tensors(tensor_data, numpy_type, autograd_type, layout):
     numpy_tensor = np.array(tensor_data, dtype=numpy_type)
 

--- a/tt-train/tests/python/test_autograd.py
+++ b/tt-train/tests/python/test_autograd.py
@@ -516,40 +516,42 @@ def test_numpy_autograd_conversion_expecting_runtime_error(tensor_data, numpy_ty
     )
 
 
-def test_to_numpy_prefer_half_returns_bfloat16_dtype():
-    # prefer_half=True should return an ml_dtypes.bfloat16 array, not float32.
+def test_to_numpy_no_device_cast_returns_bfloat16_dtype():
+    # cast_on_device=False on a bf16 tensor should return ml_dtypes.bfloat16 — the raw
+    # storage is returned without triggering a device-side typecast.
     numpy_tensor = np.array(default_tensor_data, dtype=ml_dtypes.bfloat16)
     tensor = ttml.autograd.Tensor.from_numpy(numpy_tensor, new_type=ttnn.DataType.BFLOAT16)
-    result = tensor.to_numpy(prefer_half=True)
+    result = tensor.to_numpy(cast_on_device=False)
     assert result.dtype == ml_dtypes.bfloat16, f"Expected ml_dtypes.bfloat16, got {result.dtype}"
 
 
-def test_to_numpy_prefer_half_matches_float32_path():
-    # prefer_half=True + .astype(float32) must be numerically identical to to_numpy(FLOAT32).
+def test_to_numpy_no_device_cast_matches_float32_path():
+    # cast_on_device=False + .astype(float32) must be numerically identical to the
+    # default cast_on_device=True path with new_type=FLOAT32.
     numpy_tensor = np.array(default_tensor_data, dtype=ml_dtypes.bfloat16)
     tensor = ttml.autograd.Tensor.from_numpy(numpy_tensor, new_type=ttnn.DataType.BFLOAT16)
-    via_prefer_half = tensor.to_numpy(prefer_half=True).astype(np.float32)
-    via_float32 = tensor.to_numpy(ttnn.DataType.FLOAT32)
-    np.testing.assert_array_equal(via_prefer_half, via_float32)
+    via_cpu_cast = tensor.to_numpy(cast_on_device=False).astype(np.float32)
+    via_device_cast = tensor.to_numpy(ttnn.DataType.FLOAT32)
+    np.testing.assert_array_equal(via_cpu_cast, via_device_cast)
 
 
-def test_to_numpy_prefer_half_with_new_type_float32():
-    # prefer_half=True + new_type=FLOAT32 is valid: bf16 is fetched from device (no AutocastTensor
-    # float32 cache created) and converted to float32 in C++ on the CPU side.
+def test_to_numpy_no_device_cast_with_new_type_float32():
+    # cast_on_device=False + new_type=FLOAT32: bf16 fetched from device without caching a
+    # float32 copy in AutocastTensor; conversion to float32 happens on the CPU side.
     numpy_tensor = np.array(default_tensor_data, dtype=ml_dtypes.bfloat16)
     tensor = ttml.autograd.Tensor.from_numpy(numpy_tensor, new_type=ttnn.DataType.BFLOAT16)
-    result = tensor.to_numpy(prefer_half=True, new_type=ttnn.DataType.FLOAT32)
+    result = tensor.to_numpy(cast_on_device=False, new_type=ttnn.DataType.FLOAT32)
     assert result.dtype == np.float32
     np.testing.assert_array_equal(result, tensor.to_numpy(ttnn.DataType.FLOAT32))
 
 
-def test_to_numpy_prefer_half_false_unchanged():
-    # prefer_half=False (default) must behave identically to the pre-existing default path.
+def test_to_numpy_cast_on_device_true_unchanged():
+    # cast_on_device=True (default) must behave identically to the pre-existing default path.
     numpy_tensor = np.array(default_tensor_data, dtype=ml_dtypes.bfloat16)
     tensor = ttml.autograd.Tensor.from_numpy(numpy_tensor, new_type=ttnn.DataType.BFLOAT16)
     default_result = tensor.to_numpy(ttnn.DataType.FLOAT32)
-    explicit_false_result = tensor.to_numpy(prefer_half=False, new_type=ttnn.DataType.FLOAT32)
-    np.testing.assert_array_equal(default_result, explicit_false_result)
+    explicit_true_result = tensor.to_numpy(cast_on_device=True, new_type=ttnn.DataType.FLOAT32)
+    np.testing.assert_array_equal(default_result, explicit_true_result)
 
 
 def make_tensors(tensor_data, numpy_type, autograd_type, layout):


### PR DESCRIPTION
### Summary
As per the ticket https://github.com/tenstorrent/tt-metal/issues/43404, the TinyLlama pretraining OOM crash when saving checkpoints was caused by `to_numpy` defaulting to creating a float32 copy of the bfloat16 tensor on device memory through the `ttnn::typecast` call. 

To avoid this unecessary extra memory allocation when users are trying to read tensors into numpy during model parameter serialization, a new `cast_on_device` argument (default `true`) was added to the Python nanobind `to_numpy` API allowing users to skip the automatic generation of a full-precision device tensor and defer the type conversion to the host CPU. This in turn sets a newly-added `autocast = false` argument (by default `autocast = true` to match existing behavior) in the `Tensor` and `AutocastTensor` `get_tensor` API. When `autocast = false`, the `get_value(PreferredPrecision)` will attempt to return the tensor of preferred precision. If it does not exist, then it will try to return the tensor woth the other precision. If neither exist, we get a `TT_FATAL`. Unit tests were also added.

### Checklist

- [x] [Sanity Tests](https://github.com/tenstorrent/tt-metal/actions/runs/25160553325) - [main results](https://github.com/tenstorrent/tt-metal/actions/runs/25093195989)
- [x] [Blackhole Post Commit](https://github.com/tenstorrent/tt-metal/actions/runs/25160577736) - [main results](https://github.com/tenstorrent/tt-metal/actions/runs/25091794658)
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/runs/25160506195) - [main results](https://github.com/tenstorrent/tt-metal/actions/runs/25151578768/job/73756199184)
- [x] [(Runtime) Sanity Tests](https://github.com/tenstorrent/tt-metal/actions/runs/25183483800)
- [x] New/Existing unit tests for this change

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=awliu/to_numpy_OOM_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:awliu/to_numpy_OOM_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=awliu/to_numpy_OOM_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:awliu/to_numpy_OOM_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=awliu/to_numpy_OOM_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:awliu/to_numpy_OOM_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=awliu/to_numpy_OOM_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:awliu/to_numpy_OOM_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=awliu/to_numpy_OOM_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:awliu/to_numpy_OOM_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=awliu/to_numpy_OOM_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:awliu/to_numpy_OOM_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=awliu/to_numpy_OOM_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:awliu/to_numpy_OOM_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=awliu/to_numpy_OOM_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:awliu/to_numpy_OOM_fix)