### PR TITLE
Enable fp8_e4m3 row-major output for dispatch module

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -114,7 +114,7 @@ jobs:
               pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py -k "2x4 and layer0 and device" -vvv --tb=short
               pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_moe_grouped_topk.py -k "realistic" -vvv --tb=short
               pytest models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py -m models_device_performance_bare_metal -vvv --tb=short --timeout=900
-            timeout: 65
+            timeout: 90
             test-type: loudbox
             owner_id: U08E1JCMAJF # Marko Bezulj
             model-name: deepseek_prefill

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -114,7 +114,7 @@ jobs:
               pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py -k "2x4 and layer0 and device" -vvv --tb=short
               pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_moe_grouped_topk.py -k "realistic" -vvv --tb=short
               pytest models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py -m models_device_performance_bare_metal -vvv --tb=short --timeout=900
-            timeout: 90
+            timeout: 68
             test-type: loudbox
             owner_id: U08E1JCMAJF # Marko Bezulj
             model-name: deepseek_prefill

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
@@ -15,6 +15,7 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
+from models.common.utility_functions import is_wormhole_b0
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
 from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import ALL_MESH_CONFIGS
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
@@ -135,6 +136,9 @@ def test_ttnn_dispatch(
     # Only exercise the fp8 path with random (N(0,1)) data that fits in range.
     if use_fp8_output and use_predictable_data:
         pytest.skip("predictable inputs overflow fp8_e4m3fn range; run fp8 with random data")
+
+    if use_fp8_output and is_wormhole_b0():
+        pytest.skip("fp8 output not supported on Wormhole hardware")
 
     torch.manual_seed(42)
 

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
@@ -94,7 +94,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
 @pytest.mark.parametrize(
     "seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, dispatch_buffer_capacity_factor, run_pcc_check",
     [
-        # pytest.param(32, 7168, 16, 4, 4, True, id="pcc"),
+        pytest.param(32, 7168, 16, 4, 4, True, id="pcc"),
         pytest.param(3200, 7168, 64, 2, 2, False, id="perf_no_pcc"),
     ],
 )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
@@ -31,6 +31,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_dispatch import TtDispatchModule
 from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
     assert_output_shape,
     validate_dispatch_buffer,
+    validate_dispatch_buffer_pcc,
     validate_dispatch_metadata,
 )
 from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert_dispatch_table, log_validation_results
@@ -107,6 +108,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
     [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
     ids=["tile", "row_major"],
 )
+@pytest.mark.parametrize("use_fp8_output", [False, True], ids=["bf16_out", "fp8_out"])
 @pytest.mark.parametrize("verbose", [False])
 def test_ttnn_dispatch(
     mesh_device,
@@ -119,6 +121,7 @@ def test_ttnn_dispatch(
     topology,
     use_predictable_data,
     input_layout,
+    use_fp8_output,
     verbose,
     run_pcc_check,
 ):
@@ -126,6 +129,12 @@ def test_ttnn_dispatch(
     num_devices = mesh_device.get_num_devices()
     if num_devices >= 8 and not run_pcc_check and use_predictable_data:
         pytest.skip("8-chip perf only runs with random data")
+
+    # Predictable inputs are torch.arange(...), which produces values up to ~1.8M and
+    # overflows fp8_e4m3fn's ±448 range — overflow encodes as NaN, breaking PCC.
+    # Only exercise the fp8 path with random (N(0,1)) data that fits in range.
+    if use_fp8_output and use_predictable_data:
+        pytest.skip("predictable inputs overflow fp8_e4m3fn range; run fp8 with random data")
 
     torch.manual_seed(42)
 
@@ -182,6 +191,13 @@ def test_ttnn_dispatch(
             num_dispatch_groups=num_dispatch_groups,
         )
         logger.debug("Using RANDOM test data")
+
+    # Clamp inputs to fp8_e4m3fn's finite range so any future scale/seed change can't push
+    # values into the overflow→NaN region. randn(0,1) is already well inside ±448, so this
+    # is a no-op for the current data and a guardrail for later.
+    if use_fp8_output:
+        fp8_info = torch.finfo(torch.float8_e4m3fn)
+        x = x.clamp(min=fp8_info.min, max=fp8_info.max)
 
     logger.debug(f"Input shapes: {x.shape=}, {weights.shape=}, {indices.shape=}")
 
@@ -245,6 +261,7 @@ def test_ttnn_dispatch(
         cluster_axis=sp_axis,
         num_links=num_links,
         topology=topology,
+        fp8_output=use_fp8_output,
     )
 
     # Compute gate outputs (offsets and token counts) before dispatch
@@ -276,7 +293,13 @@ def test_ttnn_dispatch(
 
     # Convert TTNN outputs to torch for comparison
     mesh_composer = get_ep_mesh_composer(mesh_device)
-    tt_out_dispatched = ttnn.to_torch(tt_dispatched, mesh_composer=mesh_composer, dtype=torch.float32)
+    if use_fp8_output:
+        # Device returned uint8 bytes that decode as float8_e4m3fn — widen to fp32 for PCC.
+        tt_out_dispatched = ttnn.to_torch(tt_dispatched, mesh_composer=mesh_composer)
+        assert tt_out_dispatched.dtype == torch.uint8, f"expected uint8 fp8 output, got {tt_out_dispatched.dtype}"
+        tt_out_dispatched = tt_out_dispatched.view(torch.float8_e4m3fn).to(torch.float32)
+    else:
+        tt_out_dispatched = ttnn.to_torch(tt_dispatched, mesh_composer=mesh_composer, dtype=torch.float32)
     tt_out_metadata = ttnn.to_torch(tt_metadata, mesh_composer=mesh_composer)
 
     assert_output_shape(tt_out_dispatched, num_dispatch_groups, dispatch_group_size, "dispatched buffer")
@@ -290,18 +313,30 @@ def test_ttnn_dispatch(
         logger.debug(f"{expert_token_counts.shape=}, {expert_token_counts=}")
         logger.debug(f"{expert_offsets.shape=}, {expert_offsets=}")
 
-    # Verify dispatched data matches reference (each EP rank against its torch reference)
-    buffer_result = validate_dispatch_buffer(
-        torch_dispatched,
-        tt_out_dispatched,
-        expert_region_offsets,
-        expert_token_counts,
-        expert_dispatch_table,
-        num_dispatch_groups,
-        dispatch_group_size,
-        experts_per_chip,
-        verbose=verbose,
-    )
+    # Verify dispatched data matches reference (each EP rank against its torch reference).
+    # FP8 path quantizes the buffer (~3-bit mantissa), so allclose is too tight — use PCC.
+    if use_fp8_output:
+        buffer_result = validate_dispatch_buffer_pcc(
+            torch_dispatched,
+            tt_out_dispatched,
+            expert_token_counts,
+            expert_dispatch_table,
+            num_dispatch_groups,
+            dispatch_group_size,
+            experts_per_chip,
+            verbose=verbose,
+        )
+    else:
+        buffer_result = validate_dispatch_buffer(
+            torch_dispatched,
+            tt_out_dispatched,
+            expert_token_counts,
+            expert_dispatch_table,
+            num_dispatch_groups,
+            dispatch_group_size,
+            experts_per_chip,
+            verbose=verbose,
+        )
 
     metadata_result = validate_dispatch_metadata(
         torch_metadata,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
@@ -319,6 +319,7 @@ def test_ttnn_dispatch(
         buffer_result = validate_dispatch_buffer_pcc(
             torch_dispatched,
             tt_out_dispatched,
+            expert_region_offsets,
             expert_token_counts,
             expert_dispatch_table,
             num_dispatch_groups,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
@@ -140,6 +140,9 @@ def test_ttnn_dispatch(
     if use_fp8_output and is_wormhole_b0():
         pytest.skip("fp8 output not supported on Wormhole hardware")
 
+    if use_fp8_output and input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        pytest.skip("fp8 output not supported with row_major input layout")
+
     torch.manual_seed(42)
 
     mesh_config = extract_mesh_config(mesh_device)

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
@@ -331,6 +331,7 @@ def test_ttnn_dispatch(
         buffer_result = validate_dispatch_buffer(
             torch_dispatched,
             tt_out_dispatched,
+            expert_region_offsets,
             expert_token_counts,
             expert_dispatch_table,
             num_dispatch_groups,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
@@ -94,7 +94,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
 @pytest.mark.parametrize(
     "seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, dispatch_buffer_capacity_factor, run_pcc_check",
     [
-        pytest.param(32, 7168, 16, 4, 4, True, id="pcc"),
+        # pytest.param(32, 7168, 16, 4, 4, True, id="pcc"),
         pytest.param(3200, 7168, 64, 2, 2, False, id="perf_no_pcc"),
     ],
 )

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -200,13 +200,17 @@ def run_model_device_perf_test_with_merge(
     )
 
 
-def _perf_param(op, worker_file, worker_test, topo, nlinks, expected_ns, op_filter, margin=0.1, layout="tile"):
+def _perf_param(
+    op, worker_file, worker_test, topo, nlinks, expected_ns, op_filter, margin=0.1, layout="tile", dtype_filter=""
+):
     """Build one pytest.param tuple for the perf tests."""
     worker_id = f"{topo}-8-{nlinks}link"
     model_name = f"deepseek_v3_{op}_{topo}_8_{nlinks}link"
     if layout != "tile":
         model_name += f"_{layout}"
-    k_filter = f"perf_no_pcc and {worker_id} and random and {layout} and bf16_out"
+    k_filter = f"perf_no_pcc and {worker_id} and random and {layout}"
+    if dtype_filter:
+        k_filter += f" and {dtype_filter}"
     return (
         f"pytest models/demos/deepseek_v3_d_p/tests/pcc/{worker_file}::{worker_test} " f"-k '{k_filter}'",
         expected_ns,
@@ -226,8 +230,19 @@ def _perf_param(op, worker_file, worker_test, topo, nlinks, expected_ns, op_filt
 
 # CI set (BH LoudBox pipeline): keep small.
 _DISPATCH_PERF_PARAMS = [
-    _perf_param("dispatch", "test_prefill_dispatch.py", "test_ttnn_dispatch", "linear", 2, 4_108_262, ""),
-    _perf_param("dispatch", "test_prefill_dispatch.py", "test_ttnn_dispatch", "ring", 2, 3_683_084, ""),
+    _perf_param(
+        "dispatch",
+        "test_prefill_dispatch.py",
+        "test_ttnn_dispatch",
+        "linear",
+        2,
+        4_108_262,
+        "",
+        dtype_filter="bf16_out",
+    ),
+    _perf_param(
+        "dispatch", "test_prefill_dispatch.py", "test_ttnn_dispatch", "ring", 2, 3_683_084, "", dtype_filter="bf16_out"
+    ),
 ]
 _COMBINE_PERF_PARAMS = [
     _perf_param(
@@ -242,7 +257,16 @@ _COMBINE_PERF_PARAMS = [
 # Payload is auto-selected by get_max_payload_size() (7k on WH, 14k on BH).
 # Baselines below are from BH (14k payload).
 _DISPATCH_PERF_PARAMS_FULL = [
-    _perf_param("dispatch", "test_prefill_dispatch.py", "test_ttnn_dispatch", topo, nlinks, expected, "")
+    _perf_param(
+        "dispatch",
+        "test_prefill_dispatch.py",
+        "test_ttnn_dispatch",
+        topo,
+        nlinks,
+        expected,
+        "",
+        dtype_filter="bf16_out",
+    )
     for topo, nlinks, expected in [
         ("linear", 1, 6_564_151),
         ("linear", 2, 3_907_070),

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -206,7 +206,7 @@ def _perf_param(op, worker_file, worker_test, topo, nlinks, expected_ns, op_filt
     model_name = f"deepseek_v3_{op}_{topo}_8_{nlinks}link"
     if layout != "tile":
         model_name += f"_{layout}"
-    k_filter = f"perf_no_pcc and {worker_id} and random and {layout}"
+    k_filter = f"perf_no_pcc and {worker_id} and random and {layout} and bf16_out"
     return (
         f"pytest models/demos/deepseek_v3_d_p/tests/pcc/{worker_file}::{worker_test} " f"-k '{k_filter}'",
         expected_ns,

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
@@ -86,6 +86,8 @@ class TtDispatchModule(LightweightModule):
             num_links: Number of fabric links for remote token writes.
             topology: Fabric topology for remote token writes.
         """
+        if fp8_output and "blackhole" not in ttnn.get_arch_name():
+            raise ValueError("fp8_output requires Blackhole hardware")
         super().__init__()
         self.mesh_device = mesh_device
         self.dispatch_group_size = dispatch_group_size

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
@@ -85,6 +85,7 @@ class TtDispatchModule(LightweightModule):
             cluster_axis: Mesh axis along which dispatch communicates (0 = SP/dispatch axis).
             num_links: Number of fabric links for remote token writes.
             topology: Fabric topology for remote token writes.
+            fp8_output: Output dtype for the dispatched buffer.
         """
         if fp8_output and "blackhole" not in ttnn.get_arch_name():
             raise ValueError("fp8_output requires Blackhole hardware")

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
@@ -263,6 +263,14 @@ class TtDispatchModule(LightweightModule):
             use_fp8_dispatch=self.fp8_output,
         )
 
+        if tt_dispatched_buffer.dtype == ttnn.uint8:
+            logger.warning(
+                """tt_dispatched_buffer dtype is uint8 but the actual content is fp8_e4m3fn. \
+                Workaround until fp8_e4m3fn is supported as a data type. \
+                Use custom kernels to typecast. See test_fp8_typecast.py
+                """
+            )
+
         tt_dispatched_buffer_shape = tt_dispatched_buffer.shape
         tt_dispatched_metadata_shape = tt_dispatch_metadata.shape
         logger.debug(f"[TtDispatchModule.forward] OUTPUT SHAPES:")

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
@@ -64,6 +64,7 @@ class TtDispatchModule(LightweightModule):
         cluster_axis: int = 0,
         num_links: int = 1,
         topology: ttnn.Topology = ttnn.Topology.Linear,
+        fp8_output: bool = False,
     ):
         """
         Initialize dispatch module with configuration parameters.
@@ -97,6 +98,7 @@ class TtDispatchModule(LightweightModule):
         self.cluster_axis = cluster_axis
         self.num_links = num_links
         self.topology = topology
+        self.fp8_output = fp8_output
 
     @staticmethod
     def shard_expert_offsets(
@@ -258,6 +260,7 @@ class TtDispatchModule(LightweightModule):
             cluster_axis=self.cluster_axis,
             num_links=self.num_links,
             topology=self.topology,
+            use_fp8_dispatch=self.fp8_output,
         )
 
         tt_dispatched_buffer_shape = tt_dispatched_buffer.shape

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
@@ -50,6 +50,12 @@ void DispatchDeviceOperation::validate_on_program_cache_miss(
         "Expert dispatch table tensor must be INT32, got {}",
         tensor_args.expert_dispatch_table_tensor.dtype());
 
+    // FP8 output requires tiled input (untilize+typecast is fused in compute; row-major path has no compute kernel)
+    TT_FATAL(
+        !(operation_attributes.use_fp8_dispatch &&
+          tensor_args.input_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR),
+        "FP8 output is not supported with ROW_MAJOR input layout; use TILE layout when fp8_output=True");
+
     // Validate output memory config is DRAM interleaved (not sharded)
     TT_FATAL(
         !operation_attributes.output_mem_config.is_sharded(),

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
@@ -51,10 +51,11 @@ void DispatchDeviceOperation::validate_on_program_cache_miss(
         tensor_args.expert_dispatch_table_tensor.dtype());
 
     // FP8 output requires tiled input (untilize+typecast is fused in compute; row-major path has no compute kernel)
-    TT_FATAL(
-        !(operation_attributes.use_fp8_dispatch &&
-          tensor_args.input_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR),
-        "FP8 output is not supported with ROW_MAJOR input layout; use TILE layout when fp8_output=True");
+    if (operation_attributes.use_fp8_dispatch) {
+        TT_FATAL(
+            tensor_args.input_tensor.layout() != tt::tt_metal::Layout::ROW_MAJOR,
+            "FP8 output is not supported with ROW_MAJOR input layout; use TILE layout when fp8_output=True");
+    }
 
     // Validate output memory config is DRAM interleaved (not sharded)
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
@@ -83,10 +83,13 @@ DispatchDeviceOperation::spec_return_value_t DispatchDeviceOperation::compute_ou
     auto dispatch_buffer_shape = ttnn::Shape({1, 1, max_dispatch_buffer_token_size, hidden_dim});
     auto dispatch_metadata_shape = ttnn::Shape({1, 1, max_dispatch_buffer_token_size, metadata_len});
 
+    // FP8 dispatch uses UINT8 (1 byte/element) for DRAM allocation; actual content is Fp8_e4m3.
+    auto dispatch_buffer_dtype = operation_attributes.use_fp8_dispatch ? DataType::UINT8 : DataType::BFLOAT16;
+
     // Create TensorSpec objects with correct dtypes
     auto dispatch_buffer_spec = TensorSpec(
         Shape(dispatch_buffer_shape),
-        tt::tt_metal::TensorLayout(DataType::BFLOAT16, tt::tt_metal::PageConfig(layout), mem_config));
+        tt::tt_metal::TensorLayout(dispatch_buffer_dtype, tt::tt_metal::PageConfig(layout), mem_config));
 
     auto dispatch_metadata_spec = TensorSpec(
         Shape(dispatch_metadata_shape),
@@ -140,7 +143,8 @@ prefill_dispatch(
     tt::tt_fabric::Topology topology,
     const ttnn::MemoryConfig& memory_config,
     const CoreRangeSet& worker_core_range_set,
-    bool use_l1_small_for_semaphores) {
+    bool use_l1_small_for_semaphores,
+    bool use_fp8_dispatch) {
     using OperationType = ttnn::operations::experimental::deepseek_prefill::dispatch::DispatchDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
@@ -155,7 +159,8 @@ prefill_dispatch(
             .topology = topology,
             .output_mem_config = memory_config,
             .worker_core_range_set = worker_core_range_set,
-            .use_l1_small_for_semaphores = use_l1_small_for_semaphores},
+            .use_l1_small_for_semaphores = use_l1_small_for_semaphores,
+            .use_fp8_dispatch = use_fp8_dispatch},
         OperationType::tensor_args_t{
             .input_tensor = input_tensor,
             .weights_tensor = weights_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
@@ -53,6 +53,9 @@ void DispatchDeviceOperation::validate_on_program_cache_miss(
     // FP8 output requires tiled input (untilize+typecast is fused in compute; row-major path has no compute kernel)
     if (operation_attributes.use_fp8_dispatch) {
         TT_FATAL(
+            tensor_args.input_tensor.device()->arch() != tt::ARCH::WORMHOLE_B0,
+            "FP8 dispatch is not supported on Wormhole_B0; use Blackhole or set fp8_output=False");
+        TT_FATAL(
             tensor_args.input_tensor.layout() != tt::tt_metal::Layout::ROW_MAJOR,
             "FP8 output is not supported with ROW_MAJOR input layout; use TILE layout when fp8_output=True");
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.hpp
@@ -61,5 +61,6 @@ prefill_dispatch(
     tt::tt_fabric::Topology topology,
     const ttnn::MemoryConfig& memory_config,
     const CoreRangeSet& worker_core_range_set,
-    bool use_l1_small_for_semaphores = false);
+    bool use_l1_small_for_semaphores = false,
+    bool use_fp8_dispatch = false);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -658,11 +658,6 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
                 .compile_args = idle_writer_compile_args}));
     }
 
-    std::map<std::string, std::string> compute_defines;
-    if (operation_attributes.use_fp8_dispatch) {
-        compute_defines["USE_FP8_DISPATCH"] = "1";
-    }
-
     // Compute kernel on idle cores
     tt::tt_metal::CreateKernel(
         program,
@@ -671,15 +666,13 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         idle_core_grid,
         tt::tt_metal::ComputeConfig{
             .math_fidelity = MathFidelity::HiFi4,
-            .compile_args =
-                {
-                    static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
-                    static_cast<uint32_t>(tt::CBIndex::c_11),  // cb_untilize_id
-                    static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
-                    (uint32_t)hidden_size,
-                    read_batch_size,
-                },
-            .defines = compute_defines});
+            .compile_args = {
+                static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
+                static_cast<uint32_t>(tt::CBIndex::c_11),  // cb_untilize_id
+                static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
+                (uint32_t)hidden_size,
+                read_batch_size,
+            }});
 
     // Compute kernel on sender cores for self-untilize (output goes to c_18)
     tt::tt_metal::CreateKernel(
@@ -689,15 +682,13 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         sender_core_grid,
         tt::tt_metal::ComputeConfig{
             .math_fidelity = MathFidelity::HiFi4,
-            .compile_args =
-                {
-                    static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
-                    static_cast<uint32_t>(tt::CBIndex::c_18),  // cb_untilize_id (reuse receive buffer)
-                    static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
-                    (uint32_t)hidden_size,
-                    read_batch_size,
-                },
-            .defines = compute_defines});
+            .compile_args = {
+                static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
+                static_cast<uint32_t>(tt::CBIndex::c_18),  // cb_untilize_id (reuse receive buffer)
+                static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
+                (uint32_t)hidden_size,
+                read_batch_size,
+            }});
 
     // ==================== Pre-compute NOC coordinates ====================
     std::vector<std::pair<uint32_t, uint32_t>> sender_noc_coords;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -39,11 +39,17 @@ void create_tensor_cb(
     const ttnn::Tensor& tensor,
     uint32_t buffering_factor,
     tt::CBIndex cb_id,
-    const std::string& tensor_name = "tensor") {
+    const std::string& tensor_name = "tensor",
+    std::optional<uint32_t> fp8_hidden_size = std::nullopt) {
     auto page_size = get_page_size(tensor);
     auto num_pages = detail::get_num_pages(tensor);
     auto aligned_page_size = get_aligned_page_size(tensor);
     auto data_format = tt::tt_metal::datatype_to_dataformat_converter(tensor.dtype());
+
+    if (fp8_hidden_size.has_value()) {
+        aligned_page_size = tt::round_up(*fp8_hidden_size, tt::tt_metal::hal::get_l1_alignment());
+        data_format = tt::DataFormat::Fp8_e4m3;
+    }
 
     uint32_t cb_size = buffering_factor * aligned_page_size;
 
@@ -271,23 +277,15 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, signal_cb_config);
     }
     // c_11: untilize output (compute → writer)
-    // FP8 path: configure as Fp8_e4m3 so pack_untilize converts BF16 tiles → FP8 row-major.
-    if (operation_attributes.use_fp8_dispatch) {
-        uint32_t fp8_page_size = tt::round_up((uint32_t)hidden_size, l1_alignment);
-        tt::tt_metal::CircularBufferConfig fp8_cb_config =
-            tt::tt_metal::CircularBufferConfig(
-                read_batch_size * fp8_page_size, {{tt::CBIndex::c_11, tt::DataFormat::Fp8_e4m3}})
-                .set_page_size(tt::CBIndex::c_11, fp8_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, fp8_cb_config);
-    } else {
-        detail::create_tensor_cb(
-            program,
-            idle_core_grid,
-            output_tensor,
-            /*buffering_factor=*/read_batch_size,
-            /*cb_id=*/tt::CBIndex::c_11,
-            "idle_untilize_output");
-    }
+    // FP8 path: pack_untilize converts BF16 tiles → FP8 row-major; page size is one aligned FP8 row.
+    detail::create_tensor_cb(
+        program,
+        idle_core_grid,
+        output_tensor,
+        /*buffering_factor=*/read_batch_size,
+        /*cb_id=*/tt::CBIndex::c_11,
+        "idle_untilize_output",
+        operation_attributes.use_fp8_dispatch ? std::optional<uint32_t>(hidden_size) : std::nullopt);
     // c_12: route table mailbox (sender writes before start_semaphore; writer reads after)
     // Layout: [entry_count u32] [entry_0..N × 6 u32s each]
     {
@@ -402,23 +400,15 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         /*cb_id=*/tt::CBIndex::c_9,
         "dispatch_table_tensor");
     // c_18: receive buffer for untilized data from idle cores (also sender self-untilize output)
-    // FP8 path: configure as Fp8_e4m3 so pack_untilize on the sender converts BF16 tiles → FP8.
-    if (operation_attributes.use_fp8_dispatch) {
-        uint32_t fp8_page_size = tt::round_up((uint32_t)hidden_size, l1_alignment);
-        tt::tt_metal::CircularBufferConfig fp8_cb_config =
-            tt::tt_metal::CircularBufferConfig(
-                read_batch_size * fp8_page_size, {{tt::CBIndex::c_18, tt::DataFormat::Fp8_e4m3}})
-                .set_page_size(tt::CBIndex::c_18, fp8_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, fp8_cb_config);
-    } else {
-        detail::create_tensor_cb(
-            program,
-            sender_core_grid,
-            output_tensor,
-            /*buffering_factor=*/read_batch_size,
-            /*cb_id=*/tt::CBIndex::c_18,
-            "receive_untilized");
-    }
+    // FP8 path: pack_untilize converts BF16 tiles → FP8 row-major; page size is one aligned FP8 row.
+    detail::create_tensor_cb(
+        program,
+        sender_core_grid,
+        output_tensor,
+        /*buffering_factor=*/read_batch_size,
+        /*cb_id=*/tt::CBIndex::c_18,
+        "receive_untilized",
+        operation_attributes.use_fp8_dispatch ? std::optional<uint32_t>(hidden_size) : std::nullopt);
     // c_19: route table scratch (sender builds local-expert route table here before NOC-writing to idle)
     {
         uint32_t max_route_entries = read_batch_size * operation_attributes.num_experts_per_tok;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -271,13 +271,23 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, signal_cb_config);
     }
     // c_11: untilize output (compute → writer)
-    detail::create_tensor_cb(
-        program,
-        idle_core_grid,
-        output_tensor,
-        /*buffering_factor=*/read_batch_size,
-        /*cb_id=*/tt::CBIndex::c_11,
-        "idle_untilize_output");
+    // FP8 path: configure as Fp8_e4m3 so pack_untilize converts BF16 tiles → FP8 row-major.
+    if (operation_attributes.use_fp8_dispatch) {
+        uint32_t fp8_page_size = tt::round_up((uint32_t)hidden_size, l1_alignment);
+        tt::tt_metal::CircularBufferConfig fp8_cb_config =
+            tt::tt_metal::CircularBufferConfig(
+                read_batch_size * fp8_page_size, {{tt::CBIndex::c_11, tt::DataFormat::Fp8_e4m3}})
+                .set_page_size(tt::CBIndex::c_11, fp8_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, idle_core_grid, fp8_cb_config);
+    } else {
+        detail::create_tensor_cb(
+            program,
+            idle_core_grid,
+            output_tensor,
+            /*buffering_factor=*/read_batch_size,
+            /*cb_id=*/tt::CBIndex::c_11,
+            "idle_untilize_output");
+    }
     // c_12: route table mailbox (sender writes before start_semaphore; writer reads after)
     // Layout: [entry_count u32] [entry_0..N × 6 u32s each]
     {
@@ -391,14 +401,24 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         /*buffering_factor=*/detail::get_num_pages(dispatch_table_tensor),
         /*cb_id=*/tt::CBIndex::c_9,
         "dispatch_table_tensor");
-    // c_18: receive buffer for untilized data from idle cores
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        output_tensor,
-        /*buffering_factor=*/read_batch_size,
-        /*cb_id=*/tt::CBIndex::c_18,
-        "receive_untilized");
+    // c_18: receive buffer for untilized data from idle cores (also sender self-untilize output)
+    // FP8 path: configure as Fp8_e4m3 so pack_untilize on the sender converts BF16 tiles → FP8.
+    if (operation_attributes.use_fp8_dispatch) {
+        uint32_t fp8_page_size = tt::round_up((uint32_t)hidden_size, l1_alignment);
+        tt::tt_metal::CircularBufferConfig fp8_cb_config =
+            tt::tt_metal::CircularBufferConfig(
+                read_batch_size * fp8_page_size, {{tt::CBIndex::c_18, tt::DataFormat::Fp8_e4m3}})
+                .set_page_size(tt::CBIndex::c_18, fp8_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, fp8_cb_config);
+    } else {
+        detail::create_tensor_cb(
+            program,
+            sender_core_grid,
+            output_tensor,
+            /*buffering_factor=*/read_batch_size,
+            /*cb_id=*/tt::CBIndex::c_18,
+            "receive_untilized");
+    }
     // c_19: route table scratch (sender builds local-expert route table here before NOC-writing to idle)
     {
         uint32_t max_route_entries = read_batch_size * operation_attributes.num_experts_per_tok;
@@ -648,7 +668,12 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
                 .compile_args = idle_writer_compile_args}));
     }
 
-    // Compute kernel on idle cores (same untilize kernel, unchanged)
+    std::map<std::string, std::string> compute_defines;
+    if (operation_attributes.use_fp8_dispatch) {
+        compute_defines["USE_FP8_DISPATCH"] = "1";
+    }
+
+    // Compute kernel on idle cores
     tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/"
@@ -656,13 +681,15 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         idle_core_grid,
         tt::tt_metal::ComputeConfig{
             .math_fidelity = MathFidelity::HiFi4,
-            .compile_args = {
-                static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
-                static_cast<uint32_t>(tt::CBIndex::c_11),  // cb_untilize_id
-                static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
-                (uint32_t)hidden_size,
-                read_batch_size,
-            }});
+            .compile_args =
+                {
+                    static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
+                    static_cast<uint32_t>(tt::CBIndex::c_11),  // cb_untilize_id
+                    static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
+                    (uint32_t)hidden_size,
+                    read_batch_size,
+                },
+            .defines = compute_defines});
 
     // Compute kernel on sender cores for self-untilize (output goes to c_18)
     tt::tt_metal::CreateKernel(
@@ -672,13 +699,15 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         sender_core_grid,
         tt::tt_metal::ComputeConfig{
             .math_fidelity = MathFidelity::HiFi4,
-            .compile_args = {
-                static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
-                static_cast<uint32_t>(tt::CBIndex::c_18),  // cb_untilize_id (reuse receive buffer)
-                static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
-                (uint32_t)hidden_size,
-                read_batch_size,
-            }});
+            .compile_args =
+                {
+                    static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
+                    static_cast<uint32_t>(tt::CBIndex::c_18),  // cb_untilize_id (reuse receive buffer)
+                    static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
+                    (uint32_t)hidden_size,
+                    read_batch_size,
+                },
+            .defines = compute_defines});
 
     // ==================== Pre-compute NOC coordinates ====================
     std::vector<std::pair<uint32_t, uint32_t>> sender_noc_coords;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -39,15 +39,14 @@ void create_tensor_cb(
     const ttnn::Tensor& tensor,
     uint32_t buffering_factor,
     tt::CBIndex cb_id,
-    const std::string& tensor_name = "tensor",
-    std::optional<uint32_t> fp8_hidden_size = std::nullopt) {
+    const std::string& tensor_name = "tensor") {
     auto page_size = get_page_size(tensor);
     auto num_pages = detail::get_num_pages(tensor);
     auto aligned_page_size = get_aligned_page_size(tensor);
     auto data_format = tt::tt_metal::datatype_to_dataformat_converter(tensor.dtype());
-
-    if (fp8_hidden_size.has_value()) {
-        aligned_page_size = tt::round_up(*fp8_hidden_size, tt::tt_metal::hal::get_l1_alignment());
+    if (data_format == tt::DataFormat::UInt8) {
+        // TODO: remove once FP8 has a dedicated dtype. In this op, UINT8 tensors only appear
+        // on the FP8 dispatch path (DRAM is allocated as UINT8 but content is Fp8_e4m3).
         data_format = tt::DataFormat::Fp8_e4m3;
     }
 
@@ -284,8 +283,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         output_tensor,
         /*buffering_factor=*/read_batch_size,
         /*cb_id=*/tt::CBIndex::c_11,
-        "idle_untilize_output",
-        operation_attributes.use_fp8_dispatch ? std::optional<uint32_t>(hidden_size) : std::nullopt);
+        "idle_untilize_output");
     // c_12: route table mailbox (sender writes before start_semaphore; writer reads after)
     // Layout: [entry_count u32] [entry_0..N × 6 u32s each]
     {
@@ -407,8 +405,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> create_at_tile_la
         output_tensor,
         /*buffering_factor=*/read_batch_size,
         /*cb_id=*/tt::CBIndex::c_18,
-        "receive_untilized",
-        operation_attributes.use_fp8_dispatch ? std::optional<uint32_t>(hidden_size) : std::nullopt);
+        "receive_untilized");
     // c_19: route table scratch (sender builds local-expert route table here before NOC-writing to idle)
     {
         uint32_t max_route_entries = read_batch_size * operation_attributes.num_experts_per_tok;
@@ -1265,6 +1262,12 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
     const GlobalSemaphore& cross_device_semaphore) {
     const bool is_tile_layout = tensor_args.input_tensor.layout() == tt::tt_metal::Layout::TILE;
     log_info(tt::LogOp, "Prefill dispatch: input tensor is {} layout", is_tile_layout ? "TILE" : "ROW_MAJOR");
+    if (operation_attributes.use_fp8_dispatch) {
+        log_warning(
+            tt::LogOp,
+            "Prefill dispatch: FP8 path — output buffer is allocated as UINT8 but content is Fp8_e4m3. "
+            "CBs reinterpret UINT8 tensors as Fp8_e4m3 (temporary, until FP8 has a dedicated dtype).");
+    }
     if (is_tile_layout) {
         return create_at_tile_layout(
             operation_attributes,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_types.hpp
@@ -28,6 +28,7 @@ struct DispatchParams {
     MemoryConfig output_mem_config;
     CoreRangeSet worker_core_range_set;
     bool use_l1_small_for_semaphores = false;
+    bool use_fp8_dispatch = false;
 
     static constexpr auto attribute_names = std::forward_as_tuple(
         "dispatch_group_size",
@@ -41,7 +42,8 @@ struct DispatchParams {
         "topology",
         "output_mem_config",
         "worker_core_range_set",
-        "use_l1_small_for_semaphores");
+        "use_l1_small_for_semaphores",
+        "use_fp8_dispatch");
 
     auto attribute_values() const {
         return std::forward_as_tuple(
@@ -56,7 +58,8 @@ struct DispatchParams {
             topology,
             output_mem_config,
             worker_core_range_set,
-            use_l1_small_for_semaphores);
+            use_l1_small_for_semaphores,
+            use_fp8_dispatch);
     };
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/untilize_dispatch.cpp
@@ -29,6 +29,7 @@ constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
 //   2: cb_in_id        - CB for untilize input tile data (c_0)
 //   3: hidden_size     - hidden dimension (e.g., 7168)
 //   4: read_batch_size - number of rows per untilize batch (32)
+
 void kernel_main() {
     constexpr uint32_t cb_signal_id = get_compile_time_arg_val(0);
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(1);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.cpp
@@ -29,7 +29,8 @@ std::array<ttnn::Tensor, 2> dispatch(
     std::optional<uint32_t> cluster_axis,
     std::optional<uint32_t> num_links,
     std::optional<tt::tt_fabric::Topology> topology,
-    bool use_l1_small_for_semaphores) {
+    bool use_l1_small_for_semaphores,
+    bool use_fp8_dispatch) {
     auto* mesh_device = input_tensor.device();
     auto sd_id = subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
     auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
@@ -73,7 +74,8 @@ std::array<ttnn::Tensor, 2> dispatch(
         usable_topology,
         memory_config_,
         subdevice_core_range_set,
-        use_l1_small_for_semaphores);
+        use_l1_small_for_semaphores,
+        use_fp8_dispatch);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::dispatch

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.hpp
@@ -30,7 +30,8 @@ std::array<ttnn::Tensor, 2> dispatch(
     std::optional<uint32_t> cluster_axis = 0,
     std::optional<uint32_t> num_links = 1,
     std::optional<tt::tt_fabric::Topology> topology = tt::tt_fabric::Topology::Linear,
-    bool use_l1_small_for_semaphores = false);
+    bool use_l1_small_for_semaphores = false,
+    bool use_fp8_dispatch = false);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::dispatch
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch_nanobind.cpp
@@ -69,6 +69,8 @@ void bind_dispatch(nb::module_& mod) {
                 Defaults to 1.
             topology (ttnn.Topology, optional): Fabric topology for remote writes.
                 Defaults to Linear.
+            fp8_output (bool, optional): Output dtype for the dispatched buffer.
+                Defaults to False.
 
         Returns:
             Tuple[ttnn.Tensor, ttnn.Tensor]:

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch_nanobind.cpp
@@ -97,7 +97,8 @@ void bind_dispatch(nb::module_& mod) {
         nb::arg("cluster_axis") = nb::none(),
         nb::arg("num_links") = 1,
         nb::arg("topology") = nb::cast(tt::tt_fabric::Topology::Linear),
-        nb::arg("use_l1_small_for_semaphores") = false);
+        nb::arg("use_l1_small_for_semaphores") = false,
+        nb::arg("use_fp8_dispatch") = false);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::dispatch::detail


### PR DESCRIPTION
This PR adds support for fp8 output from the dispatch module. The output of the dispatch module is `tt_dispatch_buffer`, which can now be either `bfloat16_b` or `fp8_e4m3` row-major.

- Added `use_fp8_output` to ttnn dispatch module which decides output data type
- Added PCC test for fp8 output only for `test_prefill_dispatch.py` ; skip `predictable data` test inside that file since values exceed fp8 range
- Current issue - the `tt_dispatch_buffer` tensor is through python seen as a UINT8 DataType (since it's 1byte, same as fp8), since there is no FP8 DataType currently (should be uplifted in future PR).

Perforamnce metric : test_prefill_distpach

# DispatchDeviceOperation Perf Summary

**Op:** `DispatchDeviceOperation` | **Dtypes:** BF16, BF16 => UINT8 (To be FP8) | **Cores:** 11

- measured on `tt_prefill_dispatch.py` - `"seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, dispatch_buffer_capacity_factor, run_pcc_check" - pytest.param(3200, 7168, 64, 2, 2, False, id="perf_no_pcc")`

- The device time (old) is bf16 output with row major bf16 input. In addition to this time, we need to add the penalty of the `to_layout()` call, so the gain is even bigger than what is in the table.

| Mesh Config    | Device Time (now) | Device Time (old) | Delta      |
|----------------|-------------------|-------------------|------------|
| linear-8-1link | 5,191 μs          | 6,587 μs          | -1,396 μs  |
| linear-8-2link | 2,874 μs          | 3,874 μs          | -1,000 μs  |
| ring-8-1link   | 4,198 μs          | 5,116 μs          | -918 μs    |
| ring-8-2link   | 2,704 μs          | 3,379 μs          | -675 μs    |
| mesh-4x2       | 2,343 μs          | 2,901 μs          | -558 μs    |
| mesh-2x4       | 1,508 μs          | 1,894 μs          | -386 μs    |

bhe2e - https://github.com/tenstorrent/tt-metal/actions/runs/25446151750 ✅ 
t3k e2e - https://github.com/tenstorrent/tt-metal/actions/runs/25446165360 ✅ 
galaxy deepseek prefill - https://github.com/tenstorrent/tt-metal/actions/runs/25446096138 ✅ 
Model status - https://github.com/tenstorrent/tt-metal/actions/runs/25446074861 ✅ 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojic/fp8_disptach_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojic/fp8_disptach_output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nostojic/fp8_disptach_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nostojic/fp8_disptach_output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nostojic/fp8_disptach_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nostojic/fp8_disptach_output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojic/fp8_disptach_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojic/fp8_disptach_output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nostojic/fp8_disptach_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nostojic/fp8_disptach_output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojic/fp8_disptach_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojic/fp8_disptach_output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojic/fp8_disptach_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojic/fp8_disptach_output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojic/fp8_disptach_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojic/fp8_disptach_output)