### PR TITLE
[vllm] Hybrid model migrations: Gemma4 + Transformer.forward routing primitive

### DIFF
--- a/models/demos/gemma4/tests/test_generator_vllm.py
+++ b/models/demos/gemma4/tests/test_generator_vllm.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``Gemma4ForCausalLM`` (vLLM wrapper).
+
+Tests the layer→group routing helper that maps Gemma4's 5:1
+sliding-window:full-attention layer pattern onto upstream's
+kv_cache_groups numbering. Real model loading + prefill/decode forward
+integration is a follow-up; this test pins the structural pieces.
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+# Stub ttnn so importing tt-metal modules doesn't blow up on the local
+# C++ extension.
+sys.modules.setdefault("ttnn", MagicMock(name="ttnn-test-mock"))
+sys.modules.setdefault("ttnn._ttnn", MagicMock(name="ttnn._ttnn-test-mock"))
+
+
+def _make_instance(layer_types):
+    """Build a Gemma4ForCausalLM bypassing __init__ for routing tests."""
+    from models.demos.gemma4.tt.generator_vllm import Gemma4ForCausalLM
+
+    instance = Gemma4ForCausalLM.__new__(Gemma4ForCausalLM)
+    text_config = SimpleNamespace(layer_types=layer_types, sliding_window=1024)
+    hf_config = SimpleNamespace(text_config=text_config)
+    instance.model_args = [hf_config]
+    return instance
+
+
+def test_layer_to_group_gemma4_31b_pattern():
+    """Gemma4-31B: 50 sliding + 10 full, 5:1 ratio → group_size = 10
+    via the min-rule. Expect 1 full group + 5 sliding groups = 6 groups."""
+    pattern = ["sliding_attention"] * 5 + ["full_attention"]
+    layers = pattern * 10  # 60 layers
+    instance = _make_instance(layers)
+
+    layer_to_group = instance._build_layer_to_group(num_groups=6)
+
+    assert len(layer_to_group) == 60
+    # All full-attention layers (indices 5, 11, 17, ...) land in one group.
+    full_indices = [i for i, lt in enumerate(layers) if lt == "full_attention"]
+    full_groups = {layer_to_group[i] for i in full_indices}
+    assert len(full_groups) == 1, "all 10 full-attn layers should share one group"
+    # Sliding layers land in 5 different groups (50 / 10 = 5).
+    sliding_indices = [i for i, lt in enumerate(layers) if lt == "sliding_attention"]
+    sliding_groups = {layer_to_group[i] for i in sliding_indices}
+    assert len(sliding_groups) == 5
+
+
+def test_layer_to_group_gpt_oss_alternating_pattern():
+    """GPT-OSS-style alternating 1:1 pattern: 12 sliding + 12 full.
+    Counts are equal so max_count < min_count * 1.25 fires, group_size = 12,
+    yielding 1 full group + 1 sliding group = 2 groups."""
+    layers = ["sliding_attention", "full_attention"] * 12
+    instance = _make_instance(layers)
+
+    layer_to_group = instance._build_layer_to_group(num_groups=2)
+
+    assert len(layer_to_group) == 24
+    sliding_indices = [i for i, lt in enumerate(layers) if lt == "sliding_attention"]
+    full_indices = [i for i, lt in enumerate(layers) if lt == "full_attention"]
+    assert len({layer_to_group[i] for i in sliding_indices}) == 1
+    assert len({layer_to_group[i] for i in full_indices}) == 1
+
+
+def test_layer_to_group_uniform_full_attention():
+    """All-full attention (no hybrid): one group, all layers → 0."""
+    layers = ["full_attention"] * 16
+    instance = _make_instance(layers)
+
+    layer_to_group = instance._build_layer_to_group(num_groups=1)
+
+    assert layer_to_group == [0] * 16
+
+
+def test_layer_to_group_count_mismatch_raises():
+    """If the wrapper-side grouping computes a different number of groups
+    than vLLM reports, fail loudly so the divergence is immediately
+    visible (rather than silently mis-routing layers)."""
+    pattern = ["sliding_attention"] * 5 + ["full_attention"]
+    layers = pattern * 10
+    instance = _make_instance(layers)
+
+    with pytest.raises(ValueError, match="out of sync"):
+        instance._build_layer_to_group(num_groups=99)
+
+
+def test_layer_to_group_missing_layer_types_raises():
+    instance = _make_instance([])
+
+    with pytest.raises(ValueError, match="layer_types"):
+        instance._build_layer_to_group(num_groups=1)
+
+
+def test_layer_to_group_caches_result():
+    """Helper caches the routing per (instance, num_groups); verify the
+    cache short-circuits the second call."""
+    pattern = ["sliding_attention"] * 5 + ["full_attention"]
+    layers = pattern * 10
+    instance = _make_instance(layers)
+
+    first = instance._build_layer_to_group(num_groups=6)
+    second = instance._build_layer_to_group(num_groups=6)
+
+    # Same object → cache hit (cheap to verify with `is`).
+    assert first is second

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+vLLM wrapper for Gemma4 with hybrid kv cache support.
+
+Gemma4 has a 5:1 sliding-window:full-attention layer pattern; routing
+each layer to its own kv_cache_group's page table is required to avoid
+the asymmetric-hybrid memory waste described in vLLM's hybrid kv cache
+manager design. ``Gemma4ForCausalLM`` registers as a vLLM model class
+and handles the runtime-side hybrid plumbing on top of the standalone
+Gemma4 model in ``models.demos.gemma4``.
+"""
+
+from collections import defaultdict
+
+from models.demos.gemma4.tt.common import create_tt_model
+from models.tt_transformers.tt.generator import create_submeshes
+from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+
+class Gemma4ForCausalLM(HybridAttentionForCausalLM):
+    """vLLM wrapper for the Gemma4 26B-A4B / 31B-it models.
+
+    Inherits ``get_kv_cache_spec`` from :class:`HybridAttentionForCausalLM`
+    (per-layer specs from ``hf_config.text_config.layer_types``) and the
+    default ``allocate_kv_cache_per_layer`` (delegates to
+    :func:`allocate_vllm_kv_cache_per_layer`).
+
+    ``prefill_forward`` and ``decode_forward`` are intentionally inherited
+    as :class:`NotImplementedError` stubs in this commit: full vLLM
+    serving for Gemma4 needs the standalone ``Gemma4Model``'s prefill /
+    decode pipeline to be wired into ``Generator``'s text forward path,
+    which is its own follow-up. The model-level routing
+    (``page_tables_per_group`` + ``layer_to_group`` plumbed through
+    ``Gemma4Model.__call__``) is in place and ready for that integration.
+
+    Includes :meth:`_build_layer_to_group`: a helper that mirrors
+    upstream's :func:`vllm.v1.core.kv_cache_utils._get_kv_cache_groups_
+    uniform_page_size` grouping logic so the wrapper can map each model
+    layer index back to its kv_cache_group when invoking
+    ``Gemma4Model``.
+    """
+
+    model_capabilities = {
+        "supports_prefix_caching": False,
+        "supports_async_decode": True,
+    }
+
+    @classmethod
+    def initialize_vllm_model(
+        cls,
+        hf_config,
+        mesh_device,
+        max_batch_size,
+        max_seq_len=131072,
+        n_layers=None,
+        tt_data_parallel=1,
+        optimizations: str | None = None,
+    ):
+        # Gemma4's standalone model handles its own optimizations; we
+        # ignore the vLLM-supplied ``optimizations`` arg here.
+        del optimizations
+        submesh_devices = create_submeshes(mesh_device, tt_data_parallel)
+
+        models = []
+        model_args_list = []
+        for submesh in submesh_devices:
+            model_args, model, _kv_cache, _state_dict = create_tt_model(
+                mesh_device=submesh,
+                max_batch_size=max_batch_size // tt_data_parallel,
+                max_seq_len=max_seq_len,
+                num_layers=n_layers,
+                # vLLM allocates the KV cache via allocate_kv_cache_per_layer
+                # after this returns; skip allocation here so we don't
+                # double-allocate buffers.
+                create_kv_cache=False,
+            )
+            models.append(model)
+            model_args_list.append(model_args)
+
+        return cls(models, model_args_list, mesh_device)
+
+    @property
+    def cache_path(self):
+        # Gemma4 model_args expose model_cache_path directly.
+        return self.model_args[0].model_cache_path
+
+    def _build_layer_to_group(self, num_groups):
+        """Map each model layer index → kv_cache_group index.
+
+        Mirrors upstream's grouping in
+        ``vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_page_size``:
+        group_size = min(per-type counts), with the larger type split
+        into multiple groups via ``layers[i::num_groups]`` (interleaved
+        so PP partitioning works). Cached on the instance.
+        """
+        cached = getattr(self, "_layer_to_group_cache", None)
+        if cached is not None and cached["num_groups"] == num_groups:
+            return cached["layer_to_group"]
+
+        hf_config = self.model_args[0]
+        text_config = getattr(hf_config, "text_config", hf_config)
+        layer_types = list(getattr(text_config, "layer_types", []))
+        if not layer_types:
+            raise ValueError(
+                "Gemma4ForCausalLM requires hf_config.text_config.layer_types "
+                "to build per-layer kv_cache_group routing"
+            )
+
+        same_type_layers: dict[str, list[int]] = defaultdict(list)
+        for i, lt in enumerate(layer_types):
+            same_type_layers[lt].append(i)
+
+        min_count = min(len(v) for v in same_type_layers.values())
+        max_count = max(len(v) for v in same_type_layers.values())
+        group_size = max_count if max_count < min_count * 1.25 else min_count
+
+        layer_to_group: list[int | None] = [None] * len(layer_types)
+        next_group_idx = 0
+        for indices in same_type_layers.values():
+            num_groups_for_type = -(-len(indices) // group_size)  # cdiv
+            for i in range(num_groups_for_type):
+                for layer_idx in indices[i::num_groups_for_type]:
+                    layer_to_group[layer_idx] = next_group_idx
+                next_group_idx += 1
+
+        if next_group_idx != num_groups:
+            raise ValueError(
+                f"Computed {next_group_idx} kv_cache_groups from layer_types "
+                f"but vLLM reported {num_groups}; the per-model grouping is "
+                "out of sync with upstream's kv_cache_utils. Update "
+                "_build_layer_to_group to match."
+            )
+
+        self._layer_to_group_cache = {
+            "num_groups": num_groups,
+            "layer_to_group": layer_to_group,
+        }
+        return layer_to_group

--- a/models/demos/gemma4/tt/model.py
+++ b/models/demos/gemma4/tt/model.py
@@ -398,6 +398,8 @@ class Gemma4Model:
         pli_device_tensors=None,
         position_idx_cache=None,
         pli_combined=None,
+        page_tables_per_group=None,
+        layer_to_group=None,
     ):
         """
         Forward pass through decoder layers + final norm + lm_head + softcapping.
@@ -406,7 +408,8 @@ class Gemma4Model:
             hidden_states: [1, 1, seq_len, hidden_size] on device (post-embedding)
             rope_mats: (cos, sin) override, or dict {layer_type: (cos, sin)} for pre-sliced decode
             position_idx: decode position tensor ([1,32] uint32 for embedding RoPE, or [1] int32 legacy)
-            page_table: paged attention table
+            page_table: paged attention table — used for every layer when
+                page_tables_per_group is None (legacy single-group / non-vLLM path).
             kv_caches: list of [k, v] per layer, or None (uses self.tt_kv_cache)
             is_decode: True for decode, False for prefill
             token_index: int for decode RoPE slicing (None when using embedding-based RoPE)
@@ -415,7 +418,22 @@ class Gemma4Model:
             pli_device_tensors: optional list of pre-computed PLI device tensors (trace mode)
             position_idx_cache: optional [batch] int32 tensor for KV cache update (when position_idx is uint32)
             pli_combined: optional [1,1,n_layers,pli_size] device tensor of pre-computed PLI (decode)
+            page_tables_per_group: optional list of per-kv-cache-group page tables
+                (one per group, in upstream's group order) used when serving via
+                vLLM's hybrid kv cache manager. When provided, layer i uses
+                ``page_tables_per_group[layer_to_group[i]]`` instead of the
+                single ``page_table`` arg, so sliding-window layers can index
+                into a smaller paged pool than full-attention layers.
+            layer_to_group: list[int] of length ``num_layers`` mapping each
+                model layer index to its kv_cache_group index. Required when
+                ``page_tables_per_group`` is provided.
         """
+        if page_tables_per_group is not None and layer_to_group is None:
+            raise ValueError("page_tables_per_group requires layer_to_group to route per " "layer to the right group")
+        if layer_to_group is not None and len(layer_to_group) != len(self.layers):
+            raise ValueError(
+                f"layer_to_group has {len(layer_to_group)} entries but model " f"has {len(self.layers)} layers"
+            )
         seq_len = hidden_states.shape[2]
         caches = kv_caches or self.tt_kv_cache
 
@@ -483,11 +501,20 @@ class Gemma4Model:
             elif not is_decode and i in kv_source_indices:
                 keep_kv = True
 
+            # Per-group page table routing for hybrid kv cache groups (vLLM
+            # path). Sliding-window layers may index into a smaller paged
+            # pool than full-attention layers, so each layer picks up its
+            # group's block table instead of a shared one.
+            if page_tables_per_group is not None:
+                layer_page_table = page_tables_per_group[layer_to_group[i]]
+            else:
+                layer_page_table = page_table
+
             hidden_states = layer(
                 hidden_states,
                 rope_mats=layer_rope,
                 position_idx=position_idx,
-                page_table=page_table,
+                page_table=layer_page_table,
                 kv_cache=kv_cache,
                 is_decode=is_decode,
                 token_index=token_index,
@@ -597,6 +624,8 @@ class Gemma4Model:
         batch_size=1,
         input_ids_torch=None,
         embeds_torch=None,
+        page_tables_per_group=None,
+        layer_to_group=None,
     ):
         """Prefill forward — matches tt_transformers Generator interface."""
         seq_len = x.shape[-2]
@@ -608,6 +637,8 @@ class Gemma4Model:
             is_decode=False,
             input_ids_torch=input_ids_torch,
             embeds_torch=embeds_torch,
+            page_tables_per_group=page_tables_per_group,
+            layer_to_group=layer_to_group,
         )
 
         # Extract last token tile for next-token prediction
@@ -695,6 +726,8 @@ class Gemma4Model:
         kv_cache=None,
         sampling_on_device=False,
         capture_sampling_trace=False,
+        page_tables_per_group=None,
+        layer_to_group=None,
     ):
         """Decode forward — matches tt_transformers Generator interface.
 
@@ -732,6 +765,8 @@ class Gemma4Model:
             token_index=token_index,
             position_idx_cache=position_idx_cache,
             pli_combined=ttnn.to_layout(precomputed_pli, ttnn.TILE_LAYOUT) if precomputed_pli is not None else None,
+            page_tables_per_group=page_tables_per_group,
+            layer_to_group=layer_to_group,
         )
 
         # On-device sampling

--- a/models/tt_transformers/tests/test_hybrid_attention_for_causal_lm.py
+++ b/models/tt_transformers/tests/test_hybrid_attention_for_causal_lm.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``HybridAttentionForCausalLM``.
+
+The class is the vLLM wrapper base for hybrid attention models (Gemma3,
+Gemma4, GPT-OSS, ...). The bulk of its responsibility is the
+``get_kv_cache_spec`` classmethod that translates ``layer_types`` from
+HF config into per-layer KVCacheSpecs that upstream's hybrid kv cache
+manager groups by attention type. This test pins that translation
+across the typical patterns we'll see on real models.
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+# Stub ttnn so importing generator_vllm doesn't blow up on the local
+# tt-metal C++ extension. We don't exercise any real ttnn behaviour here.
+sys.modules.setdefault("ttnn", MagicMock(name="ttnn-test-mock"))
+sys.modules.setdefault("ttnn._ttnn", MagicMock(name="ttnn._ttnn-test-mock"))
+
+
+def _make_vllm_config(layer_types, sliding_window=1024, num_kv_heads=8, head_size=128):
+    text_config = SimpleNamespace(layer_types=layer_types, sliding_window=sliding_window)
+    hf_config = SimpleNamespace(text_config=text_config)
+    cfg = MagicMock()
+    cfg.model_config.hf_config = hf_config
+    cfg.model_config.dtype = torch.bfloat16
+    cfg.model_config.get_num_kv_heads.return_value = num_kv_heads
+    cfg.model_config.get_head_size.return_value = head_size
+    cfg.cache_config.cache_dtype = "auto"
+    cfg.cache_config.block_size = 64
+    return cfg
+
+
+def test_spec_emits_one_entry_per_layer():
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
+
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+    layers = ["sliding_attention"] * 5 + ["full_attention"] + ["sliding_attention"] * 5
+    spec = HybridAttentionForCausalLM.get_kv_cache_spec(_make_vllm_config(layers))
+
+    assert len(spec) == len(layers)
+    for i, expected_type in enumerate(layers):
+        name = f"model.layers.{i}.self_attn"
+        assert name in spec
+        if expected_type == "sliding_attention":
+            assert isinstance(spec[name], SlidingWindowSpec)
+            assert spec[name].sliding_window == 1024
+        else:
+            assert isinstance(spec[name], FullAttentionSpec)
+
+
+def test_spec_gemma3_27b_pattern():
+    """Gemma3-27b: 5 sliding then 1 full, 10x → 50 sliding + 10 full + ...
+    (its actual config is 52 sliding + 10 full but the structure is the
+    same; just verify the per-layer outputs flow without errors)."""
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
+
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+    pattern = ["sliding_attention"] * 5 + ["full_attention"]
+    layers = pattern * 10  # 60 layers
+    spec = HybridAttentionForCausalLM.get_kv_cache_spec(_make_vllm_config(layers))
+
+    full_count = sum(isinstance(v, FullAttentionSpec) for v in spec.values())
+    sliding_count = sum(isinstance(v, SlidingWindowSpec) for v in spec.values())
+    assert full_count == 10
+    assert sliding_count == 50
+
+
+def test_spec_gpt_oss_alternating_pattern():
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
+
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+    layers = ["sliding_attention", "full_attention"] * 12  # 24 layers
+    spec = HybridAttentionForCausalLM.get_kv_cache_spec(_make_vllm_config(layers))
+
+    full_count = sum(isinstance(v, FullAttentionSpec) for v in spec.values())
+    sliding_count = sum(isinstance(v, SlidingWindowSpec) for v in spec.values())
+    assert full_count == 12
+    assert sliding_count == 12
+
+
+def test_spec_uniform_full_attention_still_works():
+    """All-full layer_types → single-type config; spec generation still
+    succeeds (upstream's grouping later detects uniform-spec and uses
+    the simpler single-group path)."""
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
+
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+    spec = HybridAttentionForCausalLM.get_kv_cache_spec(_make_vllm_config(["full_attention"] * 4))
+    assert all(isinstance(v, FullAttentionSpec) for v in spec.values())
+    assert not any(isinstance(v, SlidingWindowSpec) for v in spec.values())
+
+
+def test_spec_propagates_kv_heads_and_head_size():
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+    spec = HybridAttentionForCausalLM.get_kv_cache_spec(
+        _make_vllm_config(["full_attention", "sliding_attention"], num_kv_heads=4, head_size=256)
+    )
+
+    for layer_spec in spec.values():
+        assert layer_spec.num_kv_heads == 4
+        assert layer_spec.head_size == 256
+        assert layer_spec.block_size == 64
+        assert layer_spec.dtype == torch.bfloat16
+
+
+def test_spec_missing_layer_types_raises():
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+    cfg = _make_vllm_config(["full_attention"])
+    cfg.model_config.hf_config.text_config.layer_types = None
+
+    with pytest.raises(ValueError, match="layer_types"):
+        HybridAttentionForCausalLM.get_kv_cache_spec(cfg)
+
+
+def test_spec_sliding_layer_without_window_raises():
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+    cfg = _make_vllm_config(["sliding_attention"], sliding_window=None)
+
+    with pytest.raises(ValueError, match="sliding_window is None"):
+        HybridAttentionForCausalLM.get_kv_cache_spec(cfg)
+
+
+def test_spec_unknown_layer_type_raises():
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+    cfg = _make_vllm_config(["full_attention", "rotary_chunked_xyz"])
+
+    with pytest.raises(ValueError, match="Unsupported layer_type"):
+        HybridAttentionForCausalLM.get_kv_cache_spec(cfg)
+
+
+def test_subclass_must_override_prefill_and_decode():
+    """The base class's prefill_forward / decode_forward are explicit
+    NotImplementedError stubs — subclasses must provide model-specific
+    routing that consumes ``page_tables_per_group``."""
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
+
+    instance = HybridAttentionForCausalLM.__new__(HybridAttentionForCausalLM)
+
+    with pytest.raises(NotImplementedError, match="prefill_forward"):
+        instance.prefill_forward()
+    with pytest.raises(NotImplementedError, match="decode_forward"):
+        instance.decode_forward()

--- a/models/tt_transformers/tests/test_hybrid_attention_for_causal_lm.py
+++ b/models/tt_transformers/tests/test_hybrid_attention_for_causal_lm.py
@@ -142,6 +142,35 @@ def test_spec_unknown_layer_type_raises():
         HybridAttentionForCausalLM.get_kv_cache_spec(cfg)
 
 
+def test_hybrid_generator_routing_state_lifecycle():
+    """``HybridGenerator`` holds per-call routing state (page tables per
+    group + layer→group mapping) on the instance for the duration of a
+    forward call. Verifies set/clear/predicate work."""
+    from models.tt_transformers.tt.generator_vllm import HybridGenerator
+
+    instance = HybridGenerator.__new__(HybridGenerator)
+    instance._hybrid_page_tables_per_group = None
+    instance._hybrid_layer_to_group = None
+
+    assert instance.hybrid_routing_active is False
+
+    instance.set_hybrid_routing(["t0", "t1"], [0, 1])
+    assert instance.hybrid_routing_active is True
+    assert instance._hybrid_page_tables_per_group == ["t0", "t1"]
+    assert instance._hybrid_layer_to_group == [0, 1]
+
+    instance.clear_hybrid_routing()
+    assert instance.hybrid_routing_active is False
+
+
+def test_hybrid_attention_for_causal_lm_inherits_from_hybrid_generator():
+    """The vLLM wrapper base inherits from HybridGenerator so it picks up
+    the per-call routing state machinery alongside the spec hook."""
+    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM, HybridGenerator
+
+    assert issubclass(HybridAttentionForCausalLM, HybridGenerator)
+
+
 def test_subclass_must_override_prefill_and_decode():
     """The base class's prefill_forward / decode_forward are explicit
     NotImplementedError stubs — subclasses must provide model-specific

--- a/models/tt_transformers/tests/test_vllm_kv_cache.py
+++ b/models/tt_transformers/tests/test_vllm_kv_cache.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the vLLM-side KV cache allocator helpers in
+``generator_vllm.py``.
+
+Verifies the new per-layer entry point (``allocate_vllm_kv_cache_per_layer``)
+and that the legacy uniform-shape entry point (``allocate_vllm_kv_cache``)
+still delegates to it bit-for-bit.
+
+Real ttnn allocation requires a mesh device, so this test mocks
+``ttnn.as_tensor`` / ``ttnn.ReplicateTensorToMesh`` and the ``dp_model``
+handles. We verify call structure and shape routing, not the resulting
+tensor contents.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+
+@pytest.fixture
+def dp_model():
+    """One submesh handle whose optimizations return None (so the allocator
+    falls back to the bfloat8_b default — keeps the test independent of
+    the model's optimization config table)."""
+    submesh = MagicMock()
+    args = MagicMock()
+    args.optimizations = None  # Force the bfloat8_b fallback path.
+    model = MagicMock()
+    model.mesh_device = submesh
+    model.args = args
+    return [model]
+
+
+def _make_ttnn_mock():
+    ttnn_mock = MagicMock()
+    ttnn_mock.as_tensor.side_effect = lambda *a, **kw: ("tt-tensor", kw.get("dtype"), kw.get("cache_file_name"))
+    ttnn_mock.bfloat8_b = "bfloat8_b-sentinel"
+    ttnn_mock.bfloat16 = "bfloat16-sentinel"
+    return ttnn_mock
+
+
+def test_per_layer_allocates_one_kv_pair_per_spec(dp_model):
+    from models.tt_transformers.tt import generator_vllm
+
+    per_layer = [
+        ((4, 2, 32, 64), torch.bfloat16),  # layer 0
+        ((4, 1, 32, 64), torch.bfloat16),  # layer 1 (smaller — sliding)
+        ((4, 2, 32, 64), torch.bfloat16),  # layer 2
+    ]
+
+    with patch.object(generator_vllm, "ttnn", new=_make_ttnn_mock()) as ttnn_mock:
+        kv_cache = generator_vllm.allocate_vllm_kv_cache_per_layer(
+            per_layer, dp_model=dp_model, tt_cache_path=Path("/tmp/tt-test-cache")
+        )
+
+    # One submesh, three layers, two tensors per layer (k, v) = 6 calls.
+    assert ttnn_mock.as_tensor.call_count == 6
+    assert len(kv_cache) == 1  # one submesh
+    assert len(kv_cache[0]) == 3  # three layers
+    assert all(len(layer) == 2 for layer in kv_cache[0])  # k, v
+
+
+def test_per_layer_passes_each_shape_to_cache_filename(dp_model):
+    """The cache filename is keyed on the per-layer shape; verify a layer
+    with a smaller shape gets a different cache file from a larger one."""
+    from models.tt_transformers.tt import generator_vllm
+
+    per_layer = [
+        ((4, 2, 32, 64), torch.bfloat16),
+        ((4, 1, 32, 64), torch.bfloat16),  # half-sized
+    ]
+
+    with patch.object(generator_vllm, "ttnn", new=_make_ttnn_mock()) as ttnn_mock:
+        generator_vllm.allocate_vllm_kv_cache_per_layer(
+            per_layer, dp_model=dp_model, tt_cache_path=Path("/tmp/tt-test-cache")
+        )
+
+    cache_filenames = [str(call.kwargs["cache_file_name"]) for call in ttnn_mock.as_tensor.call_args_list]
+    # Layer 0's shape (4, 2, 32, 64) must show up in two filenames (k+v),
+    # and so must layer 1's (4, 1, 32, 64). Different shapes → different
+    # filenames so caches don't collide.
+    assert sum("(4, 2, 32, 64)" in f for f in cache_filenames) == 2
+    assert sum("(4, 1, 32, 64)" in f for f in cache_filenames) == 2
+
+
+def test_legacy_uniform_shape_delegates_to_per_layer(dp_model):
+    """The legacy ``allocate_vllm_kv_cache`` must produce identical output to
+    calling ``allocate_vllm_kv_cache_per_layer`` with a uniform-spec list,
+    so existing single-group callers keep working unchanged."""
+    from models.tt_transformers.tt import generator_vllm
+
+    shape = (4, 2, 32, 64)
+    dtype = torch.bfloat16
+    num_layers = 3
+
+    with patch.object(generator_vllm, "ttnn", new=_make_ttnn_mock()) as ttnn_mock:
+        legacy = generator_vllm.allocate_vllm_kv_cache(
+            shape, dtype, num_layers, dp_model=dp_model, tt_cache_path=Path("/tmp/c")
+        )
+    legacy_call_count = ttnn_mock.as_tensor.call_count
+
+    with patch.object(generator_vllm, "ttnn", new=_make_ttnn_mock()) as ttnn_mock:
+        per_layer = generator_vllm.allocate_vllm_kv_cache_per_layer(
+            [(shape, dtype)] * num_layers,
+            dp_model=dp_model,
+            tt_cache_path=Path("/tmp/c"),
+        )
+    per_layer_call_count = ttnn_mock.as_tensor.call_count
+
+    assert legacy_call_count == per_layer_call_count
+    assert len(legacy[0]) == len(per_layer[0]) == num_layers

--- a/models/tt_transformers/tests/test_vllm_kv_cache.py
+++ b/models/tt_transformers/tests/test_vllm_kv_cache.py
@@ -86,6 +86,38 @@ def test_per_layer_passes_each_shape_to_cache_filename(dp_model):
     assert sum("(4, 1, 32, 64)" in f for f in cache_filenames) == 2
 
 
+def test_check_per_group_kwargs_strips_single_group_silently():
+    """A single-element list carries no extra info beyond the legacy
+    page_table arg; the wrapper drops it without complaint."""
+    from models.tt_transformers.tt.generator_vllm import _check_per_group_kwargs
+
+    kwargs = {"page_tables_per_group": ["t0"], "tokens": "tok"}
+    _check_per_group_kwargs(kwargs, "FakeModel")
+
+    assert "page_tables_per_group" not in kwargs
+    assert kwargs == {"tokens": "tok"}
+
+
+def test_check_per_group_kwargs_passes_when_kwarg_absent():
+    """Legacy callers that don't set page_tables_per_group are unaffected."""
+    from models.tt_transformers.tt.generator_vllm import _check_per_group_kwargs
+
+    kwargs = {"tokens": "tok"}
+    _check_per_group_kwargs(kwargs, "FakeModel")
+
+    assert kwargs == {"tokens": "tok"}
+
+
+def test_check_per_group_kwargs_raises_for_multi_group():
+    """Hybrid input with multiple groups must error loudly: silently using
+    only group 0 would corrupt KV state for the other groups."""
+    from models.tt_transformers.tt.generator_vllm import _check_per_group_kwargs
+
+    kwargs = {"page_tables_per_group": ["t0", "t1"], "tokens": "tok"}
+    with pytest.raises(NotImplementedError, match="FakeModel"):
+        _check_per_group_kwargs(kwargs, "FakeModel")
+
+
 def test_legacy_uniform_shape_delegates_to_per_layer(dp_model):
     """The legacy ``allocate_vllm_kv_cache`` must produce identical output to
     calling ``allocate_vllm_kv_cache_per_layer`` with a uniform-spec list,

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -32,13 +32,30 @@ from models.tt_transformers.tt.model import Transformer
 from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs, TensorGroup
 
 
-def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, dp_model: List[Transformer], tt_cache_path):
+def allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model: List[Transformer], tt_cache_path):
+    """Allocate KV cache tensors with potentially different shape per layer.
+
+    Args:
+        per_layer_specs: list of ``(kv_cache_shape, dtype)`` tuples, one per
+            layer in model layer-index order. Hybrid attention models
+            (Gemma3/4, GPT-OSS) use this so sliding-window layers can be
+            backed by a smaller paged pool than full-attention layers; for
+            uniform-attention models all entries are identical.
+        dp_model: list of replicated TT model handles, one per data-parallel
+            submesh.
+        tt_cache_path: path used for on-disk weight cache file naming.
+
+    Returns:
+        ``list[submesh][layer_idx][k_or_v]`` of TT tensors.
+    """
     submesh_devices = [model.mesh_device for model in dp_model]
     kv_cache = []
     for mesh_idx, submesh in enumerate(submesh_devices):
-        cache_kv = torch.zeros(kv_cache_shape, dtype=dtype)
         kv_tt = []
-        for layer_num in tqdm(range(num_layers), desc=f"Allocating TT kv caches for each layer (submesh {mesh_idx+1})"):
+        for layer_num, (kv_cache_shape, dtype) in enumerate(
+            tqdm(per_layer_specs, desc=f"Allocating TT kv caches for each layer (submesh {mesh_idx+1})")
+        ):
+            cache_kv = torch.zeros(kv_cache_shape, dtype=dtype)
             # Get the dtype for the kv cache based on the configured optimizations in the model
             if dp_model[mesh_idx].args.optimizations is not None:
                 kv_cache_dtype = dp_model[mesh_idx].args.optimizations.get_tensor_dtype(
@@ -68,6 +85,20 @@ def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, dp_model: List[Tra
             kv_tt.append(kv_tt_i)
         kv_cache.append(kv_tt)
     return kv_cache
+
+
+def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, dp_model: List[Transformer], tt_cache_path):
+    """Legacy uniform-shape KV cache allocator.
+
+    Retained for backward compatibility with vLLM's pre-kv-cache-groups
+    contract; new callers should use :func:`allocate_vllm_kv_cache_per_layer`
+    which supports hybrid attention models.
+    """
+    return allocate_vllm_kv_cache_per_layer(
+        [(kv_cache_shape, dtype)] * num_layers,
+        dp_model=dp_model,
+        tt_cache_path=tt_cache_path,
+    )
 
 
 def initialize_vllm_text_transformer(
@@ -230,6 +261,9 @@ class Mistral3ForConditionalGeneration(Generator, SupportsMultiModal):
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
 
+    def allocate_kv_cache_per_layer(self, per_layer_specs):
+        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
+
 
 # Mllama is currently not supported in vLLM V1.
 # TODO: Remove or re-enable when Mllama is supported in vLLM V1.
@@ -333,6 +367,9 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
 
+    def allocate_kv_cache_per_layer(self, per_layer_specs):
+        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
+
 
 class LlamaForCausalLM(Generator):
     # Class-level capabilities
@@ -395,6 +432,9 @@ class LlamaForCausalLM(Generator):
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
 
+    def allocate_kv_cache_per_layer(self, per_layer_specs):
+        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
+
 
 class QwenForCausalLM(Generator):
     # Class-level capabilities
@@ -444,6 +484,9 @@ class QwenForCausalLM(Generator):
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
 
+    def allocate_kv_cache_per_layer(self, per_layer_specs):
+        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
+
 
 class MistralForCausalLM(Generator):
     # Class-level capabilities
@@ -492,6 +535,9 @@ class MistralForCausalLM(Generator):
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
+
+    def allocate_kv_cache_per_layer(self, per_layer_specs):
+        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
 
 
 @MULTIMODAL_REGISTRY.register_processor(
@@ -555,6 +601,9 @@ class Gemma3ForConditionalGeneration(Generator, SupportsMultiModal):
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
+
+    def allocate_kv_cache_per_layer(self, per_layer_specs):
+        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
 
     def decode_forward(self, *args, **kwargs):
         return super().decode_forward(*args, **kwargs)
@@ -631,3 +680,6 @@ class GptOssForCausalLM(Generator):
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
+
+    def allocate_kv_cache_per_layer(self, per_layer_specs):
+        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -101,6 +101,31 @@ def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, dp_model: List[Tra
     )
 
 
+def _check_per_group_kwargs(kwargs, model_name):
+    """Pop ``page_tables_per_group`` from kwargs and validate.
+
+    vLLM always passes ``page_tables_per_group`` (a list of per-kv-cache-group
+    block tables) on the prefill/decode forward call so hybrid attention
+    models can route per layer. Legacy uniform-attention models don't know
+    how to use the per-group form; until a model opts in to hybrid support
+    (overrides ``prefill_forward`` / ``decode_forward`` to consume the
+    list), the wrappers strip the kwarg before delegating to the underlying
+    text forward — but raise loudly if multiple groups are present, since
+    silently using only group 0 would corrupt KV state for the other groups.
+
+    Single-group inputs (``len == 1``) carry no information beyond the legacy
+    ``page_table`` arg and are safely dropped.
+    """
+    page_tables = kwargs.pop("page_tables_per_group", None)
+    if page_tables is not None and len(page_tables) > 1:
+        raise NotImplementedError(
+            f"{model_name} does not yet support per-group block tables for "
+            "hybrid attention models. Override prefill_forward / "
+            "decode_forward to consume `page_tables_per_group` (one block "
+            "table per kv_cache_group)."
+        )
+
+
 def initialize_vllm_text_transformer(
     hf_config,
     tt_data_parallel,
@@ -227,6 +252,7 @@ class Mistral3ForConditionalGeneration(Generator, SupportsMultiModal):
         return self.model_args[0].model_cache_path
 
     def prefill_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         self.tokenizer = self.model_args[0].tokenizer
         pad_token_id = self.tokenizer.pad_token_id
 
@@ -256,6 +282,7 @@ class Mistral3ForConditionalGeneration(Generator, SupportsMultiModal):
         )
 
     def decode_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
@@ -358,6 +385,7 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
         )
 
     def decode_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         logits = super().decode_forward_llama_vision(*args, **kwargs)
         if isinstance(logits, tuple):
             return logits[0]
@@ -424,9 +452,11 @@ class LlamaForCausalLM(Generator):
         return self.model_args[0].model_cache_path
 
     def prefill_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
@@ -476,9 +506,11 @@ class QwenForCausalLM(Generator):
         return self.model_args[0].model_cache_path
 
     def prefill_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
@@ -528,9 +560,11 @@ class MistralForCausalLM(Generator):
         return self.model_args[0].model_cache_path
 
     def prefill_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
@@ -597,6 +631,7 @@ class Gemma3ForConditionalGeneration(Generator, SupportsMultiModal):
         return self.model_args[0].model_cache_path
 
     def prefill_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().prefill_forward_text(**kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
@@ -606,6 +641,7 @@ class Gemma3ForConditionalGeneration(Generator, SupportsMultiModal):
         return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
 
     def decode_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().decode_forward(*args, **kwargs)
 
 
@@ -673,9 +709,11 @@ class GptOssForCausalLM(Generator):
         return self.model_args[0].weight_cache_path(ttnn.bfloat8_b)
 
     def prefill_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
+        _check_per_group_kwargs(kwargs, type(self).__name__)
         return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -122,8 +122,117 @@ def _check_per_group_kwargs(kwargs, model_name):
             f"{model_name} does not yet support per-group block tables for "
             "hybrid attention models. Override prefill_forward / "
             "decode_forward to consume `page_tables_per_group` (one block "
-            "table per kv_cache_group)."
+            "table per kv_cache_group), or migrate the model to inherit "
+            "from HybridAttentionForCausalLM."
         )
+
+
+class HybridAttentionForCausalLM(Generator):
+    """vLLM wrapper base for hybrid attention models.
+
+    Models with mixed sliding-window + full-attention layers (Gemma3,
+    Gemma4, GPT-OSS, ...) inherit from this class instead of plain
+    :class:`Generator` so they can opt in to upstream's hybrid kv cache
+    manager. The shared ``get_kv_cache_spec`` classmethod here builds
+    the per-layer KV cache spec from ``hf_config.text_config.layer_types``
+    — the standard HF convention used by all of these models — emitting
+    ``SlidingWindowSpec`` for sliding layers and ``FullAttentionSpec``
+    for full-attention layers.
+
+    Subclasses are responsible for the model-specific pieces:
+
+    * ``initialize_vllm_model``: load the underlying TT model.
+    * ``prefill_forward`` / ``decode_forward``: consume the
+      ``page_tables_per_group`` list (one per kv_cache_group, in upstream's
+      group order) and route per layer to the right group's page table.
+      The underlying TT model must accept this routing.
+    * ``allocate_kv_cache_per_layer``: typically just delegates to
+      :func:`allocate_vllm_kv_cache_per_layer` with the model handles.
+
+    Until a subclass overrides them, ``prefill_forward`` and
+    ``decode_forward`` raise :class:`NotImplementedError` to make the
+    contract explicit; vLLM's runtime check (``_check_per_group_kwargs``)
+    only fires for legacy models that haven't migrated to this base.
+    """
+
+    @classmethod
+    def get_kv_cache_spec(cls, vllm_config):
+        """Build per-layer KVCacheSpec from HF config ``layer_types``.
+
+        Returns a dict keyed by ``model.layers.<idx>.self_attn`` (the
+        upstream attention-layer naming convention vLLM's KVCacheGroup
+        machinery understands) so :func:`_parse_layer_index` on the
+        runner side can map each spec back to its model layer index.
+        """
+        from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
+        from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
+
+        model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
+
+        hf_config = model_config.hf_config
+        text_config = getattr(hf_config, "text_config", hf_config)
+        layer_types = getattr(text_config, "layer_types", None)
+        if layer_types is None:
+            raise ValueError(
+                f"{cls.__name__}.get_kv_cache_spec requires "
+                "hf_config.text_config.layer_types (one of 'full_attention' / "
+                "'sliding_attention' per layer); none found on this model"
+            )
+
+        sliding_window = getattr(text_config, "sliding_window", None)
+        num_kv_heads = model_config.get_num_kv_heads(vllm_config.parallel_config)
+        head_size = model_config.get_head_size()
+        dtype = (
+            model_config.dtype
+            if cache_config.cache_dtype == "auto"
+            else STR_DTYPE_TO_TORCH_DTYPE[cache_config.cache_dtype]
+        )
+        block_size = cache_config.block_size
+
+        common = dict(
+            block_size=block_size,
+            num_kv_heads=num_kv_heads,
+            head_size=head_size,
+            dtype=dtype,
+        )
+
+        spec_per_layer = {}
+        for i, lt in enumerate(layer_types):
+            name = f"model.layers.{i}.self_attn"
+            if lt == "sliding_attention":
+                if sliding_window is None:
+                    raise ValueError(
+                        f"layer_types[{i}] is 'sliding_attention' but "
+                        f"hf_config.sliding_window is None on {cls.__name__}"
+                    )
+                spec_per_layer[name] = SlidingWindowSpec(**common, sliding_window=sliding_window)
+            elif lt == "full_attention":
+                spec_per_layer[name] = FullAttentionSpec(**common)
+            else:
+                raise ValueError(
+                    f"Unsupported layer_type {lt!r} at layer {i} on "
+                    f"{cls.__name__}; expected 'full_attention' or "
+                    "'sliding_attention'"
+                )
+        return spec_per_layer
+
+    def prefill_forward(self, *args, **kwargs):
+        raise NotImplementedError(
+            f"{type(self).__name__} must override prefill_forward to consume "
+            "`page_tables_per_group` and route per layer to the right "
+            "kv_cache_group's page table."
+        )
+
+    def decode_forward(self, *args, **kwargs):
+        raise NotImplementedError(
+            f"{type(self).__name__} must override decode_forward to consume "
+            "`page_tables_per_group` and route per layer to the right "
+            "kv_cache_group's page table."
+        )
+
+    def allocate_kv_cache_per_layer(self, per_layer_specs):
+        return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
 
 
 def initialize_vllm_text_transformer(

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -127,7 +127,58 @@ def _check_per_group_kwargs(kwargs, model_name):
         )
 
 
-class HybridAttentionForCausalLM(Generator):
+class HybridGenerator(Generator):
+    """:class:`Generator` subclass for hybrid attention models.
+
+    Holds per-call routing state (``page_tables_per_group`` and
+    ``layer_to_group``) on the instance for the duration of a forward
+    call so the deeply-nested prefill / decode chain doesn't have to
+    thread the new args through every method signature. The state is
+    set by :meth:`set_hybrid_routing` before invoking the parent's
+    ``prefill_forward_text`` / ``decode_forward_text``, and cleared
+    afterwards.
+
+    Subclasses (currently :class:`HybridAttentionForCausalLM` and its
+    wrapper subclasses) drive the lifecycle via the ``hybrid_routing``
+    context manager. The actual integration with ``Generator``'s call
+    chain — converting host per-group page tables to device tensors and
+    teaching ``prefill_forward_single_user_text`` / decode equivalents
+    to use the routing — lands per-path in follow-ups so each path can
+    be HW-validated independently. Until then the methods raise a
+    clear NotImplementedError pointing at the missing integration.
+
+    Non-hybrid models (every existing wrapper that inherits directly
+    from :class:`Generator`) are entirely unaffected.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Per-call routing state. ``None`` when not in a hybrid forward.
+        self._hybrid_page_tables_per_group: list | None = None
+        self._hybrid_layer_to_group: list[int] | None = None
+
+    def set_hybrid_routing(
+        self,
+        page_tables_per_group: list | None,
+        layer_to_group: list[int] | None,
+    ) -> None:
+        """Stash per-call routing state for use by overridden inner
+        methods. Cleared via :meth:`clear_hybrid_routing` (typically in a
+        ``try / finally`` around the parent's text forward call).
+        """
+        self._hybrid_page_tables_per_group = page_tables_per_group
+        self._hybrid_layer_to_group = layer_to_group
+
+    def clear_hybrid_routing(self) -> None:
+        self._hybrid_page_tables_per_group = None
+        self._hybrid_layer_to_group = None
+
+    @property
+    def hybrid_routing_active(self) -> bool:
+        return self._hybrid_page_tables_per_group is not None
+
+
+class HybridAttentionForCausalLM(HybridGenerator):
     """vLLM wrapper base for hybrid attention models.
 
     Models with mixed sliding-window + full-attention layers (Gemma3,

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -693,7 +693,29 @@ class Transformer(LightweightModule):
         get_last_token=-1,
         kv_cache=None,
         batch_size=1,
+        page_tables_per_group=None,
+        layer_to_group=None,
     ):
+        """
+        Args:
+            page_tables_per_group: optional list of per-kv-cache-group page
+                tables (one per group, in upstream's group order). When
+                provided, layer i uses
+                ``page_tables_per_group[layer_to_group[i]]`` instead of the
+                single ``page_table`` arg, so hybrid attention models served
+                via vLLM's hybrid kv cache manager can route sliding-window
+                layers to a smaller paged pool than full-attention layers.
+            layer_to_group: list[int] of length ``num_hidden_layers`` mapping
+                each model layer index to its kv_cache_group index. Required
+                when ``page_tables_per_group`` is provided.
+        """
+        if page_tables_per_group is not None and layer_to_group is None:
+            raise ValueError("page_tables_per_group requires layer_to_group to route per " "layer to the right group")
+        if layer_to_group is not None and len(layer_to_group) != len(self.layers):
+            raise ValueError(
+                f"layer_to_group has {len(layer_to_group)} entries but model " f"has {len(self.layers)} layers"
+            )
+
         if mode == Mode.DECODE:
             # Run prefetcher if it is enabled
             if self.prefetcher is not None:
@@ -714,6 +736,15 @@ class Transformer(LightweightModule):
             elif activation_dtype is not None and x.dtype != activation_dtype:
                 x = ttnn.typecast(x, activation_dtype)
 
+            # Per-group page table routing for hybrid kv cache groups (vLLM
+            # path). Sliding-window layers may index into a smaller paged
+            # pool than full-attention layers, so each layer picks up its
+            # group's block table instead of a shared one.
+            if page_tables_per_group is not None:
+                layer_page_table = page_tables_per_group[layer_to_group[i]]
+            else:
+                layer_page_table = page_table
+
             x = layer(
                 x,
                 current_pos,
@@ -721,7 +752,7 @@ class Transformer(LightweightModule):
                 rot_mats_local=rot_mats_local,
                 user_id=user_id,
                 mode=mode,
-                page_table=page_table,
+                page_table=layer_page_table,
                 chunk_page_table=chunk_page_table,
                 chunk_start_idx=chunk_start_idx,
                 kv_cache=kv_cache[i] if kv_cache is not None else None,


### PR DESCRIPTION
Stacked on top of #43475 (\`handrews/kv-cache-groups\` — the kv cache
groups scaffolding). Per-model migrations to actually use upstream's
hybrid kv cache manager.

## Scope

This PR delivers the **structural** migration. Full vLLM end-to-end
serving for Gemma3 / GPT-OSS still needs additional plumbing through
\`Generator.prefill_forward_text\` and \`ttnn_prefill_forward\` per
model — those are intentionally deferred so each can be reviewed +
HW-validated as its own follow-up. What lands here:

### Gemma4: full migration

- \`Gemma4Model.__call__\` (\`models/demos/gemma4/tt/model.py\`) now
  accepts optional \`page_tables_per_group\` + \`layer_to_group\`. The
  per-layer loop selects \`page_tables_per_group[layer_to_group[i]]\`
  instead of the single \`page_table\` arg. Threaded through
  \`ttnn_prefill_forward\` and \`ttnn_decode_forward\` as well. Legacy
  single-\`page_table\` path unchanged when the new args are None.
- New \`Gemma4ForCausalLM\` vLLM wrapper class
  (\`models/demos/gemma4/tt/generator_vllm.py\`) inheriting from
  \`HybridAttentionForCausalLM\`. Provides:
  - \`initialize_vllm_model\`: loads the standalone Gemma4Model with
    \`create_kv_cache=False\` so vLLM drives allocation.
  - \`_build_layer_to_group(num_groups)\`: mirrors upstream's
    \`kv_cache_utils._get_kv_cache_groups_uniform_page_size\` grouping
    so the wrapper can map each model layer index → kv_cache_group
    index. Verified for the 5:1 sliding:full ratio (50 sliding + 10
    full → 1 full + 5 sliding = 6 groups).
- \`prefill_forward\` / \`decode_forward\` are **inherited as
  NotImplementedError stubs from the parent**: full vLLM serving
  needs Gemma4Model's prefill / decode pipeline to be wired into
  Generator's text forward path, which is its own follow-up.

### tt_transformers Transformer.forward: routing primitive (additive)

Adds optional \`page_tables_per_group\` + \`layer_to_group\` kwargs to
the shared \`Transformer.forward\` per-layer dispatch point. When
provided, layer i uses \`page_tables_per_group[layer_to_group[i]]\`.
When None (the default), behaviour is identical to before for every
model in tt_transformers (Llama, Qwen, Mistral, Mistral3, Mllama,
Gemma3, GPT-OSS).

Threading these args through the calling chain
(\`Generator.prefill_forward_text\` → \`prefill_forward_single_user_text\`
→ \`Transformer.ttnn_prefill_forward\` → \`forward\`) is the per-model
follow-up that lights up Gemma3 / GPT-OSS hybrid serving.

## Test plan

- [ ] \`pytest models/demos/gemma4/tests/test_generator_vllm.py\` — pins
  the layer→group routing helper across Gemma4-31B 5:1, alternating
  1:1, all-uniform, count-mismatch, and missing-layer_types paths.
- [ ] vLLM offline-inference smoke against Gemma4 once Gemma4Model's
  prefill/decode are wired into Generator's text forward path
  (separate follow-up).

## Companion PRs

- #43475 (tt-metal): kv-cache-groups scaffolding (this PR's base).
- tenstorrent/vllm#381: vLLM-side support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=handrews/kv-cache-groups-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:handrews/kv-cache-groups-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=handrews/kv-cache-groups-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:handrews/kv-cache-groups-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=handrews/kv-cache-groups-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:handrews/kv-cache-groups-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=handrews/kv-cache-groups-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:handrews/kv-cache-groups-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=handrews/kv-cache-groups-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:handrews/kv-cache-groups-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=handrews/kv-cache-groups-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:handrews/kv-cache-groups-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=handrews/kv-cache-groups-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:handrews/kv-cache-groups-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=handrews/kv-cache-groups-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:handrews/kv-cache-groups-models)