### PR TITLE
Fix multi-process fail on T3K profiler regression

### DIFF
--- a/tests/scripts/t3000/run_t3000_profiler_tests.sh
+++ b/tests/scripts/t3000/run_t3000_profiler_tests.sh
@@ -172,12 +172,14 @@ run_multi_host_tracy_smoke() {
     remove_default_log_locations
     mkdir -p $PROFILER_ARTIFACTS_DIR
 
+    set +e
     tt-run --bare \
         --mpi-args "--allow-run-as-root" \
         --rank-binding tests/ttnn/distributed/config/t3k_tracy_smoke_rank_bindings.yaml \
         --tracy "-r" \
         pytest tests/ttnn/distributed/test_tracy_multi_host_smoke.py | tee $PROFILER_ARTIFACTS_DIR/test_out.log
     tt_run_status=${PIPESTATUS[0]}
+    set -e
 
     if grep -q "SKIPPED" $PROFILER_ARTIFACTS_DIR/test_out.log; then
         echo "No verification as test was skipped (not a T3K)"

--- a/tests/scripts/t3000/run_t3000_profiler_tests.sh
+++ b/tests/scripts/t3000/run_t3000_profiler_tests.sh
@@ -177,20 +177,33 @@ run_multi_host_tracy_smoke() {
         --rank-binding tests/ttnn/distributed/config/t3k_tracy_smoke_rank_bindings.yaml \
         --tracy "-r" \
         pytest tests/ttnn/distributed/test_tracy_multi_host_smoke.py | tee $PROFILER_ARTIFACTS_DIR/test_out.log
+    tt_run_status=${PIPESTATUS[0]}
 
     if grep -q "SKIPPED" $PROFILER_ARTIFACTS_DIR/test_out.log; then
         echo "No verification as test was skipped (not a T3K)"
-    else
-        echo "Verifying multi-host tracy results"
-        for rank_dir in $PROFILER_ARTIFACTS_DIR/ttrun/rank*; do
-            rank=$(basename $rank_dir)
-            if [ ! -f "$rank_dir/.logs/tracy_ops_times.csv" ]; then
-                echo "ERROR: Missing tracy_ops_times.csv for $rank"
-                exit 1
-            fi
-            echo "✓ $rank: tracy host reports present"
-        done
+        return 0
     fi
+
+    if [ "$tt_run_status" -ne 0 ]; then
+        echo "ERROR: tt-run exited with status ${tt_run_status} (see $PROFILER_ARTIFACTS_DIR/test_out.log)"
+        exit 1
+    fi
+
+    # tt-run may still exit 0 when pytest fails; treat pytest summary lines as failure.
+    if grep -qE 'FAILED tests/|ERROR tests/' $PROFILER_ARTIFACTS_DIR/test_out.log; then
+        echo "ERROR: pytest reported FAILED or ERROR (see $PROFILER_ARTIFACTS_DIR/test_out.log)"
+        exit 1
+    fi
+
+    echo "Verifying multi-host tracy results"
+    for rank_dir in $PROFILER_ARTIFACTS_DIR/ttrun/rank*; do
+        rank=$(basename $rank_dir)
+        if [ ! -f "$rank_dir/.logs/tracy_ops_times.csv" ]; then
+            echo "ERROR: Missing tracy_ops_times.csv for $rank"
+            exit 1
+        fi
+        echo "✓ $rank: tracy host reports present"
+    done
 }
 
 run_profiling_test() {

--- a/tests/ttnn/distributed/config/t3k_2x1x1_mesh_graph_descriptor.textproto
+++ b/tests/ttnn/distributed/config/t3k_2x1x1_mesh_graph_descriptor.textproto
@@ -18,11 +18,7 @@ graph_descriptors {
   instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
   instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
 
-  connections {
-    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0} }
-    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1} }
-    channels { count: 2 }
-  }
+  # Disjoint: no inter-mesh fabric edges (each MPI rank uses one mesh only).
 }
 
 top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }


### PR DESCRIPTION
### Summary
multi-process test on T3K was failing internally

### Notes for reviewers
This is just fixing the test and fix that wrapper to catch the bug crash.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mo/fix_t3k_multi_proc_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mo/fix_t3k_multi_proc_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mo/fix_t3k_multi_proc_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mo/fix_t3k_multi_proc_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mo/fix_t3k_multi_proc_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mo/fix_t3k_multi_proc_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mo/fix_t3k_multi_proc_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mo/fix_t3k_multi_proc_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mo/fix_t3k_multi_proc_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mo/fix_t3k_multi_proc_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mo/fix_t3k_multi_proc_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mo/fix_t3k_multi_proc_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mo/fix_t3k_multi_proc_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mo/fix_t3k_multi_proc_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mo/fix_t3k_multi_proc_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mo/fix_t3k_multi_proc_test)