### PR TITLE
ds_prefill(dispatch hang fix)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -96,14 +96,16 @@ SEQ_LEN_25K = 25 * 1024
 @pytest.mark.parametrize("is_balanced", [True, False], ids=["balanced", "regular"])
 @pytest.mark.parametrize(
     "isl_total, dispatch_buffer_capacity_factor",
-    [(SEQ_LEN_1K, 2), (SEQ_LEN_25K, 2)],
+    [(SEQ_LEN_1K, 8), (SEQ_LEN_25K, 8)],
 )
 @pytest.mark.parametrize(
     "num_layers",
     [
+        5,
         12,
         pytest.param(61, marks=pytest.mark.skipif(not is_galaxy(), reason="Testing entire-prefill only on Galaxy")),
     ],
+    ids=["5_layers", "12_layers", "61_layers"],
 )
 @pytest.mark.parametrize(
     "n_routed_experts, gate_fallback_mode",
@@ -111,10 +113,11 @@ SEQ_LEN_25K = 25 * 1024
         (64, GateComputeMode.HOST_ALL),
         (256, GateComputeMode.HOST_ALL),
         (256, GateComputeMode.DEVICE),
+        (256, GateComputeMode.DEVICE_FP32),
     ],
-    ids=["e64_host", "e256_host", "e256_device"],
+    ids=["e64_host", "e256_host", "e256_device", "e256_device_fp32"],
 )
-@pytest.mark.parametrize("num_iterations", [1])
+@pytest.mark.parametrize("num_iterations", [1, 25, 2000], ids=["iter1", "iter25", "iter2000"])
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
     [

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
@@ -181,7 +181,7 @@ void kernel_main() {
     for (uint32_t c = 0; c < num_cores; c++) {
         noc_semaphore_inc(all_core_barrier_noc_addrs[c], 1);
     }
-    noc_async_write_barrier();
+    noc_async_atomic_barrier();
 
     const auto output_addr_gen = TensorAccessor(output_args, output_addr);
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_writer.cpp
@@ -137,6 +137,7 @@ void kernel_main() {
     uint64_t sender_c9_slot_noc_addr =
         get_noc_addr(sender_noc_x, sender_noc_y, sender_idle_c9_scratch_l1_offset + core_id * sizeof(uint32_t));
     noc_inline_dw_write(sender_c9_slot_noc_addr, my_c9_l1_offset);
+    noc_async_write_barrier();  // ensure c_9 offset has landed before atomic inc wakes sender
     noc_semaphore_inc(sender_data_ready_noc_addr, 1);
     noc_async_atomic_barrier();
 
@@ -191,7 +192,6 @@ void kernel_main() {
                 uint32_t output_page_idx = dst_token_idx * num_experts_per_tok + dst_topk_indice;
                 noc_async_write_page(
                     output_page_idx, output_addr_gen, untilize_read_ptr + t * aligned_output_page_size);
-                noc_async_writes_flushed();
             }
             noc_async_write_barrier();
         }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_writer.cpp
@@ -192,6 +192,7 @@ void kernel_main() {
                 uint32_t output_page_idx = dst_token_idx * num_experts_per_tok + dst_topk_indice;
                 noc_async_write_page(
                     output_page_idx, output_addr_gen, untilize_read_ptr + t * aligned_output_page_size);
+                noc_async_writes_flushed();
             }
             noc_async_write_barrier();
         }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
@@ -99,6 +99,7 @@ void kernel_main() {
     uint64_t sender_scratch_slot_noc_addr =
         get_noc_addr(sender_noc_x, sender_noc_y, sender_scratch_base + core_id * sizeof(uint32_t));
     noc_inline_dw_write(sender_scratch_slot_noc_addr, mailbox_l1_addr);
+    noc_async_write_barrier();  // ensure mailbox L1 addr has landed before atomic wakes sender
     uint64_t sender_mbox_ready_noc_addr =
         get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(mbox_ready_semaphore_id));
     noc_semaphore_inc(sender_mbox_ready_noc_addr, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
@@ -174,4 +174,8 @@ void kernel_main() {
         // 6. Release untilize CB
         cb_pop_front(cb_untilize_id, read_batch_size);
     }
+    // Ensure all in-flight NOC traffic has landed before kernel exit. The all-local path only
+    // calls noc_async_writes_flushed (departure-from-source); without this barrier its
+    // noc_async_write_page DRAM writes can still be in flight at program end.
+    noc_async_full_barrier();
 }


### PR DESCRIPTION
## Summary
- **dispatch/writer_untilize_dispatch.cpp**: add `noc_async_write_barrier()` so the mailbox L1 address lands before the atomic semaphore inc wakes the sender; add a final `noc_async_full_barrier()` at kernel exit so in-flight DRAM writes from `noc_async_write_page` cannot still be in flight at program end (the all-local path previously only flushed departure-from-source).
- **combine/writer_combine.cpp**: switch the all-core barrier from `noc_async_write_barrier()` to `noc_async_atomic_barrier()` since the preceding ops are `noc_semaphore_inc` atomics, not writes.
- **combine/zero_init_writer.cpp**: add `noc_async_write_barrier()` so the c_9 offset write lands before the atomic inc wakes the sender; drop the redundant per-page `noc_async_writes_flushed()` (the loop already ends with `noc_async_write_barrier()`).
- **tests/test_prefill_transformer.py**: extend parametrization for stress repro — add 5-layer config, add `e256_device_fp32`, add `iter25`/`iter2000`, bump `dispatch_buffer_capacity_factor` 2 → 8.

## Test plan
- `/deepseek-pipelines` (all 4 CI workflows)

### DeepSeek Prefill CI
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mbezulj/2605-hang-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:mbezulj/2605-hang-fix) Galaxy
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/2605-hang-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mbezulj/2605-hang-fix) T3K
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=mbezulj/2605-hang-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:mbezulj/2605-hang-fix) Single Card
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/2605-hang-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/2605-hang-fix) Blackhole

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2605-hang-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2605-hang-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/2605-hang-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/2605-hang-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2605-hang-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2605-hang-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2605-hang-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2605-hang-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/2605-hang-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/2605-hang-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2605-hang-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2605-hang-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2605-hang-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2605-hang-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2605-hang-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2605-hang-fix)