### PR TITLE
Fix: Benchmark read for large buffers reports significantly lower throughput than expected

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
@@ -64,10 +64,15 @@ static constexpr uint32_t ElementSize = sizeof(ElementType);
 
 static const std::vector<int64_t> PAGE_SIZE_ARGS = benchmark::CreateRange(32, 2048, 2);
 static constexpr uint64_t max_transfer_size{8 * GB};
-static const std::vector<int64_t> TRANSFER_SIZE_ARGS = {64 * MB};
+static const std::vector<int64_t> TRANSFER_SIZE_ARGS = {
+    1 * GB,
+    2 * GB,
+    4 * GB,
+    8 * GB,
+};
 
-static constexpr std::array<BufferType, 2> BUFFER_TYPES = {BufferType::DRAM, BufferType::L1};
-static const std::vector<int64_t> BUFFER_TYPE_ARGS = {0, 1};
+static constexpr std::array<BufferType, 2> BUFFER_TYPES = {BufferType::DRAM}; //, BufferType::L1};
+static const std::vector<int64_t> BUFFER_TYPE_ARGS = {0}; //, 1};
 
 // For sharded benchmarks: fixed page size and contiguity control
 static constexpr int64_t FIXED_PAGE_SIZE = 1024;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
@@ -64,15 +64,10 @@ static constexpr uint32_t ElementSize = sizeof(ElementType);
 
 static const std::vector<int64_t> PAGE_SIZE_ARGS = benchmark::CreateRange(32, 2048, 2);
 static constexpr uint64_t max_transfer_size{8 * GB};
-static const std::vector<int64_t> TRANSFER_SIZE_ARGS = {
-    1 * GB,
-    2 * GB,
-    4 * GB,
-    8 * GB,
-};
+static const std::vector<int64_t> TRANSFER_SIZE_ARGS = {64 * MB};
 
-static constexpr std::array<BufferType, 2> BUFFER_TYPES = {BufferType::DRAM}; //, BufferType::L1};
-static const std::vector<int64_t> BUFFER_TYPE_ARGS = {0}; //, 1};
+static constexpr std::array<BufferType, 2> BUFFER_TYPES = {BufferType::DRAM, BufferType::L1};
+static const std::vector<int64_t> BUFFER_TYPE_ARGS = {0, 1};
 
 // For sharded benchmarks: fixed page size and contiguity control
 static constexpr int64_t FIXED_PAGE_SIZE = 1024;
@@ -356,7 +351,7 @@ static void BM_read(benchmark::State& state, const std::shared_ptr<MeshDevice>& 
         ReplicatedBufferConfig{transfer_size},
         DeviceLocalBufferConfig{.page_size = page_size, .buffer_type = buffer_type},
         mesh_device.get());
-    std::vector<ElementType> host_buffer;
+    std::vector<ElementType> host_buffer(transfer_size / ElementSize);
 
     for ([[maybe_unused]] auto _ : state) {
         // EnqueueReadMeshBuffer cannot read from a replicated buffer yet, have to use ReadShard


### PR DESCRIPTION
### Summary
Closes #27846

* Pre-allocates the destination vector buffer before performing read benchmark tests, correcting throughput calculations

### Notes for reviewers

Throughput calculations were significantly off before this change. Afterwards, throughput is now essentially identical for a given page size regardless of the buffer size. The below benchmarks were generated on blackhole.

### Read Benchmark Throughput Before Change (GiB/s)

| Page Size | 1 GiB | 2 GiB | 4 GiB | 8 GiB |
|-----------|------:|------:|------:|------:|
| 32        | 0.74  | 0.74  | 0.73  | 0.70  |
| 64        | 1.25  | 1.24  | 1.23  | 1.22  |
| 128       | 1.87  | 1.86  | 1.83  | 1.82  |
| 256       | 3.65  | 2.48  | 2.42  | 2.40  |
| 512       | 6.91  | 2.96  | 2.89  | 2.86  |
| 1024      | 7.21  | 3.02  | 2.95  | 2.90  |
| 2048      | 7.38  | 3.06  | 2.96  | 2.94  |

### Read Benchmark Throughput After Change (GiB/s)

| Page Size | 1 GiB | 2 GiB | 4 GiB | 8 GiB |
|-----------|------:|------:|------:|------:|
| 32        | 0.91  | 0.91  | 0.91  | 0.91  |
| 64        | 1.82  | 1.82  | 1.82  | 1.82  |
| 128       | 3.54  | 3.54  | 3.54  | 3.54  |
| 256       | 6.72  | 6.72  | 6.72  | 6.72  |
| 512       | 12.17 | 12.18 | 12.20 | 12.20 |
| 1024      | 13.16 | 13.46 | 13.59 | 13.67 |
| 2048      | 13.74 | 14.10 | 14.02 | 14.13 |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anashTT/27846-read-large-mmio-buff-perf-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anashTT/27846-read-large-mmio-buff-perf-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anashTT/27846-read-large-mmio-buff-perf-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anashTT/27846-read-large-mmio-buff-perf-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=anashTT/27846-read-large-mmio-buff-perf-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:anashTT/27846-read-large-mmio-buff-perf-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anashTT/27846-read-large-mmio-buff-perf-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anashTT/27846-read-large-mmio-buff-perf-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anashTT/27846-read-large-mmio-buff-perf-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anashTT/27846-read-large-mmio-buff-perf-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anashTT/27846-read-large-mmio-buff-perf-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anashTT/27846-read-large-mmio-buff-perf-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anashTT/27846-read-large-mmio-buff-perf-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anashTT/27846-read-large-mmio-buff-perf-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anashTT/27846-read-large-mmio-buff-perf-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anashTT/27846-read-large-mmio-buff-perf-issue)