### PR TITLE
#42390 [Descriptor Migration] full

### DIFF
--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_common.hpp
@@ -20,13 +20,13 @@ union fill_value_t {
     float f32;
 };
 
-inline fill_value_t encode_fill_value(const std::variant<float, int>& fill_value, DataType dtype) {
+inline fill_value_t encode_fill_value(const std::variant<float, int>& fill_value, tt::tt_metal::DataType dtype) {
     fill_value_t u;
     if (std::holds_alternative<int>(fill_value)) {
         u.u32 = std::get<int>(fill_value);
     } else {
         auto float_val = std::get<float>(fill_value);
-        if (dtype == DataType::BFLOAT16) {
+        if (dtype == tt::tt_metal::DataType::BFLOAT16) {
             u.u32 = static_cast<uint32_t>(std::bit_cast<uint16_t>(bfloat16(float_val))) << 16;
         } else {
             u.f32 = float_val;
@@ -35,12 +35,12 @@ inline fill_value_t encode_fill_value(const std::variant<float, int>& fill_value
     return u;
 }
 
-inline std::map<std::string, std::string> get_writer_defines(DataType dtype) {
+inline std::map<std::string, std::string> get_writer_defines(tt::tt_metal::DataType dtype) {
     std::map<std::string, std::string> defines;
     switch (dtype) {
-        case DataType::BFLOAT16: defines["OUTPUT_DTYPE_BFLOAT16"] = "1"; break;
-        case DataType::INT32: defines["OUTPUT_DTYPE_INT32"] = "1"; break;
-        case DataType::FLOAT32: defines["OUTPUT_DTYPE_FLOAT32"] = "1"; break;
+        case tt::tt_metal::DataType::BFLOAT16: defines["OUTPUT_DTYPE_BFLOAT16"] = "1"; break;
+        case tt::tt_metal::DataType::INT32: defines["OUTPUT_DTYPE_INT32"] = "1"; break;
+        case tt::tt_metal::DataType::FLOAT32: defines["OUTPUT_DTYPE_FLOAT32"] = "1"; break;
         default: break;
     }
     return defines;

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_common.hpp
@@ -10,6 +10,7 @@
 #include <variant>
 
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <ttnn/tensor/types.hpp>
 
 namespace ttnn::operations::full {
@@ -43,6 +44,15 @@ inline std::map<std::string, std::string> get_writer_defines(DataType dtype) {
         default: break;
     }
     return defines;
+}
+
+inline tt::tt_metal::KernelDescriptor::Defines defines_from_map(const std::map<std::string, std::string>& m) {
+    tt::tt_metal::KernelDescriptor::Defines out;
+    out.reserve(m.size());
+    for (const auto& [k, v] : m) {
+        out.emplace_back(k, v);
+    }
+    return out;
 }
 
 }  // namespace ttnn::operations::full

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_interleaved.cpp
@@ -2,18 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include "ttnn/operations/moreh/moreh_helper_functions.hpp"
-#include "ttnn/operations/cb_utils.hpp"
-#include "full_program_factory_interleaved.hpp"
+#include <tt-metalium/work_split.hpp>
 #include "full_program_factory_common.hpp"
+#include "full_program_factory_interleaved.hpp"
 
 using namespace tt;
 using namespace tt::constants;
+using namespace tt::tt_metal;
 
 namespace ttnn::operations::full {
-FullInterleavedProgramFactory::cached_program_t FullInterleavedProgramFactory::create(
+
+ProgramDescriptor FullInterleavedProgramFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     [[maybe_unused]] const tensor_args_t&,
     tensor_return_value_t& output) {
@@ -31,40 +32,59 @@ FullInterleavedProgramFactory::cached_program_t FullInterleavedProgramFactory::c
 
     tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(dtype);
 
-    Program program = Program();
+    ProgramDescriptor desc;
 
     auto cb_index = tt::CBIndex::c_0;
-    tt::tt_metal::create_cb(cb_index, program, all_cores, page_size, 1, data_format);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_index),
+            .data_format = data_format,
+            .page_size = page_size,
+        }}},
+    });
 
-    auto writer_defines = get_writer_defines(dtype);
+    auto writer_defines_map = get_writer_defines(dtype);
+    auto writer_defines = defines_from_map(writer_defines_map);
     auto u = encode_fill_value(fill_value, dtype);
 
     std::vector<uint32_t> writer_compile_time_args = {(uint32_t)cb_index, elems_per_page, page_size};
     tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
 
-    auto writer_id = CreateWriteKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/full/device/kernels/writer_full.cpp",
-        all_cores,
-        writer_compile_time_args,
-        writer_defines);
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = "ttnn/cpp/ttnn/operations/full/device/kernels/writer_full.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = writer_defines;
+    writer_desc.config = WriterConfigDescriptor{};
 
     auto cores = corerange_to_cores(all_cores, std::nullopt);
 
-    std::optional<tt::tt_metal::KernelHandle> reader_id = std::nullopt;
-    if (num_pages > num_cores) {
+    KernelDescriptor reader_desc;
+    const bool has_reader = num_pages > num_cores;
+    if (has_reader) {
         auto cb_index2 = tt::CBIndex::c_1;
-        tt::tt_metal::create_cb(cb_index2, program, all_cores, page_size, 1, data_format);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = page_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_index2),
+                .data_format = data_format,
+                .page_size = page_size,
+            }}},
+        });
 
         std::vector<uint32_t> reader_compile_time_args = {(uint32_t)cb_index2, elems_per_page, page_size};
         tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(reader_compile_time_args);
 
-        reader_id = CreateReadKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/full/device/kernels/writer_full.cpp",
-            all_cores,
-            reader_compile_time_args,
-            writer_defines);
+        reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/full/device/kernels/writer_full.cpp";
+        reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        reader_desc.core_ranges = all_cores;
+        reader_desc.compile_time_args = std::move(reader_compile_time_args);
+        reader_desc.defines = defines_from_map(writer_defines_map);
+        reader_desc.config = ReaderConfigDescriptor{};
     }
 
     uint32_t page_offset = 0;
@@ -78,45 +98,34 @@ FullInterleavedProgramFactory::cached_program_t FullInterleavedProgramFactory::c
         } else {
             TT_THROW("Core not in specified core ranges");
         }
-        if (reader_id.has_value()) {
+        if (has_reader) {
             uint32_t reader_page_start = page_offset;
             uint32_t num_pages_per_reader = num_pages_per_core / 2;
-            std::vector<uint32_t> reader_args = {
-                output.buffer()->address(), u.u32, num_pages_per_reader, reader_page_start};
-            SetRuntimeArgs(program, reader_id.value(), core, reader_args);
+            reader_desc.runtime_args.emplace_back(
+                core,
+                KernelDescriptor::CoreRuntimeArgs{
+                    output.buffer()->address(), u.u32, num_pages_per_reader, reader_page_start});
 
             uint32_t writer_page_start = reader_page_start + num_pages_per_reader;
             uint32_t num_pages_per_writer = num_pages_per_core - num_pages_per_reader;
-            std::vector<uint32_t> writer_args = {
-                output.buffer()->address(), u.u32, num_pages_per_writer, writer_page_start};
-            SetRuntimeArgs(program, writer_id, core, writer_args);
+            writer_desc.runtime_args.emplace_back(
+                core,
+                KernelDescriptor::CoreRuntimeArgs{
+                    output.buffer()->address(), u.u32, num_pages_per_writer, writer_page_start});
         } else {
-            std::vector<uint32_t> writer_args = {output.buffer()->address(), u.u32, num_pages_per_core, page_offset};
-            SetRuntimeArgs(program, writer_id, core, writer_args);
+            writer_desc.runtime_args.emplace_back(
+                core,
+                KernelDescriptor::CoreRuntimeArgs{output.buffer()->address(), u.u32, num_pages_per_core, page_offset});
         }
         page_offset += num_pages_per_core;
     }
-    return {std::move(program), {writer_id, reader_id, cores}};
+
+    desc.kernels.push_back(std::move(writer_desc));
+    if (has_reader) {
+        desc.kernels.push_back(std::move(reader_desc));
+    }
+
+    return desc;
 }
 
-void FullInterleavedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    [[maybe_unused]] const tensor_args_t&,
-    tensor_return_value_t& output) {
-    auto& program = cached_program.program;
-    auto& writer_kernel_id = cached_program.shared_variables.writer_id;
-    auto& reader_kernel_id = cached_program.shared_variables.reader_id;
-    auto& cores = cached_program.shared_variables.cores;
-    for (const auto& core : cores) {
-        if (reader_kernel_id.has_value()) {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id.value(), core);
-            runtime_args[0] = output.buffer()->address();
-        }
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = output.buffer()->address();
-        }
-    }
-}
 }  // namespace ttnn::operations::full

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_interleaved.cpp
@@ -101,21 +101,13 @@ ProgramDescriptor FullInterleavedProgramFactory::create_descriptor(
         if (has_reader) {
             uint32_t reader_page_start = page_offset;
             uint32_t num_pages_per_reader = num_pages_per_core / 2;
-            reader_desc.runtime_args.emplace_back(
-                core,
-                KernelDescriptor::CoreRuntimeArgs{
-                    output.buffer()->address(), u.u32, num_pages_per_reader, reader_page_start});
+            reader_desc.emplace_runtime_args(core, {output.buffer(), u.u32, num_pages_per_reader, reader_page_start});
 
             uint32_t writer_page_start = reader_page_start + num_pages_per_reader;
             uint32_t num_pages_per_writer = num_pages_per_core - num_pages_per_reader;
-            writer_desc.runtime_args.emplace_back(
-                core,
-                KernelDescriptor::CoreRuntimeArgs{
-                    output.buffer()->address(), u.u32, num_pages_per_writer, writer_page_start});
+            writer_desc.emplace_runtime_args(core, {output.buffer(), u.u32, num_pages_per_writer, writer_page_start});
         } else {
-            writer_desc.runtime_args.emplace_back(
-                core,
-                KernelDescriptor::CoreRuntimeArgs{output.buffer()->address(), u.u32, num_pages_per_core, page_offset});
+            writer_desc.emplace_runtime_args(core, {output.buffer(), u.u32, num_pages_per_core, page_offset});
         }
         page_offset += num_pages_per_core;
     }

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_interleaved.hpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_interleaved.hpp
@@ -4,27 +4,13 @@
 
 #pragma once
 
-#include "ttnn/operation.hpp"
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include "full_device_operation_types.hpp"
 
 namespace ttnn::operations::full {
 
 struct FullInterleavedProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle writer_id{};
-        std::optional<tt::tt_metal::KernelHandle> reader_id = std::nullopt;
-        std::vector<tt::tt_metal::CoreCoord> cores;
-    };
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output);

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_nd_sharded.cpp
@@ -66,8 +66,7 @@ ProgramDescriptor FullNDShardedProgramFactory::create_descriptor(
 
     uint32_t start_shard_id = 0;
     for (auto core : ordered_cores_with_data) {
-        writer_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{output.buffer()->address(), u.u32, start_shard_id});
+        writer_desc.emplace_runtime_args(core, {output.buffer(), u.u32, start_shard_id});
         start_shard_id++;
     }
 

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_nd_sharded.cpp
@@ -5,28 +5,24 @@
 #include <cstdint>
 
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/circular_buffer_config.hpp>
-#include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include "full_program_factory_nd_sharded.hpp"
+#include <tt-metalium/work_split.hpp>
 #include "full_program_factory_common.hpp"
+#include "full_program_factory_nd_sharded.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 
 namespace ttnn::operations::full {
 
 using namespace tt;
 using namespace tt::constants;
-using namespace tt::tt_metal::detail;
+using namespace tt::tt_metal;
 
-FullNDShardedProgramFactory::cached_program_t FullNDShardedProgramFactory::create(
+ProgramDescriptor FullNDShardedProgramFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output) {
     auto fill_value = operation_attributes.fill_value;
     DataType dtype{operation_attributes.dtype};
-
-    Program program{};
 
     auto data_format = datatype_to_dataformat_converter(dtype);
     const auto& distribution_spec = output.buffer()->buffer_distribution_spec().value();
@@ -40,10 +36,19 @@ FullNDShardedProgramFactory::cached_program_t FullNDShardedProgramFactory::creat
 
     constexpr CBIndex cb_fill_value_id = CBIndex::c_24;
 
-    auto cb_value_config = tt::tt_metal::CircularBufferConfig(page_size, {{cb_fill_value_id, data_format}})
-                               .set_page_size(cb_fill_value_id, page_size);
-    CreateCircularBuffer(program, compute_core_range, cb_value_config);
-    auto writer_defines = get_writer_defines(dtype);
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = page_size,
+        .core_ranges = compute_core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_fill_value_id),
+            .data_format = data_format,
+            .page_size = page_size,
+        }}},
+    });
+
+    auto writer_defines = defines_from_map(get_writer_defines(dtype));
     auto u = encode_fill_value(fill_value, dtype);
 
     uint32_t elems_per_page = page_size / datum_size(data_format);
@@ -51,35 +56,24 @@ FullNDShardedProgramFactory::cached_program_t FullNDShardedProgramFactory::creat
         (uint32_t)cb_fill_value_id, elems_per_page, page_size, aligned_page_size, num_shards, num_compute_cores};
     tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
 
-    auto writer_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/full/device/kernels/writer_full_nd_sharded.cpp",
-        compute_core_range,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, writer_defines));
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = "ttnn/cpp/ttnn/operations/full/device/kernels/writer_full_nd_sharded.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = compute_core_range;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterConfigDescriptor{};
 
     uint32_t start_shard_id = 0;
     for (auto core : ordered_cores_with_data) {
-        SetRuntimeArgs(program, writer_id, core, {output.buffer()->address(), u.u32, start_shard_id});
+        writer_desc.runtime_args.emplace_back(
+            core, KernelDescriptor::CoreRuntimeArgs{output.buffer()->address(), u.u32, start_shard_id});
         start_shard_id++;
     }
 
-    return {std::move(program), {writer_id, ordered_cores_with_data}};
-}
+    desc.kernels.push_back(std::move(writer_desc));
 
-void FullNDShardedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& output) {
-    auto& program = cached_program.program;
-    auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    auto& cores_with_runtime_args = cached_program.shared_variables.cores_with_runtime_args;
-
-    auto output_buffer_address = output.buffer()->address();
-    for (const auto& core : cores_with_runtime_args) {
-        auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-        runtime_args[0] = output_buffer_address;
-    }
+    return desc;
 }
 
 }  // namespace ttnn::operations::full

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_nd_sharded.hpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_nd_sharded.hpp
@@ -4,26 +4,13 @@
 
 #pragma once
 
-#include "ttnn/operation.hpp"
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include "full_device_operation_types.hpp"
 
 namespace ttnn::operations::full {
 
 struct FullNDShardedProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle writer_kernel_id;
-        std::vector<CoreCoord> cores_with_runtime_args;
-    };
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output);

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_sharded.cpp
@@ -5,29 +5,24 @@
 #include <cstdint>
 
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/circular_buffer_config.hpp>
-#include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/buffer_distribution_spec.hpp>
-#include "full_program_factory_sharded.hpp"
+#include <tt-metalium/work_split.hpp>
 #include "full_program_factory_common.hpp"
+#include "full_program_factory_sharded.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 
 namespace ttnn::operations::full {
 
 using namespace tt;
 using namespace tt::constants;
-using namespace tt::tt_metal::detail;
+using namespace tt::tt_metal;
 
-FullShardedProgramFactory::cached_program_t FullShardedProgramFactory::create(
+ProgramDescriptor FullShardedProgramFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output) {
     auto fill_value = operation_attributes.fill_value;
     DataType dtype{operation_attributes.dtype};
-
-    Program program{};
 
     auto data_format = datatype_to_dataformat_converter(dtype);
 
@@ -41,10 +36,19 @@ FullShardedProgramFactory::cached_program_t FullShardedProgramFactory::create(
 
     constexpr CBIndex cb_fill_value_id = CBIndex::c_24;
 
-    auto cb_value_config = tt::tt_metal::CircularBufferConfig(page_size, {{cb_fill_value_id, data_format}})
-                               .set_page_size(cb_fill_value_id, page_size);
-    CreateCircularBuffer(program, compute_core_range, cb_value_config);
-    auto writer_defines = get_writer_defines(dtype);
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = page_size,
+        .core_ranges = compute_core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_fill_value_id),
+            .data_format = data_format,
+            .page_size = page_size,
+        }}},
+    });
+
+    auto writer_defines = defines_from_map(get_writer_defines(dtype));
     auto u = encode_fill_value(fill_value, dtype);
 
     uint32_t elems_per_page = page_size / datum_size(data_format);
@@ -52,11 +56,13 @@ FullShardedProgramFactory::cached_program_t FullShardedProgramFactory::create(
         (uint32_t)cb_fill_value_id, elems_per_page, page_size, aligned_page_size, tensor_width_in_pages};
     tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
 
-    auto writer_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/full/device/kernels/writer_full_sharded.cpp",
-        compute_core_range,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, writer_defines));
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = "ttnn/cpp/ttnn/operations/full/device/kernels/writer_full_sharded.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = compute_core_range;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.defines = std::move(writer_defines);
+    writer_desc.config = WriterConfigDescriptor{};
 
     uint32_t shard_height_in_pages = output.buffer()->shard_spec().shape_in_pages()[0];
     uint32_t shard_width_in_pages = output.buffer()->shard_spec().shape_in_pages()[1];
@@ -80,30 +86,15 @@ FullShardedProgramFactory::cached_program_t FullShardedProgramFactory::create(
         uint32_t valid_pages_height = (shard_row_idx == num_shards_across_height - 1)
                                           ? (tensor_height_in_pages - (shard_row_idx * shard_height_in_pages))
                                           : shard_height_in_pages;
-        SetRuntimeArgs(
-            program,
-            writer_id,
+        writer_desc.runtime_args.emplace_back(
             core,
-            {output.buffer()->address(), u.u32, first_page_id, valid_pages_width, valid_pages_height});
+            KernelDescriptor::CoreRuntimeArgs{
+                output.buffer()->address(), u.u32, first_page_id, valid_pages_width, valid_pages_height});
     }
 
-    return {std::move(program), {writer_id, runtime_cores}};
-}
+    desc.kernels.push_back(std::move(writer_desc));
 
-void FullShardedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& output) {
-    auto& program = cached_program.program;
-    auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    auto& cores_with_runtime_args = cached_program.shared_variables.cores_with_runtime_args;
-
-    auto output_buffer_address = output.buffer()->address();
-    for (const auto& core : cores_with_runtime_args) {
-        auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-        runtime_args[0] = output_buffer_address;
-    }
+    return desc;
 }
 
 }  // namespace ttnn::operations::full

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_sharded.cpp
@@ -86,10 +86,8 @@ ProgramDescriptor FullShardedProgramFactory::create_descriptor(
         uint32_t valid_pages_height = (shard_row_idx == num_shards_across_height - 1)
                                           ? (tensor_height_in_pages - (shard_row_idx * shard_height_in_pages))
                                           : shard_height_in_pages;
-        writer_desc.runtime_args.emplace_back(
-            core,
-            KernelDescriptor::CoreRuntimeArgs{
-                output.buffer()->address(), u.u32, first_page_id, valid_pages_width, valid_pages_height});
+        writer_desc.emplace_runtime_args(
+            core, {output.buffer(), u.u32, first_page_id, valid_pages_width, valid_pages_height});
     }
 
     desc.kernels.push_back(std::move(writer_desc));

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_sharded.hpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_sharded.hpp
@@ -4,26 +4,13 @@
 
 #pragma once
 
-#include "ttnn/operation.hpp"
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include "full_device_operation_types.hpp"
 
 namespace ttnn::operations::full {
 
 struct FullShardedProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle writer_kernel_id;
-        std::vector<CoreCoord> cores_with_runtime_args;
-    };
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output);


### PR DESCRIPTION
### Summary
Migrate the `full` operation from the legacy `ProgramFactory` + `override_runtime_arguments` pattern to the declarative `ProgramDescriptor`-based `create_descriptor` approach.

### Notes for reviewers

- Removed shared_variables_t, cached_program_t, create, override_runtime_arguments.
- Added static tt::tt_metal::ProgramDescriptor create_descriptor(...).
- Included <tt-metalium/program_descriptors.hpp> where needed for the declaration.
- defines_from_map (map → KernelDescriptor::Defines) was centralized in full_program_factory_common.hpp next to get_writer_defines, so the three factories don’t duplicate it.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-full-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-full-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-full-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-full-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-full-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/migrate-full-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-full-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/migrate-full-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-full-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-full-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-full-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/migrate-full-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-full-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/migrate-full-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-full-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/migrate-full-to-program-descriptor)