### PR TITLE
[Quasar] ALU data format config state

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
@@ -23,8 +23,8 @@
  * @tparam math_fidelity: 0 = LoFi, 2 = HiFi2, 3 = HiFi3, 4 = HiFi4 - controls precision of multiplication
  *     when input is Tf32 format. Only applicable for ELWMUL operations.
  * @tparam binary_reuse_dest: When not NONE, reuses the destination register as SrcA or SrcB
- * @param operand_A: Logical dataflow buffer id for input A, used to derive the tensor / tile shape
- * @param operand_B: Unused on Quasar. Present for API compatibility.
+ * @param operand_A: Logical dataflow buffer id for input A, used to derive the tensor shape
+ * @param operand_B: Logical dataflow buffer id for input B
  * @param acc_to_dest: Flag to control if the result should be accumulated with the current dest
  *     (NONE broadcast path only).
  */
@@ -34,11 +34,16 @@ template <
     MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary_init(
-    const std::uint32_t operand_A, [[maybe_unused]] const std::uint32_t operand_B, const bool acc_to_dest = false) {
-    const std::uint32_t operand_id = get_operand_id(operand_A);
-    const ckernel::TensorShape tensor_shape_A = get_operand_tensor_shape(operand_id);
+    const std::uint32_t operand_A, const std::uint32_t operand_B, const bool acc_to_dest = false) {
+    const std::uint32_t operandA_id = get_operand_id(operand_A);
+    const std::uint32_t operandB_id = get_operand_id(operand_B);
+    const ckernel::TensorShape tensor_shape_A = get_operand_tensor_shape(operandA_id);
+    const DataFormat srcA_format = static_cast<DataFormat>(get_operand_dst_format(operandA_id));
+    const DataFormat srcB_format = static_cast<DataFormat>(get_operand_dst_format(operandB_id));
 
     constexpr auto effective_math_fidelity = get_effective_math_fidelity<eltwise_binary_type, math_fidelity>();
+
+    _configure_default_data_format_state_<false /* IMPLIED_MATH_FORMAT */, DST_ACCUM_MODE>(srcA_format, srcB_format);
     if constexpr (src_b_bcast_type == BroadcastType::NONE) {
         _llk_math_eltwise_binary_init_<eltwise_binary_type, effective_math_fidelity, binary_reuse_dest>(
             tensor_shape_A, acc_to_dest);
@@ -76,9 +81,6 @@ template <
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_acc = true) {
     constexpr auto effective_math_fidelity = get_effective_math_fidelity<eltwise_binary_type, math_fidelity>();
-    static_assert(
-        eltwise_binary_type == EltwiseBinaryType::ELWMUL || effective_math_fidelity == MathFidelity::LoFi,
-        "Math fidelity must be LoFi for non-ELWMUL ops");
 
     WAYPOINT("MBIW");
     if constexpr (src_b_bcast_type == BroadcastType::NONE) {
@@ -104,7 +106,7 @@ inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_ac
  * @tparam src_b_bcast_type: Broadcast type for SrcB; one of {NONE, ROW, COL, SCALAR}.
  * @tparam is_fp32_dest_acc_en: Unused tparam; only for API compatibiliy.
  * @tparam math_fidelity: 0 = LoFi, 2 = HiFi2, 3 = HiFi3, 4 = HiFi4 - controls precision of multiplication
- *     when input is Tf32 format. Unused tparam; only for API compatibiliy.
+ *     when input is Tf32 format. Unused in assert and for API compatibility.
  * @tparam binary_reuse_dest: When not NONE, reuses the destination register as SrcA or SrcB.
  *     The MOVD2A/B instruction copies a face from dest to the source register before each MOP run.
  * @param operand_A: Logical dataflow buffer id for input A, used to derive the number of faces
@@ -125,6 +127,10 @@ inline void llk_math_eltwise_binary(
     [[maybe_unused]] const std::uint32_t operand_B,
     uint dst_index,
     const bool clear_fp32_dst_acc) {
+    static_assert(
+        eltwise_binary_type == EltwiseBinaryType::ELWMUL || math_fidelity == MathFidelity::LoFi,
+        "Math fidelity must be LoFi for non-ELWMUL ops");
+
     WAYPOINT("MBIW");
     if constexpr (src_b_bcast_type == BroadcastType::NONE) {
         const std::uint32_t operand_id = get_operand_id(operand_A);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
@@ -43,7 +43,8 @@ inline void llk_math_eltwise_binary_init(
 
     constexpr auto effective_math_fidelity = get_effective_math_fidelity<eltwise_binary_type, math_fidelity>();
 
-    _configure_default_data_format_state_<false /* IMPLIED_MATH_FORMAT */, DST_ACCUM_MODE>(srcA_format, srcB_format);
+    _configure_default_alu_data_format_state_<false /* IMPLIED_MATH_FORMAT */, DST_ACCUM_MODE>(
+        srcA_format, srcB_format);
     if constexpr (src_b_bcast_type == BroadcastType::NONE) {
         _llk_math_eltwise_binary_init_<eltwise_binary_type, effective_math_fidelity, binary_reuse_dest>(
             tensor_shape_A, acc_to_dest);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
@@ -17,26 +17,6 @@
  *************************************************************************/
 
 /**
- * @brief Determines whether the source register format and Float32 destination format are a supported combination
- *
- * @param src_reg_fmt: The source register format
- */
-inline bool is_src_fmt_fp32_dest_compatible(const DataFormat src_reg_fmt) {
-    return src_reg_fmt == DataFormat::Float16_b || src_reg_fmt == DataFormat::Float16 ||
-           src_reg_fmt == DataFormat::Tf32;
-}
-
-/**
- * @brief Determines whether the source register format and Int32 destination format are a supported combination
- *
- * @param src_reg_fmt: The source register format
- */
-inline bool is_src_fmt_int32_dest_compatible(const DataFormat src_reg_fmt) {
-    return src_reg_fmt == DataFormat::Int32 || src_reg_fmt == DataFormat::Int16 || src_reg_fmt == DataFormat::Int8 ||
-           src_reg_fmt == DataFormat::UInt16 || src_reg_fmt == DataFormat::UInt8;
-}
-
-/**
  *
  * @brief Configures math hardware.
  * Sets up ALU formats for math destination register and source registers.
@@ -58,16 +38,16 @@ inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::u
 
     // TODO: AM; introduce dest mode enum, issue #37483
     // Determine the dest format based on the srcA/B formats and EN_32BIT_DEST_FORMAT
-    if (EN_32BIT_DEST_FORMAT && is_src_fmt_fp32_dest_compatible(srca_format) &&
-        is_src_fmt_fp32_dest_compatible(srcb_format)) {
+    if (EN_32BIT_DEST_FORMAT && _is_src_fmt_fp32_dest_compatible_(srca_format) &&
+        _is_src_fmt_fp32_dest_compatible_(srcb_format)) {
         // TODO: AM; hardcoding false for EN_IMPLIED_MATH_FORMAT for now, will be fixed in issue #37720
         _llk_math_srcAB_hw_configure_<
             false /*EN_IMPLIED_MATH_FORMAT*/,
             true /*EN_FP32_DEST_FORMAT*/,
             false /*EN_INT32_DEST_FORMAT*/>(srca_format, srcb_format);
     } else if (
-        EN_32BIT_DEST_FORMAT && is_src_fmt_int32_dest_compatible(srca_format) &&
-        is_src_fmt_int32_dest_compatible(srcb_format)) {
+        EN_32BIT_DEST_FORMAT && _is_src_fmt_int32_dest_compatible_(srca_format) &&
+        _is_src_fmt_int32_dest_compatible_(srcb_format)) {
         // TODO: AM; hardcoding false for EN_IMPLIED_MATH_FORMAT for now, will be fixed in issue #37720
         _llk_math_srcAB_hw_configure_<
             false /*EN_IMPLIED_MATH_FORMAT*/,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_matmul_api.h
@@ -37,7 +37,8 @@ inline void llk_math_matmul_init(
     const DataFormat srcB_format = static_cast<DataFormat>(get_operand_dst_format(operandA_id));
     const DataFormat srcA_format = static_cast<DataFormat>(get_operand_dst_format(operandB_id));
 
-    _configure_default_data_format_state_<false /* IMPLIED_MATH_FORMAT */, DST_ACCUM_MODE>(srcA_format, srcB_format);
+    _configure_default_alu_data_format_state_<false /* IMPLIED_MATH_FORMAT */, DST_ACCUM_MODE>(
+        srcA_format, srcB_format);
     _llk_math_matmul_init_<math_fidelity>(ct_dim, rt_dim);
 }
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_matmul_api.h
@@ -15,7 +15,9 @@
 * @brief Initialize matrix multiply operation of Input 0 * Input 1 -> SrcB * SrcA
 
 * @tparam math_fidelity: 0 = LoFi, 2 = HiFi2, 3 = HiFi3, 4 = HiFi4 - controls precision of multiplication when
-math is in Fp32 format
+* math is in Fp32 format
+* @param operandA: Logical dataflow buffer identifier for input 0 (-> SrcB)
+* @param operandB: Logical dataflow buffer identifier for input 1 (-> SrcA)
 * @param ct_dim: number of tiles in the column dimension for a matrix multiply
 * @param rt_dim: number of tiles in the row dimension for a matrix multiply
 *
@@ -25,7 +27,17 @@ math is in Fp32 format
 * Output is a matrix block of dimension [rt_dim, ct_dim]
 */
 template <ckernel::MathFidelity math_fidelity>
-inline void llk_math_matmul_init(const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1) {
+inline void llk_math_matmul_init(
+    const std::uint32_t operandA,
+    const std::uint32_t operandB,
+    const std::uint32_t ct_dim = 1,
+    const std::uint32_t rt_dim = 1) {
+    const std::uint32_t operandA_id = get_operand_id(operandA);
+    const std::uint32_t operandB_id = get_operand_id(operandB);
+    const DataFormat srcB_format = static_cast<DataFormat>(get_operand_dst_format(operandA_id));
+    const DataFormat srcA_format = static_cast<DataFormat>(get_operand_dst_format(operandB_id));
+
+    _configure_default_data_format_state_<false /* IMPLIED_MATH_FORMAT */, DST_ACCUM_MODE>(srcA_format, srcB_format);
     _llk_math_matmul_init_<math_fidelity>(ct_dim, rt_dim);
 }
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
@@ -31,7 +31,7 @@ inline void llk_math_reduce_init(const std::uint32_t operandA, const std::uint32
     const DataFormat srcA_format = static_cast<DataFormat>(unpack_dst_format[operandA_id]);
     const DataFormat srcB_format = static_cast<DataFormat>(unpack_dst_format[operandB_id]);
 
-    _configure_default_data_format_state_<false /* IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(srcA_format, srcB_format);
+    _configure_default_alu_data_format_state_<false /* IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(srcA_format, srcB_format);
     _llk_math_reduce_init_<pool_type, reduce_dim, math_fidelity>(tensor_shape);
 }
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
@@ -16,15 +16,22 @@
  *
  * @tparam pool_type: Type of reduce pool op, values = [MAX, SUM, AVG]
  * @tparam reduce_dim: Sets the reduce dimension, values = [REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR]
+ * tparam EN_32BIT_DEST: Set to true to use 32bit destination register mode
  * @tparam math_fidelity: Only works for AVG/SUM pool types,  0 = LoFi, 2 = HiFi2, 3 = HiFi3, 4 = HiFi4 - controls
  * precision of multiplication
- * @param operand: The input operand circular buffer identifier
+ * @param operandA: The input operand Data Flow Buffer identifier
+ * @param operandB: The scaler input operand Data Flow Buffer identifier
  *
  */
-template <PoolType pool_type, ReduceDim reduce_dim, ckernel::MathFidelity math_fidelity>
-inline void llk_math_reduce_init(const std::uint32_t operandA) {
+template <PoolType pool_type, ReduceDim reduce_dim, const bool EN_32BIT_DEST, ckernel::MathFidelity math_fidelity>
+inline void llk_math_reduce_init(const std::uint32_t operandA, const std::uint32_t operandB) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
+    const std::uint32_t operandB_id = get_operand_id(operandB);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operandA_id);
+    const DataFormat srcA_format = static_cast<DataFormat>(unpack_dst_format[operandA_id]);
+    const DataFormat srcB_format = static_cast<DataFormat>(unpack_dst_format[operandB_id]);
+
+    _configure_default_data_format_state_<false /* IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(srcA_format, srcB_format);
     _llk_math_reduce_init_<pool_type, reduce_dim, math_fidelity>(tensor_shape);
 }
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -45,6 +45,10 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand = 0
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
     const std::uint32_t num_rows = num_faces * face_r_dim;
 
+    const DataFormat srcA_format = static_cast<DataFormat>(get_operand_dst_format(operand_id));
+    const DataFormat srcB_format = static_cast<DataFormat>(get_operand_dst_format(operand_id));
+    _configure_default_alu_data_format_state_<false /* IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(srcA_format, srcB_format);
+
     if constexpr (src_b_bcast_type == BroadcastType::NONE) {
         _llk_math_eltwise_unary_datacopy_init_<type, EN_32BIT_DEST>(
             num_rows /*num_rows_per_matrix*/, 1 /*num_matrices*/);

--- a/tt_metal/hw/inc/api/compute/matmul.h
+++ b/tt_metal/hw/inc/api/compute/matmul.h
@@ -190,7 +190,7 @@ ALWI void mm_init_short(
 #else
     LLK_ASSERT(transpose == 0, "Matmul transpose not yet implemented for Quasar");
     UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(in0_cb_id, in1_cb_id)));
-    MATH((llk_math_matmul_init<MATH_FIDELITY>()));
+    MATH((llk_math_matmul_init<MATH_FIDELITY>(in0_cb_id, in1_cb_id)));
 #endif
 }
 

--- a/tt_metal/hw/inc/api/compute/matmul.h
+++ b/tt_metal/hw/inc/api/compute/matmul.h
@@ -111,7 +111,7 @@ ALWI void mm_init(
 
     MATH((llk_math_hw_configure<DST_ACCUM_MODE>(in0_cb_id, in1_cb_id)));
     MATH((llk_math_pack_sync_init()));
-    MATH((llk_math_matmul_init<MATH_FIDELITY>()));
+    MATH((llk_math_matmul_init<MATH_FIDELITY>(in0_cb_id, in1_cb_id)));
 
     PACK((llk_pack_hw_configure(out_cb_id)));
     PACK((llk_pack_init(out_cb_id)));
@@ -268,7 +268,7 @@ ALWI void mm_block_init(
 
     MATH((llk_math_hw_configure<DST_ACCUM_MODE>(in0_cb_id, in1_cb_id)));
     MATH((llk_math_pack_sync_init()));
-    MATH((llk_math_matmul_init<MATH_FIDELITY>(ct_dim, rt_dim)));
+    MATH((llk_math_matmul_init<MATH_FIDELITY>(in0_cb_id, in1_cb_id, ct_dim, rt_dim)));
 
     PACK((llk_pack_hw_configure(out_cb_id)));
     PACK((llk_pack_init(out_cb_id)));
@@ -359,7 +359,7 @@ ALWI void mm_block_init_short(
 #else
     LLK_ASSERT(transpose == 0, "Matmul transpose not yet implemented for Quasar");
     UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(in0_cb_id, in1_cb_id, ct_dim, rt_dim, kt_dim)));
-    MATH((llk_math_matmul_init<MATH_FIDELITY>(ct_dim, rt_dim)));
+    MATH((llk_math_matmul_init<MATH_FIDELITY>(in0_cb_id, in1_cb_id, ct_dim, rt_dim)));
 #endif
 }
 

--- a/tt_metal/hw/inc/api/compute/reduce.h
+++ b/tt_metal/hw/inc/api/compute/reduce.h
@@ -73,7 +73,7 @@ ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb, uint32_t 
     }
 #else
     UNPACK((llk_unpack_AB_reduce_init<reduce_dim>(icb, icb_scaler)));
-    MATH((llk_math_reduce_init<reduce_type, reduce_dim, MATH_FIDELITY>(icb)));
+    MATH((llk_math_reduce_init<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(icb, icb_scaler)));
 #endif
     PACK((llk_pack_reduce_mask_config<reduce_dim, PackMode::Default>()));
 }

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_transpose_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_transpose_dest_quasar.py
@@ -142,7 +142,7 @@ TRANSPOSE_DEST_FORMATS = input_output_formats(
     formats_dest_acc_sync_transpose_dims=generate_qsr_transpose_dest_combinations(
         TRANSPOSE_DEST_FORMATS
     ),
-    implied_math_format=[ImpliedMathFormat.No],
+    implied_math_format=[ImpliedMathFormat.No, ImpliedMathFormat.Yes],
 )
 def test_transpose_dest_quasar(
     formats_dest_acc_sync_transpose_dims,

--- a/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
@@ -113,11 +113,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     DataFormat math_format     = static_cast<DataFormat>(formats.math);
     DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-    if (is_fp32_dest_acc_en && (pack_src_format == DataFormat::Float32 || pack_src_format == DataFormat::Int32))
+    if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
     {
-        // For Int32 dest, transpose dest requires opposite settings that what is usually set for Int32 dest,
-        // this is why fp32_dest is set to true and int32_dest is set to false
         _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
+    }
+    else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+    {
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
     }
     else
     {
@@ -127,6 +129,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     if constexpr (!unpack_to_dest)
     {
         // Perform datacopy if not unpack_to_dest
+        _configure_default_data_format_state_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, math_format);
         _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(
             params.num_faces * params.TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
         for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
@@ -136,6 +139,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     // Perform transpose dest
+    if (is_fp32_dest_acc_en && (pack_src_format == DataFormat::Float32 || pack_src_format == DataFormat::Int32))
+    {
+        // For Int32 dest, transpose dest requires opposite settings that what is usually set for Int32 dest,
+        // also, Int32 and Fp32 transpose dest sets Int32/Fp32 as srcA/B formats,
+        // this is why a non-default data format state is used for Int32 dest.
+        _configure_mov_src2dst_32bit_ops_data_format_state_(math_format, math_format);
+    }
+    else
+    {
+        _configure_default_data_format_state_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, math_format);
+    }
     _llk_math_transpose_dest_init_<MATH_TRANSPOSE_FACES, is_fp32_dest_acc_en>();
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
@@ -129,7 +129,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     if constexpr (!unpack_to_dest)
     {
         // Perform datacopy if not unpack_to_dest
-        _configure_default_data_format_state_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, math_format);
+        _configure_default_alu_data_format_state_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, math_format);
         _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(
             params.num_faces * params.TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
         for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
@@ -139,17 +139,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     // Perform transpose dest
-    if (is_fp32_dest_acc_en && (pack_src_format == DataFormat::Float32 || pack_src_format == DataFormat::Int32))
-    {
-        // For Int32 dest, transpose dest requires opposite settings that what is usually set for Int32 dest,
-        // also, Int32 and Fp32 transpose dest sets Int32/Fp32 as srcA/B formats,
-        // this is why a non-default data format state is used for Int32 dest.
-        _configure_mov_src2dst_32bit_ops_data_format_state_(math_format, math_format);
-    }
-    else
-    {
-        _configure_default_data_format_state_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, math_format);
-    }
+    // For Int32 dest, transpose dest requires opposite settings that what is usually set for Int32 dest,
+    // also, Int32 and Fp32 transpose dest sets Int32/Fp32 as srcA/B formats,
+    // all transpose dest operations disable implied math format,
+    // this is why a non-default ALU data format state is used for transpose dest.
+    _configure_mov_ops_explicit_alu_data_format_state_<is_fp32_dest_acc_en>(math_format, math_format);
     _llk_math_transpose_dest_init_<MATH_TRANSPOSE_FACES, is_fp32_dest_acc_en>();
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
@@ -45,7 +45,7 @@ static constexpr std::uint32_t DEST_REGISTER_HALF_SIZE = DEST_REGISTER_FULL_SIZE
 // Uint8 requires special handling because when int8 is put into DEST, the sign bit actually gets put
 // to the MSB of the 32bit container, rather than to bit 8. So for int8 the packer will read the 7 LSBs + 1 MSB,
 // but for uint8 the packer will read the 8 LSBs.
-constexpr std::uint32_t DATA_FORMAT_BIT_COUNT = 4;
+constexpr std::uint32_t DATA_FORMAT_BIT_COUNT = 5;
 // Mask to extract data format bits
 constexpr std::uint32_t DATA_FORMAT_CONFIG_MASK = (1 << DATA_FORMAT_BIT_COUNT) - 1;
 

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/cmath_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/cmath_common.h
@@ -63,6 +63,14 @@ typedef union
     alu_config_t f;
 } alu_config_u;
 
+// List of possible data format config states
+enum class DataFormatConfigSet : std::uint8_t
+{
+    UNCONFIGURED          = 0,
+    DEFAULT               = 1,
+    MOV_SRC2DST_32BIT_OPS = 2
+};
+
 // /**
 // * @brief Helper function to calculate log2,
 // * only works for 32 bit unsigned inputs

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/cmath_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/cmath_common.h
@@ -68,7 +68,7 @@ enum class DataFormatConfigSet : std::uint8_t
 {
     UNCONFIGURED          = 0,
     DEFAULT               = 1,
-    MOV_SRC2DST_32BIT_OPS = 2
+    MOV_OPS_EXPLICIT_FMT  = 2
 };
 
 // /**

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
@@ -121,17 +121,21 @@ inline void _llk_math_upk_to_dest_hw_configure_()
 inline bool _is_src_fmt_fp32_dest_compatible_(const DataFormat src_reg_fmt)
 {
     return src_reg_fmt == DataFormat::Float16_b || src_reg_fmt == DataFormat::Float16 || src_reg_fmt == DataFormat::Tf32 ||
-           src_reg_fmt == DataFormat::MxFp4_2x_A || src_reg_fmt == DataFormat::MxFp4_2x_B;
+           src_reg_fmt == DataFormat::Float32 || src_reg_fmt == DataFormat::MxFp4_2x_A || src_reg_fmt == DataFormat::MxFp4_2x_B;
 }
 
 /**
  * @brief Determines whether the source register format and Int32 destination register format are a supported combination
  *
  * @param src_reg_fmt: The source register format
+ *
+ * Int16 is absent from the list because, for the FPU, it is supported only for MOV ops and is
+ * not compatible with 32bit Dest register mode.
  */
 inline bool _is_src_fmt_int32_dest_compatible_(const DataFormat src_reg_fmt)
 {
-    return src_reg_fmt == DataFormat::Int8 || src_reg_fmt == DataFormat::UInt8 || src_reg_fmt == DataFormat::Int8_2x || src_reg_fmt == DataFormat::UInt8_2x;
+    return src_reg_fmt == DataFormat::Int8 || src_reg_fmt == DataFormat::UInt8 || src_reg_fmt == DataFormat::Int32 || src_reg_fmt == DataFormat::Int8_2x ||
+           src_reg_fmt == DataFormat::UInt8_2x;
 }
 
 /**
@@ -176,6 +180,7 @@ inline void _configure_alu_formats_(DataFormat srcA_format, DataFormat srcB_form
 
 /**
  * @brief Sets up default ALU data format state
+ *
  * @tparam EN_IMPLIED_MATH_FORMAT: If set to true, will imply math dest format
  * from SrcA reg format
  * @tparam EN_32BIT_DEST: Set to true to use 32bit math dest in Float32 or Int32 format
@@ -183,6 +188,10 @@ inline void _configure_alu_formats_(DataFormat srcA_format, DataFormat srcB_form
  * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
  * @param srcB_format: Input srcB format, used to set ALU configs if not implied math format
  * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
+ *
+ * Default ALU data format config state used for all operations which are not proven to need special handling.
+ * Implied math format can be enabled or disabled. en_int32_dest_format is set to true if 32bit Dest register mode is enabled
+ * and the source register formats are integers compatible with Int32 Dest register format.
  */
 template <bool EN_IMPLIED_MATH_FORMAT, bool EN_32BIT_DEST>
 inline void _configure_default_alu_data_format_state_(DataFormat srcA_format, DataFormat srcB_format)
@@ -200,6 +209,7 @@ inline void _configure_default_alu_data_format_state_(DataFormat srcA_format, Da
 
 /**
  * @brief Sets up MOV OPS EXPLICIT FMT ALU data format state
+ *
  * Used for transpose dest operations, which require implied math format to be disabled.
  * Int32 dest requires opposite settings that what is usually set for Int32 dest.
  * Float32 and Int32 can be set as the srcA and srcB formats.
@@ -207,6 +217,10 @@ inline void _configure_default_alu_data_format_state_(DataFormat srcA_format, Da
  * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Float32/Int8/Int16/UInt8/Int32>
  * @param srcB_format: Input srcB format, used to set ALU configs
  * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Float32/Int8/Int16/UInt8/Int32>
+ *
+ * Special ALU data format config state used for: transpose dest.
+ * Disables implied math format due to MOV op quirks. Sets en_int32_dest_format = false because ALU_ACC_CTRL_INT8_math_enabled
+ * does not work with MOVD2A/B. When unpacking Int32 or Fp32 to dest, the ALU_FORMAT_SPEC SrcA/B cfg registers are set to Int32/Fp32.
  */
 template <bool EN_32BIT_DEST>
 inline void _configure_mov_ops_explicit_alu_data_format_state_(DataFormat srcA_format, DataFormat srcB_format)

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
@@ -138,19 +138,15 @@ inline bool _is_src_fmt_int32_dest_compatible_(const DataFormat src_reg_fmt)
  * @brief Sets up ALU formats
  * @tparam EN_IMPLIED_MATH_FORMAT: If set to true, will imply math dest format
  * from SrcA reg format
- * @tparam EN_FP32_DEST_FORMAT: Set to true to use math dest in Float32
- * otherwise default behaviour is Float16/Float16_b depending on input
- * format exponent width
- * @tparam EN_INT32_DEST_FORMAT: Set to true to use math dest in Int32
- * otherwise default behaviour is Float16/Float16_b depending on input
- * format exponent width
+ * @tparam EN_32BIT_DEST: Set to true to use math dest in 32bit mode
  * @param srcA_format: Input srcA format, used to set ALU configs if not implied math format
  * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
  * @param srcB_format: Input srcB format, used to set ALU configs if not implied math format
  * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
+ * @param en_int32_dest_format: Set to true to use destination register in Int32 format
  */
-template <bool EN_IMPLIED_MATH_FORMAT, bool EN_FP32_DEST_FORMAT, bool EN_INT32_DEST_FORMAT>
-inline void _configure_alu_formats_(DataFormat srcA_format, DataFormat srcB_format)
+template <bool EN_IMPLIED_MATH_FORMAT, bool EN_32BIT_DEST>
+inline void _configure_alu_formats_(DataFormat srcA_format, DataFormat srcB_format, bool en_int32_dest_format)
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, 0, p_stall::WAIT_SFPU, p_stall::MATH);
 
@@ -168,9 +164,9 @@ inline void _configure_alu_formats_(DataFormat srcA_format, DataFormat srcB_form
     alu_config.f.ALU_FORMAT_SPEC_REG0_SrcA         = SRCA_FORMAT_MASKED;
     alu_config.f.ALU_FORMAT_SPEC_REG1_SrcB         = SRCB_FORMAT_MASKED;
 
-    alu_config.f.ALU_ACC_CTRL_Fp32_enabled      = EN_FP32_DEST_FORMAT;
-    alu_config.f.ALU_ACC_CTRL_SFPU_Fp32_enabled = EN_FP32_DEST_FORMAT;
-    alu_config.f.ALU_ACC_CTRL_INT8_math_enabled = EN_INT32_DEST_FORMAT;
+    alu_config.f.ALU_ACC_CTRL_Fp32_enabled      = EN_32BIT_DEST;
+    alu_config.f.ALU_ACC_CTRL_SFPU_Fp32_enabled = EN_32BIT_DEST;
+    alu_config.f.ALU_ACC_CTRL_INT8_math_enabled = en_int32_dest_format;
 
     for (std::uint32_t i = 0; i < NUM_WORDS_ALU_FORMAT; i++)
     {
@@ -196,20 +192,8 @@ inline void _configure_default_alu_data_format_state_(DataFormat srcA_format, Da
         return;
     }
 
-    const bool EN_FP32_DEST_FORMAT  = _is_src_fmt_fp32_dest_compatible_(srcA_format) && _is_src_fmt_fp32_dest_compatible_(srcB_format) && EN_32BIT_DEST;
-    const bool EN_INT32_DEST_FORMAT = _is_src_fmt_int32_dest_compatible_(srcA_format) && _is_src_fmt_int32_dest_compatible_(srcB_format) && EN_32BIT_DEST;
-    if (EN_FP32_DEST_FORMAT)
-    {
-        _configure_alu_formats_<EN_IMPLIED_MATH_FORMAT, true /* EN_FP32_DEST_FORMAT */, false /* EN_INT32_DEST_FORMAT */>(srcA_format, srcB_format);
-    }
-    else if (EN_INT32_DEST_FORMAT)
-    {
-        _configure_alu_formats_<EN_IMPLIED_MATH_FORMAT, false /* EN_FP32_DEST_FORMAT */, true /* EN_INT32_DEST_FORMAT */>(srcA_format, srcB_format);
-    }
-    else
-    {
-        _configure_alu_formats_<EN_IMPLIED_MATH_FORMAT, false /* EN_FP32_DEST_FORMAT */, false /* EN_INT32_DEST_FORMAT */>(srcA_format, srcB_format);
-    }
+    const bool en_int32_dest_format = _is_src_fmt_int32_dest_compatible_(srcA_format) && _is_src_fmt_int32_dest_compatible_(srcB_format) && EN_32BIT_DEST;
+    _configure_alu_formats_<EN_IMPLIED_MATH_FORMAT, EN_32BIT_DEST>(srcA_format, srcB_format, en_int32_dest_format);
 
     data_format_config_set = DataFormatConfigSet::DEFAULT;
 }
@@ -232,8 +216,7 @@ inline void _configure_mov_ops_explicit_alu_data_format_state_(DataFormat srcA_f
         return;
     }
 
-    _configure_alu_formats_<false /* EN_IMPLIED_MATH_FORMAT */, EN_32BIT_DEST /* EN_FP32_DEST_FORMAT */, false /* EN_INT32_DEST_FORMAT */>(
-        srcA_format, srcB_format);
+    _configure_alu_formats_<false /* EN_IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(srcA_format, srcB_format, false /* en_int32_dest_format */);
 
     data_format_config_set = DataFormatConfigSet::MOV_OPS_EXPLICIT_FMT;
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
@@ -152,26 +152,30 @@ inline bool _is_src_fmt_int32_dest_compatible_(const DataFormat src_reg_fmt)
 template <bool EN_IMPLIED_MATH_FORMAT, bool EN_FP32_DEST_FORMAT, bool EN_INT32_DEST_FORMAT>
 inline void _configure_alu_formats_(DataFormat srcA_format, DataFormat srcB_format)
 {
+    TTI_STALLWAIT(p_stall::STALL_CFG, 0, p_stall::WAIT_SFPU, p_stall::MATH);
+
     cfg[DISABLE_IMPLIED_SRCA_FMT_SEC0_Base_ADDR32 + TRISC_ID] = !EN_IMPLIED_MATH_FORMAT;
     cfg[DISABLE_IMPLIED_SRCB_FMT_SEC0_Base_ADDR32 + TRISC_ID] = !EN_IMPLIED_MATH_FORMAT;
 
-    if constexpr (!EN_IMPLIED_MATH_FORMAT)
+    alu_config_u alu_config         = {0};
+    std::uint8_t SRCA_FORMAT_MASKED = masked_data_format(to_underlying(srcA_format));
+    std::uint8_t SRCB_FORMAT_MASKED = masked_data_format(to_underlying(srcB_format));
+
+    alu_config.f.ALU_FORMAT_SPEC_REG_SrcA_val      = SRCA_FORMAT_MASKED;
+    alu_config.f.ALU_FORMAT_SPEC_REG_SrcA_override = !EN_IMPLIED_MATH_FORMAT;
+    alu_config.f.ALU_FORMAT_SPEC_REG_SrcB_val      = SRCB_FORMAT_MASKED;
+    alu_config.f.ALU_FORMAT_SPEC_REG_SrcB_override = !EN_IMPLIED_MATH_FORMAT;
+    alu_config.f.ALU_FORMAT_SPEC_REG0_SrcA         = SRCA_FORMAT_MASKED;
+    alu_config.f.ALU_FORMAT_SPEC_REG1_SrcB         = SRCB_FORMAT_MASKED;
+
+    alu_config.f.ALU_ACC_CTRL_Fp32_enabled      = EN_FP32_DEST_FORMAT;
+    alu_config.f.ALU_ACC_CTRL_SFPU_Fp32_enabled = EN_FP32_DEST_FORMAT;
+    alu_config.f.ALU_ACC_CTRL_INT8_math_enabled = EN_INT32_DEST_FORMAT;
+
+    for (std::uint32_t i = 0; i < NUM_WORDS_ALU_FORMAT; i++)
     {
-        std::uint8_t SRCA_FORMAT_MASKED = masked_data_format(to_underlying(srcA_format));
-        std::uint8_t SRCB_FORMAT_MASKED = masked_data_format(to_underlying(srcB_format));
-
-        cfg_rmw(ALU_FORMAT_SPEC_REG_SrcA_val_RMW, SRCA_FORMAT_MASKED);
-        cfg_rmw(ALU_FORMAT_SPEC_REG_SrcA_override_RMW, 0x1);
-        cfg_rmw(ALU_FORMAT_SPEC_REG_SrcB_val_RMW, SRCB_FORMAT_MASKED);
-        cfg_rmw(ALU_FORMAT_SPEC_REG_SrcB_override_RMW, 0x1);
-
-        cfg_rmw(ALU_FORMAT_SPEC_REG0_SrcA_RMW, SRCA_FORMAT_MASKED);
-        cfg_rmw(ALU_FORMAT_SPEC_REG1_SrcB_RMW, SRCB_FORMAT_MASKED);
+        cfg[ALU_FORMAT_SPEC_REG_SrcA_val_ADDR32 + i] = alu_config.val[i];
     }
-
-    cfg_rmw(ALU_ACC_CTRL_Fp32_enabled_RMW, EN_FP32_DEST_FORMAT);
-    cfg_rmw(ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW, EN_FP32_DEST_FORMAT);
-    cfg_rmw(ALU_ACC_CTRL_INT8_math_enabled_RMW, EN_INT32_DEST_FORMAT);
 }
 
 /**
@@ -185,14 +189,12 @@ inline void _configure_alu_formats_(DataFormat srcA_format, DataFormat srcB_form
  * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
  */
 template <bool EN_IMPLIED_MATH_FORMAT, bool EN_32BIT_DEST>
-inline void _configure_default_data_format_state_(DataFormat srcA_format, DataFormat srcB_format)
+inline void _configure_default_alu_data_format_state_(DataFormat srcA_format, DataFormat srcB_format)
 {
     if (data_format_config_set == DataFormatConfigSet::DEFAULT)
     {
         return;
     }
-
-    TTI_STALLWAIT(p_stall::STALL_CFG, 0, p_stall::WAIT_SFPU, p_stall::MATH);
 
     const bool EN_FP32_DEST_FORMAT  = _is_src_fmt_fp32_dest_compatible_(srcA_format) && _is_src_fmt_fp32_dest_compatible_(srcB_format) && EN_32BIT_DEST;
     const bool EN_INT32_DEST_FORMAT = _is_src_fmt_int32_dest_compatible_(srcA_format) && _is_src_fmt_int32_dest_compatible_(srcB_format) && EN_32BIT_DEST;
@@ -213,26 +215,27 @@ inline void _configure_default_data_format_state_(DataFormat srcA_format, DataFo
 }
 
 /**
- * @brief Sets up MOV SRC2DST 32bit ops ALU data format state
- * Used for transpose dest operations when Int32 or Fp32 dest is used.
- * Implied math format is disabled, and Int32 dest requires opposite settings that what is usually set for Int32 dest.
+ * @brief Sets up MOV OPS EXPLICIT FMT ALU data format state
+ * Used for transpose dest operations, which require implied math format to be disabled.
+ * Int32 dest requires opposite settings that what is usually set for Int32 dest.
  * Float32 and Int32 can be set as the srcA and srcB formats.
  * @param srcA_format: Input srcA format, used to set ALU configs
  * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Float32/Int8/Int16/UInt8/Int32>
  * @param srcB_format: Input srcB format, used to set ALU configs
  * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Float32/Int8/Int16/UInt8/Int32>
  */
-inline void _configure_mov_src2dst_32bit_ops_data_format_state_(DataFormat srcA_format, DataFormat srcB_format)
+template <bool EN_32BIT_DEST>
+inline void _configure_mov_ops_explicit_alu_data_format_state_(DataFormat srcA_format, DataFormat srcB_format)
 {
-    if (data_format_config_set == DataFormatConfigSet::MOV_SRC2DST_32BIT_OPS)
+    if (data_format_config_set == DataFormatConfigSet::MOV_OPS_EXPLICIT_FMT)
     {
         return;
     }
-    TTI_STALLWAIT(p_stall::STALL_CFG, 0, p_stall::WAIT_SFPU, p_stall::MATH);
 
-    _configure_alu_formats_<false /* EN_IMPLIED_MATH_FORMAT */, true /* EN_FP32_DEST_FORMAT */, false /* EN_INT32_DEST_FORMAT */>(srcA_format, srcB_format);
+    _configure_alu_formats_<false /* EN_IMPLIED_MATH_FORMAT */, EN_32BIT_DEST /* EN_FP32_DEST_FORMAT */, false /* EN_INT32_DEST_FORMAT */>(
+        srcA_format, srcB_format);
 
-    data_format_config_set = DataFormatConfigSet::MOV_SRC2DST_32BIT_OPS;
+    data_format_config_set = DataFormatConfigSet::MOV_OPS_EXPLICIT_FMT;
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
@@ -12,6 +12,8 @@ using namespace ckernel;
 using namespace ckernel::trisc;
 using namespace ckernel::math;
 
+static DataFormatConfigSet data_format_config_set = DataFormatConfigSet::UNCONFIGURED;
+
 /**
  * @brief Sets up ALU formats for math destination register
  * @tparam EN_IMPLIED_MATH_FORMAT: If set to true, will imply math dest format
@@ -40,8 +42,8 @@ inline void _llk_math_srcAB_hw_configure_(DataFormat srcA_format, DataFormat src
     cfg[DISABLE_IMPLIED_SRCA_FMT_SEC0_Base_ADDR32 + TRISC_ID] = !EN_IMPLIED_MATH_FORMAT;
     cfg[DISABLE_IMPLIED_SRCB_FMT_SEC0_Base_ADDR32 + TRISC_ID] = !EN_IMPLIED_MATH_FORMAT;
 
-    std::uint8_t SRCA_FORMAT_MASKED = static_cast<std::uint8_t>(srcA_format) & 0xFF;
-    std::uint8_t SRCB_FORMAT_MASKED = static_cast<std::uint8_t>(srcB_format) & 0xFF;
+    std::uint8_t SRCA_FORMAT_MASKED = masked_data_format(to_underlying(srcA_format));
+    std::uint8_t SRCB_FORMAT_MASKED = masked_data_format(to_underlying(srcB_format));
 
     alu_config_u alu_config;
     for (std::uint32_t i = 0; i < NUM_WORDS_ALU_FORMAT; i++)
@@ -73,6 +75,8 @@ inline void _llk_math_srcAB_hw_configure_(DataFormat srcA_format, DataFormat src
     {
         cfg[ALU_FORMAT_SPEC_REG_SrcA_val_ADDR32 + i] = alu_config.val[i];
     }
+
+    data_format_config_set = DataFormatConfigSet::DEFAULT;
 }
 
 /**
@@ -107,6 +111,128 @@ inline void _llk_math_upk_to_dest_hw_configure_()
     {
         cfg[ALU_FORMAT_SPEC_REG_SrcA_val_ADDR32 + i] = alu_config.val[i];
     }
+}
+
+/**
+ * @brief Determines whether the source register format and Float32 destination register format are a supported combination
+ *
+ * @param src_reg_fmt: The source register format
+ */
+inline bool _is_src_fmt_fp32_dest_compatible_(const DataFormat src_reg_fmt)
+{
+    return src_reg_fmt == DataFormat::Float16_b || src_reg_fmt == DataFormat::Float16 || src_reg_fmt == DataFormat::Tf32 ||
+           src_reg_fmt == DataFormat::MxFp4_2x_A || src_reg_fmt == DataFormat::MxFp4_2x_B;
+}
+
+/**
+ * @brief Determines whether the source register format and Int32 destination register format are a supported combination
+ *
+ * @param src_reg_fmt: The source register format
+ */
+inline bool _is_src_fmt_int32_dest_compatible_(const DataFormat src_reg_fmt)
+{
+    return src_reg_fmt == DataFormat::Int8 || src_reg_fmt == DataFormat::UInt8 || src_reg_fmt == DataFormat::Int8_2x || src_reg_fmt == DataFormat::UInt8_2x;
+}
+
+/**
+ * @brief Sets up ALU formats
+ * @tparam EN_IMPLIED_MATH_FORMAT: If set to true, will imply math dest format
+ * from SrcA reg format
+ * @tparam EN_FP32_DEST_FORMAT: Set to true to use math dest in Float32
+ * otherwise default behaviour is Float16/Float16_b depending on input
+ * format exponent width
+ * @tparam EN_INT32_DEST_FORMAT: Set to true to use math dest in Int32
+ * otherwise default behaviour is Float16/Float16_b depending on input
+ * format exponent width
+ * @param srcA_format: Input srcA format, used to set ALU configs if not implied math format
+ * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
+ * @param srcB_format: Input srcB format, used to set ALU configs if not implied math format
+ * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
+ */
+template <bool EN_IMPLIED_MATH_FORMAT, bool EN_FP32_DEST_FORMAT, bool EN_INT32_DEST_FORMAT>
+inline void _configure_alu_formats_(DataFormat srcA_format, DataFormat srcB_format)
+{
+    cfg[DISABLE_IMPLIED_SRCA_FMT_SEC0_Base_ADDR32 + TRISC_ID] = !EN_IMPLIED_MATH_FORMAT;
+    cfg[DISABLE_IMPLIED_SRCB_FMT_SEC0_Base_ADDR32 + TRISC_ID] = !EN_IMPLIED_MATH_FORMAT;
+
+    if constexpr (!EN_IMPLIED_MATH_FORMAT)
+    {
+        std::uint8_t SRCA_FORMAT_MASKED = masked_data_format(to_underlying(srcA_format));
+        std::uint8_t SRCB_FORMAT_MASKED = masked_data_format(to_underlying(srcB_format));
+
+        cfg_rmw(ALU_FORMAT_SPEC_REG_SrcA_val_RMW, SRCA_FORMAT_MASKED);
+        cfg_rmw(ALU_FORMAT_SPEC_REG_SrcA_override_RMW, 0x1);
+        cfg_rmw(ALU_FORMAT_SPEC_REG_SrcB_val_RMW, SRCB_FORMAT_MASKED);
+        cfg_rmw(ALU_FORMAT_SPEC_REG_SrcB_override_RMW, 0x1);
+
+        cfg_rmw(ALU_FORMAT_SPEC_REG0_SrcA_RMW, SRCA_FORMAT_MASKED);
+        cfg_rmw(ALU_FORMAT_SPEC_REG1_SrcB_RMW, SRCB_FORMAT_MASKED);
+    }
+
+    cfg_rmw(ALU_ACC_CTRL_Fp32_enabled_RMW, EN_FP32_DEST_FORMAT);
+    cfg_rmw(ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW, EN_FP32_DEST_FORMAT);
+    cfg_rmw(ALU_ACC_CTRL_INT8_math_enabled_RMW, EN_INT32_DEST_FORMAT);
+}
+
+/**
+ * @brief Sets up default ALU data format state
+ * @tparam EN_IMPLIED_MATH_FORMAT: If set to true, will imply math dest format
+ * from SrcA reg format
+ * @tparam EN_32BIT_DEST: Set to true to use 32bit math dest in Float32 or Int32 format
+ * @param srcA_format: Input srcA format, used to set ALU configs if not implied math format
+ * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
+ * @param srcB_format: Input srcB format, used to set ALU configs if not implied math format
+ * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
+ */
+template <bool EN_IMPLIED_MATH_FORMAT, bool EN_32BIT_DEST>
+inline void _configure_default_data_format_state_(DataFormat srcA_format, DataFormat srcB_format)
+{
+    if (data_format_config_set == DataFormatConfigSet::DEFAULT)
+    {
+        return;
+    }
+
+    TTI_STALLWAIT(p_stall::STALL_CFG, 0, p_stall::WAIT_SFPU, p_stall::MATH);
+
+    const bool EN_FP32_DEST_FORMAT  = _is_src_fmt_fp32_dest_compatible_(srcA_format) && _is_src_fmt_fp32_dest_compatible_(srcB_format) && EN_32BIT_DEST;
+    const bool EN_INT32_DEST_FORMAT = _is_src_fmt_int32_dest_compatible_(srcA_format) && _is_src_fmt_int32_dest_compatible_(srcB_format) && EN_32BIT_DEST;
+    if (EN_FP32_DEST_FORMAT)
+    {
+        _configure_alu_formats_<EN_IMPLIED_MATH_FORMAT, true /* EN_FP32_DEST_FORMAT */, false /* EN_INT32_DEST_FORMAT */>(srcA_format, srcB_format);
+    }
+    else if (EN_INT32_DEST_FORMAT)
+    {
+        _configure_alu_formats_<EN_IMPLIED_MATH_FORMAT, false /* EN_FP32_DEST_FORMAT */, true /* EN_INT32_DEST_FORMAT */>(srcA_format, srcB_format);
+    }
+    else
+    {
+        _configure_alu_formats_<EN_IMPLIED_MATH_FORMAT, false /* EN_FP32_DEST_FORMAT */, false /* EN_INT32_DEST_FORMAT */>(srcA_format, srcB_format);
+    }
+
+    data_format_config_set = DataFormatConfigSet::DEFAULT;
+}
+
+/**
+ * @brief Sets up MOV SRC2DST 32bit ops ALU data format state
+ * Used for transpose dest operations when Int32 or Fp32 dest is used.
+ * Implied math format is disabled, and Int32 dest requires opposite settings that what is usually set for Int32 dest.
+ * Float32 and Int32 can be set as the srcA and srcB formats.
+ * @param srcA_format: Input srcA format, used to set ALU configs
+ * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Float32/Int8/Int16/UInt8/Int32>
+ * @param srcB_format: Input srcB format, used to set ALU configs
+ * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Float32/Int8/Int16/UInt8/Int32>
+ */
+inline void _configure_mov_src2dst_32bit_ops_data_format_state_(DataFormat srcA_format, DataFormat srcB_format)
+{
+    if (data_format_config_set == DataFormatConfigSet::MOV_SRC2DST_32BIT_OPS)
+    {
+        return;
+    }
+    TTI_STALLWAIT(p_stall::STALL_CFG, 0, p_stall::WAIT_SFPU, p_stall::MATH);
+
+    _configure_alu_formats_<false /* EN_IMPLIED_MATH_FORMAT */, true /* EN_FP32_DEST_FORMAT */, false /* EN_INT32_DEST_FORMAT */>(srcA_format, srcB_format);
+
+    data_format_config_set = DataFormatConfigSet::MOV_SRC2DST_32BIT_OPS;
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
@@ -113,29 +113,46 @@ inline void _llk_math_upk_to_dest_hw_configure_()
     }
 }
 
+// Bitmask helper: maps a DataFormat enum value to its corresponding bit in a 64-bit set
+inline constexpr std::uint64_t df_bit(DataFormat df)
+{
+    return 1ULL << to_underlying(df);
+}
+
+// Set of Source register DataFormats compatible with Float32 Dest register format
+inline constexpr std::uint64_t kFp32DestCompatibleMask = df_bit(DataFormat::Float16_b) | df_bit(DataFormat::Float16) | df_bit(DataFormat::Tf32) |
+                                                         df_bit(DataFormat::Float32) | df_bit(DataFormat::MxFp4_2x_A) | df_bit(DataFormat::MxFp4_2x_B);
+
+// Set of Source register DataFormats compatible with Int32 Dest register format
+// Int16 is absent from the list because, for the FPU, it is supported only for MOV ops and is
+// not compatible with 32bit Dest register mode.
+inline constexpr std::uint64_t kInt32DestCompatibleMask =
+    df_bit(DataFormat::Int8) | df_bit(DataFormat::UInt8) | df_bit(DataFormat::Int32) | df_bit(DataFormat::Int8_2x) | df_bit(DataFormat::UInt8_2x);
+
 /**
  * @brief Determines whether the source register format and Float32 destination register format are a supported combination
  *
- * @param src_reg_fmt: The source register format
+ * @param src_reg_fmt: Source register format
+ * @return true if the bit corresponding to src_reg_fmt is set in kFp32DestCompatibleMask.
+ *         The mask is right-shifted by the enum value so the relevant bit lands at position 0,
+ *         then AND-ed with 1 to isolate it.
  */
 inline bool _is_src_fmt_fp32_dest_compatible_(const DataFormat src_reg_fmt)
 {
-    return src_reg_fmt == DataFormat::Float16_b || src_reg_fmt == DataFormat::Float16 || src_reg_fmt == DataFormat::Tf32 ||
-           src_reg_fmt == DataFormat::Float32 || src_reg_fmt == DataFormat::MxFp4_2x_A || src_reg_fmt == DataFormat::MxFp4_2x_B;
+    return (kFp32DestCompatibleMask >> to_underlying(src_reg_fmt)) & 1;
 }
 
 /**
  * @brief Determines whether the source register format and Int32 destination register format are a supported combination
  *
- * @param src_reg_fmt: The source register format
- *
- * Int16 is absent from the list because, for the FPU, it is supported only for MOV ops and is
- * not compatible with 32bit Dest register mode.
+ * @param src_reg_fmt: Source register format
+ * @return true if the bit corresponding to src_reg_fmt is set in kInt32DestCompatibleMask.
+ *         The mask is right-shifted by the enum value so the relevant bit lands at position 0,
+ *         then AND-ed with 1 to isolate it.
  */
 inline bool _is_src_fmt_int32_dest_compatible_(const DataFormat src_reg_fmt)
 {
-    return src_reg_fmt == DataFormat::Int8 || src_reg_fmt == DataFormat::UInt8 || src_reg_fmt == DataFormat::Int32 || src_reg_fmt == DataFormat::Int8_2x ||
-           src_reg_fmt == DataFormat::UInt8_2x;
+    return (kInt32DestCompatibleMask >> to_underlying(src_reg_fmt)) & 1;
 }
 
 /**


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/42789

### Summary
This PR aims to solve the issue of having different ALU data format config state for different ops. The idea is that the inits set up the desired data format cfg state for each math OP. If the correct state is already set, reconfig is skipped.

Currently, the possible ALU data fmt cfg states are `MOV_OPS_EXPLICIT_FMT`, which is used for MOV src to dest and vice versa ops (transpose dest currently), and `DEFAULT`, which is used for everything else.

Functions that support ALU data fmt state tracking are implemented in this PR and used in the transpose dest tt-llk test infra test for Quasar.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/data_fmt_cfg_state_take2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/data_fmt_cfg_state_take2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/data_fmt_cfg_state_take2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/data_fmt_cfg_state_take2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amokan/data_fmt_cfg_state_take2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amokan/data_fmt_cfg_state_take2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/data_fmt_cfg_state_take2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/data_fmt_cfg_state_take2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/data_fmt_cfg_state_take2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/data_fmt_cfg_state_take2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/data_fmt_cfg_state_take2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/data_fmt_cfg_state_take2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/data_fmt_cfg_state_take2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/data_fmt_cfg_state_take2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/data_fmt_cfg_state_take2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/data_fmt_cfg_state_take2)