### PR TITLE
fix(unary): FILL with negative float scalar into INT32 tensor yields zero

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -129,6 +129,10 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
                         "FILL value {} out of range for UInt16",
                         as_int);
                     fill_val = static_cast<std::uint32_t>(as_int);
+                } else if (input_dtype == DataType::INT32) {
+                    // Cast through int32_t first: direct float-to-uint32_t cast is UB for
+                    // negative values and yields 0 on x86/LLVM (e.g. -29.5 -> 0, not -29).
+                    fill_val = static_cast<std::uint32_t>(static_cast<std::int32_t>(param0_raw));
                 } else {
                     fill_val = static_cast<std::uint32_t>(param0_raw);
                 }


### PR DESCRIPTION
## Problem

`ttnn.fill(tensor, -29.5)` on an `INT32` tensor produces all zeros instead of `-29`.

In `unary_op_utils.cpp`, the scalar packing for `FILL` with integer dtypes does:

```cpp
} else {
    fill_val = static_cast<std::uint32_t>(param0_raw);  // param0_raw = -29.5f
}
```

`static_cast<uint32_t>(float)` is **undefined behavior** in C++ when the float value is negative (only defined for values in `[0, UINT32_MAX]`). On x86/LLVM, `CVTTSS2SI` saturates out-of-range values and the subsequent uint32 cast produces **0**, which is then passed as the fill value to the kernel.

The `UINT16` branch a few lines above already handles this correctly by casting through `int32_t` first.

## Fix

Apply the same two-step cast to the `INT32` branch:

```cpp
} else if (input_dtype == DataType::INT32) {
    fill_val = static_cast<std::uint32_t>(static_cast<std::int32_t>(param0_raw));
} else {
    fill_val = static_cast<std::uint32_t>(param0_raw);
}
```

`float → int32_t` truncates toward zero (well-defined for in-range values); `int32_t → uint32_t` is modular two's complement (always defined).

## Test

Existing test covers this exactly:
```
tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py::test_fill[torch_dtype=torch.int32-ttnn_dtype=DataType.INT32-w=128-h=64-scalar=-29.5]
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brain/fix-fill-int32-negative-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/fix-fill-int32-negative-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=brain/fix-fill-int32-negative-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:brain/fix-fill-int32-negative-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=brain/fix-fill-int32-negative-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:brain/fix-fill-int32-negative-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brain/fix-fill-int32-negative-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/fix-fill-int32-negative-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=brain/fix-fill-int32-negative-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:brain/fix-fill-int32-negative-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brain/fix-fill-int32-negative-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/fix-fill-int32-negative-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brain/fix-fill-int32-negative-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/fix-fill-int32-negative-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brain/fix-fill-int32-negative-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/fix-fill-int32-negative-scalar)