### PR TITLE
requirements-dev.txt: update the `datasets` library version to >=2.20 <3

### DIFF
--- a/models/datasets/llm_dataset_utils.py
+++ b/models/datasets/llm_dataset_utils.py
@@ -47,7 +47,7 @@ def wikitext_detokenizer(string):
 
 
 def prepare_textgen_dataset(dataset_name, dataset_config, split):
-    dataset = datasets.load_dataset(dataset_name, dataset_config, split=split, ignore_verifications=True)
+    dataset = datasets.load_dataset(dataset_name, dataset_config, split=split, verification_mode="no_checks")
     if dataset_name == "wikitext":
         dataset = wikitext_detokenizer("\n".join(dataset["text"]))
     else:

--- a/models/demos/t3000/llama2_70b/demo/eval.py
+++ b/models/demos/t3000/llama2_70b/demo/eval.py
@@ -44,7 +44,7 @@ def main(args, eval_data_args):
 
     # Dataset preparation
     dataset = datasets.load_dataset(
-        eval_data_args.dataset, eval_data_args.config, split=eval_data_args.split, ignore_verifications=True
+        eval_data_args.dataset, eval_data_args.config, split=eval_data_args.split, verification_mode="no_checks"
     )
     text = wikitext_detokenizer("\n".join(dataset["text"]))
     encodings = tokenizer.encode(text, bos=True, eos=False)  # not prepending bos

--- a/models/demos/t3000/llama2_70b/demo/eval_t3000.py
+++ b/models/demos/t3000/llama2_70b/demo/eval_t3000.py
@@ -43,7 +43,7 @@ def main(args, eval_data_args):
 
     # Dataset preparation
     dataset = datasets.load_dataset(
-        eval_data_args.dataset, eval_data_args.config, split=eval_data_args.split, ignore_verifications=True
+        eval_data_args.dataset, eval_data_args.config, split=eval_data_args.split, verification_mode="no_checks"
     )
     text = wikitext_detokenizer("\n".join(dataset["text"]))
     encodings = tokenizer.encode(text, bos=True, eos=False)  # not prepending bos

--- a/models/demos/vision/classification/vit/blackhole/tests/test_ttnn_optimized_sharded_vit_bh.py
+++ b/models/demos/vision/classification/vit/blackhole/tests/test_ttnn_optimized_sharded_vit_bh.py
@@ -87,7 +87,9 @@ def test_vit_embeddings(device, model_name, batch_size, image_size, image_channe
     config = ttnn_optimized_sharded_vit.update_model_config(config, batch_size)
     model = load_torch_model(model_location_generator, embedding=True)
 
-    dataset = load_dataset("huggingface/cats-image", revision="ccdec0af347ae11c5315146402c3e16c8bbf4149")
+    dataset = load_dataset(
+        "huggingface/cats-image", revision="ccdec0af347ae11c5315146402c3e16c8bbf4149", trust_remote_code=True
+    )
     image = dataset["test"]["image"][0]
     image_processor = AutoImageProcessor.from_pretrained("google/vit-base-patch16-224")
     torch_pixel_values = image_processor(image, return_tensors="pt").pixel_values
@@ -378,7 +380,9 @@ def test_vit(device, model_name, batch_size, image_size, image_channels, sequenc
     model = load_torch_model(model_location_generator, embedding=True)
     config = model.config
     config = ttnn_optimized_sharded_vit.update_model_config(config, batch_size)
-    dataset = load_dataset("huggingface/cats-image", revision="ccdec0af347ae11c5315146402c3e16c8bbf4149")
+    dataset = load_dataset(
+        "huggingface/cats-image", revision="ccdec0af347ae11c5315146402c3e16c8bbf4149", trust_remote_code=True
+    )
     image = dataset["test"]["image"][0]
     image_processor = AutoImageProcessor.from_pretrained("google/vit-base-patch16-224")
     torch_pixel_values = image_processor(image, return_tensors="pt").pixel_values

--- a/models/demos/vision/classification/vit/wormhole/tests/test_ttnn_optimized_sharded_vit_wh.py
+++ b/models/demos/vision/classification/vit/wormhole/tests/test_ttnn_optimized_sharded_vit_wh.py
@@ -87,7 +87,9 @@ def test_vit_embeddings(device, model_name, batch_size, image_size, image_channe
     config = ttnn_optimized_sharded_vit.update_model_config(config, batch_size)
     model = load_torch_model(model_location_generator, embedding=True)
 
-    dataset = load_dataset("huggingface/cats-image", revision="ccdec0af347ae11c5315146402c3e16c8bbf4149")
+    dataset = load_dataset(
+        "huggingface/cats-image", revision="ccdec0af347ae11c5315146402c3e16c8bbf4149", trust_remote_code=True
+    )
     image = dataset["test"]["image"][0]
     image_processor = AutoImageProcessor.from_pretrained("google/vit-base-patch16-224")
     torch_pixel_values = image_processor(image, return_tensors="pt").pixel_values
@@ -378,7 +380,9 @@ def test_vit(device, model_name, batch_size, image_size, image_channels, sequenc
     model = load_torch_model(model_location_generator, embedding=True)
     config = model.config
     config = ttnn_optimized_sharded_vit.update_model_config(config, batch_size)
-    dataset = load_dataset("huggingface/cats-image", revision="ccdec0af347ae11c5315146402c3e16c8bbf4149")
+    dataset = load_dataset(
+        "huggingface/cats-image", revision="ccdec0af347ae11c5315146402c3e16c8bbf4149", trust_remote_code=True
+    )
     image = dataset["test"]["image"][0]
     image_processor = AutoImageProcessor.from_pretrained("google/vit-base-patch16-224")
     torch_pixel_values = image_processor(image, return_tensors="pt").pixel_values

--- a/models/demos/vision/generative/stable_diffusion/wormhole/demo/demo.py
+++ b/models/demos/vision/generative/stable_diffusion/wormhole/demo/demo.py
@@ -386,7 +386,7 @@ def run_demo_inference_diffusiondb(
         num_inference_steps >= 4
     ), f"PNDMScheduler only supports num_inference_steps >= 4. Found num_inference_steps={num_inference_steps}"
     # 0. Load a sample prompt from the dataset
-    dataset = load_dataset("poloclub/diffusiondb", "2m_random_1k")
+    dataset = load_dataset("poloclub/diffusiondb", "2m_random_1k", trust_remote_code=True)
     data_1k = dataset["train"]
 
     height, width = image_size

--- a/models/demos/vision/segmentation/segformer/tests/pcc/test_segformer_for_image_classification.py
+++ b/models/demos/vision/segmentation/segformer/tests/pcc/test_segformer_for_image_classification.py
@@ -58,7 +58,7 @@ def create_custom_mesh_preprocessor(mesh_mapper=None, device=None):
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 def test_segformer_image_classificaton(device, model_location_generator):
     dataset = load_dataset("huggingface/cats-image")
-    image = dataset["train"]["image"][0]
+    image = dataset["test"]["image"][0]
     _, weights_mesh_mapper, _ = get_mesh_mappers(device)
     image_processor = AutoImageProcessor.from_pretrained("nvidia/mit-b0")
     inputs = image_processor(image, return_tensors="pt")

--- a/models/experimental/deit/tt/deit_for_image_classification_with_teacher.py
+++ b/models/experimental/deit/tt/deit_for_image_classification_with_teacher.py
@@ -45,7 +45,7 @@ class TtDeiTForImageClassificationWithTeacher(nn.Module):
 
     def forward(
         self,
-        pixel_values: Optional[ttnnr.Tensor] = None,
+        pixel_values: Optional[ttnn.Tensor] = None,
         head_mask: Optional[ttnn.Tensor] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,

--- a/scripts/download_hf_artifacts.py
+++ b/scripts/download_hf_artifacts.py
@@ -146,7 +146,7 @@ def download_datasets(args):
     # download(DATASETS, args, artifact_type="dataset")
     # datasets are using different structure then models/huggingface_hub and it's better use different API for downloading
     for dataset in DATASETS:
-        _ = load_dataset(dataset, cache_dir=args.cache_dir, ignore_verifications=True)
+        _ = load_dataset(dataset, cache_dir=args.cache_dir, verification_mode="no_checks")
     logger.info("Finished downloading datasets")
 
 

--- a/tt-train/sources/examples/gsm8k_finetune/gsm8k_finetune.py
+++ b/tt-train/sources/examples/gsm8k_finetune/gsm8k_finetune.py
@@ -377,8 +377,8 @@ def train():
 
     # Load dataset
     print("Loading GSM8K dataset...")
-    training_data = datasets.load_dataset("gsm8k", "main", split="train", ignore_verifications=True)
-    testing_data = datasets.load_dataset("gsm8k", "main", split="test", ignore_verifications=True)
+    training_data = datasets.load_dataset("gsm8k", "main", split="train", verification_mode="no_checks")
+    testing_data = datasets.load_dataset("gsm8k", "main", split="test", verification_mode="no_checks")
 
     training_data = tokenize_dataset(training_data, tokenizer)
     testing_data = tokenize_dataset(testing_data, tokenizer)

--- a/tt-train/sources/examples/qwen3/utils/dataset.py
+++ b/tt-train/sources/examples/qwen3/utils/dataset.py
@@ -114,6 +114,7 @@ def load_text_datasets(dataset_path):
             "Salesforce/wikitext",
             "wikitext-2-raw-v1",
             trust_remote_code=False,
+            verification_mode="no_checks",
         )
         train_texts = [t for t in ds["train"]["text"] if t.strip()]
         val_texts = [t for t in ds["validation"]["text"] if t.strip()]
@@ -128,7 +129,7 @@ def load_text_datasets(dataset_path):
         from datasets import load_dataset
 
         print(f"Loading dataset '{dataset_path}' from HuggingFace...")
-        ds = load_dataset(dataset_path, trust_remote_code=False)
+        ds = load_dataset(dataset_path, trust_remote_code=False, verification_mode="no_checks")
         if "train" in ds:
             train_texts = [str(t) for t in ds["train"]["text"] if str(t).strip()]
         else:

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -43,10 +43,9 @@ pytest-split==0.11.0
 pytest-benchmark==5.2.3
 jsbeautifier==1.14.7
 
-datasets>=2.20
-datasets<3
+datasets>=2.20,<3
 
-pyarrow>=21.0.0
+pyarrow>=21.0.0,<22
 torch==2.7.1 ; platform_machine == 'aarch64'
 networkx==3.1
 torchvision==0.22.1 ; platform_machine == 'aarch64'

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -42,8 +42,11 @@ pytest-timeout==2.4.0
 pytest-split==0.11.0
 pytest-benchmark==5.2.3
 jsbeautifier==1.14.7
-datasets==2.9.0
-pyarrow==20.0.0
+
+datasets>=2.20
+datasets<3
+
+pyarrow>=21.0.0
 torch==2.7.1 ; platform_machine == 'aarch64'
 networkx==3.1
 torchvision==0.22.1 ; platform_machine == 'aarch64'


### PR DESCRIPTION
### Summary
Current `datasets` library used in tt-metal has a bug (NonMatchingSplitsSizesError) that will prevent the gsm8k dataset from loading. This impacts GRPO development and gsm8k-finetune in tt-train.

Example script that breaks on version 2.9.0:
```
from __future__ import annotations
import sys
import datasets

def main() -> int:
    print(f"datasets version: {datasets.__version__}")
    print('calling: datasets.load_dataset("gsm8k", "main", split="train")')
    try:
        ds = datasets.load_dataset("gsm8k", "main", split="train")
    except Exception as e:
        print(f"FAILED with {type(e).__name__}:")
        print(e)
        return 1

    print(f"OK  num_rows={len(ds)}  features={list(ds.features)}")
    print(f"first question: {ds[0]['question']!r}")
    return 0


if __name__ == "__main__":
    sys.exit(main())
```

This PR:
* updates `datasets` library from ==2.9.0 to >=2.20 and <3 in requirements-dev.txt
* updates `pyarrow` library from ==20.0.0 to >=21.0.0
* fixes the broken scripts caused by the datasets library update. 

Main update of the datasets library between 2.9.0 and 2.20: "datasets with a python loading script now require passing trust_remote_code=True to be used. If any script calls load_dataset("some_dataset") where that dataset has a custom Python loader on the Hub, it now crashes with an error unless you pass trust_remote_code=True explicitly. In 2.9, this just worked silently."

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ichovpan/datasets-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ichovpan/datasets-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ichovpan/datasets-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ichovpan/datasets-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ichovpan/datasets-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ichovpan/datasets-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ichovpan/datasets-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ichovpan/datasets-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ichovpan/datasets-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ichovpan/datasets-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ichovpan/datasets-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ichovpan/datasets-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ichovpan/datasets-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ichovpan/datasets-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ichovpan/datasets-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ichovpan/datasets-update)