### PR TITLE
[Bugfix] DFB unpack_to_dest_mode conversion for Metal 2.0

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -33,7 +33,10 @@
 
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/experimental/host_api.hpp>  // for QuasarComputeConfig
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/hal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/experimental/context/metal_env.hpp>
 #include <tt-metalium/experimental/mock_device.hpp>
 
@@ -792,9 +795,9 @@ TEST_F(ProgramSpecTestQuasar, DataFormatNotSupportedOnTargetArchitectureFails) {
 }
 
 TEST_F(ProgramSpecTestQuasar, TooManyDFBsFailsValidation) {
-    // The hard upper limit on DFBs is hal::get_arch_num_circular_buffers()
-    // (64 on Quasar). Exceeding it should fail validation with a clear error,
-    // rather than blowing up downstream during JIT.
+    // The hard upper limit on DFBs is hal::get_arch_num_circular_buffers().
+    // Exceeding it should fail validation with a clear error, rather than blowing
+    // up downstream during JIT.
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -803,8 +806,8 @@ TEST_F(ProgramSpecTestQuasar, TooManyDFBsFailsValidation) {
     auto producer = MakeMinimalDMKernel("producer");
     auto consumer = MakeMinimalComputeKernel("consumer");
 
-    constexpr uint32_t kTooMany = 65;
-    for (uint32_t i = 0; i < kTooMany; ++i) {
+    const uint32_t too_many = tt::tt_metal::hal::get_arch_num_circular_buffers() + 1;
+    for (uint32_t i = 0; i < too_many; ++i) {
         std::string name = "dfb_" + std::to_string(i);
         auto dfb = MakeMinimalDFB(name);
         dfb.data_format_metadata = tt::DataFormat::Float16_b;
@@ -816,9 +819,10 @@ TEST_F(ProgramSpecTestQuasar, TooManyDFBsFailsValidation) {
     spec.kernels = {producer, consumer};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
+    const std::string expected_substr = "too many DataflowBufferSpecs (" + std::to_string(too_many) + ")";
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("too many DataflowBufferSpecs (65)")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(expected_substr)));
 }
 
 // ============================================================================
@@ -1267,9 +1271,12 @@ TEST_F(ProgramSpecTestQuasar, ValidUnpackToDestModeSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, ValidUnpackToDestModeOnNonZeroDfbIdSucceeds) {
-    // Companion to ValidUnpackToDestModeSucceeds: targets a DFB with a non-zero
-    // dfb_id, exercising the dfb_id != 0 path through BuildUnpackToDestModeVector.
+TEST_F(ProgramSpecTestQuasar, UnpackToDestModePlacedAtDfbIdSlot) {
+    // Regression test for the unpack_to_dest_mode sizing bug: the JIT consumer
+    // iterates hal::get_arch_num_circular_buffers() slots, so BuildUnpackToDestModeVector
+    // must size the vector to that count and place each user-supplied mode at slot dfb_id.
+    // Pre-fix code sized the vector to the number of DFBs, which produced silent
+    // OOB reads downstream when num_dfbs < max_cbs.
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -1295,7 +1302,20 @@ TEST_F(ProgramSpecTestQuasar, ValidUnpackToDestModeOnNonZeroDfbIdSucceeds) {
     spec.dataflow_buffers = {dfb0, dfb1};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    Program program = MakeProgramFromSpec(spec);
+
+    // Inspect the constructed compute kernel's QuasarComputeConfig:
+    //  - vector must be sized to max_cbs (so JIT's iteration up to max_cbs is in-bounds)
+    //  - the user-supplied mode must land at slot dfb_id (not at iteration order)
+    //  - other slots stay Default
+    const auto& impl = program.impl();
+    auto consumer_kernel = impl.get_kernel_by_spec_name("consumer");
+    const auto built_config_variant = consumer_kernel->config();
+    const auto& built_config = std::get<experimental::quasar::QuasarComputeConfig>(built_config_variant);
+
+    EXPECT_EQ(built_config.unpack_to_dest_mode.size(), tt::tt_metal::hal::get_arch_num_circular_buffers());
+    EXPECT_EQ(built_config.unpack_to_dest_mode[impl.get_dfb_handle("dfb_1")], UnpackToDestMode::UnpackToDestFp32);
+    EXPECT_EQ(built_config.unpack_to_dest_mode[impl.get_dfb_handle("dfb_0")], UnpackToDestMode::Default);
 }
 
 // ============================================================================

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -791,6 +791,36 @@ TEST_F(ProgramSpecTestQuasar, DataFormatNotSupportedOnTargetArchitectureFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB 'dfb' has data format")));
 }
 
+TEST_F(ProgramSpecTestQuasar, TooManyDFBsFailsValidation) {
+    // The hard upper limit on DFBs is hal::get_arch_num_circular_buffers()
+    // (64 on Quasar). Exceeding it should fail validation with a clear error,
+    // rather than blowing up downstream during JIT.
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalComputeKernel("consumer");
+
+    constexpr uint32_t kTooMany = 65;
+    for (uint32_t i = 0; i < kTooMany; ++i) {
+        std::string name = "dfb_" + std::to_string(i);
+        auto dfb = MakeMinimalDFB(name);
+        dfb.data_format_metadata = tt::DataFormat::Float16_b;
+        spec.dataflow_buffers.push_back(dfb);
+        BindDFBToKernel(producer, name, "p_" + std::to_string(i), KernelSpec::DFBEndpointType::PRODUCER);
+        BindDFBToKernel(consumer, name, "c_" + std::to_string(i), KernelSpec::DFBEndpointType::CONSUMER);
+    }
+
+    spec.kernels = {producer, consumer};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("too many DataflowBufferSpecs (65)")));
+}
+
 // ============================================================================
 // SECTION 3: WorkUnitSpec Validation Tests
 // ============================================================================
@@ -1233,6 +1263,37 @@ TEST_F(ProgramSpecTestQuasar, ValidUnpackToDestModeSucceeds) {
             config.unpack_to_dest_mode = {{"dfb_0", UnpackToDestMode::UnpackToDestFp32}};
         }
     }
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+}
+
+TEST_F(ProgramSpecTestQuasar, ValidUnpackToDestModeOnNonZeroDfbIdSucceeds) {
+    // Companion to ValidUnpackToDestModeSucceeds: targets a DFB with a non-zero
+    // dfb_id, exercising the dfb_id != 0 path through BuildUnpackToDestModeVector.
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalComputeKernel("consumer");
+
+    auto dfb0 = MakeMinimalDFB("dfb_0");
+    dfb0.data_format_metadata = tt::DataFormat::Float16_b;
+    auto dfb1 = MakeMinimalDFB("dfb_1");
+    dfb1.data_format_metadata = tt::DataFormat::Float16_b;
+
+    BindDFBToKernel(producer, "dfb_0", "out0", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(producer, "dfb_1", "out1", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, "dfb_0", "in0", KernelSpec::DFBEndpointType::CONSUMER);
+    BindDFBToKernel(consumer, "dfb_1", "in1", KernelSpec::DFBEndpointType::CONSUMER);
+
+    auto& compute_config = std::get<ComputeConfiguration>(consumer.config_spec);
+    compute_config.unpack_to_dest_mode = {{"dfb_1", UnpackToDestMode::UnpackToDestFp32}};
+
+    spec.kernels = {producer, consumer};
+    spec.dataflow_buffers = {dfb0, dfb1};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -36,6 +36,7 @@
 #include <tt-metalium/experimental/host_api.hpp>  // for QuasarComputeConfig
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal.hpp>
+#include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
 #include <tt-metalium/experimental/context/metal_env.hpp>
 #include <tt-metalium/experimental/mock_device.hpp>

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -675,8 +675,6 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // a DFB configuration-dependent way.
     // Unfortunately, those checks won't trigger until the DFB code runs... not until the
     // Program is actually enqueued :(
-    //
-    // TODO: Find a way to fix this usability issue.
     {
         const uint32_t max_dfbs = tt::tt_metal::hal::get_arch_num_circular_buffers();
         if (spec.dataflow_buffers.size() > max_dfbs) {
@@ -687,7 +685,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                     spec.program_id,
                     spec.dataflow_buffers.size(),
                     max_dfbs);
-            } else {
+            } else if (is_gen2_arch()) {
                 TT_THROW(
                     "ProgramSpec '{}' has too many DataflowBufferSpecs ({}). The permitted "
                     "number of DFBs for the target architecture is configuration-dependent, "
@@ -695,6 +693,8 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                     spec.program_id,
                     spec.dataflow_buffers.size(),
                     max_dfbs);
+            } else {
+                TT_FATAL(false, "Unknown architecture");
             }
         }
     }

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -662,6 +662,43 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // Validate DataflowBufferSpecs
     //////////////////////////////////
 
+    // Validate the total number of DFBs in the ProgramSpec:
+    //  - For Gen1, there's a hard limit (hal::get_arch_num_circular_buffers())
+    //  - For Gen2, the true DFB limit is configuration-dependent, based on the availability
+    //    of tile counters. This won't actually get checked until the Program is enqueued :(
+    //  - However, the Gen1 check actually DOES apply to Gen2 as a strict upper limit.
+    //    In practice, we'll run out of tile counters long before we hit the HAL CB limit,
+    //    but then runtime software sizes some buffers based on this.
+    //
+    // For Quasar, this is a partial validation only!
+    // The true number of available DFBs depends on the tile counters, which are consumed in
+    // a DFB configuration-dependent way.
+    // Unfortunately, those checks won't trigger until the DFB code runs... not until the
+    // Program is actually enqueued :(
+    //
+    // TODO: Find a way to fix this usability issue.
+    {
+        const uint32_t max_dfbs = tt::tt_metal::hal::get_arch_num_circular_buffers();
+        if (spec.dataflow_buffers.size() > max_dfbs) {
+            if (is_gen1_arch()) {
+                TT_THROW(
+                    "ProgramSpec '{}' has too many DataflowBufferSpecs ({}). The target "
+                    "architecture supports up to {}.",
+                    spec.program_id,
+                    spec.dataflow_buffers.size(),
+                    max_dfbs);
+            } else {
+                TT_THROW(
+                    "ProgramSpec '{}' has too many DataflowBufferSpecs ({}). The permitted "
+                    "number of DFBs for the target architecture is configuration-dependent, "
+                    "but {} is a hard upper limit.",
+                    spec.program_id,
+                    spec.dataflow_buffers.size(),
+                    max_dfbs);
+            }
+        }
+    }
+
     // Validate local DFB endpoint placement:
     // A local DFB's producer and consumer kernels must be on the same node (sharing SRAM memory).
     // For this to be true, the producer and consumer kernels need IDENTICAL WorkUnitSpec membership.
@@ -1282,6 +1319,46 @@ DataMovementConfig MakeGen1DataMovementConfig(const KernelSpec& kernel_spec) {
 }
 
 // ----------------------------------------------------------------------------
+// BuildUnpackToDestModeVector:
+// Translate the Metal 2.0 user-facing DFB-name->mode map into the (gross)
+// CB-indexed vector that the JIT data-format machinery expects.
+//
+// This DFB/CB translation layer is confusing. The gory details:
+//   - The JIT consumer (get_unpack_dst_formats) will read unpack_to_dest_mode at
+//     index cb_id, where cb_id is the slot used by set_dfb_data_fmt_and_tile
+//     in buf_dataformat_arr (aka, dfb->id).
+//   - The unpack_mode for a DFB "d" needs to be at unpack_modes[d->id]
+//   - The vector must be at least max_cbs long, or the consumer gets angry
+//     (it iterates buf_formats up to max_cbs).
+//   - This is true on WH, BH, and Quasar. (Yes, Quasar too.)
+//
+// What is the max CBs / DFBs?
+//   - WH/BH: Hardcoded as max_cbs. Different number on WH vs. BH.
+//   - Quasar has a variable cap, based on tile-counter registers.
+//     In actual practice, we'll run out LONG before we get the HAL-reported
+//     limit of 64.
+// ----------------------------------------------------------------------------
+
+std::vector<UnpackToDestMode> BuildUnpackToDestModeVector(
+    const std::vector<ComputeConfiguration::UnpackToDestModeEntry>& user_modes, const DFBNameToIdMap& dfb_name_to_id) {
+    const uint32_t max_cbs = tt::tt_metal::hal::get_arch_num_circular_buffers();
+    std::vector<UnpackToDestMode> unpack_modes(max_cbs, UnpackToDestMode::Default);
+    for (const auto& [dfb_name, mode] : user_modes) {
+        uint32_t dfb_id = dfb_name_to_id.at(dfb_name);
+        // This TT_FATAL is unreachable, provided that validation wasn't skipped.
+        TT_FATAL(
+            dfb_id < max_cbs,
+            "Internal Error: DFB '{}' has id {} which exceeds the JIT data-format "
+            "slot count ({}); compute kernels cannot reference DFBs past this limit",
+            dfb_name,
+            dfb_id,
+            max_cbs);
+        unpack_modes[dfb_id] = mode;
+    }
+    return unpack_modes;
+}
+
+// ----------------------------------------------------------------------------
 // MakeGen1ComputeConfig: Create a ComputeConfig (WH/BH) from a KernelSpec
 // ----------------------------------------------------------------------------
 
@@ -1289,11 +1366,8 @@ ComputeConfig MakeGen1ComputeConfig(const KernelSpec& kernel_spec, const DFBName
     TT_FATAL(kernel_spec.is_compute_kernel(), "Expected a compute kernel");
     const auto& compute_config = std::get<ComputeConfiguration>(kernel_spec.config_spec);
 
-    std::vector<UnpackToDestMode> unpack_modes(dfb_name_to_id.size(), UnpackToDestMode::Default);
-    for (const auto& [dfb_name, mode] : compute_config.unpack_to_dest_mode) {
-        uint32_t dfb_id = dfb_name_to_id.at(dfb_name);
-        unpack_modes[dfb_id] = mode;
-    }
+    std::vector<UnpackToDestMode> unpack_modes =
+        BuildUnpackToDestModeVector(compute_config.unpack_to_dest_mode, dfb_name_to_id);
 
     return ComputeConfig{
         .math_fidelity = compute_config.math_fidelity,
@@ -1335,19 +1409,8 @@ experimental::quasar::QuasarComputeConfig MakeQuasarComputeConfig(
     TT_FATAL(kernel_spec.is_compute_kernel(), "Expected a compute kernel");
     const auto& compute_config = std::get<ComputeConfiguration>(kernel_spec.config_spec);
 
-    // Handle unpack_to_dest_mode:
-    //  - The user-facing KernelSpec provides the modes keyed by DFB name.
-    //  - The unpack_to_dest_mode vector in the QuasarComputeConfig is indexed by DFB ID.
-    //  - DFB IDs are always issued sequentially from zero, so this works.
-
-    // Size the vector to the number of DFBs.
-    std::vector<UnpackToDestMode> unpack_modes(dfb_name_to_id.size(), UnpackToDestMode::Default);
-
-    // Populate unpack_modes using DFB ID as the index
-    for (const auto& [dfb_name, mode] : compute_config.unpack_to_dest_mode) {
-        uint32_t dfb_id = dfb_name_to_id.at(dfb_name);
-        unpack_modes[dfb_id] = mode;
-    }
+    std::vector<UnpackToDestMode> unpack_modes =
+        BuildUnpackToDestModeVector(compute_config.unpack_to_dest_mode, dfb_name_to_id);
 
     return experimental::quasar::QuasarComputeConfig{
         .num_threads_per_cluster = kernel_spec.num_threads,


### PR DESCRIPTION
### Summary
#### Bug
When a Metal 2.0 user specifies the `unpack_to_dest_mode` for a DFB with a compute kernel endpoint, they specify it in a user-readable way: as a vector of `{"dfb_name", unpack_mode_enum}`.

Behind the scenes, that needs to get converted into the format that the runtime expects (a vector of unpack_modes, sized to the HAL-reported `max_cbs`, with the appropriate modes slotted in by their DFB id). There was a bug in this conversion for WH/BH (correct for Quasar). It slipped through because of my over-reliance on mock device unit tests, which don't exercise the full JIT build pathway.

#### Fix
 - Add the required conversion.
 - Add missing validation checks for the maximum permissible number of DFBs in a `ProgramSpec`. For Quasar, this is a somewhat useless upper bound, but needs to be checked -- otherwise the downstream unpack mode vector conversion could fail.
 - Add some additional unit tests (smoke tests only; don't exercise the JIT path)

This obviously needs a non-mock test too. Another bugfix PR (https://github.com/tenstorrent/tt-metal/pull/43462) happens to test this pathway, so I've left off adding a HW test here.

### Notes 
This bugfix caused me to realize a usability concern. The number of DFBs allowed on Quasar is a variable number, depending on the configurations of the DFBs you use. As we currently have things, this PR adds an absolute-upper-bound validation check. But the _real_ DFB limit won't get checked until all the tile counter calculations.... which actually doesn't trigger until the `Program` gets _enqueued_. That is not great for usability.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/fix-unpack_mode-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/fix-unpack_mode-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/fix-unpack_mode-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/fix-unpack_mode-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/fix-unpack_mode-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/fix-unpack_mode-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/fix-unpack_mode-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/fix-unpack_mode-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/fix-unpack_mode-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/fix-unpack_mode-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/fix-unpack_mode-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/fix-unpack_mode-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/fix-unpack_mode-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/fix-unpack_mode-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/fix-unpack_mode-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/fix-unpack_mode-bug)