### PR TITLE
[moe_compute] Floor non-tile CB page size at LLK 16-B word boundary

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/circular_buffer_constants.h>
 #include <tt-metalium/experimental/device.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/math.hpp>
@@ -661,12 +662,14 @@ MoEComputeMeshWorkloadFactory::create_at(
         tt::DataFormat::UInt32);
 
     // CB for passing total_chunks from writer to compute kernel
-    // Single page holding one uint32_t value
+    // Single page holding one uint32_t value. Page size floored at l1_alignment /
+    // CIRCULAR_BUFFER_COMPUTE_WORD_SIZE so the unpack LLK fifo_* fields (16 B words) are non-zero
+    // when tilize_compute pops this CB.
     tt::tt_metal::create_cb(
         total_chunks_cb_id,
         program,
         tilize_core_range_set,
-        sizeof(uint32_t),
+        std::max({static_cast<uint32_t>(sizeof(uint32_t)), l1_alignment, CIRCULAR_BUFFER_COMPUTE_WORD_SIZE}),
         1,  // single page
         tt::DataFormat::UInt32);
 
@@ -680,12 +683,14 @@ MoEComputeMeshWorkloadFactory::create_at(
         |     Name       |   CB Index    |   Dtype    | Tile? | Tiles/CB |  Total size (B) |
         ------------------------------------------------------------------------------------
         | cb_s2c_in      | CBIndex::c_0  | Float16_b  | true  |    224*2 |      917504     |
-        | cb_r2c_w0      | CBIndex::c_1  | Bfp4_b     | true  |    14*6  |      48384      |
-        | cb_c2w_rdy     | CBIndex::c_2  | Float32    | false |    1     |      4          |
-        | cb_w2c_rdy     | CBIndex::c_3  | Float32    | false |    1     |      4          |
-        | cb_s2c_in2     | CBIndex::c_4  | Float16_b  | true  |    6*12  |      147456     |
-        | cb_w2c_md      | CBIndex::c_5  | UInt32     | false |    2     |      8          |
+        | cb_r2c_w0      | CBIndex::c_3  | Bfp4_b     | true  |    14*6  |      48384      |
+        | cb_c2w_rdy     | CBIndex::c_4  | Float32    | false |    1     | see below       |
+        | cb_w2c_rdy     | CBIndex::c_5  | Float32    | false |    1     | see below       |
+        | cb_s2c_in2     | CBIndex::c_6  | Float16_b  | true  |    6*12  |      147456     |
+        | cb_w2c_md      | CBIndex::c_7  | UInt32     | false |    2     | see below       |
         ------------------------------------------------------------------------------------
+        Non-tile CBs use page_size >= max(datum_size, l1_alignment, CIRCULAR_BUFFER_COMPUTE_WORD_SIZE)
+        so LLK fifo_* fields (16 B words; circular_buffer_constants.h) are non-zero on compute push/pop.
     */
 
     // Define the CB configuration as a tuple: name, CBIndex, DataFormat, tiles_per_cb
@@ -702,15 +707,15 @@ MoEComputeMeshWorkloadFactory::create_at(
         matmul_cb_specs0.emplace_back("cb_c2c_ones_tile", tt::CBIndex::c_8, tt::DataFormat::Float16_b, true, 1);
     }
 
-    std::map<std::string, tt::tt_metal::CBHandle> matmul_cb_handles;
-
     // Create CBs
     for (const auto& [name, index, data_format, is_tile, tiles_per_cb] : matmul_cb_specs0) {
-        const uint32_t bytes_per_tile = is_tile ? tt::tile_size(data_format) : tt::datum_size(data_format);
+        const uint32_t bytes_per_tile =
+            is_tile ? tt::tile_size(data_format)
+                    : std::max({tt::datum_size(data_format), l1_alignment, CIRCULAR_BUFFER_COMPUTE_WORD_SIZE});
         const auto cb_config = tt::tt_metal::CircularBufferConfig(tiles_per_cb * bytes_per_tile, {{index, data_format}})
                                    .set_page_size(index, bytes_per_tile);
 
-        matmul_cb_handles[name] = tt::tt_metal::CreateCircularBuffer(program, matmul_core_range_set, cb_config);
+        tt::tt_metal::CreateCircularBuffer(program, matmul_core_range_set, cb_config);
     }
 
     //-------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

Fixes an LLK-assert trip seen with `TT_METAL_LLK_ASSERTS=1` on `moe_compute` when running tests in [`tests/nightly/tg/ccl/moe/test_moe_compute_6U.py`](https://github.com/tenstorrent/tt-metal/tree/main/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py):

```
LLK_ASSERT(cb.fifo_rd_ptr < cb.fifo_limit, "CB pop_front: fifo_rd_ptr already at or past fifo_limit")
```

LLK stores `fifo_size`/`fifo_page_size`/`fifo_limit` in 16-B words (`cb_addr_shift = 4`). Any non-tile CB with page or total size < 16 B rounds those fields to 0, so `fifo_limit == fifo_addr` from init and the first compute-side `cb_pop_front`/`cb_push_back` trips. Without `LLK_ASSERTS=1` the bug silently no-op'd pointer advances; reads via `get_tile_address` masked it.

Fix: floor non-tile CB page sizes at `max(datum_size, l1_alignment, CIRCULAR_BUFFER_COMPUTE_WORD_SIZE)`. Affects `cb_c2w_rdy` / `cb_w2c_rdy` / `cb_w2c_md` (matmul cores) and `total_chunks_cb_id` (tilize cores). +48 B / matmul core, +12 B / tilize core.

### Notes
- `brisc_activated_count_cb_id` and `brisc_expert_counts_cb_id` are dataflow-only today, so they don't trip the assert. Will regress if a future change adds compute-side access.
- Cleanest long-term fix is upstream in Metalium (enforce `page_size >= CIRCULAR_BUFFER_COMPUTE_WORD_SIZE` at CB-config time). Out of scope here.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gchoudhary/fix-llk-assert-trip-in-moe_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gchoudhary/fix-llk-assert-trip-in-moe_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gchoudhary/fix-llk-assert-trip-in-moe_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gchoudhary/fix-llk-assert-trip-in-moe_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gchoudhary/fix-llk-assert-trip-in-moe_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gchoudhary/fix-llk-assert-trip-in-moe_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gchoudhary/fix-llk-assert-trip-in-moe_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gchoudhary/fix-llk-assert-trip-in-moe_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=gchoudhary/fix-llk-assert-trip-in-moe_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:gchoudhary/fix-llk-assert-trip-in-moe_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gchoudhary/fix-llk-assert-trip-in-moe_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gchoudhary/fix-llk-assert-trip-in-moe_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gchoudhary/fix-llk-assert-trip-in-moe_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gchoudhary/fix-llk-assert-trip-in-moe_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gchoudhary/fix-llk-assert-trip-in-moe_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gchoudhary/fix-llk-assert-trip-in-moe_compute)