### PR TITLE
[Bugfix] Reject semaphore bindings to compute kernels on Quasar

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -509,9 +509,9 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingsSucceed) {
     EXPECT_NO_THROW(MakeProgramFromSpec(spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, SemaphoreBoundToComputeKernelSucceedsOnQuasar) {
-    // Quasar permits compute kernels to participate in semaphore signalling.
-    // (The corresponding Gen1 test asserts this is rejected on WH/BH.)
+TEST_F(ProgramSpecTestQuasar, SemaphoreBoundToComputeKernelFailsOnQuasar) {
+    // Compute kernels cannot have semaphore bindings on any arch.
+    // (This may later change for Quasar.)
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     SemaphoreSpec sem;
@@ -524,7 +524,10 @@ TEST_F(ProgramSpecTestQuasar, SemaphoreBoundToComputeKernelSucceedsOnQuasar) {
     spec.kernels[1].semaphore_bindings = {
         KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "done_flag"}};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("Semaphore bindings are not currently supported for compute kernels.")));
 }
 
 TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingUnknownSemaphoreFails) {
@@ -1794,8 +1797,7 @@ TEST_F(ProgramSpecTestGen1, KernelTargetsOutOfBoundsNodeFails) {
 }
 
 TEST_F(ProgramSpecTestGen1, SemaphoreBoundToComputeKernelFailsOnGen1) {
-    // On WH/BH, compute kernels cannot participate in semaphore signalling.
-    // (The corresponding Quasar test asserts this is allowed there.)
+    // Compute kernels cannot have semaphore bindings on Gen 1
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
     SemaphoreSpec sem;
@@ -1811,7 +1813,7 @@ TEST_F(ProgramSpecTestGen1, SemaphoreBoundToComputeKernelFailsOnGen1) {
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("has semaphore bindings, but it is a compute kernel.")));
+            ::testing::HasSubstr("Semaphore bindings are not currently supported for compute kernels.")));
 }
 
 TEST_F(ProgramSpecTestGen1, SemaphoreBoundToDMKernelSucceedsOnGen1) {

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -658,6 +658,17 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         }
     }
 
+    // Compute kernels cannot have any semaphore bindings.
+    // (This may later change for Quasar.)
+    for (const auto& kernel : spec.kernels) {
+        if (kernel.is_compute_kernel() && !kernel.semaphore_bindings.empty()) {
+            TT_THROW(
+                "KernelSpec '{}' has semaphore bindings. "
+                "Semaphore bindings are not currently supported for compute kernels.",
+                kernel.unique_id);
+        }
+    }
+
     //////////////////////////////////
     // Validate DataflowBufferSpecs
     //////////////////////////////////
@@ -756,19 +767,6 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 "SemaphoreSpec '{}' has initial_value={} but only zero is supported on Quasar",
                 sem.unique_id,
                 sem.initial_value);
-        }
-    }
-
-    // On Gen1 (WH/BH), semaphores can only be bound to DM kernels, not compute kernels.
-    // Compute-kernel semaphore access is a Quasar-only feature.
-    if (is_gen1_arch()) {
-        for (const auto& kernel : spec.kernels) {
-            if (kernel.is_compute_kernel() && !kernel.semaphore_bindings.empty()) {
-                TT_THROW(
-                    "KernelSpec '{}' has semaphore bindings, but it is a compute kernel. "
-                    "On WH/BH, semaphores can only be bound to data movement kernels.",
-                    kernel.unique_id);
-            }
         }
     }
 

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -661,12 +661,11 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // Compute kernels cannot have any semaphore bindings.
     // (This may later change for Quasar.)
     for (const auto& kernel : spec.kernels) {
-        if (kernel.is_compute_kernel() && !kernel.semaphore_bindings.empty()) {
-            TT_THROW(
-                "KernelSpec '{}' has semaphore bindings. "
-                "Semaphore bindings are not currently supported for compute kernels.",
-                kernel.unique_id);
-        }
+        TT_FATAL(
+            !kernel.is_compute_kernel() || kernel.semaphore_bindings.empty(),
+            "KernelSpec '{}' has semaphore bindings. "
+            "Semaphore bindings are not currently supported for compute kernels.",
+            kernel.unique_id);
     }
 
     //////////////////////////////////


### PR DESCRIPTION
### Summary
In Metal 2.0, the host API expresses kernel "resource bindings". If you want to use a semaphore from a kernel, you must bind that semaphore to your kernel on the host side. You then get a semaphore accessor, which the kernel code uses to access the semaphore.

**Bug**
The current `KernelSpec` validation allows semaphore bindings to compute kernels (on Quasar only). This is actually not supported.

**Fix**
Update the validation check to reject. Update unit tests to match.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/no-compute-kernel-sem-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/no-compute-kernel-sem-bindings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/no-compute-kernel-sem-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/no-compute-kernel-sem-bindings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/no-compute-kernel-sem-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/no-compute-kernel-sem-bindings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/no-compute-kernel-sem-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/no-compute-kernel-sem-bindings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/no-compute-kernel-sem-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/no-compute-kernel-sem-bindings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/no-compute-kernel-sem-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/no-compute-kernel-sem-bindings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/no-compute-kernel-sem-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/no-compute-kernel-sem-bindings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/no-compute-kernel-sem-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/no-compute-kernel-sem-bindings)