### PR TITLE
expose some socket interface and helpers for blaze migration writer

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
@@ -121,6 +121,20 @@ public:
 
     uint32_t get_config_buffer_address() const { return config_buffer_address_; }
 
+    uint32_t get_fifo_size() const { return fifo_size_; }
+
+    bool has_space(std::optional<uint32_t> num_bytes_to_check);
+
+    // Cumulative bytes pushed into the FIFO (wraps modulo 2^32). Snapshot this
+    // after a write() call to get a watermark, then pass it to acked_past()
+    // later to test whether the device has consumed up to that point.
+    uint32_t get_bytes_sent() const { return bytes_sent_; }
+
+    // Returns true iff the device has acked past `watermark`. Uses the
+    // cached bytes_acked_ on the fast path; mfences + refreshes from
+    // bytes_acked_ptr_[0] only when the cache is insufficient.
+    bool acked_past(uint32_t watermark);
+
     void set_page_size(uint32_t page_size);
 
     void write(void* data, uint32_t num_pages);

--- a/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
@@ -6,8 +6,13 @@
 
 #include <tt-metalium/experimental/sockets/mesh_socket.hpp>
 #include <tt-metalium/experimental/pinned_memory.hpp>
+#include <cstdint>
+#include <functional>
 #include <memory>
+#include <optional>
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace tt::umd {
 class TlbWindow;
@@ -125,9 +130,12 @@ public:
 
     bool has_space(std::optional<uint32_t> num_bytes_to_check);
 
-    // Cumulative bytes pushed into the FIFO (wraps modulo 2^32). Snapshot this
-    // after a write() call to get a watermark, then pass it to acked_past()
-    // later to test whether the device has consumed up to that point.
+    // Virtual ring-buffer producer offset (wraps modulo 2^32). Advanced by
+    // payload bytes on normal writes, and by an additional tail-padding amount
+    // on wrap (to skip the unusable tail of the page-aligned FIFO). The device
+    // advances bytes_acked by the same amounts, keeping both sides in lockstep.
+    // Snapshot this after a write() call to get a watermark, then pass it to
+    // acked_past() to test whether the device has consumed up to that point.
     uint32_t get_bytes_sent() const { return bytes_sent_; }
 
     // Returns true iff the device has acked past `watermark`. Uses the

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -274,6 +274,40 @@ void H2DSocket::reserve_bytes(uint32_t num_bytes) {
     }
 }
 
+bool H2DSocket::has_space(std::optional<uint32_t> num_bytes_to_check) {
+    TT_FATAL(page_size_ > 0, "Page size must be set before checking for data.");
+    uint32_t num_bytes = num_bytes_to_check.value_or(page_size_);
+    uint32_t bytes_free = fifo_size_ - (bytes_sent_ - bytes_acked_);
+
+    // bytes_acked_ is monotonically increasing -> more bytes acked => more bytes_free
+    // If we bytes_acked_old < bytes_acked_new => bytes_free_old < bytes_free_new
+    // If bytes_free_old > num_bytes then this is safe as bytes_free_new > bytes_free_old > num_bytes necessarily
+    if (bytes_free >= num_bytes) {
+        return true;
+    }
+
+    tt_driver_atomics::mfence();
+    volatile uint32_t bytes_acked_value = bytes_acked_ptr_[0];
+    bytes_free = fifo_size_ - (bytes_sent_ - bytes_acked_value);
+    bytes_acked_ = bytes_acked_value;
+    return bytes_free >= num_bytes;
+}
+
+bool H2DSocket::acked_past(uint32_t watermark) {
+    // in_flight = bytes_sent_ - bytes_acked_ (unsigned, always <= fifo_size_)
+    // bytes_since_watermark = bytes_sent_ - watermark (unsigned, in [0, fifo_size_])
+    // Write at watermark is done iff bytes_acked_ >= watermark, equivalently
+    // in_flight <= bytes_since_watermark.
+    uint32_t bytes_since_watermark = bytes_sent_ - watermark;
+    if (bytes_sent_ - bytes_acked_ <= bytes_since_watermark) {
+        return true;
+    }
+    tt_driver_atomics::mfence();
+    volatile uint32_t bytes_acked_value = bytes_acked_ptr_[0];
+    bytes_acked_ = bytes_acked_value;
+    return bytes_sent_ - bytes_acked_ <= bytes_since_watermark;
+}
+
 void H2DSocket::push_bytes(uint32_t num_bytes) {
     if (write_ptr_ + num_bytes >= fifo_curr_size_) {
         write_ptr_ = write_ptr_ + num_bytes - fifo_curr_size_;

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -275,7 +275,7 @@ void H2DSocket::reserve_bytes(uint32_t num_bytes) {
 }
 
 bool H2DSocket::has_space(std::optional<uint32_t> num_bytes_to_check) {
-    TT_FATAL(page_size_ > 0, "Page size must be set before checking for data.");
+    TT_FATAL(page_size_ > 0, "Page size must be set before checking for space.");
     uint32_t num_bytes = num_bytes_to_check.value_or(page_size_);
     uint32_t bytes_free = fifo_size_ - (bytes_sent_ - bytes_acked_);
 
@@ -328,6 +328,7 @@ void H2DSocket::set_page_size(uint32_t page_size) {
     TT_FATAL(pcie_alignment_ > 0, "PCIe alignment not initialized.");
     TT_FATAL(page_size % pcie_alignment_ == 0, "Page size must be PCIE-aligned.");
     TT_FATAL(page_size <= fifo_size_, "Page size must be less than or equal to the FIFO size.");
+    TT_FATAL(fifo_size_ % page_size == 0, "Page size must evenly divide FIFO size.");
 
     uint32_t next_fifo_wr_ptr = align(write_ptr_, page_size);
     uint32_t fifo_page_aligned_size = fifo_size_ - (fifo_size_ % page_size);


### PR DESCRIPTION
### Summary
Expose some H2D socket inner working to match with `blaze-metal` branch. `tt-blaze` points to `blaze-metal` as it's `tt-metal` submodule version.
 

Exposes certain getters to check fifo size, whether there is free space to push into the socket, and if enough bytes have been acked. These methods are used by the `SocketDeviceWriter` (Uses the H2D socket) when performing `async_writes` and their associated `try_pop_completed` calls. 

May be better to have these methods have `private` access specifier, but is used by the `tt-blaze` repository. 

See [here](https://github.com/tenstorrent/tt-blaze/commit/46f5bb3532b43abe94ea06ffc16e8c5373363dd1#diff-7dcd4dfc39779a0eb02019591dfd76b47ccf7eaa1721fbfb04d00f1d595a1af1) for commit regarding `SocketDeviceWriter` implementation and in particular the async implementation, and why these methods are useful.


### Notes for reviewers
CC: @SeanNijjar 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nzhao/expose-socket-interface)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nzhao/expose-socket-interface)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nzhao/expose-socket-interface)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nzhao/expose-socket-interface)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nzhao/expose-socket-interface)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nzhao/expose-socket-interface)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nzhao/expose-socket-interface)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nzhao/expose-socket-interface)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nzhao/expose-socket-interface)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nzhao/expose-socket-interface)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nzhao/expose-socket-interface)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nzhao/expose-socket-interface)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nzhao/expose-socket-interface)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nzhao/expose-socket-interface)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nzhao/expose-socket-interface)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nzhao/expose-socket-interface)
