### PR TITLE
tools/tracy: launch child via sys.executable, not literal python3

### DIFF
--- a/tools/tracy/__main__.py
+++ b/tools/tracy/__main__.py
@@ -385,7 +385,7 @@ def main():
             originalArgs.remove("-r")
             osCmd = " ".join(originalArgs[1:])
 
-            testCommand = f"python3 -m tracy {osCmd}"
+            testCommand = f"{sys.executable} -m tracy {osCmd}"
 
             envVars = dict(os.environ)
             if options.device:


### PR DESCRIPTION
## Summary
- `tools/tracy/__main__.py` builds the recursive `python -m tracy …` child command as a literal `"python3 -m tracy …"` string and runs it via `subprocess.Popen(shell=True)`. The `/bin/sh -c` child is non-interactive and does not source rc files, so it resolves `python3` purely through the parent's `os.environ["PATH"]`.
- Under mpirun-spawned ranks the venv (`…/python_env/bin`) is not ahead of `/usr/bin` in that `PATH` (because activation lives in `.bashrc`, which non-interactive shells skip). Each rank's tracy child therefore picks `/usr/bin/python3` and aborts with `No module named tracy`, even though `mpirun which python3` (rc-sourcing) reports the venv python.
- Switching the child invocation to `sys.executable` runs it under the same interpreter already executing tracy on that rank, sidestepping `PATH` lookup entirely. `sys` is already in scope via `from tracy import *`.

Verified on a quad-galaxy `tt-run --tracy "-r"` invocation that previously failed with `/usr/bin/python3: No module named tracy` on every rank — now launches under the venv python on each rank and produces a Tracy capture.

Profiler CI run: https://github.com/tenstorrent/tt-metal/actions/runs/25175312817

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/tracy-use-sys-executable)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/tracy-use-sys-executable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/tracy-use-sys-executable)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/tracy-use-sys-executable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ipotkonjak/tracy-use-sys-executable)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ipotkonjak/tracy-use-sys-executable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/tracy-use-sys-executable)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/tracy-use-sys-executable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/tracy-use-sys-executable)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/tracy-use-sys-executable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/tracy-use-sys-executable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/tracy-use-sys-executable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/tracy-use-sys-executable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/tracy-use-sys-executable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/tracy-use-sys-executable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/tracy-use-sys-executable)