### PR TITLE
Fix: Heap buffer overflow caused by EnqueueWriteMeshBuffer

### DIFF
--- a/docs/source/tt-metalium/tt_metal/examples/matmul_single_core.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/matmul_single_core.rst
@@ -354,8 +354,8 @@ The overall execution flow is managed by enqueuing commands:
     // Don't need to set runtime args for compute kernel, as everything is passed as compile-time args
 
     // Upload input data to device
-    distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a.data(), false);
-    distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b.data(), false);
+    distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a, false);
+    distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b, false);
 
     // execute program, and read results
     distributed::MeshWorkload workload;

--- a/tech_reports/prog_examples/NoC_tile_transfer/NoC_tile_transfer.md
+++ b/tech_reports/prog_examples/NoC_tile_transfer/NoC_tile_transfer.md
@@ -83,8 +83,8 @@ We initialize the input with the value `14`:
 
 ```cpp
 const uint16_t input_data = 14;
-std::vector<uint16_t> src_vec(1, input_data);
-distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, src_vec.data(), false);
+std::vector<uint16_t> src_vec(buffer_config.size / sizeof(uint16_t), input_data);
+distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, src_vec, false);
 ```
 
 ---

--- a/tech_reports/prog_examples/multicast/multicast.md
+++ b/tech_reports/prog_examples/multicast/multicast.md
@@ -80,7 +80,7 @@ uint32_t dram_bank_id = 0;
 auto src0_dram_buffer = MakeBufferBFP16(mesh_device, num_tiles, false);
 ...
 std::vector<bfloat16> identity_tile = create_identity_matrix(32, 32, 32);
-distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, identity_tile.data(), false);
+distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, identity_tile, false);
 ```
 
 Notice we set the `dram_bank_id = 0`.  In this basic DRAM configuration, this happens to be the default bank for our tile, and will be passed later as a runtime argument for our coordinator kernel.  This ensures that when the time comes, the coordinator core can read from `src0_dram_buffer` and retrieve that neat little tile.

--- a/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
+++ b/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
@@ -324,11 +324,11 @@ Once the reader kernel is finished padding the tensor and storing the new data i
 # Dispatch program to device for execution
 
 ``` cpp
-distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec.data(), false);
-distributed::EnqueueWriteMeshBuffer(cq, pad_buffer, pad_vec.data(), false);
+distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec, false);
+distributed::EnqueueWriteMeshBuffer(cq, pad_buffer, pad_vec, false);
 workload.add_program(device_range, std::move(program));
 distributed::EnqueueMeshWorkload(cq, workload, false);
-distributed::EnqueueReadMeshBuffer(cq, dst_buffer, dst_vec.data(), false);
+distributed::EnqueueReadMeshBuffer(cq, dst_buffer, dst_vec.data(), true);
 distributed::Finish(cq);
 /* ... */
 mesh_device->close();

--- a/tech_reports/prog_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.md
+++ b/tech_reports/prog_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.md
@@ -100,7 +100,7 @@ std::shared_ptr<distributed::MeshBuffer> src_dram_buffer =
 std::shared_ptr<distributed::MeshBuffer> dst_dram_buffer =
     distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
 
-distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, src_vec.data(), false);
+distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, src_vec, false);
 ```
 
 ---

--- a/tech_reports/prog_examples/shard_data_rm/shard_data_rm.md
+++ b/tech_reports/prog_examples/shard_data_rm/shard_data_rm.md
@@ -182,7 +182,7 @@ Once the data is written to the circular buffer, `cb_push_back` is called to mak
 # Program execution
 
 ``` cpp
-distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec.data(), false);
+distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec, false);
 workload.add_program(device_range, std::move(program));
 distributed::EnqueueMeshWorkload(cq, workload, false);
 distributed::Finish(cq);

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -214,6 +214,22 @@ TEST_F(MeshBufferTest2x4, ReplicatedBufferInitialization) {
     EXPECT_EQ(replicated_buffer->device_local_size(), 16 << 10);
 }
 
+TEST_F(MeshBufferTestSuite, EnqueueWriteMeshBufferValidSrcSize) {
+    constexpr size_t buffer_size = 16;
+
+    const DeviceLocalBufferConfig device_local_config{
+        .page_size = buffer_size, .buffer_type = BufferType::DRAM, .bottom_up = false};
+    const ReplicatedBufferConfig buffer_config{.size = buffer_size};
+    auto mesh_buffer = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
+    std::vector<uint8_t> small_src_vec(buffer_size / 2, 0);
+    std::vector<uint8_t> exact_src_vec(buffer_size, 0);
+    std::vector<uint8_t> large_src_vec(buffer_size * 2, 0);
+
+    EXPECT_THROW(EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), mesh_buffer, small_src_vec), std::exception);
+    EXPECT_NO_THROW(EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), mesh_buffer, exact_src_vec, true));
+    EXPECT_NO_THROW(EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), mesh_buffer, large_src_vec, true));
+}
+
 TEST_F(MeshBufferTest2x4, Deallocation) {
     // Verify that a buffer is deallocated on the MeshDevice when it goes
     // out of scope on host. Create a buffer with a certain config in limited

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -72,6 +72,12 @@ void EnqueueWriteMeshBuffer(
     std::shared_ptr<MeshBuffer>& mesh_buffer,
     const std::vector<DType>& src,
     bool blocking = false) {
+    TT_FATAL(src.size() * sizeof(DType) >= mesh_buffer->size(),
+        "Source vector is too small for mesh buffer: mesh buffer size={} bytes, source size={} * {} bytes",
+        mesh_buffer->size(),
+        src.size(),
+        sizeof(DType));
+
     mesh_cq.enqueue_write_mesh_buffer(mesh_buffer, src.data(), blocking);
 }
 

--- a/tt_metal/programming_examples/NoC_tile_transfer/noc_tile_transfer.cpp
+++ b/tt_metal/programming_examples/NoC_tile_transfer/noc_tile_transfer.cpp
@@ -58,7 +58,7 @@ int main() {
 
     // Source data preparation and DRAM transfer
     const uint16_t input_data = 14;  // Example input data
-    std::vector<uint16_t> src_vec(1, input_data);
+    std::vector<uint16_t> src_vec(buffer_config.size / sizeof(uint16_t), input_data);
     distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, src_vec, false);
 
     // L1 circular buffer setup

--- a/tt_metal/programming_examples/hello_world_datatypes_kernel/hello_world_datatypes_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datatypes_kernel/hello_world_datatypes_kernel.cpp
@@ -61,7 +61,7 @@ int main() {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Initialize Float data on host and upload to the DRAM buffer (non-blocking upload)
-    std::vector<float> init_data = {1.23};
+    std::vector<float> init_data(buffer_size / sizeof(float), 1.23);
     distributed::EnqueueWriteMeshBuffer(cq, dram_buffer, init_data, false);
 
     // Set runtime args, add program to mesh workload, and enqueue (non-blocking)


### PR DESCRIPTION
### Summary
Closes #43381 

- Adds a TT_FATAL assert check to EnqueueWriteMeshBuffer verifying the src vector size is large enough to fill the entire mesh buffer
- Fixes the examples incorrectly passing src vectors smaller than the mesh buffer
- Corrects EnqueueWriteMeshBuffer usage inside docs
- Added unit test to check for expected behavior from EnqueueWriteMeshBuffer

### Notes for reviewers
The size of the mesh buffer defines the size of the data buffer that will be transferred during a memcpy to device

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anashTT/heap-buff-overflow-enqueue-write-mesh-buff)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anashTT/heap-buff-overflow-enqueue-write-mesh-buff)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anashTT/heap-buff-overflow-enqueue-write-mesh-buff)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anashTT/heap-buff-overflow-enqueue-write-mesh-buff)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=anashTT/heap-buff-overflow-enqueue-write-mesh-buff)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:anashTT/heap-buff-overflow-enqueue-write-mesh-buff)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anashTT/heap-buff-overflow-enqueue-write-mesh-buff)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anashTT/heap-buff-overflow-enqueue-write-mesh-buff)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anashTT/heap-buff-overflow-enqueue-write-mesh-buff)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anashTT/heap-buff-overflow-enqueue-write-mesh-buff)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anashTT/heap-buff-overflow-enqueue-write-mesh-buff)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anashTT/heap-buff-overflow-enqueue-write-mesh-buff)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anashTT/heap-buff-overflow-enqueue-write-mesh-buff)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anashTT/heap-buff-overflow-enqueue-write-mesh-buff)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anashTT/heap-buff-overflow-enqueue-write-mesh-buff)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anashTT/heap-buff-overflow-enqueue-write-mesh-buff)