### PR TITLE
fix(test): restore REDUCE_OP/REDUCE_DIM defines for tilizeA_B_reduce_init in sentinel

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_compute_kernel_sentinel.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_compute_kernel_sentinel.cpp
@@ -105,6 +105,8 @@ bool single_core_compute_kernel_sentinel(
     defines["LIGHTWEIGHT_KERNEL_ASSERTS"] = "1";
     defines["TT_METAL_COMPUTE_KERNEL_SENTINEL_ENABLED"] = "1";
     defines["TT_METAL_COMPUTE_KERNEL_SENTINEL_DEFAULT_INJECTION"] = "1";
+    defines["REDUCE_OP"] = "PoolType::SUM";
+    defines["REDUCE_DIM"] = "ReduceDim::REDUCE_ROW";
 
     auto compute_kernel = tt_metal::CreateKernel(
         program_,


### PR DESCRIPTION
## Problem

PR #41637 removed `REDUCE_OP` and `REDUCE_DIM` preprocessor defines from the sentinel test fixture when migrating `reduce_init()` to explicit template params. However `tilizeA_B_reduce_init()` still internally uses those macros:

```cpp
// tilize.h
#if (defined(REDUCE_OP) and defined(REDUCE_DIM)) or defined(__DOXYGEN__)
template <bool neginf_srcA = true, bool zero_srcA_reduce = false>
ALWI void tilizeA_B_reduce_init(...) {
    MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, ...>()));
    ...
}
#endif
```

Without the defines, the function is excluded by its `#if` guard and the sentinel kernel fails to compile (trisc2 build failure on BH ttsim).

## Fix

Add the defines back to the test fixture. No changes to `tilize.h` or the kernel — the API is not modified.

```cpp
defines["REDUCE_OP"] = "PoolType::SUM";
defines["REDUCE_DIM"] = "ReduceDim::REDUCE_ROW";
```

## Testing

```
TT_METAL_SLOW_DISPATCH_MODE=1 build/test/tt_metal/unit_tests_llk --gtest_filter=MeshDeviceFixture.TensixComputeKernelSentinel
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brain/fix-tilizeA-B-reduce-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/fix-tilizeA-B-reduce-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=brain/fix-tilizeA-B-reduce-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:brain/fix-tilizeA-B-reduce-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=brain/fix-tilizeA-B-reduce-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:brain/fix-tilizeA-B-reduce-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brain/fix-tilizeA-B-reduce-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/fix-tilizeA-B-reduce-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=brain/fix-tilizeA-B-reduce-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:brain/fix-tilizeA-B-reduce-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brain/fix-tilizeA-B-reduce-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/fix-tilizeA-B-reduce-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brain/fix-tilizeA-B-reduce-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/fix-tilizeA-B-reduce-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brain/fix-tilizeA-B-reduce-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/fix-tilizeA-B-reduce-init)