### PR TITLE
LLK ttsim harness: pre-pay sim cycles after a SOFT_RESET deassert

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/device.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/device.py
@@ -15,6 +15,7 @@ from ttexalens.hardware.risc_debug import CallstackEntry
 from ttexalens.tt_exalens_lib import (
     ParsedElfFile,
     TTException,
+    advance_simulated_clock,
     arc_msg,
     callstack,
     check_context,
@@ -172,6 +173,12 @@ def commit_tensix_soft_reset(
     get_register_store(location, device_id).write_register(
         "RISCV_DEBUG_REG_SOFT_RESET_0", soft_reset
     )
+
+    # This path bypasses umd's deassert_risc_reset API (which has its own simulated-clock
+    # advance). On TTSim a freshly-deasserted RISC needs simulated cycles to clear CRT init
+    # before the next host op lands — pre-pay them explicitly. No-op on silicon.
+    if not value:
+        advance_simulated_clock(1000, device_id=device_id)
 
     end_time = time.time() + 0.1  # 100ms
     while time.time() < end_time:


### PR DESCRIPTION
## Summary

The companion tt-umd PR drops the \`advance_clock(1000)\` floor on every \`write_to_device\` — the brisc-CRT-startup pre-pay now fires only on the umd reset APIs (\`send_tensix_risc_reset\` / \`deassert_risc_reset\`) that actually need it. That's a ~228× speedup on small writes, which recovers the ~40 min regression in the galaxy \`unit_tests_api\` ttsim CI runs.

\`commit_tensix_soft_reset\` writes \`RISCV_DEBUG_REG_SOFT_RESET_0\` directly via \`register_store\`, so it bypasses umd's reset API and doesn't get the new advance. Without an explicit pre-pay here, a freshly-deasserted brisc only has ~4 sim cycles before the harness issues \`commit_brisc_command\` — way short of what brisc needs to clear CRT init, so the handshake hangs.

Add an explicit \`advance_simulated_clock(1000)\` call after the deassert. No-op on silicon (wallclock advances naturally).

### Companion PRs

Both required; this PR will not work standalone until the matching tt-umd / tt-exalens releases land.

- tt-umd PR https://github.com/tenstorrent/tt-umd/pull/2557 — drops the \`write_to_device\` floor and adds the \`advance_simulated_clock\` binding.
- tt-exalens PR https://github.com/tenstorrent/tt-exalens/pull/1002 — exposes \`advance_simulated_clock\` through \`tt_exalens_lib\`.

## Test plan

- [x] LLK Float16_b 6-test smoke (\`test_eltwise_unary_datacopy\` on BH ttsim v1.5.4) with companion tt-umd + tt-exalens changes: 6/6 pass
- [ ] Silicon path unchanged (\`advance_simulated_clock\` is a no-op on silicon)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/llk-ttsim-deassert-clock)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/llk-ttsim-deassert-clock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/llk-ttsim-deassert-clock)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/llk-ttsim-deassert-clock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/llk-ttsim-deassert-clock)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/llk-ttsim-deassert-clock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/llk-ttsim-deassert-clock)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/llk-ttsim-deassert-clock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/llk-ttsim-deassert-clock)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/llk-ttsim-deassert-clock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/llk-ttsim-deassert-clock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/llk-ttsim-deassert-clock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/llk-ttsim-deassert-clock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/llk-ttsim-deassert-clock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/llk-ttsim-deassert-clock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/llk-ttsim-deassert-clock)