### PR TITLE
Mark lregs that TT series clobbers [FIX]

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -14,6 +14,7 @@ sfpi_inline void load_value_param_float(uint value) { sfpi::vConstIntPrgm0 = val
 
 template <bool IS_MAX_OP>
 sfpi_inline void calculate_unary_max_min_float_body() {
+    sfpi::l_reg[sfpi::LRegs::LReg0].in_use();
     TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
 
     if constexpr (IS_MAX_OP) {
@@ -49,6 +50,8 @@ inline void calculate_unary_max_min(uint value) {
 #else
     constexpr int offset = 0;
 
+    sfpi::l_reg[sfpi::LRegs::LReg0].in_use();
+    sfpi::l_reg[sfpi::LRegs::LReg1].in_use();
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         int a = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
@@ -68,6 +71,7 @@ sfpi_inline void load_value_param_int(uint value) {
 
 template <bool IS_MAX_OP, bool IS_UNSIGNED = false>
 sfpi_inline void calculate_unary_max_min_int32_body(uint value) {
+    sfpi::l_reg[sfpi::LRegs::LReg0].in_use();
     TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
 
     if (IS_UNSIGNED ^ ((int)value >= 0)) {
@@ -117,6 +121,7 @@ inline void calculate_unary_max_min_int32(uint value) {
         // 0 | ...  | [a] L16 = not(a)      |     |       |         |
         // 1 | ...  |                       |     |       | [a] L16 |
 
+        sfpi::l_reg[sfpi::LRegs::LReg0].in_use();
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             constexpr int a = p_sfpu::LREG0;
@@ -141,6 +146,8 @@ inline void calculate_unary_max_min_int32(uint value) {
         // 0 | ...  |                     |     |       |       |
         // 1 | ...  |                     |     |       | [a]   |
 
+        sfpi::l_reg[sfpi::LRegs::LReg0].in_use();
+        sfpi::l_reg[sfpi::LRegs::LReg1].in_use();
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             int a = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -14,6 +14,7 @@ sfpi_inline void load_value_param_float(uint value) { sfpi::vConstIntPrgm0 = val
 
 template <bool IS_MAX_OP>
 sfpi_inline void calculate_unary_max_min_float_body() {
+    sfpi::l_reg[sfpi::LRegs::LReg0].in_use();
     TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
 
     if constexpr (IS_MAX_OP) {
@@ -49,6 +50,8 @@ inline void calculate_unary_max_min(uint value) {
 #else
     constexpr int offset = 0;
 
+    sfpi::l_reg[sfpi::LRegs::LReg0].in_use();
+    sfpi::l_reg[sfpi::LRegs::LReg1].in_use();
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         int a = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
@@ -68,6 +71,7 @@ sfpi_inline void load_value_param_int(uint value) {
 
 template <bool IS_MAX_OP, bool IS_UNSIGNED = false>
 sfpi_inline void calculate_unary_max_min_int32_body(uint value) {
+    sfpi::l_reg[sfpi::LRegs::LReg0].in_use();
     TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
 
     if (IS_UNSIGNED ^ ((int)value >= 0)) {
@@ -117,6 +121,7 @@ inline void calculate_unary_max_min_int32(uint value) {
         // 0 | ...  | [a] L16 = not(a)      |     |       |         |
         // 1 | ...  |                       |     |       | [a] L16 |
 
+        sfpi::l_reg[sfpi::LRegs::LReg0].in_use();
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             constexpr int a = p_sfpu::LREG0;
@@ -141,6 +146,8 @@ inline void calculate_unary_max_min_int32(uint value) {
         // 0 | ...  |                     |     |       |       |
         // 1 | ...  |                     |     |       | [a]   |
 
+        sfpi::l_reg[sfpi::LRegs::LReg0].in_use();
+        sfpi::l_reg[sfpi::LRegs::LReg1].in_use();
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             int a = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -43,10 +43,8 @@ sfpi_inline sfpi::vFloat _trunc_body_(sfpi::vFloat val)
     // apply mask
     TTI_SFPAND(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
 
-    // Make sure compiler avoids these two regs here, ugh. And make
-    // sure the DCE pass considers this live without warning.
-    sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vFloat(sfpi::l_reg[sfpi::LRegs::LReg2]);
-    sfpi::l_reg[sfpi::LRegs::LReg3] = sfpi::vFloat(sfpi::l_reg[sfpi::LRegs::LReg3]);
+    sfpi::l_reg[sfpi::LRegs::LReg2].in_use();
+    sfpi::l_reg[sfpi::LRegs::LReg3].in_use();
 
     return sfpi::l_reg[sfpi::LRegs::LReg1];
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -43,10 +43,8 @@ sfpi_inline sfpi::vFloat _trunc_body_(sfpi::vFloat val)
     // apply mask
     TTI_SFPAND(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
 
-    // Make sure compiler avoids these two regs here, ugh. And make
-    // sure the DCE pass considers this live without warning.
-    sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vFloat(sfpi::l_reg[sfpi::LRegs::LReg2]);
-    sfpi::l_reg[sfpi::LRegs::LReg3] = sfpi::vFloat(sfpi::l_reg[sfpi::LRegs::LReg3]);
+    sfpi::l_reg[sfpi::LRegs::LReg2].in_use();
+    sfpi::l_reg[sfpi::LRegs::LReg3].in_use();
 
     return sfpi::l_reg[sfpi::LRegs::LReg1];
 }


### PR DESCRIPTION
### Summary
Mixing builtins (via or not-via sfpi.h) and TT macros means one has to be very careful so that the compiler knows which registers are being used in the TT series. A new compiler optimization triggered here because it is not told that the TT series modifies any registers.

I've added a named member fn to mark this, rather than use the self-assignment syntax of the last go.

As the compiler release notes, it is likely we will need more of these as the compiler gets smarter.  But it's probably something we can do mechanically

https://github.com/tenstorrent/sfpi/releases/tag/7.45.0

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/lregs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/lregs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/lregs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/lregs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/lregs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/lregs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/lregs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/lregs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/lregs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/lregs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/lregs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/lregs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/lregs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/lregs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/lregs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/lregs)