### PR TITLE
[Feature] Add compiler includes to kernel host APIs (legacy + Metal 2.0)

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -29,6 +29,7 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <filesystem>
 #include <optional>
 #include <type_traits>
 
@@ -2479,6 +2480,47 @@ TEST_F(ProgramSpecTestGen1, IdenticalTensorSpecProducesIdenticalKernelHash) {
     auto hash_a = prog_a.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash();
     auto hash_b = prog_b.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash();
     EXPECT_EQ(hash_a, hash_b);
+}
+
+TEST_F(ProgramSpecTestGen1, CompilerIncludePathsForwardedToKernelConfig) {
+    // KernelSpec.compiler_options.include_paths should be picked up as `-I<path>` flags
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    const std::vector<std::filesystem::path> dm_paths = {"/tmp/dm_first", "/tmp/dm_second"};
+    const std::vector<std::filesystem::path> compute_paths = {"/tmp/compute_only"};
+
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel", DataMovementProcessor::RISCV_0);
+    dm_kernel.compiler_options.include_paths = dm_paths;
+
+    auto compute_kernel = MakeMinimalComputeKernel("compute_kernel");
+    compute_kernel.compiler_options.include_paths = compute_paths;
+
+    auto dfb = MakeMinimalDFB("dfb_0");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+    BindDFBToKernel(dm_kernel, "dfb_0", "input_dfb", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(compute_kernel, "dfb_0", "input_dfb", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {dm_kernel, compute_kernel};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units =
+        std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel", "compute_kernel"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    const auto& impl = program.impl();
+    auto built_dm = impl.get_kernel_by_spec_name("dm_kernel");
+    auto built_compute = impl.get_kernel_by_spec_name("compute_kernel");
+
+    const auto built_dm_variant = built_dm->config();
+    const auto& built_dm_config = std::get<DataMovementConfig>(built_dm_variant);
+    EXPECT_EQ(built_dm_config.compiler_include_paths, dm_paths);
+
+    const auto built_compute_variant = built_compute->config();
+    const auto& built_compute_config = std::get<ComputeConfig>(built_compute_variant);
+    EXPECT_EQ(built_compute_config.compiler_include_paths, compute_paths);
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -35,6 +35,7 @@ set(UNIT_TESTS_API_SOURCES
     test_buffer_region.cpp
     test_compile_time_args.cpp
     test_compile_defines.cpp
+    test_compiler_include_paths.cpp
     test_direct.cpp
     test_dram_kernels.cpp
     test_dram_to_l1_multicast.cpp

--- a/tests/tt_metal/tt_metal/api/test_compiler_include_paths.cpp
+++ b/tests/tt_metal/tt_metal/api/test_compiler_include_paths.cpp
@@ -14,14 +14,16 @@
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
 
-#include "device_fixture.hpp"
+#include "multi_device_fixture.hpp"
 
 namespace tt::tt_metal {
+
+using CompilerIncludePathsTest = GenericMeshDeviceFixture;
 
 // Verifies that DataMovementConfig::compiler_include_paths is honored by the JIT build:
 // the user-supplied directory is added as an `-I` flag, so a header placed there is
 // resolvable from the kernel source.
-TEST_F(MeshDeviceFixture, TensixCompilerIncludePathsAreHonoredByJitBuild) {
+TEST_F(CompilerIncludePathsTest, TensixCompilerIncludePathsAreHonoredByJitBuild) {
     namespace fs = std::filesystem;
 
     // Stage a unique temp dir with a header that defines a sentinel macro.
@@ -48,23 +50,86 @@ void kernel_main() {
 }
 )";
 
-    for (const auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        Program program = CreateProgram();
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_devices()[0];
+    Program program = CreateProgram();
 
-        DataMovementConfig config{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compiler_include_paths = {include_dir},
-        };
+    DataMovementConfig config{
+        .processor = DataMovementProcessor::RISCV_0,
+        .noc = NOC::RISCV_0_default,
+        .compiler_include_paths = {include_dir},
+    };
 
-        EXPECT_NO_THROW({
-            CreateKernelFromString(program, kernel_src, CoreCoord{0, 0}, config);
-            detail::CompileProgram(device, program);
-        });
-    }
+    EXPECT_NO_THROW({
+        CreateKernelFromString(program, kernel_src, CoreCoord{0, 0}, config);
+        detail::CompileProgram(device, program);
+    });
 
     fs::remove_all(include_dir);
+}
+
+// Relative paths must be resolved against the current working directory. Construct a
+// path that exists relative to CWD and pass it through, verifying that the build
+// succeeds because the resolver normalizes it against CWD.
+TEST_F(CompilerIncludePathsTest, TensixCompilerIncludePathsResolveRelativeViaCwd) {
+    namespace fs = std::filesystem;
+
+    const fs::path absolute_include_dir =
+        fs::temp_directory_path() / fs::path(
+                                        "tt_metal_compiler_include_paths_relative_test_" +
+                                        std::to_string(::testing::UnitTest::GetInstance()->random_seed()));
+    fs::create_directories(absolute_include_dir);
+    {
+        std::ofstream header(absolute_include_dir / "user_header.h");
+        header << "#pragma once\n#define USER_HEADER_SENTINEL 0xC0DEu\n";
+    }
+
+    // Express the same directory as a relative path from CWD. The resolver should
+    // normalize this against CWD and accept it.
+    const fs::path relative_include_dir = fs::relative(absolute_include_dir, fs::current_path());
+    ASSERT_TRUE(relative_include_dir.is_relative()) << "Test setup error: expected a relative path";
+
+    const std::string kernel_src = R"(
+#include "api/dataflow/dataflow_api.h"
+#include "user_header.h"
+
+void kernel_main() {
+    volatile uint32_t tt_l1_ptr* l1_ptr = (volatile uint32_t tt_l1_ptr*)0x100000;
+    *l1_ptr = USER_HEADER_SENTINEL;
+}
+)";
+
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_devices()[0];
+    Program program = CreateProgram();
+
+    DataMovementConfig config{
+        .processor = DataMovementProcessor::RISCV_0,
+        .noc = NOC::RISCV_0_default,
+        .compiler_include_paths = {relative_include_dir},
+    };
+
+    EXPECT_NO_THROW({
+        CreateKernelFromString(program, kernel_src, CoreCoord{0, 0}, config);
+        detail::CompileProgram(device, program);
+    });
+
+    fs::remove_all(absolute_include_dir);
+}
+
+// Relative paths that don't resolve to an existing directory must fail-fast at kernel
+// construction (rather than silently degrading at compile time).
+TEST_F(CompilerIncludePathsTest, TensixCompilerIncludePathsUnresolvedRelativePathThrows) {
+    Program program = CreateProgram();
+
+    DataMovementConfig config{
+        .processor = DataMovementProcessor::RISCV_0,
+        .noc = NOC::RISCV_0_default,
+        .compiler_include_paths = {"this_directory_does_not_exist_anywhere_xyz123"},
+    };
+
+    EXPECT_THROW(
+        { CreateKernelFromString(program, "void kernel_main() {}", CoreCoord{0, 0}, config); }, std::exception);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/test_compiler_include_paths.cpp
+++ b/tests/tt_metal/tt_metal/api/test_compiler_include_paths.cpp
@@ -3,17 +3,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <enchantum/enchantum.hpp>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <type_traits>
+#include <vector>
 
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
 
+#include "impl/kernels/kernel.hpp"
+#include "impl/program/program_impl.hpp"
+#include "jit_build/build.hpp"
+#include "jit_build/build_env_manager.hpp"
 #include "multi_device_fixture.hpp"
 
 namespace tt::tt_metal {
@@ -130,6 +139,133 @@ TEST_F(CompilerIncludePathsTest, TensixCompilerIncludePathsUnresolvedRelativePat
 
     EXPECT_THROW(
         { CreateKernelFromString(program, "void kernel_main() {}", CoreCoord{0, 0}, config); }, std::exception);
+}
+
+// Two kernels identical in every respect except their compiler_include_paths must
+// produce different compute_hash() values. This ensures they don't collide on the
+// same kernel-binary cache slot — different `-I` lists can resolve different headers
+// at the same `#include` line, so the resulting binaries can semantically differ.
+TEST_F(CompilerIncludePathsTest, TensixCompilerIncludePathsAffectKernelHash) {
+    // Absolute paths that don't need to exist (resolver passes them through unmodified).
+    Program program_a = CreateProgram();
+    DataMovementConfig config_a{
+        .processor = DataMovementProcessor::RISCV_0,
+        .noc = NOC::RISCV_0_default,
+        .compiler_include_paths = {"/tmp/compiler_include_paths_test_path_a"},
+    };
+    auto handle_a = CreateKernelFromString(program_a, "void kernel_main() {}", CoreCoord{0, 0}, config_a);
+
+    Program program_b = CreateProgram();
+    DataMovementConfig config_b{
+        .processor = DataMovementProcessor::RISCV_0,
+        .noc = NOC::RISCV_0_default,
+        .compiler_include_paths = {"/tmp/compiler_include_paths_test_path_b"},
+    };
+    auto handle_b = CreateKernelFromString(program_b, "void kernel_main() {}", CoreCoord{0, 0}, config_b);
+
+    auto kernel_a = program_a.impl().get_kernel(handle_a);
+    auto kernel_b = program_b.impl().get_kernel(handle_b);
+
+    EXPECT_NE(kernel_a->compute_hash(), kernel_b->compute_hash())
+        << "Kernels with different compiler_include_paths must produce different compute_hash() values";
+}
+
+// Editing a header that's reachable via compiler_include_paths must trigger a rebuild
+// on the next compile, even though the kernel source and the include-path list are
+// unchanged. This proves the two cache layers cooperate correctly:
+//   - compute_hash() depends on the path *list*, not header contents — so the same
+//     source + same path list maps to the same kernel cache slot
+//   - the .dephash mechanism (gcc -MF) records every header gcc opened with content
+//     hashes, so editing a header invalidates the slot and triggers a rebuild
+// If either layer were broken, this test would fail in a specific, diagnostic way.
+TEST_F(CompilerIncludePathsTest, TensixHeaderEditTriggersRebuild) {
+    namespace fs = std::filesystem;
+
+    const fs::path include_dir =
+        fs::temp_directory_path() / fs::path(
+                                        "tt_metal_compiler_include_paths_rebuild_test_" +
+                                        std::to_string(::testing::UnitTest::GetInstance()->random_seed()));
+    fs::create_directories(include_dir);
+    const fs::path header_path = include_dir / "user_header.h";
+
+    auto write_header = [&](uint32_t value) {
+        std::ofstream header(header_path);
+        header << "#pragma once\n#define USER_HEADER_SENTINEL 0x" << std::hex << value << "u\n";
+    };
+
+    auto read_file_bytes = [](const fs::path& p) {
+        std::ifstream f(p, std::ios::binary);
+        return std::vector<char>{std::istreambuf_iterator<char>(f), {}};
+    };
+
+    // Volatile L1 store keeps the constant materialized in the binary, so different
+    // sentinel values produce different compiled output.
+    const std::string kernel_src = R"(
+#include "api/dataflow/dataflow_api.h"
+#include "user_header.h"
+
+void kernel_main() {
+    volatile uint32_t tt_l1_ptr* l1_ptr = (volatile uint32_t tt_l1_ptr*)0x100000;
+    *l1_ptr = USER_HEADER_SENTINEL;
+}
+)";
+
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_devices()[0];
+
+    auto compile_and_get_elf_path = [&]() -> fs::path {
+        Program program = CreateProgram();
+        DataMovementConfig config{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compiler_include_paths = {include_dir},
+        };
+        auto kernel_handle = CreateKernelFromString(program, kernel_src, CoreCoord{0, 0}, config);
+        detail::CompileProgram(device, program);
+
+        const uint32_t tensix_core_type =
+            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+        const uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
+        const int riscv_id = static_cast<std::underlying_type_t<DataMovementProcessor>>(DataMovementProcessor::RISCV_0);
+        const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
+            device->build_id(), tensix_core_type, dm_class_idx, riscv_id);
+        const auto& kernels = program.impl().get_kernels(static_cast<uint32_t>(HalProgrammableCoreType::TENSIX));
+        const std::string full_kernel_name = kernels.at(kernel_handle)->get_full_kernel_name();
+        return build_state.get_target_out_path(full_kernel_name);
+    };
+
+    // First compile: header has sentinel 0xC0DE.
+    write_header(0xC0DE);
+    fs::path elf_path_v1 = compile_and_get_elf_path();
+    ASSERT_TRUE(fs::exists(elf_path_v1));
+    auto bytes_v1 = read_file_bytes(elf_path_v1);
+    ASSERT_FALSE(bytes_v1.empty());
+
+    // Edit the header to use a different sentinel value.
+    write_header(0xBEEF);
+
+    // Clear the per-process dedup cache (JitBuildCache) before recompiling. That
+    // cache is keyed on compute_hash and short-circuits the build path entirely
+    // when a kernel with the same hash has already been built in this process.
+    // We want to exercise the *disk-level* dephash machinery (which detects header
+    // content changes), so we have to bypass the in-process layer first. In real
+    // workflows this isn't an issue: header edits happen between process runs,
+    // and a fresh process starts with an empty in-process cache.
+    jit_build_cache_clear();
+
+    // Second compile. Same source + same include-path list, so we map to the same
+    // cache slot — but the dephash mechanism should detect the header content change
+    // and rebuild.
+    fs::path elf_path_v2 = compile_and_get_elf_path();
+
+    EXPECT_EQ(elf_path_v1, elf_path_v2)
+        << "Same source + same include-path list should map to the same kernel cache slot";
+
+    auto bytes_v2 = read_file_bytes(elf_path_v2);
+    EXPECT_NE(bytes_v1, bytes_v2) << "Editing a header in compiler_include_paths should trigger a rebuild "
+                                     "(if this fails, the .dephash mechanism is not catching the header edit)";
+
+    fs::remove_all(include_dir);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/test_compiler_include_paths.cpp
+++ b/tests/tt_metal/tt_metal/api/test_compiler_include_paths.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+#include "device_fixture.hpp"
+
+namespace tt::tt_metal {
+
+// Verifies that DataMovementConfig::compiler_include_paths is honored by the JIT build:
+// the user-supplied directory is added as an `-I` flag, so a header placed there is
+// resolvable from the kernel source.
+TEST_F(MeshDeviceFixture, TensixCompilerIncludePathsAreHonoredByJitBuild) {
+    namespace fs = std::filesystem;
+
+    // Stage a unique temp dir with a header that defines a sentinel macro.
+    const fs::path include_dir =
+        fs::temp_directory_path() / fs::path(
+                                        "tt_metal_compiler_include_paths_test_" +
+                                        std::to_string(::testing::UnitTest::GetInstance()->random_seed()));
+    fs::create_directories(include_dir);
+    const fs::path header_path = include_dir / "user_header.h";
+    {
+        std::ofstream header(header_path);
+        header << "#pragma once\n#define USER_HEADER_SENTINEL 0xC0DEu\n";
+    }
+
+    // Inline kernel source that only compiles if user_header.h is found via -I.
+    // Read the sentinel into L1 to give the optimizer a reason to keep it.
+    const std::string kernel_src = R"(
+#include "api/dataflow/dataflow_api.h"
+#include "user_header.h"
+
+void kernel_main() {
+    volatile uint32_t tt_l1_ptr* l1_ptr = (volatile uint32_t tt_l1_ptr*)0x100000;
+    *l1_ptr = USER_HEADER_SENTINEL;
+}
+)";
+
+    for (const auto& mesh_device : this->devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        Program program = CreateProgram();
+
+        DataMovementConfig config{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compiler_include_paths = {include_dir},
+        };
+
+        EXPECT_NO_THROW({
+            CreateKernelFromString(program, kernel_src, CoreCoord{0, 0}, config);
+            detail::CompileProgram(device, program);
+        });
+    }
+
+    fs::remove_all(include_dir);
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/experimental/host_api.hpp
+++ b/tt_metal/api/tt-metalium/experimental/host_api.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <filesystem>
 #include <string>
 #include <variant>
 #include <tt-metalium/core_coord.hpp>
@@ -57,6 +58,9 @@ struct QuasarDataMovementConfig {
 
     // Set the compiler and linker optimization level
     KernelBuildOptLevel opt_level = KernelBuildOptLevel::O2;
+
+    // Provide include paths for the kernel compiler (-I)
+    std::vector<std::filesystem::path> compiler_include_paths;
 };
 
 struct QuasarComputeConfig {
@@ -82,8 +86,11 @@ struct QuasarComputeConfig {
     //     CreateKernel(program, "kernel.cpp", core, QuasarComputeConfig{.compile_args = compile_args,
     //     .named_compile_args = named_compile_args})
     std::unordered_map<std::string, uint32_t> named_compile_args;
+
     // Set the compiler and linker optimization level
     KernelBuildOptLevel opt_level = KernelBuildOptLevel::O3;
+    // Provide include paths for the kernel compiler (-I)
+    std::vector<std::filesystem::path> compiler_include_paths;
 };
 
 /**

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -123,7 +123,7 @@ struct KernelSpec {
     // Kernel compiler options
     ///////////////////////////////////////////////////////////////////
     struct CompilerOptions {
-        using IncludePaths = std::vector<std::string>;
+        using IncludePaths = std::vector<std::filesystem::path>;
         using Defines = std::vector<std::pair<std::string, std::string>>;
         using OptLevel = tt::tt_metal::KernelBuildOptLevel;
 

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -6,6 +6,7 @@
 
 #include <optional>
 #include <cstdint>
+#include <filesystem>
 #include <map>
 #include <string_view>
 #include <unordered_map>
@@ -78,6 +79,8 @@ struct DataMovementConfig {
     std::unordered_map<std::string, uint32_t> named_compile_args;
     // Set the compiler and linker optimization level
     KernelBuildOptLevel opt_level = KernelBuildOptLevel::O2;
+    // Provide include paths for the kernel compiler (-I)
+    std::vector<std::filesystem::path> compiler_include_paths;
 };
 
 struct ReaderDataMovementConfig : public DataMovementConfig {
@@ -85,7 +88,8 @@ struct ReaderDataMovementConfig : public DataMovementConfig {
         std::vector<uint32_t> compile_args = {},
         std::map<std::string, std::string> defines = {},
         std::unordered_map<std::string, uint32_t> named_compile_args = {},
-        KernelBuildOptLevel opt_level = KernelBuildOptLevel::O2);
+        KernelBuildOptLevel opt_level = KernelBuildOptLevel::O2,
+        std::vector<std::filesystem::path> compiler_include_paths = {});
 };
 
 struct WriterDataMovementConfig : public DataMovementConfig {
@@ -93,7 +97,8 @@ struct WriterDataMovementConfig : public DataMovementConfig {
         std::vector<uint32_t> compile_args = {},
         std::map<std::string, std::string> defines = {},
         std::unordered_map<std::string, uint32_t> named_compile_args = {},
-        KernelBuildOptLevel opt_level = KernelBuildOptLevel::O2);
+        KernelBuildOptLevel opt_level = KernelBuildOptLevel::O2,
+        std::vector<std::filesystem::path> compiler_include_paths = {});
 };
 
 struct ComputeConfig {
@@ -118,6 +123,8 @@ struct ComputeConfig {
     std::unordered_map<std::string, uint32_t> named_compile_args;
     // Set the compiler and linker optimization level
     KernelBuildOptLevel opt_level = KernelBuildOptLevel::O3;
+    // Provide include paths for the kernel compiler (-I)
+    std::vector<std::filesystem::path> compiler_include_paths;
 };
 
 // These are only used in op_profiler, are unstable and have not been designed for general use.

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -16,6 +16,7 @@
 #include <umd/device/types/core_coordinates.hpp>
 
 #include <bitset>
+#include <filesystem>
 #include <optional>
 #include <variant>
 #include <vector>
@@ -120,6 +121,7 @@ struct KernelDescriptor {
     using CompileTimeArgs = std::vector<uint32_t>;
     using NamedCompileTimeArgs = std::vector<std::pair<std::string, uint32_t>>;
     using Defines = std::vector<std::pair<std::string, std::string>>;
+    using IncludePaths = std::vector<std::filesystem::path>;
     using CoreRuntimeArgs = std::vector<uint32_t>;
     using RuntimeArgs = std::vector<std::pair<CoreCoord, CoreRuntimeArgs>>;
     using CommonRuntimeArgs = CoreRuntimeArgs;
@@ -145,6 +147,8 @@ struct KernelDescriptor {
     std::optional<KernelBuildOptLevel> opt_level = std::nullopt;
 
     ConfigDescriptor config;
+
+    IncludePaths compiler_include_paths;
 
     // Buffer args declared via emplace_runtime_args() / emplace_common_runtime_args().
     // The framework resolves these to direct pointers into the cached Program on cache miss,

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -89,11 +89,14 @@ fs::path resolve_path(const fs::path& given_file_name) {
     TT_THROW("Kernel file {} doesn't exist in any of the searched paths!", given_file_name);
 }
 
-// Resolve a user-supplied compiler include path (-I). Absolute paths pass through
-// unchanged (the user has been explicit; gcc itself will warn at compile time if the
-// directory doesn't exist). Relative paths are resolved against the current working
-// directory and must point at an existing directory — typos fail fast at kernel
-// construction rather than producing a confusing build failure later.
+// Resolve a user-supplied compiler include path (-I):
+//  - Absolute paths pass through unchanged
+//  - Relative paths are resolved against the current working directory
+//
+// If the user-supplied path doesn't exist:
+//  - Absolute path will go straight to gcc, which will warn about the missing dir
+//  - Unresolved relative path will throw here
+//
 fs::path resolve_compiler_include_dir(const fs::path& given) {
     if (given.is_absolute()) {
         return given;

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -88,6 +88,25 @@ fs::path resolve_path(const fs::path& given_file_name) {
     // Not found
     TT_THROW("Kernel file {} doesn't exist in any of the searched paths!", given_file_name);
 }
+
+// Resolve a user-supplied compiler include path (-I). Absolute paths pass through
+// unchanged (the user has been explicit; gcc itself will warn at compile time if the
+// directory doesn't exist). Relative paths are resolved against the current working
+// directory and must point at an existing directory — typos fail fast at kernel
+// construction rather than producing a confusing build failure later.
+fs::path resolve_compiler_include_dir(const fs::path& given) {
+    if (given.is_absolute()) {
+        return given;
+    }
+    auto resolved = fs::current_path() / given;
+    if (!fs::is_directory(resolved)) {
+        TT_THROW(
+            "Compiler include directory '{}' not found relative to current working directory '{}'.",
+            given.string(),
+            fs::current_path().string());
+    }
+    return resolved;
+}
 }  // namespace
 
 KernelSource::KernelSource(const std::string& source, const SourceType& source_type) :
@@ -272,20 +291,6 @@ std::string_view DramKernel::get_compiler_opt_level() const { return enchantum::
 
 std::string_view DramKernel::get_linker_opt_level() const { return this->get_compiler_opt_level(); }
 
-void DataMovementKernel::process_include_paths(const std::function<void(const std::string& path)>& callback) const {
-    Kernel::process_include_paths(callback);
-    for (const auto& path : this->config_.compiler_include_paths) {
-        callback(path.string());
-    }
-}
-
-void ComputeKernel::process_include_paths(const std::function<void(const std::string& path)>& callback) const {
-    Kernel::process_include_paths(callback);
-    for (const auto& path : this->config_.compiler_include_paths) {
-        callback(path.string());
-    }
-}
-
 void Kernel::process_compile_time_args(const std::function<void(const std::vector<uint32_t>& values)> callback) const {
     callback(this->compile_time_args());
 }
@@ -323,6 +328,17 @@ void Kernel::process_include_paths(const std::function<void(const std::string& p
     // source is transformed and inlined (as with simplified compute kernel syntax).
     if (kernel_src_.source_type_ == KernelSource::FILE_PATH) {
         callback(kernel_src_.path_.parent_path().string());
+    }
+    for (const auto& path : this->resolved_compiler_include_paths_) {
+        callback(path);
+    }
+}
+
+void Kernel::set_compiler_include_paths(const std::vector<std::filesystem::path>& paths) {
+    this->resolved_compiler_include_paths_.clear();
+    this->resolved_compiler_include_paths_.reserve(paths.size());
+    for (const auto& p : paths) {
+        this->resolved_compiler_include_paths_.push_back(resolve_compiler_include_dir(p).string());
     }
 }
 
@@ -1112,14 +1128,6 @@ std::string_view QuasarDataMovementKernel::get_compiler_opt_level() const {
 
 std::string_view QuasarDataMovementKernel::get_linker_opt_level() const { return this->get_compiler_opt_level(); }
 
-void QuasarDataMovementKernel::process_include_paths(
-    const std::function<void(const std::string& path)>& callback) const {
-    Kernel::process_include_paths(callback);
-    for (const auto& path : this->config_.compiler_include_paths) {
-        callback(path.string());
-    }
-}
-
 std::string QuasarDataMovementKernel::config_hash() const {
     // DataMovementProcessor values must be sorted to ensure consistent ordering for hash generation
     TT_ASSERT(std::is_sorted(this->dm_processors_.begin(), this->dm_processors_.end()));
@@ -1205,13 +1213,6 @@ std::string_view QuasarComputeKernel::get_compiler_opt_level() const {
 }
 
 std::string_view QuasarComputeKernel::get_linker_opt_level() const { return this->get_compiler_opt_level(); }
-
-void QuasarComputeKernel::process_include_paths(const std::function<void(const std::string& path)>& callback) const {
-    Kernel::process_include_paths(callback);
-    for (const auto& path : this->config_.compiler_include_paths) {
-        callback(path.string());
-    }
-}
 
 std::string QuasarComputeKernel::config_hash() const {
     // QuasarComputeProcessor values must be sorted to ensure consistent ordering for hash generation

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -272,6 +272,20 @@ std::string_view DramKernel::get_compiler_opt_level() const { return enchantum::
 
 std::string_view DramKernel::get_linker_opt_level() const { return this->get_compiler_opt_level(); }
 
+void DataMovementKernel::process_include_paths(const std::function<void(const std::string& path)>& callback) const {
+    Kernel::process_include_paths(callback);
+    for (const auto& path : this->config_.compiler_include_paths) {
+        callback(path.string());
+    }
+}
+
+void ComputeKernel::process_include_paths(const std::function<void(const std::string& path)>& callback) const {
+    Kernel::process_include_paths(callback);
+    for (const auto& path : this->config_.compiler_include_paths) {
+        callback(path.string());
+    }
+}
+
 void Kernel::process_compile_time_args(const std::function<void(const std::vector<uint32_t>& values)> callback) const {
     callback(this->compile_time_args());
 }
@@ -505,6 +519,16 @@ uint64_t Kernel::compute_hash() const {
     hasher.update(this->kernel_src_.source_);
     hasher.update(this->compile_time_args_.begin(), this->compile_time_args_.end());
     hasher.update(this->config_hash());
+
+    // Include paths affect compilation: the gcc -I order is significant (left-to-right
+    // header resolution), so different lists or orderings must produce different binaries.
+    // Header contents are tracked separately via the per-object .dephash mechanism.
+    size_t num_include_paths = 0;
+    this->process_include_paths([&](const std::string& path) {
+        hasher.update(path);
+        ++num_include_paths;
+    });
+    hasher.update(static_cast<uint64_t>(num_include_paths));
     return hasher.digest();
 }
 
@@ -1088,6 +1112,14 @@ std::string_view QuasarDataMovementKernel::get_compiler_opt_level() const {
 
 std::string_view QuasarDataMovementKernel::get_linker_opt_level() const { return this->get_compiler_opt_level(); }
 
+void QuasarDataMovementKernel::process_include_paths(
+    const std::function<void(const std::string& path)>& callback) const {
+    Kernel::process_include_paths(callback);
+    for (const auto& path : this->config_.compiler_include_paths) {
+        callback(path.string());
+    }
+}
+
 std::string QuasarDataMovementKernel::config_hash() const {
     // DataMovementProcessor values must be sorted to ensure consistent ordering for hash generation
     TT_ASSERT(std::is_sorted(this->dm_processors_.begin(), this->dm_processors_.end()));
@@ -1173,6 +1205,13 @@ std::string_view QuasarComputeKernel::get_compiler_opt_level() const {
 }
 
 std::string_view QuasarComputeKernel::get_linker_opt_level() const { return this->get_compiler_opt_level(); }
+
+void QuasarComputeKernel::process_include_paths(const std::function<void(const std::string& path)>& callback) const {
+    Kernel::process_include_paths(callback);
+    for (const auto& path : this->config_.compiler_include_paths) {
+        callback(path.string());
+    }
+}
 
 std::string QuasarComputeKernel::config_hash() const {
     // QuasarComputeProcessor values must be sorted to ensure consistent ordering for hash generation

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -280,10 +280,9 @@ protected:
     // Populated by subclass constructors via set_compiler_include_paths()
     std::vector<std::string> resolved_compiler_include_paths_;
 
-    // Resolve user-supplied include paths and store them on the kernel. Absolute
-    // paths pass through unmodified; relative paths are resolved against the current
-    // working directory and must point at an existing directory (typos throw at
-    // kernel construction rather than producing a confusing build failure later).
+    // Resolve user-supplied include paths and store them on the kernel:
+    //  - Absolute paths pass through unmodified
+    //  - Relative paths are resolved against the current working directory
     void set_compiler_include_paths(const std::vector<std::filesystem::path>& paths);
 
     virtual std::string config_hash() const = 0;

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -276,6 +276,16 @@ protected:
     std::unordered_map<uint64_t, std::vector<const ll_api::memory*>> binaries_;
     std::optional<experimental::PrecompiledKernelConfig> precompiled_config_;
 
+    // User-supplied include paths (-I), resolved to absolute paths
+    // Populated by subclass constructors via set_compiler_include_paths()
+    std::vector<std::string> resolved_compiler_include_paths_;
+
+    // Resolve user-supplied include paths and store them on the kernel. Absolute
+    // paths pass through unmodified; relative paths are resolved against the current
+    // working directory and must point at an existing directory (typos throw at
+    // kernel construction rather than producing a confusing build failure later).
+    void set_compiler_include_paths(const std::vector<std::filesystem::path>& paths);
+
     virtual std::string config_hash() const = 0;
 
     std::vector<std::string> file_paths(IDevice& device, const std::string& binary_root) const;
@@ -315,6 +325,7 @@ public:
         TT_FATAL(
             MetalContext::instance().get_cluster().arch() != ARCH::QUASAR,
             "DataMovementKernel is not supported on Quasar. Use QuasarDataMovementKernel instead.");
+        this->set_compiler_include_paths(config_.compiler_include_paths);
     }
 
     ~DataMovementKernel() override = default;
@@ -329,8 +340,6 @@ public:
     Config config() const override { return this->config_; }
 
     void process_defines(std::function<void(const std::string& define, const std::string& value)>) const override;
-
-    void process_include_paths(const std::function<void(const std::string& path)>&) const override;
 
     std::string_view get_compiler_opt_level() const override;
 
@@ -451,6 +460,7 @@ public:
         TT_FATAL(
             MetalContext::instance().get_cluster().arch() != ARCH::QUASAR,
             "ComputeKernel is not supported on Quasar. Use QuasarComputeKernel instead.");
+        this->set_compiler_include_paths(config_.compiler_include_paths);
     }
 
     ~ComputeKernel() override = default;
@@ -466,8 +476,6 @@ public:
     Config config() const override { return this->config_; }
 
     void process_defines(std::function<void(const std::string& define, const std::string& value)>) const override;
-
-    void process_include_paths(const std::function<void(const std::string& path)>&) const override;
 
     std::string_view get_compiler_opt_level() const override;
 
@@ -542,6 +550,7 @@ public:
             "Number of DM cores per cluster specified in config must match number of DM cores per cluster that have "
             "been reserved");
         TT_FATAL(std::is_sorted(dm_processors_.begin(), dm_processors_.end()), "DM cores must be ordered");
+        this->set_compiler_include_paths(config_.compiler_include_paths);
     }
 
     ~QuasarDataMovementKernel() override = default;
@@ -557,8 +566,6 @@ public:
     Config config() const override { return this->config_; }
 
     void process_defines(std::function<void(const std::string& define, const std::string& value)>) const override;
-
-    void process_include_paths(const std::function<void(const std::string& path)>&) const override;
 
     std::string_view get_compiler_opt_level() const override;
 
@@ -615,6 +622,7 @@ public:
             "per Tensix engine must match number of compute cores per cluster that have been reserved");
         TT_FATAL(
             std::is_sorted(compute_processors_.begin(), compute_processors_.end()), "Compute cores must be ordered");
+        this->set_compiler_include_paths(config_.compiler_include_paths);
     }
 
     ~QuasarComputeKernel() override = default;
@@ -629,8 +637,6 @@ public:
     Config config() const override { return this->config_; }
 
     void process_defines(std::function<void(const std::string& define, const std::string& value)>) const override;
-
-    void process_include_paths(const std::function<void(const std::string& path)>&) const override;
 
     std::string_view get_compiler_opt_level() const override;
 

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -6,6 +6,7 @@
 
 #include <umd/device/types/core_coordinates.hpp>
 #include <cstdint>
+#include <filesystem>
 #include <optional>
 #include <string>
 #include <string_view>

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -330,6 +330,8 @@ public:
 
     void process_defines(std::function<void(const std::string& define, const std::string& value)>) const override;
 
+    void process_include_paths(const std::function<void(const std::string& path)>&) const override;
+
     std::string_view get_compiler_opt_level() const override;
 
     std::string_view get_linker_opt_level() const override;
@@ -465,6 +467,8 @@ public:
 
     void process_defines(std::function<void(const std::string& define, const std::string& value)>) const override;
 
+    void process_include_paths(const std::function<void(const std::string& path)>&) const override;
+
     std::string_view get_compiler_opt_level() const override;
 
     std::string_view get_linker_opt_level() const override;
@@ -554,6 +558,8 @@ public:
 
     void process_defines(std::function<void(const std::string& define, const std::string& value)>) const override;
 
+    void process_include_paths(const std::function<void(const std::string& path)>&) const override;
+
     std::string_view get_compiler_opt_level() const override;
 
     std::string_view get_linker_opt_level() const override;
@@ -623,6 +629,8 @@ public:
     Config config() const override { return this->config_; }
 
     void process_defines(std::function<void(const std::string& define, const std::string& value)>) const override;
+
+    void process_include_paths(const std::function<void(const std::string& path)>&) const override;
 
     std::string_view get_compiler_opt_level() const override;
 

--- a/tt_metal/impl/kernels/kernel_types.cpp
+++ b/tt_metal/impl/kernels/kernel_types.cpp
@@ -14,7 +14,8 @@ ReaderDataMovementConfig::ReaderDataMovementConfig(
     std::vector<uint32_t> compile_args,
     std::map<std::string, std::string> defines,
     std::unordered_map<std::string, uint32_t> named_compile_args,
-    KernelBuildOptLevel opt_level) :
+    KernelBuildOptLevel opt_level,
+    std::vector<std::filesystem::path> compiler_include_paths) :
     DataMovementConfig{
         .processor = DataMovementProcessor::RISCV_1,
         .noc = detail::preferred_noc_for_dram_read(tt::tt_metal::MetalContext::instance().get_cluster().arch()),
@@ -22,13 +23,15 @@ ReaderDataMovementConfig::ReaderDataMovementConfig(
         .compile_args = std::move(compile_args),
         .defines = std::move(defines),
         .named_compile_args = std::move(named_compile_args),
-        .opt_level = opt_level} {}
+        .opt_level = opt_level,
+        .compiler_include_paths = std::move(compiler_include_paths)} {}
 
 WriterDataMovementConfig::WriterDataMovementConfig(
     std::vector<uint32_t> compile_args,
     std::map<std::string, std::string> defines,
     std::unordered_map<std::string, uint32_t> named_compile_args,
-    KernelBuildOptLevel opt_level) :
+    KernelBuildOptLevel opt_level,
+    std::vector<std::filesystem::path> compiler_include_paths) :
     DataMovementConfig{
         .processor = DataMovementProcessor::RISCV_0,
         .noc = detail::preferred_noc_for_dram_write(tt::tt_metal::MetalContext::instance().get_cluster().arch()),
@@ -36,6 +39,7 @@ WriterDataMovementConfig::WriterDataMovementConfig(
         .compile_args = std::move(compile_args),
         .defines = std::move(defines),
         .named_compile_args = std::move(named_compile_args),
-        .opt_level = opt_level} {}
+        .opt_level = opt_level,
+        .compiler_include_paths = std::move(compiler_include_paths)} {}
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -548,14 +548,6 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // A Program needs at least one kernel
     TT_FATAL(!spec.kernels.empty(), "A ProgramSpec must have at least one KernelSpec");
 
-    // Validate no unimplemented compiler options are used
-    for (const auto& kernel : spec.kernels) {
-        TT_FATAL(
-            kernel.compiler_options.include_paths.empty(),
-            "KernelSpec '{}' specifies include_paths -- this feature is not yet implemented. (Coming soon!)",
-            kernel.unique_id);
-    }
-
     // Validate no per-node thread maps are used (not yet implemented)
     for (const auto& kernel : spec.kernels) {
         TT_FATAL(
@@ -1589,6 +1581,7 @@ DataMovementConfig MakeGen1DataMovementConfig(const KernelSpec& kernel_spec) {
         .defines = to_defines_map(kernel_spec.compiler_options.defines),
         .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_arg_bindings),
         .opt_level = kernel_spec.compiler_options.opt_level,
+        .compiler_include_paths = kernel_spec.compiler_options.include_paths,
     };
 }
 
@@ -1654,6 +1647,7 @@ ComputeConfig MakeGen1ComputeConfig(const KernelSpec& kernel_spec, const DFBName
         .defines = to_defines_map(kernel_spec.compiler_options.defines),
         .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_arg_bindings),
         .opt_level = kernel_spec.compiler_options.opt_level,
+        .compiler_include_paths = kernel_spec.compiler_options.include_paths,
     };
 }
 
@@ -1671,6 +1665,7 @@ experimental::quasar::QuasarDataMovementConfig MakeQuasarDataMovementConfig(cons
         .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_arg_bindings),
         .is_legacy_kernel = false,
         .opt_level = kernel_spec.compiler_options.opt_level,
+        .compiler_include_paths = kernel_spec.compiler_options.include_paths,
     };
 }
 
@@ -1698,6 +1693,7 @@ experimental::quasar::QuasarComputeConfig MakeQuasarComputeConfig(
         .defines = to_defines_map(kernel_spec.compiler_options.defines),
         .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_arg_bindings),
         .opt_level = kernel_spec.compiler_options.opt_level,
+        .compiler_include_paths = kernel_spec.compiler_options.include_paths,
     };
 }
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -326,6 +326,9 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
         std::unordered_map<std::string, uint32_t> named_compile_args(
             kernel_descriptor.named_compile_time_args.begin(), kernel_descriptor.named_compile_time_args.end());
 
+        std::vector<std::filesystem::path> compiler_include_paths(
+            kernel_descriptor.compiler_include_paths.begin(), kernel_descriptor.compiler_include_paths.end());
+
         auto config = std::visit(
             tt::stl::overloaded{
                 [&](const ReaderConfigDescriptor&) -> std::variant<DataMovementConfig, ComputeConfig> {
@@ -333,14 +336,16 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
                         std::move(compile_args),
                         std::move(defines),
                         std::move(named_compile_args),
-                        kernel_descriptor.opt_level.value_or(KernelBuildOptLevel::O2)};
+                        kernel_descriptor.opt_level.value_or(KernelBuildOptLevel::O2),
+                        std::move(compiler_include_paths)};
                 },
                 [&](const WriterConfigDescriptor&) -> std::variant<DataMovementConfig, ComputeConfig> {
                     return WriterDataMovementConfig{
                         std::move(compile_args),
                         std::move(defines),
                         std::move(named_compile_args),
-                        kernel_descriptor.opt_level.value_or(KernelBuildOptLevel::O2)};
+                        kernel_descriptor.opt_level.value_or(KernelBuildOptLevel::O2),
+                        std::move(compiler_include_paths)};
                 },
                 [&](const DataMovementConfigDescriptor& dm_descriptor)
                     -> std::variant<DataMovementConfig, ComputeConfig> {
@@ -352,6 +357,7 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
                         .defines = std::move(defines),
                         .named_compile_args = std::move(named_compile_args),
                         .opt_level = kernel_descriptor.opt_level.value_or(KernelBuildOptLevel::O2),
+                        .compiler_include_paths = std::move(compiler_include_paths),
                     };
                 },
                 [&](const ComputeConfigDescriptor& compute_descriptor)
@@ -367,6 +373,7 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
                         .defines = std::move(defines),
                         .named_compile_args = std::move(named_compile_args),
                         .opt_level = kernel_descriptor.opt_level.value_or(KernelBuildOptLevel::O3),
+                        .compiler_include_paths = std::move(compiler_include_paths),
                     };
                 },
             },

--- a/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
+++ b/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
@@ -688,7 +688,8 @@ void py_module_types(nb::module_& mod) {
                 tt::tt_metal::KernelDescriptor::RuntimeArgs,
                 tt::tt_metal::KernelDescriptor::CommonRuntimeArgs,
                 std::optional<tt::tt_metal::KernelBuildOptLevel>,
-                tt::tt_metal::KernelDescriptor::ConfigDescriptor>(),
+                tt::tt_metal::KernelDescriptor::ConfigDescriptor,
+                tt::tt_metal::KernelDescriptor::IncludePaths>(),
             nb::arg("kernel_source"),
             nb::arg("source_type") = nb::cast(tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH),
             nb::arg("core_ranges"),
@@ -699,6 +700,7 @@ void py_module_types(nb::module_& mod) {
             nb::arg("common_runtime_args") = tt::tt_metal::KernelDescriptor::CommonRuntimeArgs(),
             nb::arg("opt_level") = nb::none(),
             nb::arg("config"),
+            nb::arg("compiler_include_paths") = nb::cast(tt::tt_metal::KernelDescriptor::IncludePaths()),
             R"pbdoc(
                 Initialize a KernelDescriptor with complete configuration.
 
@@ -713,6 +715,7 @@ void py_module_types(nb::module_& mod) {
                     common_runtime_args: Common runtime arguments shared across kernels
                     opt_level: Optimization level for kernel compilation
                     config: Configuration descriptor for the kernel
+                    compiler_include_paths: Additional include paths passed to the kernel compiler as -I flags
             )pbdoc")
         .def_rw(
             "kernel_source",
@@ -771,6 +774,10 @@ void py_module_types(nb::module_& mod) {
             &tt::tt_metal::KernelDescriptor::common_runtime_args,
             "Common runtime arguments shared across all cores")
         .def_rw("config", &tt::tt_metal::KernelDescriptor::config, "Configuration descriptor for the kernel")
+        .def_rw(
+            "compiler_include_paths",
+            &tt::tt_metal::KernelDescriptor::compiler_include_paths,
+            "Additional include paths passed to the kernel compiler as -I flags")
         .def(
             "clear_runtime_args",
             [](tt::tt_metal::KernelDescriptor& self) { self.runtime_args.clear(); },

--- a/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
+++ b/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
@@ -18,6 +18,7 @@
 #include <nanobind/operators.h>
 #include <nanobind/make_iterator.h>
 #include <nanobind/stl/bind_vector.h>
+#include <nanobind/stl/filesystem.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/pair.h>
 #include <nanobind/stl/string.h>


### PR DESCRIPTION
## PR Type
Feature

## Summary

The PR adds a `compiler_include_paths` field to the kernel build APIs, which allows kernel authors to specify additional `-I` flags for the JIT compile. Specified paths can be absolute or relative (resolved from CWD).

Though originally intended as a Metal 2.0 feature, at the request of Blaze, I've adding this to the legacy APIs as well. That means that `compiler_include_paths` is added to:
 - **Metal 2.0 host API**: `KernelSpec::CompilerOptions::IncludePaths`
 - **Legacy `CreateKernel` API**: `DataMovementConfig`, `ComputeConfig` 
 - **`ProgramDescriptor`**: `KernelDescriptor::compiler_include_paths` 
 - **`ProgramDescriptor` nanobind**: For the Python API version of `ProgramDescriptor`...
 - **Temporary Quasar shim APIs**: `QuasarDataMovementConfig`, `QuasarComputeConfig`

For in-tree code that wants paths rooted at the install location, callers can build absolute paths from `std::getenv("TT_METAL_HOME")`.

## Notes for Reviewers

Two mildly interesting things:
 - **Relative path resolution** is different for `compiler_include_paths` than for kernel file source. This was a deliberate choice. Runtime will search high and low to find a kernel file source (i.e. check multiple roots). But for `-I-`, I followed the "normal" convention (also used by NVRTC and OpenCL). Relative path is relative to CWD; I don't look elsewhere. I figured any other behavior would be surprising and hard to explain.
 - **Kernel cache correctness** was thought through (and tested), but would appreciate eyes. `Kernel::compute_hash` incorporates the resolved include paths; dephash sees the actual header contents. Changing the contents of an included header _will_ correctly trigger a recompile, even if the kernel itself didn't change. I added an explicit test for this.

## Future Work

 - Remove the `ttnn` filepaths from the "this list is insane" includes list in build.cpp! Kernels that leverage common kernel library functionality should add the include directories via `compiler_include_paths` instead.
 - Consider a `tt_metal_home()` helper function to get the absolute path to `$TT_METAL_HOME`, as that'll be a common need.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/add-compiler-includes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/add-compiler-includes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/add-compiler-includes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/add-compiler-includes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/add-compiler-includes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/add-compiler-includes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/add-compiler-includes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/add-compiler-includes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/add-compiler-includes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/add-compiler-includes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/add-compiler-includes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/add-compiler-includes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/add-compiler-includes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/add-compiler-includes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/add-compiler-includes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/add-compiler-includes)