### PR TITLE
Fix DeepSeek decode perf warmup signposts

### DIFF
--- a/models/demos/deepseek_v3/tests/test_device_perf_utils.py
+++ b/models/demos/deepseek_v3/tests/test_device_perf_utils.py
@@ -6,6 +6,15 @@ import csv
 import pytest
 
 from models.demos.deepseek_v3.utils.device_perf_utils import _parse_signposts, filter_profile_csv, process_profile_stats
+from models.demos.deepseek_v3.utils.signpost_names import (
+    DECODE_EXECUTE_TRACE_SAMPLE_ON_DEVICE_SIGNPOST,
+    DECODE_EXECUTE_TRACE_SIGNPOST,
+    DECODE_TRACE_CAPTURE_SIGNPOST,
+    DECODE_WARMUP_SIGNPOST,
+    FIRST_DENSE_LAYER_SIGNPOST,
+    FIRST_MOE_LAYER_SIGNPOST,
+    WARMUP_MODEL_SIGNPOST,
+)
 
 HEADER = [
     "OP CODE",
@@ -34,35 +43,35 @@ def _write_csv(path, header, rows):
 
 def test_parse_signposts_uses_nested_decode_warmup_inside_warmup_model():
     rows = [
-        _signpost("warmup_model"),
+        _signpost(WARMUP_MODEL_SIGNPOST),
         _op("prefill_op"),
-        _signpost("decode_warmup"),
+        _signpost(DECODE_WARMUP_SIGNPOST),
         _op("embedding_op"),
-        _signpost("first_dense_layer"),
+        _signpost(FIRST_DENSE_LAYER_SIGNPOST),
         _op("dense_op"),
-        _signpost("first_dense_layer"),
-        _signpost("first_moe_layer"),
+        _signpost(FIRST_DENSE_LAYER_SIGNPOST),
+        _signpost(FIRST_MOE_LAYER_SIGNPOST),
         _op("moe_op"),
-        _signpost("first_moe_layer"),
+        _signpost(FIRST_MOE_LAYER_SIGNPOST),
         _op("tail_op"),
-        _signpost("decode_warmup"),
-        _signpost("decode_trace_capture"),
+        _signpost(DECODE_WARMUP_SIGNPOST),
+        _signpost(DECODE_TRACE_CAPTURE_SIGNPOST),
         _op("trace_capture_op"),
-        _signpost("decode_trace_capture"),
-        _signpost("warmup_model"),
-        _signpost("decode_execute_trace"),
+        _signpost(DECODE_TRACE_CAPTURE_SIGNPOST),
+        _signpost(WARMUP_MODEL_SIGNPOST),
+        _signpost(DECODE_EXECUTE_TRACE_SIGNPOST),
         _op("trace_embedding_op"),
         _op("trace_dense_op"),
         _op("trace_moe_op"),
         _op("trace_tail_op"),
-        _signpost("decode_execute_trace_sample_on_device"),
+        _signpost(DECODE_EXECUTE_TRACE_SAMPLE_ON_DEVICE_SIGNPOST),
         _op("sample_op"),
-        _signpost("decode_execute_trace"),
+        _signpost(DECODE_EXECUTE_TRACE_SIGNPOST),
         _op("trace_embedding_op_1"),
         _op("trace_dense_op_1"),
         _op("trace_moe_op_1"),
         _op("trace_tail_op_1"),
-        _signpost("decode_execute_trace_sample_on_device"),
+        _signpost(DECODE_EXECUTE_TRACE_SAMPLE_ON_DEVICE_SIGNPOST),
     ]
 
     info = _parse_signposts(rows, op_code_idx=0, op_type_idx=2)
@@ -75,40 +84,40 @@ def test_parse_signposts_uses_nested_decode_warmup_inside_warmup_model():
         "tail": (10, 10),
     }
     assert info["trace_capture_range"] == (12, 14)
-    assert info["trace_execution_ranges"] == [(17, 22)]
+    assert info["trace_execution_ranges"] == [(17, 20), (24, 27)]
 
 
 def test_filter_profile_csv_ignores_outer_warmup_model_and_labels_decode_warmup(tmp_path):
     rows = [
-        _signpost("warmup_model"),
+        _signpost(WARMUP_MODEL_SIGNPOST),
         _op("prefill_op"),
-        _signpost("decode_warmup"),
+        _signpost(DECODE_WARMUP_SIGNPOST),
         _op("embedding_op"),
-        _signpost("first_dense_layer"),
+        _signpost(FIRST_DENSE_LAYER_SIGNPOST),
         _op("dense_op"),
-        _signpost("first_dense_layer"),
-        _signpost("first_moe_layer"),
+        _signpost(FIRST_DENSE_LAYER_SIGNPOST),
+        _signpost(FIRST_MOE_LAYER_SIGNPOST),
         _op("moe_op", attributes="cluster_axis=0"),
-        _signpost("first_moe_layer"),
+        _signpost(FIRST_MOE_LAYER_SIGNPOST),
         _op("tail_op"),
-        _signpost("decode_warmup"),
-        _signpost("decode_trace_capture"),
+        _signpost(DECODE_WARMUP_SIGNPOST),
+        _signpost(DECODE_TRACE_CAPTURE_SIGNPOST),
         _op("trace_capture_op"),
-        _signpost("decode_trace_capture"),
-        _signpost("warmup_model"),
-        _signpost("decode_execute_trace"),
+        _signpost(DECODE_TRACE_CAPTURE_SIGNPOST),
+        _signpost(WARMUP_MODEL_SIGNPOST),
+        _signpost(DECODE_EXECUTE_TRACE_SIGNPOST),
         _op("trace_embedding_op"),
         _op("trace_dense_op"),
         _op("trace_moe_op", attributes="cluster_axis=0"),
         _op("trace_tail_op"),
-        _signpost("decode_execute_trace_sample_on_device"),
+        _signpost(DECODE_EXECUTE_TRACE_SAMPLE_ON_DEVICE_SIGNPOST),
         _op("sample_op"),
-        _signpost("decode_execute_trace"),
+        _signpost(DECODE_EXECUTE_TRACE_SIGNPOST),
         _op("trace_embedding_op_1"),
         _op("trace_dense_op_1"),
         _op("trace_moe_op_1", attributes="cluster_axis=0"),
         _op("trace_tail_op_1"),
-        _signpost("decode_execute_trace_sample_on_device"),
+        _signpost(DECODE_EXECUTE_TRACE_SAMPLE_ON_DEVICE_SIGNPOST),
     ]
     input_path = tmp_path / "ops.csv"
     output_path = tmp_path / "filtered.csv"
@@ -128,7 +137,10 @@ def test_filter_profile_csv_ignores_outer_warmup_model_and_labels_decode_warmup(
         ("trace_execution_0", "trace_dense_op", "Dense Decoder"),
         ("trace_execution_0", "trace_moe_op", "MoE Decoder"),
         ("trace_execution_0", "trace_tail_op", "Tail"),
-        ("trace_execution_0", "sample_op", "Tail"),
+        ("trace_execution_1", "trace_embedding_op_1", "Embedding"),
+        ("trace_execution_1", "trace_dense_op_1", "Dense Decoder"),
+        ("trace_execution_1", "trace_moe_op_1", "MoE Decoder"),
+        ("trace_execution_1", "trace_tail_op_1", "Tail"),
     ]
     assert filtered_rows[2]["OP TYPE"] == "CCL"
 

--- a/models/demos/deepseek_v3/tests/test_device_perf_utils.py
+++ b/models/demos/deepseek_v3/tests/test_device_perf_utils.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import csv
+
+import pytest
+
+from models.demos.deepseek_v3.utils.device_perf_utils import _parse_signposts, filter_profile_csv, process_profile_stats
+
+HEADER = [
+    "OP CODE",
+    "DEVICE ID",
+    "OP TYPE",
+    "ATTRIBUTES",
+    "OP TO OP LATENCY [ns]",
+    "DEVICE KERNEL DURATION [ns]",
+]
+
+
+def _signpost(name):
+    return [name, "", "signpost", "", "", ""]
+
+
+def _op(name, *, device_id="0", attributes="", latency_ns="1000", duration_ns="2000"):
+    return [name, device_id, "operation", attributes, latency_ns, duration_ns]
+
+
+def _write_csv(path, header, rows):
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+
+def test_parse_signposts_uses_nested_decode_warmup_inside_warmup_model():
+    rows = [
+        _signpost("warmup_model"),
+        _op("prefill_op"),
+        _signpost("decode_warmup"),
+        _op("embedding_op"),
+        _signpost("first_dense_layer"),
+        _op("dense_op"),
+        _signpost("first_dense_layer"),
+        _signpost("first_moe_layer"),
+        _op("moe_op"),
+        _signpost("first_moe_layer"),
+        _op("tail_op"),
+        _signpost("decode_warmup"),
+        _signpost("decode_trace_capture"),
+        _op("trace_capture_op"),
+        _signpost("decode_trace_capture"),
+        _signpost("warmup_model"),
+        _signpost("decode_execute_trace"),
+        _op("trace_embedding_op"),
+        _op("trace_dense_op"),
+        _op("trace_moe_op"),
+        _op("trace_tail_op"),
+        _signpost("decode_execute_trace_sample_on_device"),
+        _op("sample_op"),
+        _signpost("decode_execute_trace"),
+        _op("trace_embedding_op_1"),
+        _op("trace_dense_op_1"),
+        _op("trace_moe_op_1"),
+        _op("trace_tail_op_1"),
+        _signpost("decode_execute_trace_sample_on_device"),
+    ]
+
+    info = _parse_signposts(rows, op_code_idx=0, op_type_idx=2)
+
+    assert info["warmup_range"] == (3, 10)
+    assert info["warmup_structure"] == {
+        "embedding": (3, 3),
+        "dense": (5, 5),
+        "moe": (8, 8),
+        "tail": (10, 10),
+    }
+    assert info["trace_capture_range"] == (12, 14)
+    assert info["trace_execution_ranges"] == [(17, 22)]
+
+
+def test_filter_profile_csv_ignores_outer_warmup_model_and_labels_decode_warmup(tmp_path):
+    rows = [
+        _signpost("warmup_model"),
+        _op("prefill_op"),
+        _signpost("decode_warmup"),
+        _op("embedding_op"),
+        _signpost("first_dense_layer"),
+        _op("dense_op"),
+        _signpost("first_dense_layer"),
+        _signpost("first_moe_layer"),
+        _op("moe_op", attributes="cluster_axis=0"),
+        _signpost("first_moe_layer"),
+        _op("tail_op"),
+        _signpost("decode_warmup"),
+        _signpost("decode_trace_capture"),
+        _op("trace_capture_op"),
+        _signpost("decode_trace_capture"),
+        _signpost("warmup_model"),
+        _signpost("decode_execute_trace"),
+        _op("trace_embedding_op"),
+        _op("trace_dense_op"),
+        _op("trace_moe_op", attributes="cluster_axis=0"),
+        _op("trace_tail_op"),
+        _signpost("decode_execute_trace_sample_on_device"),
+        _op("sample_op"),
+        _signpost("decode_execute_trace"),
+        _op("trace_embedding_op_1"),
+        _op("trace_dense_op_1"),
+        _op("trace_moe_op_1", attributes="cluster_axis=0"),
+        _op("trace_tail_op_1"),
+        _signpost("decode_execute_trace_sample_on_device"),
+    ]
+    input_path = tmp_path / "ops.csv"
+    output_path = tmp_path / "filtered.csv"
+    _write_csv(input_path, HEADER, rows)
+
+    filter_profile_csv(input_path, output_path)
+
+    with open(output_path, "r", newline="", encoding="utf-8") as f:
+        filtered_rows = list(csv.DictReader(f))
+
+    assert [(row["RUN TYPE"], row["OP CODE"], row["OP LEVEL"]) for row in filtered_rows] == [
+        ("warmup", "embedding_op", "Embedding"),
+        ("warmup", "dense_op", "Dense Decoder"),
+        ("warmup", "moe_op", "MoE Decoder"),
+        ("warmup", "tail_op", "Tail"),
+        ("trace_execution_0", "trace_embedding_op", "Embedding"),
+        ("trace_execution_0", "trace_dense_op", "Dense Decoder"),
+        ("trace_execution_0", "trace_moe_op", "MoE Decoder"),
+        ("trace_execution_0", "trace_tail_op", "Tail"),
+        ("trace_execution_0", "sample_op", "Tail"),
+    ]
+    assert filtered_rows[2]["OP TYPE"] == "CCL"
+
+
+def test_process_profile_stats_rejects_missing_warmup_reference(tmp_path):
+    filtered_path = tmp_path / "filtered.csv"
+    merged_path = tmp_path / "merged.csv"
+    _write_csv(
+        filtered_path,
+        [
+            "OP CODE",
+            "DEVICE ID",
+            "RUN TYPE",
+            "OP TYPE",
+            "OP LEVEL",
+            "OP TO OP LATENCY [us]",
+            "DEVICE KERNEL DURATION [us]",
+        ],
+        [["trace_op", "0", "trace_execution_0", "Non CCL", "Embedding", "1.0", "2.0"]],
+    )
+
+    with pytest.raises(ValueError, match="No warmup reference ops found"):
+        process_profile_stats(filtered_path, merged_path)

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -42,6 +42,13 @@ from models.demos.deepseek_v3.utils.config_helpers import (
 )
 from models.demos.deepseek_v3.utils.debug_utils import dump_ttnn_meminfo
 from models.demos.deepseek_v3.utils.run_config import create_run_config, deallocate_weight_config_tensors
+from models.demos.deepseek_v3.utils.signpost_names import (
+    DECODE_EXECUTE_TRACE_SAMPLE_ON_DEVICE_SIGNPOST,
+    DECODE_EXECUTE_TRACE_SIGNPOST,
+    DECODE_TRACE_CAPTURE_SIGNPOST,
+    DECODE_WARMUP_SIGNPOST,
+    WARMUP_MODEL_SIGNPOST,
+)
 from models.demos.deepseek_v3.utils.weight_config import get_weight_config
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
@@ -344,7 +351,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         warmup_start_pos = torch.zeros(self.batch_size, dtype=torch.int32)
         signpost_decode_warmup = self.signpost and not enable_trace
         if signpost_decode_warmup:
-            signpost(header="decode_warmup")
+            signpost(header=DECODE_WARMUP_SIGNPOST)
         decode_logits = self.decode_forward(
             tokens=warmup_tokens,
             start_pos=warmup_start_pos,
@@ -354,7 +361,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         )
         if signpost_decode_warmup:
             ttnn.synchronize_device(self.mesh_device)
-            signpost(header="decode_warmup")
+            signpost(header=DECODE_WARMUP_SIGNPOST)
 
         if sample_on_device:
             self._sample_tokens_device(decode_logits, enable_trace=enable_trace)
@@ -1910,16 +1917,16 @@ class DeepseekGenerator(WarmupForwardMixin):
 
         if warmup_cache_key not in self._warmup_completed_configs:
             if self.signpost:
-                signpost(header="warmup_model")
-            profiler.start("warmup_model")
+                signpost(header=WARMUP_MODEL_SIGNPOST)
+            profiler.start(WARMUP_MODEL_SIGNPOST)
             self.warmup_model(min_token_len, max_token_len)
-            profiler.end("warmup_model")
+            profiler.end(WARMUP_MODEL_SIGNPOST)
             if self.signpost:
-                signpost(header="warmup_model")
+                signpost(header=WARMUP_MODEL_SIGNPOST)
 
             self._warmup_completed_configs.add(warmup_cache_key)
         else:
-            # Keep profiler timing for "warmup_model" even when warmup is skipped.
+            # Keep profiler timing stable even when warmup is skipped.
             logger.info(f"Skipping warmup_model; warmup already completed for cache key={warmup_cache_key}.")
 
         decode_steps_for_stats = 0
@@ -2899,7 +2906,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         self.ccl.reset_sem_counters()
         logger.info("Begin capturing decode trace...")
         if self.signpost:
-            signpost(header="decode_trace_capture")
+            signpost(header=DECODE_TRACE_CAPTURE_SIGNPOST)
         trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
 
         # Only capture the rot_mats generation from rot_idxs (all ttnn ops, no from_torch)
@@ -2914,7 +2921,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         )
         ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
         if self.signpost:
-            signpost(header="decode_trace_capture")
+            signpost(header=DECODE_TRACE_CAPTURE_SIGNPOST)
         logger.info("Decode trace capture complete.")
         self._trace_id = trace_id
 
@@ -2966,7 +2973,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             torch_input = tokens.view(1, 1, -1).to(torch.int32)
 
             if self.signpost:
-                signpost(header="decode_execute_trace")
+                signpost(header=DECODE_EXECUTE_TRACE_SIGNPOST)
 
             host_tokens = ttnn.from_torch(
                 torch_input,
@@ -3012,7 +3019,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             if sample_on_device:
                 # return trace output for sampling on device, no need to get logits on host
                 if self.signpost:
-                    signpost(header="decode_execute_trace_sample_on_device")
+                    signpost(header=DECODE_EXECUTE_TRACE_SAMPLE_ON_DEVICE_SIGNPOST)
                 if self.profile_decode:
                     # trigger the profiler to read the device side data each iteration to not miss any data
                     ttnn.ReadDeviceProfiler(self.mesh_device)
@@ -3027,7 +3034,7 @@ class DeepseekGenerator(WarmupForwardMixin):
                 ),
             )
             if self.signpost:
-                signpost(header="decode_execute_trace")
+                signpost(header=DECODE_EXECUTE_TRACE_SIGNPOST)
             if self.profile_decode:
                 # trigger the profiler to read the device side data each iteration to not miss any data
                 ttnn.ReadDeviceProfiler(self.mesh_device)

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -342,6 +342,9 @@ class DeepseekGenerator(WarmupForwardMixin):
     def _warmup_model_decode_demo(self, enable_trace: bool, sample_on_device: bool):
         warmup_tokens = torch.zeros(self.batch_size, dtype=torch.int32)
         warmup_start_pos = torch.zeros(self.batch_size, dtype=torch.int32)
+        signpost_decode_warmup = self.signpost and not enable_trace
+        if signpost_decode_warmup:
+            signpost(header="decode_warmup")
         decode_logits = self.decode_forward(
             tokens=warmup_tokens,
             start_pos=warmup_start_pos,
@@ -349,6 +352,9 @@ class DeepseekGenerator(WarmupForwardMixin):
             page_table=None,
             sample_on_device=sample_on_device,
         )
+        if signpost_decode_warmup:
+            ttnn.synchronize_device(self.mesh_device)
+            signpost(header="decode_warmup")
 
         if sample_on_device:
             self._sample_tokens_device(decode_logits, enable_trace=enable_trace)

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -1926,7 +1926,7 @@ class DeepseekGenerator(WarmupForwardMixin):
 
             self._warmup_completed_configs.add(warmup_cache_key)
         else:
-            # Keep profiler timing stable even when warmup is skipped.
+            # Warmup already ran for this runtime configuration.
             logger.info(f"Skipping warmup_model; warmup already completed for cache key={warmup_cache_key}.")
 
         decode_steps_for_stats = 0

--- a/models/demos/deepseek_v3/tt/model/row_batched_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_batched_model.py
@@ -33,6 +33,7 @@ from models.demos.deepseek_v3.utils.run_config import (
     WeightConfig,
 )
 from models.demos.deepseek_v3.utils.shared_state_addon import SharedStateAddOn
+from models.demos.deepseek_v3.utils.signpost_names import FIRST_DENSE_LAYER_SIGNPOST, FIRST_MOE_LAYER_SIGNPOST
 from models.tt_transformers.tt.common import PagedAttentionConfig
 
 
@@ -314,19 +315,19 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
             # Profile mode: run only first dense layer + first MoE layer
             # First dense layer (MLP)
             if cfg["mlp_decoder_block"]:
-                signpost(header="first_dense_layer")
+                signpost(header=FIRST_DENSE_LAYER_SIGNPOST)
                 x = DecoderBlock2D.forward_decode(
                     x, position_idxs, cfg["mlp_decoder_block"][0], rope_tensors, page_tables[0]
                 )
-                signpost(header="first_dense_layer")
+                signpost(header=FIRST_DENSE_LAYER_SIGNPOST)
             # First MoE layer
             if cfg["moe_decoder_block"]:
-                signpost(header="first_moe_layer")
+                signpost(header=FIRST_MOE_LAYER_SIGNPOST)
                 moe_page_table_idx = len(cfg["mlp_decoder_block"])
                 x = MoEDecoderBlock2D.forward_decode(
                     x, position_idxs, cfg["moe_decoder_block"][0], rope_tensors, page_tables[moe_page_table_idx]
                 )
-                signpost(header="first_moe_layer")
+                signpost(header=FIRST_MOE_LAYER_SIGNPOST)
 
         else:
             # Normal mode: run all layers

--- a/models/demos/deepseek_v3/utils/device_perf_utils.py
+++ b/models/demos/deepseek_v3/utils/device_perf_utils.py
@@ -486,6 +486,13 @@ def process_profile_stats(filtered_csv_path, merged_csv_path):
     """
     rows = _read_filtered_csv(filtered_csv_path)
     reference = _get_warmup_reference(rows)
+    if not reference:
+        num_trace_executions = _get_num_trace_executions(rows)
+        raise ValueError(
+            "No warmup reference ops found in the filtered DeepSeek decode profile CSV. "
+            "Check that decode_warmup signposts bracket the untraced decode warmup "
+            f"(trace executions found: {num_trace_executions})."
+        )
 
     level_counts = defaultdict(int)
     for op_info in reference:

--- a/models/demos/deepseek_v3/utils/device_perf_utils.py
+++ b/models/demos/deepseek_v3/utils/device_perf_utils.py
@@ -16,6 +16,15 @@ from collections import defaultdict
 
 from loguru import logger
 
+from models.demos.deepseek_v3.utils.signpost_names import (
+    DECODE_EXECUTE_TRACE_SAMPLE_ON_DEVICE_SIGNPOST,
+    DECODE_EXECUTE_TRACE_SIGNPOST,
+    DECODE_TRACE_CAPTURE_SIGNPOST,
+    DECODE_WARMUP_SIGNPOST,
+    FIRST_DENSE_LAYER_SIGNPOST,
+    FIRST_MOE_LAYER_SIGNPOST,
+)
+
 # ============================================================================
 # CSV filtering helpers  (from process_decode_demo_profile.py)
 # ============================================================================
@@ -73,29 +82,32 @@ def _parse_signposts(rows, *, op_code_idx=0, op_type_idx=1):
     in_warmup = False
 
     for idx, name in signpost_positions:
-        if name == "decode_warmup":
+        if name == DECODE_WARMUP_SIGNPOST:
             if warmup_open is None:
                 warmup_open = idx
                 in_warmup = True
             else:
                 warmup_close = idx
                 in_warmup = False
-        elif name == "decode_trace_capture":
+        elif name == DECODE_TRACE_CAPTURE_SIGNPOST:
             if trace_capture_open is None:
                 trace_capture_open = idx
             else:
                 trace_capture_close = idx
-        elif name == "decode_execute_trace":
+        elif name == DECODE_EXECUTE_TRACE_SIGNPOST:
             if len(trace_exec_opens) == len(trace_exec_closes):
                 trace_exec_opens.append(idx)
             else:
                 trace_exec_closes.append(idx)
-        elif name == "first_dense_layer" and in_warmup:
+        elif name == DECODE_EXECUTE_TRACE_SAMPLE_ON_DEVICE_SIGNPOST:
+            if len(trace_exec_opens) > len(trace_exec_closes):
+                trace_exec_closes.append(idx)
+        elif name == FIRST_DENSE_LAYER_SIGNPOST and in_warmup:
             if first_dense_layer_warmup_open is None:
                 first_dense_layer_warmup_open = idx
             else:
                 first_dense_layer_warmup_close = idx
-        elif name == "first_moe_layer" and in_warmup:
+        elif name == FIRST_MOE_LAYER_SIGNPOST and in_warmup:
             if first_moe_layer_warmup_open is None:
                 first_moe_layer_warmup_open = idx
             else:
@@ -490,7 +502,7 @@ def process_profile_stats(filtered_csv_path, merged_csv_path):
         num_trace_executions = _get_num_trace_executions(rows)
         raise ValueError(
             "No warmup reference ops found in the filtered DeepSeek decode profile CSV. "
-            "Check that decode_warmup signposts bracket the untraced decode warmup "
+            f"Check that {DECODE_WARMUP_SIGNPOST} signposts bracket the untraced decode warmup "
             f"(trace executions found: {num_trace_executions})."
         )
 

--- a/models/demos/deepseek_v3/utils/signpost_names.py
+++ b/models/demos/deepseek_v3/utils/signpost_names.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+WARMUP_MODEL_SIGNPOST = "warmup_model"
+DECODE_WARMUP_SIGNPOST = "decode_warmup"
+DECODE_TRACE_CAPTURE_SIGNPOST = "decode_trace_capture"
+DECODE_EXECUTE_TRACE_SIGNPOST = "decode_execute_trace"
+DECODE_EXECUTE_TRACE_SAMPLE_ON_DEVICE_SIGNPOST = "decode_execute_trace_sample_on_device"
+FIRST_DENSE_LAYER_SIGNPOST = "first_dense_layer"
+FIRST_MOE_LAYER_SIGNPOST = "first_moe_layer"


### PR DESCRIPTION
## Summary
- Restore decode-only `decode_warmup` signposts around the DeepSeek demo warmup that feeds the decode perf profile parser.
- Share DeepSeek profiler signpost names between producers, parser, and tests.
- Close sampled trace execution ranges on `decode_execute_trace_sample_on_device`, so sampled device-token rows are not folded into decode execution stats.
- Fail fast when filtered DeepSeek decode profile stats contain no warmup reference ops instead of producing empty/zeroed output.
- Add parser/filter coverage for nested `warmup_model`, sampled trace execution signposts, and the missing-warmup error case.

## Root Cause
`test_decode_demo_perf.py` filters the Galaxy profiler CSV by looking for the untraced decode warmup between `decode_warmup` signposts. The broader model warmup flow kept `warmup_model` markers, but the decode-specific markers were missing, so the post-processor could not recover a warmup reference sequence for the traced decode run.

While addressing review feedback, the sampled trace parser was also tightened: in the real `sample_on_device=True` path, `decode_execute_trace_sample_on_device` marks the end of a sampled trace execution before sampling rows appear.

Fixes #43526

## Validation
- `pre-commit run --files models/demos/deepseek_v3/tests/test_device_perf_utils.py models/demos/deepseek_v3/tt/generator.py models/demos/deepseek_v3/tt/model/row_batched_model.py models/demos/deepseek_v3/utils/device_perf_utils.py models/demos/deepseek_v3/utils/signpost_names.py`
- `/tmp/tt-metal-43526-venv/bin/python -m pytest models/demos/deepseek_v3/tests/test_device_perf_utils.py -q --confcutdir=models/demos/deepseek_v3/tests`
- `python3.10 -m py_compile models/demos/deepseek_v3/tt/generator.py models/demos/deepseek_v3/tt/model/row_batched_model.py models/demos/deepseek_v3/utils/device_perf_utils.py models/demos/deepseek_v3/utils/signpost_names.py models/demos/deepseek_v3/tests/test_device_perf_utils.py`
- `git diff --cached --check`
- `(Galaxy) perf tests` dispatched with `model=deepseek_v3`: https://github.com/tenstorrent/tt-metal/actions/runs/25346651713

[![(Galaxy) perf tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml/badge.svg?branch=flow/43526-deepseek-decode-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml?query=branch%3Aflow%2F43526-deepseek-decode-warmup)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=flow/43526-deepseek-decode-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:flow/43526-deepseek-decode-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=flow/43526-deepseek-decode-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:flow/43526-deepseek-decode-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=flow/43526-deepseek-decode-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:flow/43526-deepseek-decode-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=flow/43526-deepseek-decode-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:flow/43526-deepseek-decode-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=flow/43526-deepseek-decode-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:flow/43526-deepseek-decode-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=flow/43526-deepseek-decode-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:flow/43526-deepseek-decode-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=flow/43526-deepseek-decode-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:flow/43526-deepseek-decode-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=flow/43526-deepseek-decode-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:flow/43526-deepseek-decode-warmup)