### PR TITLE
fabric: fix Z/NESW mismatch race causing intermesh connection drops

### DIFF
--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2972,7 +2972,15 @@ std::vector<PortDescriptor> ControlPlane::propose_port_descriptors_for_exit_node
 
         // Deferred intermesh_* updates until after rank-0 pairing (Z/NESW may change).
         auto try_assign_port = [&](bool use_z_direction) -> bool {
-            for (const auto& [port_id_pair, port_chip_id] : mesh_edge_ports_to_chip_id[*my_mesh_id]) {
+            std::vector<std::pair<port_id_t, ChipId>> sorted_edge_ports(
+                mesh_edge_ports_to_chip_id[*my_mesh_id].begin(),
+                mesh_edge_ports_to_chip_id[*my_mesh_id].end());
+            std::sort(sorted_edge_ports.begin(), sorted_edge_ports.end(), [](const auto& a, const auto& b) {
+                if (a.first.first != b.first.first)
+                    return static_cast<int>(a.first.first) < static_cast<int>(b.first.first);
+                return a.first.second < b.first.second;
+            });
+            for (const auto& [port_id_pair, port_chip_id] : sorted_edge_ports) {
                 if (exit_node_chip != port_chip_id) {
                     continue;
                 }
@@ -3240,25 +3248,25 @@ void ControlPlane::forward_intermesh_connections_from_controller(AnnotatedInterm
                 tt::stl::Span<std::byte>(
                     reinterpret_cast<std::byte*>(&serialized_table_size), sizeof(serialized_table_size)),
                 Rank{static_cast<int>(peer_rank)},
-                Tag{0});
+                Tag{1});
             distributed_context.send(
                 tt::stl::as_writable_bytes(
                     tt::stl::Span<uint8_t>(serialized_connections.data(), serialized_connections.size())),
                 Rank{static_cast<int>(peer_rank)},
-                Tag{0});
+                Tag{1});
         }
     } else {
         distributed_context.recv(
             tt::stl::Span<std::byte>(
                 reinterpret_cast<std::byte*>(&serialized_table_size), sizeof(serialized_table_size)),
             Rank{0},
-            Tag{0});
+            Tag{1});
         serialized_connections.resize(serialized_table_size);
         distributed_context.recv(
             tt::stl::as_writable_bytes(
                 tt::stl::Span<uint8_t>(serialized_connections.data(), serialized_connections.size())),
             Rank{0},
-            Tag{0});
+            Tag{1});
         intermesh_connections = deserialize_intermesh_connections_from_bytes(serialized_connections);
     }
     distributed_context.barrier();
@@ -3285,7 +3293,9 @@ AnnotatedIntermeshConnections ControlPlane::pair_logical_intermesh_ports(const P
     for (const auto& [src_mesh, dest_mesh_to_proposals] : port_descriptors) {
         for (const auto& [dest_mesh, proposals] : dest_mesh_to_proposals) {
             for (const auto& proposal : proposals) {
-                occupied_nesw_port_ids[*src_mesh].insert(proposal.port_id);
+                if (proposal.port_id.first != RoutingDirection::Z) {
+                    occupied_nesw_port_ids[*src_mesh].insert(proposal.port_id);
+                }
             }
         }
     }
@@ -3411,7 +3421,7 @@ AnnotatedIntermeshConnections ControlPlane::pair_logical_intermesh_ports(const P
                             *src_mesh,
                             *dst_mesh,
                             src_proposal.connection_hash);
-                        break;
+                        continue;
                     }
                 }
 
@@ -3428,7 +3438,7 @@ AnnotatedIntermeshConnections ControlPlane::pair_logical_intermesh_ports(const P
                         *src_mesh,
                         *dst_mesh,
                         src_proposal.connection_hash);
-                    break;
+                    continue;
                 }
                 auto record_z_port_commit = [&](uint32_t mesh_id, port_id_t port, uint32_t neighbor_mesh_id) {
                     if (port.first == RoutingDirection::Z) {

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2953,8 +2953,9 @@ std::vector<PortDescriptor> ControlPlane::propose_port_descriptors_for_exit_node
         mesh_edge_ports_to_chip_id[*my_mesh_id].begin(),
         mesh_edge_ports_to_chip_id[*my_mesh_id].end());
     std::sort(sorted_edge_ports.begin(), sorted_edge_ports.end(), [](const auto& a, const auto& b) {
-        if (a.first.first != b.first.first)
+        if (a.first.first != b.first.first) {
             return static_cast<int>(a.first.first) < static_cast<int>(b.first.first);
+        }
         return a.first.second < b.first.second;
     });
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2947,6 +2947,17 @@ std::vector<PortDescriptor> ControlPlane::propose_port_descriptors_for_exit_node
             *neighbor_mesh_id);
     }
 
+    // Build once outside the per-exit-node loop: mesh_edge_ports_to_chip_id[my_mesh_id] is
+    // constant throughout this function, so there is no need to re-sort on every iteration.
+    std::vector<std::pair<port_id_t, ChipId>> sorted_edge_ports(
+        mesh_edge_ports_to_chip_id[*my_mesh_id].begin(),
+        mesh_edge_ports_to_chip_id[*my_mesh_id].end());
+    std::sort(sorted_edge_ports.begin(), sorted_edge_ports.end(), [](const auto& a, const auto& b) {
+        if (a.first.first != b.first.first)
+            return static_cast<int>(a.first.first) < static_cast<int>(b.first.first);
+        return a.first.second < b.first.second;
+    });
+
     for (const auto& exit_node : exit_nodes) {
         FabricNodeId exit_node_fabric_node_id = this->get_fabric_node_id_from_asic_id(*exit_node.src_exit_node);
 
@@ -2971,15 +2982,9 @@ std::vector<PortDescriptor> ControlPlane::propose_port_descriptors_for_exit_node
         auto exit_node_chip = exit_node_fabric_node_id.chip_id;
 
         // Deferred intermesh_* updates until after rank-0 pairing (Z/NESW may change).
+        // sorted_edge_ports is computed once before this loop (mesh_edge_ports_to_chip_id[my_mesh_id]
+        // is constant for the lifetime of this function).
         auto try_assign_port = [&](bool use_z_direction) -> bool {
-            std::vector<std::pair<port_id_t, ChipId>> sorted_edge_ports(
-                mesh_edge_ports_to_chip_id[*my_mesh_id].begin(),
-                mesh_edge_ports_to_chip_id[*my_mesh_id].end());
-            std::sort(sorted_edge_ports.begin(), sorted_edge_ports.end(), [](const auto& a, const auto& b) {
-                if (a.first.first != b.first.first)
-                    return static_cast<int>(a.first.first) < static_cast<int>(b.first.first);
-                return a.first.second < b.first.second;
-            });
             for (const auto& [port_id_pair, port_chip_id] : sorted_edge_ports) {
                 if (exit_node_chip != port_chip_id) {
                     continue;


### PR DESCRIPTION
## Summary

Fixes a non-deterministic failure in `ControlPlaneFixture.TestBlitzDecodePipelineBuilder` (superpod 64-mesh variant) where intermesh connections were silently dropped, producing:

```
Z/non-Z mismatch M29<->M30 (hash=...); no swap possible, dropping
No inter-mesh connection from mesh 29 to mesh 30
```

Root cause was 4 compounding bugs in `pair_logical_intermesh_ports` and `propose_port_descriptors_for_exit_nodes`:

### Bug 1 — `occupied_nesw_port_ids` over-population (direct cause)
Z-direction proposals were inserted into `occupied_nesw_port_ids`, making `find_free_port(..., want_z=false)` always return `nullopt`. This meant the Z→NESW demotion swap **always failed**, so any Z/NESW mismatch was always dropped rather than resolved.

### Bug 2 — `break` instead of `continue` in mismatch handler  
On the first unresolvable proposal for a mesh pair, `break` exited the entire proposal loop, silently dropping all remaining proposals for that pair. Changed to `continue`.

### Bug 3 — Non-deterministic `unordered_map` iteration  
`try_assign_port` iterated `mesh_edge_ports_to_chip_id[mesh]` (an `unordered_map`) without ordering — different hash layouts across ranks/runs caused different ports to be assigned to the same physical cable, triggering mismatches non-deterministically. Fixed by sorting by `(RoutingDirection, channel_id)` before iteration.

### Bug 4 — MPI Tag reuse  
`forward_intermesh_connections_from_controller` reused `Tag{0}` from `forward_descriptors_to_controller`. Changed to `Tag{1}` to avoid potential message interleaving.

## Failing CI run
https://github.com/tenstorrent/tt-metal/actions/runs/25254108653
- `fabric-cpu-only-unit-tests (wormhole_b0)` — FAILED
- `Merge Gate Status` — FAILED

## Test plan
- [x] `ControlPlaneFixture.TestBlitzDecodePipelineBuilder` (superpod, 64-mesh) — was failing
- [x] `ControlPlaneFixture.TestBlitzDecodePipelineBuilder` (single-pod, 16-mesh) — regression check
- [x] Full fabric CPU-only test suite (`run_fabric_cpu_only_unit_tests.sh`)
- [x] Run deterministically multiple times to confirm non-determinism is resolved

## Related files
- `tt_metal/fabric/control_plane.cpp`
- `tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp`

---
🤖 This PR was created by **BrAIn** (Claude AI assistant). Reviewed and authored on behalf of @Riddy21.

## CI Results

> Last updated: 2026-05-02 — commit `8d556d2f` (clang-tidy fix)

| Workflow | Result | Run | Notes |
|----------|--------|-----|-------|
| PR Gate | ✅ success | [25265086085](https://github.com/tenstorrent/tt-metal/actions/runs/25265086085) | |
| Blackhole Post-Commit | ✅ success | [25264138366](https://github.com/tenstorrent/tt-metal/actions/runs/25264138366) | |
| Sanity Tests | ✅ success | [25264139889](https://github.com/tenstorrent/tt-metal/actions/runs/25264139889) | |
| T3K Unit Tests | ❌ failure | [25264137456](https://github.com/tenstorrent/tt-metal/actions/runs/25264137456) | Pre-existing on `main` — same 3 jobs (`t3k_dits_tests`, `t3k_tt_metal_multiprocess_tests`, `t3k_ttnn_tests`) failing for 5+ consecutive days |
| Galaxy Unit Tests | ❌ failure | [25264137976](https://github.com/tenstorrent/tt-metal/actions/runs/25264137976) | Pre-existing on `main` — `Galaxy Multi-Process tests` failing for 5+ days |
| Multi-Host Deployment | ❌ failure | [25264138813](https://github.com/tenstorrent/tt-metal/actions/runs/25264138813) | Flaky infrastructure — `multi-host-t3k` also fails on `main` (run [25251797770](https://github.com/tenstorrent/tt-metal/actions/runs/25251797770)); different jobs rotate each run |

**Verdict: No regressions introduced by this PR.** All failures are pre-existing or infrastructure flakiness verified against `main`.