### PR TITLE
Fix use-after-close in MeshBuffer::deallocate() when using hybrid allocator

### DIFF
--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -269,12 +269,18 @@ void MeshBuffer::deallocate() {
         // 2. During teardown, device state may be partially destroyed, causing segfaults.
         if (MetalContext::instance(mesh_device->impl().get_context_id()).rtoptions().get_allocator_mode_hybrid()) {
             // Unmirror lockstep L1 allocation from each device's lockstep allocator.
+            // Skip per-device unmirror if the device has been closed (default_allocator_ reset
+            // by Device::close()). This can happen at process teardown when the mesh device is
+            // closed before stray tensors are destroyed by the garbage collector. Mirrors the
+            // device_->is_initialized() guard in Buffer::deallocate_impl().
             if (std::holds_alternative<OwnedBufferState>(state_) &&
                 device_local_config_.buffer_type == BufferType::L1) {
                 for (const auto& [coord, device_buffer] : buffers_) {
                     if (mesh_device->impl().is_local(coord)) {
                         auto* device = mesh_device->impl().get_device(coord);
-                        device->allocator_impl()->unmirror_lockstep_allocation(address_);
+                        if (device->is_initialized()) {
+                            device->allocator_impl()->unmirror_lockstep_allocation(address_);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Summary

Guard MeshBuffer::deallocate()'s per-device unmirror_lockstep_allocation call with device->is_initialized() so it doesn't run after the underlying Device has been closed.

### Problem

With TT_METAL_ALLOCATOR_MODE_HYBRID=1, the DeepSeek-V3-B1 demo segfaults on every rank at the very end of the run:

```
pthread_mutex_lock+0x4
AllocatorImpl::unmirror_lockstep_allocation+0x12
MeshBuffer::deallocate+0x175
Tensor::deallocate_impl+0x11c
Tensor::~Tensor+0x10
```

The demo's exit calls MeshDevice::close(), which will reset every device's default_allocator_ to null. Python destructs lingering ttnn.Tensors whose destructors run MeshBuffer::deallocate(). In the hybrid allocator branch this will dereferences device->allocator_impl() (now a null unique_ptr) to call unmirror_lockstep_allocation — std::lock_guard<std::mutex> lock(mutex_) then calls pthread_mutex_lock(nullptr), which will segfault.

### Fix 

Skip the per-device unmirror when the device has been closed. This mirrors the existing `device_->is_initialized()` guard in `Buffer::deallocate_impl()`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=esmal/allocator-crash)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmal/allocator-crash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=esmal/allocator-crash)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:esmal/allocator-crash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmal/allocator-crash)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/allocator-crash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmal/allocator-crash)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/allocator-crash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=esmal/allocator-crash)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:esmal/allocator-crash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=esmal/allocator-crash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/allocator-crash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=esmal/allocator-crash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/allocator-crash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=esmal/allocator-crash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/allocator-crash)