### PR TITLE
gpt_oss/experts: fall back to Kt when no nontrivial divisor of Kt fits

### DIFF
--- a/models/demos/gpt_oss/tt/experts/config.py
+++ b/models/demos/gpt_oss/tt/experts/config.py
@@ -145,13 +145,20 @@ class ProgramConfig:
         # The sparse matmul kernel asserts `Kt % in0_block_w == 0`. Different
         # tp factors produce different Kt (e.g. down's K = intermediate/tp:
         # tp=8 → Kt=12, tp=1 → Kt=90), and the configured in0_block_w may not
-        # divide them all. Snap down to the largest divisor of Kt ≤ configured;
-        # when Kt is already divisible by the configured value this is a no-op
-        # (so existing Wormhole tunings are preserved).
+        # divide them all. Snap to the largest divisor of Kt that does not
+        # exceed the configured ceiling; when Kt is already divisible by the
+        # configured value this is a no-op (so existing Wormhole tunings are
+        # preserved). When Kt is prime (or coprime with every value ≤
+        # configured, e.g. Kt=23 on tp=4) the only divisor under the ceiling
+        # is 1, which collapses the matmul to a tile-by-tile inner loop and
+        # roughly halves prefill throughput. In that case fall back to Kt
+        # itself — always a divisor, and small enough to fit in L1 for the
+        # Kt range produced by realistic gpt-oss TP shardings (Kt ≤ ~90).
         if k is not None:
             Kt = int(math.ceil(k / 32))
             if Kt % in0_block_w != 0:
-                in0_block_w = max(d for d in range(1, in0_block_w + 1) if Kt % d == 0)
+                divisors = [d for d in range(2, in0_block_w + 1) if Kt % d == 0]
+                in0_block_w = max(divisors) if divisors else Kt
 
         return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=ttnn.CoreCoord(core_x, core_y),


### PR DESCRIPTION
## Summary
Generalizes the snap-down on `Kt % in0_block_w != 0` in `models/demos/gpt_oss/tt/experts/config.py`: when the only divisor of `Kt` that fits under the configured ceiling is 1 (i.e. `Kt` is prime above the ceiling), fall back to `Kt` itself instead of collapsing the inner loop to a single tile.

Stacks on top of #43279 (this branch is forked off `handrews/gpt-oss-p150` HEAD `fd155e073b8`).

## Why
On the `(1, 4)` P300x2 mesh enabled by 7f4bcb9, the down-projection has `Kt = ceil(intermediate / tp / 32) = 23` (prime). With the existing search `range(1, in0_block_w + 1)` and the configured `decode_down_in0_block_w = prefill_down_in0_block_w = 12`, the only divisor of 23 in `[1, 12]` is 1, so `in0_block_w` snaps to 1. The model loads but the sparse matmul runs tile-by-tile in K, roughly halving prefill throughput and adding ~15% to TPOT.
Other meshes hit non-trivial divisors and aren't affected.

## Per-mesh behaviour

| Mesh | TP | Down Kt | Ceiling | Old snap | New snap |
| -- | -- | -- | -- | -- | -- |
| T3K (1, 8) | 8 | 12 | 12 | 12 (no-op) | 12 (no-op) |
| QB2 (1, 4) | 4 | 23 (prime) | 12 | 1 (broken) | 23 (Kt fallback) |
| P150 (1, 1) | 1 | 90 | 12 | 10 | 10 (identical) |
| Galaxy (4, 8) | 32 | ~3 | 12 | ≤ ceiling | identical |

## Validation

| ISL | OSL | Old (snap → 1) | New (snap → 23) |
| -- | -- | -- | -- |
| 128 | 128 | TTFT 1831 ms · prefill 70 TPS · TPOT 52.9 ms | TTFT 892 ms · prefill 144 TPS · TPOT 45.6 ms |
| 1024 | 128 | TTFT 14436 ms · prefill 71 TPS | TTFT 6943 ms · prefill 148 TPS |
| 4096 | 128 | TTFT 57840 ms · prefill 71 TPS | TTFT 27855 ms · prefill 147 TPS |
| 8192 | 128 | TTFT 115726 ms · prefill 71 TPS | TTFT 55746 ms · prefill 147 TPS |
| 32768 | 128 | TTFT 464344 ms · prefill 71 TPS | TTFT 224398 ms · prefill 146 TPS |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=adam/gpt-oss-bh-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:adam/gpt-oss-bh-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=adam/gpt-oss-bh-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:adam/gpt-oss-bh-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=adam/gpt-oss-bh-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:adam/gpt-oss-bh-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=adam/gpt-oss-bh-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:adam/gpt-oss-bh-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=adam/gpt-oss-bh-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:adam/gpt-oss-bh-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=adam/gpt-oss-bh-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:adam/gpt-oss-bh-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=adam/gpt-oss-bh-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:adam/gpt-oss-bh-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=adam/gpt-oss-bh-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:adam/gpt-oss-bh-qb2)