### PR TITLE
[Bugfix] Fix Metal 2.0 named kernel arguments include order bug

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -31,6 +31,7 @@ namespace tt::tt_metal::experimental::metal2_host_api {
 namespace {
 
 using test_helpers::BindDFBToKernel;
+using test_helpers::MakeMinimalComputeKernel;
 using test_helpers::MakeMinimalDFB;
 using test_helpers::MakeMinimalGen1DMKernel;
 using test_helpers::MakeMinimalWorkUnit;
@@ -305,6 +306,121 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
 
     ASSERT_EQ(output_data.size(), input_data.size());
     EXPECT_EQ(output_data, input_data);
+}
+
+// ============================================================================
+// Named Args Loopback — Compute Producer
+// ============================================================================
+//
+// Companion test for NamedArgsLoopback that exercises the named-args surface
+// from the COMPUTE compile path (TRISC_UNPACK / TRISC_MATH / TRISC_PACK).
+// The named-args helpers reach a compute kernel via a completely different
+// include chain than a DM kernel.
+//
+// Pipeline:
+//   Compute kernel (TRISC) — produces out_dfb. Reads named RTAs/CRTAs/CTAs +
+//       RTA/CRTA varargs; writes the XOR sum of all of them into the first
+//       uint32_t of every entry, zeros the rest.
+//   DM Consumer (NCRISC) — out_dfb → DRAM output. Positional varargs only.
+//
+// The kernel does NOT use the unpack/math/pack tile pipeline — just raw L1 writes
+// from PACK after reserve_back. This is a plumbing test only; didn't want to
+// tangle with type conversions....
+//
+// Verification: the host arranges every named arg + every vararg so their XOR
+// equals a known target. Output DRAM should contain {target, 0, 0, …} per
+// entry, exactly. A wrong offset on any accessor → wrong sum → test fails on
+// the byte-for-byte compare.
+
+TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
+    auto mesh_device = devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+
+    constexpr uint32_t entry_size = 1024;
+    constexpr uint32_t num_entries_in_dfb = 4;
+    constexpr uint32_t num_transfers = 8;
+    constexpr uint32_t total_bytes = entry_size * num_transfers;
+
+    const NodeCoord node{0, 0};
+
+    InterleavedBufferConfig dram_config{
+        .device = device, .size = total_bytes, .page_size = total_bytes, .buffer_type = BufferType::DRAM};
+    auto output_buffer = CreateBuffer(dram_config);
+
+    ProgramSpec spec;
+    spec.program_id = "named_args_loopback_compute";
+
+    // Compute kernel: produces out_dfb. The kernel under test — exercises every
+    // named-arg accessor (RTA / CRTA / two CTAs) plus RTA + CRTA varargs.
+    auto compute = MakeMinimalComputeKernel("compute");
+    compute.source =
+        KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/compute/named_args_loopback_compute.cpp"};
+    compute.runtime_arguments_schema.named_runtime_args = {"input_offset"};
+    compute.runtime_arguments_schema.named_common_runtime_args = {"num_tiles"};
+    compute.runtime_arguments_schema.num_runtime_varargs = 2;
+    compute.runtime_arguments_schema.num_common_runtime_varargs = 1;
+    compute.compile_time_arg_bindings = {{"magic", 0xCAFE0001u}, {"entry_size", entry_size}};
+
+    // Consumer: NCRISC reads out_dfb → DRAM. Reuses dfb_accessor_loopback_consumer.cpp
+    // verbatim (positional varargs only).
+    auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
+    consumer.source =
+        KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp"};
+    consumer.runtime_arguments_schema.num_runtime_varargs = 3;
+
+    auto out_dfb = MakeMinimalDFB("out_dfb", entry_size, num_entries_in_dfb);
+    out_dfb.data_format_metadata = tt::DataFormat::Float16_b;
+
+    BindDFBToKernel(compute, "out_dfb", "out_dfb", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, "out_dfb", "a_dfb_named_bob", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {compute, consumer};
+    spec.dataflow_buffers = {out_dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", node, {"compute", "consumer"})};
+
+    Program program = MakeProgramFromSpec(spec);
+
+    // Pick non-trivial bits so a wrong-offset read is unlikely to coincidentally
+    // produce the same XOR. The compute kernel's sum is:
+    //   magic ^ entry_size ^ num_tiles ^ input_offset ^ va0 ^ va1 ^ cv0
+    // Solve for cv0 to make the sum equal kTargetXorSum.
+    constexpr uint32_t kTargetXorSum = 0xDEADBEEFu;
+    constexpr uint32_t kMagic = 0xCAFE0001u;
+    constexpr uint32_t kInputOffset = 0x12345678u;
+    constexpr uint32_t kVararg0 = 0xAAAA1111u;
+    constexpr uint32_t kVararg1 = 0xBBBB2222u;
+    constexpr uint32_t kCommonVararg0 =
+        kTargetXorSum ^ kMagic ^ entry_size ^ num_transfers ^ kInputOffset ^ kVararg0 ^ kVararg1;
+
+    ProgramRunParams params;
+    params.kernel_run_params = {
+        ProgramRunParams::KernelRunParams{
+            .kernel_spec_name = "compute",
+            .named_runtime_args = {{.node = node, .args = {{"input_offset", kInputOffset}}}},
+            .named_common_runtime_args = {{"num_tiles", num_transfers}},
+            .runtime_varargs = {{node, {kVararg0, kVararg1}}},
+            .common_runtime_varargs = {kCommonVararg0},
+        },
+        ProgramRunParams::KernelRunParams{
+            .kernel_spec_name = "consumer",
+            .runtime_varargs = {{node, {output_buffer->address(), 0u, num_transfers}}},
+        },
+    };
+    SetProgramRunParameters(program, params);
+
+    detail::LaunchProgram(device, program);
+
+    std::vector<uint32_t> output_data;
+    detail::ReadFromBuffer(output_buffer, output_data);
+
+    constexpr uint32_t words_per_entry = entry_size / sizeof(uint32_t);
+    std::vector<uint32_t> expected(total_bytes / sizeof(uint32_t), 0u);
+    for (uint32_t e = 0; e < num_transfers; ++e) {
+        expected[e * words_per_entry] = kTargetXorSum;
+    }
+
+    ASSERT_EQ(output_data.size(), expected.size());
+    EXPECT_EQ(output_data, expected);
 }
 
 // ============================================================================

--- a/tests/tt_metal/tt_metal/test_kernels/compute/named_args_loopback_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/named_args_loopback_compute.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Test kernel: Metal 2.0 named-args producer (compute side).
+// Acts as the producer of an output DFB: every entry it pushes contains the
+// XOR sum of every named arg + vararg the kernel was given, deposited into the
+// first uint32_t of the entry's L1 slot. A DM consumer carries those entries
+// to a DRAM buffer the host can verify byte-for-byte.
+//
+// Companion test on the COMPUTE compile path (TRISC_UNPACK / TRISC_MATH /
+// TRISC_PACK) for the existing dataflow named_args_loopback pair, which only
+// covers the BRISC/NCRISC compile path. The named-args surface reaches a
+// compute kernel via a different include chain (compute_kernel_api.h →
+// api/compute/common.h) than DM (api/dataflow/dataflow_api.h), and
+// experimental/kernel_args.h must work in both contexts.
+//
+// Exercises the Metal 2.0 kernel-args feature surface:
+//   args::magic        — named CTA (compile-time)
+//   args::entry_size   — named CTA (compile-time)
+//   args::num_tiles    — named CRTA (broadcast at runtime)
+//   args::input_offset — named RTA (per-node at runtime)
+//   get_vararg(0..1)   — two RTA varargs
+//   get_common_vararg(0) — one CRTA vararg
+//
+// Verification: the host arranges all six values so their XOR equals a known
+// target. The output DRAM should contain that target in word 0 of every
+// entry, with the rest zeroed. A wrong offset on any accessor → wrong sum →
+// wrong word in DRAM output → test fails. (No tile compute pipeline is
+// involved — the kernel writes raw bytes to the output DFB's L1 slot, which
+// avoids Float16_b lossy conversion and inter-TRISC sync issues that aren't
+// what this test is trying to cover.)
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "experimental/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    // CTAs — compile-time constants, so the constexpr form is legal here.
+    constexpr uint32_t magic = get_arg(args::magic);
+    constexpr uint32_t entry_size = get_arg(args::entry_size);
+
+    // CRTA (broadcast at runtime)
+    const uint32_t num_tiles = get_arg(args::num_tiles);
+
+    // RTA (per-node at runtime)
+    const uint32_t input_offset = get_arg(args::input_offset);
+
+    // XOR every named arg + every vararg — exercises all six accessor paths.
+    const uint32_t vararg_xor =
+        magic ^ entry_size ^ num_tiles ^ input_offset ^ get_vararg(0) ^ get_vararg(1) ^ get_common_vararg(0);
+
+    experimental::DataflowBuffer dfb_out(dfb::out_dfb);
+
+    for (uint32_t t = 0; t < num_tiles; ++t) {
+        dfb_out.reserve_back(1);  // implementation gates this to PACK only
+
+        // PACK is the only TRISC that needs to populate the L1 slot — the
+        // others reach reserve_back / push_back as no-ops via the impl gates.
+        // On tt-1xx TRISCs, fifo_wr_ptr is stored as a 16-byte unit address;
+        // shift left 4 to get a byte address for L1 access.
+#ifdef TRISC_PACK
+        {
+            volatile tt_l1_ptr uint32_t* out_ptr = (volatile tt_l1_ptr uint32_t*)(dfb_out.get_write_ptr() << 4);
+            out_ptr[0] = vararg_xor;
+            const uint32_t words = entry_size / sizeof(uint32_t);
+            for (uint32_t w = 1; w < words; ++w) {
+                out_ptr[w] = 0;
+            }
+        }
+#endif
+
+        dfb_out.push_back(1);  // implementation gates this to PACK only
+    }
+}

--- a/tt_metal/hw/inc/experimental/kernel_args.h
+++ b/tt_metal/hw/inc/experimental/kernel_args.h
@@ -24,6 +24,22 @@
 //
 // NOTE: Currently, only uint32_t args are supported. However, named kernel arguments via
 // get_arg() will later be extended to support arbitrary POD types.
+//
+// DEPENDENCY NOTE::
+// This header requires the following to be visible at the point of inclusion:
+//  - `get_arg_addr`
+//  - `get_common_arg_addr`
+//  - `get_arg_val<T>`
+//  - `get_common_arg_val<T>`
+//  - `FORCE_INLINE` macros
+//  - `tt_l1_ptr` macros
+// On the DM path, those come from `api/dataflow/dataflow_api.h`, which the firmware wrapper
+// (brisck.cc, ncrisck.cc, etc.) includes before <kernel_includes.hpp>.
+// On the TRISC path, those come from `api/compute/common.h`, but nothing pulls that in before
+// <kernel_includes.hpp>. We need to manually include here.
+#ifdef COMPILE_FOR_TRISC
+#include "api/compute/common.h"
+#endif
 
 namespace experimental {
 

--- a/tt_metal/hw/inc/experimental/kernel_args.h
+++ b/tt_metal/hw/inc/experimental/kernel_args.h
@@ -25,7 +25,7 @@
 // NOTE: Currently, only uint32_t args are supported. However, named kernel arguments via
 // get_arg() will later be extended to support arbitrary POD types.
 //
-// DEPENDENCY NOTE::
+// DEPENDENCY NOTE:
 // This header requires the following to be visible at the point of inclusion:
 //  - `get_arg_addr`
 //  - `get_common_arg_addr`


### PR DESCRIPTION
### Summary

**Bug**
Metal 2.0 adds named runtime and common runtime argument syntax. The mechanics of that happen through an auto-generated header file, `kernel_args_generated.h`. This file needs some symbols to be already defined at the point of inclusion. This is available in `api/dataflow/dataflow_api.h` for DM kernels, and `api/compute/common.h` for compute kernels.

For compute kernels, the necessary header (`api/compute/common.h`) wasn't getting automatically included before the generated `kernel_args_generated.h`.

**Fix**
Trivial fix -- add the missing header on the TRISC compile path:
```
#ifdef COMPILE_FOR_TRISC
#include "api/compute/common.h"
#endif
```

**Changes**
 - Emit the missing code into `kernel_args_generated.h` (in `genfiles.cpp`)
 - Add a compute kernel test exercising all of the Metal 2.0 named arguments features.

### Notes for reviewers
This bugfix stands alone. But, the test I added also needs the bugfix from https://github.com/tenstorrent/tt-metal/pull/43461. That PR will need to merge before this one.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/fix-compute-kernel-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/fix-compute-kernel-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/fix-compute-kernel-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/fix-compute-kernel-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/fix-compute-kernel-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/fix-compute-kernel-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/fix-compute-kernel-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/fix-compute-kernel-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/fix-compute-kernel-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/fix-compute-kernel-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/fix-compute-kernel-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/fix-compute-kernel-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/fix-compute-kernel-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/fix-compute-kernel-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/fix-compute-kernel-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/fix-compute-kernel-args)