### PR TITLE
Matmul DM: K-loop v1, per-core heatmap stamps, NOC1 saturation tests

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -56,7 +56,7 @@ Both API versions run the same test cases but use different underlying implement
 | Transaction ID              | 600-602, 610-611                | Tests the usage and effects of transaction IDs in NOC transactions.                     |
 | PCIe Read Bandwidth         | 603, 605                        | Measures PCIe read bandwidth from host memory to L1 on a single Tensix core.            |
 | PCIe Write Bandwidth        | 604                             | Measures PCIe write bandwidth from L1 to host memory on a single Tensix core.           |
-| Matmul                      | 1000-1228                       | 1D v1, 1D v2, and 2D matmul DM tests across grid shapes, subblock dims, K depths, non-origin starts, and DRAM banks. Per-variant offsets: 1D v1 +0 (1000-1028), 1D v2 +100 (1100-1128), 2D +200 (1200-1228). 1D: in0 multicast + in1 DRAM read. 2D: in0 row multicast + in1 column multicast (all L1, no DRAM). |
+| Matmul                      | 1000-1231                       | 1D v1, 1D v2, and 2D matmul DM tests across grid shapes, subblock dims, K depths, non-origin starts, and DRAM banks. Per-variant offsets: 1D v1 +0 (1000-1031), 1D v2 +100 (1100-1131), 2D +200 (1200-1231). 1D: in0 row multicast + in1 column multicast (row 0 reads its DRAM slice once, then multicasts down the column). 2D: in0 row multicast + in1 column multicast (all L1, no DRAM). Perf-characterization sweeps: 1029 (4x4 K=1 sub_r {1..256}), 1030 (4x4 K=8 (sub_r, sub_c) 2D), 1031 (8x7 K=8 (sub_r, sub_c) 2D). |
 | NOC API Latency             | 700-706                         | Measures latency (cycles) of NOC API calls using experimental dataflow 2.0 API.         |
 | NOC Estimator               | 800-817                         | Comprehensive bandwidth sweeps for NOC estimation across all patterns and mechanisms.    |
 | Quasar Addrgen              | 900-909                         | Quasar-only: example kernels exercising the hardware address generator (1D/2D/face/interleaved). Requires Quasar simulator. |
@@ -152,4 +152,4 @@ By default, per-core bandwidth is computed as `(Number of transactions × Transa
 ```cpp
 DeviceTimestampedData("Per-core bytes", actual_bytes_pushed_by_this_core);
 ```
-When present, `gather_bw_per_core` uses this stamp as the numerator for that core, exposing sender-vs-receiver asymmetry on the heatmap. The matmul kernels (`in0_kernel.cpp`, `in0_kernel_v2.cpp`, `in0_kernel_2d.cpp`, `in1_kernel_2d.cpp`) all do this so the heatmaps correctly show which cores are doing the multicast work.
+When present, `gather_bw_per_core` uses this stamp as the numerator for that core, exposing sender-vs-receiver asymmetry on the heatmap. All five matmul multicast kernels (`in0_kernel.cpp`, `in0_kernel_v2.cpp`, `in0_kernel_2d.cpp`, `in1_kernel.cpp`, `in1_kernel_2d.cpp`) do this so the heatmaps correctly show which cores are doing the multicast work.

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -146,3 +146,10 @@ python tests/tt_metal/tt_metal/data_movement/python/heatmap.py -n 16 -s 4096
 The script generates:
 - A heatmap PNG file showing per-core bandwidth
 - Console output with numerical bandwidth values per core
+
+### Per-core stamps (`Per-core bytes`)
+By default, per-core bandwidth is computed as `(Number of transactions × Transaction size) / duration_cycles` using the global per-run attributes — same numerator on every core. For tests where the per-core NOC traffic is asymmetric (e.g. matmul multicast, where only one column actually sends), kernels can stamp a per-core override:
+```cpp
+DeviceTimestampedData("Per-core bytes", actual_bytes_pushed_by_this_core);
+```
+When present, `gather_bw_per_core` uses this stamp as the numerator for that core, exposing sender-vs-receiver asymmetry on the heatmap. The matmul kernels (`in0_kernel.cpp`, `in0_kernel_v2.cpp`, `in0_kernel_2d.cpp`, `in1_kernel_2d.cpp`) all do this so the heatmaps correctly show which cores are doing the multicast work.

--- a/tests/tt_metal/tt_metal/data_movement/matmul/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/README.md
@@ -351,7 +351,7 @@ After program execution, the host reads back L1 memory from every core and verif
 
 ## Test Cases
 
-All 26 configurations are defined in `test_matmul_common.hpp` and shared by 1D v1, 1D v2, and 2D.
+All 28 configurations are defined in `test_matmul_common.hpp` and shared by 1D v1, 1D v2, and 2D.
 Test names follow the pattern: `ID{id}_R{r}_C{c}_K{k}_sr{sr}_sc{sc}_sk{sk}_X{x}Y{y}_bank{b}` where `{id}` is the BASE id from the config. The actual profiler `test_id` has the per-variant offset added (see [Per-variant test IDs](#per-variant-test-ids)).
 
 ### Grid Shape Tests
@@ -416,6 +416,20 @@ These test the three key relationships between K and C that affect v2's rotating
 | 1023 | 2x4       | 2 | K < C        | Only columns 0-1 send; columns 2-3 are always receivers. |
 | 1024 | 2x3       | 3 | K = C        | Each column sends exactly once — balanced workload. |
 | 1025 | 2x3       | 5 | K % C != 0   | Columns 0-1 send twice, column 2 sends once — uneven. |
+
+### Subblock Sweep Tests (perf characterization)
+
+These tests sweep one subblock dimension to characterize per-transaction bandwidth/latency on the in0 multicast path (1027, 1029) or the in1 path (1028) or both (1030). All use a 4x4 grid.
+
+| ID   | K | Sweep var | Sweep range | Held | Purpose |
+|------|---|-----------|-------------|------|---------|
+| 1026 | 4 | `subblock_k_dim` | {1, 2, 4, 8} | sub_r=4, sub_c=4 | K subblock size sweep — characterizes K-loop scaling. |
+| 1027 | 8 | `subblock_r_dim` | {1, 2, 4, 8, 16, 32} | sub_c=1, sub_k=1 | R subblock size sweep — varies in0 transaction size; K-loop runs 8 iterations per sweep point. |
+| 1028 | 8 | `subblock_c_dim` | {1, 2, 4, 8, 16, 32} | sub_r=1, sub_k=1 | C subblock size sweep — varies in1 per-core read size from DRAM. |
+| 1029 | 1 | `subblock_r_dim` | {1, 2, 4, 8, 16, 32, 64, 128, 256} | sub_c=1, sub_k=1 | R subblock size sweep, **single transaction** (K=1). Lets each data point be a single multicast of `subblock_r * 2048` bytes (no K-loop overhead). Extends past 1027 to characterize multicast bandwidth as a function of single-transaction size. |
+| 1030 | 8 | (sub_r, sub_c) 2D | sub_r ∈ {1, 2, 4, 8, 16}; sub_c ∈ {1, 2, 4, 8, 16, 32} | sub_k=1 | 2D Cartesian sweep over (in0, in1) sizes — 30 sweep points. sub_r is capped at 16 so the largest (sub_r=16, sub_c=32) corner fits col-0 L1 (~1 MiB). |
+
+For 1029 and 1030 the kernel issues per-K-subblock transactions, so `Number of transactions` in the profiler equals K. For 1029 each sweep point is one transaction; for 1030 each sweep point is K=8 transactions per core.
 
 ## Running the Tests
 

--- a/tests/tt_metal/tt_metal/data_movement/matmul/kernels/barrier_sync.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/kernels/barrier_sync.hpp
@@ -7,29 +7,9 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 
-/**
- * @brief Wait for all cores to reach the barrier before proceeding.
- *
- * This implements a coordinator-broadcast barrier synchronization:
- * 1. Each core increments a semaphore on the coordinator core
- * 2. The coordinator waits locally until its semaphore reaches num_cores
- * 3. The coordinator multicasts a "done" signal to all participating cores
- * 4. All cores wait for the "done" signal on their local semaphore
- *
- * This avoids the prior polling-read pattern that caused NOC congestion
- * with large core counts and potential issues with atomic wrap semantics.
- *
- * @param barrier_sem_id      Semaphore ID for arrival counting (on coordinator)
- * @param barrier_done_sem_id Semaphore ID for done broadcast (on all cores)
- * @param barrier_coord_x     Physical X coordinate of the coordinator core
- * @param barrier_coord_y     Physical Y coordinate of the coordinator core
- * @param num_cores           Total number of cores participating in the barrier
- * @param local_scratch_addr  Local L1 address for temporary storage (4 bytes)
- * @param mcast_start_x       Multicast rectangle start X (translated coords)
- * @param mcast_start_y       Multicast rectangle start Y (translated coords)
- * @param mcast_end_x         Multicast rectangle end X (translated coords)
- * @param mcast_end_y         Multicast rectangle end Y (translated coords)
- */
+// Coordinator-broadcast barrier: each core increments a counter on the coordinator,
+// which then multicasts a done signal once the count reaches num_cores. Avoids the
+// NOC congestion of polling-read barriers and atomic wrap edge cases.
 FORCE_INLINE void barrier_sync(
     uint32_t barrier_sem_id,
     uint32_t barrier_done_sem_id,
@@ -41,38 +21,28 @@ FORCE_INLINE void barrier_sync(
     uint32_t mcast_start_y,
     uint32_t mcast_end_x,
     uint32_t mcast_end_y) {
-    // Single core: nothing to synchronize.
     if (num_cores <= 1) {
         return;
     }
 
-    // Get L1 addresses for both semaphores
     uint32_t barrier_sem_addr = get_semaphore(barrier_sem_id);
     uint32_t done_sem_addr = get_semaphore(barrier_done_sem_id);
-
-    // Get NOC address of coordinator's barrier semaphore
     uint64_t barrier_noc_addr = get_noc_addr(barrier_coord_x, barrier_coord_y, barrier_sem_addr);
 
-    // Step 1: Signal arrival by incrementing the coordinator's semaphore
     noc_semaphore_inc(barrier_noc_addr, 1);
     noc_async_atomic_barrier();
 
-    // Check if this core is the coordinator
     bool is_coordinator = (my_x[0] == barrier_coord_x && my_y[0] == barrier_coord_y);
 
     if (is_coordinator) {
-        // Step 2: Coordinator waits locally until all cores have arrived
         volatile tt_l1_ptr uint32_t* barrier_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem_addr);
         noc_semaphore_wait_min(barrier_sem_ptr, num_cores);
-        noc_semaphore_set(barrier_sem_ptr, 0);  // Reset for potential reuse
+        noc_semaphore_set(barrier_sem_ptr, 0);
 
-        // Step 3: Multicast "done" signal to all cores (including self)
-        // Write 1 to local scratch as the source value for the multicast
         volatile tt_l1_ptr uint32_t* scratch_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_scratch_addr);
         *scratch_ptr = 1;
 
-        // Build the multicast address for the done semaphore on all cores
-        // NOC0 and NOC1 have opposite routing directions, so swap start/end for NOC1
+        // NOC0/NOC1 have opposite routing, so swap start/end for NOC1.
         uint64_t dst_done_sem_mcast_addr =
             noc_index == 0
                 ? get_noc_multicast_addr(mcast_start_x, mcast_start_y, mcast_end_x, mcast_end_y, done_sem_addr)
@@ -82,8 +52,7 @@ FORCE_INLINE void barrier_sync(
         noc_async_write_barrier();
     }
 
-    // Step 4: All cores (including coordinator) wait for the done signal
     volatile tt_l1_ptr uint32_t* done_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(done_sem_addr);
     noc_semaphore_wait(done_sem_ptr, 1);
-    noc_semaphore_set(done_sem_ptr, 0);  // Reset for potential reuse
+    noc_semaphore_set(done_sem_ptr, 0);
 }

--- a/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel.cpp
@@ -16,16 +16,17 @@ void kernel_main() {
     constexpr uint32_t sender_valid_sem_id = get_compile_time_arg_val(7);
     constexpr uint32_t receiver_sem_id = get_compile_time_arg_val(8);
 
-    uint32_t l1_base_address = get_arg_val<uint32_t>(0);        // sender: source of in0 data
-    uint32_t mcast_size_bytes = get_arg_val<uint32_t>(1);       // sender: bytes to multicast
-    uint32_t in0_mcast_output_addr = get_arg_val<uint32_t>(2);  // all cores: multicast dest
+    uint32_t l1_base_address = get_arg_val<uint32_t>(0);        // sender: source of in0 data (all K subblocks)
+    uint32_t num_subblocks_k_dim = get_arg_val<uint32_t>(1);    // K iterations
+    uint32_t k_subblock_size_bytes = get_arg_val<uint32_t>(2);  // bytes per K subblock
+    uint32_t in0_mcast_output_addr = get_arg_val<uint32_t>(3);  // all cores: multicast dest base
     // Barrier synchronization args
-    uint32_t barrier_sem_id = get_arg_val<uint32_t>(3);
-    uint32_t barrier_coord_x = get_arg_val<uint32_t>(4);
-    uint32_t barrier_coord_y = get_arg_val<uint32_t>(5);
-    uint32_t num_cores = get_arg_val<uint32_t>(6);
-    uint32_t local_barrier_addr = get_arg_val<uint32_t>(7);
-    uint32_t barrier_done_sem_id = get_arg_val<uint32_t>(8);
+    uint32_t barrier_sem_id = get_arg_val<uint32_t>(4);
+    uint32_t barrier_coord_x = get_arg_val<uint32_t>(5);
+    uint32_t barrier_coord_y = get_arg_val<uint32_t>(6);
+    uint32_t num_cores = get_arg_val<uint32_t>(7);
+    uint32_t local_barrier_addr = get_arg_val<uint32_t>(8);
+    uint32_t barrier_done_sem_id = get_arg_val<uint32_t>(9);
 
     uint32_t sender_sem_addr = get_semaphore(sender_sem_id);
     uint32_t sender_valid_sem_addr = get_semaphore(sender_valid_sem_id);
@@ -34,14 +35,14 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* sender_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_sem_addr);
     volatile tt_l1_ptr uint32_t* receiver_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_sem_addr);
 
+    // Column 0 is the fixed sender for every K iteration in v1.
     bool is_sender = (my_x[0] == physical_start_x);
 
-    uint64_t dst_data_mcast_addr =
-        get_noc_multicast_addr(physical_start_x, my_y[0], physical_end_x, my_y[0], in0_mcast_output_addr);
+    // Multicast addresses for my row. The L1 destination is OR-ed in per-iteration so the
+    // same base can be reused across the K-loop with different output offsets.
+    uint64_t row_mcast_base = get_noc_multicast_addr(physical_start_x, my_y[0], physical_end_x, my_y[0], 0);
 
-    uint64_t dst_receiver_sem_mcast_addr =
-        get_noc_multicast_addr(physical_start_x, my_y[0], physical_end_x, my_y[0], receiver_sem_addr);
-
+    // Address of the column-0 sender's sender_sem (used by receivers to signal readiness).
     uint64_t sender_sem_noc_addr = get_noc_addr(physical_start_x, my_y[0], sender_sem_addr);
 
     barrier_sync(
@@ -58,31 +59,52 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV0");
-        if (is_sender) {
-            noc_semaphore_wait(sender_sem_ptr, num_cores_c_dim - 1);
-            noc_semaphore_set(sender_sem_ptr, 0);
 
-            if constexpr (num_cores_c_dim > 1) {
-                noc_async_write_multicast_loopback_src(
-                    l1_base_address, dst_data_mcast_addr, mcast_size_bytes, num_cores_c_dim, true);
+        for (uint32_t k = 0; k < num_subblocks_k_dim; k++) {
+            uint32_t output_addr = in0_mcast_output_addr + k * k_subblock_size_bytes;
 
-                noc_semaphore_set_multicast_loopback_src(
-                    sender_valid_sem_addr, dst_receiver_sem_mcast_addr, num_cores_c_dim, false);
+            if (is_sender) {
+                // Source advances through the K subblocks held contiguously at l1_base_address.
+                uint32_t src_addr = l1_base_address + k * k_subblock_size_bytes;
+
+                // Wait for all C-1 receivers in the row to signal readiness for this iteration.
+                noc_semaphore_wait(sender_sem_ptr, num_cores_c_dim - 1);
+                noc_semaphore_set(sender_sem_ptr, 0);
+
+                if constexpr (num_cores_c_dim > 1) {
+                    uint64_t dst_data_mcast_addr = row_mcast_base | output_addr;
+                    noc_async_write_multicast_loopback_src(
+                        src_addr, dst_data_mcast_addr, k_subblock_size_bytes, num_cores_c_dim, true);
+
+                    uint64_t dst_receiver_sem_mcast_addr = row_mcast_base | receiver_sem_addr;
+                    noc_semaphore_set_multicast_loopback_src(
+                        sender_valid_sem_addr, dst_receiver_sem_mcast_addr, num_cores_c_dim, false);
+                } else {
+                    // Single column (C=1): unicast self-write (HW limitation with single-core multicast loopback).
+                    uint64_t local_dest_addr = get_noc_addr(my_x[0], my_y[0], output_addr);
+                    noc_async_write(src_addr, local_dest_addr, k_subblock_size_bytes);
+                    noc_async_write_barrier();
+                    noc_semaphore_set(receiver_sem_ptr, 1);
+                }
             } else {
-                uint64_t local_dest_addr = get_noc_addr(my_x[0], my_y[0], in0_mcast_output_addr);
-                noc_async_write(l1_base_address, local_dest_addr, mcast_size_bytes);
-                noc_async_write_barrier();
-                noc_semaphore_set(receiver_sem_ptr, 1);
+                // RECEIVER: signal readiness to the column-0 sender.
+                noc_semaphore_inc(sender_sem_noc_addr, 1);
             }
-        } else {
-            noc_semaphore_inc(sender_sem_noc_addr, 1);
-        }
 
-        noc_semaphore_wait(receiver_sem_ptr, 1);
-        noc_semaphore_set(receiver_sem_ptr, 0);
+            // All cores wait for data arrival, then reset for next iteration.
+            noc_semaphore_wait(receiver_sem_ptr, 1);
+            noc_semaphore_set(receiver_sem_ptr, 0);
+        }
     }
 
     DeviceTimestampedData("Test id", test_id);
-    DeviceTimestampedData("Number of transactions", 1);
-    DeviceTimestampedData("Transaction size in bytes", mcast_size_bytes);
+    DeviceTimestampedData("Number of transactions", num_subblocks_k_dim);
+    DeviceTimestampedData("Transaction size in bytes", k_subblock_size_bytes);
+    // Per-core actual NOC bytes pushed by this core's RISCV_0 across the K-loop.
+    // Sender (col 0) multicasts k_subblock_size_bytes K times; receivers issue K
+    // semaphore incs (one atomic op flit each).
+    constexpr uint32_t SEM_INC_BYTES = 16;
+    uint32_t per_core_bytes =
+        is_sender ? (num_subblocks_k_dim * k_subblock_size_bytes) : (num_subblocks_k_dim * SEM_INC_BYTES);
+    DeviceTimestampedData("Per-core bytes", per_core_bytes);
 }

--- a/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel.cpp
@@ -16,11 +16,10 @@ void kernel_main() {
     constexpr uint32_t sender_valid_sem_id = get_compile_time_arg_val(7);
     constexpr uint32_t receiver_sem_id = get_compile_time_arg_val(8);
 
-    uint32_t l1_base_address = get_arg_val<uint32_t>(0);        // sender: source of in0 data (all K subblocks)
-    uint32_t num_subblocks_k_dim = get_arg_val<uint32_t>(1);    // K iterations
-    uint32_t k_subblock_size_bytes = get_arg_val<uint32_t>(2);  // bytes per K subblock
-    uint32_t in0_mcast_output_addr = get_arg_val<uint32_t>(3);  // all cores: multicast dest base
-    // Barrier synchronization args
+    uint32_t l1_base_address = get_arg_val<uint32_t>(0);
+    uint32_t num_subblocks_k_dim = get_arg_val<uint32_t>(1);
+    uint32_t k_subblock_size_bytes = get_arg_val<uint32_t>(2);
+    uint32_t in0_mcast_output_addr = get_arg_val<uint32_t>(3);
     uint32_t barrier_sem_id = get_arg_val<uint32_t>(4);
     uint32_t barrier_coord_x = get_arg_val<uint32_t>(5);
     uint32_t barrier_coord_y = get_arg_val<uint32_t>(6);
@@ -35,14 +34,9 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* sender_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_sem_addr);
     volatile tt_l1_ptr uint32_t* receiver_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_sem_addr);
 
-    // Column 0 is the fixed sender for every K iteration in v1.
     bool is_sender = (my_x[0] == physical_start_x);
 
-    // Multicast addresses for my row. The L1 destination is OR-ed in per-iteration so the
-    // same base can be reused across the K-loop with different output offsets.
     uint64_t row_mcast_base = get_noc_multicast_addr(physical_start_x, my_y[0], physical_end_x, my_y[0], 0);
-
-    // Address of the column-0 sender's sender_sem (used by receivers to signal readiness).
     uint64_t sender_sem_noc_addr = get_noc_addr(physical_start_x, my_y[0], sender_sem_addr);
 
     barrier_sync(
@@ -64,10 +58,8 @@ void kernel_main() {
             uint32_t output_addr = in0_mcast_output_addr + k * k_subblock_size_bytes;
 
             if (is_sender) {
-                // Source advances through the K subblocks held contiguously at l1_base_address.
                 uint32_t src_addr = l1_base_address + k * k_subblock_size_bytes;
 
-                // Wait for all C-1 receivers in the row to signal readiness for this iteration.
                 noc_semaphore_wait(sender_sem_ptr, num_cores_c_dim - 1);
                 noc_semaphore_set(sender_sem_ptr, 0);
 
@@ -80,18 +72,16 @@ void kernel_main() {
                     noc_semaphore_set_multicast_loopback_src(
                         sender_valid_sem_addr, dst_receiver_sem_mcast_addr, num_cores_c_dim, false);
                 } else {
-                    // Single column (C=1): unicast self-write (HW limitation with single-core multicast loopback).
+                    // C=1: unicast self-write (HW limit on single-core multicast loopback).
                     uint64_t local_dest_addr = get_noc_addr(my_x[0], my_y[0], output_addr);
                     noc_async_write(src_addr, local_dest_addr, k_subblock_size_bytes);
                     noc_async_write_barrier();
                     noc_semaphore_set(receiver_sem_ptr, 1);
                 }
             } else {
-                // RECEIVER: signal readiness to the column-0 sender.
                 noc_semaphore_inc(sender_sem_noc_addr, 1);
             }
 
-            // All cores wait for data arrival, then reset for next iteration.
             noc_semaphore_wait(receiver_sem_ptr, 1);
             noc_semaphore_set(receiver_sem_ptr, 0);
         }
@@ -100,9 +90,7 @@ void kernel_main() {
     DeviceTimestampedData("Test id", test_id);
     DeviceTimestampedData("Number of transactions", num_subblocks_k_dim);
     DeviceTimestampedData("Transaction size in bytes", k_subblock_size_bytes);
-    // Per-core actual NOC bytes pushed by this core's RISCV_0 across the K-loop.
-    // Sender (col 0) multicasts k_subblock_size_bytes K times; receivers issue K
-    // semaphore incs (one atomic op flit each).
+    // TX-only: sender K * k_subblock_size_bytes; receiver K * 16 (one atomic flit each).
     constexpr uint32_t SEM_INC_BYTES = 16;
     uint32_t per_core_bytes =
         is_sender ? (num_subblocks_k_dim * k_subblock_size_bytes) : (num_subblocks_k_dim * SEM_INC_BYTES);

--- a/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel_2d.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel_2d.cpp
@@ -53,10 +53,12 @@ void kernel_main() {
         physical_end_x,
         physical_end_y);
 
+    // Track number of times this core acted as sender across the K-loop. Declared outside
+    // the timer zone so we can stamp it after the zone ends without inflating duration_cycles.
+    uint32_t local_k_send_idx = 0;
     {
         DeviceZoneScopedN("RISCV0");
         // K-loop: iterate through all K subblocks, rotating sender across columns
-        uint32_t local_k_send_idx = 0;
 
         for (uint32_t k = 0; k < num_subblocks_k_dim; k++) {
             uint32_t sender_col = k % num_cores_c_dim;
@@ -102,4 +104,11 @@ void kernel_main() {
     DeviceTimestampedData("Test id", test_id);
     DeviceTimestampedData("Number of transactions", num_subblocks_k_dim);
     DeviceTimestampedData("Transaction size in bytes", k_subblock_size_bytes);
+    // Per-core actual NOC bytes pushed by this core's RISCV_0 across the K-loop.
+    // Sender iterations multicast k_subblock_size_bytes row-wise; receiver iterations
+    // issue a single semaphore inc atomic op.
+    constexpr uint32_t SEM_INC_BYTES = 16;
+    uint32_t num_recv_iters = num_subblocks_k_dim - local_k_send_idx;
+    uint32_t per_core_bytes = local_k_send_idx * k_subblock_size_bytes + num_recv_iters * SEM_INC_BYTES;
+    DeviceTimestampedData("Per-core bytes", per_core_bytes);
 }

--- a/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel_2d.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel_2d.cpp
@@ -29,7 +29,7 @@ void kernel_main() {
     uint32_t num_cores = get_arg_val<uint32_t>(9);
     uint32_t local_barrier_addr = get_arg_val<uint32_t>(10);
     uint32_t barrier_done_sem_id = get_arg_val<uint32_t>(11);
-    // col_phys_x[c] = get_arg_val<uint32_t>(12 + c) for c in [0, num_cores_c_dim)
+    // col_phys_x[c] at runtime arg index (12 + c)
 
     uint32_t sender_sem_addr = get_semaphore(sender_sem_id);
     uint32_t sender_valid_sem_addr = get_semaphore(sender_valid_sem_id);
@@ -38,7 +38,6 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* sender_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_sem_addr);
     volatile tt_l1_ptr uint32_t* receiver_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_sem_addr);
 
-    // Multicast addresses for my row (same Y for all cores in the row, varying X)
     uint64_t row_mcast_base = get_noc_multicast_addr(physical_start_x, my_y[0], physical_end_x, my_y[0], 0);
 
     barrier_sync(
@@ -53,23 +52,19 @@ void kernel_main() {
         physical_end_x,
         physical_end_y);
 
-    // Track number of times this core acted as sender across the K-loop. Declared outside
-    // the timer zone so we can stamp it after the zone ends without inflating duration_cycles.
+    // Outside the timer zone so the stamp doesn't inflate duration_cycles.
     uint32_t local_k_send_idx = 0;
     {
         DeviceZoneScopedN("RISCV0");
-        // K-loop: iterate through all K subblocks, rotating sender across columns
 
         for (uint32_t k = 0; k < num_subblocks_k_dim; k++) {
             uint32_t sender_col = k % num_cores_c_dim;
             uint32_t output_addr = in0_mcast_output_addr + k * k_subblock_size_bytes;
 
             if (my_col_idx == sender_col) {
-                // --- SENDER: multicast this K subblock to all cores in my row ---
                 uint32_t src_addr = l1_base_address + local_k_send_idx * k_subblock_size_bytes;
                 local_k_send_idx++;
 
-                // Wait for all receivers in the row to signal readiness
                 noc_semaphore_wait(sender_sem_ptr, num_cores_c_dim - 1);
                 noc_semaphore_set(sender_sem_ptr, 0);
 
@@ -82,20 +77,18 @@ void kernel_main() {
                     noc_semaphore_set_multicast_loopback_src(
                         sender_valid_sem_addr, dst_receiver_sem_mcast_addr, num_cores_c_dim, false);
                 } else {
-                    // Single column: unicast self-write (HW limitation with single-core multicast loopback)
+                    // C=1: unicast self-write (HW limit on single-core multicast loopback).
                     uint64_t local_dest_addr = get_noc_addr(my_x[0], my_y[0], output_addr);
                     noc_async_write(src_addr, local_dest_addr, k_subblock_size_bytes);
                     noc_async_write_barrier();
                     noc_semaphore_set(receiver_sem_ptr, 1);
                 }
             } else {
-                // --- RECEIVER: signal readiness to sender ---
                 uint32_t sender_phys_x = get_arg_val<uint32_t>(12 + sender_col);
                 uint64_t sender_sem_noc_addr = get_noc_addr(sender_phys_x, my_y[0], sender_sem_addr);
                 noc_semaphore_inc(sender_sem_noc_addr, 1);
             }
 
-            // All cores wait for data arrival, then reset for next iteration
             noc_semaphore_wait(receiver_sem_ptr, 1);
             noc_semaphore_set(receiver_sem_ptr, 0);
         }
@@ -104,9 +97,7 @@ void kernel_main() {
     DeviceTimestampedData("Test id", test_id);
     DeviceTimestampedData("Number of transactions", num_subblocks_k_dim);
     DeviceTimestampedData("Transaction size in bytes", k_subblock_size_bytes);
-    // Per-core actual NOC bytes pushed by this core's RISCV_0 across the K-loop.
-    // Sender iterations multicast k_subblock_size_bytes row-wise; receiver iterations
-    // issue a single semaphore inc atomic op.
+    // TX-only: sender iter = k_subblock_size_bytes; receiver iter = 16 (one atomic flit).
     constexpr uint32_t SEM_INC_BYTES = 16;
     uint32_t num_recv_iters = num_subblocks_k_dim - local_k_send_idx;
     uint32_t per_core_bytes = local_k_send_idx * k_subblock_size_bytes + num_recv_iters * SEM_INC_BYTES;

--- a/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel_v2.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel_v2.cpp
@@ -29,7 +29,7 @@ void kernel_main() {
     uint32_t num_cores = get_arg_val<uint32_t>(9);
     uint32_t local_barrier_addr = get_arg_val<uint32_t>(10);
     uint32_t barrier_done_sem_id = get_arg_val<uint32_t>(11);
-    // col_phys_x[c] = get_arg_val<uint32_t>(12 + c) for c in [0, num_cores_c_dim)
+    // col_phys_x[c] at runtime arg index (12 + c)
 
     uint32_t sender_sem_addr = get_semaphore(sender_sem_id);
     uint32_t sender_valid_sem_addr = get_semaphore(sender_valid_sem_id);
@@ -38,7 +38,6 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* sender_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_sem_addr);
     volatile tt_l1_ptr uint32_t* receiver_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_sem_addr);
 
-    // Multicast addresses for my row (same for all K iterations, only the L1 offset changes)
     uint64_t row_mcast_base = get_noc_multicast_addr(physical_start_x, my_y[0], physical_end_x, my_y[0], 0);
 
     barrier_sync(
@@ -53,23 +52,19 @@ void kernel_main() {
         physical_end_x,
         physical_end_y);
 
-    // Track number of times this core acted as sender across the K-loop. Declared outside
-    // the timer zone so we can stamp it after the zone ends without inflating duration_cycles.
+    // Outside the timer zone so the stamp doesn't inflate duration_cycles.
     uint32_t local_k_send_idx = 0;
     {
         DeviceZoneScopedN("RISCV0");
-        // K-loop: iterate through all K subblocks, rotating sender across columns
 
         for (uint32_t k = 0; k < num_subblocks_k_dim; k++) {
             uint32_t sender_col = k % num_cores_c_dim;
             uint32_t output_addr = in0_mcast_output_addr + k * k_subblock_size_bytes;
 
             if (my_col_idx == sender_col) {
-                // --- SENDER: multicast this K subblock to all cores in my row ---
                 uint32_t src_addr = l1_base_address + local_k_send_idx * k_subblock_size_bytes;
                 local_k_send_idx++;
 
-                // Wait for all receivers in the row to signal readiness
                 noc_semaphore_wait(sender_sem_ptr, num_cores_c_dim - 1);
                 noc_semaphore_set(sender_sem_ptr, 0);
 
@@ -82,20 +77,18 @@ void kernel_main() {
                     noc_semaphore_set_multicast_loopback_src(
                         sender_valid_sem_addr, dst_receiver_sem_mcast_addr, num_cores_c_dim, false);
                 } else {
-                    // Single column: unicast self-write (HW limitation with single-core multicast loopback)
+                    // C=1: unicast self-write (HW limit on single-core multicast loopback).
                     uint64_t local_dest_addr = get_noc_addr(my_x[0], my_y[0], output_addr);
                     noc_async_write(src_addr, local_dest_addr, k_subblock_size_bytes);
                     noc_async_write_barrier();
                     noc_semaphore_set(receiver_sem_ptr, 1);
                 }
             } else {
-                // --- RECEIVER: signal readiness to sender ---
                 uint32_t sender_phys_x = get_arg_val<uint32_t>(12 + sender_col);
                 uint64_t sender_sem_noc_addr = get_noc_addr(sender_phys_x, my_y[0], sender_sem_addr);
                 noc_semaphore_inc(sender_sem_noc_addr, 1);
             }
 
-            // All cores wait for data arrival, then reset for next iteration
             noc_semaphore_wait(receiver_sem_ptr, 1);
             noc_semaphore_set(receiver_sem_ptr, 0);
         }
@@ -104,9 +97,7 @@ void kernel_main() {
     DeviceTimestampedData("Test id", test_id);
     DeviceTimestampedData("Number of transactions", num_subblocks_k_dim);
     DeviceTimestampedData("Transaction size in bytes", k_subblock_size_bytes);
-    // Per-core actual NOC bytes pushed by this core's RISCV_0 across the K-loop.
-    // Sender iterations multicast k_subblock_size_bytes; receiver iterations issue a single
-    // semaphore inc atomic op. Lets the heatmap show which columns multicast more often.
+    // TX-only: sender iter = k_subblock_size_bytes; receiver iter = 16 (one atomic flit).
     constexpr uint32_t SEM_INC_BYTES = 16;
     uint32_t num_recv_iters = num_subblocks_k_dim - local_k_send_idx;
     uint32_t per_core_bytes = local_k_send_idx * k_subblock_size_bytes + num_recv_iters * SEM_INC_BYTES;

--- a/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel_v2.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel_v2.cpp
@@ -53,10 +53,12 @@ void kernel_main() {
         physical_end_x,
         physical_end_y);
 
+    // Track number of times this core acted as sender across the K-loop. Declared outside
+    // the timer zone so we can stamp it after the zone ends without inflating duration_cycles.
+    uint32_t local_k_send_idx = 0;
     {
         DeviceZoneScopedN("RISCV0");
         // K-loop: iterate through all K subblocks, rotating sender across columns
-        uint32_t local_k_send_idx = 0;
 
         for (uint32_t k = 0; k < num_subblocks_k_dim; k++) {
             uint32_t sender_col = k % num_cores_c_dim;
@@ -102,4 +104,11 @@ void kernel_main() {
     DeviceTimestampedData("Test id", test_id);
     DeviceTimestampedData("Number of transactions", num_subblocks_k_dim);
     DeviceTimestampedData("Transaction size in bytes", k_subblock_size_bytes);
+    // Per-core actual NOC bytes pushed by this core's RISCV_0 across the K-loop.
+    // Sender iterations multicast k_subblock_size_bytes; receiver iterations issue a single
+    // semaphore inc atomic op. Lets the heatmap show which columns multicast more often.
+    constexpr uint32_t SEM_INC_BYTES = 16;
+    uint32_t num_recv_iters = num_subblocks_k_dim - local_k_send_idx;
+    uint32_t per_core_bytes = local_k_send_idx * k_subblock_size_bytes + num_recv_iters * SEM_INC_BYTES;
+    DeviceTimestampedData("Per-core bytes", per_core_bytes);
 }

--- a/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in1_kernel.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in1_kernel.cpp
@@ -5,25 +5,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "barrier_sync.hpp"
 
-// in1 path for 1D / 1D v2 matmul.
-//
-// Row 0 is the fixed sender for every column. Once at the start of the timer zone
-// it reads the ENTIRE in1 column slice from DRAM into a local L1 source buffer
-// (one big noc_async_read of in1_per_core_read_size_bytes), then iterates K times
-// multicasting each k_subblock_size_bytes chunk down its column. Rows 1..R-1 only
-// signal readiness and wait — they never touch DRAM.
-//
-// One big DRAM read amortizes setup overhead and pipelines better than K small
-// reads. After K multicasts every core in the column has the full in1 column
-// data assembled in its multicast output buffer.
-//
-// This eliminates the per-core DRAM bottleneck of the previous "every core reads
-// DRAM" approach: only C cores (one per column, on row 0) hit DRAM, and the
-// remaining R-1 cores per column receive the data via L1-to-L1 NOC multicast.
-//
-// Single-row case (R=1): every core is its own row-0 sender. Each core reads DRAM
-// independently; no multicast is needed. Falls back to a unicast self-write into
-// the mcast output buffer (HW limitation with single-core multicast loopback).
 void kernel_main() {
     constexpr uint32_t test_id = get_compile_time_arg_val(0);
     constexpr uint32_t dram_bank_id = get_compile_time_arg_val(1);
@@ -57,14 +38,10 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* sender_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_sem_addr);
     volatile tt_l1_ptr uint32_t* receiver_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_sem_addr);
 
-    // Row 0 is the fixed sender (reads DRAM once, then multicasts K subblocks down its column).
     bool is_sender = (my_y[0] == physical_start_y);
 
-    // Column-wise multicast addresses. NOC1 (RISCV_1) has reversed routing direction,
-    // so swap start_y and end_y when constructing the multicast destination.
+    // NOC1 has reversed routing, so swap start_y and end_y for the column multicast.
     uint64_t col_mcast_base = get_noc_multicast_addr(my_x[0], physical_end_y, my_x[0], physical_start_y, 0);
-
-    // Address of row-0 sender's sender_sem in this column (used by receivers to signal readiness).
     uint64_t sender_sem_noc_addr = get_noc_addr(my_x[0], physical_start_y, sender_sem_addr);
 
     barrier_sync(
@@ -82,24 +59,20 @@ void kernel_main() {
     {
         DeviceZoneScopedN("RISCV1");
 
-        // Phase 1 (sender only): read the entire in1 column slice from DRAM in ONE call.
-        // Lets DRAM pipeline a single large transfer instead of K serialized small ones.
+        // One big DRAM read pipelines better than K serialized small ones.
         if (is_sender) {
             uint64_t dram_noc_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_per_core_dram_read_addr);
             noc_async_read(dram_noc_addr, in1_l1_source_addr, in1_per_core_read_size_bytes);
             noc_async_read_barrier();
         }
 
-        // Phase 2: K-loop multicasts each subblock from the source buffer down the column.
         for (uint32_t k = 0; k < num_subblocks_k_dim; k++) {
             uint32_t output_offset = k * k_subblock_size_bytes;
             uint32_t output_addr = in1_mcast_output_addr + output_offset;
 
             if (is_sender) {
-                // Source partition for this K iteration: contiguous within the pre-read buffer.
                 uint32_t src_addr = in1_l1_source_addr + output_offset;
 
-                // Wait for all R-1 receivers in the column to signal readiness.
                 noc_semaphore_wait(sender_sem_ptr, num_cores_r_dim - 1);
                 noc_semaphore_set(sender_sem_ptr, 0);
 
@@ -112,18 +85,16 @@ void kernel_main() {
                     noc_semaphore_set_multicast_loopback_src(
                         sender_valid_sem_addr, dst_receiver_sem_mcast_addr, num_cores_r_dim, false);
                 } else {
-                    // Single row (R=1): unicast self-write (HW limitation with single-core multicast loopback).
+                    // R=1: unicast self-write (HW limit on single-core multicast loopback).
                     uint64_t local_dest_addr = get_noc_addr(my_x[0], my_y[0], output_addr);
                     noc_async_write(src_addr, local_dest_addr, k_subblock_size_bytes);
                     noc_async_write_barrier();
                     noc_semaphore_set(receiver_sem_ptr, 1);
                 }
             } else {
-                // RECEIVER: signal readiness to the row-0 sender in this column.
                 noc_semaphore_inc(sender_sem_noc_addr, 1);
             }
 
-            // All cores wait for data arrival, then reset for next iteration.
             noc_semaphore_wait(receiver_sem_ptr, 1);
             noc_semaphore_set(receiver_sem_ptr, 0);
         }
@@ -132,10 +103,7 @@ void kernel_main() {
     DeviceTimestampedData("Test id", test_id);
     DeviceTimestampedData("Number of transactions", num_subblocks_k_dim);
     DeviceTimestampedData("Transaction size in bytes", k_subblock_size_bytes);
-    // Per-core actual NOC bytes pushed by this core's RISCV_1 across the K-loop.
-    // Row-0 sender multicasts k_subblock_size_bytes K times; receivers issue K
-    // semaphore incs (one atomic op flit each). DRAM read RX is not counted in the
-    // TX-only convention shared with the other matmul kernels.
+    // TX-only: sender K * k_subblock_size_bytes; receiver K * 16 (one atomic flit each).
     constexpr uint32_t SEM_INC_BYTES = 16;
     uint32_t per_core_bytes =
         is_sender ? (num_subblocks_k_dim * k_subblock_size_bytes) : (num_subblocks_k_dim * SEM_INC_BYTES);

--- a/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in1_kernel.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in1_kernel.cpp
@@ -5,7 +5,25 @@
 #include "api/dataflow/dataflow_api.h"
 #include "barrier_sync.hpp"
 
-// DRAM to L1 read
+// in1 path for 1D / 1D v2 matmul.
+//
+// Row 0 is the fixed sender for every column. Once at the start of the timer zone
+// it reads the ENTIRE in1 column slice from DRAM into a local L1 source buffer
+// (one big noc_async_read of in1_per_core_read_size_bytes), then iterates K times
+// multicasting each k_subblock_size_bytes chunk down its column. Rows 1..R-1 only
+// signal readiness and wait — they never touch DRAM.
+//
+// One big DRAM read amortizes setup overhead and pipelines better than K small
+// reads. After K multicasts every core in the column has the full in1 column
+// data assembled in its multicast output buffer.
+//
+// This eliminates the per-core DRAM bottleneck of the previous "every core reads
+// DRAM" approach: only C cores (one per column, on row 0) hit DRAM, and the
+// remaining R-1 cores per column receive the data via L1-to-L1 NOC multicast.
+//
+// Single-row case (R=1): every core is its own row-0 sender. Each core reads DRAM
+// independently; no multicast is needed. Falls back to a unicast self-write into
+// the mcast output buffer (HW limitation with single-core multicast loopback).
 void kernel_main() {
     constexpr uint32_t test_id = get_compile_time_arg_val(0);
     constexpr uint32_t dram_bank_id = get_compile_time_arg_val(1);
@@ -13,21 +31,41 @@ void kernel_main() {
     constexpr uint32_t physical_start_y = get_compile_time_arg_val(3);
     constexpr uint32_t physical_end_x = get_compile_time_arg_val(4);
     constexpr uint32_t physical_end_y = get_compile_time_arg_val(5);
+    constexpr uint32_t num_cores_r_dim = get_compile_time_arg_val(6);
+    constexpr uint32_t sender_sem_id = get_compile_time_arg_val(7);
+    constexpr uint32_t sender_valid_sem_id = get_compile_time_arg_val(8);
+    constexpr uint32_t receiver_sem_id = get_compile_time_arg_val(9);
 
-    uint32_t in1_per_core_read_addr = get_arg_val<uint32_t>(0);
-    uint32_t in1_per_core_read_size_bytes = get_arg_val<uint32_t>(1);
-    uint32_t in1_output_addr = get_arg_val<uint32_t>(2);
+    uint32_t in1_per_core_dram_read_addr = get_arg_val<uint32_t>(0);   // sender: per-column DRAM offset
+    uint32_t in1_per_core_read_size_bytes = get_arg_val<uint32_t>(1);  // sender: total bytes to read from DRAM
+    uint32_t num_subblocks_k_dim = get_arg_val<uint32_t>(2);           // K iterations
+    uint32_t k_subblock_size_bytes = get_arg_val<uint32_t>(3);         // bytes per K subblock
+    uint32_t in1_l1_source_addr = get_arg_val<uint32_t>(4);            // sender: L1 buffer for DRAM read (full column)
+    uint32_t in1_mcast_output_addr = get_arg_val<uint32_t>(5);         // all cores: multicast dest base
     // Barrier synchronization args
-    uint32_t barrier_sem_id = get_arg_val<uint32_t>(3);
-    uint32_t barrier_coord_x = get_arg_val<uint32_t>(4);
-    uint32_t barrier_coord_y = get_arg_val<uint32_t>(5);
-    uint32_t num_cores = get_arg_val<uint32_t>(6);
-    uint32_t local_barrier_addr = get_arg_val<uint32_t>(7);
-    uint32_t barrier_done_sem_id = get_arg_val<uint32_t>(8);
-    uint32_t profiling_num_transactions = get_arg_val<uint32_t>(9);
-    uint32_t profiling_transaction_size = get_arg_val<uint32_t>(10);
+    uint32_t barrier_sem_id = get_arg_val<uint32_t>(6);
+    uint32_t barrier_coord_x = get_arg_val<uint32_t>(7);
+    uint32_t barrier_coord_y = get_arg_val<uint32_t>(8);
+    uint32_t num_cores = get_arg_val<uint32_t>(9);
+    uint32_t local_barrier_addr = get_arg_val<uint32_t>(10);
+    uint32_t barrier_done_sem_id = get_arg_val<uint32_t>(11);
 
-    uint64_t dram_noc_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_per_core_read_addr);
+    uint32_t sender_sem_addr = get_semaphore(sender_sem_id);
+    uint32_t sender_valid_sem_addr = get_semaphore(sender_valid_sem_id);
+    uint32_t receiver_sem_addr = get_semaphore(receiver_sem_id);
+
+    volatile tt_l1_ptr uint32_t* sender_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_sem_addr);
+    volatile tt_l1_ptr uint32_t* receiver_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_sem_addr);
+
+    // Row 0 is the fixed sender (reads DRAM once, then multicasts K subblocks down its column).
+    bool is_sender = (my_y[0] == physical_start_y);
+
+    // Column-wise multicast addresses. NOC1 (RISCV_1) has reversed routing direction,
+    // so swap start_y and end_y when constructing the multicast destination.
+    uint64_t col_mcast_base = get_noc_multicast_addr(my_x[0], physical_end_y, my_x[0], physical_start_y, 0);
+
+    // Address of row-0 sender's sender_sem in this column (used by receivers to signal readiness).
+    uint64_t sender_sem_noc_addr = get_noc_addr(my_x[0], physical_start_y, sender_sem_addr);
 
     barrier_sync(
         barrier_sem_id,
@@ -43,12 +81,63 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV1");
-        // Address, destination, and size are host-validated runtime args
-        noc_async_read(dram_noc_addr, in1_output_addr, in1_per_core_read_size_bytes);
-        noc_async_read_barrier();
+
+        // Phase 1 (sender only): read the entire in1 column slice from DRAM in ONE call.
+        // Lets DRAM pipeline a single large transfer instead of K serialized small ones.
+        if (is_sender) {
+            uint64_t dram_noc_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_per_core_dram_read_addr);
+            noc_async_read(dram_noc_addr, in1_l1_source_addr, in1_per_core_read_size_bytes);
+            noc_async_read_barrier();
+        }
+
+        // Phase 2: K-loop multicasts each subblock from the source buffer down the column.
+        for (uint32_t k = 0; k < num_subblocks_k_dim; k++) {
+            uint32_t output_offset = k * k_subblock_size_bytes;
+            uint32_t output_addr = in1_mcast_output_addr + output_offset;
+
+            if (is_sender) {
+                // Source partition for this K iteration: contiguous within the pre-read buffer.
+                uint32_t src_addr = in1_l1_source_addr + output_offset;
+
+                // Wait for all R-1 receivers in the column to signal readiness.
+                noc_semaphore_wait(sender_sem_ptr, num_cores_r_dim - 1);
+                noc_semaphore_set(sender_sem_ptr, 0);
+
+                if constexpr (num_cores_r_dim > 1) {
+                    uint64_t dst_data_mcast_addr = col_mcast_base | output_addr;
+                    noc_async_write_multicast_loopback_src(
+                        src_addr, dst_data_mcast_addr, k_subblock_size_bytes, num_cores_r_dim, true);
+
+                    uint64_t dst_receiver_sem_mcast_addr = col_mcast_base | receiver_sem_addr;
+                    noc_semaphore_set_multicast_loopback_src(
+                        sender_valid_sem_addr, dst_receiver_sem_mcast_addr, num_cores_r_dim, false);
+                } else {
+                    // Single row (R=1): unicast self-write (HW limitation with single-core multicast loopback).
+                    uint64_t local_dest_addr = get_noc_addr(my_x[0], my_y[0], output_addr);
+                    noc_async_write(src_addr, local_dest_addr, k_subblock_size_bytes);
+                    noc_async_write_barrier();
+                    noc_semaphore_set(receiver_sem_ptr, 1);
+                }
+            } else {
+                // RECEIVER: signal readiness to the row-0 sender in this column.
+                noc_semaphore_inc(sender_sem_noc_addr, 1);
+            }
+
+            // All cores wait for data arrival, then reset for next iteration.
+            noc_semaphore_wait(receiver_sem_ptr, 1);
+            noc_semaphore_set(receiver_sem_ptr, 0);
+        }
     }
 
     DeviceTimestampedData("Test id", test_id);
-    DeviceTimestampedData("Number of transactions", profiling_num_transactions);
-    DeviceTimestampedData("Transaction size in bytes", profiling_transaction_size);
+    DeviceTimestampedData("Number of transactions", num_subblocks_k_dim);
+    DeviceTimestampedData("Transaction size in bytes", k_subblock_size_bytes);
+    // Per-core actual NOC bytes pushed by this core's RISCV_1 across the K-loop.
+    // Row-0 sender multicasts k_subblock_size_bytes K times; receivers issue K
+    // semaphore incs (one atomic op flit each). DRAM read RX is not counted in the
+    // TX-only convention shared with the other matmul kernels.
+    constexpr uint32_t SEM_INC_BYTES = 16;
+    uint32_t per_core_bytes =
+        is_sender ? (num_subblocks_k_dim * k_subblock_size_bytes) : (num_subblocks_k_dim * SEM_INC_BYTES);
+    DeviceTimestampedData("Per-core bytes", per_core_bytes);
 }

--- a/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in1_kernel_2d.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in1_kernel_2d.cpp
@@ -29,7 +29,7 @@ void kernel_main() {
     uint32_t num_cores = get_arg_val<uint32_t>(9);
     uint32_t local_barrier_addr = get_arg_val<uint32_t>(10);
     uint32_t barrier_done_sem_id = get_arg_val<uint32_t>(11);
-    // row_phys_y[r] = get_arg_val<uint32_t>(12 + r) for r in [0, num_cores_r_dim)
+    // row_phys_y[r] at runtime arg index (12 + r)
 
     uint32_t sender_sem_addr = get_semaphore(sender_sem_id);
     uint32_t sender_valid_sem_addr = get_semaphore(sender_valid_sem_id);
@@ -38,8 +38,7 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* sender_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_sem_addr);
     volatile tt_l1_ptr uint32_t* receiver_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_sem_addr);
 
-    // Multicast addresses for my column (same X for all cores in the column, varying Y).
-    // NOC1 (RISCV_1) has reversed routing direction, so swap start_y and end_y.
+    // NOC1 has reversed routing, so swap start_y and end_y for the column multicast.
     uint64_t col_mcast_base = get_noc_multicast_addr(my_x[0], physical_end_y, my_x[0], physical_start_y, 0);
 
     barrier_sync(
@@ -54,23 +53,19 @@ void kernel_main() {
         physical_end_x,
         physical_end_y);
 
-    // Track number of times this core acted as sender across the K-loop. Declared outside
-    // the timer zone so we can stamp it after the zone ends without inflating duration_cycles.
+    // Outside the timer zone so the stamp doesn't inflate duration_cycles.
     uint32_t local_k_send_idx = 0;
     {
         DeviceZoneScopedN("RISCV1");
-        // K-loop: iterate through all K subblocks, rotating sender across rows
 
         for (uint32_t k = 0; k < num_subblocks_k_dim; k++) {
             uint32_t sender_row = k % num_cores_r_dim;
             uint32_t output_addr = in1_mcast_output_addr + k * k_subblock_size_bytes;
 
             if (my_row_idx == sender_row) {
-                // --- SENDER: multicast this K subblock to all cores in my column ---
                 uint32_t src_addr = l1_base_address + local_k_send_idx * k_subblock_size_bytes;
                 local_k_send_idx++;
 
-                // Wait for all receivers in the column to signal readiness
                 noc_semaphore_wait(sender_sem_ptr, num_cores_r_dim - 1);
                 noc_semaphore_set(sender_sem_ptr, 0);
 
@@ -83,20 +78,18 @@ void kernel_main() {
                     noc_semaphore_set_multicast_loopback_src(
                         sender_valid_sem_addr, dst_receiver_sem_mcast_addr, num_cores_r_dim, false);
                 } else {
-                    // Single row: unicast self-write (HW limitation with single-core multicast loopback)
+                    // R=1: unicast self-write (HW limit on single-core multicast loopback).
                     uint64_t local_dest_addr = get_noc_addr(my_x[0], my_y[0], output_addr);
                     noc_async_write(src_addr, local_dest_addr, k_subblock_size_bytes);
                     noc_async_write_barrier();
                     noc_semaphore_set(receiver_sem_ptr, 1);
                 }
             } else {
-                // --- RECEIVER: signal readiness to sender ---
                 uint32_t sender_phys_y = get_arg_val<uint32_t>(12 + sender_row);
                 uint64_t sender_sem_noc_addr = get_noc_addr(my_x[0], sender_phys_y, sender_sem_addr);
                 noc_semaphore_inc(sender_sem_noc_addr, 1);
             }
 
-            // All cores wait for data arrival, then reset for next iteration
             noc_semaphore_wait(receiver_sem_ptr, 1);
             noc_semaphore_set(receiver_sem_ptr, 0);
         }
@@ -105,9 +98,7 @@ void kernel_main() {
     DeviceTimestampedData("Test id", test_id);
     DeviceTimestampedData("Number of transactions", num_subblocks_k_dim);
     DeviceTimestampedData("Transaction size in bytes", k_subblock_size_bytes);
-    // Per-core actual NOC bytes pushed by this core's RISCV_1 across the K-loop.
-    // Sender iterations multicast k_subblock_size_bytes column-wise; receiver iterations
-    // issue a single semaphore inc atomic op.
+    // TX-only: sender iter = k_subblock_size_bytes; receiver iter = 16 (one atomic flit).
     constexpr uint32_t SEM_INC_BYTES = 16;
     uint32_t num_recv_iters = num_subblocks_k_dim - local_k_send_idx;
     uint32_t per_core_bytes = local_k_send_idx * k_subblock_size_bytes + num_recv_iters * SEM_INC_BYTES;

--- a/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in1_kernel_2d.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/kernels/in1_kernel_2d.cpp
@@ -54,10 +54,12 @@ void kernel_main() {
         physical_end_x,
         physical_end_y);
 
+    // Track number of times this core acted as sender across the K-loop. Declared outside
+    // the timer zone so we can stamp it after the zone ends without inflating duration_cycles.
+    uint32_t local_k_send_idx = 0;
     {
         DeviceZoneScopedN("RISCV1");
         // K-loop: iterate through all K subblocks, rotating sender across rows
-        uint32_t local_k_send_idx = 0;
 
         for (uint32_t k = 0; k < num_subblocks_k_dim; k++) {
             uint32_t sender_row = k % num_cores_r_dim;
@@ -103,4 +105,11 @@ void kernel_main() {
     DeviceTimestampedData("Test id", test_id);
     DeviceTimestampedData("Number of transactions", num_subblocks_k_dim);
     DeviceTimestampedData("Transaction size in bytes", k_subblock_size_bytes);
+    // Per-core actual NOC bytes pushed by this core's RISCV_1 across the K-loop.
+    // Sender iterations multicast k_subblock_size_bytes column-wise; receiver iterations
+    // issue a single semaphore inc atomic op.
+    constexpr uint32_t SEM_INC_BYTES = 16;
+    uint32_t num_recv_iters = num_subblocks_k_dim - local_k_send_idx;
+    uint32_t per_core_bytes = local_k_send_idx * k_subblock_size_bytes + num_recv_iters * SEM_INC_BYTES;
+    DeviceTimestampedData("Per-core bytes", per_core_bytes);
 }

--- a/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_1d.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_1d.cpp
@@ -27,10 +27,8 @@ using MatmulTestConfig = unit_tests::dm::matmul::MatmulTestConfig;
 
 uint32_t runtime_host_id = 0;
 
-/// @brief Reads from DRAM to L1 with each core reading only its adjacent bank
-/// @param mesh_device - MeshDevice to run the test on
-/// @param test_config - Configuration of the test
-/// @return true if test passes
+/// @brief 1D matmul: column 0 is the fixed in0 sender, row 0 is the fixed in1 sender
+///        (reads its full column from DRAM once, then K-loop multicasts down the column).
 bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, const MatmulTestConfig& test_config) {
     IDevice* device = mesh_device->impl().get_device(0);
 
@@ -50,7 +48,6 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
 
     Program program = CreateProgram();
 
-    // Validate grid dimensions match config
     uint32_t grid_cols = test_config.end_logical_core.x - test_config.start_logical_core.x + 1;
     uint32_t grid_rows = test_config.end_logical_core.y - test_config.start_logical_core.y + 1;
     if (grid_cols != test_config.num_subblocks_c_dim) {
@@ -73,7 +70,7 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     CoreRangeSet matmul_cores({CoreRange(test_config.start_logical_core, test_config.end_logical_core)});
     vector<CoreCoord> matmul_cores_list = corerange_to_cores(matmul_cores);
 
-    // Logical core sets for in0. The first column of cores will need the host writing the content into L1.
+    // First column receives in0 source data from the host.
     CoreCoord in0_logical_start_coord = test_config.start_logical_core;
     CoreCoord in0_logical_end_coord = CoreCoord(test_config.start_logical_core.x, test_config.end_logical_core.y);
     CoreRangeSet in0_cores({CoreRange(in0_logical_start_coord, in0_logical_end_coord)});
@@ -89,30 +86,21 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     uint32_t in0_pages_bytes = in0_pages * test_config.page_size_bytes;
     uint32_t in1_pages_bytes = in1_pages * test_config.page_size_bytes;
 
-    // Bytes the column-0 sender multicasts per K iteration (one K subblock for one row).
-    // Matches the v2 / 2D definition so the kernel can run a K-loop of `num_subblocks_k_dim`
-    // multicasts of `k_subblock_size_bytes` each.
     uint32_t k_subblock_size_bytes =
         test_config.subblock_r_dim * test_config.subblock_k_dim * test_config.page_size_bytes;
-
-    // in1 K subblock size: bytes the row-0 sender multicasts per K iteration down its column.
-    // Each iteration delivers subblock_k_dim * subblock_c_dim pages of one column to all rows.
     uint32_t in1_k_subblock_size_bytes =
         test_config.subblock_k_dim * test_config.subblock_c_dim * test_config.page_size_bytes;
 
     uint32_t l1_base_address = unit_tests::dm::get_l1_address_and_size(mesh_device, in0_cores_list[0]).base_address;
 
-    // in0 Input
     vector<uint32_t> in0_input = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
         -100.0f, 100.0f, in0_pages_bytes / sizeof(bfloat16), chrono::system_clock::now().time_since_epoch().count());
 
-    // Write in0 input to L1 of the first column of cores
     vector<uint32_t> in0_per_core_pages;
     unordered_map<uint32_t, vector<uint32_t>> dim_r_to_in0_pages_map;
     uint32_t pages_per_core = in0_input.size() / in0_cores_list.size();
     uint32_t pages_per_core_size_bytes = pages_per_core * sizeof(uint32_t);
     for (uint32_t i = 0; i < in0_cores_list.size(); i++) {
-        // in0_per_core_pages should contain the pages that the i-th core in in0_cores_list will read
         for (uint32_t j = 0; j < pages_per_core; j++) {
             in0_per_core_pages.push_back(in0_input[i * pages_per_core + j]);
         }
@@ -122,83 +110,50 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
         in0_per_core_pages.clear();
     }
 
-    // in1 Input
     vector<uint32_t> in1_input = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
         -100.0f, 100.0f, in1_pages_bytes / sizeof(bfloat16), chrono::system_clock::now().time_since_epoch().count());
 
-    // DRAM Address
     DramAddressInfo dram_info = unit_tests::dm::get_dram_address_and_size();
     uint32_t input_dram_address = dram_info.base_address;
-
-    // Write Input to DRAM
     detail::WriteToDeviceDRAMChannel(device, test_config.dram_bank_id, input_dram_address, in1_input);
     MetalContext::instance().get_cluster().dram_barrier(device->id());
 
-    // in1_per_core_read_size_bytes is how much each core should read from the DRAM bank
     uint32_t in1_per_core_read_size_bytes = in1_pages_bytes / test_config.num_subblocks_c_dim;
-    // in1_per_core_read_addr stores the memory address where each core should read from DRAM bank
     vector<uint32_t> in1_per_core_read_addr;
     in1_per_core_read_addr.reserve(test_config.num_subblocks_c_dim);
     for (uint32_t i = 0; i < test_config.num_subblocks_c_dim; i++) {
         in1_per_core_read_addr.push_back(input_dram_address + i * in1_per_core_read_size_bytes);
     }
-    // in0_mcast_output_addr is the memory address where each core will leave the in0 mcast output in L1.
+
     uint32_t in0_mcast_output_addr = l1_base_address + pages_per_core_size_bytes + matmul::L1_DEBUG_PADDING_BYTES;
 
-    // in1_l1_source_addr: where row-0 cores read the full in1 column slice from DRAM before
-    // multicasting it down the column. Only row-0 cores actually use this region; other rows
-    // leave it unused. Must be aligned to NOC_DRAM_READ_ALIGNMENT_BYTES (64 on Blackhole) so
-    // the low bits match the DRAM source address. Sized to in1_per_core_read_size_bytes so
-    // the entire DRAM slice fits in one big noc_async_read.
+    // 64-byte alignment required so low bits match the DRAM source address (Blackhole).
     uint32_t in1_l1_source_addr_unaligned =
         l1_base_address + ((pages_per_core_size_bytes + matmul::L1_DEBUG_PADDING_BYTES) << 1);
     uint32_t in1_l1_source_addr = (in1_l1_source_addr_unaligned + 63) & ~63U;
-
-    // in1_mcast_output_addr: where the column-wise multicast deposits the full in1 column data
-    // for every core (sender via loopback, receivers via direct write). This is what gets
-    // verified against the golden DRAM copy after the program completes.
     uint32_t in1_mcast_output_addr = in1_l1_source_addr + in1_per_core_read_size_bytes + matmul::L1_DEBUG_PADDING_BYTES;
 
-    // ---- in0 multicast semaphores ----
-    // sender_sem: lives on every core, but only the sender (first-column) core waits on it.
-    //   Receivers increment it via noc_semaphore_inc to signal they are ready.
-    //   Sender waits until value == (num_subblocks_c_dim - 1).
+    // Three-semaphore mcast protocol: receivers inc sender_sem to signal ready; sender
+    // multicasts data, then multicasts sender_valid_sem (init 1) into receiver_sem on all
+    // cores; receivers wait for receiver_sem == 1 and reset it.
     uint32_t sender_sem_id = CreateSemaphore(program, matmul_cores, 0);
-
-    // sender_valid_sem: lives on every core, initialised to 1.
-    //   The sender uses its local copy as the *source value* when it calls
-    //   noc_semaphore_set_multicast_loopback_src to set the receiver_sem on
-    //   all cores in the row to 1.
     uint32_t sender_valid_sem_id = CreateSemaphore(program, matmul_cores, 1);
-
-    // receiver_sem: lives on every core, initialised to 0.
-    //   After the sender multicasts data, it also multicasts sender_valid_sem's
-    //   value (1) into receiver_sem on every core in the row.
-    //   Each receiver waits until receiver_sem == 1, then resets it to 0.
     uint32_t receiver_sem_id = CreateSemaphore(program, matmul_cores, 0);
 
-    // ---- in1 multicast semaphores (column-wise, NOC1) ----
-    // Same three-semaphore protocol as in0 but on the in1 / RISCV_1 side: row 0 is the
-    // fixed sender for each column; rows 1..R-1 increment risc1_sender_sem to signal
-    // readiness, sender multicasts data + valid signal down the column, all cores
-    // wait on risc1_receiver_sem == 1.
+    // Same protocol, column-wise on RISCV_1 (in1 path, row 0 is the fixed sender).
     uint32_t risc1_sender_sem_id = CreateSemaphore(program, matmul_cores, 0);
     uint32_t risc1_sender_valid_sem_id = CreateSemaphore(program, matmul_cores, 1);
     uint32_t risc1_receiver_sem_id = CreateSemaphore(program, matmul_cores, 0);
 
-    // ---- barrier synchronization semaphores ----
-    // One barrier per RISC processor so RISCV_0 and RISCV_1 synchronize independently.
-    // Each barrier uses two semaphores: one for arrival counting, one for done broadcast.
+    // Independent barriers per RISC: arrival counter + done broadcast.
     uint32_t risc0_barrier_sem_id = CreateSemaphore(program, matmul_cores, 0);
     uint32_t risc0_barrier_done_sem_id = CreateSemaphore(program, matmul_cores, 0);
     uint32_t risc1_barrier_sem_id = CreateSemaphore(program, matmul_cores, 0);
     uint32_t risc1_barrier_done_sem_id = CreateSemaphore(program, matmul_cores, 0);
 
-    // Coordinator = first matmul core; all cores increment its semaphore, coordinator multicasts done.
     CoreCoord barrier_coordinator_phys = device->worker_core_from_logical_core(matmul_cores_list[0]);
     uint32_t num_cores = matmul_cores_list.size();
 
-    // Local scratch addresses for barrier (placed after in1 mcast output region, 16-byte aligned).
     uint32_t risc0_local_barrier_addr = (in1_mcast_output_addr + in1_per_core_read_size_bytes + 15) & ~15U;
     uint32_t risc1_local_barrier_addr = risc0_local_barrier_addr + 16;
 
@@ -227,7 +182,6 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
         risc1_receiver_sem_id,                    // 9  in1 receiver semaphore ID
     };
 
-    // Kernels
     auto risc0_kernel = CreateKernel(
         program,
         "tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel.cpp",
@@ -246,7 +200,6 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
             .noc = NOC::RISCV_1_default,
             .compile_args = risc1_compile_args});
 
-    // Assign Runtime Args
     for (auto & i : matmul_cores_list) {
         vector<uint32_t> risc0_core_runtime_args = {
             l1_base_address,                       // 0  Sender: source addr of in0 data (all K subblocks contiguous)
@@ -279,11 +232,9 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
         tt::tt_metal::SetRuntimeArgs(program, risc1_kernel, i, risc1_core_runtime_args);
     }
 
-    // Assign unique id
     log_info(tt::LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
     program.set_runtime_id(unit_tests::dm::runtime_host_id++);
 
-    // LAUNCH PROGRAM - Use mesh workload approach
     auto mesh_workload = distributed::MeshWorkload();
     vector<uint32_t> coord_data = {0, 0};
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
@@ -293,7 +244,6 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
-    // Verify in0 read output in L1 for each core
     for (auto & i : matmul_cores_list) {
         vector<uint32_t> in0_read_output;
         detail::ReadFromDeviceL1(
@@ -312,7 +262,6 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
         }
     }
 
-    // Verify in1 read output in L1 for each core
     vector<uint32_t> golden_in1_read_output;
     uint32_t total_in1_read_elements = in1_per_core_read_size_bytes / sizeof(uint32_t);
     for (auto & i : matmul_cores_list) {

--- a/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_1d.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_1d.cpp
@@ -89,6 +89,12 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     uint32_t in0_pages_bytes = in0_pages * test_config.page_size_bytes;
     uint32_t in1_pages_bytes = in1_pages * test_config.page_size_bytes;
 
+    // Bytes the column-0 sender multicasts per K iteration (one K subblock for one row).
+    // Matches the v2 / 2D definition so the kernel can run a K-loop of `num_subblocks_k_dim`
+    // multicasts of `k_subblock_size_bytes` each.
+    uint32_t k_subblock_size_bytes =
+        test_config.subblock_r_dim * test_config.subblock_k_dim * test_config.page_size_bytes;
+
     uint32_t l1_base_address = unit_tests::dm::get_l1_address_and_size(mesh_device, in0_cores_list[0]).base_address;
 
     // in0 Input
@@ -218,15 +224,16 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     // Assign Runtime Args
     for (auto & i : matmul_cores_list) {
         vector<uint32_t> risc0_core_runtime_args = {
-            l1_base_address,                       // 0  Sender: source addr of in0 data in L1
-            pages_per_core_size_bytes,             // 1  Sender: number of bytes to multicast
-            in0_mcast_output_addr,                 // 2  All cores: L1 dest addr for multicast data
-            risc0_barrier_sem_id,                  // 3  Barrier arrival semaphore ID
-            (uint32_t)barrier_coordinator_phys.x,  // 4  Barrier coordinator physical X
-            (uint32_t)barrier_coordinator_phys.y,  // 5  Barrier coordinator physical Y
-            num_cores,                             // 6  Total number of cores in barrier
-            risc0_local_barrier_addr,              // 7  Local L1 scratch addr for barrier
-            risc0_barrier_done_sem_id,             // 8  Barrier done semaphore ID
+            l1_base_address,                       // 0  Sender: source addr of in0 data (all K subblocks contiguous)
+            test_config.num_subblocks_k_dim,       // 1  Number of K subblocks (loop iterations)
+            k_subblock_size_bytes,                 // 2  Bytes per K subblock multicast
+            in0_mcast_output_addr,                 // 3  All cores: L1 dest base addr for multicast data
+            risc0_barrier_sem_id,                  // 4  Barrier arrival semaphore ID
+            (uint32_t)barrier_coordinator_phys.x,  // 5  Barrier coordinator physical X
+            (uint32_t)barrier_coordinator_phys.y,  // 6  Barrier coordinator physical Y
+            num_cores,                             // 7  Total number of cores in barrier
+            risc0_local_barrier_addr,              // 8  Local L1 scratch addr for barrier
+            risc0_barrier_done_sem_id,             // 9  Barrier done semaphore ID
         };
         uint32_t col_idx = i.x - test_config.start_logical_core.x;
         vector<uint32_t> risc1_core_runtime_args = {

--- a/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_1d.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_1d.cpp
@@ -95,6 +95,11 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     uint32_t k_subblock_size_bytes =
         test_config.subblock_r_dim * test_config.subblock_k_dim * test_config.page_size_bytes;
 
+    // in1 K subblock size: bytes the row-0 sender multicasts per K iteration down its column.
+    // Each iteration delivers subblock_k_dim * subblock_c_dim pages of one column to all rows.
+    uint32_t in1_k_subblock_size_bytes =
+        test_config.subblock_k_dim * test_config.subblock_c_dim * test_config.page_size_bytes;
+
     uint32_t l1_base_address = unit_tests::dm::get_l1_address_and_size(mesh_device, in0_cores_list[0]).base_address;
 
     // in0 Input
@@ -137,15 +142,22 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     for (uint32_t i = 0; i < test_config.num_subblocks_c_dim; i++) {
         in1_per_core_read_addr.push_back(input_dram_address + i * in1_per_core_read_size_bytes);
     }
-    // in0_mcast_output_addr is the memory address where each core will leave the in0 mcast output in L1
+    // in0_mcast_output_addr is the memory address where each core will leave the in0 mcast output in L1.
     uint32_t in0_mcast_output_addr = l1_base_address + pages_per_core_size_bytes + matmul::L1_DEBUG_PADDING_BYTES;
 
-    // in1_output_addr is the memory address where each core will leave the in1 read output in L1. It is placed after
-    // in0 mcast output in L1. Must be aligned to NOC_DRAM_READ_ALIGNMENT_BYTES (64 on Blackhole) so the low bits match
-    // the DRAM source address.
-    uint32_t in1_output_addr_unaligned =
+    // in1_l1_source_addr: where row-0 cores read the full in1 column slice from DRAM before
+    // multicasting it down the column. Only row-0 cores actually use this region; other rows
+    // leave it unused. Must be aligned to NOC_DRAM_READ_ALIGNMENT_BYTES (64 on Blackhole) so
+    // the low bits match the DRAM source address. Sized to in1_per_core_read_size_bytes so
+    // the entire DRAM slice fits in one big noc_async_read.
+    uint32_t in1_l1_source_addr_unaligned =
         l1_base_address + ((pages_per_core_size_bytes + matmul::L1_DEBUG_PADDING_BYTES) << 1);
-    uint32_t in1_output_addr = (in1_output_addr_unaligned + 63) & ~63U;
+    uint32_t in1_l1_source_addr = (in1_l1_source_addr_unaligned + 63) & ~63U;
+
+    // in1_mcast_output_addr: where the column-wise multicast deposits the full in1 column data
+    // for every core (sender via loopback, receivers via direct write). This is what gets
+    // verified against the golden DRAM copy after the program completes.
+    uint32_t in1_mcast_output_addr = in1_l1_source_addr + in1_per_core_read_size_bytes + matmul::L1_DEBUG_PADDING_BYTES;
 
     // ---- in0 multicast semaphores ----
     // sender_sem: lives on every core, but only the sender (first-column) core waits on it.
@@ -165,6 +177,15 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     //   Each receiver waits until receiver_sem == 1, then resets it to 0.
     uint32_t receiver_sem_id = CreateSemaphore(program, matmul_cores, 0);
 
+    // ---- in1 multicast semaphores (column-wise, NOC1) ----
+    // Same three-semaphore protocol as in0 but on the in1 / RISCV_1 side: row 0 is the
+    // fixed sender for each column; rows 1..R-1 increment risc1_sender_sem to signal
+    // readiness, sender multicasts data + valid signal down the column, all cores
+    // wait on risc1_receiver_sem == 1.
+    uint32_t risc1_sender_sem_id = CreateSemaphore(program, matmul_cores, 0);
+    uint32_t risc1_sender_valid_sem_id = CreateSemaphore(program, matmul_cores, 1);
+    uint32_t risc1_receiver_sem_id = CreateSemaphore(program, matmul_cores, 0);
+
     // ---- barrier synchronization semaphores ----
     // One barrier per RISC processor so RISCV_0 and RISCV_1 synchronize independently.
     // Each barrier uses two semaphores: one for arrival counting, one for done broadcast.
@@ -177,8 +198,8 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     CoreCoord barrier_coordinator_phys = device->worker_core_from_logical_core(matmul_cores_list[0]);
     uint32_t num_cores = matmul_cores_list.size();
 
-    // Local scratch addresses for barrier (placed after in1 output region, 16-byte aligned)
-    uint32_t risc0_local_barrier_addr = (in1_output_addr + in1_per_core_read_size_bytes + 15) & ~15U;
+    // Local scratch addresses for barrier (placed after in1 mcast output region, 16-byte aligned).
+    uint32_t risc0_local_barrier_addr = (in1_mcast_output_addr + in1_per_core_read_size_bytes + 15) & ~15U;
     uint32_t risc1_local_barrier_addr = risc0_local_barrier_addr + 16;
 
     vector<uint32_t> risc0_compile_args = {
@@ -195,11 +216,15 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
 
     vector<uint32_t> risc1_compile_args = {
         test_config.test_id,                      // 0  Test ID
-        test_config.dram_bank_id,                 // 1  DRAM bank that all cores will read from
+        test_config.dram_bank_id,                 // 1  DRAM bank row-0 cores read from
         (uint32_t)matmul_physical_start_coord.x,  // 2  Physical start x (for barrier mcast)
-        (uint32_t)matmul_physical_start_coord.y,  // 3  Physical start y
+        (uint32_t)matmul_physical_start_coord.y,  // 3  Physical start y (== sender row y)
         (uint32_t)matmul_physical_end_coord.x,    // 4  Physical end x
         (uint32_t)matmul_physical_end_coord.y,    // 5  Physical end y
+        test_config.num_subblocks_r_dim,          // 6  Number of cores per column (R dim)
+        risc1_sender_sem_id,                      // 7  in1 sender semaphore ID
+        risc1_sender_valid_sem_id,                // 8  in1 sender-valid semaphore ID (init 1)
+        risc1_receiver_sem_id,                    // 9  in1 receiver semaphore ID
     };
 
     // Kernels
@@ -237,17 +262,18 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
         };
         uint32_t col_idx = i.x - test_config.start_logical_core.x;
         vector<uint32_t> risc1_core_runtime_args = {
-            in1_per_core_read_addr[col_idx],       // 0  Each core reads from addr based on its column
-            in1_per_core_read_size_bytes,          // 1  Each core reads the same amount of data
-            in1_output_addr,                       // 2  Each core writes to the same address in L1
-            risc1_barrier_sem_id,                  // 3  Barrier arrival semaphore ID
-            (uint32_t)barrier_coordinator_phys.x,  // 4  Barrier coordinator physical X
-            (uint32_t)barrier_coordinator_phys.y,  // 5  Barrier coordinator physical Y
-            num_cores,                             // 6  Total number of cores in barrier
-            risc1_local_barrier_addr,              // 7  Local L1 scratch addr for barrier
-            risc1_barrier_done_sem_id,             // 8  Barrier done semaphore ID
-            1,                                     // 9  Profiling: number of transactions
-            in1_per_core_read_size_bytes,          // 10 Profiling: transaction size in bytes
+            in1_per_core_read_addr[col_idx],       // 0  Per-column DRAM offset (row 0 only reads it)
+            in1_per_core_read_size_bytes,          // 1  Total bytes to read from DRAM (row 0 only)
+            test_config.num_subblocks_k_dim,       // 2  K iterations
+            in1_k_subblock_size_bytes,             // 3  Bytes per K subblock multicast
+            in1_l1_source_addr,                    // 4  Row-0 DRAM read destination in L1
+            in1_mcast_output_addr,                 // 5  All cores: column multicast dest base
+            risc1_barrier_sem_id,                  // 6  Barrier arrival semaphore ID
+            (uint32_t)barrier_coordinator_phys.x,  // 7  Barrier coordinator physical X
+            (uint32_t)barrier_coordinator_phys.y,  // 8  Barrier coordinator physical Y
+            num_cores,                             // 9  Total number of cores in barrier
+            risc1_local_barrier_addr,              // 10 Local L1 scratch addr for barrier
+            risc1_barrier_done_sem_id,             // 11 Barrier done semaphore ID
         };
         tt::tt_metal::SetRuntimeArgs(program, risc0_kernel, i, risc0_core_runtime_args);
         tt::tt_metal::SetRuntimeArgs(program, risc1_kernel, i, risc1_core_runtime_args);
@@ -291,8 +317,7 @@ bool run_dm_1d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     uint32_t total_in1_read_elements = in1_per_core_read_size_bytes / sizeof(uint32_t);
     for (auto & i : matmul_cores_list) {
         vector<uint32_t> in1_read_output;
-        detail::ReadFromDeviceL1(
-            device, i, in1_output_addr, in1_per_core_read_size_bytes, in1_read_output);
+        detail::ReadFromDeviceL1(device, i, in1_mcast_output_addr, in1_per_core_read_size_bytes, in1_read_output);
         uint32_t cur_c_dim = i.x - test_config.start_logical_core.x;
         for (uint32_t j = 0; j < total_in1_read_elements; j++) {
             golden_in1_read_output.push_back(in1_input[cur_c_dim * total_in1_read_elements + j]);

--- a/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_1d_v2.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_1d_v2.cpp
@@ -27,10 +27,8 @@ using MatmulTestConfig = unit_tests::dm::matmul::MatmulTestConfig;
 
 uint32_t runtime_host_id = 0;
 
-/// @brief 1D matmul data movement with K-loop rotating sender for in0.
-///        in0 K subblocks are distributed round-robin across columns.
-///        Each column takes turns multicasting its K subblock to all cores in the same row.
-///        in1 is read from DRAM (same as v1).
+/// @brief 1D matmul v2: in0 senders rotate round-robin across columns; in1 keeps the
+///        v1 row-0 fixed-sender DRAM-read path.
 bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device, const MatmulTestConfig& test_config) {
     IDevice* device = mesh_device->impl().get_device(0);
 
@@ -75,7 +73,6 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
     CoreCoord matmul_physical_start_coord = device->worker_core_from_logical_core(test_config.start_logical_core);
     CoreCoord matmul_physical_end_coord = device->worker_core_from_logical_core(test_config.end_logical_core);
 
-    // Build per-column physical X coordinate array
     vector<uint32_t> col_phys_x(grid_cols);
     for (uint32_t c = 0; c < grid_cols; c++) {
         CoreCoord logical_col_core(test_config.start_logical_core.x + c, test_config.start_logical_core.y);
@@ -83,79 +80,56 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
         col_phys_x[c] = phys.x;
     }
 
-    // ---- Size calculations ----
     uint32_t K = test_config.num_subblocks_k_dim;
     uint32_t C = test_config.num_subblocks_c_dim;
     uint32_t R = test_config.num_subblocks_r_dim;
 
-    // Size of one K subblock for one row: subblock_r_dim * subblock_k_dim pages
     uint32_t k_subblock_size_bytes =
         test_config.subblock_r_dim * test_config.subblock_k_dim * test_config.page_size_bytes;
-
-    // Maximum K subblocks any column holds
     uint32_t max_k_per_col = (K + C - 1) / C;
     uint32_t max_source_data_bytes = max_k_per_col * k_subblock_size_bytes;
 
-    // in1 sizes (same as v1)
     uint32_t in1_pages = (test_config.num_subblocks_k_dim * test_config.subblock_k_dim) *
                          (test_config.num_subblocks_c_dim * test_config.subblock_c_dim);
     uint32_t in1_pages_bytes = in1_pages * test_config.page_size_bytes;
     uint32_t in1_per_core_read_size_bytes = in1_pages_bytes / test_config.num_subblocks_c_dim;
-
-    // in1 K subblock size: bytes the row-0 sender multicasts per K iteration down its column.
     uint32_t in1_k_subblock_size_bytes =
         test_config.subblock_k_dim * test_config.subblock_c_dim * test_config.page_size_bytes;
 
     uint32_t l1_base_address = unit_tests::dm::get_l1_address_and_size(mesh_device, matmul_cores_list[0]).base_address;
 
-    // ---- L1 Memory Layout ----
-    // l1_base_address:                              in0 source data (per-core K subblocks)
-    // l1_base_address + max_source_data + pad:      in0 multicast output (all K subblocks)
-    // aligned(output_end + pad):                    in1 source (row 0 only, full column from DRAM)
-    // in1_source_end + pad:                         in1 multicast output (all cores)
-    // after in1_mcast_out: barrier scratch
+    // L1 layout: in0 source -> in0 mcast out -> in1 source (64B-aligned) -> in1 mcast out -> barrier scratch.
     uint32_t in0_mcast_output_addr = l1_base_address + max_source_data_bytes + matmul::L1_DEBUG_PADDING_BYTES;
     uint32_t in0_output_total_bytes = K * k_subblock_size_bytes;
 
-    // in1_l1_source_addr: row-0 reads the full in1 column slice from DRAM here. Must be
-    // 64-byte aligned so the low bits match the DRAM source address.
     uint32_t in1_l1_source_addr_unaligned =
         in0_mcast_output_addr + in0_output_total_bytes + matmul::L1_DEBUG_PADDING_BYTES;
     uint32_t in1_l1_source_addr = (in1_l1_source_addr_unaligned + 63) & ~63U;
-
-    // in1_mcast_output_addr: where the column multicast deposits the full in1 column data
-    // for every core. This is what gets verified against the golden DRAM copy.
     uint32_t in1_mcast_output_addr = in1_l1_source_addr + in1_per_core_read_size_bytes + matmul::L1_DEBUG_PADDING_BYTES;
 
-    // ---- Generate in0 data ----
     uint32_t in0_pages = (R * test_config.subblock_r_dim) * (K * test_config.subblock_k_dim);
     uint32_t in0_pages_bytes = in0_pages * test_config.page_size_bytes;
     vector<uint32_t> in0_input = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
         -100.0f, 100.0f, in0_pages_bytes / sizeof(bfloat16), chrono::system_clock::now().time_since_epoch().count());
 
-    // Per-row data size in uint32_t elements
     uint32_t row_data_size_uint32 = in0_input.size() / R;
     uint32_t k_subblock_size_uint32 = k_subblock_size_bytes / sizeof(uint32_t);
 
-    // ---- Distribute in0 data round-robin across all cores ----
-    // Build golden data map: row_y -> full row data (for verification)
+    // Golden in0 row data, indexed by row's logical y.
     unordered_map<uint32_t, vector<uint32_t>> dim_r_to_in0_pages_map;
-
     for (uint32_t r = 0; r < R; r++) {
         vector<uint32_t> row_data(
             in0_input.begin() + r * row_data_size_uint32, in0_input.begin() + (r + 1) * row_data_size_uint32);
         dim_r_to_in0_pages_map[test_config.start_logical_core.y + r] = row_data;
     }
 
-    // Write per-core in0 source data: each core (c, r) gets K subblocks {c, c+C, c+2C, ...} for row r
+    // Each core (c, r) gets K subblocks {c, c+C, c+2C, ...} from row r.
     for (auto & core_idx : matmul_cores_list) {
         uint32_t col_idx = core_idx.x - test_config.start_logical_core.x;
         uint32_t row_idx = core_idx.y - test_config.start_logical_core.y;
 
         vector<uint32_t> core_in0_data;
         uint32_t row_base = row_idx * row_data_size_uint32;
-
-        // Round-robin distribute K subblocks for this row across columns
         for (uint32_t k = col_idx; k < K; k += C) {
             uint32_t k_offset = k * k_subblock_size_uint32;
             for (uint32_t e = 0; e < k_subblock_size_uint32; e++) {
@@ -168,7 +142,6 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
         }
     }
 
-    // ---- Generate and write in1 data (same as v1) ----
     vector<uint32_t> in1_input = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
         -100.0f, 100.0f, in1_pages_bytes / sizeof(bfloat16), chrono::system_clock::now().time_since_epoch().count());
 
@@ -183,18 +156,14 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
         in1_per_core_read_addr.push_back(input_dram_address + i * in1_per_core_read_size_bytes);
     }
 
-    // ---- Semaphores ----
-    // in0 multicast semaphores (same semantics as v1)
+    // in0 row-wise mcast (rotating sender) and in1 column-wise mcast (row 0 fixed sender).
     uint32_t sender_sem_id = CreateSemaphore(program, matmul_cores, 0);
     uint32_t sender_valid_sem_id = CreateSemaphore(program, matmul_cores, 1);
     uint32_t receiver_sem_id = CreateSemaphore(program, matmul_cores, 0);
-
-    // in1 multicast semaphores (column-wise on RISCV_1) — row 0 is the fixed sender.
     uint32_t risc1_sender_sem_id = CreateSemaphore(program, matmul_cores, 0);
     uint32_t risc1_sender_valid_sem_id = CreateSemaphore(program, matmul_cores, 1);
     uint32_t risc1_receiver_sem_id = CreateSemaphore(program, matmul_cores, 0);
 
-    // Barrier synchronization semaphores
     uint32_t risc0_barrier_sem_id = CreateSemaphore(program, matmul_cores, 0);
     uint32_t risc0_barrier_done_sem_id = CreateSemaphore(program, matmul_cores, 0);
     uint32_t risc1_barrier_sem_id = CreateSemaphore(program, matmul_cores, 0);
@@ -206,7 +175,6 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
     uint32_t risc0_local_barrier_addr = (in1_mcast_output_addr + in1_per_core_read_size_bytes + 15) & ~15U;
     uint32_t risc1_local_barrier_addr = risc0_local_barrier_addr + 16;
 
-    // ---- Compile-time args ----
     vector<uint32_t> risc0_compile_args = {
         test_config.test_id,                      // 0  Test ID
         (uint32_t)matmul_physical_start_coord.x,  // 1  Physical start x
@@ -232,7 +200,6 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
         risc1_receiver_sem_id,                    // 9  in1 receiver semaphore ID
     };
 
-    // ---- Kernels ----
     auto risc0_kernel = CreateKernel(
         program,
         "tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel_v2.cpp",
@@ -251,11 +218,9 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
             .noc = NOC::RISCV_1_default,
             .compile_args = risc1_compile_args});
 
-    // ---- Assign Runtime Args ----
     for (auto & i : matmul_cores_list) {
         uint32_t col_idx = i.x - test_config.start_logical_core.x;
 
-        // Count K subblocks this column sends
         uint32_t num_k_this_core = 0;
         for (uint32_t k = col_idx; k < K; k += C) {
             num_k_this_core++;
@@ -275,7 +240,6 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
             risc0_local_barrier_addr,              // 10 Local L1 scratch addr for barrier
             risc0_barrier_done_sem_id,             // 11 Barrier done semaphore ID
         };
-        // Append per-column physical X coordinates
         for (uint32_t c = 0; c < C; c++) {
             risc0_core_runtime_args.push_back(col_phys_x[c]);
         }
@@ -299,7 +263,6 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
         tt::tt_metal::SetRuntimeArgs(program, risc1_kernel, i, risc1_core_runtime_args);
     }
 
-    // ---- Launch ----
     log_info(tt::LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, runtime_host_id);
     program.set_runtime_id(runtime_host_id++);
 
@@ -312,8 +275,7 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
-    // ---- Verify in0 multicast output ----
-    // After the K loop, each core should have all K subblocks for its row in order
+    // Each core should hold all K subblocks for its row, in order.
     for (auto & i : matmul_cores_list) {
         vector<uint32_t> in0_read_output;
         detail::ReadFromDeviceL1(
@@ -331,7 +293,6 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
         }
     }
 
-    // ---- Verify in1 DRAM read output (same as v1) ----
     vector<uint32_t> golden_in1_read_output;
     uint32_t total_in1_read_elements = in1_per_core_read_size_bytes / sizeof(uint32_t);
     for (auto & i : matmul_cores_list) {

--- a/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_1d_v2.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_1d_v2.cpp
@@ -102,19 +102,30 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
     uint32_t in1_pages_bytes = in1_pages * test_config.page_size_bytes;
     uint32_t in1_per_core_read_size_bytes = in1_pages_bytes / test_config.num_subblocks_c_dim;
 
+    // in1 K subblock size: bytes the row-0 sender multicasts per K iteration down its column.
+    uint32_t in1_k_subblock_size_bytes =
+        test_config.subblock_k_dim * test_config.subblock_c_dim * test_config.page_size_bytes;
+
     uint32_t l1_base_address = unit_tests::dm::get_l1_address_and_size(mesh_device, matmul_cores_list[0]).base_address;
 
     // ---- L1 Memory Layout ----
     // l1_base_address:                              in0 source data (per-core K subblocks)
     // l1_base_address + max_source_data + pad:      in0 multicast output (all K subblocks)
-    // aligned(output_end + pad):                    in1 DRAM read output
-    // after in1: barrier scratch
+    // aligned(output_end + pad):                    in1 source (row 0 only, full column from DRAM)
+    // in1_source_end + pad:                         in1 multicast output (all cores)
+    // after in1_mcast_out: barrier scratch
     uint32_t in0_mcast_output_addr = l1_base_address + max_source_data_bytes + matmul::L1_DEBUG_PADDING_BYTES;
     uint32_t in0_output_total_bytes = K * k_subblock_size_bytes;
 
-    uint32_t in1_output_addr_unaligned =
+    // in1_l1_source_addr: row-0 reads the full in1 column slice from DRAM here. Must be
+    // 64-byte aligned so the low bits match the DRAM source address.
+    uint32_t in1_l1_source_addr_unaligned =
         in0_mcast_output_addr + in0_output_total_bytes + matmul::L1_DEBUG_PADDING_BYTES;
-    uint32_t in1_output_addr = (in1_output_addr_unaligned + 63) & ~63U;
+    uint32_t in1_l1_source_addr = (in1_l1_source_addr_unaligned + 63) & ~63U;
+
+    // in1_mcast_output_addr: where the column multicast deposits the full in1 column data
+    // for every core. This is what gets verified against the golden DRAM copy.
+    uint32_t in1_mcast_output_addr = in1_l1_source_addr + in1_per_core_read_size_bytes + matmul::L1_DEBUG_PADDING_BYTES;
 
     // ---- Generate in0 data ----
     uint32_t in0_pages = (R * test_config.subblock_r_dim) * (K * test_config.subblock_k_dim);
@@ -178,6 +189,11 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
     uint32_t sender_valid_sem_id = CreateSemaphore(program, matmul_cores, 1);
     uint32_t receiver_sem_id = CreateSemaphore(program, matmul_cores, 0);
 
+    // in1 multicast semaphores (column-wise on RISCV_1) — row 0 is the fixed sender.
+    uint32_t risc1_sender_sem_id = CreateSemaphore(program, matmul_cores, 0);
+    uint32_t risc1_sender_valid_sem_id = CreateSemaphore(program, matmul_cores, 1);
+    uint32_t risc1_receiver_sem_id = CreateSemaphore(program, matmul_cores, 0);
+
     // Barrier synchronization semaphores
     uint32_t risc0_barrier_sem_id = CreateSemaphore(program, matmul_cores, 0);
     uint32_t risc0_barrier_done_sem_id = CreateSemaphore(program, matmul_cores, 0);
@@ -187,7 +203,7 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
     CoreCoord barrier_coordinator_phys = device->worker_core_from_logical_core(matmul_cores_list[0]);
     uint32_t num_cores = matmul_cores_list.size();
 
-    uint32_t risc0_local_barrier_addr = (in1_output_addr + in1_per_core_read_size_bytes + 15) & ~15U;
+    uint32_t risc0_local_barrier_addr = (in1_mcast_output_addr + in1_per_core_read_size_bytes + 15) & ~15U;
     uint32_t risc1_local_barrier_addr = risc0_local_barrier_addr + 16;
 
     // ---- Compile-time args ----
@@ -205,11 +221,15 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
 
     vector<uint32_t> risc1_compile_args = {
         test_config.test_id,                      // 0  Test ID
-        test_config.dram_bank_id,                 // 1  DRAM bank
-        (uint32_t)matmul_physical_start_coord.x,  // 2  Physical start x
-        (uint32_t)matmul_physical_start_coord.y,  // 3  Physical start y
+        test_config.dram_bank_id,                 // 1  DRAM bank row-0 cores read from
+        (uint32_t)matmul_physical_start_coord.x,  // 2  Physical start x (for barrier)
+        (uint32_t)matmul_physical_start_coord.y,  // 3  Physical start y (== sender row y)
         (uint32_t)matmul_physical_end_coord.x,    // 4  Physical end x
         (uint32_t)matmul_physical_end_coord.y,    // 5  Physical end y
+        R,                                        // 6  Number of cores per column (R dim)
+        risc1_sender_sem_id,                      // 7  in1 sender semaphore ID
+        risc1_sender_valid_sem_id,                // 8  in1 sender-valid semaphore ID (init 1)
+        risc1_receiver_sem_id,                    // 9  in1 receiver semaphore ID
     };
 
     // ---- Kernels ----
@@ -261,17 +281,18 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
         }
 
         vector<uint32_t> risc1_core_runtime_args = {
-            in1_per_core_read_addr[col_idx],       // 0  DRAM read address based on column
-            in1_per_core_read_size_bytes,          // 1  DRAM read size
-            in1_output_addr,                       // 2  L1 output address for in1
-            risc1_barrier_sem_id,                  // 3  Barrier arrival semaphore ID
-            (uint32_t)barrier_coordinator_phys.x,  // 4  Barrier coordinator physical X
-            (uint32_t)barrier_coordinator_phys.y,  // 5  Barrier coordinator physical Y
-            num_cores,                             // 6  Total number of cores in barrier
-            risc1_local_barrier_addr,              // 7  Local L1 scratch addr for barrier
-            risc1_barrier_done_sem_id,             // 8  Barrier done semaphore ID
-            1,                                     // 9  Profiling: number of transactions
-            in1_per_core_read_size_bytes,          // 10 Profiling: per-K-subblock transaction size
+            in1_per_core_read_addr[col_idx],       // 0  Per-column DRAM offset (row 0 only reads it)
+            in1_per_core_read_size_bytes,          // 1  Total bytes to read from DRAM (row 0 only)
+            K,                                     // 2  K iterations
+            in1_k_subblock_size_bytes,             // 3  Bytes per K subblock multicast
+            in1_l1_source_addr,                    // 4  Row-0 DRAM read destination in L1
+            in1_mcast_output_addr,                 // 5  All cores: column multicast dest base
+            risc1_barrier_sem_id,                  // 6  Barrier arrival semaphore ID
+            (uint32_t)barrier_coordinator_phys.x,  // 7  Barrier coordinator physical X
+            (uint32_t)barrier_coordinator_phys.y,  // 8  Barrier coordinator physical Y
+            num_cores,                             // 9  Total number of cores in barrier
+            risc1_local_barrier_addr,              // 10 Local L1 scratch addr for barrier
+            risc1_barrier_done_sem_id,             // 11 Barrier done semaphore ID
         };
 
         tt::tt_metal::SetRuntimeArgs(program, risc0_kernel, i, risc0_core_runtime_args);
@@ -315,8 +336,7 @@ bool run_dm_1d_matmul_v2(const shared_ptr<distributed::MeshDevice>& mesh_device,
     uint32_t total_in1_read_elements = in1_per_core_read_size_bytes / sizeof(uint32_t);
     for (auto & i : matmul_cores_list) {
         vector<uint32_t> in1_read_output;
-        detail::ReadFromDeviceL1(
-            device, i, in1_output_addr, in1_per_core_read_size_bytes, in1_read_output);
+        detail::ReadFromDeviceL1(device, i, in1_mcast_output_addr, in1_per_core_read_size_bytes, in1_read_output);
         uint32_t cur_c_dim = i.x - test_config.start_logical_core.x;
         for (uint32_t j = 0; j < total_in1_read_elements; j++) {
             golden_in1_read_output.push_back(in1_input[cur_c_dim * total_in1_read_elements + j]);

--- a/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_2d.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_2d.cpp
@@ -27,10 +27,8 @@ using MatmulTestConfig = unit_tests::dm::matmul::MatmulTestConfig;
 
 uint32_t runtime_host_id = 0;
 
-/// @brief 2D matmul data movement with rotating sender for both in0 and in1.
-///        in0 K subblocks are distributed round-robin across columns; each column multicasts across its row.
-///        in1 K subblocks are distributed round-robin across rows; each row multicasts across its column.
-///        No DRAM is used — all data is written to L1 by the host.
+/// @brief 2D matmul: rotating sender on both axes (in0 round-robin across columns,
+///        in1 round-robin across rows). No DRAM — host writes all data to L1.
 bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, const MatmulTestConfig& test_config) {
     IDevice* device = mesh_device->impl().get_device(0);
 
@@ -75,7 +73,6 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     CoreCoord matmul_physical_start_coord = device->worker_core_from_logical_core(test_config.start_logical_core);
     CoreCoord matmul_physical_end_coord = device->worker_core_from_logical_core(test_config.end_logical_core);
 
-    // Build per-column physical X coordinate array (for in0 row-wise multicast)
     vector<uint32_t> col_phys_x(grid_cols);
     for (uint32_t c = 0; c < grid_cols; c++) {
         CoreCoord logical_col_core(test_config.start_logical_core.x + c, test_config.start_logical_core.y);
@@ -83,7 +80,6 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
         col_phys_x[c] = phys.x;
     }
 
-    // Build per-row physical Y coordinate array (for in1 column-wise multicast)
     vector<uint32_t> row_phys_y(grid_rows);
     for (uint32_t r = 0; r < grid_rows; r++) {
         CoreCoord logical_row_core(test_config.start_logical_core.x, test_config.start_logical_core.y + r);
@@ -91,37 +87,23 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
         row_phys_y[r] = phys.y;
     }
 
-    // ---- Size calculations ----
     uint32_t K = test_config.num_subblocks_k_dim;
     uint32_t C = test_config.num_subblocks_c_dim;
     uint32_t R = test_config.num_subblocks_r_dim;
 
-    // in0 K subblock: subblock_r_dim * subblock_k_dim pages (one K subblock for one row)
     uint32_t in0_k_subblock_size_bytes =
         test_config.subblock_r_dim * test_config.subblock_k_dim * test_config.page_size_bytes;
-
-    // in1 K subblock: subblock_k_dim * subblock_c_dim pages (one K subblock for one column)
     uint32_t in1_k_subblock_size_bytes =
         test_config.subblock_k_dim * test_config.subblock_c_dim * test_config.page_size_bytes;
 
-    // Maximum K subblocks any column holds for in0
     uint32_t max_in0_k_per_col = (K + C - 1) / C;
     uint32_t in0_max_source_data_bytes = max_in0_k_per_col * in0_k_subblock_size_bytes;
-
-    // Maximum K subblocks any row holds for in1
     uint32_t max_in1_k_per_row = (K + R - 1) / R;
     uint32_t in1_max_source_data_bytes = max_in1_k_per_row * in1_k_subblock_size_bytes;
 
     uint32_t l1_base_address = unit_tests::dm::get_l1_address_and_size(mesh_device, matmul_cores_list[0]).base_address;
 
-    // ---- L1 Memory Layout ----
-    // l1_base:                                    in0 source data (this col's K subblocks)
-    // in0_source_end + pad:                       in0 mcast output (K * in0_k_sub_size)
-    // in0_mcast_end + pad:                        in1 source data (this row's K subblocks)
-    // in1_source_end + pad:                       in1 mcast output (K * in1_k_sub_size)
-    // align16(in1_mcast_end):                     RISCV_0 barrier scratch (16 bytes)
-    // align16(risc0_scratch + 16):                RISCV_1 barrier scratch (16 bytes)
-
+    // L1 layout: in0 source -> in0 mcast out -> in1 source -> in1 mcast out -> RISCV_0/1 barrier scratch.
     uint32_t in0_mcast_output_addr = l1_base_address + in0_max_source_data_bytes + matmul::L1_DEBUG_PADDING_BYTES;
     uint32_t in0_output_total_bytes = K * in0_k_subblock_size_bytes;
 
@@ -132,7 +114,6 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     uint32_t risc0_local_barrier_addr = (in1_mcast_output_addr + in1_output_total_bytes + 15) & ~15U;
     uint32_t risc1_local_barrier_addr = risc0_local_barrier_addr + 16;
 
-    // ---- Generate in0 data ----
     uint32_t in0_pages = (R * test_config.subblock_r_dim) * (K * test_config.subblock_k_dim);
     uint32_t in0_pages_bytes = in0_pages * test_config.page_size_bytes;
     vector<uint32_t> in0_input = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
@@ -141,8 +122,7 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     uint32_t in0_row_data_size_uint32 = in0_input.size() / R;
     uint32_t in0_k_subblock_size_uint32 = in0_k_subblock_size_bytes / sizeof(uint32_t);
 
-    // ---- Generate in1 data ----
-    // in1 is laid out as C column groups, each with K contiguous subblocks
+    // in1 is laid out as C column groups, each with K contiguous subblocks.
     uint32_t in1_pages = (K * test_config.subblock_k_dim) * (C * test_config.subblock_c_dim);
     uint32_t in1_pages_bytes = in1_pages * test_config.page_size_bytes;
     vector<uint32_t> in1_input = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
@@ -151,32 +131,27 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     uint32_t in1_col_data_size_uint32 = in1_input.size() / C;
     uint32_t in1_k_subblock_size_uint32 = in1_k_subblock_size_bytes / sizeof(uint32_t);
 
-    // ---- Distribute in0 data round-robin across columns ----
-    // Golden data map: row_y -> full row data (for in0 verification)
+    // Golden in0 row data, indexed by row's logical y.
     unordered_map<uint32_t, vector<uint32_t>> dim_r_to_in0_pages_map;
-
     for (uint32_t r = 0; r < R; r++) {
         vector<uint32_t> row_data(
             in0_input.begin() + r * in0_row_data_size_uint32, in0_input.begin() + (r + 1) * in0_row_data_size_uint32);
         dim_r_to_in0_pages_map[test_config.start_logical_core.y + r] = row_data;
     }
 
-    // ---- Distribute in1 data round-robin across rows ----
-    // Golden data map: col_x -> full column data (for in1 verification)
+    // Golden in1 column data, indexed by column's logical x.
     unordered_map<uint32_t, vector<uint32_t>> dim_c_to_in1_pages_map;
-
     for (uint32_t c = 0; c < C; c++) {
         vector<uint32_t> col_data(
             in1_input.begin() + c * in1_col_data_size_uint32, in1_input.begin() + (c + 1) * in1_col_data_size_uint32);
         dim_c_to_in1_pages_map[test_config.start_logical_core.x + c] = col_data;
     }
 
-    // ---- Write per-core in0 and in1 source data ----
+    // Each core (c, r): in0 = K subblocks {c, c+C, ...} from row r; in1 = {r, r+R, ...} from col c.
     for (const auto& core : matmul_cores_list) {
         uint32_t col_idx = core.x - test_config.start_logical_core.x;
         uint32_t row_idx = core.y - test_config.start_logical_core.y;
 
-        // in0: column c gets K subblocks {c, c+C, c+2C, ...} from row r
         vector<uint32_t> core_in0_data;
         uint32_t in0_row_base = row_idx * in0_row_data_size_uint32;
         for (uint32_t k = col_idx; k < K; k += C) {
@@ -189,7 +164,6 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
             detail::WriteToDeviceL1(device, core, l1_base_address, core_in0_data);
         }
 
-        // in1: row r gets K subblocks {r, r+R, r+2R, ...} from column c
         vector<uint32_t> core_in1_data;
         uint32_t in1_col_base = col_idx * in1_col_data_size_uint32;
         for (uint32_t k = row_idx; k < K; k += R) {
@@ -203,18 +177,14 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
         }
     }
 
-    // ---- Semaphores ----
-    // in0 multicast semaphores (row-wise, same as v2)
+    // in0 row-wise mcast and in1 column-wise mcast; both use rotating senders.
     uint32_t in0_sender_sem_id = CreateSemaphore(program, matmul_cores, 0);
     uint32_t in0_sender_valid_sem_id = CreateSemaphore(program, matmul_cores, 1);
     uint32_t in0_receiver_sem_id = CreateSemaphore(program, matmul_cores, 0);
-
-    // in1 multicast semaphores (column-wise)
     uint32_t in1_sender_sem_id = CreateSemaphore(program, matmul_cores, 0);
     uint32_t in1_sender_valid_sem_id = CreateSemaphore(program, matmul_cores, 1);
     uint32_t in1_receiver_sem_id = CreateSemaphore(program, matmul_cores, 0);
 
-    // Barrier synchronization semaphores
     uint32_t risc0_barrier_sem_id = CreateSemaphore(program, matmul_cores, 0);
     uint32_t risc0_barrier_done_sem_id = CreateSemaphore(program, matmul_cores, 0);
     uint32_t risc1_barrier_sem_id = CreateSemaphore(program, matmul_cores, 0);
@@ -223,7 +193,6 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     CoreCoord barrier_coordinator_phys = device->worker_core_from_logical_core(matmul_cores_list[0]);
     uint32_t num_cores = matmul_cores_list.size();
 
-    // ---- Compile-time args ----
     vector<uint32_t> risc0_compile_args = {
         test_config.test_id,                      // 0  Test ID
         (uint32_t)matmul_physical_start_coord.x,  // 1  Physical start x
@@ -248,7 +217,6 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
         in1_receiver_sem_id,                      // 8  in1 receiver semaphore ID
     };
 
-    // ---- Kernels ----
     auto risc0_kernel = CreateKernel(
         program,
         "tests/tt_metal/tt_metal/data_movement/matmul/kernels/in0_kernel_2d.cpp",
@@ -267,18 +235,15 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
             .noc = NOC::RISCV_1_default,
             .compile_args = risc1_compile_args});
 
-    // ---- Assign Runtime Args ----
     for (const auto& core : matmul_cores_list) {
         uint32_t col_idx = core.x - test_config.start_logical_core.x;
         uint32_t row_idx = core.y - test_config.start_logical_core.y;
 
-        // Count in0 K subblocks this column sends
         uint32_t num_in0_k_this_core = 0;
         for (uint32_t k = col_idx; k < K; k += C) {
             num_in0_k_this_core++;
         }
 
-        // Count in1 K subblocks this row sends
         uint32_t num_in1_k_this_core = 0;
         for (uint32_t k = row_idx; k < K; k += R) {
             num_in1_k_this_core++;
@@ -298,7 +263,6 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
             risc0_local_barrier_addr,              // 10 Local L1 scratch addr for barrier
             risc0_barrier_done_sem_id,             // 11 Barrier done semaphore ID
         };
-        // Append per-column physical X coordinates
         for (uint32_t c = 0; c < C; c++) {
             risc0_core_runtime_args.push_back(col_phys_x[c]);
         }
@@ -317,7 +281,6 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
             risc1_local_barrier_addr,              // 10 Local L1 scratch addr for barrier
             risc1_barrier_done_sem_id,             // 11 Barrier done semaphore ID
         };
-        // Append per-row physical Y coordinates
         for (uint32_t r = 0; r < R; r++) {
             risc1_core_runtime_args.push_back(row_phys_y[r]);
         }
@@ -326,7 +289,6 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
         tt::tt_metal::SetRuntimeArgs(program, risc1_kernel, core, risc1_core_runtime_args);
     }
 
-    // ---- Launch ----
     log_info(tt::LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, runtime_host_id);
     program.set_runtime_id(runtime_host_id++);
 
@@ -339,8 +301,7 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
-    // ---- Verify in0 multicast output ----
-    // After the K loop, each core should have all K subblocks for its row in order
+    // Each core should hold all K subblocks for its row, in order.
     for (const auto& core : matmul_cores_list) {
         vector<uint32_t> in0_read_output;
         detail::ReadFromDeviceL1(device, core, in0_mcast_output_addr, in0_output_total_bytes, in0_read_output);
@@ -356,8 +317,7 @@ bool run_dm_2d_matmul(const shared_ptr<distributed::MeshDevice>& mesh_device, co
         }
     }
 
-    // ---- Verify in1 multicast output ----
-    // After the K loop, each core should have all K subblocks for its column in order
+    // Each core should hold all K subblocks for its column, in order.
     for (const auto& core : matmul_cores_list) {
         vector<uint32_t> in1_read_output;
         detail::ReadFromDeviceL1(device, core, in1_mcast_output_addr, in1_output_total_bytes, in1_read_output);

--- a/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_common.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_common.hpp
@@ -30,7 +30,7 @@ struct MatmulTestConfig {
     uint32_t subblock_r_dim = 1;
     uint32_t subblock_c_dim = 1;
     uint32_t subblock_k_dim = 1;
-    uint32_t page_size_bytes = 1;
+    uint32_t page_size_bytes = 2048;
     DataFormat l1_data_format = DataFormat::Float16_b;
     uint32_t dram_bank_id = 0;
 
@@ -160,7 +160,6 @@ inline std::vector<MatmulTestConfig> get_matmul_test_configs() {
          .subblock_k_dim_sweep = {1u, 2u, 4u, 8u}},
 
         // ---- R subblock size sweep ----
-        // ID 1027: 4x4 grid, K=4, subblock_k=4, subblock_c=1, sweep subblock_r_dim.
         {.test_id = 1027,
          .num_subblocks_r_dim = 4,
          .num_subblocks_c_dim = 4,
@@ -178,11 +177,28 @@ inline std::vector<MatmulTestConfig> get_matmul_test_configs() {
          .subblock_r_dim = 1,
          .subblock_k_dim = 1,
          .subblock_c_dim_sweep = {1u, 2u, 4u, 8u, 16u, 32u}},
+
+        {.test_id = 1029,
+         .num_subblocks_r_dim = 4,
+         .num_subblocks_c_dim = 4,
+         .num_subblocks_k_dim = 1,
+         .subblock_c_dim = 1,
+         .subblock_k_dim = 1,
+         .subblock_r_dim_sweep = {1u, 2u, 4u, 8u, 16u, 32u, 64u, 128u, 256u}},
+
+        {.test_id = 1030,
+         .num_subblocks_r_dim = 4,
+         .num_subblocks_c_dim = 4,
+         .num_subblocks_k_dim = 8,
+         .subblock_k_dim = 1,
+         .subblock_r_dim_sweep = {1u, 2u, 4u, 8u, 16u},
+         .subblock_c_dim_sweep = {1u, 2u, 4u, 8u, 16u, 32u}},
     };
 
     return configs;
 }
 
+// sweep in1 and keep in0 constant for new test
 struct MatmulTestNameGenerator {
     std::string operator()(const ::testing::TestParamInfo<MatmulTestConfig>& info) const {
         const auto& c = info.param;

--- a/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_common.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_common.hpp
@@ -14,8 +14,7 @@ namespace tt::tt_metal::unit_tests::dm::matmul {
 
 constexpr uint32_t L1_DEBUG_PADDING_BYTES = 0x10;
 
-// Per-variant test_id offsets. Each matmul variant shares the same MatmulTestConfig list,
-// so we offset the test_id per variant to keep profiler results (CSVs/plots) separate.
+// Per-variant test_id offsets keep profiler results (CSVs/plots) separate across variants.
 constexpr uint32_t MATMUL_1D_TEST_ID_OFFSET = 0;
 constexpr uint32_t MATMUL_1D_V2_TEST_ID_OFFSET = 100;
 constexpr uint32_t MATMUL_2D_TEST_ID_OFFSET = 200;
@@ -43,7 +42,6 @@ struct MatmulTestConfig {
 };
 
 // Hardcoded test configurations shared by all matmul test variants.
-// Each config is an explicit, representative test point.
 inline std::vector<MatmulTestConfig> get_matmul_test_configs() {
     std::vector<MatmulTestConfig> configs = {
         // ---- Grid shape tests ----
@@ -194,12 +192,6 @@ inline std::vector<MatmulTestConfig> get_matmul_test_configs() {
          .subblock_r_dim_sweep = {1u, 2u, 4u, 8u, 16u},
          .subblock_c_dim_sweep = {1u, 2u, 4u, 8u, 16u}},
 
-        // ID 1031: 8-wide grid version of 1030. Same K=8 + (sub_r, sub_c) Cartesian sweep.
-        // R=7 (not 8) so this fits Wormhole B0 with typical Tensix harvesting (8 cols x
-        // 7 rows usable). 56 cores total. Per-core L1 footprint is independent of R/C in
-        // the 1D path since in0_per_core = K * sub_r * P and in1_per_core = K * sub_c * P,
-        // so the same {1,2,4,8,16} sweep range that fits 1030 also fits 1031. Worst
-        // corner stays at ~1 MiB per col-0 row-0 core.
         {.test_id = 1031,
          .num_subblocks_r_dim = 7,
          .num_subblocks_c_dim = 8,
@@ -212,7 +204,6 @@ inline std::vector<MatmulTestConfig> get_matmul_test_configs() {
     return configs;
 }
 
-// sweep in1 and keep in0 constant for new test
 struct MatmulTestNameGenerator {
     std::string operator()(const ::testing::TestParamInfo<MatmulTestConfig>& info) const {
         const auto& c = info.param;

--- a/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_common.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/matmul/test_matmul_common.hpp
@@ -192,7 +192,21 @@ inline std::vector<MatmulTestConfig> get_matmul_test_configs() {
          .num_subblocks_k_dim = 8,
          .subblock_k_dim = 1,
          .subblock_r_dim_sweep = {1u, 2u, 4u, 8u, 16u},
-         .subblock_c_dim_sweep = {1u, 2u, 4u, 8u, 16u, 32u}},
+         .subblock_c_dim_sweep = {1u, 2u, 4u, 8u, 16u}},
+
+        // ID 1031: 8-wide grid version of 1030. Same K=8 + (sub_r, sub_c) Cartesian sweep.
+        // R=7 (not 8) so this fits Wormhole B0 with typical Tensix harvesting (8 cols x
+        // 7 rows usable). 56 cores total. Per-core L1 footprint is independent of R/C in
+        // the 1D path since in0_per_core = K * sub_r * P and in1_per_core = K * sub_c * P,
+        // so the same {1,2,4,8,16} sweep range that fits 1030 also fits 1031. Worst
+        // corner stays at ~1 MiB per col-0 row-0 core.
+        {.test_id = 1031,
+         .num_subblocks_r_dim = 7,
+         .num_subblocks_c_dim = 8,
+         .num_subblocks_k_dim = 8,
+         .subblock_k_dim = 1,
+         .subblock_r_dim_sweep = {1u, 2u, 4u, 8u, 16u},
+         .subblock_c_dim_sweep = {1u, 2u, 4u, 8u, 16u}},
     };
 
     return configs;

--- a/tests/tt_metal/tt_metal/data_movement/python/stats_collector.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/stats_collector.py
@@ -62,13 +62,8 @@ class StatsCollector:
                     dm_stats[risc]["analysis"]["stats"][core] = core_analysis[analysis_key]["stats"]
                     dm_stats[risc]["analysis"]["series"].extend(core_analysis[analysis_key]["series"])
 
-        # Gather test attributes
-        # Two views of attribute stamps:
-        #   - global: last-write-wins per (run_host_id, zone_name); stable for tests that
-        #     stamp the same value on every core.
-        #   - per-core: keyed by (run_host_id, core, zone_name); used when kernels stamp
-        #     role-specific values (e.g. matmul sender vs receiver). event[4] is the core
-        #     appended in tracy.process_device_log.core_to_device_timeseries.
+        # Gather test attributes. Two views: global (last-write-wins per zone_name) and
+        # per-core (keyed by core) for role-specific stamps like matmul sender vs receiver.
         for risc in dm_stats.keys():
             attributes = dm_stats[risc]["attributes"]
             attributes_per_core = dm_stats[risc]["attributes_per_core"]
@@ -171,14 +166,11 @@ class StatsCollector:
                 transaction_size = attributes.get("Transaction size in bytes", 0)
 
                 duration = entry["duration_cycles"]
-                # Effective bandwidth from global attrs — same formula on every core,
-                # represents "how fast did the multicast complete". Used for the aggregate
-                # (median) reported to performance_checker / plotter / stats_reporter.
+                # Effective (uniform) bandwidth — used as the aggregate median.
                 bandwidth = num_transactions * transaction_size / duration if duration else 0
 
-                # Per-core actual NOC bandwidth — uses the role-specific "Per-core bytes"
-                # stamp when available so the heatmap can show sender vs receiver asymmetry.
-                # Falls back to the effective bandwidth when no per-core stamp exists.
+                # Per-core NOC bandwidth from "Per-core bytes" stamp (heatmap shows
+                # sender/receiver asymmetry). Falls back to effective when not stamped.
                 core_attrs = attributes_per_core.get(run_host_id, {}).get(core, {})
                 per_core_bytes = core_attrs.get("Per-core bytes")
                 if per_core_bytes is not None and duration:
@@ -221,13 +213,9 @@ class StatsCollector:
                 wall_clock_time = max_end - min_start if max_end > min_start else float(np.max(durations))
                 transaction_size = attributes.get("Transaction size in bytes", 0)
                 num_transactions = attributes.get("Number of transactions", 1)
-                # Matmul-only override: when every core in the run stamped "Per-core bytes"
-                # (matmul multicast kernels), sum the per-core actual NOC bytes instead of
-                # using num_cores * transaction_size * num_transactions. The latter assumes
-                # every core multicasts every iteration, which over-counts by a factor of C
-                # for rotating-sender / fixed-sender multicast tests. Falls back to the
-                # original formula for every other test in the suite, including 1D in1
-                # (which doesn't stamp "Per-core bytes").
+                # If every core stamped "Per-core bytes" (matmul mcast kernels), sum the
+                # actual per-core NOC bytes; otherwise use the uniform formula (which
+                # over-counts by C for rotating/fixed-sender multicast tests).
                 run_per_core = attributes_per_core.get(run_host_id, {})
                 per_core_byte_values = [run_per_core.get(c, {}).get("Per-core bytes") for c in cores]
                 if cores and all(v is not None for v in per_core_byte_values):
@@ -246,8 +234,7 @@ class StatsCollector:
                     "bandwidth": agg_bandwidth,
                     "attributes": attributes,
                     "all_durations": durations,
-                    # Per-core values when "Per-core bytes" is stamped (e.g. matmul);
-                    # otherwise identical to the effective-bandwidth list.
+                    # Per-core when "Per-core bytes" is stamped, else effective.
                     "all_bandwidths": bandwidths_per_core,
                     "all_cores": cores,
                     "transaction_size": transaction_size,

--- a/tests/tt_metal/tt_metal/data_movement/python/stats_collector.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/stats_collector.py
@@ -43,6 +43,7 @@ class StatsCollector:
             dm_stats[risc] = {
                 "analysis": {"stats": dict(), "series": []},
                 "attributes": dict(),
+                "attributes_per_core": dict(),
             }
 
         # Gather analysis stats
@@ -62,18 +63,34 @@ class StatsCollector:
                     dm_stats[risc]["analysis"]["series"].extend(core_analysis[analysis_key]["series"])
 
         # Gather test attributes
-
+        # Two views of attribute stamps:
+        #   - global: last-write-wins per (run_host_id, zone_name); stable for tests that
+        #     stamp the same value on every core.
+        #   - per-core: keyed by (run_host_id, core, zone_name); used when kernels stamp
+        #     role-specific values (e.g. matmul sender vs receiver). event[4] is the core
+        #     appended in tracy.process_device_log.core_to_device_timeseries.
         for risc in dm_stats.keys():
             attributes = dm_stats[risc]["attributes"]
+            attributes_per_core = dm_stats[risc]["attributes_per_core"]
             events_key = self.riscv_to_analysis_event[risc]["events"]
 
             for event in stats["devices"][0]["cores"]["DEVICE"]["riscs"]["TENSIX"]["events"][events_key]:
                 run_host_id = event[0]["run_host_id"]
+                zone_name = event[0]["zone_name"]
+                value = event[2]
+                core = event[4] if len(event) > 4 else None
 
                 if run_host_id in attributes.keys():
-                    attributes[run_host_id][event[0]["zone_name"]] = event[2]
+                    attributes[run_host_id][zone_name] = value
                 else:
-                    attributes[run_host_id] = {event[0]["zone_name"]: event[2]}
+                    attributes[run_host_id] = {zone_name: value}
+
+                if core is not None:
+                    if run_host_id not in attributes_per_core:
+                        attributes_per_core[run_host_id] = {}
+                    if core not in attributes_per_core[run_host_id]:
+                        attributes_per_core[run_host_id][core] = {}
+                    attributes_per_core[run_host_id][core][zone_name] = value
 
         aggregate_stats = self.aggregate_performance(dm_stats)
 
@@ -140,28 +157,46 @@ class StatsCollector:
         for riscv in RISCV_PROCESSORS:
             grouped_durations = defaultdict(list)
             grouped_bandwidths = defaultdict(list)
+            grouped_bandwidths_per_core = defaultdict(list)
             grouped_cores = defaultdict(list)
             grouped_start_cycles = defaultdict(list)
             grouped_end_cycles = defaultdict(list)
+            attributes_per_core = dm_stats[riscv].get("attributes_per_core", {})
 
             for entry in dm_stats[riscv]["analysis"]["series"]:
                 run_host_id = entry["duration_type"][0]["run_host_id"]
                 attributes = dm_stats[riscv]["attributes"][run_host_id]
+                core = entry["core"]
                 num_transactions = attributes.get("Number of transactions", 1)
                 transaction_size = attributes.get("Transaction size in bytes", 0)
 
                 duration = entry["duration_cycles"]
+                # Effective bandwidth from global attrs — same formula on every core,
+                # represents "how fast did the multicast complete". Used for the aggregate
+                # (median) reported to performance_checker / plotter / stats_reporter.
                 bandwidth = num_transactions * transaction_size / duration if duration else 0
+
+                # Per-core actual NOC bandwidth — uses the role-specific "Per-core bytes"
+                # stamp when available so the heatmap can show sender vs receiver asymmetry.
+                # Falls back to the effective bandwidth when no per-core stamp exists.
+                core_attrs = attributes_per_core.get(run_host_id, {}).get(core, {})
+                per_core_bytes = core_attrs.get("Per-core bytes")
+                if per_core_bytes is not None and duration:
+                    bandwidth_per_core = per_core_bytes / duration
+                else:
+                    bandwidth_per_core = bandwidth
 
                 grouped_durations[run_host_id].append(duration)
                 grouped_bandwidths[run_host_id].append(bandwidth)
-                grouped_cores[run_host_id].append(entry["core"])
+                grouped_bandwidths_per_core[run_host_id].append(bandwidth_per_core)
+                grouped_cores[run_host_id].append(core)
                 grouped_start_cycles[run_host_id].append(entry.get("start_cycle", 0))
                 grouped_end_cycles[run_host_id].append(entry.get("end_cycle", 0))
 
             agg = {}
             for run_host_id, durations in grouped_durations.items():
                 bandwidths = grouped_bandwidths[run_host_id]
+                bandwidths_per_core = grouped_bandwidths_per_core[run_host_id]
                 attributes = dm_stats[riscv]["attributes"][run_host_id]
                 test_id = attributes.get("Test id")
                 cores = grouped_cores[run_host_id]
@@ -186,7 +221,19 @@ class StatsCollector:
                 wall_clock_time = max_end - min_start if max_end > min_start else float(np.max(durations))
                 transaction_size = attributes.get("Transaction size in bytes", 0)
                 num_transactions = attributes.get("Number of transactions", 1)
-                total_bytes = num_cores * transaction_size * num_transactions
+                # Matmul-only override: when every core in the run stamped "Per-core bytes"
+                # (matmul multicast kernels), sum the per-core actual NOC bytes instead of
+                # using num_cores * transaction_size * num_transactions. The latter assumes
+                # every core multicasts every iteration, which over-counts by a factor of C
+                # for rotating-sender / fixed-sender multicast tests. Falls back to the
+                # original formula for every other test in the suite, including 1D in1
+                # (which doesn't stamp "Per-core bytes").
+                run_per_core = attributes_per_core.get(run_host_id, {})
+                per_core_byte_values = [run_per_core.get(c, {}).get("Per-core bytes") for c in cores]
+                if cores and all(v is not None for v in per_core_byte_values):
+                    total_bytes = sum(per_core_byte_values)
+                else:
+                    total_bytes = num_cores * transaction_size * num_transactions
                 combined_bandwidth = total_bytes / wall_clock_time if wall_clock_time > 0 else 0
 
                 # Use real clock frequency from device if logged
@@ -199,7 +246,9 @@ class StatsCollector:
                     "bandwidth": agg_bandwidth,
                     "attributes": attributes,
                     "all_durations": durations,
-                    "all_bandwidths": bandwidths,
+                    # Per-core values when "Per-core bytes" is stamped (e.g. matmul);
+                    # otherwise identical to the effective-bandwidth list.
+                    "all_bandwidths": bandwidths_per_core,
                     "all_cores": cores,
                     "transaction_size": transaction_size,
                     "num_transactions": num_transactions,

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -896,6 +896,10 @@ tests:
     name: "1D Matmul Test 1030 - 4x4 K=1 NOC1 Saturation (in1 512KiB per core, page=8192)"
     bandwidth_mode: "combined"
 
+  1031:
+    name: "1D Matmul Test 1031 - 8x7 K=8 (sub_r, sub_c) 2D Sweep"
+    bandwidth_mode: "combined"
+
   1112:
     name: "1D V2 Matmul Test 1112 - 2x2 K=2 Subblock K Sweep"
     bandwidth_mode: "combined"
@@ -936,6 +940,10 @@ tests:
     name: "1D V2 Matmul Test 1130 - 4x4 K=1 NOC1 Saturation (in1 512KiB per core, page=8192)"
     bandwidth_mode: "combined"
 
+  1131:
+    name: "1D V2 Matmul Test 1131 - 8x7 K=8 (sub_r, sub_c) 2D Sweep"
+    bandwidth_mode: "combined"
+
   1212:
     name: "2D Matmul Test 1212 - 2x2 K=2 Subblock K Sweep"
     bandwidth_mode: "combined"
@@ -974,4 +982,8 @@ tests:
 
   1230:
     name: "2D Matmul Test 1230 - 4x4 K=1 NOC1 Saturation (in1 512KiB per core, page=8192)"
+    bandwidth_mode: "combined"
+
+  1231:
+    name: "2D Matmul Test 1231 - 8x7 K=8 (sub_r, sub_c) 2D Sweep"
     bandwidth_mode: "combined"

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -893,7 +893,7 @@ tests:
     bandwidth_mode: "combined"
 
   1030:
-    name: "1D Matmul Test 1030 - 4x4 K=1 NOC1 Saturation (in1 512KiB per core, page=8192)"
+    name: "1D Matmul Test 1030 - 4x4 K=8 NOC1 Saturation (in1 512KiB per core, page=2048)"
     bandwidth_mode: "combined"
 
   1031:

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -888,6 +888,14 @@ tests:
     name: "1D Matmul Test 1028 - 4x4 K=8 Subblock C Sweep"
     bandwidth_mode: "combined"
 
+  1029:
+    name: "1D Matmul Test 1029 - 4x4 K=1 Subblock R Sweep (single transaction)"
+    bandwidth_mode: "combined"
+
+  1030:
+    name: "1D Matmul Test 1030 - 4x4 K=1 NOC1 Saturation (in1 512KiB per core, page=8192)"
+    bandwidth_mode: "combined"
+
   1112:
     name: "1D V2 Matmul Test 1112 - 2x2 K=2 Subblock K Sweep"
     bandwidth_mode: "combined"
@@ -920,6 +928,14 @@ tests:
     name: "1D V2 Matmul Test 1128 - 4x4 K=8 Subblock C Sweep"
     bandwidth_mode: "combined"
 
+  1129:
+    name: "1D V2 Matmul Test 1129 - 4x4 K=1 Subblock R Sweep (single transaction)"
+    bandwidth_mode: "combined"
+
+  1130:
+    name: "1D V2 Matmul Test 1130 - 4x4 K=1 NOC1 Saturation (in1 512KiB per core, page=8192)"
+    bandwidth_mode: "combined"
+
   1212:
     name: "2D Matmul Test 1212 - 2x2 K=2 Subblock K Sweep"
     bandwidth_mode: "combined"
@@ -950,4 +966,12 @@ tests:
 
   1228:
     name: "2D Matmul Test 1228 - 4x4 K=8 Subblock C Sweep"
+    bandwidth_mode: "combined"
+
+  1229:
+    name: "2D Matmul Test 1229 - 4x4 K=1 Subblock R Sweep (single transaction)"
+    bandwidth_mode: "combined"
+
+  1230:
+    name: "2D Matmul Test 1230 - 4x4 K=1 NOC1 Saturation (in1 512KiB per core, page=8192)"
     bandwidth_mode: "combined"

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -893,7 +893,7 @@ tests:
     bandwidth_mode: "combined"
 
   1030:
-    name: "1D Matmul Test 1030 - 4x4 K=8 NOC1 Saturation (in1 512KiB per core, page=2048)"
+    name: "1D Matmul Test 1030 - 4x4 K=8 (sub_r, sub_c) 2D Sweep"
     bandwidth_mode: "combined"
 
   1031:
@@ -937,7 +937,7 @@ tests:
     bandwidth_mode: "combined"
 
   1130:
-    name: "1D V2 Matmul Test 1130 - 4x4 K=1 NOC1 Saturation (in1 512KiB per core, page=8192)"
+    name: "1D V2 Matmul Test 1130 - 4x4 K=8 (sub_r, sub_c) 2D Sweep"
     bandwidth_mode: "combined"
 
   1131:
@@ -981,7 +981,7 @@ tests:
     bandwidth_mode: "combined"
 
   1230:
-    name: "2D Matmul Test 1230 - 4x4 K=8 NOC1 Saturation (in1 512KiB per core, page=2048)"
+    name: "2D Matmul Test 1230 - 4x4 K=8 (sub_r, sub_c) 2D Sweep"
     bandwidth_mode: "combined"
 
   1231:

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -981,7 +981,7 @@ tests:
     bandwidth_mode: "combined"
 
   1230:
-    name: "2D Matmul Test 1230 - 4x4 K=1 NOC1 Saturation (in1 512KiB per core, page=8192)"
+    name: "2D Matmul Test 1230 - 4x4 K=8 NOC1 Saturation (in1 512KiB per core, page=2048)"
     bandwidth_mode: "combined"
 
   1231:


### PR DESCRIPTION
Summary         
                                                                                                                                                    
  Restructures the matmul data-movement microbenchmark to better characterize NOC behavior, adds per-core profiling stamps for heatmap analysis, and
   adds new perf-characterization tests up to an 8x7 grid.                                                                                          
                  
  Kernel changes                                                                                                                                    
                  
  - in0_kernel.cpp (1D v1): refactored from one big multicast of the full row to a K-loop that issues num_subblocks_k_dim multicasts of             
  k_subblock_size_bytes each. Column 0 stays the fixed sender; the sender_sem / receiver_sem rendezvous resets cleanly between iterations. Runtime
  args mirror v2.                                                                                                                                   
  - in1_kernel.cpp (1D v1 + v2): refactored so only row 0 per column reads DRAM, in one big noc_async_read of the full column slice, then K-loop
  multicasts each subblock down its column. Receivers signal readiness only — they never touch DRAM. Eliminates the per-core DRAM bottleneck of the 
  prior "every core reads DRAM" path. R=1 falls back to a unicast self-write (HW limit on single-core multicast loopback).
  - All four matmul multicast kernels (in0_kernel, in0_kernel_v2, in0_kernel_2d, in1_kernel_2d) now stamp Per-core bytes per core: senders stamp K *
   k_subblock_size, receivers stamp K * 16 (one atomic flit each). Lets the heatmap show which cores actually do multicast work.                    
   
  Post-processing changes (stats_collector.py)                                                                                                      
                  
  - Extracts per-core attributes (using the core appended in tracy.process_device_log.core_to_device_timeseries) in addition to the existing global 
  last-write-wins map.
  - aggregate_performance produces two bandwidth lists: the global formula for agg_bandwidth (used by perf_checker / plotter, unchanged behavior)   
  and a per-core list seeded by Per-core bytes for all_bandwidths (used by gather_bw_per_core for the heatmap).                                     
  - combined_bandwidth gains a matmul-only override: when every core stamped Per-core bytes, total_bytes = sum(per_core_bytes) rather than num_cores
   * transaction_size * num_transactions. Fixes the C-fold over-count for rotating-sender tests so combined_bw matches the heatmap sum. Non-matmul  
  tests take the original formula via the else-branch — byte-for-byte unchanged.
                                                                                                                                                    
  New tests       

  - ID 1029: 4x4, K=1, sub_r sweep {1, 2, 4, 8, 16, 32, 64, 128, 256}. Single-transaction extension of 1027 — characterizes multicast bw vs         
  transaction size with no K-loop overhead.
  - ID 1030: 4x4, K=8, 2D Cartesian sweep over (sub_r, sub_c), both in {1..16} (25 points). Grows in1 via sub_c to drive RISCV_1 toward NOC peak.   
  The 2D variant reaches ~27 B/cycle (~84% of NOC peak) since in1 is L1-to-L1 multicast; 1D variants stay DRAM-bandwidth-limited until the new in1  
  path lifts that ceiling.
  - ID 1031: 8x7, K=8, 2D sweep over (sub_r, sub_c) in {1..16}. R=7 to fit Wormhole B0's harvested grid.                                            
  - Per-variant offsets give 1129/1130/1131 (1D v2) and 1229/1230/1231 (2D), with test_information.yaml mappings.                                   
                                                                                                                                                    
  Touched test scaffolding                                                                                                                          
                                                                                                                                                    
  - test_matmul_1d.cpp / test_matmul_1d_v2.cpp: passes new in1 runtime args (per-column DRAM addr, total read size, L1 source addr, K,              
  k_subblock_size_bytes), adds three NOC1 mcast semaphores, and reads the in1 mcast output buffer for verification.
  - test_matmul_common.hpp: page_size_bytes default 1 → 2048; adds 1029/1030/1031 configs.                                                          
  - READMEs: documents the new 1029/1030/1031 tests and the Per-core bytes heatmap convention.  
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=matmulPerformance)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:matmulPerformance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=matmulPerformance)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:matmulPerformance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=matmulPerformance)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:matmulPerformance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=matmulPerformance)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:matmulPerformance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=matmulPerformance)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:matmulPerformance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=matmulPerformance)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:matmulPerformance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=matmulPerformance)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:matmulPerformance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=matmulPerformance)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:matmulPerformance)