### PR TITLE
[Bugfix] Fix unset trisc mask bug

### DIFF
--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -49,8 +49,8 @@ void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_
             dfb->config.num_producers >= 1 && dfb->config.num_producers <= 4,
             "Tensix producer count must be between 1 and 4, got {}",
             dfb->config.num_producers);
-        dfb->config.producer_risc_mask = static_cast<uint16_t>(((1u << dfb->config.num_producers) - 1u) << ::dfb::TENSIX_RISC_OFFSET);
-        dfb->tensix_trisc_mask |= (1u << 2);  // Tensix producer uses trisc2
+        dfb->config.producer_risc_mask =
+            static_cast<uint16_t>(((1u << dfb->config.num_producers) - 1u) << ::dfb::TENSIX_RISC_OFFSET);
     } else if (auto dm_producer = std::dynamic_pointer_cast<experimental::quasar::QuasarDataMovementKernel>(producer_kernel)) {
         TT_FATAL(
             dfb->config.num_producers >= 1 && dfb->config.num_producers <= 8,
@@ -77,8 +77,8 @@ void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_
             dfb->config.num_consumers >= 1 && dfb->config.num_consumers <= 4,
             "Tensix consumer count must be between 1 and 4, got {}",
             dfb->config.num_consumers);
-        dfb->config.consumer_risc_mask = static_cast<uint16_t>(((1u << dfb->config.num_consumers) - 1u) << ::dfb::TENSIX_RISC_OFFSET);
-        dfb->tensix_trisc_mask |= (1u << 0);  // Default: Tensix consumer uses trisc0; use (1u << 3) for trisc3
+        dfb->config.consumer_risc_mask =
+            static_cast<uint16_t>(((1u << dfb->config.num_consumers) - 1u) << ::dfb::TENSIX_RISC_OFFSET);
     } else if (auto dm_consumer = std::dynamic_pointer_cast<experimental::quasar::QuasarDataMovementKernel>(consumer_kernel)) {
         TT_FATAL(
             dfb->config.num_consumers >= 1 && dfb->config.num_consumers <= 8,
@@ -815,6 +815,20 @@ void ProgramImpl::finalize_single_dfb_config(
 
     TT_FATAL(config.producer_risc_mask != 0, "producer_risc_mask must be set before program launch. Either set it in DataflowBufferConfig or call BindDataflowBufferToProducerConsumerKernels after creating kernels");
     TT_FATAL(config.consumer_risc_mask != 0, "consumer_risc_mask must be set before program launch. Either set it in DataflowBufferConfig or call BindDataflowBufferToProducerConsumerKernels after creating kernels");
+
+    // Quasar-only:
+    // Derive tensix_trisc_mask from the (now-final) risc masks.
+    // has_tensix_risc checks bits 8-11 (zero on Gen1 masks).
+    //  - producer compute -> set trisc2 (bit 2)
+    //  - consumer compute -> set trisc0 (bit 0)
+    // TODO: if/when consumer-compute can target trisc3 instead of trisc0, that
+    // selection would need a dedicated DataflowBufferConfig field.
+    if (has_tensix_risc(config.producer_risc_mask)) {
+        dfb->tensix_trisc_mask |= (1u << 2);
+    }
+    if (has_tensix_risc(config.consumer_risc_mask)) {
+        dfb->tensix_trisc_mask |= (1u << 0);
+    }
 
     const bool is_intra_tensix =
         config.tensix_scope.has_value() && *config.tensix_scope == TensixScope::INTRA;

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -823,12 +823,8 @@ void ProgramImpl::finalize_single_dfb_config(
     //  - consumer compute -> set trisc0 (bit 0)
     // TODO: if/when consumer-compute can target trisc3 instead of trisc0, that
     // selection would need a dedicated DataflowBufferConfig field.
-    if (has_tensix_risc(config.producer_risc_mask)) {
-        dfb->tensix_trisc_mask |= (1u << 2);
-    }
-    if (has_tensix_risc(config.consumer_risc_mask)) {
-        dfb->tensix_trisc_mask |= (1u << 0);
-    }
+    dfb->tensix_trisc_mask = (has_tensix_risc(config.producer_risc_mask) ? (1u << 2) : 0u) |
+                             (has_tensix_risc(config.consumer_risc_mask) ? (1u << 0) : 0u);
 
     const bool is_intra_tensix =
         config.tensix_scope.has_value() && *config.tensix_scope == TensixScope::INTRA;


### PR DESCRIPTION
### Summary

**Bug**
In Metal 2.0 Programs, DFBs with Quasar compute endpoints had `tensix_trisc_mask` = 0, causing TRISC kernels to short-circuit DFB API calls. Found during preliminary op migration experiments (thanks Borys!).

**Fix**
Move `tensix_trisc_mask` derivation into `finalize_single_dfb_config`, deriving from the RISC mask on the `DataflowBufferConfig` (which can be set either via Metal 2.0, or through the temporary scrappy `CreateDFB` APIs).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/fix-unset-trisc-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/fix-unset-trisc-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/fix-unset-trisc-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/fix-unset-trisc-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/fix-unset-trisc-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/fix-unset-trisc-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/fix-unset-trisc-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/fix-unset-trisc-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/fix-unset-trisc-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/fix-unset-trisc-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/fix-unset-trisc-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/fix-unset-trisc-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/fix-unset-trisc-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/fix-unset-trisc-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/fix-unset-trisc-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/fix-unset-trisc-mask)