### PR TITLE
WH: recover Llama 3.3 70B Galaxy perf via kernel-config slack

### DIFF
--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
@@ -156,23 +156,10 @@
 #error "Packet header pool base and size must be 16-byte aligned"
 #endif
 
-// Compatibility padding so MEM_MAP_END (and downstream user-allocatable L1 base
-// computed from it in wh_hal_tensix.cpp) keeps the position it had before #43082,
-// when MEM_BRISC_FIRMWARE_SIZE was 6*1024 + 2560. Issue #43360: shrinking BRISC
-// firmware to fit in 6KB shifted the user L1 base down by 2560 bytes and cost
-// ~3 t/s/u on Llama 3.3 70B Galaxy text_demo via worse L1-bank distribution for
-// sharded tensors. Padding here (rather than restoring MEM_BRISC_FIRMWARE_SIZE)
-// leaves MEM_TENSIX_FABRIC_CONNECTIONS_BASE / MEM_PACKET_HEADER_POOL_BASE
-// untouched, avoiding the fabric-CCL deadlock from PR #41021's layout.
-#define MEM_L1_LAYOUT_COMPAT_PAD_SIZE 2560
-#if (MEM_L1_LAYOUT_COMPAT_PAD_SIZE % 16 != 0)
-#error "MEM_L1_LAYOUT_COMPAT_PAD_SIZE must be 16-byte aligned"
-#endif
-
 // Read-only reserved memory boundary for watcher checks
 #define MEM_MAP_READ_ONLY_END (MEM_TENSIX_FABRIC_CONNECTIONS_BASE + MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO)
 // Read-write reserved memory boundary for watcher checks
-#define MEM_MAP_END (MEM_PACKET_HEADER_POOL_BASE + MEM_PACKET_HEADER_POOL_SIZE + MEM_L1_LAYOUT_COMPAT_PAD_SIZE)
+#define MEM_MAP_END (MEM_PACKET_HEADER_POOL_BASE + MEM_PACKET_HEADER_POOL_SIZE)
 
 // Every address after MEM_MAP_END is a "scratch" address
 // These can be used by FW during init, but aren't usable once FW reaches "ready"

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
@@ -156,10 +156,23 @@
 #error "Packet header pool base and size must be 16-byte aligned"
 #endif
 
+// Compatibility padding so MEM_MAP_END (and downstream user-allocatable L1 base
+// computed from it in wh_hal_tensix.cpp) keeps the position it had before #43082,
+// when MEM_BRISC_FIRMWARE_SIZE was 6*1024 + 2560. Issue #43360: shrinking BRISC
+// firmware to fit in 6KB shifted the user L1 base down by 2560 bytes and cost
+// ~3 t/s/u on Llama 3.3 70B Galaxy text_demo via worse L1-bank distribution for
+// sharded tensors. Padding here (rather than restoring MEM_BRISC_FIRMWARE_SIZE)
+// leaves MEM_TENSIX_FABRIC_CONNECTIONS_BASE / MEM_PACKET_HEADER_POOL_BASE
+// untouched, avoiding the fabric-CCL deadlock from PR #41021's layout.
+#define MEM_L1_LAYOUT_COMPAT_PAD_SIZE 2560
+#if (MEM_L1_LAYOUT_COMPAT_PAD_SIZE % 16 != 0)
+#error "MEM_L1_LAYOUT_COMPAT_PAD_SIZE must be 16-byte aligned"
+#endif
+
 // Read-only reserved memory boundary for watcher checks
 #define MEM_MAP_READ_ONLY_END (MEM_TENSIX_FABRIC_CONNECTIONS_BASE + MEM_TENSIX_FABRIC_OFFSET_OF_ALIGNED_INFO)
 // Read-write reserved memory boundary for watcher checks
-#define MEM_MAP_END (MEM_PACKET_HEADER_POOL_BASE + MEM_PACKET_HEADER_POOL_SIZE)
+#define MEM_MAP_END (MEM_PACKET_HEADER_POOL_BASE + MEM_PACKET_HEADER_POOL_SIZE + MEM_L1_LAYOUT_COMPAT_PAD_SIZE)
 
 // Every address after MEM_MAP_END is a "scratch" address
 // These can be used by FW during init, but aren't usable once FW reaches "ready"

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix.cpp
@@ -34,7 +34,18 @@ HalCoreInfoType create_tensix_mem_map() {
     constexpr std::uint32_t max_alignment = std::max(DRAM_ALIGNMENT, L1_ALIGNMENT);
 
     std::vector<DeviceAddr> mem_map_bases;
-    const uint32_t default_l1_kernel_config_size = 69 * 1024;
+    // 69 KiB kernel-config region + 2560 bytes of compatibility slack so
+    // DEFAULT_UNRESERVED (user-allocatable L1 base) lands at the same address it
+    // had before #43082 shrank MEM_BRISC_FIRMWARE_SIZE by 2560 bytes. Without
+    // this slack Llama 3.3 70B Galaxy text_demo regresses ~3 t/s/u (#43360)
+    // because sharded-tensor placement is sensitive to the user-L1 base offset.
+    // Adjusting only this host-side constant (rather than MEM_MAP_END or
+    // MEM_BRISC_FIRMWARE_SIZE) keeps every L1 reserved-region address — including
+    // MEM_BRISC_INIT_LOCAL_L1_BASE_SCRATCH that BRISC firmware references —
+    // exactly where they are now, so the BRISC firmware ELF (which fits the
+    // stock 6 KB region with only 40 bytes to spare under PROFILE_PERF_COUNTERS)
+    // is unaffected.
+    const uint32_t default_l1_kernel_config_size = 69 * 1024 + 2560;
 
     mem_map_bases.resize(static_cast<std::size_t>(HalL1MemAddrType::COUNT), 0);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BASE)] = MEM_L1_BASE;


### PR DESCRIPTION
### Ticket                                                      
  Fixes #43360

  ### Problem description                                                                                                                                                                       
  Llama 3.3 70B Galaxy `text_demo` regressed by ~3 t/s/u on commit `4919a5a`. That commit shrank `MEM_BRISC_FIRMWARE_SIZE` from `6*1024 + 2560` back to `6*1024` after optimizing perf-counter
  BRISC firmware code to fit in the stock 6 KB region — the earlier `+2560` bump on `main` had caused fabric-CCL deadlocks on `test_decoder_block.py` and a sanity-test regression on           
  `test_binary_add_uint16_bcast`, which is why it had to be reverted.
                                                                                                                                                                                                
  The shrink had a side effect: removing 2560 bytes from `MEM_BRISC_FIRMWARE_SIZE` cascades through every region defined relative to it, lowering `MEM_MAP_END` by 2560. In `wh_hal_tensix.cpp`,
   `KERNEL_CONFIG_BASE` and `DEFAULT_UNRESERVED` (user-allocatable L1 base) are computed from `MEM_MAP_END`, so the user-L1 base shifted down by 2560 too. Llama 3.3 70B Galaxy's sharded-tensor
   placement is tuned for the previous user-L1 base position; the new lower base regresses decode by ~3 t/s/u via worse L1-bank distribution.                                                   
                                                                                                                                                                                                                             
  ### What's changed                                                                                                                                                                            
  Bump `default_l1_kernel_config_size` in `tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix.cpp` from `69 * 1024` to `69 * 1024 + 2560`. Host-only; one constant.
                                                                                                                                                                                                
  This pushes `DEFAULT_UNRESERVED` (user-L1 base) up by 2560 bytes — restoring the tensor base address that Llama's sharded layout is tuned for — while leaving `MEM_BRISC_FIRMWARE_SIZE`,      
  `MEM_MAP_END`, `MEM_BRISC_INIT_LOCAL_L1_BASE_SCRATCH`, `MEM_TENSIX_FABRIC_CONNECTIONS_BASE`, `MEM_PACKET_HEADER_POOL_BASE`, and every other reserved-region address bit-identical to current  
  `main`. Result:                                                                                                                                                                               
                                                                  
  - BRISC firmware ELF is unchanged → it still fits in the 6 KB region under `PROFILE_PERF_COUNTERS=47`, so the `test_perf_op_report.py [Matmul_perf_counters]` profiler-regression CI test     
  stays green.
  - Fabric-region addresses are unchanged → `test_decoder_block.py` (fabric-CCL deadlock) and `test_binary_add_uint16_bcast` (sanity) failures previously associated with shifting these regions
   do not return.                                                                                                                                                                               
   
  The kernel-config region (between `KERNEL_CONFIG_BASE = MEM_MAP_END` and `DEFAULT_UNRESERVED`) gains 2560 bytes of unused slack; the cost is deducted from the user-allocatable L1 size.      
                                                                  
  ### Why exactly 2560                                                                                                                                                                          
  This is the per-RISC firmware allocation unit established in the codebase for cross-architecture circular-buffer descriptor storage. It decomposes as:
                                                                                                                                                                                                
  - **2048 bytes** = 64 CBs × 32 bytes/`CBInterface`.                                                                                                                                           
    - 64 CBs is the cross-architecture host-side CB allocation maximum (Blackhole's hardware-supported count, accommodated by BH's 4 KB TRISC local data RAM; Wormhole's 2 KB TRISC local data  
  RAM only supports 32 CBs at runtime, but host arrays are sized for the maximum). See `tt_metal/api/tt-metalium/circular_buffer_constants.h`.                                                  
    - 32 bytes/`CBInterface` is the descriptor struct's fixed size.
  - **+ 512 bytes** = ad-hoc firmware-code headroom for cases that need extra space, e.g. profiler-enabled builds. Introduced in PR #35963 ("Increase CB limit to 64 on Blackhole").            
  - **= 2560 bytes total.**                                                                                                                                                                     
                                                                                                                                                                                                
  The value is live in the codebase as Blackhole's per-RISC firmware allocation unit:                                                                                                           
                                                                                                                                                                                                
  ```c                                                            
  // tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
  #define MEM_BRISC_FIRMWARE_SIZE  (6 * 1024 + 2560)   // 8704                                                                                                                                  
  #define MEM_NCRISC_FIRMWARE_SIZE 2560                                                                                                                                                         
  #define MEM_TRISC0_FIRMWARE_SIZE 2560                                                                                                                                                         
  #define MEM_TRISC1_FIRMWARE_SIZE 2560                                                                                                                                                         
  #define MEM_TRISC2_FIRMWARE_SIZE 2560                                                                                                                                                         
  ```
                                                                                                                                                                                                
  For Wormhole, 2560 is also the precise amount needed to restore user-L1 base to the address Llama's sharded-tensor placement was tuned against: the layout against which Llama was tuned had  
  `MEM_BRISC_FIRMWARE_SIZE = 6*1024 + 2560`, and removing those 2560 bytes is what shifted user-L1 base down. Adding 2560 bytes via `default_l1_kernel_config_size` puts it back exactly.
                                                                                                                                                                                                
  Alignment: 2560 is divisible by 16 (NoC alignment, enforced by existing `static_assert` in `wh_hal_tensix_asserts.hpp`), 32 (DRAM alignment), 64 (cache line), 128, 256, and 512 — every      
  downstream address that was N-byte aligned remains so.
                                                                                                                                                                                                
  Smaller values would only partially recover the regression; larger values would push user-L1 base above the parent layout into untested territory and waste more user-allocatable L1.                          
                                                                                                                                                                                                
  ### Notes for reviewers                                                                                                                                                                       
  - Single-file, single-constant change in `wh_hal_tensix.cpp`. No `dev_mem_map.h` changes, no firmware ELF changes, no kernel-side code changes.                                               
  - BH and Quasar `*_hal_tensix.cpp` are intentionally untouched.                                                                                                                               
  - The branch has 2 commits — `78df785` (an earlier `dev_mem_map.h`-padding approach that broke the BRISC firmware ELF by 4 bytes via longer immediate-value encodings of shifted scratch      
  addresses) and the actual fix `dbf20c2`. Squash on merge so only the fix lands.                                                                                                               
        

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvlahovic/perf_regression_llama_3_3_70b_galaxy_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvlahovic/perf_regression_llama_3_3_70b_galaxy_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mvlahovic/perf_regression_llama_3_3_70b_galaxy_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mvlahovic/perf_regression_llama_3_3_70b_galaxy_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mvlahovic/perf_regression_llama_3_3_70b_galaxy_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mvlahovic/perf_regression_llama_3_3_70b_galaxy_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvlahovic/perf_regression_llama_3_3_70b_galaxy_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvlahovic/perf_regression_llama_3_3_70b_galaxy_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mvlahovic/perf_regression_llama_3_3_70b_galaxy_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mvlahovic/perf_regression_llama_3_3_70b_galaxy_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mvlahovic/perf_regression_llama_3_3_70b_galaxy_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mvlahovic/perf_regression_llama_3_3_70b_galaxy_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mvlahovic/perf_regression_llama_3_3_70b_galaxy_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mvlahovic/perf_regression_llama_3_3_70b_galaxy_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mvlahovic/perf_regression_llama_3_3_70b_galaxy_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mvlahovic/perf_regression_llama_3_3_70b_galaxy_pr)