### PR TITLE
[tt-train] Adding LR to Optimizer State Dicts

### DIFF
--- a/tt-train/sources/ttml/optimizers/adamw.cpp
+++ b/tt-train/sources/ttml/optimizers/adamw.cpp
@@ -93,6 +93,7 @@ void AdamW::step() {
 serialization::StateDict AdamW::get_state_dict() const {
     serialization::StateDict dict;
     dict["steps"] = m_steps;
+    dict["lr"] = m_config.lr;
     dict["exp_avg"] = m_exp_avg;
     dict["exp_avg_sq"] = m_exp_avg_sq;
     dict["amsgrad"] = m_config.amsgrad;
@@ -104,6 +105,9 @@ serialization::StateDict AdamW::get_state_dict() const {
 
 void AdamW::set_state_dict(const serialization::StateDict& dict) {
     set_steps(serialization::get_value_type<size_t>(dict, "steps"));
+    if (dict.contains("lr")) {
+        set_lr(serialization::get_value_type<float>(dict, "lr"));
+    }
     m_exp_avg = std::get<serialization::NamedParameters>(dict.at("exp_avg"));
     m_exp_avg_sq = std::get<serialization::NamedParameters>(dict.at("exp_avg_sq"));
 

--- a/tt-train/sources/ttml/optimizers/adamw_composite.cpp
+++ b/tt-train/sources/ttml/optimizers/adamw_composite.cpp
@@ -103,6 +103,7 @@ void MorehAdamW::step() {
     state_dict[kFirstMoment] = m_first_moment;
     state_dict[kSecondMoment] = m_second_moment;
     state_dict[kSteps] = m_steps;
+    state_dict["lr"] = m_config.lr;
 
     return state_dict;
 }
@@ -111,6 +112,9 @@ void MorehAdamW::set_state_dict(const serialization::StateDict& dict) {
     m_first_moment = std::get<serialization::NamedParameters>(dict.at(kFirstMoment));
     m_second_moment = std::get<serialization::NamedParameters>(dict.at(kSecondMoment));
     m_steps = serialization::get_value_type<size_t>(dict, kSteps);
+    if (dict.contains("lr")) {
+        set_lr(serialization::get_value_type<float>(dict, "lr"));
+    }
 }
 
 [[nodiscard]] size_t MorehAdamW::get_steps() const {
@@ -256,6 +260,7 @@ void AdamWComposite::step() {
     state_dict[kMaxExpAvgSq] = m_max_exp_avg_sq;
     state_dict[kKahanCompensation] = m_kahan_compensation;
     state_dict[kSteps] = m_steps;
+    state_dict["lr"] = m_config.lr;
 
     return state_dict;
 }
@@ -266,6 +271,9 @@ void AdamWComposite::set_state_dict(const serialization::StateDict& dict) {
     m_max_exp_avg_sq = std::get<serialization::NamedParameters>(dict.at(kMaxExpAvgSq));
     m_kahan_compensation = std::get<serialization::NamedParameters>(dict.at(kKahanCompensation));
     m_steps = serialization::get_value_type<size_t>(dict, kSteps);
+    if (dict.contains("lr")) {
+        set_lr(serialization::get_value_type<float>(dict, "lr"));
+    }
 }
 
 [[nodiscard]] size_t AdamWComposite::get_steps() const {

--- a/tt-train/sources/ttml/optimizers/adamw_full_precision.cpp
+++ b/tt-train/sources/ttml/optimizers/adamw_full_precision.cpp
@@ -104,6 +104,7 @@ void AdamWFullPrecision::step() {
 serialization::StateDict AdamWFullPrecision::get_state_dict() const {
     serialization::StateDict dict;
     dict["steps"] = m_steps;
+    dict["lr"] = m_config.lr;
     dict["master_weights"] = m_master_weights;
     dict["exp_avg"] = m_exp_avg;
     dict["exp_avg_sq"] = m_exp_avg_sq;
@@ -116,6 +117,9 @@ serialization::StateDict AdamWFullPrecision::get_state_dict() const {
 
 void AdamWFullPrecision::set_state_dict(const serialization::StateDict& dict) {
     set_steps(serialization::get_value_type<size_t>(dict, "steps"));
+    if (dict.contains("lr")) {
+        set_lr(serialization::get_value_type<float>(dict, "lr"));
+    }
     m_master_weights = std::get<serialization::NamedParameters>(dict.at("master_weights"));
     m_exp_avg = std::get<serialization::NamedParameters>(dict.at("exp_avg"));
     m_exp_avg_sq = std::get<serialization::NamedParameters>(dict.at("exp_avg_sq"));

--- a/tt-train/sources/ttml/optimizers/muon_composite.cpp
+++ b/tt-train/sources/ttml/optimizers/muon_composite.cpp
@@ -68,12 +68,16 @@ serialization::StateDict MuonComposite::get_state_dict() const {
     serialization::StateDict dict;
     dict["momentum_buffer"] = m_momentum_buffer;
     dict["steps"] = m_steps;
+    dict["lr"] = m_config.lr;
     return dict;
 }
 
 void MuonComposite::set_state_dict(const serialization::StateDict& dict) {
     m_momentum_buffer = std::get<serialization::NamedParameters>(dict.at("momentum_buffer"));
     m_steps = serialization::get_value_type<size_t>(dict, "steps");
+    if (dict.contains("lr")) {
+        set_lr(serialization::get_value_type<float>(dict, "lr"));
+    }
 }
 
 size_t MuonComposite::get_steps() const {

--- a/tt-train/sources/ttml/optimizers/sgd.cpp
+++ b/tt-train/sources/ttml/optimizers/sgd.cpp
@@ -84,12 +84,16 @@ serialization::StateDict SGD::get_state_dict() const {
     serialization::StateDict dict;
     dict["momentum"] = m_momentum;
     dict["steps"] = m_steps;
+    dict["lr"] = m_config.lr;
     return dict;
 }
 
 void SGD::set_state_dict(const serialization::StateDict& dict) {
     m_momentum = std::get<serialization::NamedParameters>(dict.at("momentum"));
     m_steps = serialization::get_value_type<size_t>(dict, "steps");
+    if (dict.contains("lr")) {
+        set_lr(serialization::get_value_type<float>(dict, "lr"));
+    }
 }
 
 size_t SGD::get_steps() const {

--- a/tt-train/sources/ttml/optimizers/sgd_composite.cpp
+++ b/tt-train/sources/ttml/optimizers/sgd_composite.cpp
@@ -106,12 +106,16 @@ serialization::StateDict SGDComposite::get_state_dict() const {
     serialization::StateDict dict;
     dict["theta"] = m_theta;
     dict["steps"] = m_steps;
+    dict["lr"] = m_config.lr;
     return dict;
 }
 
 void SGDComposite::set_state_dict(const serialization::StateDict& dict) {
     m_theta = std::get<serialization::NamedParameters>(dict.at("theta"));
     m_steps = serialization::get_value_type<size_t>(dict, "steps");
+    if (dict.contains("lr")) {
+        set_lr(serialization::get_value_type<float>(dict, "lr"));
+    }
 }
 
 size_t SGDComposite::get_steps() const {


### PR DESCRIPTION
### Summary
Currently, ttml optimizers do not save and restore learning rates in their state dicts. This PR adds the lr to the state dict to be saved and restored for optimizer checkpointing. This matches PyTorch behavior and removes the need for the user manually restore the lr with a call to `optimizer.set_lr(lr)` when restoring a checkpoint.
### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=awliu/optimizer_saving_lr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:awliu/optimizer_saving_lr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=awliu/optimizer_saving_lr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:awliu/optimizer_saving_lr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=awliu/optimizer_saving_lr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:awliu/optimizer_saving_lr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=awliu/optimizer_saving_lr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:awliu/optimizer_saving_lr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=awliu/optimizer_saving_lr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:awliu/optimizer_saving_lr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=awliu/optimizer_saving_lr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:awliu/optimizer_saving_lr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=awliu/optimizer_saving_lr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:awliu/optimizer_saving_lr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=awliu/optimizer_saving_lr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:awliu/optimizer_saving_lr)