### PR TITLE
mx formats dram stride api fix

### DIFF
--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/circular_buffer_constants.h>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/experimental/buffer_kernel_binding.hpp>
 #include <algorithm>
 #include <map>
 #include <memory>
@@ -540,29 +541,10 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
                 .noc = NOC::RISCV_0_default,
                 .compile_args = {cb_index, /*use_dfbs=*/false}});
 
-        // DRAM buffers use page_size = buffer_size (whole buffer), so compute
-        // the per-tile stride directly. single_tile_size is the real per-tile
-        // stride here since tiles are packed contiguously inside the buffer.
-        SetRuntimeArgs(
-            program_,
-            reader_kernel,
-            core,
-            {
-                (uint32_t)src_dram_buffer->address(),
-                0,
-                (uint32_t)num_tiles,
-                single_tile_size,
-            });
-        SetRuntimeArgs(
-            program_,
-            writer_kernel,
-            core,
-            {
-                (uint32_t)dst_dram_buffer->address(),
-                0,
-                (uint32_t)num_tiles,
-                single_tile_size,
-            });
+        using tt::tt_metal::experimental::BindBufferToKernel;
+        using tt::tt_metal::experimental::BufferRole;
+        BindBufferToKernel(program_, reader_kernel, core, *src_dram_buffer, num_tiles, BufferRole::Read);
+        BindBufferToKernel(program_, writer_kernel, core, *dst_dram_buffer, num_tiles, BufferRole::Write);
 
         std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
             buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -8,6 +8,7 @@
 #include <sys/types.h>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/experimental/buffer_kernel_binding.hpp>
 #include <tt-metalium/experimental/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <iostream>
@@ -259,30 +260,12 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
 
     tt_metal::detail::WriteToBuffer(input_dram_buffer, inputs);
 
-    // DRAM buffer is configured with page_size = byte_size (whole buffer),
-    // so aligned_page_size() returns the whole-buffer stride, not per-tile.
-    // Derive the per-tile DRAM stride directly from byte_size / num_tiles.
-    const uint32_t per_tile_stride = static_cast<uint32_t>(byte_size / test_config.num_tiles);
-    tt_metal::SetRuntimeArgs(
-        program_,
-        reader_kernel,
-        test_config.core,
-        {
-            static_cast<uint32_t>(input_dram_byte_address),
-            0,
-            static_cast<uint32_t>(test_config.num_tiles),
-            per_tile_stride,
-        });
-    tt_metal::SetRuntimeArgs(
-        program_,
-        writer_kernel,
-        test_config.core,
-        {
-            static_cast<uint32_t>(output_dram_byte_address),
-            0,
-            static_cast<uint32_t>(test_config.num_tiles),
-            per_tile_stride,
-        });
+    using tt_metal::experimental::BindBufferToKernel;
+    using tt_metal::experimental::BufferRole;
+    BindBufferToKernel(
+        program_, reader_kernel, test_config.core, *input_dram_buffer, test_config.num_tiles, BufferRole::Read);
+    BindBufferToKernel(
+        program_, writer_kernel, test_config.core, *output_dram_buffer, test_config.num_tiles, BufferRole::Write);
 
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
@@ -434,10 +417,9 @@ bool reader_datacopy_writer(
 
     uint32_t num_tiles_per_thread = test_config.num_tiles / num_threads;
     log_info(tt::LogTest, "Num tiles per thread: {}", num_tiles_per_thread);
-    // DRAM buffer uses page_size = byte_size (whole-buffer), so derive the
-    // per-tile stride directly. byte_size covers all test_config.num_tiles
-    // tiles across all threads; the stride between consecutive tiles in DRAM
-    // is byte_size / test_config.num_tiles.
+    // Multi-threaded case: kernel arg `num_tiles` is per-thread, but DRAM
+    // stride is per-buffer-tile. BindBufferToKernel assumes those are the
+    // same number, so this site keeps the manual SetRuntimeArgs form.
     const uint32_t per_tile_stride = static_cast<uint32_t>(byte_size / test_config.num_tiles);
     tt_metal::SetRuntimeArgs(
         program_,

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_checkpoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_checkpoint.cpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/buffer_kernel_binding.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>
@@ -317,20 +318,10 @@ static void run_dump_cb(DevicePrintFixture* fixture, const std::shared_ptr<distr
         s.core,
         ComputeConfig{.compile_args = {static_cast<uint32_t>(NUM_TILES)}});
 
-    // SingleCoreSetup configures the DRAM buffers with page_size = buf_sz
-    // (whole buffer), so aligned_page_size would over-return. The real
-    // per-tile DRAM stride is just tt::tile_size(FMT).
-    const uint32_t per_tile_dram_stride = static_cast<uint32_t>(tt::tile_size(FMT));
-    SetRuntimeArgs(
-        *s.program,
-        reader,
-        s.core,
-        {static_cast<uint32_t>(s.input_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES), per_tile_dram_stride});
-    SetRuntimeArgs(
-        *s.program,
-        writer,
-        s.core,
-        {static_cast<uint32_t>(s.output_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES), per_tile_dram_stride});
+    using tt::tt_metal::experimental::BindBufferToKernel;
+    using tt::tt_metal::experimental::BufferRole;
+    BindBufferToKernel(*s.program, reader, s.core, *s.input_dram, NUM_TILES, BufferRole::Read);
+    BindBufferToKernel(*s.program, writer, s.core, *s.output_dram, NUM_TILES, BufferRole::Write);
 
     auto input =
         tt::test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, NUM_TILES * 1024);
@@ -374,19 +365,10 @@ static void run_dump_l1(DevicePrintFixture* fixture, const std::shared_ptr<distr
         s.core,
         ComputeConfig{.compile_args = {static_cast<uint32_t>(NUM_TILES)}});
 
-    // See run_dump_cb: DRAM buffer is single whole-buffer page, so pass the
-    // real per-tile stride (tile_size(FMT)) directly.
-    const uint32_t per_tile_dram_stride = static_cast<uint32_t>(tt::tile_size(FMT));
-    SetRuntimeArgs(
-        *s.program,
-        reader,
-        s.core,
-        {static_cast<uint32_t>(s.input_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES), per_tile_dram_stride});
-    SetRuntimeArgs(
-        *s.program,
-        writer,
-        s.core,
-        {static_cast<uint32_t>(s.output_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES), per_tile_dram_stride});
+    using tt::tt_metal::experimental::BindBufferToKernel;
+    using tt::tt_metal::experimental::BufferRole;
+    BindBufferToKernel(*s.program, reader, s.core, *s.input_dram, NUM_TILES, BufferRole::Read);
+    BindBufferToKernel(*s.program, writer, s.core, *s.output_dram, NUM_TILES, BufferRole::Write);
 
     auto input =
         tt::test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, NUM_TILES * 1024);
@@ -430,19 +412,10 @@ static void run_dump_typed(DevicePrintFixture* fixture, const std::shared_ptr<di
         s.core,
         ComputeConfig{.compile_args = {static_cast<uint32_t>(NUM_TILES)}});
 
-    // See run_dump_cb: DRAM buffer is single whole-buffer page, so pass the
-    // real per-tile stride (tile_size(FMT)) directly.
-    const uint32_t per_tile_dram_stride = static_cast<uint32_t>(tt::tile_size(FMT));
-    SetRuntimeArgs(
-        *s.program,
-        reader,
-        s.core,
-        {static_cast<uint32_t>(s.input_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES), per_tile_dram_stride});
-    SetRuntimeArgs(
-        *s.program,
-        writer,
-        s.core,
-        {static_cast<uint32_t>(s.output_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES), per_tile_dram_stride});
+    using tt::tt_metal::experimental::BindBufferToKernel;
+    using tt::tt_metal::experimental::BufferRole;
+    BindBufferToKernel(*s.program, reader, s.core, *s.input_dram, NUM_TILES, BufferRole::Read);
+    BindBufferToKernel(*s.program, writer, s.core, *s.output_dram, NUM_TILES, BufferRole::Write);
 
     auto input =
         tt::test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, NUM_TILES * 1024);

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tensix_dest.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tensix_dest.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/experimental/buffer_kernel_binding.hpp>
 #include <functional>
 #include <iomanip>
 #include <map>
@@ -227,20 +228,7 @@ private:
 // Type alias for a shared pointer to a Buffer in DRAM
 using DramBuffer = std::shared_ptr<distributed::MeshBuffer>;
 
-// Generates the runtime arguments for the DRAM kernel
-static std::vector<uint32_t> get_dram_kernel_runtime_arguments(const DramBuffer& dram_buffer, size_t num_tiles) {
-    // create_dram_mesh_buffer() configures page_size = byte_size (whole-buffer
-    // single page), so page_size/aligned_page_size would over-return the
-    // stride. Derive per-tile stride from total size / num_tiles instead.
-    const uint32_t per_tile_stride =
-        num_tiles == 0 ? 0 : static_cast<uint32_t>(dram_buffer->device_local_size() / num_tiles);
-    return {
-        static_cast<uint32_t>(dram_buffer->address()),
-        static_cast<uint32_t>(0),
-        static_cast<uint32_t>(num_tiles),
-        per_tile_stride,
-    };
-}
+// (legacy helper removed — runtime args are now packed by BindBufferToKernel)
 
 // Creates a circular buffer (L1 cache) for the specified core and data format
 static CBHandle create_circular_buffer(
@@ -292,8 +280,13 @@ static DramBuffer prepare_reader(
             .compile_args = {DEFAULT_INPUT_CB_INDEX, /*use_dfbs=*/false}});
 
     // Set runtime arguments for the reader kernel
-    tt_metal::SetRuntimeArgs(
-        program_, reader_kernel, config.core, get_dram_kernel_runtime_arguments(input_dram_buffer, config.num_tiles));
+    tt_metal::experimental::BindBufferToKernel(
+        program_,
+        reader_kernel,
+        config.core,
+        *input_dram_buffer,
+        config.num_tiles,
+        tt_metal::experimental::BufferRole::Read);
 
     return input_dram_buffer;
 }
@@ -324,8 +317,13 @@ static DramBuffer prepare_writer(
             .compile_args = {DEFAULT_OUTPUT_CB_INDEX, /*use_dfbs=*/false}});
 
     // Set runtime arguments for the writer kernel
-    tt_metal::SetRuntimeArgs(
-        program_, writer_kernel, config.core, get_dram_kernel_runtime_arguments(output_dram_buffer, config.num_tiles));
+    tt_metal::experimental::BindBufferToKernel(
+        program_,
+        writer_kernel,
+        config.core,
+        *output_dram_buffer,
+        config.num_tiles,
+        tt_metal::experimental::BufferRole::Write);
     return output_dram_buffer;
 }
 

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/experimental/buffer_kernel_binding.hpp>
 #include <functional>
 #include <iomanip>
 #include <map>
@@ -234,21 +235,6 @@ private:
 // Type alias for a shared pointer to a Buffer in DRAM
 using DramBuffer = std::shared_ptr<distributed::MeshBuffer>;
 
-// Generates the runtime arguments for the DRAM kernel
-static std::vector<uint32_t> get_dram_kernel_runtime_arguments(const DramBuffer& dram_buffer, size_t num_tiles) {
-    // create_dram_mesh_buffer() configures page_size = byte_size (whole-buffer
-    // single page), so page_size/aligned_page_size would over-return the
-    // stride. Derive per-tile stride from total size / num_tiles instead.
-    const uint32_t per_tile_stride =
-        num_tiles == 0 ? 0 : static_cast<uint32_t>(dram_buffer->device_local_size() / num_tiles);
-    return {
-        static_cast<uint32_t>(dram_buffer->address()),
-        static_cast<uint32_t>(0),
-        static_cast<uint32_t>(num_tiles),
-        per_tile_stride,
-    };
-}
-
 // Creates a circular buffer (L1 cache) for the specified core and data format
 static CBHandle create_circular_buffer(
     distributed::MeshWorkload& workload,
@@ -299,8 +285,13 @@ static DramBuffer prepare_reader(
             .compile_args = {DEFAULT_INPUT_CB_INDEX, /*use_dfbs=*/false}});
 
     // Set runtime arguments for the reader kernel
-    tt_metal::SetRuntimeArgs(
-        program_, reader_kernel, config.core, get_dram_kernel_runtime_arguments(input_dram_buffer, config.num_tiles));
+    tt_metal::experimental::BindBufferToKernel(
+        program_,
+        reader_kernel,
+        config.core,
+        *input_dram_buffer,
+        config.num_tiles,
+        tt_metal::experimental::BufferRole::Read);
 
     return input_dram_buffer;
 }
@@ -331,8 +322,13 @@ static DramBuffer prepare_writer(
             .compile_args = {DEFAULT_OUTPUT_CB_INDEX, /*use_dfbs=*/false}});
 
     // Set runtime arguments for the writer kernel
-    tt_metal::SetRuntimeArgs(
-        program_, writer_kernel, config.core, get_dram_kernel_runtime_arguments(output_dram_buffer, config.num_tiles));
+    tt_metal::experimental::BindBufferToKernel(
+        program_,
+        writer_kernel,
+        config.core,
+        *output_dram_buffer,
+        config.num_tiles,
+        tt_metal::experimental::BufferRole::Write);
     return output_dram_buffer;
 }
 

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/mxfp4.hpp>
 #include <tt-metalium/tile.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/experimental/buffer_kernel_binding.hpp>
 #include <tt-metalium/experimental/host_api.hpp>
 #include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
 #include <tt_stl/assert.hpp>
@@ -111,13 +112,14 @@ static vector<uint32_t> run_mxfp4_typecast(
     tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program, l1_output_dfb, compute, writer);
 
     detail::WriteToBuffer(src_buffer, src_vec);
-    // Pass aligned DRAM page stride so the reader/writer advance the DRAM
-    // pointer by the allocator's aligned_page_size (576 for MxFp4 on Quasar
-    // due to 64B DRAM alignment) while the DFB streams native 544-byte tiles.
-    uint32_t src_dram_stride = static_cast<uint32_t>(src_buffer->aligned_page_size());
-    uint32_t dst_dram_stride = static_cast<uint32_t>(dst_buffer->aligned_page_size());
-    SetRuntimeArgs(program, reader, core, {src_buffer->address(), 0, num_tiles, src_dram_stride});
-    SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, num_tiles, dst_dram_stride});
+    // BindBufferToKernel computes the DRAM page stride (= buffer.size() /
+    // num_tiles) and packs {addr, bank_id, num_tiles, stride} into the
+    // kernel's runtime args. The kernel reads them via BoundBuffer<DRAM>, so
+    // it never sees the L1 (544 B) vs DRAM-aligned (576 B) asymmetry.
+    using tt_metal::experimental::BindBufferToKernel;
+    using tt_metal::experimental::BufferRole;
+    BindBufferToKernel(program, reader, core, *src_buffer, num_tiles, BufferRole::Read);
+    BindBufferToKernel(program, writer, core, *dst_buffer, num_tiles, BufferRole::Write);
 
     detail::LaunchProgram(dev, program, /*wait_until_cores_done=*/true);
 

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -44,6 +44,7 @@
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include <umd/device/types/arch.hpp>
 #include "impl/data_format/bfloat16_utils.hpp"
+#include <tt-metalium/experimental/buffer_kernel_binding.hpp>
 #include <tt-metalium/experimental/host_api.hpp>
 #include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
 
@@ -667,13 +668,10 @@ static void run_quasar_tilize_untilize_test(
     }
     detail::WriteToBuffer(src_dram_buffer, src_vec);
 
-    // This test configures the DRAM buffers as a single whole-buffer page, so
-    // aligned_page_size() returns the whole-buffer stride rather than per-tile.
-    // Compute the real per-tile DRAM stride directly from the buffer size.
-    const uint32_t src_tile_stride_bytes = src_dram_buffer_size / num_tiles;
-    const uint32_t dst_tile_stride_bytes = dst_dram_buffer_size / num_tiles;
-    SetRuntimeArgs(program, reader, core, {dram_buffer_src_addr, (uint32_t)0, num_tiles, src_tile_stride_bytes});
-    SetRuntimeArgs(program, writer, core, {dram_buffer_dst_addr, (uint32_t)0, num_tiles, dst_tile_stride_bytes});
+    using tt::tt_metal::experimental::BindBufferToKernel;
+    using tt::tt_metal::experimental::BufferRole;
+    BindBufferToKernel(program, reader, core, *src_dram_buffer, num_tiles, BufferRole::Read);
+    BindBufferToKernel(program, writer, core, *dst_dram_buffer, num_tiles, BufferRole::Write);
 
     detail::LaunchProgram(dev, program, true);
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
@@ -6,6 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/kernel_thread_globals.h"
+#include "experimental/bound_buffer.h"
 #include "experimental/dataflow_buffer.h"
 #include "experimental/endpoints.h"
 #include "experimental/noc.h"
@@ -16,16 +17,14 @@
 void kernel_main() {
     const uint32_t cb_id = get_compile_time_arg_val(0);
     constexpr bool use_dfbs = get_compile_time_arg_val(1) == 1;
-    uint32_t src_addr  = get_arg_val<uint32_t>(0); // global base address
-    uint32_t src_bank_id = get_arg_val<uint32_t>(1); // data is in one bank
-    uint32_t num_tiles = get_arg_val<uint32_t>(2);
-    // DRAM page stride: the allocator may round page_size up (e.g. to
-    // NOC_DRAM_READ_ALIGNMENT_BYTES = 64 on Quasar), so tiles are spaced
-    // further apart in DRAM than their native size. Callers pass
-    // Buffer::aligned_page_size() here; the kernel advances the DRAM
-    // pointer by this stride while the DFB/CB still streams native-size
-    // tiles into L1.
-    uint32_t dram_page_stride = get_arg_val<uint32_t>(3);
+
+    // Buffer descriptor (base address, bank_id, num_tiles, per-tile DRAM
+    // stride) is supplied at runtime-arg slot 0..3 by BindBufferToKernel on
+    // the host. The previously-explicit `dram_page_stride` arg is now hidden
+    // inside BoundBuffer — kernel devs no longer see DRAM page-alignment vs.
+    // native tile size asymmetry.
+    experimental::BoundBuffer<experimental::AllocatorBankType::DRAM> src(/*arg_slot=*/0);
+    const uint32_t num_tiles = src.num_tiles();
 
     constexpr uint32_t ublock_size_tiles = 1;
 
@@ -35,8 +34,6 @@ void kernel_main() {
     uint32_t producer_idx = 0;
 #endif
 
-    constexpr experimental::AllocatorBankType bank_type = experimental::AllocatorBankType::DRAM;
-    experimental::AllocatorBank<bank_type> src_dram;
     experimental::Noc noc;
     if constexpr (use_dfbs) {
         experimental::DataflowBuffer dfb(cb_id);
@@ -46,18 +43,18 @@ void kernel_main() {
         // round-robin, stride_factor = N, and each producer walks DRAM tiles
         // [producer_idx, producer_idx+N, producer_idx+2N, ...].
         uint32_t stride_factor = dfb.get_stride_size() / ublock_size_bytes;
-        uint32_t tlocal_src_addr = src_addr + (producer_idx * dram_page_stride);
 
         for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
+            const uint32_t addr = src.tile_addr(producer_idx + i * stride_factor);
 #ifdef ARCH_QUASAR
-            noc.async_read<experimental::Noc::TxnIdMode::ENABLED>(src_dram, dfb, {.bank_id = src_bank_id, .addr = tlocal_src_addr}, {});
+            noc.async_read<experimental::Noc::TxnIdMode::ENABLED>(
+                src.bank(), dfb, {.bank_id = src.bank_id(), .addr = addr}, {});
 #else
             dfb.reserve_back(ublock_size_tiles);
-            noc.async_read(src_dram, dfb, ublock_size_bytes, {.bank_id = src_bank_id, .addr = tlocal_src_addr}, {});
+            noc.async_read(src.bank(), dfb, ublock_size_bytes, {.bank_id = src.bank_id(), .addr = addr}, {});
             noc.async_read_barrier();
             dfb.push_back(ublock_size_tiles);
 #endif
-            tlocal_src_addr += dram_page_stride * stride_factor;
         }
         dfb.finish();
     }
@@ -68,10 +65,9 @@ void kernel_main() {
 
         for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
             cb.reserve_back(ublock_size_tiles);
-            noc.async_read(src_dram, cb, ublock_size_bytes, {.bank_id = src_bank_id, .addr = src_addr}, {});
+            noc.async_read(src.bank(), cb, ublock_size_bytes, {.bank_id = src.bank_id(), .addr = src.tile_addr(i)}, {});
             noc.async_read_barrier();
             cb.push_back(ublock_size_tiles);
-            src_addr += dram_page_stride;
         }
     }
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
@@ -4,6 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/kernel_thread_globals.h"
+#include "experimental/bound_buffer.h"
 #include "experimental/dataflow_buffer.h"
 #include "experimental/endpoints.h"
 #include "experimental/noc.h"
@@ -14,16 +15,14 @@
 void kernel_main() {
     const uint32_t cb_id = get_compile_time_arg_val(0);
     constexpr bool use_dfbs = get_compile_time_arg_val(1) == 1;
-    uint32_t dst_addr  = get_arg_val<uint32_t>(0); // global base address
-    uint32_t dst_bank_id = get_arg_val<uint32_t>(1); // data is in one bank
-    uint32_t num_tiles = get_arg_val<uint32_t>(2);
-    // DRAM page stride: the allocator may round page_size up (e.g. to
-    // NOC_DRAM_READ_ALIGNMENT_BYTES = 64 on Quasar), so tiles are spaced
-    // further apart in DRAM than their native size. Callers pass
-    // Buffer::aligned_page_size() here; the kernel advances the DRAM
-    // pointer by this stride while the DFB/CB still streams native-size
-    // tiles into L1.
-    uint32_t dram_page_stride = get_arg_val<uint32_t>(3);
+
+    // Buffer descriptor (base address, bank_id, num_tiles, per-tile DRAM
+    // stride) is supplied at runtime-arg slot 0..3 by BindBufferToKernel on
+    // the host. The previously-explicit `dram_page_stride` arg is now hidden
+    // inside BoundBuffer — kernel devs no longer see DRAM page-alignment vs.
+    // native tile size asymmetry.
+    experimental::BoundBuffer<experimental::AllocatorBankType::DRAM> dst(/*arg_slot=*/0);
+    const uint32_t num_tiles = dst.num_tiles();
 
     uint32_t ublock_size_tiles = 1;
 
@@ -33,8 +32,6 @@ void kernel_main() {
     uint32_t consumer_idx = 0;
 #endif
 
-    constexpr experimental::AllocatorBankType bank_type = experimental::AllocatorBankType::DRAM;
-    experimental::AllocatorBank<bank_type> dst_dram;
     experimental::Noc noc;
 
     if constexpr (use_dfbs) {
@@ -46,18 +43,17 @@ void kernel_main() {
         // [consumer_idx, consumer_idx+N, consumer_idx+2N, ...].
         uint32_t stride_factor = dfb.get_stride_size() / ublock_size_bytes;
 
-        uint32_t tlocal_dst_addr = dst_addr + (consumer_idx * dram_page_stride);
-
         for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
+            const uint32_t addr = dst.tile_addr(consumer_idx + i * stride_factor);
 #ifdef ARCH_QUASAR
-            noc.async_write<experimental::Noc::TxnIdMode::ENABLED>(dfb, dst_dram, {}, {.bank_id = dst_bank_id, .addr = tlocal_dst_addr});
+            noc.async_write<experimental::Noc::TxnIdMode::ENABLED>(
+                dfb, dst.bank(), {}, {.bank_id = dst.bank_id(), .addr = addr});
 #else
             dfb.wait_front(ublock_size_tiles);
-            noc.async_write(dfb, dst_dram, ublock_size_bytes, {}, {.bank_id = dst_bank_id, .addr = tlocal_dst_addr});
+            noc.async_write(dfb, dst.bank(), ublock_size_bytes, {}, {.bank_id = dst.bank_id(), .addr = addr});
             noc.async_write_barrier();
             dfb.pop_front(ublock_size_tiles);
 #endif
-            tlocal_dst_addr += dram_page_stride * stride_factor;
         }
 
         dfb.finish();
@@ -73,10 +69,10 @@ void kernel_main() {
 
         for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
             cb.wait_front(ublock_size_tiles);
-            noc.async_write(cb, dst_dram, ublock_size_bytes, {}, {.bank_id = dst_bank_id, .addr = dst_addr});
+            noc.async_write(
+                cb, dst.bank(), ublock_size_bytes, {}, {.bank_id = dst.bank_id(), .addr = dst.tile_addr(i)});
             noc.async_write_barrier();
             cb.pop_front(ublock_size_tiles);
-            dst_addr += dram_page_stride;
         }
     }
 #endif

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
+#include <tt-metalium/experimental/buffer_kernel_binding.hpp>
 #include <tt-metalium/experimental/host_api.hpp>
 #include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
 #include "impl/data_format/bfloat16_utils.hpp"
@@ -109,16 +110,10 @@ static void run_pack_relu_test(IDevice* dev, uint32_t relu_config, const std::fu
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(dram_buffer_size, 1.0f, 0xCAFE);
     detail::WriteToBuffer(src_dram_buffer, src_vec);
 
-    SetRuntimeArgs(
-        program,
-        reader,
-        core,
-        {dram_buffer_src_addr, 0, num_tiles, static_cast<uint32_t>(src_dram_buffer->aligned_page_size())});
-    SetRuntimeArgs(
-        program,
-        writer,
-        core,
-        {dram_buffer_dst_addr, 0, num_tiles, static_cast<uint32_t>(dst_dram_buffer->aligned_page_size())});
+    using tt::tt_metal::experimental::BindBufferToKernel;
+    using tt::tt_metal::experimental::BufferRole;
+    BindBufferToKernel(program, reader, core, *src_dram_buffer, num_tiles, BufferRole::Read);
+    BindBufferToKernel(program, writer, core, *dst_dram_buffer, num_tiles, BufferRole::Write);
     SetRuntimeArgs(program, compute, core, {relu_config});
 
     detail::LaunchProgram(dev, program, true);

--- a/tt_metal/api/tt-metalium/experimental/buffer_kernel_binding.hpp
+++ b/tt_metal/api/tt-metalium/experimental/buffer_kernel_binding.hpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <initializer_list>
+#include <variant>
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt_stl/span.hpp>
+
+namespace tt::tt_metal {
+class Buffer;
+class Program;
+namespace distributed {
+class MeshBuffer;
+}  // namespace distributed
+}  // namespace tt::tt_metal
+
+namespace tt::tt_metal::experimental {
+
+enum class BufferRole : uint8_t { Read, Write };
+
+// Pack the runtime arguments for a kernel that wants per-tile DRAM access to
+// `buffer` without manually computing the DRAM page stride.
+//
+// Behavior: builds the runtime-arg vector
+//     {addr, bank_id, num_tiles, per_tile_dram_stride, ...extra_args}
+// where per_tile_dram_stride = buffer.size() / num_tiles. That formula works
+// for both common buffer configurations:
+//   * page_size == tile_size      -> equals buffer.aligned_page_size()
+//   * page_size == whole_buffer   -> equals total_bytes / num_tiles
+// so callers no longer have to know which idiom their buffer is in or where
+// DRAM page-alignment padding kicks in.
+//
+// The kernel reads these via the BoundBuffer<DRAM> wrapper in
+// "experimental/bound_buffer.h", e.g. `BoundBuffer<DRAM> src(/*slot=*/0)`.
+// Extra args are read at runtime-arg index 4+ via the standard get_arg_val<>.
+//
+// Note: SetRuntimeArgs may only be called once per kernel/core, so this
+// function calls it exactly once. Do not call SetRuntimeArgs separately for
+// the same kernel/core after BindBufferToKernel; pass any additional args via
+// `extra_args`.
+void BindBufferToKernel(
+    Program& program,
+    KernelHandle kernel,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+    const Buffer& buffer,
+    uint32_t num_tiles,
+    BufferRole role,
+    tt::stl::Span<const uint32_t> extra_args = {});
+
+void BindBufferToKernel(
+    Program& program,
+    KernelHandle kernel,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+    const Buffer& buffer,
+    uint32_t num_tiles,
+    BufferRole role,
+    std::initializer_list<uint32_t> extra_args);
+
+// Overloads for distributed::MeshBuffer. Uses MeshBuffer::address() and
+// device_local_size() — equivalent semantics to the Buffer overload above.
+void BindBufferToKernel(
+    Program& program,
+    KernelHandle kernel,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+    const distributed::MeshBuffer& buffer,
+    uint32_t num_tiles,
+    BufferRole role,
+    tt::stl::Span<const uint32_t> extra_args = {});
+
+void BindBufferToKernel(
+    Program& program,
+    KernelHandle kernel,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+    const distributed::MeshBuffer& buffer,
+    uint32_t num_tiles,
+    BufferRole role,
+    std::initializer_list<uint32_t> extra_args);
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/hw/inc/experimental/bound_buffer.h
+++ b/tt_metal/hw/inc/experimental/bound_buffer.h
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/endpoints.h"
+
+namespace experimental {
+
+/**
+ * @brief Kernel-side wrapper that reads its DRAM buffer descriptor
+ * (address, bank_id, num_tiles, per-tile DRAM stride) from a fixed runtime-arg
+ * slot populated by BindBufferToKernel on the host.
+ *
+ * The host-side BindBufferToKernel packs 4 runtime args at `slot..slot+3`:
+ *     arg[slot+0] = base address of buffer in DRAM
+ *     arg[slot+1] = bank_id (currently 0; reserved for future interleaved support)
+ *     arg[slot+2] = num_tiles
+ *     arg[slot+3] = per-tile DRAM stride (= buffer.size() / num_tiles)
+ *
+ * Kernel devs use this instead of computing strides themselves:
+ *     experimental::BoundBuffer<AllocatorBankType::DRAM> src(0);
+ *     for (uint32_t i = 0; i < src.num_tiles(); ++i) {
+ *         noc.async_read(src.bank(), dfb,
+ *                        {.bank_id = src.bank_id(), .addr = src.tile_addr(i)}, {});
+ *     }
+ *
+ * The DRAM page-alignment vs. native-tile-size asymmetry that previously
+ * forced kernel devs to thread an explicit `dram_page_stride` runtime arg is
+ * fully hidden: the host computes the right stride from buffer.size(), and
+ * the kernel just walks tiles.
+ *
+ * @note Experimental; subject to change as the host API redesign lands.
+ */
+template <AllocatorBankType bank_type>
+class BoundBuffer {
+public:
+    explicit FORCE_INLINE BoundBuffer(uint32_t arg_slot = 0) :
+        base_addr_(get_arg_val<uint32_t>(arg_slot + 0)),
+        bank_id_(get_arg_val<uint32_t>(arg_slot + 1)),
+        num_tiles_(get_arg_val<uint32_t>(arg_slot + 2)),
+        per_tile_stride_(get_arg_val<uint32_t>(arg_slot + 3)) {}
+
+    FORCE_INLINE uint32_t num_tiles() const { return num_tiles_; }
+    FORCE_INLINE uint32_t bank_id() const { return bank_id_; }
+    FORCE_INLINE uint32_t base_addr() const { return base_addr_; }
+    FORCE_INLINE uint32_t stride() const { return per_tile_stride_; }
+    FORCE_INLINE uint32_t tile_addr(uint32_t tile_index) const { return base_addr_ + tile_index * per_tile_stride_; }
+    FORCE_INLINE AllocatorBank<bank_type> bank() const { return AllocatorBank<bank_type>{}; }
+
+    // First runtime-arg index *after* this binding's reserved slots. Use this
+    // when chaining multiple BoundBuffers or computing where user extra-args
+    // start. For a single binding at slot 0, user extras live at index 4+.
+    static constexpr uint32_t kArgCount = 4;
+
+private:
+    uint32_t base_addr_;
+    uint32_t bank_id_;
+    uint32_t num_tiles_;
+    uint32_t per_tile_stride_;
+};
+
+}  // namespace experimental

--- a/tt_metal/impl/buffers/buffer_kernel_binding.cpp
+++ b/tt_metal/impl/buffers/buffer_kernel_binding.cpp
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/experimental/buffer_kernel_binding.hpp>
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+#include <tt_stl/assert.hpp>
+
+#include <vector>
+
+namespace tt::tt_metal::experimental {
+
+namespace {
+
+constexpr uint32_t kBindingArgCount = 4;  // {addr, bank_id, num_tiles, stride}
+
+void bind_raw(
+    Program& program,
+    KernelHandle kernel,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+    uint64_t buffer_address,
+    uint64_t buffer_size,
+    uint32_t num_tiles,
+    BufferRole role,
+    tt::stl::Span<const uint32_t> extra_args) {
+    TT_FATAL(num_tiles > 0, "BindBufferToKernel: num_tiles must be > 0");
+    TT_FATAL(
+        buffer_size % num_tiles == 0,
+        "BindBufferToKernel: buffer size {} not evenly divisible by num_tiles {}",
+        buffer_size,
+        num_tiles);
+
+    // Universal per-tile DRAM stride: works whether the buffer was configured
+    // with page_size == tile_size (allocator may pad to L1/DRAM alignment, in
+    // which case size == num_pages * aligned_page_size) or with
+    // page_size == whole_buffer (in which case size == total bytes the user
+    // intends to interpret as num_tiles tiles).
+    const uint32_t per_tile_stride = static_cast<uint32_t>(buffer_size / num_tiles);
+
+    std::vector<uint32_t> args;
+    args.reserve(kBindingArgCount + extra_args.size());
+    args.push_back(static_cast<uint32_t>(buffer_address));
+    args.push_back(0);  // bank_id; PoC assumes single-bank addressing as today's kernels do
+    args.push_back(num_tiles);
+    args.push_back(per_tile_stride);
+    args.insert(args.end(), extra_args.begin(), extra_args.end());
+
+    SetRuntimeArgs(program, kernel, core_spec, args);
+    (void)role;  // reserved for future use (e.g. read-only vs write-only validation)
+}
+
+}  // namespace
+
+void BindBufferToKernel(
+    Program& program,
+    KernelHandle kernel,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+    const Buffer& buffer,
+    uint32_t num_tiles,
+    BufferRole role,
+    tt::stl::Span<const uint32_t> extra_args) {
+    bind_raw(
+        program,
+        kernel,
+        core_spec,
+        static_cast<uint64_t>(buffer.address()),
+        static_cast<uint64_t>(buffer.size()),
+        num_tiles,
+        role,
+        extra_args);
+}
+
+void BindBufferToKernel(
+    Program& program,
+    KernelHandle kernel,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+    const Buffer& buffer,
+    uint32_t num_tiles,
+    BufferRole role,
+    std::initializer_list<uint32_t> extra_args) {
+    bind_raw(
+        program,
+        kernel,
+        core_spec,
+        static_cast<uint64_t>(buffer.address()),
+        static_cast<uint64_t>(buffer.size()),
+        num_tiles,
+        role,
+        tt::stl::Span<const uint32_t>(extra_args.begin(), extra_args.size()));
+}
+
+void BindBufferToKernel(
+    Program& program,
+    KernelHandle kernel,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+    const distributed::MeshBuffer& buffer,
+    uint32_t num_tiles,
+    BufferRole role,
+    tt::stl::Span<const uint32_t> extra_args) {
+    bind_raw(
+        program,
+        kernel,
+        core_spec,
+        static_cast<uint64_t>(buffer.address()),
+        static_cast<uint64_t>(buffer.device_local_size()),
+        num_tiles,
+        role,
+        extra_args);
+}
+
+void BindBufferToKernel(
+    Program& program,
+    KernelHandle kernel,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+    const distributed::MeshBuffer& buffer,
+    uint32_t num_tiles,
+    BufferRole role,
+    std::initializer_list<uint32_t> extra_args) {
+    bind_raw(
+        program,
+        kernel,
+        core_spec,
+        static_cast<uint64_t>(buffer.address()),
+        static_cast<uint64_t>(buffer.device_local_size()),
+        num_tiles,
+        role,
+        tt::stl::Span<const uint32_t>(extra_args.begin(), extra_args.size()));
+}
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -24,6 +24,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/per_core_allocation/memory_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/per_core_allocation/mesh_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer_kernel_binding.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer_distribution_spec.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer_page_mapping.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/tensor_accessor_args.cpp


### PR DESCRIPTION
### Summary
Mx formats have an issue with dram padding. MxFp4 in particular:

The full tile of MxFp4 is 544 bytes long.

In metal we write the tiles to DRAM and then from DRAM to L1 in tests and other way around.

When we use dataflow kernels, we always give them the stride (how much to skip to get to the next tile). So far this has always been the same for both DRAM and L1.

However, DRAM has to have tiles aligned to pages (64 byte alignment). Regardless of what we give as a stride parameter (Tile size) it will always choose it's own stride based on this one and write to DRAM with this stride. In all cases this stride was the same value as the tile size parameter since they were always aligned to 64 bytes.

In our case however, we need MxFp4 tiles consecutively written 544 bytes after 544 bytes. 544 is not divisible by 64. Therefore DRAM was always resorting to aligning it to 576 when writing to itself.

It was writting into DRAM that way but when it came to kernels actually reading the data and transferring it to L1, they used our 544 parameter and for every tile that's not the first one, we had the 32 bytes of garbage (576 - 544 = 32).

We had to therefore split the parameter and make a stride for DRAM reading (576) and a stride for L1 (544).

Therefore we had to add this parameter to be passed in all tests that use
tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
and
tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp

to make the calls consistent across the repo even though most tests don't use that parameter as they always have the alignment correctly set.


This is good but makes it adds a parameter that kernel developers have to keep an eye out on and if they are not aware of its functionality completely, they could cause bugs.

### Solution

This PR is supposed to remove that redundancy by introducing a buffer binder that takes care of the parameters by itself and hides it from developers.

The "freedom from stride awareness" lives in exactly three line-level pieces:

1. Host absorbs the alignment math — `buffer_kernel_binding.cpp`

`const uint32_t per_tile_stride = static_cast<uint32_t>(buffer_size / num_tiles);`
This is the only place that has to know the answer. Whatever the allocator did with DRAM padding is already baked into `buffer.size()`, so dividing by num_tiles always gives the right inter-tile spacing. The kernel dev never types aligned_page_size(), never knows what 64 means, never sees the asymmetry.

2. Kernel→address indirection — `bound_buffer.h`

```
FORCE_INLINE uint32_t tile_addr(uint32_t tile_index) const {
    return base_addr_ + tile_index * per_tile_stride_;
}
```
The kernel asks for "tile index i"; this method does the multiply with a stride the kernel never named. Per-tile stride is still mathematically present (it has to be — the bytes don't move themselves), but it's a private member of BoundBuffer, not a kernel local.

3. The bind line — `direct_reader_unary.cpp`

`experimental::BoundBuffer<experimental::AllocatorBankType::DRAM> src(/*arg_slot=*/0);`
This single line is where the kernel "subscribes" to the descriptor. Everything downstream `(src.tile_addr(i), src.bank_id(), src.num_tiles())` is keyed off it. There's no `get_arg_val<uint32_t>(3)` and no comment explaining why DRAM stride differs from tile size.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=uvelimirovic/mx_formats_dram_stride)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:uvelimirovic/mx_formats_dram_stride)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=uvelimirovic/mx_formats_dram_stride)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:uvelimirovic/mx_formats_dram_stride)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=uvelimirovic/mx_formats_dram_stride)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:uvelimirovic/mx_formats_dram_stride)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=uvelimirovic/mx_formats_dram_stride)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:uvelimirovic/mx_formats_dram_stride)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=uvelimirovic/mx_formats_dram_stride)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:uvelimirovic/mx_formats_dram_stride)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=uvelimirovic/mx_formats_dram_stride)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:uvelimirovic/mx_formats_dram_stride)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=uvelimirovic/mx_formats_dram_stride)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:uvelimirovic/mx_formats_dram_stride)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=uvelimirovic/mx_formats_dram_stride)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:uvelimirovic/mx_formats_dram_stride)