### PR TITLE
#42991: properly clear memory before using it in group norm

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_bh_unet3d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_bh_unet3d.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Regression test for the U-Net 3D GroupNorm PCC drop on Blackhole (issue #42991).
+
+These shapes correspond to three GroupNorm call-sites observed in the U-Net 3D
+model. Originally reproduced via tt_metal_repro/test_unet3d_group_norm_blackhole.py
+which loaded fixture activations/weights from disk; here we substitute torch.randn
+of the same shapes so the test is self-contained and can run as a nightly.
+
+The interesting case is `dec1_upsample_cat_gn1_conv1_relu1_then_gn2`: when no
+core_grid is supplied, ttnn.group_norm auto-selects an 11x10 grid on Blackhole,
+which previously hit a stale-L1 bug in the multicast-sender reader kernel
+(`reader_mcast_sender_unary_gn.cpp`) where partial-sum tiles in `cb_ex_external`
+were not fully cleared between out-blocks, causing PCC to drop from ~0.999 to
+~0.88. The fix tile-clears `cb_ex_external` whenever a new tile is started so
+the `REDUCE_SCALAR` in the compute kernel does not pick up garbage.
+
+We deliberately do not pass `core_grid=` so the auto-selection path
+(GroupNormMcastProgramFactory) is exercised, which is the path that hit the bug.
+"""
+
+import pytest
+import torch
+
+import ttnn
+
+from models.common.utility_functions import run_for_blackhole
+
+
+# (case_id, N, C, D, H, W, num_groups, eps)
+UNET3D_CASES = [
+    ("enc1_pool_then_gn", 1, 32, 64, 120, 120, 8, 1e-5),
+    ("dec1_upsample_cat_gn1_conv1_relu1_then_gn2", 1, 64, 64, 120, 120, 8, 1e-5),
+    ("dec2_upsample_cat_gn1_conv1_relu1_then_gn2", 1, 32, 128, 240, 240, 8, 1e-5),
+]
+
+
+def _pcc(a: torch.Tensor, b: torch.Tensor) -> float:
+    """Pearson correlation coefficient on flattened fp64 tensors. Same
+    convention as tt-xla's compute_pcc and tt-metal's assert_with_pcc."""
+    a64 = a.detach().to(torch.float64).flatten()
+    b64 = b.detach().to(torch.float64).flatten()
+    if torch.allclose(a64, b64, rtol=1e-2, atol=1e-2):
+        return 1.0
+    va = a64 - a64.mean()
+    vb = b64 - b64.mean()
+    denom = float(va.norm() * vb.norm())
+    if denom == 0.0:
+        return float("nan")
+    return float((va @ vb) / denom)
+
+
+def _to_ttnn_input(x_ncdhw: torch.Tensor, device) -> ttnn.Tensor:
+    """Convert (1, C, D, H, W) torch -> (1, 1, D*H*W, C) ttnn TILE in DRAM,
+    mirroring the layout the model pipeline produces in the failing IR."""
+    n, c, d, h, w = x_ncdhw.shape
+    assert n == 1, "Only batch size 1 is exercised by this test."
+    x_nhwc_flat = x_ncdhw.permute(0, 2, 3, 4, 1).contiguous().reshape(1, 1, d * h * w, c)
+    return ttnn.from_torch(
+        x_nhwc_flat.to(torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def _to_ttnn_weight_or_bias(w_flat: torch.Tensor, num_channels: int, device) -> ttnn.Tensor:
+    """Use the canonical tt-metal helper so the layout matches the IR
+    (``1 x 1 x ceil(C/32) x 32`` row-major bf16 in DRAM)."""
+    assert w_flat.numel() == num_channels, f"Expected weight/bias of length {num_channels}, got {w_flat.numel()}"
+    padded = ttnn.create_group_norm_weight_bias_rm(w_flat.to(torch.bfloat16), num_channels, num_cores_x=1)
+    return ttnn.from_torch(
+        padded,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def _torch_reference(
+    x_ncdhw: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor, num_groups: int, eps: float
+) -> torch.Tensor:
+    """Reference ``group_norm`` computed in fp32 on the bf16-quantised input,
+    then re-cast to bf16. This mirrors what the device sees while keeping fp32
+    accumulation in the math, matching the wormhole result we compare against."""
+    x_bf = x_ncdhw.to(torch.bfloat16).to(torch.float32)
+    w_bf = weight.to(torch.bfloat16).to(torch.float32)
+    b_bf = bias.to(torch.bfloat16).to(torch.float32)
+    out = torch.nn.functional.group_norm(x_bf, num_groups, w_bf, b_bf, eps=eps)
+    return out.to(torch.bfloat16)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)
+@pytest.mark.parametrize(
+    "case_id, N, C, D, H, W, num_groups, eps",
+    UNET3D_CASES,
+    ids=[c[0] for c in UNET3D_CASES],
+)
+@run_for_blackhole(reason_str="auto-selected core_grid path differs on Blackhole; this is the BH regression case")
+def test_group_norm_bh_unet3d(device, case_id, N, C, D, H, W, num_groups, eps):
+    torch.manual_seed(0)
+
+    x = torch.randn((N, C, D, H, W), dtype=torch.float32)
+    weight = torch.randn((C,), dtype=torch.float32)
+    bias = torch.randn((C,), dtype=torch.float32)
+
+    golden = _torch_reference(x, weight, bias, num_groups, eps)
+
+    x_tt = _to_ttnn_input(x, device)
+    w_tt = _to_ttnn_weight_or_bias(weight, C, device)
+    b_tt = _to_ttnn_weight_or_bias(bias, C, device)
+
+    y_tt = ttnn.group_norm(
+        x_tt,
+        num_groups=num_groups,
+        epsilon=eps,
+        weight=w_tt,
+        bias=b_tt,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        inplace=False,
+        num_out_blocks=-1,
+    )
+    ttnn.synchronize_device(device)
+
+    y_torch_4d = ttnn.to_torch(y_tt)
+    y_torch_5d = y_torch_4d.reshape(1, D, H, W, C).permute(0, 4, 1, 2, 3).contiguous()
+
+    pcc = _pcc(golden, y_torch_5d)
+    print(f"[{case_id}] PCC(ttnn vs torch.group_norm) = {pcc:.6f}")
+
+    assert pcc >= 0.99, f"[{case_id}] PCC={pcc:.6f} below 0.99 threshold. This reproduces tt-metal#42991."

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
@@ -301,8 +301,14 @@ void kernel_main() {
                                 cb_ex2_partial.wait_front(1);
                             }
 
-                            // read self Ex partial - on the first iteration, read a full tile for overwriting
-                            // garbage in L1, on subsequent just treat it as another core
+                            // Read self Ex partial. Whenever the next stride write would land at the
+                            // start of a tile in cb_ex_external, first overwrite that tile with a
+                            // full-tile copy of cb_ex_partial. Otherwise the 14 bytes between every
+                            // 16-byte stride write would retain stale L1 data from earlier programs,
+                            // which the downstream REDUCE_SCALAR over the entire CB would then sum in
+                            // (issue #42991: the heuristic out_blocks * (num_mcast_cores * 16) often
+                            // does not divide single_tile_size_bytes, so without this only tile 0 is
+                            // ever cleared by the original first-iteration big read).
                             uint32_t l1_read_addr_ex_par =
                                 cur_read_iteration== 0 ? cb_ex_partial.get_read_ptr() : cb_ex2_partial.get_read_ptr();
                             experimental::UnicastEndpoint remote_ep;
@@ -321,6 +327,15 @@ void kernel_main() {
 
                                 // read data from other cores
                                 for (uint32_t i = 0; i < num_mcast_cores - 1; ++i) {
+                                    if (cb_ex_external_bytes_written % single_tile_size_bytes == 0) {
+                                        // About to write the first stride of a fresh tile in
+                                        // cb_ex_external -- clear the whole tile first by reading
+                                        // the local cb_ex_partial tile into it, mirroring the
+                                        // self-read big-read above.
+                                        experimental::UnicastEndpoint clear_ep;
+                                        noc.async_read(clear_ep, experimental::CoreLocalMem<uint32_t>(l1_write_addr_external), single_tile_size_bytes, {.noc_x = noc_coord_x[0], .noc_y = noc_coord_y[0], .addr = l1_read_addr_ex_par}, {});
+                                        noc.async_read_barrier();
+                                    }
                                     experimental::UnicastEndpoint remote_ep;
                                     noc.async_read(remote_ep, experimental::CoreLocalMem<uint32_t>(l1_write_addr_external), num_bytes_read, {.noc_x = noc_coord_x[i + 1], .noc_y = noc_coord_y[i + 1], .addr = l1_read_addr_ex_par}, {});
                                     l1_write_addr_external += 16;


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Addresses #42991 

<h3 class="mt-6 mb-2 font-semibold text-xl" data-streamdown="heading-3" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 8px; font-size: 1.15em; line-height: 1.25; --tw-font-weight: 600; font-weight: 600; color: rgb(216, 222, 233); margin-top: 18px; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Root cause</h3><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The multicast sender reader kernel<span> </span><code class="md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: rgb(129, 161, 193); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all; cursor: pointer;"><span class="md-inline-path-filename">reader_mcast_sender_unary_gn.cpp</span></code><span> </span>writes per-receiver partial sums into<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">cb_ex_external</code><span> </span>as<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">2-byte values at 16-byte strides</span>. Originally only the very first tile of<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">cb_ex_external</code><span> </span>was guaranteed to be cleared, via a one-shot full-tile self-read on the first iteration. That worked only because the heuristic out-block size<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">out_blocks * (num_mcast_cores * 16)</code><span> </span>happened to be a multiple of<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">single_tile_size_bytes</code><span> </span>(2048) for the common 8×8 grid.</p><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">On Blackhole the auto-selected grid for one of the U-Net 3D GroupNorm call-sites is<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">11×10</span>, where that product no longer divides 2048. As a result, every tile in<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">cb_ex_external</code><span> </span>past the first one had its 14-byte gaps between strides left as stale L1 from earlier kernel runs. The compute kernel's<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">REDUCE_SCALAR</code><span> </span>then summed those bytes into the global mean/variance, producing PCC ~0.50/0.88/0.99-with-sign-flips depending on the call-site (vs. ~0.999 on Wormhole).</p><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This also explains the observed sequence-dependent and fresh-boot-only successes: the PCC depended on whatever happened to be sitting in L1 from the previous program.</p><h3 class="mt-6 mb-2 font-semibold text-xl" data-streamdown="heading-3" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 8px; font-size: 1.15em; line-height: 1.25; --tw-font-weight: 600; font-weight: 600; color: rgb(216, 222, 233); margin-top: 18px; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fix</h3><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">In the sender's receiver-read loop, detect when the next 16-byte stride write will land at the start of a fresh tile in<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">cb_ex_external</code><span> </span>and, before writing, do a full<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">single_tile_size_bytes</code><span> </span>self-read from<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">cb_ex_partial</code><span> </span>into that tile region. This mirrors the existing first-iteration big-read and guarantees every byte the compute kernel will reduce over has been written.</p><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Only the legacy (non-Welford) reduction path is affected; the Welford sender uses 16-byte-aligned slots and a different combine and was already safe.</p><h3 class="mt-6 mb-2 font-semibold text-xl" data-streamdown="heading-3" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 8px; font-size: 1.15em; line-height: 1.25; --tw-font-weight: 600; font-weight: 600; color: rgb(216, 222, 233); margin-top: 18px; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Test</h3><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Added<span> </span><code class="md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: rgb(129, 161, 193); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all; cursor: pointer;"><span class="md-inline-path-prefix">tests/ttnn/nightly/unit_tests/operations/fused/</span><span class="md-inline-path-filename">test_group_norm_bh_unet3d.py</span></code><span> </span>with the three U-Net 3D GroupNorm call-sites that surfaced the bug:</p><div class="ui-scroll-area" data-visibility="hover" data-direction="horizontal" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; --scrollbar-size: 6px; --scrollbar-inset: 0px; --scrollbar-thumb-top-offset: 6px; position: relative; overflow: hidden; display: grid; grid-template: 1fr / 1fr; margin: 1em 0px; border-color: color(srgb 0.8 0.8 0.8 / 0.28); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; border-radius: 6px; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-scroll-area__viewport" style="grid-area: 1 / 1; min-height: 0px; max-height: 100%; border-radius: inherit; overflow: auto hidden; scroll-padding: 0px 4px; overscroll-behavior: contain; scrollbar-width: none;"><div class="ui-scroll-area__content" style="box-sizing: border-box; width: auto; min-width: 100%; max-width: 100%; min-height: 100%; display: flex; flex-direction: row; height: fit-content;">
Test ID | NCDHW | C | num_groups | Auto grid (BH)
-- | -- | -- | -- | --
enc1_pool_then_gn | (1, 32, 64, 120, 120) | 32 | 8 | 10×10
dec1_upsample_cat_gn1_conv1_relu1_then_gn2 | (1, 64, 64, 120, 120) | 64 | 8 | 11×10 (the misaligned case)
dec2_upsample_cat_gn1_conv1_relu1_then_gn2 | (1, 32, 128, 240, 240) | 32 | 8 | 10×10

</div></div></div><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Activations and weights are<span> </span><code class="md-inline-path-filename-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;"><span class="md-inline-path-filename">torch.randn</span></code><span> </span>of the model's shapes (no<span> </span><code class="md-inline-path-filename-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;"><span class="md-inline-path-filename">.pt</span></code><span> </span>fixtures required), passed through the same NCDHW→<code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">(1,1,DHW,C)</code><span> </span>bf16 TILE/DRAM layout as the model. Crucially the test does<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">not</span><span> </span>pass<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">core_grid=</code>, so the auto-selected mcast factory path is exercised. PCC threshold is 0.99 — comfortably distinguishes the broken state from the fixed state (~0.999).</p><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(216, 222, 233); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Gated with<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.14); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">@run_for_blackhole</code>.</p><br class="Apple-interchange-newline">

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-42991_gn_unet)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-42991_gn_unet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-42991_gn_unet)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-42991_gn_unet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-42991_gn_unet)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-42991_gn_unet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-42991_gn_unet)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-42991_gn_unet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-42991_gn_unet)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-42991_gn_unet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-42991_gn_unet)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-42991_gn_unet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-42991_gn_unet)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-42991_gn_unet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-42991_gn_unet)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-42991_gn_unet)