### PR TITLE
bspm-tp8: regression tests for 100%-bfp0 routed experts

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_matmul_expert.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_matmul_expert.py
@@ -2845,3 +2845,203 @@ def test_matmul_expert_bspm_sparse_activation(bh_2d_mesh_device):
         active_expert_ids=[0, 2],  # sparse: only experts 0 and 2 selected this step
         pcc_threshold=0.90,
     )
+
+
+@pytest.mark.skip_post_commit
+@pytest.mark.requires_grid_size((12, 10))
+def test_matmul_expert_all_bfp0_kernel_skip_tp8(bh_2d_mesh_device):
+    """Diagnostic for TP=8 + all-bfp0 routed expert through the DRAM matmul kernel.
+
+    R26 iter 2 production BSPMs contain ~356 fully-zeroed routed experts (every
+    tile in every projection assigned code 3 / bfp0). The BSPM TP=8 cache helper
+    (``get_or_create_bspm_expert_tp8``) accepts these correctly thanks to the
+    defensive ``max(_align(global_max, alignment), alignment)`` floor in
+    ``_pack_data_and_assignment``, but it's untested whether the DRAM streaming
+    matmul kernel handles a 0-byte ``tiles.bin`` per-shard correctly at runtime.
+
+    This test sets up the production TP=8 routed-expert path (per-device shape
+    K=7168, N=256 — gate_proj at TP=8) with a synthetic all-bfp0 assignment, runs
+    ``ExpertKernel.op``, and asserts every per-device output is exactly zero.
+    Random weights are uploaded but every value is quantized away by the bfp0
+    code, so the on-device representation is a 0-byte tiles.bin per shard.
+
+    Expected first-pass behavior: this test may **fail** if the DRAM kernel
+    does not gracefully handle an all-bfp0 weight (e.g., reads garbage past the
+    0-byte tile buffer).  A failure here is the signal that we need a kernel-side
+    fix before fully-zeroed experts work end-to-end in production runs.
+    """
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < 8:
+        pytest.skip("Test requires at least 8 devices (4x2 mesh)")
+
+    import numpy as np
+
+    from models.demos.deepseek_v3_b1.weights.transforms.moe import shuffle_dram_assignment
+
+    mesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape(4, 2))
+    mesh_rows, mesh_cols = 4, 2
+    num_devices = mesh_rows * mesh_cols  # 8
+
+    # Production gate_proj sliced TP=8: per-device (K=7168, N=256).
+    M, K = 1, 7168
+    per_device_N = 256
+    tile_w = 32
+    n_parallel_per_bank = 1
+    k_parallel_per_bank = 1
+    cores_per_dram_bank = n_parallel_per_bank * k_parallel_per_bank
+
+    grids = _setup_core_grids(mesh, cores_per_dram_bank, 0, None, False)
+    dram_core_grid = grids["dram_core_grid"]
+    compute_core_grid = grids["compute_core_grid"]
+    num_dram_cores = len(grids["dram_cores_list"])
+    num_banks = num_dram_cores // cores_per_dram_bank
+    num_cores = compute_core_grid.num_cores()
+
+    Kt, dram_per_core_N, subblock_k, subblock_n, N_dram_per_device = _compute_dram_matmul_params(
+        K,
+        per_device_N,
+        tile_w,
+        num_banks,
+        num_dram_cores,
+        num_dram_cores,
+        cores_per_dram_bank,
+        None,  # num_subblocks_k → default
+        None,  # num_subblocks_n → default
+        k_parallel_per_bank=k_parallel_per_bank,
+    )
+    assert N_dram_per_device == per_device_N, f"unexpected N_dram_per_device={N_dram_per_device} != {per_device_N}"
+
+    # ----- All-bfp0 assignment (every tile is code 3) -----
+    K_tiles = K // tile_w
+    N_tiles = per_device_N // tile_w
+    per_device_assignment = np.full((K_tiles, N_tiles), 3, dtype=np.int8)
+    per_device_assignment_shuffled = shuffle_dram_assignment(per_device_assignment, num_banks)
+    # Stack along K so the 4D weight (mesh_rows, mesh_cols, K, N) lines up with
+    # an assignment of shape (num_devices*K_tiles, N_tiles) — the convention
+    # CompressedTensor expects for multi-device + Shard2dMeshMapper(dims=(0,1)).
+    stacked_assignment = np.tile(per_device_assignment_shuffled, (num_devices, 1))
+
+    # Random per-device weights.  Every value gets quantized away by bfp0 →
+    # 0 packed bytes per shard.  The kernel must still output zero.
+    per_device_shuffled = []
+    for dev_idx in range(num_devices):
+        torch.manual_seed(dev_idx + 7)
+        b = torch.randn(K, per_device_N).float()
+        per_device_shuffled.append(shuffle_tensor_tiles(b, tile_w, num_banks))
+    b_4d = torch.stack(per_device_shuffled).reshape(mesh_rows, mesh_cols, K, per_device_N)
+
+    # Per-device WIDTH_SHARDED DRAM mem config.
+    dram_grid_size = mesh.dram_grid_size()
+    dram_grid = ttnn.CoreRangeSet(
+        [
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1),
+            )
+        ]
+    )
+    shard_width = dram_per_core_N * tile_w * n_parallel_per_bank
+    dram_b_mem = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(dram_grid, [K, shard_width], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+
+    # Build the all-bfp0 CompressedTensor directly (bypass from_torch + assigner).
+    # This is the same path get_or_create_bspm_expert_tp8 takes via from_bspm.
+    ct = CompressedTensor(
+        b_4d,
+        stacked_assignment,
+        device=mesh,
+        memory_config=dram_b_mem,
+        per_core_allocation=False,
+        mesh_mapper_config=ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementShard(1)]),
+    )
+    logger.info(f"All-bfp0 TP=8 ct.tile_counts: {ct.tile_counts}")
+    total_tiles = num_devices * K_tiles * N_tiles
+    assert ct.tile_counts.get("bfp0", 0) == total_tiles, f"Expected {total_tiles} bfp0 tiles, got {ct.tile_counts}"
+    assert ct.max_shard_size > 0, "Defensive floor must keep max_shard_size > 0 on TP=8 all-bfp0 upload"
+
+    # ----- Kernel inputs -----
+    torch_a = torch.randn((M, K), dtype=torch.bfloat16)
+    a_tensor = _build_activation_tensor(torch_a, mesh, compute_core_grid, num_cores, M, K, tile_w)
+    is_dram_flags = [1]
+    index_tensor = _build_index_tensor([0], mesh, compute_core_grid, num_cores, is_dram_flags)
+
+    num_subblocks_k = Kt // subblock_k
+    dram_meta_tensors = create_dram_expert_tensors_multi_device(
+        mesh,
+        [ct],
+        subblock_k,
+        num_subblocks_k,
+        dram_per_core_N,
+        n_parallel_per_bank=n_parallel_per_bank,
+        num_total_experts=1,
+        is_dram_flags=is_dram_flags,
+        subblock_n=subblock_n,
+        k_parallel_per_bank=k_parallel_per_bank,
+    )
+
+    out_tensor = _build_dram_output(
+        mesh,
+        M,
+        dram_per_core_N,
+        1,  # num_active_experts
+        num_dram_cores,
+        num_devices,
+        dram_core_grid,
+        tile_w,
+    )
+
+    # ----- Run the kernel -----
+    result = ExpertKernel.op(
+        a_tensor,
+        [],  # sram_cts
+        [ct],  # dram_cts
+        out_tensor,
+        index_tensor,
+        num_active_experts=1,
+        subblock_k=subblock_k,
+        subblock_n=subblock_n,
+        dram_core_grid=dram_core_grid,
+        dram_meta_tensors=dram_meta_tensors,
+        dram_per_core_n=dram_per_core_N,
+        has_sram=False,
+        sram_core_grid=None,
+        sram_fmt_tensors={},
+        sram_base_addr_tensors={},
+        sram_k_offsets=None,
+        n_parallel_per_bank=n_parallel_per_bank,
+        k_parallel_per_bank=k_parallel_per_bank,
+        sram_per_core_n=0,
+        sram_k_per_core=Kt,
+        sram_output_tensor=None,
+        dram_fuse_silu=False,
+        tp_expert=True,
+        num_loop_iters=1,
+    )
+
+    # ----- Per-device output zero check -----
+    # Mirror _validate_dram_output's slicing for one active dram expert, no K-parallelism.
+    dram_core_width = dram_per_core_N * tile_w
+    failures = []
+    max_abs_overall = 0.0
+    for dev_idx, out_dev in enumerate(ttnn.get_device_tensors(result)):
+        output_dev = ttnn.to_torch(out_dev)
+        slices = []
+        for bank_idx in range(num_banks):
+            core_flat_idx = bank_idx * cores_per_dram_bank
+            start = core_flat_idx * dram_core_width  # exp_offset=0, per_core_slots=1
+            slices.append(output_dev[..., start : start + dram_core_width])
+        expert_output = torch.cat(slices, dim=-1)
+        max_abs = float(expert_output.abs().max().item())
+        max_abs_overall = max(max_abs_overall, max_abs)
+        logger.info(f"Device {dev_idx}: all-bfp0 output max abs={max_abs}, shape={tuple(expert_output.shape)}")
+        if not torch.all(expert_output == 0):
+            failures.append((dev_idx, max_abs))
+
+    assert not failures, (
+        f"All-bfp0 TP=8 kernel produced non-zero output on {len(failures)}/{num_devices} device(s); "
+        f"max abs across mesh = {max_abs_overall}.  Devices failing: {[f[0] for f in failures]}.  "
+        f"This means the DRAM matmul kernel does not handle a fully-bfp0 weight cleanly — a fix is "
+        f"needed before R26's ~356 all-zero experts work in production."
+    )

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_compressed_tensor.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_compressed_tensor.py
@@ -573,3 +573,67 @@ def test_from_bspm_tile_counts(device):
     assert counts.get("bfp4", 0) > total_tiles // 2, f"bfp4 should dominate at 3.5 b/e: {counts}"
     # Should NOT be all-bfp4 (that would mean BSPM codes were ignored)
     assert counts.get("bfp4", 0) < total_tiles, f"All tiles are bfp4 — BSPM assignment was not applied: {counts}"
+
+
+def test_from_bspm_all_bfp0_assignment(device):
+    """Synthetic regression for 100%-bfp0 (all-zero) BSPM assignments.
+
+    R26 iter 2 production BSPMs contain ~356 fully-zeroed routed experts (entire
+    expert/projection assigned code 3 / bfp0). ``pack_compact_tiles`` writes zero
+    bytes for these and ``global_max`` in ``_pack_data_and_assignment`` lands on
+    0, which would SIGFPE in the C++ buffer ``page_size`` path without the
+    ``max(_align(global_max, alignment), alignment)`` defensive floor.
+
+    Verifies:
+      - ``from_bspm()`` does not crash on an all-bfp0 assignment.
+      - ``max_shard_size > 0`` (floor kicked in, no zero-sized buffer page).
+      - ``tile_counts`` reports every tile as bfp0.
+      - ``to_torch()`` round-trips to an all-zeros weight tensor.
+    """
+    K, N = 128, 256  # 4x8 tile grid, divides cleanly across 8 DRAM banks
+    tiles_h, tiles_w = K // 32, N // 32
+
+    # All-bfp0: every tile is code 3 (zero).
+    assignment = np.full((tiles_h, tiles_w), 3, dtype=np.int8)
+
+    # Random weights — every value gets quantized away by the bfp0 code.
+    torch.manual_seed(0)
+    weight = torch.randn(K, N).float()
+
+    num_banks = device.dram_grid_size().x
+    N_padded = ((N + num_banks * 32 - 1) // (num_banks * 32)) * (num_banks * 32)
+    per_core_N = N_padded // num_banks
+    dram_grid = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device.dram_grid_size().x - 1, 0))}
+    )
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(dram_grid, [K, per_core_N], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+
+    # Smoke: must not crash. Without the defensive floor in
+    # _pack_data_and_assignment this would SIGFPE in the C++ buffer setup.
+    ct = CompressedTensor.from_bspm(weight, assignment, device=device, memory_config=mem_config)
+
+    # Floor invariant: max_shard_size must be a strictly positive multiple of
+    # the buffer alignment, not zero.  We don't pin the exact alignment constant
+    # — just that the resulting shard size is non-zero.
+    assert ct.max_shard_size > 0, (
+        f"max_shard_size={ct.max_shard_size}; defensive floor in "
+        f"_pack_data_and_assignment must keep it above zero when every tile is bfp0"
+    )
+
+    # Tile-count sanity: every tile should be bfp0, no other formats present.
+    counts = ct.tile_counts
+    total_tiles = tiles_h * tiles_w
+    print(f"All-bfp0 tile counts: {counts} / {total_tiles} total")
+    assert counts.get("bfp0", 0) == total_tiles, f"Expected {total_tiles} bfp0 tiles, got {counts}"
+    for fmt in ("bfp8", "bfp4", "bfp2"):
+        assert counts.get(fmt, 0) == 0, f"Unexpected {fmt} tiles in all-bfp0 assignment: {counts}"
+
+    # Round-trip: bfp0 stores no data, so unpack must produce zeros.
+    recovered = ct.to_torch()
+    assert torch.all(
+        recovered == 0
+    ), f"All-bfp0 round-trip should produce zeros, got max abs value {recovered.abs().max().item()}"


### PR DESCRIPTION
## Summary

R26 iter 2 production BSPMs contain ~356 fully-zeroed routed experts — entire \`(expert, projection)\` slots where every tile is assigned code 3 (\`bfp0\`/zero) by the BSPM allocator. This PR adds two regression tests that gate the mechanisms that make all-bfp0 experts work end-to-end at TP=8 — both currently passing.

## Why all-bfp0 experts work — the layered protections (corrected)

A fully-zeroed expert exercises a path that has zero packed weight bytes per shard. For the \`matmul_expert\` OP that this PR's TP=8 test exercises (via \`ExpertKernel.op\`), four layers cooperate to make this safe:

### 1. Host-side defensive floor on \`max_shard_size\`

\`pack_compact_tiles\` writes 0 bytes for every code-3 tile (\`if mant_bits == 0: continue\`). For an all-bfp0 expert, every per-device shard's compressed payload is **0 bytes** and \`global_max\` in \`_pack_data_and_assignment\` lands on 0.

Without protection, the C++ ttnn buffer constructor would compute \`page_size = max_shard_size\` and then \`num_pages = total_size / page_size\` — divide-by-zero, **SIGFPE** before any kernel runs.

The defensive floor at \`compressed_tensor.py:804\`:
\`\`\`python
self.max_shard_size = max(_align(global_max, alignment), alignment)
\`\`\`
forces \`max_shard_size >= alignment\`. On Blackhole DRAM \`alignment = max(NOC_DRAM_READ, NOC_DRAM_WRITE) = max(64, 16) = 64\` bytes (per \`tt_metal/hw/inc/internal/tt-1xx/blackhole/noc/noc_parameters.h:379-393\`). So an all-bfp0 expert allocates a **minimum 64-byte zero-padded DRAM shard per device** instead of a 0-byte one — though as we'll see, this DRAM region is never actually read.

\`max_shard_size\` is *not* divided by \`num_subblocks_k/n\` anywhere — subblock dispatch is metadata-driven, not byte-quotient-driven. The 64 bytes are just the smallest legal NOC allocation unit so the buffer constructor doesn't divide-by-zero.

### 2. Host-side per-subblock byte counts

\`matmul_expert/op.py:79-89\` in \`_compute_expert_subblock_metadata\` precomputes the **byte size of each subblock** (sum of per-tile sizes from \`_TILE_SIZES = [1088, 576, 320, 0]\` for bfp8/bfp4/bfp2/bfp0):

\`\`\`python
iter_bytes = 0
for _t in range(tiles_per_block):
    fmt_idx = int(shard_assignment[tile_idx])
    iter_bytes += _TILE_SIZES[fmt_idx]      # bfp0 contributes 0
    tile_idx += 1
...
block_sizes.append(iter_bytes)               # 0 bytes for an all-bfp0 subblock
\`\`\`

Per-tile fmt is also packed into 3-bit metadata (10 tiles per uint32) by \`_pack_tile_metadata\` (\`matmul_expert/op.py:168-207\`); LLK fmt code for bfp0 is \`0\` (per \`_ASSIGNMENT_TO_LLK_FMT = [3, 2, 1, 0]\`).

### 3. NCRISC reader skips the DRAM read entirely

\`unified_kernels/matmul_expert_compressed_dram.hpp:441-455\`:
\`\`\`cpp
uint32_t block_size = static_cast<uint32_t>(block_size_ptr[iter]) * BLOCK_SIZE_UNIT;
...
uint32_t remaining = block_size;
while (remaining > 0) {                       // <-- block_size=0 → loop never runs
    ...
    noc_async_read_one_packet_with_state_with_trid(...);
    ...
}
\`\`\`

For an all-bfp0 subblock, \`block_size = 0\` → the read loop never executes. **No DRAM read transaction is issued.** The 64-byte minimum-aligned weight shard from layer (1) is never touched on the NOC.

### 4. UNPACK (LLK) takes a short opcode-replay path

\`kernel_includes/.../tt_llk_blackhole/llk_lib/llk_unpack_AB_compressed_custom_mm.h:102-108\`:
\`\`\`cpp
if (curr == 0) {                              // current tile's format == 0 = bfp0
    if (use_b) {
        return lltt::replay_insn(22, 3);      // 3-instruction "zero" replay path
    } else {
        return lltt::replay_insn(24, 1);      // 1-instruction "zero" replay path
    }
}
return lltt::replay_insn(start_idx + start_offset, replay_len);  // normal unpack
\`\`\`

A 32-entry \`FMTABLE\` indexed by \`(prev_fmt, curr_fmt, use_b)\` selects the replay sequence. The \`curr == 0\` branch short-circuits to a "to-zero" path that doesn't actually unpack data — \`srcA\` stays zero, multiply produces 0, accumulator stays 0.

## Note on the \`MEM_ZEROS_BASE\` redirect

The \`ZEROS_ADDR_SHIFTED\`/\`MEM_ZEROS_BASE\` mechanism (per-tile metadata redirect to a fixed L1 zero region in \`pack_tile_pairs\`) is implemented in **\`matmul_custom_compressed/op.py:77-87\`**, a *different* OP. \`matmul_expert\` does not use that mechanism — it relies on the \`block_size=0 → no read\` + \`fmt=0 → opcode-replay-skip\` path described above.

The PR's TP=8 kernel test runs \`ExpertKernel.op\` (matmul_expert), so layers 1–4 above are what's actually being exercised.

## Tests added

### \`test_compressed_tensor.py::test_from_bspm_all_bfp0_assignment\`
- Single-device upload + readback. No kernel.
- Builds \`assignment = np.full((4, 8), 3, dtype=np.int8)\` + random weights.
- Calls \`CompressedTensor.from_bspm\` with a DRAM \`WIDTH_SHARDED\` mem config.
- Asserts: \`max_shard_size > 0\` (floor invariant), \`tile_counts == {bfp0: 32}\`, \`to_torch()\` round-trips to all zeros.
- Catches regressions in layer (1) — host-side defensive floor.

### \`test_matmul_expert.py::test_matmul_expert_all_bfp0_kernel_skip_tp8\`
- TP=8 (4×2 submesh) end-to-end matmul through \`ExpertKernel.op\` (matmul_expert OP).
- Production gate_proj shape sliced TP=8: per-device \`(K=7168, N=256)\`.
- Synthesizes an all-bfp0 stacked assignment (bypasses BSPM file load) + random weights.
- Runs the DRAM streaming matmul kernel against a random \`bfloat16\` activation.
- For each of the 8 devices, slices the output by DRAM bank and asserts \`torch.all(expert_output == 0)\`.
- Catches regressions in layers (2)–(4) — host-side block_size computation, NCRISC zero-byte read skip, UNPACK opcode-replay zero path.

Both gated behind \`@pytest.mark.skip_post_commit\` and \`@pytest.mark.requires_grid_size((12, 10))\`, matching the existing BSPM test markers.

## Test plan

- [x] Single-device test passes locally.
- [x] TP=8 kernel test passes locally — confirms the four-layer protection chain is intact end-to-end.
- [ ] Run as part of nightly / opt-in suite alongside the existing \`test_matmul_expert_bspm_*\` family.

## Caveats

- The TP=8 kernel test cannot distinguish between the four protection layers individually — if any one fires, the output is zero. To pin down which layer is doing the work would require fault-injection or profiler traces, both out of scope here.
- These tests don't exercise the case where bfp0 tiles are *mixed* with bfp4/bfp2 tiles within the same expert. That path is exercised by the existing \`test_matmul_expert_bspm_*\` family when run with \`BSPM_RESULTS_DIR\` set against R26's BSPM file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)