### PR TITLE
Make narrow test arch agnostic

### DIFF
--- a/tests/ttnn/docs_examples/test_data_movement_examples.py
+++ b/tests/ttnn/docs_examples/test_data_movement_examples.py
@@ -265,5 +265,5 @@ def test_sort(device):
 
 def test_narrow(device):
     input_tensor = ttnn.rand((32, 16, 16, 4), dtype=ttnn.bfloat16, device=device)
-    narrowed_tensor = ttnn.narrow(input_tensor, 0, 12, 8)
+    narrowed_tensor = ttnn.narrow(input_tensor, 0, 0, 12)
     logger.info("Narrowed Tensor Shape:", narrowed_tensor.shape)

--- a/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow_nanobind.cpp
@@ -34,7 +34,7 @@ void bind_narrow(nb::module_& mod) {
         Example:
 
             >>> tensor = ttnn.rand((32, 16, 16, 4), dtype=ttnn.bfloat16, device=device)
-            >>> output = ttnn.narrow(tensor, 0, 12, 8)
+            >>> output = ttnn.narrow(tensor, 0, 0, 12)
 
         )doc";
 


### PR DESCRIPTION
### Summary
Test was failing on blackhole devices due to different DRAM bank count.
Changed test to be independent on bank count.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=itaraban/fix-narrow-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:itaraban/fix-narrow-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=itaraban/fix-narrow-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:itaraban/fix-narrow-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=itaraban/fix-narrow-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:itaraban/fix-narrow-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=itaraban/fix-narrow-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:itaraban/fix-narrow-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=itaraban/fix-narrow-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:itaraban/fix-narrow-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=itaraban/fix-narrow-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:itaraban/fix-narrow-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=itaraban/fix-narrow-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:itaraban/fix-narrow-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=itaraban/fix-narrow-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:itaraban/fix-narrow-test)