### PR TITLE
[vllm] KV cache groups scaffolding for hybrid attention models

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -357,14 +357,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        # TEMPORARY :rw — kv-cache-groups changes the paged-attention KV
-        # cache shape (e.g. (6176, 2, 64, 128) instead of the prior shape),
-        # so the pre-staged .tensorbin files under /mnt/MLPerf/huggingface/
-        # tt_cache no longer match and need regenerating. With the regular
-        # :ro mount the regen attempt hits TT_FATAL "Read-only file system".
-        # Revert this hunk to :ro after one successful run on each SKU has
-        # repopulated the cache.
-        - ${{ (matrix.test-group.runner-label == 'BH-QB-GE' && '/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface:rw') || '/mnt/MLPerf:/mnt/MLPerf:rw' }}
+        - ${{ (matrix.test-group.runner-label == 'BH-QB-GE' && '/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface:ro') || '/mnt/MLPerf:/mnt/MLPerf:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -357,7 +357,14 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ (matrix.test-group.runner-label == 'BH-QB-GE' && '/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface:ro') || '/mnt/MLPerf:/mnt/MLPerf:ro' }}
+        # TEMPORARY :rw — kv-cache-groups changes the paged-attention KV
+        # cache shape (e.g. (6176, 2, 64, 128) instead of the prior shape),
+        # so the pre-staged .tensorbin files under /mnt/MLPerf/huggingface/
+        # tt_cache no longer match and need regenerating. With the regular
+        # :ro mount the regen attempt hits TT_FATAL "Read-only file system".
+        # Revert this hunk to :ro after one successful run on each SKU has
+        # repopulated the cache.
+        - ${{ (matrix.test-group.runner-label == 'BH-QB-GE' && '/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface:rw') || '/mnt/MLPerf:/mnt/MLPerf:rw' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -422,6 +422,20 @@ class Model:
 
         return logits
 
+    def _page_table_mesh_mapper(self, B):
+        """Mesh mapper for per-layer page tables, matching the layout that
+        :meth:`prepare_decode_inputs_host` uses for the legacy single
+        ``page_table`` kwarg: shard the batch dim across mesh axis 0 when
+        ``users_row_sharded`` (and ``B>1``), replicate otherwise. The
+        hybrid bridge chunks the global page table per-DP before
+        reaching this submesh, so ``B`` is the per-DP batch — same as
+        what the legacy path sees on entry to
+        ``prepare_decode_inputs_host``.
+        """
+        if self.users_row_sharded and B > 1:
+            return ttnn.ShardTensor2dMesh(self.mesh_device, dims=(0, None), mesh_shape=self.mesh_device.shape)
+        return ttnn.ReplicateTensorToMesh(self.mesh_device)
+
     def _page_tables_to_ttnn(self, page_tables_per_layer):
         """Resolve a per-layer torch list to *persistent* ttnn device
         tensors (allocate-only) — see
@@ -449,7 +463,7 @@ class Model:
                         device=self.mesh_device,
                         dtype=ttnn.int32,
                         layout=ttnn.ROW_MAJOR_LAYOUT,
-                        mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                        mesh_mapper=self._page_table_mesh_mapper(pt.shape[0]),
                     )
                 )
             self._persistent_per_layer_page_tables = persistent
@@ -473,7 +487,7 @@ class Model:
                 device=None,
                 dtype=ttnn.int32,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
-                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                mesh_mapper=self._page_table_mesh_mapper(pt.shape[0]),
             )
             ttnn.copy_host_to_device_tensor(host_pt, persistent[i])
 

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -422,6 +422,31 @@ class Model:
 
         return logits
 
+    def _page_tables_to_ttnn(self, page_tables_per_layer):
+        """Convert a per-layer list of ``torch.Tensor`` page tables to ttnn
+        tensors on this model's mesh. The vLLM hybrid bridge passes torch
+        tensors because the routing kwarg is opaque to ``Generator``'s
+        existing host→device plumbing; do the conversion here so attention
+        layers always see ttnn tensors. Already-ttnn entries pass through.
+        """
+        if page_tables_per_layer is None:
+            return None
+        converted = []
+        for pt in page_tables_per_layer:
+            if pt is None or isinstance(pt, ttnn.Tensor):
+                converted.append(pt)
+                continue
+            converted.append(
+                ttnn.from_torch(
+                    pt,
+                    device=self.mesh_device,
+                    dtype=ttnn.int32,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                )
+            )
+        return converted
+
     def ttnn_decode_forward(
         self,
         tokens,
@@ -439,6 +464,7 @@ class Model:
             # generator's many internal ttnn_decode_forward sites can't all
             # plumb the new kwarg cleanly. Pick it up here when present.
             page_tables_per_layer = getattr(self, "_active_page_tables_per_layer", None)
+        page_tables_per_layer = self._page_tables_to_ttnn(page_tables_per_layer)
         """
         Decode forward pass - processes single tokens.
         Matches tt-transformers interface where rot_mat_idxs are used for on-device RoPE lookup.
@@ -501,6 +527,7 @@ class Model:
             # on the model when in vLLM hybrid mode, since Generator's prefill
             # path doesn't thread the kwarg.
             page_tables_per_layer = getattr(self, "_active_page_tables_per_layer", None)
+        page_tables_per_layer = self._page_tables_to_ttnn(page_tables_per_layer)
         """Prefill forward pass - processes full sequences"""
         # Use provided rotation matrices or slice from rope_setup (matches tt-transformers)
         seq_len = x.shape[-2]

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -423,29 +423,59 @@ class Model:
         return logits
 
     def _page_tables_to_ttnn(self, page_tables_per_layer):
-        """Convert a per-layer list of ``torch.Tensor`` page tables to ttnn
-        tensors on this model's mesh. The vLLM hybrid bridge passes torch
-        tensors because the routing kwarg is opaque to ``Generator``'s
-        existing host→device plumbing; do the conversion here so attention
-        layers always see ttnn tensors. Already-ttnn entries pass through.
+        """Resolve a per-layer torch list to *persistent* ttnn device
+        tensors (allocate-only) — see
+        :meth:`Transformer._page_tables_to_ttnn` for the trace-capture
+        rationale. Same pattern: lazy alloc on first call, updates happen
+        from outside the traced forward via
+        :meth:`update_persistent_per_layer_page_tables`.
         """
         if page_tables_per_layer is None:
             return None
-        converted = []
-        for pt in page_tables_per_layer:
-            if pt is None or isinstance(pt, ttnn.Tensor):
-                converted.append(pt)
-                continue
-            converted.append(
-                ttnn.from_torch(
-                    pt,
-                    device=self.mesh_device,
-                    dtype=ttnn.int32,
-                    layout=ttnn.ROW_MAJOR_LAYOUT,
-                    mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        persistent = getattr(self, "_persistent_per_layer_page_tables", None)
+        n = len(page_tables_per_layer)
+        if persistent is None or len(persistent) != n:
+            persistent = []
+            for pt in page_tables_per_layer:
+                if pt is None:
+                    persistent.append(None)
+                    continue
+                if isinstance(pt, ttnn.Tensor):
+                    persistent.append(pt)
+                    continue
+                persistent.append(
+                    ttnn.from_torch(
+                        pt,
+                        device=self.mesh_device,
+                        dtype=ttnn.int32,
+                        layout=ttnn.ROW_MAJOR_LAYOUT,
+                        mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                    )
                 )
+            self._persistent_per_layer_page_tables = persistent
+        return persistent
+
+    def update_persistent_per_layer_page_tables(self, page_tables_per_layer):
+        """Update content of persistent per-layer page_table device
+        tensors in place — see
+        :meth:`Transformer.update_persistent_per_layer_page_tables`.
+        """
+        if page_tables_per_layer is None:
+            return
+        persistent = getattr(self, "_persistent_per_layer_page_tables", None)
+        if persistent is None or len(persistent) != len(page_tables_per_layer):
+            return
+        for i, pt in enumerate(page_tables_per_layer):
+            if pt is None or persistent[i] is None or isinstance(pt, ttnn.Tensor):
+                continue
+            host_pt = ttnn.from_torch(
+                pt,
+                device=None,
+                dtype=ttnn.int32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
             )
-        return converted
+            ttnn.copy_host_to_device_tensor(host_pt, persistent[i])
 
     def ttnn_decode_forward(
         self,

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -337,6 +337,7 @@ class Model:
         sampling_on_device=False,
         batch_size=1,
         skip_lm_head=False,
+        page_tables_per_layer=None,
     ):
         """
         Shared forward pass through decoder layers and final projection.
@@ -345,8 +346,16 @@ class Model:
             hidden_states: Input tensor
             rope_mats: RoPE rotation matrices [cos, sin]
             current_pos: Current position (for decode) or None (for prefill)
-            page_table: Page table for paged attention
-            kv_cache: KV cache list per layer
+            page_table: Single page table; used for every layer when
+                ``page_tables_per_layer`` is None (legacy / uniform attention).
+            kv_cache: KV cache list per layer.
+            page_tables_per_layer: Optional list of per-layer page tables, one
+                entry per decoder layer. When set, each layer's attention
+                receives ``page_tables_per_layer[i]`` instead of ``page_table``.
+                vLLM's hybrid kv cache manager produces this list so
+                sliding-window layers can index a smaller paged pool than
+                full-attention layers (KV cache groups). When None, behavior is
+                byte-equivalent to the pre-hybrid path.
 
         Returns:
             logits: Output logits
@@ -354,14 +363,21 @@ class Model:
         # Determine mode based on current_pos presence
         mode = Mode.DECODE if current_pos is not None else Mode.PREFILL
 
+        if page_tables_per_layer is not None and len(page_tables_per_layer) != len(self.layers):
+            raise ValueError(
+                f"page_tables_per_layer has {len(page_tables_per_layer)} entries "
+                f"but model has {len(self.layers)} layers"
+            )
+
         # Process through decoder layers
         for i, decoder_layer in enumerate(self.layers):
             layer_kv_cache = kv_cache[i] if kv_cache is not None else None
+            layer_page_table = page_tables_per_layer[i] if page_tables_per_layer is not None else page_table
             hidden_states = decoder_layer(
                 hidden_states,
                 position_embeddings=rope_mats,
                 position_idx=current_pos,
-                page_table=page_table,
+                page_table=layer_page_table,
                 kv_cache=layer_kv_cache,
                 is_decode=is_decode,
                 user_id=user_id,
@@ -415,7 +431,14 @@ class Model:
         kv_cache=None,
         sampling_on_device=False,
         capture_sampling_trace=False,
+        page_tables_per_layer=None,
     ):
+        if page_tables_per_layer is None:
+            # vLLM hybrid path: the bridge stashes the per-layer list on the
+            # model object before calling Generator.decode_forward, since the
+            # generator's many internal ttnn_decode_forward sites can't all
+            # plumb the new kwarg cleanly. Pick it up here when present.
+            page_tables_per_layer = getattr(self, "_active_page_tables_per_layer", None)
         """
         Decode forward pass - processes single tokens.
         Matches tt-transformers interface where rot_mat_idxs are used for on-device RoPE lookup.
@@ -442,6 +465,7 @@ class Model:
             kv_cache=kv_cache,
             is_decode=True,
             sampling_on_device=sampling_on_device,
+            page_tables_per_layer=page_tables_per_layer,
         )
 
         if sampling_on_device and self.sampling is not None:
@@ -470,7 +494,13 @@ class Model:
         kv_cache=None,
         batch_size=1,
         skip_lm_head=False,
+        page_tables_per_layer=None,
     ):
+        if page_tables_per_layer is None:
+            # See ttnn_decode_forward: the bridge stashes per-layer page tables
+            # on the model when in vLLM hybrid mode, since Generator's prefill
+            # path doesn't thread the kwarg.
+            page_tables_per_layer = getattr(self, "_active_page_tables_per_layer", None)
         """Prefill forward pass - processes full sequences"""
         # Use provided rotation matrices or slice from rope_setup (matches tt-transformers)
         seq_len = x.shape[-2]
@@ -495,6 +525,7 @@ class Model:
             user_id=user_id,
             batch_size=batch_size,
             skip_lm_head=skip_lm_head,
+            page_tables_per_layer=page_tables_per_layer,
         )
 
         return logits

--- a/models/demos/qwen3_vl/tt/model.py
+++ b/models/demos/qwen3_vl/tt/model.py
@@ -482,7 +482,19 @@ class Transformer(TTTransformer):
         kv_cache=None,
         visual_pos_masks=None,
         deepstack_visual_embeds=None,
+        page_tables_per_layer=None,
     ):
+        # The parent ``ttnn_*_forward`` always passes ``page_tables_per_layer``
+        # (the hybrid kv-cache-groups kwarg). Qwen3-VL is non-hybrid today so
+        # the list is None in practice, but accept it and route per-layer the
+        # same way the parent does so behaviour stays aligned if/when this
+        # model is ever migrated.
+        if page_tables_per_layer is not None and len(page_tables_per_layer) != len(self.layers):
+            raise ValueError(
+                f"page_tables_per_layer has {len(page_tables_per_layer)} entries "
+                f"but model has {len(self.layers)} layers"
+            )
+
         for i, layer in enumerate(self.layers):
             # No-op if callers already provide the right memory config
             activation_dtype = self.decoders_optimizations.get_tensor_dtype(decoder_id=i, tensor=TensorGroup.ACTIVATION)
@@ -491,6 +503,7 @@ class Transformer(TTTransformer):
             elif activation_dtype is not None and x.dtype != activation_dtype:
                 x = ttnn.typecast(x, activation_dtype)
 
+            layer_page_table = page_tables_per_layer[i] if page_tables_per_layer is not None else page_table
             x = layer(
                 x,
                 current_pos,
@@ -498,7 +511,7 @@ class Transformer(TTTransformer):
                 rot_mats_local=rot_mats_local,
                 user_id=user_id,
                 mode=mode,
-                page_table=page_table,
+                page_table=layer_page_table,
                 chunk_page_table=chunk_page_table,
                 chunk_start_idx=chunk_start_idx,
                 kv_cache=kv_cache[i] if kv_cache is not None else None,

--- a/models/tt_transformers/tests/test_hybrid_attention_for_causal_lm.py
+++ b/models/tt_transformers/tests/test_hybrid_attention_for_causal_lm.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``HybridAttentionForCausalLM``.
+
+The class is the vLLM wrapper base for hybrid attention models (Gemma3,
+Gemma4, GPT-OSS, ...). The bulk of its responsibility is the
+``get_kv_cache_spec`` classmethod that translates ``layer_types`` from
+HF config into per-layer KVCacheSpecs that upstream's hybrid kv cache
+manager groups by attention type. This test pins that translation
+across the typical patterns we'll see on real models.
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+# Stub ttnn so importing generator_vllm doesn't blow up on the local
+# tt-metal C++ extension. We don't exercise any real ttnn behaviour here.
+sys.modules.setdefault("ttnn", MagicMock(name="ttnn-test-mock"))
+sys.modules.setdefault("ttnn._ttnn", MagicMock(name="ttnn._ttnn-test-mock"))
+
+
+def _make_vllm_config(layer_types, sliding_window=1024, num_kv_heads=8, head_size=128):
+    text_config = SimpleNamespace(layer_types=layer_types, sliding_window=sliding_window)
+    hf_config = SimpleNamespace(text_config=text_config)
+    cfg = MagicMock()
+    cfg.model_config.hf_config = hf_config
+    cfg.model_config.dtype = torch.bfloat16
+    cfg.model_config.get_num_kv_heads.return_value = num_kv_heads
+    cfg.model_config.get_head_size.return_value = head_size
+    cfg.cache_config.cache_dtype = "auto"
+    cfg.cache_config.block_size = 64
+    return cfg
+
+
+def test_spec_emits_one_entry_per_layer():
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
+
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+    layers = ["sliding_attention"] * 5 + ["full_attention"] + ["sliding_attention"] * 5
+    spec = HybridAttentionForCausalLM.get_kv_cache_spec(_make_vllm_config(layers))
+
+    assert len(spec) == len(layers)
+    for i, expected_type in enumerate(layers):
+        name = f"model.layers.{i}.self_attn"
+        assert name in spec
+        if expected_type == "sliding_attention":
+            assert isinstance(spec[name], SlidingWindowSpec)
+            assert spec[name].sliding_window == 1024
+        else:
+            assert isinstance(spec[name], FullAttentionSpec)
+
+
+def test_spec_gemma3_27b_pattern():
+    """Gemma3-27b: 5 sliding then 1 full, 10x → 50 sliding + 10 full + ...
+    (its actual config is 52 sliding + 10 full but the structure is the
+    same; just verify the per-layer outputs flow without errors)."""
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
+
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+    pattern = ["sliding_attention"] * 5 + ["full_attention"]
+    layers = pattern * 10  # 60 layers
+    spec = HybridAttentionForCausalLM.get_kv_cache_spec(_make_vllm_config(layers))
+
+    full_count = sum(isinstance(v, FullAttentionSpec) for v in spec.values())
+    sliding_count = sum(isinstance(v, SlidingWindowSpec) for v in spec.values())
+    assert full_count == 10
+    assert sliding_count == 50
+
+
+def test_spec_gpt_oss_alternating_pattern():
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
+
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+    layers = ["sliding_attention", "full_attention"] * 12  # 24 layers
+    spec = HybridAttentionForCausalLM.get_kv_cache_spec(_make_vllm_config(layers))
+
+    full_count = sum(isinstance(v, FullAttentionSpec) for v in spec.values())
+    sliding_count = sum(isinstance(v, SlidingWindowSpec) for v in spec.values())
+    assert full_count == 12
+    assert sliding_count == 12
+
+
+def test_spec_uniform_full_attention_still_works():
+    """All-full layer_types → single-type config; spec generation still
+    succeeds (upstream's grouping later detects uniform-spec and uses
+    the simpler single-group path)."""
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
+
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+    spec = HybridAttentionForCausalLM.get_kv_cache_spec(_make_vllm_config(["full_attention"] * 4))
+    assert all(isinstance(v, FullAttentionSpec) for v in spec.values())
+    assert not any(isinstance(v, SlidingWindowSpec) for v in spec.values())
+
+
+def test_spec_propagates_kv_heads_and_head_size():
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+    spec = HybridAttentionForCausalLM.get_kv_cache_spec(
+        _make_vllm_config(["full_attention", "sliding_attention"], num_kv_heads=4, head_size=256)
+    )
+
+    for layer_spec in spec.values():
+        assert layer_spec.num_kv_heads == 4
+        assert layer_spec.head_size == 256
+        assert layer_spec.block_size == 64
+        assert layer_spec.dtype == torch.bfloat16
+
+
+def test_spec_missing_layer_types_raises():
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+    cfg = _make_vllm_config(["full_attention"])
+    cfg.model_config.hf_config.text_config.layer_types = None
+
+    with pytest.raises(ValueError, match="layer_types"):
+        HybridAttentionForCausalLM.get_kv_cache_spec(cfg)
+
+
+def test_spec_sliding_layer_without_window_raises():
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+    cfg = _make_vllm_config(["sliding_attention"], sliding_window=None)
+
+    with pytest.raises(ValueError, match="sliding_window is None"):
+        HybridAttentionForCausalLM.get_kv_cache_spec(cfg)
+
+
+def test_spec_unknown_layer_type_raises():
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+    cfg = _make_vllm_config(["full_attention", "rotary_chunked_xyz"])
+
+    with pytest.raises(ValueError, match="Unsupported layer_type"):
+        HybridAttentionForCausalLM.get_kv_cache_spec(cfg)
+
+
+def test_subclass_must_override_prefill_and_decode():
+    """The base class's prefill_forward / decode_forward are explicit
+    NotImplementedError stubs — subclasses must provide model-specific
+    routing that consumes ``page_tables_per_group``."""
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+    instance = HybridAttentionForCausalLM.__new__(HybridAttentionForCausalLM)
+
+    with pytest.raises(NotImplementedError, match="prefill_forward"):
+        instance.prefill_forward()
+    with pytest.raises(NotImplementedError, match="decode_forward"):
+        instance.decode_forward()

--- a/models/tt_transformers/tests/test_vllm_kv_cache.py
+++ b/models/tt_transformers/tests/test_vllm_kv_cache.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the vLLM-side KV cache allocator helpers in
+``generator_vllm.py``.
+
+Verifies the new per-layer entry point (``allocate_vllm_kv_cache_per_layer``)
+and that the legacy uniform-shape entry point (``allocate_vllm_kv_cache``)
+still delegates to it bit-for-bit.
+
+Real ttnn allocation requires a mesh device, so this test mocks
+``ttnn.as_tensor`` / ``ttnn.ReplicateTensorToMesh`` and the ``dp_model``
+handles. We verify call structure and shape routing, not the resulting
+tensor contents.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+
+@pytest.fixture
+def dp_model():
+    """One submesh handle whose optimizations return None (so the allocator
+    falls back to the bfloat8_b default — keeps the test independent of
+    the model's optimization config table)."""
+    submesh = MagicMock()
+    args = MagicMock()
+    args.optimizations = None  # Force the bfloat8_b fallback path.
+    model = MagicMock()
+    model.mesh_device = submesh
+    model.args = args
+    return [model]
+
+
+def _make_ttnn_mock():
+    ttnn_mock = MagicMock()
+    ttnn_mock.as_tensor.side_effect = lambda *a, **kw: ("tt-tensor", kw.get("dtype"), kw.get("cache_file_name"))
+    ttnn_mock.bfloat8_b = "bfloat8_b-sentinel"
+    ttnn_mock.bfloat16 = "bfloat16-sentinel"
+    return ttnn_mock
+
+
+def test_per_layer_allocates_one_kv_pair_per_spec(dp_model):
+    from models.tt_transformers.tt import generator_vllm
+
+    per_layer = [
+        ((4, 2, 32, 64), torch.bfloat16),  # layer 0
+        ((4, 1, 32, 64), torch.bfloat16),  # layer 1 (smaller — sliding)
+        ((4, 2, 32, 64), torch.bfloat16),  # layer 2
+    ]
+
+    with patch.object(generator_vllm, "ttnn", new=_make_ttnn_mock()) as ttnn_mock:
+        kv_cache = generator_vllm.allocate_vllm_kv_cache_per_layer(
+            per_layer, dp_model=dp_model, tt_cache_path=Path("/tmp/tt-test-cache")
+        )
+
+    # One submesh, three layers, two tensors per layer (k, v) = 6 calls.
+    assert ttnn_mock.as_tensor.call_count == 6
+    assert len(kv_cache) == 1  # one submesh
+    assert len(kv_cache[0]) == 3  # three layers
+    assert all(len(layer) == 2 for layer in kv_cache[0])  # k, v
+
+
+def test_per_layer_passes_each_shape_to_cache_filename(dp_model):
+    """The cache filename is keyed on the per-layer shape; verify a layer
+    with a smaller shape gets a different cache file from a larger one."""
+    from models.tt_transformers.tt import generator_vllm
+
+    per_layer = [
+        ((4, 2, 32, 64), torch.bfloat16),
+        ((4, 1, 32, 64), torch.bfloat16),  # half-sized
+    ]
+
+    with patch.object(generator_vllm, "ttnn", new=_make_ttnn_mock()) as ttnn_mock:
+        generator_vllm.allocate_vllm_kv_cache_per_layer(
+            per_layer, dp_model=dp_model, tt_cache_path=Path("/tmp/tt-test-cache")
+        )
+
+    cache_filenames = [str(call.kwargs["cache_file_name"]) for call in ttnn_mock.as_tensor.call_args_list]
+    # Layer 0's shape (4, 2, 32, 64) must show up in two filenames (k+v),
+    # and so must layer 1's (4, 1, 32, 64). Different shapes → different
+    # filenames so caches don't collide.
+    assert sum("(4, 2, 32, 64)" in f for f in cache_filenames) == 2
+    assert sum("(4, 1, 32, 64)" in f for f in cache_filenames) == 2
+
+
+def test_legacy_uniform_shape_delegates_to_per_layer(dp_model):
+    """The legacy ``allocate_vllm_kv_cache`` must produce identical output to
+    calling ``allocate_vllm_kv_cache_per_layer`` with a uniform-spec list,
+    so existing single-group callers keep working unchanged."""
+    from models.tt_transformers.tt import generator_vllm
+
+    shape = (4, 2, 32, 64)
+    dtype = torch.bfloat16
+    num_layers = 3
+
+    with patch.object(generator_vllm, "ttnn", new=_make_ttnn_mock()) as ttnn_mock:
+        legacy = generator_vllm.allocate_vllm_kv_cache(
+            shape, dtype, num_layers, dp_model=dp_model, tt_cache_path=Path("/tmp/c")
+        )
+    legacy_call_count = ttnn_mock.as_tensor.call_count
+
+    with patch.object(generator_vllm, "ttnn", new=_make_ttnn_mock()) as ttnn_mock:
+        per_layer = generator_vllm.allocate_vllm_kv_cache_per_layer(
+            [(shape, dtype)] * num_layers,
+            dp_model=dp_model,
+            tt_cache_path=Path("/tmp/c"),
+        )
+    per_layer_call_count = ttnn_mock.as_tensor.call_count
+
+    assert legacy_call_count == per_layer_call_count
+    assert len(legacy[0]) == len(per_layer[0]) == num_layers

--- a/models/tt_transformers/tests/test_vllm_kv_cache.py
+++ b/models/tt_transformers/tests/test_vllm_kv_cache.py
@@ -86,38 +86,6 @@ def test_per_layer_passes_each_shape_to_cache_filename(dp_model):
     assert sum("(4, 1, 32, 64)" in f for f in cache_filenames) == 2
 
 
-def test_check_per_group_kwargs_strips_single_group_silently():
-    """A single-element list carries no extra info beyond the legacy
-    page_table arg; the wrapper drops it without complaint."""
-    from models.tt_transformers.tt.generator_vllm import _check_per_group_kwargs
-
-    kwargs = {"page_tables_per_group": ["t0"], "tokens": "tok"}
-    _check_per_group_kwargs(kwargs, "FakeModel")
-
-    assert "page_tables_per_group" not in kwargs
-    assert kwargs == {"tokens": "tok"}
-
-
-def test_check_per_group_kwargs_passes_when_kwarg_absent():
-    """Legacy callers that don't set page_tables_per_group are unaffected."""
-    from models.tt_transformers.tt.generator_vllm import _check_per_group_kwargs
-
-    kwargs = {"tokens": "tok"}
-    _check_per_group_kwargs(kwargs, "FakeModel")
-
-    assert kwargs == {"tokens": "tok"}
-
-
-def test_check_per_group_kwargs_raises_for_multi_group():
-    """Hybrid input with multiple groups must error loudly: silently using
-    only group 0 would corrupt KV state for the other groups."""
-    from models.tt_transformers.tt.generator_vllm import _check_per_group_kwargs
-
-    kwargs = {"page_tables_per_group": ["t0", "t1"], "tokens": "tok"}
-    with pytest.raises(NotImplementedError, match="FakeModel"):
-        _check_per_group_kwargs(kwargs, "FakeModel")
-
-
 def test_legacy_uniform_shape_delegates_to_per_layer(dp_model):
     """The legacy ``allocate_vllm_kv_cache`` must produce identical output to
     calling ``allocate_vllm_kv_cache_per_layer`` with a uniform-spec list,

--- a/models/tt_transformers/tests/test_vllm_kv_cache.py
+++ b/models/tt_transformers/tests/test_vllm_kv_cache.py
@@ -42,13 +42,16 @@ def _make_ttnn_mock():
     return ttnn_mock
 
 
-def test_per_layer_allocates_one_kv_pair_per_spec(dp_model):
+def test_per_layer_allocates_one_kv_pair_per_unique_tensor(dp_model):
+    """Each unique ``tensor_idx`` allocates one (k, v) pair; layers that
+    share a ``tensor_idx`` reuse the same handles."""
     from models.tt_transformers.tt import generator_vllm
 
+    # Layers 0, 1, 2 all use tensor_idx=0,1,2 respectively → three buffers.
     per_layer = [
-        ((4, 2, 32, 64), torch.bfloat16),  # layer 0
-        ((4, 1, 32, 64), torch.bfloat16),  # layer 1 (smaller — sliding)
-        ((4, 2, 32, 64), torch.bfloat16),  # layer 2
+        ((4, 2, 32, 64), torch.bfloat16, 0),
+        ((4, 2, 32, 64), torch.bfloat16, 1),
+        ((4, 2, 32, 64), torch.bfloat16, 2),
     ]
 
     with patch.object(generator_vllm, "ttnn", new=_make_ttnn_mock()) as ttnn_mock:
@@ -63,14 +66,40 @@ def test_per_layer_allocates_one_kv_pair_per_spec(dp_model):
     assert all(len(layer) == 2 for layer in kv_cache[0])  # k, v
 
 
-def test_per_layer_passes_each_shape_to_cache_filename(dp_model):
-    """The cache filename is keyed on the per-layer shape; verify a layer
-    with a smaller shape gets a different cache file from a larger one."""
+def test_shared_tensor_idx_reuses_one_buffer(dp_model):
+    """Layers sharing a ``tensor_idx`` (HMA tensor sharing) point at the
+    same underlying ttnn handles and only one allocation runs per
+    ``tensor_idx``."""
+    from models.tt_transformers.tt import generator_vllm
+
+    # Layers 0 and 2 share tensor 0; layer 1 has its own tensor 1.
+    per_layer = [
+        ((4, 2, 32, 64), torch.bfloat16, 0),
+        ((4, 2, 32, 64), torch.bfloat16, 1),
+        ((4, 2, 32, 64), torch.bfloat16, 0),
+    ]
+
+    with patch.object(generator_vllm, "ttnn", new=_make_ttnn_mock()) as ttnn_mock:
+        kv_cache = generator_vllm.allocate_vllm_kv_cache_per_layer(
+            per_layer, dp_model=dp_model, tt_cache_path=Path("/tmp/tt-test-cache")
+        )
+
+    # 2 unique tensor_idx values × 2 (k, v) = 4 allocations.
+    assert ttnn_mock.as_tensor.call_count == 4
+    # Layers 0 and 2 must reference the *same* handle list.
+    assert kv_cache[0][0] is kv_cache[0][2]
+    assert kv_cache[0][0] is not kv_cache[0][1]
+
+
+def test_per_layer_keys_cache_filename_on_tensor_idx(dp_model):
+    """Cache filenames must distinguish independent buffers even when
+    shapes are identical, so on-disk caches can't collide across layers
+    that don't share a ``tensor_idx``."""
     from models.tt_transformers.tt import generator_vllm
 
     per_layer = [
-        ((4, 2, 32, 64), torch.bfloat16),
-        ((4, 1, 32, 64), torch.bfloat16),  # half-sized
+        ((4, 2, 32, 64), torch.bfloat16, 0),
+        ((4, 2, 32, 64), torch.bfloat16, 1),
     ]
 
     with patch.object(generator_vllm, "ttnn", new=_make_ttnn_mock()) as ttnn_mock:
@@ -79,17 +108,15 @@ def test_per_layer_passes_each_shape_to_cache_filename(dp_model):
         )
 
     cache_filenames = [str(call.kwargs["cache_file_name"]) for call in ttnn_mock.as_tensor.call_args_list]
-    # Layer 0's shape (4, 2, 32, 64) must show up in two filenames (k+v),
-    # and so must layer 1's (4, 1, 32, 64). Different shapes → different
-    # filenames so caches don't collide.
-    assert sum("(4, 2, 32, 64)" in f for f in cache_filenames) == 2
-    assert sum("(4, 1, 32, 64)" in f for f in cache_filenames) == 2
+    assert sum("_t0" in f for f in cache_filenames) == 2
+    assert sum("_t1" in f for f in cache_filenames) == 2
 
 
 def test_legacy_uniform_shape_delegates_to_per_layer(dp_model):
     """The legacy ``allocate_vllm_kv_cache`` must produce identical output to
-    calling ``allocate_vllm_kv_cache_per_layer`` with a uniform-spec list,
-    so existing single-group callers keep working unchanged."""
+    calling ``allocate_vllm_kv_cache_per_layer`` with a per-layer triple
+    list (each layer its own ``tensor_idx``), so existing single-group
+    callers keep working unchanged."""
     from models.tt_transformers.tt import generator_vllm
 
     shape = (4, 2, 32, 64)
@@ -104,7 +131,7 @@ def test_legacy_uniform_shape_delegates_to_per_layer(dp_model):
 
     with patch.object(generator_vllm, "ttnn", new=_make_ttnn_mock()) as ttnn_mock:
         per_layer = generator_vllm.allocate_vllm_kv_cache_per_layer(
-            [(shape, dtype)] * num_layers,
+            [(shape, dtype, i) for i in range(num_layers)],
             dp_model=dp_model,
             tt_cache_path=Path("/tmp/c"),
         )

--- a/models/tt_transformers/tests/test_vllm_kv_cache.py
+++ b/models/tt_transformers/tests/test_vllm_kv_cache.py
@@ -86,6 +86,38 @@ def test_per_layer_passes_each_shape_to_cache_filename(dp_model):
     assert sum("(4, 1, 32, 64)" in f for f in cache_filenames) == 2
 
 
+def test_check_per_group_kwargs_strips_single_group_silently():
+    """A single-element list carries no extra info beyond the legacy
+    page_table arg; the wrapper drops it without complaint."""
+    from models.tt_transformers.tt.generator_vllm import _check_per_group_kwargs
+
+    kwargs = {"page_tables_per_group": ["t0"], "tokens": "tok"}
+    _check_per_group_kwargs(kwargs, "FakeModel")
+
+    assert "page_tables_per_group" not in kwargs
+    assert kwargs == {"tokens": "tok"}
+
+
+def test_check_per_group_kwargs_passes_when_kwarg_absent():
+    """Legacy callers that don't set page_tables_per_group are unaffected."""
+    from models.tt_transformers.tt.generator_vllm import _check_per_group_kwargs
+
+    kwargs = {"tokens": "tok"}
+    _check_per_group_kwargs(kwargs, "FakeModel")
+
+    assert kwargs == {"tokens": "tok"}
+
+
+def test_check_per_group_kwargs_raises_for_multi_group():
+    """Hybrid input with multiple groups must error loudly: silently using
+    only group 0 would corrupt KV state for the other groups."""
+    from models.tt_transformers.tt.generator_vllm import _check_per_group_kwargs
+
+    kwargs = {"page_tables_per_group": ["t0", "t1"], "tokens": "tok"}
+    with pytest.raises(NotImplementedError, match="FakeModel"):
+        _check_per_group_kwargs(kwargs, "FakeModel")
+
+
 def test_legacy_uniform_shape_delegates_to_per_layer(dp_model):
     """The legacy ``allocate_vllm_kv_cache`` must produce identical output to
     calling ``allocate_vllm_kv_cache_per_layer`` with a uniform-spec list,

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -749,7 +749,7 @@ class Attention(LightweightModule):
         # This is because the SDPA op in decode mode has different number of reductions depending on batch size
         # Which leads to slightly different outputs from attention (due to accumulated errors)
         sdpa_decode_prog_cfg = self.args.get_attn_sdpa_decode_program_config(self.prefetcher)
-        if page_table:
+        if page_table is not None:
             attn_output_1G4D = ttnn.transformer.paged_scaled_dot_product_attention_decode(
                 q_heads_1BQD,
                 keys,
@@ -1032,7 +1032,7 @@ class Attention(LightweightModule):
         ttnn.deallocate(k_heads_1KSD)
 
         # sharding k_fill to deal with update_cache memory limitation
-        if seq_len >= self.min_kv_prefill_shard_seqlen and not self.TG and not page_table:
+        if seq_len >= self.min_kv_prefill_shard_seqlen and not self.TG and page_table is None:
             k_fill = ttnn.interleaved_to_sharded(k_heads_1KSD_8b, self.args.get_attn_kv_prefill_mem_config(seq_len))
         else:
             k_fill = k_heads_1KSD_8b
@@ -1042,7 +1042,7 @@ class Attention(LightweightModule):
         ttnn.deallocate(v_heads_1VSD)
 
         # sharding v_fill to deal with update_cache memory limitation
-        if seq_len >= self.min_kv_prefill_shard_seqlen and not self.TG and not page_table:
+        if seq_len >= self.min_kv_prefill_shard_seqlen and not self.TG and page_table is None:
             v_fill = ttnn.interleaved_to_sharded(v_heads_1VSD_8b, self.args.get_attn_kv_prefill_mem_config(seq_len))
         else:
             v_fill = v_heads_1VSD_8b
@@ -1050,7 +1050,7 @@ class Attention(LightweightModule):
         if self.TG:
             k_fill = self.prefill_prepare_tensor_for_kv_cache(k_fill, user_id)
             v_fill = self.prefill_prepare_tensor_for_kv_cache(v_fill, user_id)
-        if page_table:
+        if page_table is not None:
             # In the case that the tokens have been padded along the seq len dimension, we need to fill the cache with the unpadded k/v values.
             # Assume that the page table does not have padding, so we can use it to get the unpadded page len.
             block_size = keys_BKSD.shape[2]
@@ -1085,7 +1085,7 @@ class Attention(LightweightModule):
                 # Fill cache for this specific slot with scalar batch_idx
                 ttnn.experimental.paged_fill_cache(keys_BKSD, k_user_sliced, fill_page_table, batch_idx=slot_idx)
                 ttnn.experimental.paged_fill_cache(values_BKSD, v_user_sliced, fill_page_table, batch_idx=slot_idx)
-        elif page_table:
+        elif page_table is not None:
             # Single user path with page_table
             page_len = fill_page_table.shape[1] * block_size
             k_fill_sliced = k_fill[:, :, :page_len, :] if page_len < k_fill.shape[2] else k_fill
@@ -1104,7 +1104,7 @@ class Attention(LightweightModule):
                 v_fill,
                 user_id % self.batch_size_per_device_group,
             )
-        if seq_len >= self.min_kv_prefill_shard_seqlen and not self.TG and not page_table:
+        if seq_len >= self.min_kv_prefill_shard_seqlen and not self.TG and page_table is None:
             ttnn.deallocate(k_fill)
             ttnn.deallocate(v_fill)
 

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -227,6 +227,26 @@ class HybridAttentionForCausalLM(Generator):
     def allocate_kv_cache_per_layer(self, per_layer_specs):
         return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
 
+    def _ensure_page_tables_per_layer(self, page_tables_per_layer, page_table):
+        """When invoked outside the vLLM hybrid plugin (e.g. by warmup
+        which only knows about the legacy single ``page_table``), broadcast
+        the single page table to a per-layer list. This is required so
+        trace capture exercises the per-layer code path inside
+        ``Transformer.forward`` — otherwise the trace specializes on the
+        legacy fallback branch and runtime per-layer updates are silently
+        ignored at replay (the trace reads from whatever address the
+        legacy single tensor lived at during capture). The persistent
+        device tensors allocated in ``Transformer._page_tables_to_ttnn``
+        are then bound at trace time and updated in place each call.
+        """
+        if page_tables_per_layer is not None or page_table is None:
+            return page_tables_per_layer
+        # Broadcast the same torch tensor across every layer in every
+        # submesh — content is identical, persistent allocation gives each
+        # layer its own device tensor at a stable address.
+        num_layers = len(self.model[0].layers)
+        return [page_table] * num_layers
+
 
 def initialize_vllm_text_transformer(
     hf_config,
@@ -758,10 +778,24 @@ class Gemma3ForConditionalGeneration(HybridAttentionForCausalLM, SupportsMultiMo
         return _Stash(self.model, page_tables_per_layer)
 
     def prefill_forward(self, *args, page_tables_per_layer=None, **kwargs):
+        page_tables_per_layer = self._ensure_page_tables_per_layer(page_tables_per_layer, kwargs.get("page_table"))
+        # Push the per-layer block IDs into the persistent device buffers
+        # *before* entering ``Generator.prefill_forward_text`` — that path
+        # may execute a captured trace, which reads block IDs from the
+        # persistent addresses and forbids in-trace writes. Allocation
+        # itself happens lazily in ``Transformer._page_tables_to_ttnn``
+        # the first time the inner forward runs (warmup compile).
+        if page_tables_per_layer is not None:
+            for m in self.model:
+                m.update_persistent_per_layer_page_tables(page_tables_per_layer)
         with self._route_per_layer_page_tables(page_tables_per_layer):
             return super().prefill_forward_text(**kwargs)
 
     def decode_forward(self, *args, page_tables_per_layer=None, **kwargs):
+        page_tables_per_layer = self._ensure_page_tables_per_layer(page_tables_per_layer, kwargs.get("page_table"))
+        if page_tables_per_layer is not None:
+            for m in self.model:
+                m.update_persistent_per_layer_page_tables(page_tables_per_layer)
         with self._route_per_layer_page_tables(page_tables_per_layer):
             # Skip ``HybridAttentionForCausalLM.decode_forward``, which is a
             # NotImplementedError placeholder; route to ``Generator``'s
@@ -836,10 +870,21 @@ class GptOssForCausalLM(HybridAttentionForCausalLM):
         return _Stash(self.model, page_tables_per_layer)
 
     def prefill_forward(self, *args, page_tables_per_layer=None, **kwargs):
+        page_tables_per_layer = self._ensure_page_tables_per_layer(page_tables_per_layer, kwargs.get("page_table"))
+        # See ``Gemma3ForConditionalGeneration.prefill_forward`` for why
+        # the persistent-buffer update has to happen *before* the inner
+        # decode/prefill path that may run captured traces.
+        if page_tables_per_layer is not None:
+            for m in self.model:
+                m.update_persistent_per_layer_page_tables(page_tables_per_layer)
         with self._route_per_layer_page_tables(page_tables_per_layer):
             return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, page_tables_per_layer=None, **kwargs):
+        page_tables_per_layer = self._ensure_page_tables_per_layer(page_tables_per_layer, kwargs.get("page_table"))
+        if page_tables_per_layer is not None:
+            for m in self.model:
+                m.update_persistent_per_layer_page_tables(page_tables_per_layer)
         with self._route_per_layer_page_tables(page_tables_per_layer):
             # Skip ``HybridAttentionForCausalLM.decode_forward``, which is a
             # NotImplementedError placeholder; route to ``Generator``'s

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -33,28 +33,40 @@ from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs,
 
 
 def allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model: List[Transformer], tt_cache_path):
-    """Allocate KV cache tensors with potentially different shape per layer.
+    """Allocate KV cache tensors with optional cross-layer DRAM sharing.
 
     Args:
-        per_layer_specs: list of ``(kv_cache_shape, dtype)`` tuples, one per
-            layer in model layer-index order. Hybrid attention models
-            (Gemma3/4, GPT-OSS) use this so sliding-window layers can be
-            backed by a smaller paged pool than full-attention layers; for
-            uniform-attention models all entries are identical.
+        per_layer_specs: list of ``(kv_cache_shape, dtype, tensor_idx)``
+            triples, one per layer in model layer-index order. Layers with
+            the same ``tensor_idx`` share one underlying TT tensor — this
+            is upstream's HMA tensor-sharing layout (e.g. for Gemma3 5:1,
+            one full-attention layer and several sliding-window layers
+            collapse to a single DRAM buffer; per-group block tables keep
+            their slot accesses disjoint at runtime). Layers with unique
+            ``tensor_idx`` get their own buffer.
         dp_model: list of replicated TT model handles, one per data-parallel
             submesh.
         tt_cache_path: path used for on-disk weight cache file naming.
 
     Returns:
-        ``list[submesh][layer_idx][k_or_v]`` of TT tensors.
+        ``list[submesh][layer_idx][k_or_v]`` of TT tensors. Multiple
+        ``layer_idx`` entries may refer to the same underlying tensor
+        objects when they share a ``tensor_idx``.
     """
     submesh_devices = [model.mesh_device for model in dp_model]
     kv_cache = []
     for mesh_idx, submesh in enumerate(submesh_devices):
+        # tensor_idx -> [k, v] ttnn handles; reused across all layers that
+        # share a buffer.
+        unique_buffers: dict[int, list] = {}
         kv_tt = []
-        for layer_num, (kv_cache_shape, dtype) in enumerate(
+        for layer_num, (kv_cache_shape, dtype, tensor_idx) in enumerate(
             tqdm(per_layer_specs, desc=f"Allocating TT kv caches for each layer (submesh {mesh_idx+1})")
         ):
+            existing = unique_buffers.get(tensor_idx)
+            if existing is not None:
+                kv_tt.append(existing)
+                continue
             cache_kv = torch.zeros(kv_cache_shape, dtype=dtype)
             # Get the dtype for the kv cache based on the configured optimizations in the model
             if dp_model[mesh_idx].args.optimizations is not None:
@@ -77,11 +89,14 @@ def allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model: List[Transformer
                     memory_config=ttnn.DRAM_MEMORY_CONFIG,
                     dtype=kv_cache_dtype,
                     # Separate cache files for K and V to avoid collision.
-                    cache_file_name=tt_cache_path / f"empty_{kv}cache_paged_attention{kv_cache_shape}",
+                    # ``tensor_idx`` distinguishes shared buffers that have the
+                    # same shape but back different layer subsets.
+                    cache_file_name=tt_cache_path / f"empty_{kv}cache_paged_attention{kv_cache_shape}_t{tensor_idx}",
                 )
                 for kv in ["k", "v"]
             ]
 
+            unique_buffers[tensor_idx] = kv_tt_i
             kv_tt.append(kv_tt_i)
         kv_cache.append(kv_tt)
     return kv_cache
@@ -91,11 +106,11 @@ def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, dp_model: List[Tra
     """Uniform-shape KV cache allocator for non-hybrid models.
 
     Hybrid attention models should use :func:`allocate_vllm_kv_cache_per_layer`,
-    which takes a per-layer ``(shape, dtype)`` list so sliding-window layers
-    can be backed by a smaller paged pool than full-attention layers.
+    which takes a per-layer ``(shape, dtype, tensor_idx)`` list so layers
+    can share DRAM buffers per upstream's HMA tensor-sharing model.
     """
     return allocate_vllm_kv_cache_per_layer(
-        [(kv_cache_shape, dtype)] * num_layers,
+        [(kv_cache_shape, dtype, i) for i in range(num_layers)],
         dp_model=dp_model,
         tt_cache_path=tt_cache_path,
     )
@@ -748,7 +763,10 @@ class Gemma3ForConditionalGeneration(HybridAttentionForCausalLM, SupportsMultiMo
 
     def decode_forward(self, *args, page_tables_per_layer=None, **kwargs):
         with self._route_per_layer_page_tables(page_tables_per_layer):
-            return super().decode_forward(*args, **kwargs)
+            # Skip ``HybridAttentionForCausalLM.decode_forward``, which is a
+            # NotImplementedError placeholder; route to ``Generator``'s
+            # actual decode implementation.
+            return super(HybridAttentionForCausalLM, self).decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
@@ -823,7 +841,10 @@ class GptOssForCausalLM(HybridAttentionForCausalLM):
 
     def decode_forward(self, *args, page_tables_per_layer=None, **kwargs):
         with self._route_per_layer_page_tables(page_tables_per_layer):
-            return super().decode_forward(*args, **kwargs)
+            # Skip ``HybridAttentionForCausalLM.decode_forward``, which is a
+            # NotImplementedError placeholder; route to ``Generator``'s
+            # actual decode implementation.
+            return super(HybridAttentionForCausalLM, self).decode_forward(*args, **kwargs)
 
     @classmethod
     def initialize_vllm_model(

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -247,6 +247,77 @@ class HybridAttentionForCausalLM(Generator):
         num_layers = len(self.model[0].layers)
         return [page_table] * num_layers
 
+    def _chunk_page_tables_per_dp(self, page_tables_per_layer):
+        """Split a global per-layer list along DP into one per-layer list
+        per submesh.
+
+        The plugin pads each per-layer table to the global
+        ``(max_num_seqs * data_parallel, max_num_blocks_per_req)`` shape
+        (see ``TTModelRunner._block_tables_per_layer``); warmup likewise
+        builds a global-batch tensor. ``Generator.decode_forward`` already
+        does ``torch.chunk(page_table, self.data_parallel, 0)`` for the
+        legacy single-page-table path before the per-submesh
+        ``prepare_inputs_decode``; the hybrid bridge has to do the
+        equivalent so each submesh's ``_page_tables_to_ttnn`` receives a
+        per-DP slice whose batch dim matches the submesh's K/V tensors.
+        Without this, ``paged_update_cache`` asserts a batch-size mismatch
+        on multi-DP runs.
+        """
+        if page_tables_per_layer is None:
+            return None
+        dp = self.data_parallel
+        if dp <= 1:
+            return [page_tables_per_layer]
+        per_submesh = [list() for _ in range(dp)]
+        for pt in page_tables_per_layer:
+            if pt is None or isinstance(pt, ttnn.Tensor):
+                # Already-resolved or absent entries pass through unchanged
+                # to every submesh — chunking only applies to torch tensors
+                # carrying global batch.
+                for s in per_submesh:
+                    s.append(pt)
+                continue
+            chunks = torch.chunk(pt, dp, dim=0)
+            for s, c in zip(per_submesh, chunks):
+                s.append(c)
+        return per_submesh
+
+    def _route_per_layer_page_tables(self, per_submesh_page_tables):
+        """Stash each submesh's per-layer page-table list on its model
+        handle for the duration of a forward call.
+
+        ``Generator``'s prefill/decode paths invoke
+        ``model[i].ttnn_prefill_forward`` / ``ttnn_decode_forward`` from
+        many sites (warmup, trace capture, traced replay, etc.) without
+        forwarding an arbitrary kwarg. Threading the per-layer list through
+        every site would be a wide change for a feature only this hybrid
+        bridge consumes, so we use a localised attribute injection: each
+        model reads ``getattr(self, "_active_page_tables_per_layer", None)``
+        when its own kwarg is None. ``per_submesh_page_tables[i]`` is the
+        per-layer slice that submesh ``i`` should see; ``None`` clears the
+        stash entirely (legacy fallback).
+        """
+
+        class _Stash:
+            def __init__(self, models, per_submesh):
+                self._models = models
+                self._per_submesh = per_submesh
+
+            def __enter__(self):
+                if self._per_submesh is None:
+                    return
+                for m, value in zip(self._models, self._per_submesh):
+                    m._active_page_tables_per_layer = value
+
+            def __exit__(self, *_):
+                if self._per_submesh is None:
+                    return
+                for m in self._models:
+                    if hasattr(m, "_active_page_tables_per_layer"):
+                        del m._active_page_tables_per_layer
+
+        return _Stash(self.model, per_submesh_page_tables)
+
 
 def initialize_vllm_text_transformer(
     hf_config,
@@ -749,54 +820,28 @@ class Gemma3ForConditionalGeneration(HybridAttentionForCausalLM, SupportsMultiMo
     def cache_path(self):
         return self.model_args[0].model_cache_path
 
-    def _route_per_layer_page_tables(self, page_tables_per_layer):
-        """See :class:`GptOssForCausalLM._route_per_layer_page_tables`.
-
-        Localised attribute injection so the per-layer list reaches the
-        many ``ttnn_*_forward`` call sites in :class:`Generator` without
-        threading a feature-specific kwarg through every one of them.
-        """
-
-        class _Stash:
-            def __init__(self, models, value):
-                self._models = models
-                self._value = value
-
-            def __enter__(self):
-                if self._value is None:
-                    return
-                for m in self._models:
-                    m._active_page_tables_per_layer = self._value
-
-            def __exit__(self, *_):
-                if self._value is None:
-                    return
-                for m in self._models:
-                    if hasattr(m, "_active_page_tables_per_layer"):
-                        del m._active_page_tables_per_layer
-
-        return _Stash(self.model, page_tables_per_layer)
-
     def prefill_forward(self, *args, page_tables_per_layer=None, **kwargs):
         page_tables_per_layer = self._ensure_page_tables_per_layer(page_tables_per_layer, kwargs.get("page_table"))
+        per_submesh = self._chunk_page_tables_per_dp(page_tables_per_layer)
         # Push the per-layer block IDs into the persistent device buffers
         # *before* entering ``Generator.prefill_forward_text`` — that path
         # may execute a captured trace, which reads block IDs from the
         # persistent addresses and forbids in-trace writes. Allocation
         # itself happens lazily in ``Transformer._page_tables_to_ttnn``
         # the first time the inner forward runs (warmup compile).
-        if page_tables_per_layer is not None:
-            for m in self.model:
-                m.update_persistent_per_layer_page_tables(page_tables_per_layer)
-        with self._route_per_layer_page_tables(page_tables_per_layer):
+        if per_submesh is not None:
+            for m, pt_for_submesh in zip(self.model, per_submesh):
+                m.update_persistent_per_layer_page_tables(pt_for_submesh)
+        with self._route_per_layer_page_tables(per_submesh):
             return super().prefill_forward_text(**kwargs)
 
     def decode_forward(self, *args, page_tables_per_layer=None, **kwargs):
         page_tables_per_layer = self._ensure_page_tables_per_layer(page_tables_per_layer, kwargs.get("page_table"))
-        if page_tables_per_layer is not None:
-            for m in self.model:
-                m.update_persistent_per_layer_page_tables(page_tables_per_layer)
-        with self._route_per_layer_page_tables(page_tables_per_layer):
+        per_submesh = self._chunk_page_tables_per_dp(page_tables_per_layer)
+        if per_submesh is not None:
+            for m, pt_for_submesh in zip(self.model, per_submesh):
+                m.update_persistent_per_layer_page_tables(pt_for_submesh)
+        with self._route_per_layer_page_tables(per_submesh):
             # Skip ``HybridAttentionForCausalLM.decode_forward``, which is a
             # NotImplementedError placeholder; route to ``Generator``'s
             # actual decode implementation.
@@ -835,57 +880,25 @@ class GptOssForCausalLM(HybridAttentionForCausalLM):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def _route_per_layer_page_tables(self, page_tables_per_layer):
-        """Context-manager-style helper: stash the per-layer list on each TT
-        model in ``self.model`` for the duration of a forward call.
-
-        ``Generator``'s prefill/decode paths invoke
-        ``model[i].ttnn_prefill_forward`` / ``ttnn_decode_forward`` from many
-        sites (warmup, trace capture, traced replay, etc.) without forwarding
-        an arbitrary kwarg. Threading ``page_tables_per_layer`` through every
-        site would be a wide change for a feature only this hybrid bridge
-        consumes, so we use a localised attribute injection instead: the
-        models read ``getattr(self, "_active_page_tables_per_layer", None)``
-        when their own kwarg is None.
-        """
-
-        class _Stash:
-            def __init__(self, models, value):
-                self._models = models
-                self._value = value
-
-            def __enter__(self):
-                if self._value is None:
-                    return
-                for m in self._models:
-                    m._active_page_tables_per_layer = self._value
-
-            def __exit__(self, *_):
-                if self._value is None:
-                    return
-                for m in self._models:
-                    if hasattr(m, "_active_page_tables_per_layer"):
-                        del m._active_page_tables_per_layer
-
-        return _Stash(self.model, page_tables_per_layer)
-
     def prefill_forward(self, *args, page_tables_per_layer=None, **kwargs):
         page_tables_per_layer = self._ensure_page_tables_per_layer(page_tables_per_layer, kwargs.get("page_table"))
+        per_submesh = self._chunk_page_tables_per_dp(page_tables_per_layer)
         # See ``Gemma3ForConditionalGeneration.prefill_forward`` for why
         # the persistent-buffer update has to happen *before* the inner
         # decode/prefill path that may run captured traces.
-        if page_tables_per_layer is not None:
-            for m in self.model:
-                m.update_persistent_per_layer_page_tables(page_tables_per_layer)
-        with self._route_per_layer_page_tables(page_tables_per_layer):
+        if per_submesh is not None:
+            for m, pt_for_submesh in zip(self.model, per_submesh):
+                m.update_persistent_per_layer_page_tables(pt_for_submesh)
+        with self._route_per_layer_page_tables(per_submesh):
             return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, page_tables_per_layer=None, **kwargs):
         page_tables_per_layer = self._ensure_page_tables_per_layer(page_tables_per_layer, kwargs.get("page_table"))
-        if page_tables_per_layer is not None:
-            for m in self.model:
-                m.update_persistent_per_layer_page_tables(page_tables_per_layer)
-        with self._route_per_layer_page_tables(page_tables_per_layer):
+        per_submesh = self._chunk_page_tables_per_dp(page_tables_per_layer)
+        if per_submesh is not None:
+            for m, pt_for_submesh in zip(self.model, per_submesh):
+                m.update_persistent_per_layer_page_tables(pt_for_submesh)
+        with self._route_per_layer_page_tables(per_submesh):
             # Skip ``HybridAttentionForCausalLM.decode_forward``, which is a
             # NotImplementedError placeholder; route to ``Generator``'s
             # actual decode implementation.

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -642,7 +642,28 @@ class MistralForCausalLM(Generator):
     info=Gemma3ProcessingInfo,
     dummy_inputs=Gemma3DummyInputsBuilder,
 )
-class Gemma3ForConditionalGeneration(Generator, SupportsMultiModal):
+class Gemma3ForConditionalGeneration(HybridAttentionForCausalLM, SupportsMultiModal):
+    """Gemma3 multimodal — hybrid attention (sliding-window + full).
+
+    Gemma3's text decoder alternates ``sliding_attention`` and
+    ``full_attention`` per ``hf_config.text_config.layer_types`` (a 5:1
+    ratio in the 27B variant), so the bridge inherits from
+    :class:`HybridAttentionForCausalLM` to opt into vLLM's hybrid kv cache
+    manager. Sliding-window layers index a smaller paged pool than
+    full-attention layers — the per-layer KV cache shape difference is
+    where the asymmetric-hybrid memory savings live, and was the original
+    motivation for kv-cache-groups (it's what unblocks the 62-layer × 107
+    MB-per-layer DRAM OOM on T3K seen in run 25437459815).
+
+    Mirrors the ``GptOssForCausalLM`` plumbing: ``prefill_forward`` /
+    ``decode_forward`` stash ``page_tables_per_layer`` on each
+    ``self.model[i]`` for the duration of a single
+    ``super().{prefill_forward_text,decode_forward}`` call. The underlying
+    ``Transformer.ttnn_*_forward`` (which ``TtGemmaModel`` inherits)
+    picks up the stash via ``_active_page_tables_per_layer`` and routes
+    each layer's attention to its own page table.
+    """
+
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": False,
@@ -693,17 +714,44 @@ class Gemma3ForConditionalGeneration(Generator, SupportsMultiModal):
     def cache_path(self):
         return self.model_args[0].model_cache_path
 
-    def prefill_forward(self, *args, **kwargs):
-        return super().prefill_forward_text(**kwargs)
+    def _route_per_layer_page_tables(self, page_tables_per_layer):
+        """See :class:`GptOssForCausalLM._route_per_layer_page_tables`.
+
+        Localised attribute injection so the per-layer list reaches the
+        many ``ttnn_*_forward`` call sites in :class:`Generator` without
+        threading a feature-specific kwarg through every one of them.
+        """
+
+        class _Stash:
+            def __init__(self, models, value):
+                self._models = models
+                self._value = value
+
+            def __enter__(self):
+                if self._value is None:
+                    return
+                for m in self._models:
+                    m._active_page_tables_per_layer = self._value
+
+            def __exit__(self, *_):
+                if self._value is None:
+                    return
+                for m in self._models:
+                    if hasattr(m, "_active_page_tables_per_layer"):
+                        del m._active_page_tables_per_layer
+
+        return _Stash(self.model, page_tables_per_layer)
+
+    def prefill_forward(self, *args, page_tables_per_layer=None, **kwargs):
+        with self._route_per_layer_page_tables(page_tables_per_layer):
+            return super().prefill_forward_text(**kwargs)
+
+    def decode_forward(self, *args, page_tables_per_layer=None, **kwargs):
+        with self._route_per_layer_page_tables(page_tables_per_layer):
+            return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
-
-    def allocate_kv_cache_per_layer(self, per_layer_specs):
-        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
-
-    def decode_forward(self, *args, **kwargs):
-        return super().decode_forward(*args, **kwargs)
 
 
 class GptOssForCausalLM(HybridAttentionForCausalLM):

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -32,13 +32,30 @@ from models.tt_transformers.tt.model import Transformer
 from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs, TensorGroup
 
 
-def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, dp_model: List[Transformer], tt_cache_path):
+def allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model: List[Transformer], tt_cache_path):
+    """Allocate KV cache tensors with potentially different shape per layer.
+
+    Args:
+        per_layer_specs: list of ``(kv_cache_shape, dtype)`` tuples, one per
+            layer in model layer-index order. Hybrid attention models
+            (Gemma3/4, GPT-OSS) use this so sliding-window layers can be
+            backed by a smaller paged pool than full-attention layers; for
+            uniform-attention models all entries are identical.
+        dp_model: list of replicated TT model handles, one per data-parallel
+            submesh.
+        tt_cache_path: path used for on-disk weight cache file naming.
+
+    Returns:
+        ``list[submesh][layer_idx][k_or_v]`` of TT tensors.
+    """
     submesh_devices = [model.mesh_device for model in dp_model]
     kv_cache = []
     for mesh_idx, submesh in enumerate(submesh_devices):
-        cache_kv = torch.zeros(kv_cache_shape, dtype=dtype)
         kv_tt = []
-        for layer_num in tqdm(range(num_layers), desc=f"Allocating TT kv caches for each layer (submesh {mesh_idx+1})"):
+        for layer_num, (kv_cache_shape, dtype) in enumerate(
+            tqdm(per_layer_specs, desc=f"Allocating TT kv caches for each layer (submesh {mesh_idx+1})")
+        ):
+            cache_kv = torch.zeros(kv_cache_shape, dtype=dtype)
             # Get the dtype for the kv cache based on the configured optimizations in the model
             if dp_model[mesh_idx].args.optimizations is not None:
                 kv_cache_dtype = dp_model[mesh_idx].args.optimizations.get_tensor_dtype(
@@ -68,6 +85,20 @@ def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, dp_model: List[Tra
             kv_tt.append(kv_tt_i)
         kv_cache.append(kv_tt)
     return kv_cache
+
+
+def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, dp_model: List[Transformer], tt_cache_path):
+    """Legacy uniform-shape KV cache allocator.
+
+    Retained for backward compatibility with vLLM's pre-kv-cache-groups
+    contract; new callers should use :func:`allocate_vllm_kv_cache_per_layer`
+    which supports hybrid attention models.
+    """
+    return allocate_vllm_kv_cache_per_layer(
+        [(kv_cache_shape, dtype)] * num_layers,
+        dp_model=dp_model,
+        tt_cache_path=tt_cache_path,
+    )
 
 
 def initialize_vllm_text_transformer(
@@ -230,6 +261,9 @@ class Mistral3ForConditionalGeneration(Generator, SupportsMultiModal):
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
 
+    def allocate_kv_cache_per_layer(self, per_layer_specs):
+        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
+
 
 # Mllama is currently not supported in vLLM V1.
 # TODO: Remove or re-enable when Mllama is supported in vLLM V1.
@@ -333,6 +367,9 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
 
+    def allocate_kv_cache_per_layer(self, per_layer_specs):
+        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
+
 
 class LlamaForCausalLM(Generator):
     # Class-level capabilities
@@ -395,6 +432,9 @@ class LlamaForCausalLM(Generator):
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
 
+    def allocate_kv_cache_per_layer(self, per_layer_specs):
+        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
+
 
 class QwenForCausalLM(Generator):
     # Class-level capabilities
@@ -444,6 +484,9 @@ class QwenForCausalLM(Generator):
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
 
+    def allocate_kv_cache_per_layer(self, per_layer_specs):
+        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
+
 
 class MistralForCausalLM(Generator):
     # Class-level capabilities
@@ -492,6 +535,9 @@ class MistralForCausalLM(Generator):
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
+
+    def allocate_kv_cache_per_layer(self, per_layer_specs):
+        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
 
 
 @MULTIMODAL_REGISTRY.register_processor(
@@ -555,6 +601,9 @@ class Gemma3ForConditionalGeneration(Generator, SupportsMultiModal):
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
+
+    def allocate_kv_cache_per_layer(self, per_layer_specs):
+        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
 
     def decode_forward(self, *args, **kwargs):
         return super().decode_forward(*args, **kwargs)
@@ -631,3 +680,6 @@ class GptOssForCausalLM(Generator):
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
+
+    def allocate_kv_cache_per_layer(self, per_layer_specs):
+        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -101,32 +101,6 @@ def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, dp_model: List[Tra
     )
 
 
-def _check_per_group_kwargs(kwargs, model_name):
-    """Pop ``page_tables_per_group`` from kwargs and validate.
-
-    vLLM always passes ``page_tables_per_group`` (a list of per-kv-cache-group
-    block tables) on the prefill/decode forward call so hybrid attention
-    models can route per layer. Legacy uniform-attention models don't know
-    how to use the per-group form; until a model opts in to hybrid support
-    (overrides ``prefill_forward`` / ``decode_forward`` to consume the
-    list), the wrappers strip the kwarg before delegating to the underlying
-    text forward — but raise loudly if multiple groups are present, since
-    silently using only group 0 would corrupt KV state for the other groups.
-
-    Single-group inputs (``len == 1``) carry no information beyond the legacy
-    ``page_table`` arg and are safely dropped.
-    """
-    page_tables = kwargs.pop("page_tables_per_group", None)
-    if page_tables is not None and len(page_tables) > 1:
-        raise NotImplementedError(
-            f"{model_name} does not yet support per-group block tables for "
-            "hybrid attention models. Override prefill_forward / "
-            "decode_forward to consume `page_tables_per_group` (one block "
-            "table per kv_cache_group), or migrate the model to inherit "
-            "from HybridAttentionForCausalLM."
-        )
-
-
 class HybridAttentionForCausalLM(Generator):
     """vLLM wrapper base for hybrid attention models.
 
@@ -151,8 +125,9 @@ class HybridAttentionForCausalLM(Generator):
 
     Until a subclass overrides them, ``prefill_forward`` and
     ``decode_forward`` raise :class:`NotImplementedError` to make the
-    contract explicit; vLLM's runtime check (``_check_per_group_kwargs``)
-    only fires for legacy models that haven't migrated to this base.
+    contract explicit. Legacy (non-hybrid) models never see the
+    ``page_tables_per_group`` kwarg — vLLM's plugin opts in via the
+    presence of ``get_kv_cache_spec`` on the model class.
     """
 
     @classmethod
@@ -361,7 +336,6 @@ class Mistral3ForConditionalGeneration(Generator, SupportsMultiModal):
         return self.model_args[0].model_cache_path
 
     def prefill_forward(self, *args, **kwargs):
-        _check_per_group_kwargs(kwargs, type(self).__name__)
         self.tokenizer = self.model_args[0].tokenizer
         pad_token_id = self.tokenizer.pad_token_id
 
@@ -391,14 +365,10 @@ class Mistral3ForConditionalGeneration(Generator, SupportsMultiModal):
         )
 
     def decode_forward(self, *args, **kwargs):
-        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
-
-    def allocate_kv_cache_per_layer(self, per_layer_specs):
-        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
 
 
 # Mllama is currently not supported in vLLM V1.
@@ -494,7 +464,6 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
         )
 
     def decode_forward(self, *args, **kwargs):
-        _check_per_group_kwargs(kwargs, type(self).__name__)
         logits = super().decode_forward_llama_vision(*args, **kwargs)
         if isinstance(logits, tuple):
             return logits[0]
@@ -503,9 +472,6 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
-
-    def allocate_kv_cache_per_layer(self, per_layer_specs):
-        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
 
 
 class LlamaForCausalLM(Generator):
@@ -561,18 +527,13 @@ class LlamaForCausalLM(Generator):
         return self.model_args[0].model_cache_path
 
     def prefill_forward(self, *args, **kwargs):
-        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
-
-    def allocate_kv_cache_per_layer(self, per_layer_specs):
-        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
 
 
 class QwenForCausalLM(Generator):
@@ -615,18 +576,13 @@ class QwenForCausalLM(Generator):
         return self.model_args[0].model_cache_path
 
     def prefill_forward(self, *args, **kwargs):
-        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
-
-    def allocate_kv_cache_per_layer(self, per_layer_specs):
-        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
 
 
 class MistralForCausalLM(Generator):
@@ -669,18 +625,13 @@ class MistralForCausalLM(Generator):
         return self.model_args[0].model_cache_path
 
     def prefill_forward(self, *args, **kwargs):
-        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
-
-    def allocate_kv_cache_per_layer(self, per_layer_specs):
-        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
 
 
 @MULTIMODAL_REGISTRY.register_processor(
@@ -740,7 +691,6 @@ class Gemma3ForConditionalGeneration(Generator, SupportsMultiModal):
         return self.model_args[0].model_cache_path
 
     def prefill_forward(self, *args, **kwargs):
-        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().prefill_forward_text(**kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
@@ -750,7 +700,6 @@ class Gemma3ForConditionalGeneration(Generator, SupportsMultiModal):
         return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
 
     def decode_forward(self, *args, **kwargs):
-        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().decode_forward(*args, **kwargs)
 
 
@@ -818,11 +767,9 @@ class GptOssForCausalLM(Generator):
         return self.model_args[0].weight_cache_path(ttnn.bfloat8_b)
 
     def prefill_forward(self, *args, **kwargs):
-        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -101,6 +101,31 @@ def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, dp_model: List[Tra
     )
 
 
+def _check_per_group_kwargs(kwargs, model_name):
+    """Pop ``page_tables_per_group`` from kwargs and validate.
+
+    vLLM always passes ``page_tables_per_group`` (a list of per-kv-cache-group
+    block tables) on the prefill/decode forward call so hybrid attention
+    models can route per layer. Legacy uniform-attention models don't know
+    how to use the per-group form; until a model opts in to hybrid support
+    (overrides ``prefill_forward`` / ``decode_forward`` to consume the
+    list), the wrappers strip the kwarg before delegating to the underlying
+    text forward — but raise loudly if multiple groups are present, since
+    silently using only group 0 would corrupt KV state for the other groups.
+
+    Single-group inputs (``len == 1``) carry no information beyond the legacy
+    ``page_table`` arg and are safely dropped.
+    """
+    page_tables = kwargs.pop("page_tables_per_group", None)
+    if page_tables is not None and len(page_tables) > 1:
+        raise NotImplementedError(
+            f"{model_name} does not yet support per-group block tables for "
+            "hybrid attention models. Override prefill_forward / "
+            "decode_forward to consume `page_tables_per_group` (one block "
+            "table per kv_cache_group)."
+        )
+
+
 def initialize_vllm_text_transformer(
     hf_config,
     tt_data_parallel,
@@ -227,6 +252,7 @@ class Mistral3ForConditionalGeneration(Generator, SupportsMultiModal):
         return self.model_args[0].model_cache_path
 
     def prefill_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         self.tokenizer = self.model_args[0].tokenizer
         pad_token_id = self.tokenizer.pad_token_id
 
@@ -256,6 +282,7 @@ class Mistral3ForConditionalGeneration(Generator, SupportsMultiModal):
         )
 
     def decode_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
@@ -358,6 +385,7 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
         )
 
     def decode_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         logits = super().decode_forward_llama_vision(*args, **kwargs)
         if isinstance(logits, tuple):
             return logits[0]
@@ -424,9 +452,11 @@ class LlamaForCausalLM(Generator):
         return self.model_args[0].model_cache_path
 
     def prefill_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
@@ -476,9 +506,11 @@ class QwenForCausalLM(Generator):
         return self.model_args[0].model_cache_path
 
     def prefill_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
@@ -528,9 +560,11 @@ class MistralForCausalLM(Generator):
         return self.model_args[0].model_cache_path
 
     def prefill_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
@@ -597,6 +631,7 @@ class Gemma3ForConditionalGeneration(Generator, SupportsMultiModal):
         return self.model_args[0].model_cache_path
 
     def prefill_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().prefill_forward_text(**kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
@@ -606,6 +641,7 @@ class Gemma3ForConditionalGeneration(Generator, SupportsMultiModal):
         return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
 
     def decode_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().decode_forward(*args, **kwargs)
 
 
@@ -673,9 +709,11 @@ class GptOssForCausalLM(Generator):
         return self.model_args[0].weight_cache_path(ttnn.bfloat8_b)
 
     def prefill_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -88,11 +88,11 @@ def allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model: List[Transformer
 
 
 def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, dp_model: List[Transformer], tt_cache_path):
-    """Legacy uniform-shape KV cache allocator.
+    """Uniform-shape KV cache allocator for non-hybrid models.
 
-    Retained for backward compatibility with vLLM's pre-kv-cache-groups
-    contract; new callers should use :func:`allocate_vllm_kv_cache_per_layer`
-    which supports hybrid attention models.
+    Hybrid attention models should use :func:`allocate_vllm_kv_cache_per_layer`,
+    which takes a per-layer ``(shape, dtype)`` list so sliding-window layers
+    can be backed by a smaller paged pool than full-attention layers.
     """
     return allocate_vllm_kv_cache_per_layer(
         [(kv_cache_shape, dtype)] * num_layers,

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -122,8 +122,117 @@ def _check_per_group_kwargs(kwargs, model_name):
             f"{model_name} does not yet support per-group block tables for "
             "hybrid attention models. Override prefill_forward / "
             "decode_forward to consume `page_tables_per_group` (one block "
-            "table per kv_cache_group)."
+            "table per kv_cache_group), or migrate the model to inherit "
+            "from HybridAttentionForCausalLM."
         )
+
+
+class HybridAttentionForCausalLM(Generator):
+    """vLLM wrapper base for hybrid attention models.
+
+    Models with mixed sliding-window + full-attention layers (Gemma3,
+    Gemma4, GPT-OSS, ...) inherit from this class instead of plain
+    :class:`Generator` so they can opt in to upstream's hybrid kv cache
+    manager. The shared ``get_kv_cache_spec`` classmethod here builds
+    the per-layer KV cache spec from ``hf_config.text_config.layer_types``
+    — the standard HF convention used by all of these models — emitting
+    ``SlidingWindowSpec`` for sliding layers and ``FullAttentionSpec``
+    for full-attention layers.
+
+    Subclasses are responsible for the model-specific pieces:
+
+    * ``initialize_vllm_model``: load the underlying TT model.
+    * ``prefill_forward`` / ``decode_forward``: consume the
+      ``page_tables_per_group`` list (one per kv_cache_group, in upstream's
+      group order) and route per layer to the right group's page table.
+      The underlying TT model must accept this routing.
+    * ``allocate_kv_cache_per_layer``: typically just delegates to
+      :func:`allocate_vllm_kv_cache_per_layer` with the model handles.
+
+    Until a subclass overrides them, ``prefill_forward`` and
+    ``decode_forward`` raise :class:`NotImplementedError` to make the
+    contract explicit; vLLM's runtime check (``_check_per_group_kwargs``)
+    only fires for legacy models that haven't migrated to this base.
+    """
+
+    @classmethod
+    def get_kv_cache_spec(cls, vllm_config):
+        """Build per-layer KVCacheSpec from HF config ``layer_types``.
+
+        Returns a dict keyed by ``model.layers.<idx>.self_attn`` (the
+        upstream attention-layer naming convention vLLM's KVCacheGroup
+        machinery understands) so :func:`_parse_layer_index` on the
+        runner side can map each spec back to its model layer index.
+        """
+        from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
+        from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
+
+        model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
+
+        hf_config = model_config.hf_config
+        text_config = getattr(hf_config, "text_config", hf_config)
+        layer_types = getattr(text_config, "layer_types", None)
+        if layer_types is None:
+            raise ValueError(
+                f"{cls.__name__}.get_kv_cache_spec requires "
+                "hf_config.text_config.layer_types (one of 'full_attention' / "
+                "'sliding_attention' per layer); none found on this model"
+            )
+
+        sliding_window = getattr(text_config, "sliding_window", None)
+        num_kv_heads = model_config.get_num_kv_heads(vllm_config.parallel_config)
+        head_size = model_config.get_head_size()
+        dtype = (
+            model_config.dtype
+            if cache_config.cache_dtype == "auto"
+            else STR_DTYPE_TO_TORCH_DTYPE[cache_config.cache_dtype]
+        )
+        block_size = cache_config.block_size
+
+        common = dict(
+            block_size=block_size,
+            num_kv_heads=num_kv_heads,
+            head_size=head_size,
+            dtype=dtype,
+        )
+
+        spec_per_layer = {}
+        for i, lt in enumerate(layer_types):
+            name = f"model.layers.{i}.self_attn"
+            if lt == "sliding_attention":
+                if sliding_window is None:
+                    raise ValueError(
+                        f"layer_types[{i}] is 'sliding_attention' but "
+                        f"hf_config.sliding_window is None on {cls.__name__}"
+                    )
+                spec_per_layer[name] = SlidingWindowSpec(**common, sliding_window=sliding_window)
+            elif lt == "full_attention":
+                spec_per_layer[name] = FullAttentionSpec(**common)
+            else:
+                raise ValueError(
+                    f"Unsupported layer_type {lt!r} at layer {i} on "
+                    f"{cls.__name__}; expected 'full_attention' or "
+                    "'sliding_attention'"
+                )
+        return spec_per_layer
+
+    def prefill_forward(self, *args, **kwargs):
+        raise NotImplementedError(
+            f"{type(self).__name__} must override prefill_forward to consume "
+            "`page_tables_per_group` and route per layer to the right "
+            "kv_cache_group's page table."
+        )
+
+    def decode_forward(self, *args, **kwargs):
+        raise NotImplementedError(
+            f"{type(self).__name__} must override decode_forward to consume "
+            "`page_tables_per_group` and route per layer to the right "
+            "kv_cache_group's page table."
+        )
+
+    def allocate_kv_cache_per_layer(self, per_layer_specs):
+        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
 
 
 def initialize_vllm_text_transformer(

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -117,16 +117,19 @@ class HybridAttentionForCausalLM(Generator):
 
     * ``initialize_vllm_model``: load the underlying TT model.
     * ``prefill_forward`` / ``decode_forward``: consume the
-      ``page_tables_per_group`` list (one per kv_cache_group, in upstream's
-      group order) and route per layer to the right group's page table.
-      The underlying TT model must accept this routing.
+      ``page_tables_per_layer`` list (one tensor per decoder layer, layer-
+      aligned with the model's ``self.layers``) and pass each entry to its
+      corresponding attention layer. The plugin pre-expands
+      ``block_tables_per_group`` into this per-layer view at submission
+      time so bridges don't have to re-derive vLLM's group construction
+      order — see ``TTModelRunner._block_tables_per_layer``.
     * ``allocate_kv_cache_per_layer``: typically just delegates to
       :func:`allocate_vllm_kv_cache_per_layer` with the model handles.
 
     Until a subclass overrides them, ``prefill_forward`` and
     ``decode_forward`` raise :class:`NotImplementedError` to make the
     contract explicit. Legacy (non-hybrid) models never see the
-    ``page_tables_per_group`` kwarg — vLLM's plugin opts in via the
+    ``page_tables_per_layer`` kwarg — vLLM's plugin opts in via the
     presence of ``get_kv_cache_spec`` on the model class.
     """
 
@@ -195,15 +198,15 @@ class HybridAttentionForCausalLM(Generator):
     def prefill_forward(self, *args, **kwargs):
         raise NotImplementedError(
             f"{type(self).__name__} must override prefill_forward to consume "
-            "`page_tables_per_group` and route per layer to the right "
-            "kv_cache_group's page table."
+            "`page_tables_per_layer` and pass each entry to the matching "
+            "attention layer."
         )
 
     def decode_forward(self, *args, **kwargs):
         raise NotImplementedError(
             f"{type(self).__name__} must override decode_forward to consume "
-            "`page_tables_per_group` and route per layer to the right "
-            "kv_cache_group's page table."
+            "`page_tables_per_layer` and pass each entry to the matching "
+            "attention layer."
         )
 
     def allocate_kv_cache_per_layer(self, per_layer_specs):
@@ -703,8 +706,25 @@ class Gemma3ForConditionalGeneration(Generator, SupportsMultiModal):
         return super().decode_forward(*args, **kwargs)
 
 
-class GptOssForCausalLM(Generator):
-    """GPT-OSS model for vLLM integration"""
+class GptOssForCausalLM(HybridAttentionForCausalLM):
+    """GPT-OSS model for vLLM integration.
+
+    GPT-OSS is a hybrid attention model — its layers alternate between
+    full attention and sliding-window attention per ``hf_config.layer_types``.
+    Inheriting from :class:`HybridAttentionForCausalLM` opts into vLLM's
+    hybrid kv cache manager so sliding-window layers can index a smaller
+    paged pool than full-attention layers, recovering the asymmetric-hybrid
+    memory waste described in vLLM's hybrid kv cache manager design.
+
+    The bridge accepts ``page_tables_per_layer`` from the plugin (one tensor
+    per decoder layer, layer-aligned with the underlying TT model's
+    ``self.layers``) and stashes it on each TT model handle as
+    ``_active_page_tables_per_layer`` so the model's ``ttnn_prefill_forward``
+    / ``ttnn_decode_forward`` pick it up without us having to thread the
+    kwarg through every call site in :class:`Generator`. The attribute is
+    cleared on the way out so a subsequent legacy single-page-table call
+    isn't accidentally affected.
+    """
 
     # Class-level capabilities
     model_capabilities = {
@@ -714,6 +734,48 @@ class GptOssForCausalLM(Generator):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    def _route_per_layer_page_tables(self, page_tables_per_layer):
+        """Context-manager-style helper: stash the per-layer list on each TT
+        model in ``self.model`` for the duration of a forward call.
+
+        ``Generator``'s prefill/decode paths invoke
+        ``model[i].ttnn_prefill_forward`` / ``ttnn_decode_forward`` from many
+        sites (warmup, trace capture, traced replay, etc.) without forwarding
+        an arbitrary kwarg. Threading ``page_tables_per_layer`` through every
+        site would be a wide change for a feature only this hybrid bridge
+        consumes, so we use a localised attribute injection instead: the
+        models read ``getattr(self, "_active_page_tables_per_layer", None)``
+        when their own kwarg is None.
+        """
+
+        class _Stash:
+            def __init__(self, models, value):
+                self._models = models
+                self._value = value
+
+            def __enter__(self):
+                if self._value is None:
+                    return
+                for m in self._models:
+                    m._active_page_tables_per_layer = self._value
+
+            def __exit__(self, *_):
+                if self._value is None:
+                    return
+                for m in self._models:
+                    if hasattr(m, "_active_page_tables_per_layer"):
+                        del m._active_page_tables_per_layer
+
+        return _Stash(self.model, page_tables_per_layer)
+
+    def prefill_forward(self, *args, page_tables_per_layer=None, **kwargs):
+        with self._route_per_layer_page_tables(page_tables_per_layer):
+            return super().prefill_forward_text(*args, **kwargs)
+
+    def decode_forward(self, *args, page_tables_per_layer=None, **kwargs):
+        with self._route_per_layer_page_tables(page_tables_per_layer):
+            return super().decode_forward(*args, **kwargs)
 
     @classmethod
     def initialize_vllm_model(
@@ -766,14 +828,8 @@ class GptOssForCausalLM(Generator):
     def cache_path(self):
         return self.model_args[0].weight_cache_path(ttnn.bfloat8_b)
 
-    def prefill_forward(self, *args, **kwargs):
-        return super().prefill_forward_text(*args, **kwargs)
-
-    def decode_forward(self, *args, **kwargs):
-        return super().decode_forward(*args, **kwargs)
-
+    # prefill_forward / decode_forward are defined above with the
+    # per-layer page-table stash; allocate_kv_cache_per_layer is inherited
+    # from HybridAttentionForCausalLM.
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
-
-    def allocate_kv_cache_per_layer(self, per_layer_specs):
-        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -610,32 +610,78 @@ class Transformer(LightweightModule):
         )
 
     def _page_tables_to_ttnn(self, page_tables_per_layer):
-        """Convert a per-layer list of ``torch.Tensor`` page tables to ttnn
-        tensors on this model's mesh, mirroring the single-``page_table``
-        conversion in :meth:`prepare_prefill_inputs_host`. The plugin passes
-        the per-layer list as torch tensors because the routing kwarg is
-        opaque to ``Generator``'s pre-existing host→device conversion paths;
-        do the conversion here so attention layers always see ttnn tensors.
-        Already-ttnn entries pass through unchanged so callers that did the
-        conversion themselves aren't double-converted.
+        """Resolve a per-layer list of ``torch.Tensor`` page tables to a
+        list of *persistent* ttnn device tensors (allocate-only).
+
+        Tracing bakes each input tensor's device address into the captured
+        graph; replaying the trace reads from those exact addresses
+        regardless of any new ttnn objects created on the Python side.
+        Allocating fresh device tensors on every call would therefore
+        make traced inference read stale memory at the original
+        addresses, so we lazily allocate one persistent device tensor per
+        layer on first use and *only* update contents from outside the
+        traced ``ttnn_*_forward`` calls (writes are forbidden during trace
+        capture). The hybrid bridge calls
+        :meth:`update_persistent_per_layer_page_tables` *before* invoking
+        ``Generator``'s decode/prefill which executes traces — that's
+        where content updates happen.
+
+        First call (warmup compile) populates the persistent buffers from
+        the input torch tensors; subsequent calls return the existing
+        buffers unchanged. ``None`` entries propagate; already-ttnn
+        entries pass through.
         """
         if page_tables_per_layer is None:
             return None
-        converted = []
-        for pt in page_tables_per_layer:
-            if pt is None or isinstance(pt, ttnn.Tensor):
-                converted.append(pt)
-                continue
-            converted.append(
-                ttnn.from_torch(
-                    pt,
-                    device=self.mesh_device,
-                    dtype=ttnn.int32,
-                    layout=ttnn.ROW_MAJOR_LAYOUT,
-                    mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        persistent = getattr(self, "_persistent_per_layer_page_tables", None)
+        n = len(page_tables_per_layer)
+        if persistent is None or len(persistent) != n:
+            persistent = []
+            for pt in page_tables_per_layer:
+                if pt is None:
+                    persistent.append(None)
+                    continue
+                if isinstance(pt, ttnn.Tensor):
+                    persistent.append(pt)
+                    continue
+                persistent.append(
+                    ttnn.from_torch(
+                        pt,
+                        device=self.mesh_device,
+                        dtype=ttnn.int32,
+                        layout=ttnn.ROW_MAJOR_LAYOUT,
+                        mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                    )
                 )
+            self._persistent_per_layer_page_tables = persistent
+        return persistent
+
+    def update_persistent_per_layer_page_tables(self, page_tables_per_layer):
+        """Update content of persistent per-layer page_table device
+        tensors in place. Called by the hybrid bridge *before* invoking
+        ``Generator``'s decode/prefill so traced replay observes the new
+        block IDs at the captured addresses. Must be called outside trace
+        capture (writes forbidden inside).
+
+        No-op if persistent tensors haven't been allocated yet (first
+        call goes through :meth:`_page_tables_to_ttnn`'s allocation).
+        """
+        if page_tables_per_layer is None:
+            return
+        persistent = getattr(self, "_persistent_per_layer_page_tables", None)
+        if persistent is None or len(persistent) != len(page_tables_per_layer):
+            return
+        for i, pt in enumerate(page_tables_per_layer):
+            if pt is None or persistent[i] is None or isinstance(pt, ttnn.Tensor):
+                continue
+            host_pt = ttnn.from_torch(
+                pt,
+                device=None,
+                dtype=ttnn.int32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
             )
-        return converted
+            ttnn.copy_host_to_device_tensor(host_pt, persistent[i])
 
     def _increment_decode_positions_device(self, current_pos, rot_mat_idxs):
         ttnn.plus_one(current_pos, skip_negative_entries=True)

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -592,6 +592,7 @@ class Transformer(LightweightModule):
             # forward call rather than threading the kwarg through Generator's
             # many ttnn_prefill_forward call sites. Pick it up here when set.
             page_tables_per_layer = getattr(self, "_active_page_tables_per_layer", None)
+        page_tables_per_layer = self._page_tables_to_ttnn(page_tables_per_layer)
         return self.forward(
             x,
             current_pos=None,
@@ -607,6 +608,34 @@ class Transformer(LightweightModule):
             batch_size=batch_size,
             page_tables_per_layer=page_tables_per_layer,
         )
+
+    def _page_tables_to_ttnn(self, page_tables_per_layer):
+        """Convert a per-layer list of ``torch.Tensor`` page tables to ttnn
+        tensors on this model's mesh, mirroring the single-``page_table``
+        conversion in :meth:`prepare_prefill_inputs_host`. The plugin passes
+        the per-layer list as torch tensors because the routing kwarg is
+        opaque to ``Generator``'s pre-existing host→device conversion paths;
+        do the conversion here so attention layers always see ttnn tensors.
+        Already-ttnn entries pass through unchanged so callers that did the
+        conversion themselves aren't double-converted.
+        """
+        if page_tables_per_layer is None:
+            return None
+        converted = []
+        for pt in page_tables_per_layer:
+            if pt is None or isinstance(pt, ttnn.Tensor):
+                converted.append(pt)
+                continue
+            converted.append(
+                ttnn.from_torch(
+                    pt,
+                    device=self.mesh_device,
+                    dtype=ttnn.int32,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                )
+            )
+        return converted
 
     def _increment_decode_positions_device(self, current_pos, rot_mat_idxs):
         ttnn.plus_one(current_pos, skip_negative_entries=True)
@@ -636,6 +665,7 @@ class Transformer(LightweightModule):
             # See ttnn_prefill_forward: hybrid bridges stash the per-layer list
             # on the model when active, since Generator doesn't thread the kwarg.
             page_tables_per_layer = getattr(self, "_active_page_tables_per_layer", None)
+        page_tables_per_layer = self._page_tables_to_ttnn(page_tables_per_layer)
 
         tt_logits = self.forward(
             x_embed,

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -580,11 +580,18 @@ class Transformer(LightweightModule):
         get_last_token=-1,
         kv_cache=None,
         batch_size=1,
+        page_tables_per_layer=None,
     ):
         """
         This method will take device tensors and any other args to run forward.
         It returns ttnn device tensors.
         """
+        if page_tables_per_layer is None:
+            # vLLM hybrid bridges (HybridAttentionForCausalLM subclasses) stash
+            # the per-layer list on the model handle for the duration of a
+            # forward call rather than threading the kwarg through Generator's
+            # many ttnn_prefill_forward call sites. Pick it up here when set.
+            page_tables_per_layer = getattr(self, "_active_page_tables_per_layer", None)
         return self.forward(
             x,
             current_pos=None,
@@ -598,6 +605,7 @@ class Transformer(LightweightModule):
             get_last_token=get_last_token,
             kv_cache=kv_cache,
             batch_size=batch_size,
+            page_tables_per_layer=page_tables_per_layer,
         )
 
     def _increment_decode_positions_device(self, current_pos, rot_mat_idxs):
@@ -613,6 +621,7 @@ class Transformer(LightweightModule):
         kv_cache=None,
         sampling_on_device=False,
         capture_sampling_trace=False,
+        page_tables_per_layer=None,
     ):
         """
         This method will take device tensors and any other args to run forward.
@@ -623,6 +632,11 @@ class Transformer(LightweightModule):
 
         x_embed = self._transform_decode_inputs_device(x)
 
+        if page_tables_per_layer is None:
+            # See ttnn_prefill_forward: hybrid bridges stash the per-layer list
+            # on the model when active, since Generator doesn't thread the kwarg.
+            page_tables_per_layer = getattr(self, "_active_page_tables_per_layer", None)
+
         tt_logits = self.forward(
             x_embed,
             current_pos,
@@ -631,6 +645,7 @@ class Transformer(LightweightModule):
             mode=Mode.DECODE,
             page_table=page_table,
             kv_cache=kv_cache,
+            page_tables_per_layer=page_tables_per_layer,
         )
 
         if sampling_on_device and self.sampling is not None:
@@ -693,11 +708,18 @@ class Transformer(LightweightModule):
         get_last_token=-1,
         kv_cache=None,
         batch_size=1,
+        page_tables_per_layer=None,
     ):
         if mode == Mode.DECODE:
             # Run prefetcher if it is enabled
             if self.prefetcher is not None:
                 self.prefetcher.run()
+
+        if page_tables_per_layer is not None and len(page_tables_per_layer) != len(self.layers):
+            raise ValueError(
+                f"page_tables_per_layer has {len(page_tables_per_layer)} entries "
+                f"but model has {len(self.layers)} layers"
+            )
 
         for i, layer in enumerate(self.layers):
             # No-op if callers already provide the right memory config
@@ -714,6 +736,14 @@ class Transformer(LightweightModule):
             elif activation_dtype is not None and x.dtype != activation_dtype:
                 x = ttnn.typecast(x, activation_dtype)
 
+            # vLLM hybrid kv-cache-groups: each attention layer gets its own
+            # paged pool (sliding-window vs full-attention have different
+            # block counts). When ``page_tables_per_layer`` is None we fall
+            # back to broadcasting the single ``page_table`` to every layer
+            # — byte-equivalent to the pre-hybrid path used by every legacy
+            # caller (demos, unit tests, non-hybrid vLLM bridges).
+            layer_page_table = page_tables_per_layer[i] if page_tables_per_layer is not None else page_table
+
             x = layer(
                 x,
                 current_pos,
@@ -721,7 +751,7 @@ class Transformer(LightweightModule):
                 rot_mats_local=rot_mats_local,
                 user_id=user_id,
                 mode=mode,
-                page_table=page_table,
+                page_table=layer_page_table,
                 chunk_page_table=chunk_page_table,
                 chunk_start_idx=chunk_start_idx,
                 kv_cache=kv_cache[i] if kv_cache is not None else None,

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -609,6 +609,21 @@ class Transformer(LightweightModule):
             page_tables_per_layer=page_tables_per_layer,
         )
 
+    def _page_table_mesh_mapper(self, B):
+        """Mesh mapper for per-layer page tables, matching the layout that
+        :meth:`prepare_decode_inputs_host` uses for the legacy single
+        ``page_table`` kwarg: shard the batch dim across mesh axis 1 on
+        Galaxy when ``B>1``, replicate otherwise. The hybrid bridge
+        chunks the global page table per-DP before calling into a
+        submesh, so ``B`` here is the per-DP batch — same value the
+        legacy path sees on entry to ``prepare_decode_inputs_host``.
+        """
+        return ttnn.ShardTensor2dMesh(
+            self.mesh_device,
+            dims=(None, -2) if (self.args.is_galaxy and B > 1) else (None, None),
+            mesh_shape=self.args.cluster_shape,
+        )
+
     def _page_tables_to_ttnn(self, page_tables_per_layer):
         """Resolve a per-layer list of ``torch.Tensor`` page tables to a
         list of *persistent* ttnn device tensors (allocate-only).
@@ -650,7 +665,7 @@ class Transformer(LightweightModule):
                         device=self.mesh_device,
                         dtype=ttnn.int32,
                         layout=ttnn.ROW_MAJOR_LAYOUT,
-                        mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                        mesh_mapper=self._page_table_mesh_mapper(pt.shape[0]),
                     )
                 )
             self._persistent_per_layer_page_tables = persistent
@@ -679,7 +694,7 @@ class Transformer(LightweightModule):
                 device=None,
                 dtype=ttnn.int32,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
-                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                mesh_mapper=self._page_table_mesh_mapper(pt.shape[0]),
             )
             ttnn.copy_host_to_device_tensor(host_pt, persistent[i])
 


### PR DESCRIPTION
Companion to tenstorrent/vllm#381 (plus follow-up commits on the same
`handrews/kv-cache-groups` branch in vllm) — the tt-metal side of vLLM's
hybrid kv cache groups support, now plumbed end-to-end through every
hybrid attention model the TT backend ships: **Gemma3** (4B / 12B / 27B)
and **GPT-OSS**.

## Summary

### Scaffolding (`93866d090c0`, `f57ede66115`, `3c9813ba1aa`, `2740062312a`)

- `allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model, tt_cache_path)` — entry point that takes `(shape, dtype, tensor_idx)` triples per layer, so hybrid models can back sliding-window layers with a smaller paged pool than full-attention layers. Layers sharing a `tensor_idx` collapse onto one DRAM buffer (upstream HMA tensor-sharing). Legacy `allocate_vllm_kv_cache(shape, dtype, num_layers, ...)` is kept and now thin-wraps the per-layer entry point with a uniform spec list — byte-equivalent for current callers.
- `HybridAttentionForCausalLM` base class. Provides default `get_kv_cache_spec` building per-layer KVCacheSpecs from `hf_config.text_config.layer_types` (the standard HF convention shared by Gemma3 / Gemma4 / GPT-OSS), the per-layer allocator, and `prefill_forward` / `decode_forward` stubs.
- Shared per-DP page-table chunking + per-submesh routing helpers on the base class so each `model[i]` only sees its DP slice of every layer's page table.

### Hybrid models migrated

- **`GptOssForCausalLM`** (`967b6b9d43d`) inherits from `HybridAttentionForCausalLM`. `gpt_oss/tt/model.py` accepts `page_tables_per_layer` end-to-end (warmup, trace capture, traced replay) and routes layer `i` to its own page table.
- **`Gemma3ForConditionalGeneration`** (`67d3704126c`) likewise. `tt_transformers/tt/model.Transformer.forward` / `ttnn_prefill_forward` / `ttnn_decode_forward` accept `page_tables_per_layer` and propagate it to attention layers; `TtGemmaModel` inherits the change automatically.
- Bridges use a localised attribute stash (`_active_page_tables_per_layer`) on each TT submodel instead of threading the kwarg through `Generator`'s ~13 `ttnn_*_forward` call sites. The stash is cleared on `__exit__` so legacy single-`page_table` calls aren't affected.

### Correctness fixes surfaced during bringup

- **HMA tensor sharing** (`317efab877f`) — per-`tensor_idx` dedup in the per-layer allocator drops the on-DRAM buffer count from `num_layers` to `max(layers_per_group)`. Gemma3-4b on N150 fits 5 unique buffers instead of 34 (OOMed at layer 9). Cache filenames carry a `_t<idx>` suffix so independent buffers with the same shape can't collide on disk.
- **Prefill unblock** (`df889202ee0`) — six `if page_table:` truthy checks in `Attention.forward_prefill` switched to `is None` / `is not None` (raised "ambiguous boolean" once per-layer tensors arrived). Per-layer torch tensors are now converted to ttnn at the top of every `ttnn_*_forward` so `paged_fill_cache` doesn't reject them with a type error.
- **Trace-safe persistent buffers** (`f70d891074d`) — `Transformer._page_tables_to_ttnn` is allocate-only: lazily allocates one ttnn device tensor per layer on first use and returns the same buffers thereafter; `update_persistent_per_layer_page_tables` does host→device content updates from outside trace capture (writes inside capture are forbidden). Without this the trace specialised on the legacy fallback branch during warmup and per-layer updates were silently ignored at replay (Gemma3-4b N150 was producing multilingual garbage). The hybrid bridge broadcasts the warmup `page_table` across every layer so trace capture binds to the persistent buffers.
- **DP / Galaxy parity** (`7161fc5e09e`) — `HybridAttentionForCausalLM` chunks `page_tables_per_layer` along DP before stashing on each submesh, mirroring `Generator.decode_forward`'s `torch.chunk(page_table, self.data_parallel, 0)`. Inside each submesh the per-layer ttnn tensor is built with the same mesh mapper `prepare_decode_inputs_host` uses for the legacy kwarg: `ShardTensor2dMesh(dims=(None, -2))` on Galaxy when `B>1` for tt-transformers, `ShardTensor2dMesh(dims=(0, None))` when `users_row_sharded` for gpt-oss, replicate otherwise. This unblocked the gemma3-27B Galaxy DP=4 `paged_update_cache` batch-mismatch assertion.
- **Qwen3-VL forward override** (`77457b12f2f`) — `qwen3_vl/tt/model.py:Transformer` overrides `forward()` with VL-specific kwargs and didn't carry the new `page_tables_per_layer`, tripping `TypeError` in decode warmup once `ttnn_decode_forward` started passing it. Override now accepts the kwarg and routes per-layer the same way the parent does so behaviour stays aligned if the model is ever migrated to hybrid attention. (Other `Transformer` subclasses — `qwen25_vl`, `multimodal/gemma3/gemma_e2e_model`, `mistral_24b` — don't override `forward` and inherit unchanged.)

## Behavioural impact on non-hybrid models

Zero. Llama / Qwen / Mistral / Mistral3 / Mllama bridges remain plain `Generator` subclasses; with the runtime-side opt-in dispatch in vLLM (sends `page_tables_per_layer` only when the class exposes `get_kv_cache_spec`, calls `allocate_kv_cache_per_layer` only when present), they never see the new kwargs and never have the per-layer allocator called on them. DP=1 / non-Galaxy / non-row-sharded paths in the new mesh-mapper helpers fall back to a replicate-equivalent mapper, so previously-working hybrid configs are byte-identical too.

## Verification

- vLLM nightly run with full hybrid coverage (Gemma3 4B / 12B / 27B + GPT-OSS, including DP=4 on Galaxy): https://github.com/tenstorrent/tt-metal/actions/runs/25494325484 — re-launched after the qwen3_vl fix and the `[TEMP]` workflow revert (`1accfa17b6d`, restored `/mnt/MLPerf` to `:ro` once the cache had been repopulated by run 25491617440).
- All models tests: https://github.com/tenstorrent/tt-metal/actions/runs/25505562089

## Test plan

- [x] `pytest models/tt_transformers/tests/test_vllm_kv_cache.py` — per-layer allocator delegation, legacy/per-layer parity, HMA tensor sharing.
- [x] `pytest models/tt_transformers/tests/test_hybrid_attention_for_causal_lm.py` — spec generation across Gemma3 5:1, GPT-OSS 1:1, all-full uniform fallback, error paths.
- [ ] vLLM nightly linked above — Gemma3 (4B / 12B / 27B), GPT-OSS, and Qwen3-VL end-to-end serving including DP=4 on Galaxy. (Status: re-launched after the qwen3_vl fix landed.)
- [ ] Llama-3.1-8B vLLM offline-inference smoke as non-regression on legacy paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=handrews/kv-cache-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:handrews/kv-cache-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=handrews/kv-cache-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:handrews/kv-cache-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=handrews/kv-cache-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:handrews/kv-cache-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=handrews/kv-cache-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:handrews/kv-cache-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=handrews/kv-cache-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:handrews/kv-cache-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=handrews/kv-cache-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:handrews/kv-cache-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=handrews/kv-cache-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:handrews/kv-cache-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=handrews/kv-cache-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:handrews/kv-cache-groups)
