### PR TITLE
Revert TT_METAL_CACHE changes from PR #43379

### DIFF
--- a/.github/workflows/multi-host-deepseekv3.yaml
+++ b/.github/workflows/multi-host-deepseekv3.yaml
@@ -179,6 +179,7 @@ jobs:
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e PYTHONPATH=${{ github.workspace }}
             -e TT_METAL_HOME=${{ github.workspace }}
+            -e TT_METAL_CACHE=${{ steps.capture-home.outputs.home }}/.metal_cache
             -e ARCH_NAME=wormhole_b0
             -e TT_METAL_RELAX_PGD_SLOT_CONSTRAINTS=1
             -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
@@ -204,6 +205,7 @@ jobs:
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e PYTHONPATH=${{ github.workspace }}
             -e TT_METAL_HOME=${{ github.workspace }}
+            -e TT_METAL_CACHE=${{ steps.capture-home.outputs.home }}/.metal_cache
             -e ARCH_NAME=wormhole_b0
             -e TT_METAL_RELAX_PGD_SLOT_CONSTRAINTS=1
             -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
@@ -230,6 +232,7 @@ jobs:
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e PYTHONPATH=${{ github.workspace }}
             -e TT_METAL_HOME=${{ github.workspace }}
+            -e TT_METAL_CACHE=${{ steps.capture-home.outputs.home }}/.metal_cache
             -e ARCH_NAME=wormhole_b0
             -e TT_METAL_RELAX_PGD_SLOT_CONSTRAINTS=1
             -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
@@ -257,6 +260,7 @@ jobs:
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e PYTHONPATH=${{ github.workspace }}
             -e TT_METAL_HOME=${{ github.workspace }}
+            -e TT_METAL_CACHE=${{ steps.capture-home.outputs.home }}/.metal_cache
             -e ARCH_NAME=wormhole_b0
             -e TT_METAL_RELAX_PGD_SLOT_CONSTRAINTS=1
             -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
@@ -285,6 +289,7 @@ jobs:
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e PYTHONPATH=${{ github.workspace }}
             -e TT_METAL_HOME=${{ github.workspace }}
+            -e TT_METAL_CACHE=${{ steps.capture-home.outputs.home }}/.metal_cache
             -e ARCH_NAME=wormhole_b0
             -e TT_METAL_RELAX_PGD_SLOT_CONSTRAINTS=1
             -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
@@ -320,6 +325,7 @@ jobs:
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e PYTHONPATH=${{ github.workspace }}
             -e TT_METAL_HOME=${{ github.workspace }}
+            -e TT_METAL_CACHE=${{ steps.capture-home.outputs.home }}/.metal_cache
             -e ARCH_NAME=wormhole_b0
             -e TT_METAL_RELAX_PGD_SLOT_CONSTRAINTS=1
             -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
@@ -356,6 +362,7 @@ jobs:
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e PYTHONPATH=${{ github.workspace }}
             -e TT_METAL_HOME=${{ github.workspace }}
+            -e TT_METAL_CACHE=${{ steps.capture-home.outputs.home }}/.metal_cache
             -e ARCH_NAME=wormhole_b0
             -e TT_METAL_RELAX_PGD_SLOT_CONSTRAINTS=1
             -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
@@ -391,6 +398,7 @@ jobs:
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e PYTHONPATH=${{ github.workspace }}
             -e TT_METAL_HOME=${{ github.workspace }}
+            -e TT_METAL_CACHE=${{ steps.capture-home.outputs.home }}/.metal_cache
             -e ARCH_NAME=wormhole_b0
             -e TT_METAL_RELAX_PGD_SLOT_CONSTRAINTS=1
             -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
@@ -426,6 +434,7 @@ jobs:
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e PYTHONPATH=${{ github.workspace }}
             -e TT_METAL_HOME=${{ github.workspace }}
+            -e TT_METAL_CACHE=${{ steps.capture-home.outputs.home }}/.metal_cache
             -e ARCH_NAME=wormhole_b0
             -e TT_METAL_RELAX_PGD_SLOT_CONSTRAINTS=1
             -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
@@ -461,6 +470,7 @@ jobs:
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e PYTHONPATH=${{ github.workspace }}
             -e TT_METAL_HOME=${{ github.workspace }}
+            -e TT_METAL_CACHE=${{ steps.capture-home.outputs.home }}/.metal_cache
             -e ARCH_NAME=wormhole_b0
             -e TT_METAL_RELAX_PGD_SLOT_CONSTRAINTS=1
             -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
@@ -497,6 +507,7 @@ jobs:
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e PYTHONPATH=${{ github.workspace }}
             -e TT_METAL_HOME=${{ github.workspace }}
+            -e TT_METAL_CACHE=${{ steps.capture-home.outputs.home }}/.metal_cache
             -e ARCH_NAME=wormhole_b0
             -e TT_METAL_RELAX_PGD_SLOT_CONSTRAINTS=1
             -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
@@ -532,6 +543,7 @@ jobs:
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e PYTHONPATH=${{ github.workspace }}
             -e TT_METAL_HOME=${{ github.workspace }}
+            -e TT_METAL_CACHE=${{ steps.capture-home.outputs.home }}/.metal_cache
             -e ARCH_NAME=wormhole_b0
             -e TT_METAL_RELAX_PGD_SLOT_CONSTRAINTS=1
             -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -264,14 +264,6 @@ run_quad_galaxy_unit_tests() {
 # Environment setup helpers
 ###############################################################################
 
-# Kernel cache must be local per host (not NFS/shared home) to avoid multihost races.
-_ensure_local_tt_metal_cache() {
-    unset TT_METAL_CACHE 2>/dev/null || true
-    local rid="${GITHUB_RUN_ID:-$$}"
-    export TT_METAL_CACHE="${TMPDIR:-/tmp}/tt_metal_kernel_cache_${rid}"
-    mkdir -p "${TT_METAL_CACHE}"
-}
-
 # MLPerf weight cache is read-only in CI. Module-test jobs set MULTIHOST_DS_V3_WEIGHT_CACHE=1;
 # demos omit it so DEEPSEEK_V3_CACHE stays unset unless explicitly overridden elsewhere.
 _resolve_deepseekv3_cache() {
@@ -315,7 +307,6 @@ resolve_deepseekv3_model() {
 }
 
 setup_dual_galaxy_env() {
-    _ensure_local_tt_metal_cache
     export RANK_BINDING_YAML="tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"
     export MESH_GRAPH_DESCRIPTOR="tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.textproto"
     export HOSTS="$(extract_hosts_from_hostfile 2)"
@@ -350,7 +341,6 @@ setup_dual_galaxy_env() {
 }
 
 setup_quad_galaxy_env() {
-    _ensure_local_tt_metal_cache
     export RANK_BINDING_YAML="tests/tt_metal/distributed/config/quad_galaxy_rank_bindings.yaml"
     export MESH_GRAPH_DESCRIPTOR="tt_metal/fabric/mesh_graph_descriptors/quad_galaxy_torus_xy_graph_descriptor.textproto"
     export HOSTS="$(extract_hosts_from_hostfile 4)"


### PR DESCRIPTION
### Summary
Restore prior TT_METAL_CACHE handling while preserving the DeepSeek V3 cache resolution behavior introduced by PR #43379, this is already a local cache and the new change actually caused failures in multi host deployment CI pipeline even though it passed the deepseek multihost pipeline.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
