### PR TITLE
Optimize conv3d data movement paths

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
@@ -4,13 +4,17 @@
 
 #include "conv3d_program_factory.hpp"
 #include "conv3d_device_operation_types.hpp"
+#include "kernels/conv3d_gather_tuning.hpp"
+#include "kernels/conv3d_weight_share.hpp"
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/constants.hpp>
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/data_movement/pad/pad.hpp"
 #include <algorithm>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/hal.hpp>
+#include <hostdevcommon/common_values.hpp>
 
 namespace ttnn::experimental::prim {
 
@@ -109,13 +113,18 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
 
     // Matmul subblock sizing. out_subblock_w fills the dst register row; out_subblock_h
     // batches multiple tile-rows per matmul call for weight reuse.
-    // On Wormhole B0 the matmul unit benefits from sub_h > 1 (preferred 2×4 subblock).
-    // On Blackhole the row-by-row fused tilize+matmul is faster, so keep sub_h = 1 with optimized blockings.
-    const uint32_t dst_size = fp32_dest_acc_en ? 4 : 8;
+    // On Wormhole B0 the matmul unit benefits from sub_h > 1 (preferred 2x4 subblock).
+    // On Blackhole the row-by-row fused tilize+matmul is faster with the current
+    // row-major subblock layout, so keep sub_h = 1 with optimized blockings.
+    const uint32_t dst_size = ttnn::get_dest_reg_count(compute_kernel_config);
     const uint32_t out_subblock_w = std::min(matmul_N_t, dst_size);
-    const bool scale_subblock_h =
-        tt::tt_metal::hal::get_arch() == tt::ARCH::WORMHOLE_B0 && out_subblock_w == matmul_N_t;
+    const auto arch = tt::tt_metal::hal::get_arch();
+    const bool scale_subblock_h = arch == tt::ARCH::WORMHOLE_B0 && out_subblock_w == matmul_N_t;
     const uint32_t out_subblock_h = scale_subblock_h ? largest_divisor_up_to(matmul_M_t, dst_size / out_subblock_w) : 1;
+    const uint32_t output_write_bytes_per_transaction = C_out_block * dtype_bytes;
+    const bool small_output_write_transactions =
+        output_write_bytes_per_transaction <= tt::constants::TILE_WIDTH * dtype_bytes;
+    const bool enable_streaming_output = C_in_num_blocks == 1 && matmul_M_t > 1 && small_output_write_transactions;
 
     uint32_t num_patches_tile_padded = tt::round_up(num_patches, tt::constants::TILE_HEIGHT);
 
@@ -184,14 +193,6 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         matmul_M_t * matmul_N_t,  // untilize will write padded rows, so this must be sized to avoid overflowing CB
         data_format);
 
-    // Zero-filled CB for FPU accumulate: add_tiles does DST += A + B, so we use B=0
-    // to effectively do DST += A for fp32 reduction accumulation.
-    uint32_t cb_zero_tiled_id = 32;
-    if (use_fp32_partials) {
-        cb_zero_tiled_id = next_cb_index++;
-        tt::tt_metal::create_cb(cb_zero_tiled_id, program, core_grid, tile_size, 1, data_format);
-    }
-
     uint32_t cb_reduction_tiled_id =
         32;  // Invalid value for cb index since there is only 32 of them and the indices go from 0 to 31
     uint32_t cb_worker_ack_back_id =
@@ -228,6 +229,16 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
 
     bool is_padding_zeros = operation_attributes.padding_mode == "zeros";
 
+    uint32_t in_row_size_bytes = input_tensor.buffer()->aligned_page_size();
+    uint32_t out_row_size_bytes = output_tensor.buffer()->aligned_page_size();
+
+    const uint32_t device_num_dram_banks = static_cast<uint32_t>(input_tensor.device()->num_dram_channels());
+    TT_FATAL(device_num_dram_banks > 0, "Device must report at least one DRAM channel");
+    const bool input_is_dram_interleaved =
+        input_tensor.buffer()->is_dram() &&
+        input_tensor.buffer()->buffer_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED &&
+        !input_tensor.buffer()->buffer_distribution_spec().has_value();
+
     // L1 pre-fetch buffer for kernels > 1x1x1 with no dilation.
     // Gathers the spatial receptive field from DRAM once per spatial block, then vol2col reads from L1.
     // Budget: remaining L1 after other CBs and kernel code/stack, capped at 500 KB.
@@ -246,9 +257,6 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         other_cbs_bytes += partial_tile_size * matmul_M_t * matmul_N_t;  // reduction (same format as partials)
         other_cbs_bytes += tile_size;                                    // worker_ack
     }
-    if (use_fp32_partials) {
-        other_cbs_bytes += tile_size;  // zero tile for FPU accumulate reduction
-    }
     if (use_bias) {
         other_cbs_bytes += tile_size * matmul_N_t;  // bias
     }
@@ -258,11 +266,22 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
     const uint32_t kT = operation_attributes.kernel_size[0];
     const uint32_t kH = operation_attributes.kernel_size[1];
     const uint32_t kW = operation_attributes.kernel_size[2];
+    const uint32_t W_shard_full_for_coalesce =
+        (config.W_out_block - 1) * operation_attributes.stride[2] + operation_attributes.kernel_size[2];
+    const uint32_t coalesced_read_row_bytes = C_in_block_bytes;
+    // Coalescing pays for a scratch L1 reorder pass; require enough columns to give each
+    // DRAM bank multiple pages so the larger bank-local bursts amortize the extra L1 traffic.
+    const uint32_t coalesced_min_w_shard = 2 * device_num_dram_banks;
+    const bool coalesced_shard_reads_candidate = input_is_dram_interleaved && C_in_num_blocks == 1 &&
+                                                 C_in_block_bytes == in_row_size_bytes &&
+                                                 W_shard_full_for_coalesce >= coalesced_min_w_shard;
 
     uint32_t cb_input_shard_id = 32;  // Invalid; set below if using L1 prefetch
     uint32_t T_shard_max = 0;
     uint32_t H_shard_max = 0;
     uint32_t W_shard_max = 0;
+    bool enable_coalesced_shard_reads = false;
+    uint32_t coalesced_scratch_rows = 0;
 
     const bool has_spatial_reuse = (kT > 1 || kH > 1 || kW > 1);
     const bool has_no_dilation =
@@ -278,21 +297,44 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         W_shard_max = (config.W_out_block - 1) * operation_attributes.stride[2] + kW;
         uint32_t shard_positions_max = T_shard_max * H_shard_max * W_shard_max;
         uint32_t shard_bytes = shard_positions_max * C_in_block_bytes;
+        uint32_t shard_rows_max = T_shard_max * H_shard_max;
+        uint32_t coalesced_scratch_pages_per_row = W_shard_max;
+        uint32_t coalesced_scratch_row_bytes = coalesced_scratch_pages_per_row * C_in_block_bytes;
+        uint32_t coalesced_scratch_rows_fit = (coalesced_scratch_row_bytes > 0 && shard_bytes < l1_prefetch_max_bytes)
+                                                  ? (l1_prefetch_max_bytes - shard_bytes) / coalesced_scratch_row_bytes
+                                                  : 0;
+        uint32_t coalesced_scratch_rows_candidate =
+            coalesced_shard_reads_candidate ? std::min(shard_rows_max, coalesced_scratch_rows_fit) : 0;
+        // Keep at least one row per DRAM bank in scratch when possible; smaller batches underfill the
+        // coalesced gather and tend to lose to the direct reader after the L1 reorder cost.
+        uint32_t coalesced_scratch_rows_min =
+            coalesced_shard_reads_candidate ? std::min(shard_rows_max, device_num_dram_banks) : 0;
+        uint32_t coalesced_scratch_positions = coalesced_scratch_rows_candidate * coalesced_scratch_pages_per_row;
+        uint32_t shard_positions_with_coalesced_scratch = shard_positions_max + coalesced_scratch_positions;
+        uint32_t shard_bytes_with_coalesced_scratch = shard_positions_with_coalesced_scratch * C_in_block_bytes;
 
         if (shard_bytes <= l1_prefetch_max_bytes) {
+            enable_coalesced_shard_reads = coalesced_shard_reads_candidate &&
+                                           coalesced_scratch_rows_candidate >= coalesced_scratch_rows_min &&
+                                           shard_bytes_with_coalesced_scratch <= l1_prefetch_max_bytes;
+            coalesced_scratch_rows = enable_coalesced_shard_reads ? coalesced_scratch_rows_candidate : 0;
+            const uint32_t shard_positions_alloc =
+                shard_positions_max + coalesced_scratch_rows * coalesced_scratch_pages_per_row;
+            const uint32_t shard_bytes_alloc = shard_positions_alloc * C_in_block_bytes;
             cb_input_shard_id = next_cb_index++;
             tt::tt_metal::create_cb(
-                cb_input_shard_id, program, core_grid, C_in_block_bytes, shard_positions_max, data_format);
+                cb_input_shard_id, program, core_grid, C_in_block_bytes, shard_positions_alloc, data_format);
 
             log_debug(
                 tt::LogOp,
                 "L1 prefetch: T_shard_max={}, H_shard_max={}, W_shard_max={}, shard_positions={}, "
-                "shard_bytes={}, cb_id={}",
+                "scratch_positions={}, shard_bytes={}, cb_id={}",
                 T_shard_max,
                 H_shard_max,
                 W_shard_max,
                 shard_positions_max,
-                shard_bytes,
+                coalesced_scratch_rows * coalesced_scratch_pages_per_row,
+                shard_bytes_alloc,
                 cb_input_shard_id);
         } else {
             log_debug(
@@ -306,8 +348,10 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         }
     }
 
-    uint32_t in_row_size_bytes = input_tensor.buffer()->aligned_page_size();
-    uint32_t out_row_size_bytes = output_tensor.buffer()->aligned_page_size();
+    const uint32_t coalesced_max_chunk_bytes =
+        enable_coalesced_shard_reads
+            ? tt::div_up(W_shard_full_for_coalesce, device_num_dram_banks) * coalesced_read_row_bytes
+            : 0;
 
     log_debug(tt::LogOp, "Input tensor shape: N={}, T={}, H={}, W={}, C={}", N, T_in, H_in, W_in, C_in);
     log_debug(tt::LogOp, "Output tensor shape: T={}, H={}, W={}, C={}", T_out, H_out, W_out, C_out);
@@ -340,160 +384,19 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
     log_debug(tt::LogOp, "Input row size (bytes): {}", in_row_size_bytes);
     log_debug(tt::LogOp, "Output row size (bytes): {}", out_row_size_bytes);
     log_debug(tt::LogOp, "Data format: {}", data_format);
-
-    // Set up semaphore for synchronization. It is dual-purpose.
-    // On the reducer core, it tracks the number of workers that are done with an output block.
-    // On the worker core, it is a valid bit indicating the worker can continue.
-    auto semaphore_id = tt::tt_metal::CreateSemaphore(program, core_grid, 0);
-
-    std::vector<uint32_t> reader_compile_time_args = {
-        cb_vol2col_rm_id,
-        N,
-        T_in,
-        H_in,
-        W_in,
-        C_in,
-        T_out,
-        H_out,
-        W_out,
-        C_out,
-        operation_attributes.padding[0],
-        operation_attributes.padding[1],
-        operation_attributes.padding[2],
-        operation_attributes.kernel_size[0],
-        operation_attributes.kernel_size[1],
-        operation_attributes.kernel_size[2],
-        config.T_out_block,
-        config.H_out_block,
-        config.W_out_block,
-        C_out_num_blocks,
-        in_row_size_bytes,
-        C_in_block_bytes,
-        out_row_size_bytes,
-        is_padding_zeros,
-        semaphore_id,
-        operation_attributes.stride[0],
-        operation_attributes.stride[1],
-        operation_attributes.stride[2],
-        operation_attributes.dilation[0],
-        operation_attributes.dilation[1],
-        operation_attributes.dilation[2],
-        cb_input_shard_id,
-        T_shard_max,
-        H_shard_max,
-        W_shard_max,
-        patch_pad_bytes};
-    tt::tt_metal::TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_compile_time_args);
-
-    auto reader_kernels_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp",
-        core_grid,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
-
-    // Matmul parameters (out_subblock_h, out_subblock_w, dst_size computed earlier for CB sizing)
-    const uint32_t in0_block_w = matmul_K_t;
-
-    TT_FATAL(matmul_N_t % out_subblock_w == 0, "matmul_N_t must be divisible by out_subblock_w");
-    TT_FATAL(
-        matmul_M_t % out_subblock_h == 0,
-        "matmul_M_t ({}) must be divisible by out_subblock_h ({})",
-        matmul_M_t,
-        out_subblock_h);
-    const uint32_t in0_num_subblocks = 1;
-    const uint32_t in1_num_subblocks = matmul_N_t / out_subblock_w;
-
-    log_debug(tt::LogOp, "Matmul parameters:");
-    log_debug(tt::LogOp, "  matmul_M_t: {}", matmul_M_t);
-    log_debug(tt::LogOp, "  matmul_K_t: {}", matmul_K_t);
-    log_debug(tt::LogOp, "  matmul_N_t: {}", matmul_N_t);
-    log_debug(tt::LogOp, "  dst_size: {}", dst_size);
-    log_debug(tt::LogOp, "  in0_block_w: {}", in0_block_w);
-    log_debug(tt::LogOp, "  out_subblock_w: {}", out_subblock_w);
-    log_debug(tt::LogOp, "  out_subblock_h: {}", out_subblock_h);
-    log_debug(tt::LogOp, "  in0_num_subblocks: {}", in0_num_subblocks);
-    log_debug(tt::LogOp, "  in1_num_subblocks: {}", in1_num_subblocks);
-
-    std::vector<uint32_t> compute_compile_time_args = {
-        cb_vol2col_rm_id,
-        cb_vol2col_tiled_id,
-        cb_weight_tiled_id,
-        cb_bias_tiled_id,
-        cb_matmul_interm_tiled_id,
-        cb_matmul_result_rm_id,
-        cb_reduction_tiled_id,
-        cb_worker_ack_back_id,
-        N,
-        num_patches,
-        matmul_M_t,
-        matmul_K_t,
-        matmul_N_t,
-        (uint32_t)use_bias,
-        T_out,
-        H_out,
-        W_out,
-        config.T_out_block,
-        config.H_out_block,
-        config.W_out_block,
-        C_out_num_blocks,
-        in0_num_subblocks,
-        in1_num_subblocks,
-        in0_block_w,
+    log_debug(
+        tt::LogOp,
+        "Coalesced shard reads: enable={}, dram_banks={}, W_shard_full={}, scratch_rows={}, read_row_bytes={}, "
+        "max_chunk_bytes={}, streaming_output={}, out_subblock={}x{}",
+        enable_coalesced_shard_reads,
+        device_num_dram_banks,
+        W_shard_full_for_coalesce,
+        coalesced_scratch_rows,
+        coalesced_read_row_bytes,
+        coalesced_max_chunk_bytes,
+        enable_streaming_output,
         out_subblock_h,
-        out_subblock_w,
-        semaphore_id,
-        (uint32_t)use_fp32_partials,
-        cb_zero_tiled_id};
-
-    auto compute_kernels_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp",
-        core_grid,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .math_approx_mode = math_approx_mode,
-            .compile_args = compute_compile_time_args});
-
-    std::vector<uint32_t> writer_compile_time_args = {
-        cb_matmul_result_rm_id,
-        cb_weight_tiled_id,
-        cb_bias_tiled_id,
-        cb_matmul_interm_tiled_id,
-        cb_reduction_tiled_id,
-        cb_worker_ack_back_id,
-        N,
-        T_out,
-        H_out,
-        W_out,
-        config.T_out_block,
-        config.H_out_block,
-        config.W_out_block,
-        C_out_num_blocks,
-        matmul_M_t,
-        matmul_K_t,
-        matmul_N_t,
-        num_patches_tile_padded,
-        out_row_size_bytes,
-        C_out_block_bytes,
-        (uint32_t)use_bias,
-        semaphore_id,
-        cb_zero_tiled_id};
-    tt::tt_metal::TensorAccessorArgs(*output_tensor.buffer()).append_to(writer_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*weight_tensor.buffer()).append_to(writer_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(bias_tensor.has_value() ? bias_tensor.value().buffer() : nullptr)
-        .append_to(writer_compile_time_args);
-
-    auto writer_kernels_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp",
-        core_grid,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
-
-    uint32_t input_addr = input_tensor.buffer()->address();
-    uint32_t out_addr = output_tensor.buffer()->address();
-    uint32_t weight_addr = weight_tensor.buffer()->address();
-    uint32_t bias_addr = bias_tensor.has_value() ? bias_tensor.value().buffer()->address() : 0;
+        out_subblock_w);
 
     /**
      * Compute parallelism for multi-core.
@@ -566,165 +469,554 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
     const uint32_t h_out_per_core = tt::div_up(H_out_blocks, h_out_parallel_factor);
     const uint32_t w_out_per_core = tt::div_up(W_out_blocks, w_out_parallel_factor);
 
-    // Track cores that need to perform reduction together
-    std::vector<std::vector<uint32_t>> reduction_groups(total_output_parallel);
+    // Weight sharing: all cores with the same (c_in_idx, c_out_idx) read identical weights.
+    // weight_share_mode (see WeightShareMode in conv3d_weight_share.hpp):
+    //   Disabled — single-core group: each active core reads its own weight slice.
+    //   Chain    — per-group forwarding chain (SDPA-style hop chain).
+    //   Mcast    — each group multicasts over its own row-strip rectangle.
+    //
+    // Layout for mcast: each group occupies `rows_per_group = ceil(group_size / grid.x)`
+    // contiguous rows, full grid width. The `num_groups` strips stack along Y. Within a strip,
+    // active cores fill row-major; the trailing slots become passive participants. This makes
+    // every group a clean rectangle, lets each one fire its own hardware multicast, and keeps
+    // reduction-pair members vertically aligned (same x, y differing by a multiple of strip
+    // height) so reduction reads stay short. Falls back to chain if the strips don't fit.
+    const uint32_t group_size = t_out_parallel_factor * h_out_parallel_factor * w_out_parallel_factor;
+    const uint32_t num_groups = c_in_parallel_factor * c_out_parallel_factor;
+    WeightShareMode weight_share_mode = WeightShareMode::Disabled;
+    uint32_t mcast_rows_per_group = 0;
+    if (group_size > 1) {
+        const uint32_t rows_per_group = (group_size + grid_size.x - 1) / grid_size.x;
+        const bool mcast_fits = (uint64_t)num_groups * rows_per_group <= grid_size.y;
+        if (mcast_fits) {
+            weight_share_mode = WeightShareMode::Mcast;
+            mcast_rows_per_group = rows_per_group;
+        } else {
+            weight_share_mode = WeightShareMode::Chain;
+        }
+    }
+    log_debug(
+        tt::LogOp,
+        "Weight share: mode={}, group_size={}, num_groups={}, rows_per_group={}",
+        static_cast<uint32_t>(weight_share_mode),
+        group_size,
+        num_groups,
+        mcast_rows_per_group);
 
-    // First loop: Calculate runtime args and build reduction groups
-    std::vector<std::vector<uint32_t>> reader_args_per_core(num_cores);
-    std::vector<std::vector<uint32_t>> compute_args_per_core(num_cores);
-    std::vector<std::vector<uint32_t>> writer_args_per_core(num_cores);
-    std::vector<uint32_t> reducer_core_ids(total_output_parallel, UINT32_MAX);
-    std::vector<std::vector<uint32_t>> worker_core_ids(total_output_parallel);
+    // Set up semaphore for synchronization. It is dual-purpose.
+    // On the reducer core, it tracks the number of workers that are done with an output block.
+    // On the worker core, it is a valid bit indicating the worker can continue.
+    auto semaphore_id = tt::tt_metal::CreateSemaphore(program, core_grid, 0);
 
-    // Track physical coordinates for reducers and workers
-    std::vector<uint32_t> reducer_core_physical_xs(total_output_parallel);
-    std::vector<uint32_t> reducer_core_physical_ys(total_output_parallel);
-    std::vector<std::vector<uint32_t>> worker_core_physical_xs(total_output_parallel);
-    std::vector<std::vector<uint32_t>> worker_core_physical_ys(total_output_parallel);
+    // Weight-mcast semaphores. Always created so writer kernel can take their ids as compile-time
+    // constants. They are only used when enable_weight_mcast is true at runtime.
+    auto weights_mcast_sender_sem_id = tt::tt_metal::CreateSemaphore(program, core_grid, INVALID);
+    auto weights_mcast_receiver_sem_id = tt::tt_metal::CreateSemaphore(program, core_grid, INVALID);
+
+    // Trid-ring depth for gather_rows_to_shard.  Per-shape autotune (see
+    // conv3d_trid_pipeline_findings.md).  Cutoff constants live in
+    // kernels/conv3d_gather_tuning.hpp so the kernel-side per-call fast-path stays
+    // pinned to the same numbers.  Two data-movement metrics gate the ring:
+    //
+    //   1. Reader-vs-compute balance — bytes per matmul tile op:
+    //      intensity = T_shard * H_shard * W_shard * C_in_block_bytes / (M_t * K_t * N_t)
+    //      Below kGatherIntensityCutoffBytes the kernel is compute-bound; ring overhead
+    //      exceeds reader gain.
+    //
+    //   2. Representative gather burst size — reads per inner gather:
+    //      inner_burst = T_shard * W_shard
+    //      Below kGatherInnerBurstCutoff the host does not compile ring support. The
+    //      reader still applies the stricter 2 * selected_trid_depth per-call guard
+    //      before using the ring, so small edge gathers fall back to a single barrier.
+    //
+    // When either threshold fails, gather_trids = 0 and all ring code in the kernel is
+    // constexpr-elided.
+    const uint32_t k_T = operation_attributes.kernel_size[0];
+    const uint32_t k_H = operation_attributes.kernel_size[1];
+    const uint32_t k_W = operation_attributes.kernel_size[2];
+    const uint32_t T_shard = (config.T_out_block - 1) * operation_attributes.stride[0] + k_T;
+    const uint32_t H_shard = (config.H_out_block - 1) * operation_attributes.stride[1] + k_H;
+    const uint32_t W_shard = (config.W_out_block - 1) * operation_attributes.stride[2] + k_W;
+    const uint64_t reader_bytes_per_block = static_cast<uint64_t>(T_shard) * H_shard * W_shard * C_in_block_bytes;
+    const uint64_t matmul_tiles = static_cast<uint64_t>(matmul_M_t) * matmul_K_t * matmul_N_t;
+    const uint64_t bytes_per_tile = matmul_tiles == 0 ? 0 : (reader_bytes_per_block / matmul_tiles);
+    const uint32_t inner_gather_burst = T_shard * W_shard;
+    // Adaptive depth: shapes with inner_burst >= kGatherTridDepthHigh fill the deeper
+    // ring; smaller bursts that still clear the lower cutoff use the shallower ring
+    // (depth-8 drain on a small burst would barrier-on-(i-N) before earlier reads
+    // had time to drain — same anti-pattern that the cutoff guards against, just at
+    // a finer granularity). Below the lower cutoff or below the intensity floor,
+    // ring is fully off.
+    const bool intensity_pass = bytes_per_tile >= conv3d_gather_tuning::kGatherIntensityCutoffBytes;
+    uint32_t gather_trids = 0;
+    if (intensity_pass) {
+        if (inner_gather_burst >= conv3d_gather_tuning::kGatherTridDepthHigh) {
+            gather_trids = conv3d_gather_tuning::kGatherTridDepthHigh;
+        } else if (inner_gather_burst >= conv3d_gather_tuning::kGatherInnerBurstCutoff) {
+            gather_trids = conv3d_gather_tuning::kGatherTridDepthLow;
+        }
+    }
+
+    // Coalesced shard reads already issue larger DRAM transactions through the scratch window.
+    // Keeping the trid ring enabled only affects fallback edge gathers and measured as overhead.
+    if (enable_coalesced_shard_reads) {
+        gather_trids = 0;
+    }
+    log_debug(
+        tt::LogOp,
+        "gather trid ring: bytes_per_tile={}, inner_burst={}, gather_trids={}",
+        bytes_per_tile,
+        inner_gather_burst,
+        gather_trids);
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        cb_vol2col_rm_id,
+        N,
+        T_in,
+        H_in,
+        W_in,
+        C_in,
+        T_out,
+        H_out,
+        W_out,
+        C_out,
+        operation_attributes.padding[0],
+        operation_attributes.padding[1],
+        operation_attributes.padding[2],
+        operation_attributes.kernel_size[0],
+        operation_attributes.kernel_size[1],
+        operation_attributes.kernel_size[2],
+        config.T_out_block,
+        config.H_out_block,
+        config.W_out_block,
+        C_out_num_blocks,
+        in_row_size_bytes,
+        C_in_block_bytes,
+        out_row_size_bytes,
+        is_padding_zeros,
+        semaphore_id,
+        operation_attributes.stride[0],
+        operation_attributes.stride[1],
+        operation_attributes.stride[2],
+        operation_attributes.dilation[0],
+        operation_attributes.dilation[1],
+        operation_attributes.dilation[2],
+        cb_input_shard_id,
+        T_shard_max,
+        H_shard_max,
+        W_shard_max,
+        patch_pad_bytes,
+        gather_trids,
+        static_cast<uint32_t>(enable_coalesced_shard_reads),
+        coalesced_scratch_rows};
+    tt::tt_metal::TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_compile_time_args);
+
+    auto reader_kernels_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp",
+        core_grid,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    // Matmul parameters (out_subblock_h, out_subblock_w, dst_size computed earlier for CB sizing)
+    const uint32_t in0_block_w = matmul_K_t;
+
+    TT_FATAL(matmul_N_t % out_subblock_w == 0, "matmul_N_t must be divisible by out_subblock_w");
+    TT_FATAL(
+        matmul_M_t % out_subblock_h == 0,
+        "matmul_M_t ({}) must be divisible by out_subblock_h ({})",
+        matmul_M_t,
+        out_subblock_h);
+    const uint32_t in0_num_subblocks = 1;
+    const uint32_t in1_num_subblocks = matmul_N_t / out_subblock_w;
+
+    log_debug(tt::LogOp, "Matmul parameters:");
+    log_debug(tt::LogOp, "  matmul_M_t: {}", matmul_M_t);
+    log_debug(tt::LogOp, "  matmul_K_t: {}", matmul_K_t);
+    log_debug(tt::LogOp, "  matmul_N_t: {}", matmul_N_t);
+    log_debug(tt::LogOp, "  dst_size: {}", dst_size);
+    log_debug(tt::LogOp, "  in0_block_w: {}", in0_block_w);
+    log_debug(tt::LogOp, "  out_subblock_w: {}", out_subblock_w);
+    log_debug(tt::LogOp, "  out_subblock_h: {}", out_subblock_h);
+    log_debug(tt::LogOp, "  in0_num_subblocks: {}", in0_num_subblocks);
+    log_debug(tt::LogOp, "  in1_num_subblocks: {}", in1_num_subblocks);
+
+    std::vector<uint32_t> compute_compile_time_args = {
+        cb_vol2col_rm_id,
+        cb_vol2col_tiled_id,
+        cb_weight_tiled_id,
+        cb_bias_tiled_id,
+        cb_matmul_interm_tiled_id,
+        cb_matmul_result_rm_id,
+        cb_reduction_tiled_id,
+        cb_worker_ack_back_id,
+        N,
+        num_patches,
+        matmul_M_t,
+        matmul_K_t,
+        matmul_N_t,
+        (uint32_t)use_bias,
+        T_out,
+        H_out,
+        W_out,
+        config.T_out_block,
+        config.H_out_block,
+        config.W_out_block,
+        C_out_num_blocks,
+        in0_num_subblocks,
+        in1_num_subblocks,
+        in0_block_w,
+        out_subblock_h,
+        out_subblock_w,
+        semaphore_id,
+        (uint32_t)use_fp32_partials,
+        // Stream final output rows only for many small output writes when there is a writer tail to overlap.
+        (uint32_t)(enable_streaming_output ? 1 : 0)};
+
+    auto compute_kernels_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp",
+        core_grid,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_compile_time_args});
+
+    std::vector<uint32_t> writer_compile_time_args = {
+        cb_matmul_result_rm_id,
+        cb_weight_tiled_id,
+        cb_bias_tiled_id,
+        cb_matmul_interm_tiled_id,
+        cb_reduction_tiled_id,
+        cb_worker_ack_back_id,
+        N,
+        T_out,
+        H_out,
+        W_out,
+        config.T_out_block,
+        config.H_out_block,
+        config.W_out_block,
+        C_out_num_blocks,
+        matmul_M_t,
+        matmul_K_t,
+        matmul_N_t,
+        num_patches_tile_padded,
+        out_row_size_bytes,
+        C_out_block_bytes,
+        (uint32_t)use_bias,
+        semaphore_id,
+        static_cast<uint32_t>(weight_share_mode),
+        weights_mcast_sender_sem_id,
+        weights_mcast_receiver_sem_id,
+        static_cast<uint32_t>(enable_streaming_output)};
+    tt::tt_metal::TensorAccessorArgs(*output_tensor.buffer()).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*weight_tensor.buffer()).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(bias_tensor.has_value() ? bias_tensor.value().buffer() : nullptr)
+        .append_to(writer_compile_time_args);
+
+    auto writer_kernels_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp",
+        core_grid,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    uint32_t input_addr = input_tensor.buffer()->address();
+    uint32_t out_addr = output_tensor.buffer()->address();
+    uint32_t weight_addr = weight_tensor.buffer()->address();
+    uint32_t bias_addr = bias_tensor.has_value() ? bias_tensor.value().buffer()->address() : 0;
+
+    // Per-core work assignment via the original core_id row-major mapping. See WeightMcastRole
+    // in conv3d_weight_share.hpp for the role values.
+    struct CoreWork {
+        bool has_work = false;
+        bool is_reducer = false;
+        uint32_t c_in_idx = 0;
+        uint32_t c_out_idx = 0;
+        uint32_t t_out_idx = 0;
+        uint32_t h_out_idx = 0;
+        uint32_t w_out_idx = 0;
+        uint32_t reduction_group_id = 0;
+        uint32_t mcast_group_id = 0;
+        uint32_t c_in_block_start = 0, c_in_block_end = 0;
+        uint32_t c_out_block_start = 0, c_out_block_end = 0;
+        uint32_t t_out_start = 0, t_out_end = 0;
+        uint32_t h_out_start = 0, h_out_end = 0;
+        uint32_t w_out_start = 0, w_out_end = 0;
+        WeightMcastRole weight_mcast_role = WeightMcastRole::Local;
+        // Chain pred/succ (chain roles) or mcast sender NoC (mcast receiver/passive use pred fields).
+        // McastSender also carries the sender coordinate here for uniform runtime args; writer ignores it.
+        uint32_t pred_noc_x = 0, pred_noc_y = 0;
+        uint32_t succ_noc_x = 0, succ_noc_y = 0;
+        // Mcast bbox in physical NoC coords (already swapped for NOC_1). Sender role only.
+        uint32_t mcast_bbox_start_x = 0, mcast_bbox_start_y = 0;
+        uint32_t mcast_bbox_end_x = 0, mcast_bbox_end_y = 0;
+        uint32_t mcast_num_dests = 0;
+        // Iterations for passive participation: matches active receivers' loop count.
+        uint32_t mcast_num_iters = 0;
+    };
 
     auto cores = corerange_to_cores(core_grid, num_cores, true);
     auto* device = input_tensor.device();
+    std::vector<CoreWork> core_work(num_cores);
+
+    auto compute_block_ranges = [&](CoreWork& cw) {
+        cw.c_in_block_start = cw.c_in_idx * c_in_per_core;
+        cw.c_in_block_end = std::min(cw.c_in_block_start + c_in_per_core, C_in_num_blocks);
+        cw.c_out_block_start = cw.c_out_idx * c_out_per_core;
+        cw.c_out_block_end = std::min(cw.c_out_block_start + c_out_per_core, C_out_num_blocks);
+        const uint32_t t_block_start = cw.t_out_idx * t_out_per_core;
+        const uint32_t t_block_end = std::min(t_block_start + t_out_per_core, T_out_blocks);
+        const uint32_t h_block_start = cw.h_out_idx * h_out_per_core;
+        const uint32_t h_block_end = std::min(h_block_start + h_out_per_core, H_out_blocks);
+        const uint32_t w_block_start = cw.w_out_idx * w_out_per_core;
+        const uint32_t w_block_end = std::min(w_block_start + w_out_per_core, W_out_blocks);
+        cw.t_out_start = t_block_start * config.T_out_block;
+        cw.t_out_end = std::min(t_block_end * config.T_out_block, T_out);
+        cw.h_out_start = h_block_start * config.H_out_block;
+        cw.h_out_end = std::min(h_block_end * config.H_out_block, H_out);
+        cw.w_out_start = w_block_start * config.W_out_block;
+        cw.w_out_end = std::min(w_block_end * config.W_out_block, W_out);
+        cw.has_work = (cw.c_in_block_end > cw.c_in_block_start) && (cw.c_out_block_end > cw.c_out_block_start) &&
+                      (cw.t_out_end > cw.t_out_start) && (cw.h_out_end > cw.h_out_start) &&
+                      (cw.w_out_end > cw.w_out_start);
+        cw.is_reducer = cw.has_work && cw.c_in_idx == 0;
+        cw.reduction_group_id = cw.c_out_idx * (t_out_parallel_factor * h_out_parallel_factor * w_out_parallel_factor) +
+                                cw.t_out_idx * (h_out_parallel_factor * w_out_parallel_factor) +
+                                cw.h_out_idx * w_out_parallel_factor + cw.w_out_idx;
+        cw.mcast_group_id = cw.c_in_idx * c_out_parallel_factor + cw.c_out_idx;
+    };
 
     for (uint32_t core_id = 0; core_id < num_cores; ++core_id) {
-        CoreCoord core = cores.at(core_id);
-
-        // First, determine which output block and which C_in range this core handles
-        uint32_t output_idx = core_id % total_output_parallel;
-        uint32_t c_in_idx = core_id / total_output_parallel;
-
-        // Decompose output_idx into (c_out, t_out, h_out, w_out) coordinates
-        uint32_t c_out_idx = output_idx / (t_out_parallel_factor * h_out_parallel_factor * w_out_parallel_factor);
-        uint32_t remaining = output_idx % (t_out_parallel_factor * h_out_parallel_factor * w_out_parallel_factor);
-
-        uint32_t t_out_idx = remaining / (h_out_parallel_factor * w_out_parallel_factor);
-        remaining = remaining % (h_out_parallel_factor * w_out_parallel_factor);
-
-        uint32_t h_out_idx = remaining / w_out_parallel_factor;
-        uint32_t w_out_idx = remaining % w_out_parallel_factor;
-
-        // Calculate reduction group ID (same as output_idx)
-        uint32_t reduction_group_id = output_idx;
-
-        // Calculate block ranges
-        uint32_t c_in_block_start = c_in_idx * c_in_per_core;
-        uint32_t c_in_block_end = std::min(c_in_block_start + c_in_per_core, C_in_num_blocks);
-
-        uint32_t c_out_block_start = c_out_idx * c_out_per_core;
-        uint32_t c_out_block_end = std::min(c_out_block_start + c_out_per_core, C_out_num_blocks);
-
-        uint32_t t_out_block_start = t_out_idx * t_out_per_core;
-        uint32_t t_out_block_end = std::min(t_out_block_start + t_out_per_core, T_out_blocks);
-
-        uint32_t h_out_block_start = h_out_idx * h_out_per_core;
-        uint32_t h_out_block_end = std::min(h_out_block_start + h_out_per_core, H_out_blocks);
-
-        uint32_t w_out_block_start = w_out_idx * w_out_per_core;
-        uint32_t w_out_block_end = std::min(w_out_block_start + w_out_per_core, W_out_blocks);
-
-        // Calculate actual indices
-        uint32_t t_out_start = t_out_block_start * config.T_out_block;
-        uint32_t t_out_end = std::min(t_out_block_end * config.T_out_block, T_out);
-
-        uint32_t h_out_start = h_out_block_start * config.H_out_block;
-        uint32_t h_out_end = std::min(h_out_block_end * config.H_out_block, H_out);
-
-        uint32_t w_out_start = w_out_block_start * config.W_out_block;
-        uint32_t w_out_end = std::min(w_out_block_end * config.W_out_block, W_out);
-
-        // Check if this core has actual work to do
-        bool has_work = (c_in_block_end > c_in_block_start) && (c_out_block_end > c_out_block_start) &&
-                        (t_out_end > t_out_start) && (h_out_end > h_out_start) && (w_out_end > w_out_start);
-
-        bool is_reducer = has_work && c_in_idx == 0;
-
-        // Only include in reduction group if there's actual work to do
-        if (has_work) {
-            // Add this core to its reduction group
-            reduction_groups[reduction_group_id].push_back(core_id);
-
-            // Track reducer and worker cores
-            if (is_reducer) {
-                reducer_core_ids[reduction_group_id] = core_id;
-                // Get physical coordinates for reducer core
-                auto reducer_core_physical = device->worker_core_from_logical_core(core);
-                reducer_core_physical_xs[reduction_group_id] = (uint32_t)reducer_core_physical.x;
-                reducer_core_physical_ys[reduction_group_id] = (uint32_t)reducer_core_physical.y;
-            } else {
-                worker_core_ids[reduction_group_id].push_back(core_id);
-                // Get physical coordinates for worker core
-                auto worker_core_physical = device->worker_core_from_logical_core(core);
-                worker_core_physical_xs[reduction_group_id].push_back((uint32_t)worker_core_physical.x);
-                worker_core_physical_ys[reduction_group_id].push_back((uint32_t)worker_core_physical.y);
-            }
-        }
-
-        log_debug(
-            tt::LogOp,
-            "Core {},{}: C_in=[{},{}), C_out=[{},{}), T_out=[{},{}), H_out=[{},{}), W_out=[{},{}), "
-            "ReductionGroup={}, C_in_idx={}, HasWork={}, IsReducer={}",
-            core.x,
-            core.y,
-            c_in_block_start,
-            c_in_block_end,
-            c_out_block_start,
-            c_out_block_end,
-            t_out_start,
-            t_out_end,
-            h_out_start,
-            h_out_end,
-            w_out_start,
-            w_out_end,
-            reduction_group_id,
-            c_in_idx,
-            has_work,
-            is_reducer);
-
-        // Store runtime args for later use
-        reader_args_per_core[core_id] = {
-            input_addr,
-            c_in_block_start,
-            c_in_block_end,
-            c_out_block_start,
-            c_out_block_end,
-            t_out_start,
-            t_out_end,
-            h_out_start,
-            h_out_end,
-            w_out_start,
-            w_out_end,
-        };
-
-        compute_args_per_core[core_id] = {
-            c_in_block_start,
-            c_in_block_end,
-            c_out_block_start,
-            c_out_block_end,
-            t_out_start,
-            t_out_end,
-            h_out_start,
-            h_out_end,
-            w_out_start,
-            w_out_end,
-            (uint32_t)is_reducer};
-
-        writer_args_per_core[core_id] = {
-            out_addr,
-            weight_addr,
-            bias_addr,
-            c_in_block_start,
-            c_in_block_end,
-            c_out_block_start,
-            c_out_block_end,
-            t_out_start,
-            t_out_end,
-            h_out_start,
-            h_out_end,
-            w_out_start,
-            w_out_end,
-            (uint32_t)is_reducer};
+        CoreWork& cw = core_work[core_id];
+        const uint32_t output_idx = core_id % total_output_parallel;
+        cw.c_in_idx = core_id / total_output_parallel;
+        const uint32_t hw_par = h_out_parallel_factor * w_out_parallel_factor;
+        cw.c_out_idx = output_idx / (t_out_parallel_factor * hw_par);
+        const uint32_t rem0 = output_idx % (t_out_parallel_factor * hw_par);
+        cw.t_out_idx = rem0 / hw_par;
+        const uint32_t rem1 = rem0 % hw_par;
+        cw.h_out_idx = rem1 / w_out_parallel_factor;
+        cw.w_out_idx = rem1 % w_out_parallel_factor;
+        compute_block_ranges(cw);
     }
 
-    // Log reduction groups information
+    // Per-mode setup: chain (multi-group) builds per-group forwarding chains; mcast (single
+    // group) computes a logical bbox and assigns roles to all cores within it (active and
+    // passive participants).
+    if (weight_share_mode == WeightShareMode::Chain) {
+        // Build per-group chain: order cores by core_id, link each one's predecessor and successor.
+        // Chain ordering by core_id keeps the chain "physically nearby" since core_id maps row-major
+        // onto the grid, which keeps each hop short on the NoC.
+        std::vector<std::vector<uint32_t>> mcast_groups(num_groups);
+        for (uint32_t core_id = 0; core_id < num_cores; ++core_id) {
+            const CoreWork& cw = core_work[core_id];
+            if (!cw.has_work) {
+                continue;
+            }
+            mcast_groups[cw.mcast_group_id].push_back(core_id);
+        }
+        for (uint32_t gid = 0; gid < num_groups; ++gid) {
+            const auto& members = mcast_groups[gid];
+            if (members.size() < 2) {
+                continue;  // single-core group: leave role=0 (local DRAM read).
+            }
+            for (size_t i = 0; i < members.size(); ++i) {
+                const uint32_t cid = members[i];
+                CoreWork& cw = core_work[cid];
+                const bool is_injector = (i == 0);
+                const bool is_tail = (i + 1 == members.size());
+                cw.weight_mcast_role = is_injector
+                                           ? WeightMcastRole::ChainInjector
+                                           : (is_tail ? WeightMcastRole::ChainTail : WeightMcastRole::ChainMiddle);
+                if (!is_injector) {
+                    const auto pred_phys = device->worker_core_from_logical_core(cores.at(members[i - 1]));
+                    cw.pred_noc_x = (uint32_t)pred_phys.x;
+                    cw.pred_noc_y = (uint32_t)pred_phys.y;
+                }
+                if (!is_tail) {
+                    const auto succ_phys = device->worker_core_from_logical_core(cores.at(members[i + 1]));
+                    cw.succ_noc_x = (uint32_t)succ_phys.x;
+                    cw.succ_noc_y = (uint32_t)succ_phys.y;
+                }
+            }
+        }
+    } else if (weight_share_mode == WeightShareMode::Mcast) {
+        // Row-strip placement: each (c_in_idx, c_out_idx) group occupies `mcast_rows_per_group`
+        // contiguous rows of the worker grid. The default row-major core_id assignment above
+        // doesn't match this layout, so reassign every CoreWork from the rectangle.
+        //
+        // Sender column staggering (SDPA-style): for each group we pick the sender slot inside
+        // the bbox whose physical column is furthest from the columns already chosen by
+        // previous groups' senders. This spreads DRAM weight reads (and ack convergence)
+        // across columns / DRAM channels instead of stacking every sender on column 0. The
+        // chosen slot still runs compute as a normal mcast member (role 4 = sender + work).
+        const uint32_t rows_per_group = mcast_rows_per_group;
+        const uint32_t bbox_num_cores = grid_size.x * rows_per_group;
+        const auto writer_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+        const uint32_t hw_par = h_out_parallel_factor * w_out_parallel_factor;
+
+        // Reset assignments before re-laying out.
+        for (uint32_t core_id = 0; core_id < num_cores; ++core_id) {
+            core_work[core_id] = CoreWork{};
+        }
+
+        // Track physical-x columns already used as senders so we can max-min the next pick.
+        std::vector<uint32_t> used_sender_phys_xs;
+        used_sender_phys_xs.reserve(num_groups);
+
+        auto pick_sender_within_idx = [&](uint32_t bbox_y_start_log) {
+            // Return a within-bbox active slot.  The first group keeps the historical top-left
+            // sender; later groups choose the active slot whose physical column is furthest from
+            // already-used sender columns.
+            uint32_t sender_within_idx = 0;
+            if (!used_sender_phys_xs.empty()) {
+                uint32_t best_min_dist = 0;
+                for (uint32_t cand_idx = 0; cand_idx < group_size; ++cand_idx) {
+                    const uint32_t cand_x = cand_idx % grid_size.x;
+                    const uint32_t cand_y = bbox_y_start_log + cand_idx / grid_size.x;
+                    const uint32_t cand_phys_x =
+                        (uint32_t)device->worker_core_from_logical_core(CoreCoord{cand_x, cand_y}).x;
+                    uint32_t min_dist = UINT32_MAX;
+                    for (uint32_t used_x : used_sender_phys_xs) {
+                        const uint32_t d = cand_phys_x > used_x ? cand_phys_x - used_x : used_x - cand_phys_x;
+                        min_dist = std::min(min_dist, d);
+                    }
+                    if (min_dist > best_min_dist) {
+                        best_min_dist = min_dist;
+                        sender_within_idx = cand_idx;
+                    }
+                }
+            }
+            return sender_within_idx;
+        };
+
+        for (uint32_t gid = 0; gid < num_groups; ++gid) {
+            // mcast_group_id ordering matches the default: c_in_idx * c_out_par + c_out_idx.
+            const uint32_t c_in_idx = gid / c_out_parallel_factor;
+            const uint32_t c_out_idx = gid % c_out_parallel_factor;
+
+            // Per-group iteration count must match active receivers' writer loop:
+            // N * this_c_in_blocks * this_c_out_blocks.  The TT_FATAL above currently
+            // pins c_in_per_core == 1, but keeping the c_in factor here makes the
+            // passive handshake formula match the active loop if that invariant is
+            // relaxed later.  When C_out_num_blocks is ragged, this_c_out_blocks keeps
+            // trailing passive cores from running extra handshakes and deadlocking
+            // the sender's per-iteration ack wait.
+            const uint32_t this_c_in_blocks = std::min(c_in_per_core, C_in_num_blocks - c_in_idx * c_in_per_core);
+            const uint32_t this_c_out_blocks = std::min(c_out_per_core, C_out_num_blocks - c_out_idx * c_out_per_core);
+            const uint32_t mcast_iters = N * this_c_in_blocks * this_c_out_blocks;
+
+            const uint32_t bbox_y_start_log = gid * rows_per_group;
+            const uint32_t bbox_y_end_log = bbox_y_start_log + rows_per_group - 1;
+            const uint32_t bbox_x_end_log = grid_size.x - 1;
+
+            auto bbox_start_phys = device->worker_core_from_logical_core(CoreCoord{0, bbox_y_start_log});
+            auto bbox_end_phys = device->worker_core_from_logical_core(CoreCoord{bbox_x_end_log, bbox_y_end_log});
+            // Conv2d-style swap so the multicast hardware sees the rect in NOC_1's orientation.
+            if (writer_noc == tt::tt_metal::NOC::NOC_1) {
+                std::swap(bbox_start_phys, bbox_end_phys);
+            }
+
+            const uint32_t sender_within_idx = pick_sender_within_idx(bbox_y_start_log);
+            const uint32_t sender_x_log = sender_within_idx % grid_size.x;
+            const uint32_t sender_y_log = bbox_y_start_log + sender_within_idx / grid_size.x;
+            const auto sender_phys = device->worker_core_from_logical_core(CoreCoord{sender_x_log, sender_y_log});
+            used_sender_phys_xs.push_back((uint32_t)sender_phys.x);
+
+            // Sender is inside the bbox; EXCLUDE_SRC mcast → num_dests = bbox_cores - 1.
+            const uint32_t num_receivers = bbox_num_cores - 1;
+
+            for (uint32_t y_off = 0; y_off < rows_per_group; ++y_off) {
+                for (uint32_t x = 0; x < grid_size.x; ++x) {
+                    const uint32_t y = bbox_y_start_log + y_off;
+                    const uint32_t within_idx = y_off * grid_size.x + x;
+                    const uint32_t target_core_id = y * grid_size.x + x;
+                    CoreWork& cw = core_work[target_core_id];
+
+                    const bool is_sender_slot = within_idx == sender_within_idx;
+
+                    if (within_idx < group_size) {
+                        cw.c_in_idx = c_in_idx;
+                        cw.c_out_idx = c_out_idx;
+                        cw.t_out_idx = within_idx / hw_par;
+                        const uint32_t rem = within_idx % hw_par;
+                        cw.h_out_idx = rem / w_out_parallel_factor;
+                        cw.w_out_idx = rem % w_out_parallel_factor;
+                        compute_block_ranges(cw);
+                        cw.weight_mcast_role =
+                            is_sender_slot ? WeightMcastRole::McastSender : WeightMcastRole::McastReceiver;
+                    } else {
+                        cw.weight_mcast_role = WeightMcastRole::McastPassive;
+                    }
+                    // Receivers/passives use pred_noc_* as the sender NoC coordinate.  The
+                    // sender slot also gets its own coordinate to keep runtime args uniform;
+                    // writer.cpp does not read pred_noc_* for McastSender.
+                    cw.pred_noc_x = (uint32_t)sender_phys.x;
+                    cw.pred_noc_y = (uint32_t)sender_phys.y;
+                    cw.mcast_bbox_start_x = (uint32_t)bbox_start_phys.x;
+                    cw.mcast_bbox_start_y = (uint32_t)bbox_start_phys.y;
+                    cw.mcast_bbox_end_x = (uint32_t)bbox_end_phys.x;
+                    cw.mcast_bbox_end_y = (uint32_t)bbox_end_phys.y;
+                    cw.mcast_num_dests = num_receivers;
+                    cw.mcast_num_iters = mcast_iters;
+                }
+            }
+
+            log_debug(
+                tt::LogOp,
+                "Mcast group {} (c_in={}, c_out={}): bbox logical(0,{})..({},{}); "
+                "phys swapped({},{})..({},{}); sender logical({},{}) phys_x={} within_idx={}; "
+                "num_receivers={}, mcast_iters={}",
+                gid,
+                c_in_idx,
+                c_out_idx,
+                bbox_y_start_log,
+                bbox_x_end_log,
+                bbox_y_end_log,
+                bbox_start_phys.x,
+                bbox_start_phys.y,
+                bbox_end_phys.x,
+                bbox_end_phys.y,
+                sender_x_log,
+                sender_y_log,
+                sender_phys.x,
+                sender_within_idx,
+                num_receivers,
+                mcast_iters);
+        }
+    }
+
+    // Build reduction groups from logical reduction keys (c_out_idx, t_out_idx, h_out_idx, w_out_idx).
+    const uint32_t num_reduction_groups = total_output_parallel;
+    std::vector<std::vector<uint32_t>> reduction_groups(num_reduction_groups);
+    std::vector<uint32_t> reducer_core_ids(num_reduction_groups, UINT32_MAX);
+    std::vector<std::vector<uint32_t>> worker_core_ids(num_reduction_groups);
+    std::vector<uint32_t> reducer_core_physical_xs(num_reduction_groups, 0);
+    std::vector<uint32_t> reducer_core_physical_ys(num_reduction_groups, 0);
+    std::vector<std::vector<uint32_t>> worker_core_physical_xs(num_reduction_groups);
+    std::vector<std::vector<uint32_t>> worker_core_physical_ys(num_reduction_groups);
+
+    for (uint32_t core_id = 0; core_id < num_cores; ++core_id) {
+        const CoreWork& cw = core_work[core_id];
+        if (!cw.has_work) {
+            continue;
+        }
+        CoreCoord core = cores.at(core_id);
+        const auto core_physical = device->worker_core_from_logical_core(core);
+        const uint32_t group_id = cw.reduction_group_id;
+        reduction_groups[group_id].push_back(core_id);
+        if (cw.is_reducer) {
+            reducer_core_ids[group_id] = core_id;
+            reducer_core_physical_xs[group_id] = (uint32_t)core_physical.x;
+            reducer_core_physical_ys[group_id] = (uint32_t)core_physical.y;
+        } else {
+            worker_core_ids[group_id].push_back(core_id);
+            worker_core_physical_xs[group_id].push_back((uint32_t)core_physical.x);
+            worker_core_physical_ys[group_id].push_back((uint32_t)core_physical.y);
+        }
+    }
+
+    // Log reduction groups.
     for (uint32_t group_id = 0; group_id < reduction_groups.size(); group_id++) {
         const auto& group = reduction_groups[group_id];
         if (!group.empty()) {
@@ -736,75 +1028,104 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
                 }
                 cores_str += "(" + std::to_string(core.x) + "," + std::to_string(core.y) + ")";
             }
-
-            [[maybe_unused]] CoreCoord reducer_core = {
-                reducer_core_ids[group_id] % grid_size.x, reducer_core_ids[group_id] / grid_size.x};
-
             log_debug(
                 tt::LogOp,
-                "Reduction Group {}: {} cores [{}], Reducer: ({},{})",
+                "Reduction Group {}: {} cores [{}], ReducerPhysical: ({},{})",
                 group_id,
                 group.size(),
                 cores_str,
-                reducer_core.x,
-                reducer_core.y);
+                reducer_core_physical_xs[group_id],
+                reducer_core_physical_ys[group_id]);
         }
     }
 
-    // Second loop: Set runtime args with reducer and worker information
+    // Build and set runtime args.
     for (uint32_t core_id = 0; core_id < num_cores; ++core_id) {
         CoreCoord core = cores.at(core_id);
-        uint32_t output_idx = core_id % total_output_parallel;
-        uint32_t reduction_group_id = output_idx;
+        const CoreWork& cw = core_work[core_id];
+        const uint32_t group_id = cw.reduction_group_id;
 
-        auto& reader_args = reader_args_per_core[core_id];
-        auto& compute_args = compute_args_per_core[core_id];
-        auto& writer_args = writer_args_per_core[core_id];
+        std::vector<uint32_t> reader_args = {
+            input_addr,
+            cw.c_in_block_start,
+            cw.c_in_block_end,
+            cw.c_out_block_start,
+            cw.c_out_block_end,
+            cw.t_out_start,
+            cw.t_out_end,
+            cw.h_out_start,
+            cw.h_out_end,
+            cw.w_out_start,
+            cw.w_out_end,
+        };
 
-        // Get is_reducer value from the stored arguments
-        [[maybe_unused]] bool is_reducer = (writer_args[13] == 1);
+        const uint32_t num_workers = cw.has_work ? (uint32_t)worker_core_ids[group_id].size() : 0u;
 
-        // Add worker cores count first so the kernel can use it to conditionally read reduction args
-        uint32_t num_workers = worker_core_ids[reduction_group_id].size();
-        compute_args.push_back(num_workers);
-        writer_args.push_back(num_workers);
+        std::vector<uint32_t> compute_args = {
+            cw.c_in_block_start,
+            cw.c_in_block_end,
+            cw.c_out_block_start,
+            cw.c_out_block_end,
+            cw.t_out_start,
+            cw.t_out_end,
+            cw.h_out_start,
+            cw.h_out_end,
+            cw.w_out_start,
+            cw.w_out_end,
+            (uint32_t)cw.is_reducer,
+            num_workers};
 
-        // Add reducer core coordinates and worker core coordinates only when there are workers
+        std::vector<uint32_t> writer_args = {
+            out_addr,
+            weight_addr,
+            bias_addr,
+            cw.c_in_block_start,
+            cw.c_in_block_end,
+            cw.c_out_block_start,
+            cw.c_out_block_end,
+            cw.t_out_start,
+            cw.t_out_end,
+            cw.h_out_start,
+            cw.h_out_end,
+            cw.w_out_start,
+            cw.w_out_end,
+            (uint32_t)cw.is_reducer,
+            static_cast<uint32_t>(cw.weight_mcast_role),
+            cw.pred_noc_x,
+            cw.pred_noc_y,
+            cw.succ_noc_x,
+            cw.succ_noc_y,
+            cw.mcast_bbox_start_x,
+            cw.mcast_bbox_start_y,
+            cw.mcast_bbox_end_x,
+            cw.mcast_bbox_end_y,
+            cw.mcast_num_dests,
+            cw.mcast_num_iters,
+            num_workers};
+
         if (num_workers > 0) {
-            writer_args.push_back(reducer_core_physical_xs[reduction_group_id]);
-            writer_args.push_back(reducer_core_physical_ys[reduction_group_id]);
-
+            writer_args.push_back(reducer_core_physical_xs[group_id]);
+            writer_args.push_back(reducer_core_physical_ys[group_id]);
             writer_args.insert(
-                writer_args.end(),
-                worker_core_physical_xs[reduction_group_id].begin(),
-                worker_core_physical_xs[reduction_group_id].end());
+                writer_args.end(), worker_core_physical_xs[group_id].begin(), worker_core_physical_xs[group_id].end());
             writer_args.insert(
-                writer_args.end(),
-                worker_core_physical_ys[reduction_group_id].begin(),
-                worker_core_physical_ys[reduction_group_id].end());
+                writer_args.end(), worker_core_physical_ys[group_id].begin(), worker_core_physical_ys[group_id].end());
         }
 
-        // Prepare worker cores string for logging
-        std::string worker_cores_str;
-        for (uint32_t i = 0; i < num_workers; i++) {
-            if (!worker_cores_str.empty()) {
-                worker_cores_str += ", ";
-            }
-            worker_cores_str += "(" + std::to_string(worker_core_physical_xs[reduction_group_id][i]) + "," +
-                                std::to_string(worker_core_physical_ys[reduction_group_id][i]) + ")";
-        }
         log_debug(
             tt::LogOp,
-            "Core ({},{}): IsReducer={}, ReductionGroup={}, ReducerCore=({},{}), Workers=[{}]",
+            "Core ({},{}): HasWork={}, IsReducer={}, ChainRole={}, "
+            "ReductionGroup={}, C_in_idx={}, C_out_idx={}, NumWorkers={}",
             core.x,
             core.y,
-            is_reducer,
-            reduction_group_id,
-            reducer_core_physical_xs[reduction_group_id],
-            reducer_core_physical_ys[reduction_group_id],
-            worker_cores_str);
+            cw.has_work,
+            cw.is_reducer,
+            static_cast<uint32_t>(cw.weight_mcast_role),
+            group_id,
+            cw.c_in_idx,
+            cw.c_out_idx,
+            num_workers);
 
-        // Set runtime args
         SetRuntimeArgs(program, reader_kernels_id, core, reader_args);
         SetRuntimeArgs(program, compute_kernels_id, core, compute_args);
         SetRuntimeArgs(program, writer_kernels_id, core, writer_args);

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
@@ -725,7 +725,7 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
     uint32_t weight_addr = weight_tensor.buffer()->address();
     uint32_t bias_addr = bias_tensor.has_value() ? bias_tensor.value().buffer()->address() : 0;
 
-    // Per-core work assignment via the original core_id row-major mapping. See WeightMcastRole
+    // Per-core work assignment via the original core_id row-major mapping. See WeightShareRole
     // in conv3d_weight_share.hpp for the role values.
     struct CoreWork {
         bool has_work = false;
@@ -742,11 +742,12 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         uint32_t t_out_start = 0, t_out_end = 0;
         uint32_t h_out_start = 0, h_out_end = 0;
         uint32_t w_out_start = 0, w_out_end = 0;
-        WeightMcastRole weight_mcast_role = WeightMcastRole::Local;
-        // Chain pred/succ (chain roles) or mcast sender NoC (mcast receiver/passive use pred fields).
-        // McastSender also carries the sender coordinate here for uniform runtime args; writer ignores it.
-        uint32_t pred_noc_x = 0, pred_noc_y = 0;
-        uint32_t succ_noc_x = 0, succ_noc_y = 0;
+        WeightShareRole weight_share_role = WeightShareRole::Local;
+        // Where this core receives weights from: chain predecessor (chain roles) or mcast sender
+        // (mcast receiver/passive). McastSender carries its own coord for uniform runtime args.
+        uint32_t weight_src_noc_x = 0, weight_src_noc_y = 0;
+        // Chain forwarding target (chain injector/middle). Unused for other roles.
+        uint32_t chain_succ_noc_x = 0, chain_succ_noc_y = 0;
         // Mcast bbox in physical NoC coords (already swapped for NOC_1). Sender role only.
         uint32_t mcast_bbox_start_x = 0, mcast_bbox_start_y = 0;
         uint32_t mcast_bbox_end_x = 0, mcast_bbox_end_y = 0;
@@ -825,18 +826,18 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
                 CoreWork& cw = core_work[cid];
                 const bool is_injector = (i == 0);
                 const bool is_tail = (i + 1 == members.size());
-                cw.weight_mcast_role = is_injector
-                                           ? WeightMcastRole::ChainInjector
-                                           : (is_tail ? WeightMcastRole::ChainTail : WeightMcastRole::ChainMiddle);
+                cw.weight_share_role = is_injector
+                                           ? WeightShareRole::ChainInjector
+                                           : (is_tail ? WeightShareRole::ChainTail : WeightShareRole::ChainMiddle);
                 if (!is_injector) {
                     const auto pred_phys = device->worker_core_from_logical_core(cores.at(members[i - 1]));
-                    cw.pred_noc_x = (uint32_t)pred_phys.x;
-                    cw.pred_noc_y = (uint32_t)pred_phys.y;
+                    cw.weight_src_noc_x = (uint32_t)pred_phys.x;
+                    cw.weight_src_noc_y = (uint32_t)pred_phys.y;
                 }
                 if (!is_tail) {
                     const auto succ_phys = device->worker_core_from_logical_core(cores.at(members[i + 1]));
-                    cw.succ_noc_x = (uint32_t)succ_phys.x;
-                    cw.succ_noc_y = (uint32_t)succ_phys.y;
+                    cw.chain_succ_noc_x = (uint32_t)succ_phys.x;
+                    cw.chain_succ_noc_y = (uint32_t)succ_phys.y;
                 }
             }
         }
@@ -943,16 +944,15 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
                         cw.h_out_idx = rem / w_out_parallel_factor;
                         cw.w_out_idx = rem % w_out_parallel_factor;
                         compute_block_ranges(cw);
-                        cw.weight_mcast_role =
-                            is_sender_slot ? WeightMcastRole::McastSender : WeightMcastRole::McastReceiver;
+                        cw.weight_share_role =
+                            is_sender_slot ? WeightShareRole::McastSender : WeightShareRole::McastReceiver;
                     } else {
-                        cw.weight_mcast_role = WeightMcastRole::McastPassive;
+                        cw.weight_share_role = WeightShareRole::McastPassive;
                     }
-                    // Receivers/passives use pred_noc_* as the sender NoC coordinate.  The
-                    // sender slot also gets its own coordinate to keep runtime args uniform;
-                    // writer.cpp does not read pred_noc_* for McastSender.
-                    cw.pred_noc_x = (uint32_t)sender_phys.x;
-                    cw.pred_noc_y = (uint32_t)sender_phys.y;
+                    // Receivers/passives source weights from the sender. Sender carries its own
+                    // coord for uniform runtime args; writer.cpp ignores it for McastSender.
+                    cw.weight_src_noc_x = (uint32_t)sender_phys.x;
+                    cw.weight_src_noc_y = (uint32_t)sender_phys.y;
                     cw.mcast_bbox_start_x = (uint32_t)bbox_start_phys.x;
                     cw.mcast_bbox_start_y = (uint32_t)bbox_start_phys.y;
                     cw.mcast_bbox_end_x = (uint32_t)bbox_end_phys.x;
@@ -1090,11 +1090,11 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
             cw.w_out_start,
             cw.w_out_end,
             (uint32_t)cw.is_reducer,
-            static_cast<uint32_t>(cw.weight_mcast_role),
-            cw.pred_noc_x,
-            cw.pred_noc_y,
-            cw.succ_noc_x,
-            cw.succ_noc_y,
+            static_cast<uint32_t>(cw.weight_share_role),
+            cw.weight_src_noc_x,
+            cw.weight_src_noc_y,
+            cw.chain_succ_noc_x,
+            cw.chain_succ_noc_y,
             cw.mcast_bbox_start_x,
             cw.mcast_bbox_start_y,
             cw.mcast_bbox_end_x,
@@ -1120,7 +1120,7 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
             core.y,
             cw.has_work,
             cw.is_reducer,
-            static_cast<uint32_t>(cw.weight_mcast_role),
+            static_cast<uint32_t>(cw.weight_share_role),
             group_id,
             cw.c_in_idx,
             cw.c_out_idx,

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
@@ -75,8 +75,9 @@ void matmul_blocks(
 
 template <uint32_t rows, uint32_t cols>
 void add_bias_inplace(uint32_t inout_cb, uint32_t bias_cb) {
-    // Math add path used when inout_cb is not physically full, so L1 pack
-    // accumulation cannot safely target the old tile slots.
+    // Math-side broadcast add (`add_tiles_bcast_rows`): used when inout_cb is not
+    // physically full, so we cannot rely on pop+reserve returning the same L1 slots
+    // and the pack-side L1-acc path in `add_inplace_l1_acc` is unsafe.
 
     constexpr uint32_t num_tiles = rows * cols;
     constexpr uint32_t max_dst_tiles = compute_kernel_lib::DEST_AUTO_LIMIT;
@@ -96,9 +97,7 @@ void add_bias_inplace(uint32_t inout_cb, uint32_t bias_cb) {
             cb_pop_front(inout_cb, cols_cur);
             cb_reserve_back(inout_cb, cols_cur);
             tile_regs_wait();
-            for (uint32_t j = 0; j < cols_cur; ++j) {
-                pack_tile(j, inout_cb);
-            }
+            pack_tile_block(0, inout_cb, cols_cur);
             cb_push_back(inout_cb, cols_cur);
             tile_regs_release();
         }
@@ -107,15 +106,16 @@ void add_bias_inplace(uint32_t inout_cb, uint32_t bias_cb) {
 
 template <uint32_t rows, uint32_t cols, bool consume_add_cb>
 void add_inplace_l1_acc(uint32_t inout_cb, uint32_t add_cb) {
-    // Requires inout_cb to be physically full: pop+reserve must return the
-    // same L1 slots so pack L1 accumulation targets the existing tiles.
-    // consume_add_cb=false means add_cb is a single bias row reused for every
-    // output row; consume_add_cb=true means add_cb is a full block consumed tile-for-tile.
+    // Pack-side L1 accumulation (`pack_reconfig_l1_acc(1)` + indexed pack): cheaper
+    // than the math add in `add_bias_inplace` because the add fuses into the pack,
+    // but requires inout_cb to be physically full — pop+reserve must return the
+    // same L1 slots so the indexed pack lands on top of the existing tiles.
+    // consume_add_cb=false: add_cb is a single bias row reused for every output row.
+    // consume_add_cb=true:  add_cb is a full block consumed tile-for-tile (reduction).
     constexpr uint32_t num_tiles = rows * cols;
     constexpr uint32_t add_tiles = consume_add_cb ? num_tiles : cols;
     constexpr uint32_t max_dst_tiles = compute_kernel_lib::DEST_AUTO_LIMIT;
     static_assert(rows > 0 && cols > 0);
-    static_assert((consume_add_cb && add_tiles == num_tiles) || (!consume_add_cb && add_tiles == cols));
 
     cb_wait_front(inout_cb, num_tiles);
     cb_wait_front(add_cb, add_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
@@ -12,6 +12,7 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/reconfig_data_format.h"
+#include "ttnn/cpp/ttnn/kernel_lib/dest_helpers.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
 
@@ -73,56 +74,157 @@ void matmul_blocks(
 }
 
 template <uint32_t rows, uint32_t cols>
-void add_bias_inplace(uint32_t in0_cb, uint32_t in1_cb) {
-    // Precondition: in0_cb has rows*cols produced
-    // Precondition: in1_cb has rows produced
-    // Postcondition: in0_cb has rows*cols produced
-    // Postcondition: in1_cb has rows produced
+void add_bias_inplace(uint32_t inout_cb, uint32_t bias_cb) {
+    // Math add path used when inout_cb is not physically full, so L1 pack
+    // accumulation cannot safely target the old tile slots.
 
     constexpr uint32_t num_tiles = rows * cols;
-    constexpr uint32_t dst_tiles = 1;
+    constexpr uint32_t max_dst_tiles = compute_kernel_lib::DEST_AUTO_LIMIT;
 
-    add_bcast_rows_init_short(in0_cb, in1_cb);
-    cb_wait_front(in0_cb, num_tiles);
-    cb_wait_front(in1_cb, cols);
+    add_bcast_rows_init_short(inout_cb, bias_cb);
+    cb_wait_front(inout_cb, num_tiles);
+    cb_wait_front(bias_cb, cols);
     for (uint32_t i = 0; i < rows; ++i) {
-        for (uint32_t j = 0; j < cols; ++j) {
+        for (uint32_t col_start = 0; col_start < cols; col_start += max_dst_tiles) {
+            const uint32_t cols_cur = (cols - col_start) < max_dst_tiles ? (cols - col_start) : max_dst_tiles;
+
             tile_regs_acquire();
-            // Add jth tile of bias to each column j of in0_cb
-            add_tiles_bcast_rows(in0_cb, in1_cb, 0, j, 0);
+            for (uint32_t j = 0; j < cols_cur; ++j) {
+                add_tiles_bcast_rows(inout_cb, bias_cb, j, col_start + j, j);
+            }
             tile_regs_commit();
-            cb_pop_front(in0_cb, dst_tiles);
-            cb_reserve_back(in0_cb, dst_tiles);
+            cb_pop_front(inout_cb, cols_cur);
+            cb_reserve_back(inout_cb, cols_cur);
             tile_regs_wait();
-            pack_tile(0, in0_cb);
-            cb_push_back(in0_cb, dst_tiles);
+            for (uint32_t j = 0; j < cols_cur; ++j) {
+                pack_tile(j, inout_cb);
+            }
+            cb_push_back(inout_cb, cols_cur);
             tile_regs_release();
         }
     }
 }
 
-template <uint32_t num_tiles>
-void add_block_inplace(uint32_t in0_cb, uint32_t in1_cb) {
-    // Precondition: in0_cb has num_tiles produced
-    // Precondition: in1_cb has num_tiles produced
-    // Postcondition: in0_cb has num_tiles produced
-    // Postcondition: in1_cb has num_tiles consumed
+template <uint32_t rows, uint32_t cols, bool consume_add_cb>
+void add_inplace_l1_acc(uint32_t inout_cb, uint32_t add_cb) {
+    // Requires inout_cb to be physically full: pop+reserve must return the
+    // same L1 slots so pack L1 accumulation targets the existing tiles.
+    // consume_add_cb=false means add_cb is a single bias row reused for every
+    // output row; consume_add_cb=true means add_cb is a full block consumed tile-for-tile.
+    constexpr uint32_t num_tiles = rows * cols;
+    constexpr uint32_t add_tiles = consume_add_cb ? num_tiles : cols;
+    constexpr uint32_t max_dst_tiles = compute_kernel_lib::DEST_AUTO_LIMIT;
+    static_assert(rows > 0 && cols > 0);
+    static_assert((consume_add_cb && add_tiles == num_tiles) || (!consume_add_cb && add_tiles == cols));
 
-    constexpr uint32_t dst_tiles = 1;
+    cb_wait_front(inout_cb, num_tiles);
+    cb_wait_front(add_cb, add_tiles);
 
-    add_tiles_init(in0_cb, in1_cb);
-    for (uint32_t i = 0; i < num_tiles; ++i) {
-        tile_regs_acquire();
-        add_tiles(in0_cb, in1_cb, 0, 0, 0);
-        tile_regs_commit();
-        cb_pop_front(in0_cb, dst_tiles);
-        cb_pop_front(in1_cb, dst_tiles);
-        cb_reserve_back(in0_cb, dst_tiles);
-        tile_regs_wait();
-        pack_tile(0, in0_cb);
-        cb_push_back(in0_cb, dst_tiles);
-        tile_regs_release();
+    copy_tile_to_dst_init_short_with_dt(inout_cb, add_cb);
+    pack_reconfig_data_format(inout_cb);
+    pack_reconfig_l1_acc(1);
+    for (uint32_t i = 0; i < rows; ++i) {
+        for (uint32_t col_start = 0; col_start < cols; col_start += max_dst_tiles) {
+            const uint32_t cols_cur = (cols - col_start) < max_dst_tiles ? (cols - col_start) : max_dst_tiles;
+            const uint32_t add_offset = consume_add_cb ? 0 : col_start;
+
+            tile_regs_acquire();
+            for (uint32_t j = 0; j < cols_cur; ++j) {
+                copy_tile(add_cb, add_offset + j, j);
+            }
+            tile_regs_commit();
+            cb_pop_front(inout_cb, cols_cur);
+            if constexpr (consume_add_cb) {
+                cb_pop_front(add_cb, cols_cur);
+            }
+            cb_reserve_back(inout_cb, cols_cur);
+            tile_regs_wait();
+            for (uint32_t j = 0; j < cols_cur; ++j) {
+                pack_tile<true>(j, inout_cb, j);
+            }
+            cb_push_back(inout_cb, cols_cur);
+            tile_regs_release();
+        }
     }
+    pack_reconfig_l1_acc(0);
+}
+
+template <uint32_t rows, uint32_t cols, bool use_fp32_partials, bool use_bias, uint32_t inout_cb, uint32_t bias_cb>
+void add_bias_inplace_l1_acc_if_needed() {
+    if constexpr (use_bias) {
+        if constexpr (use_fp32_partials) {
+            reconfig_data_format(inout_cb, bias_cb);
+        }
+        add_inplace_l1_acc<rows, cols, false>(inout_cb, bias_cb);
+    }
+}
+
+template <uint32_t rows, uint32_t cols, bool use_fp32_partials, uint32_t in_cb, uint32_t out_cb>
+void untilize_block() {
+    constexpr auto untilize_reconfig_mode =
+        use_fp32_partials ? compute_kernel_lib::untilize_config::ReconfigureRegisterDatatypeMode::UnpackReconfigure
+                          : compute_kernel_lib::untilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure;
+    compute_kernel_lib::untilize<
+        cols,
+        in_cb,
+        out_cb,
+        compute_kernel_lib::untilize_config::InitUninitMode::InitAndUninit,
+        compute_kernel_lib::untilize_config::WaitMode::WaitUpfront,
+        untilize_reconfig_mode>(rows);
+}
+
+template <
+    uint32_t rows,
+    uint32_t cols,
+    bool use_fp32_partials,
+    bool use_bias,
+    uint32_t inout_cb,
+    uint32_t bias_cb,
+    uint32_t out_cb>
+void bias_untilize_fullblock() {
+    cb_wait_front(inout_cb, rows * cols);
+    if constexpr (rows == 1 && cols == 1) {
+        if constexpr (use_bias) {
+            if constexpr (use_fp32_partials) {
+                reconfig_data_format(inout_cb, bias_cb);
+            }
+            add_bias_inplace<rows, cols>(inout_cb, bias_cb);
+        }
+    } else {
+        add_bias_inplace_l1_acc_if_needed<rows, cols, use_fp32_partials, use_bias, inout_cb, bias_cb>();
+    }
+    untilize_block<rows, cols, use_fp32_partials, inout_cb, out_cb>();
+}
+
+template <uint32_t rows, uint32_t cols, bool use_fp32_partials, uint32_t local_cb, uint32_t remote_cb>
+void reduce_fullblock_inplace(uint32_t num_workers) {
+    constexpr uint32_t num_tiles = rows * cols;
+
+    cb_wait_front(local_cb, num_tiles);
+
+    if constexpr (use_fp32_partials) {
+        reconfig_data_format_srca(local_cb);
+    }
+    for (uint32_t i = 0; i < num_workers; i++) {
+        cb_wait_front(remote_cb, num_tiles);
+        // Flatten rows x cols into one logical row so the full remote partial block is
+        // consumed tile-for-tile while preserving the physical-full inout_cb invariant.
+        add_inplace_l1_acc<1, num_tiles, true>(local_cb, remote_cb);
+    }
+}
+
+template <
+    uint32_t rows,
+    uint32_t cols,
+    bool use_fp32_partials,
+    bool use_bias,
+    uint32_t local_cb,
+    uint32_t remote_cb,
+    uint32_t bias_cb,
+    uint32_t out_cb>
+void reduce_bias_untilize_fullblock(uint32_t num_workers) {
+    reduce_fullblock_inplace<rows, cols, use_fp32_partials, local_cb, remote_cb>(num_workers);
+    bias_untilize_fullblock<rows, cols, use_fp32_partials, use_bias, local_cb, bias_cb, out_cb>();
 }
 
 void kernel_main() {
@@ -159,11 +261,13 @@ void kernel_main() {
 
     constexpr uint32_t semaphore_id = get_compile_time_arg_val(26);
     constexpr bool use_fp32_partials = get_compile_time_arg_val(27) == 1;
-    constexpr uint32_t cb_zero_tiled = get_compile_time_arg_val(28);
+    // Stream final single-tile C_out rows through bias/untilize when the writer can overlap the compute tail.
+    constexpr bool enable_streaming_output = get_compile_time_arg_val(28) == 1;
 
     constexpr uint32_t weight_tiles = matmul_K_t * matmul_N_t;
     constexpr uint32_t output_tiles = matmul_M_t * matmul_N_t;
     constexpr uint32_t batch_tiles = subblock_h * matmul_K_t;
+    constexpr uint32_t subblock_tiles = subblock_h * matmul_N_t;
 
     mm_init(cb_vol2col_tiled, cb_weight_tiled, cb_matmul_interm_tiled);
 
@@ -249,83 +353,68 @@ void kernel_main() {
                                         subblock_w,
                                         false /* transpose */);
                                     cb_pop_front(cb_vol2col_tiled, batch_tiles);
-                                }
-                            }
 
-                            // Stall on matmul/bias to finish
-                            cb_wait_front(cb_matmul_interm_tiled, output_tiles);
+                                    if constexpr (enable_streaming_output) {
+                                        // Streaming emits subblocks before cb_matmul_interm_tiled is physically full,
+                                        // so bias uses math add and untilizes immediately.  The full-block path below
+                                        // waits for the whole block and can use L1 pack accumulation instead.
+                                        cb_wait_front(cb_matmul_interm_tiled, subblock_tiles);
 
-                            if (!is_reducer) {
-                                // not reducer implies that we are a worker and there are multiple workers in this
-                                // reduction group
-
-                                // Signal to writer that we have partial results
-                                cb_reserve_back(cb_reduction_tiled, output_tiles);
-                                cb_push_back(cb_reduction_tiled, output_tiles);
-
-                                // Wait for writer to ack that our data has been used
-                                cb_wait_front(cb_worker_ack_back, 1);
-                                cb_pop_front(cb_worker_ack_back, 1);
-
-                                // Clear our partial results and continue
-                                cb_pop_front(cb_matmul_interm_tiled, output_tiles);
-                            } else {
-                                // We are a reducer core.
-                                if constexpr (use_fp32_partials) {
-                                    cb_wait_front(cb_zero_tiled, 1);
-                                    reconfig_data_format_srca(cb_matmul_interm_tiled);
-                                    // pack_reconfig not needed — packer already fp32 from pre-matmul reconfig
-                                }
-                                for (uint32_t i = 0; i < num_workers; i++) {
-                                    cb_wait_front(cb_reduction_tiled, output_tiles);
-
-                                    if constexpr (use_fp32_partials) {
-                                        for (uint32_t t = 0; t < output_tiles; t++) {
-                                            tile_regs_acquire();
-                                            // Re-init before each op: copy_tile and add_tiles
-                                            // share the MATH unit config, so each needs its own
-                                            // init per tile iteration.
-                                            copy_tile_init(cb_matmul_interm_tiled);
-                                            copy_tile(cb_matmul_interm_tiled, 0, 0);
-                                            add_tiles_init(cb_reduction_tiled, cb_zero_tiled, true);
-                                            add_tiles(cb_reduction_tiled, cb_zero_tiled, 0, 0, 0);
-                                            tile_regs_commit();
-
-                                            cb_pop_front(cb_matmul_interm_tiled, 1);
-                                            cb_pop_front(cb_reduction_tiled, 1);
-                                            cb_reserve_back(cb_matmul_interm_tiled, 1);
-                                            tile_regs_wait();
-                                            pack_tile(0, cb_matmul_interm_tiled);
-                                            cb_push_back(cb_matmul_interm_tiled, 1);
-                                            tile_regs_release();
+                                        if constexpr (use_bias) {
+                                            if constexpr (use_fp32_partials) {
+                                                reconfig_data_format(cb_matmul_interm_tiled, cb_bias_tiled);
+                                            }
+                                            add_bias_inplace<subblock_h, matmul_N_t>(
+                                                cb_matmul_interm_tiled, cb_bias_tiled);
                                         }
-                                    } else {
-                                        add_block_inplace<output_tiles>(cb_matmul_interm_tiled, cb_reduction_tiled);
+
+                                        constexpr auto untilize_reconfig_mode_sb =
+                                            use_fp32_partials ? compute_kernel_lib::untilize_config::
+                                                                    ReconfigureRegisterDatatypeMode::UnpackReconfigure
+                                                              : compute_kernel_lib::untilize_config::
+                                                                    ReconfigureRegisterDatatypeMode::NoReconfigure;
+                                        compute_kernel_lib::untilize<
+                                            matmul_N_t,
+                                            cb_matmul_interm_tiled,
+                                            cb_matmul_result_rm,
+                                            compute_kernel_lib::untilize_config::InitUninitMode::InitAndUninit,
+                                            compute_kernel_lib::untilize_config::WaitMode::WaitUpfront,
+                                            untilize_reconfig_mode_sb>(subblock_h);
                                     }
-                                }
-                                // Apply bias only if we are a reducer, and do it after reduction
-                                if constexpr (use_bias) {
-                                    if constexpr (use_fp32_partials) {
-                                        reconfig_data_format(cb_matmul_interm_tiled, cb_bias_tiled);
-                                    }
-                                    add_bias_inplace<matmul_M_t, matmul_N_t>(cb_matmul_interm_tiled, cb_bias_tiled);
-                                }
-                                // Untilize result
-                                {
-                                    constexpr auto untilize_reconfig_mode =
-                                        use_fp32_partials ? compute_kernel_lib::untilize_config::
-                                                                ReconfigureRegisterDatatypeMode::UnpackReconfigure
-                                                          : compute_kernel_lib::untilize_config::
-                                                                ReconfigureRegisterDatatypeMode::NoReconfigure;
-                                    compute_kernel_lib::untilize<
-                                        matmul_N_t,
-                                        cb_matmul_interm_tiled,
-                                        cb_matmul_result_rm,
-                                        compute_kernel_lib::untilize_config::InitUninitMode::InitAndUninit,
-                                        compute_kernel_lib::untilize_config::WaitMode::WaitUpfront,
-                                        untilize_reconfig_mode>(matmul_M_t);
                                 }
                             }
+
+                            if constexpr (!enable_streaming_output) {
+                                // Stall on matmul/bias to finish
+                                cb_wait_front(cb_matmul_interm_tiled, output_tiles);
+
+                                if (!is_reducer) {
+                                    // not reducer implies that we are a worker and there are multiple workers in this
+                                    // reduction group
+
+                                    // Signal to writer that we have partial results
+                                    cb_reserve_back(cb_reduction_tiled, output_tiles);
+                                    cb_push_back(cb_reduction_tiled, output_tiles);
+
+                                    // Wait for writer to ack that our data has been used
+                                    cb_wait_front(cb_worker_ack_back, 1);
+                                    cb_pop_front(cb_worker_ack_back, 1);
+
+                                    // Clear our partial results and continue
+                                    cb_pop_front(cb_matmul_interm_tiled, output_tiles);
+                                } else {
+                                    // We are a reducer core.
+                                    reduce_bias_untilize_fullblock<
+                                        matmul_M_t,
+                                        matmul_N_t,
+                                        use_fp32_partials,
+                                        use_bias,
+                                        cb_matmul_interm_tiled,
+                                        cb_reduction_tiled,
+                                        cb_bias_tiled,
+                                        cb_matmul_result_rm>(num_workers);
+                                }
+                            }  // end if constexpr (!enable_streaming_output)
                         }
                     }
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/conv3d_gather_tuning.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/conv3d_gather_tuning.hpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <stdint.h>
+
+// Shared between conv3d_program_factory (host) and reader_vol2col (kernel) so the
+// trid-ring cutoffs stay in one place.
+//
+// Two cooperating gates select whether gather_rows_to_shard runs the trid ring:
+//
+//   1. Host per-shape classifier (program_factory): if the shape is compute-bound,
+//      `gather_trids` is set to 0 and all ring code is constexpr-elided in the
+//      kernel.  See conv3d_program_factory.cpp.
+//
+//   2. Kernel per-call fast-path (reader_vol2col): even when the host enables the
+//      ring, an individual gather call with too few reads to fill at least two ring
+//      cycles takes the issue-all + single-trailing-barrier path.  Threshold is
+//      `2 * selected_trid_depth` reads.  The host cutoff below is intentionally
+//      looser: it selects whether the shape should compile ring support at all;
+//      each concrete gather call can still fall back locally when it is too small.
+namespace conv3d_gather_tuning {
+
+// Trid ring depths.  Two values: kGatherTridDepthHigh for shapes with large
+// per-call gather bursts (full-rate pipelining), kGatherTridDepthLow for shapes
+// with smaller bursts (shallower ring still hides per-read latency without the
+// drain overhead of the deeper ring).  Selection happens at host time based on
+// the per-shape inner-gather burst size.
+constexpr uint32_t kGatherTridDepthHigh = 8;
+constexpr uint32_t kGatherTridDepthLow = 4;
+
+// Host gate: minimum bytes per matmul tile op (T_shard * H_shard * W_shard *
+// C_in_block_bytes / matmul_tiles).  Below this the kernel is compute-bound and
+// the ring overhead exceeds the reader gain.
+constexpr uint64_t kGatherIntensityCutoffBytes = 128;
+
+// Host selector: minimum reads per representative inner gather (T_shard * W_shard)
+// before compiling the shallow ring.  This is one ring depth, not the kernel's
+// two-depth per-call guard, because the host is choosing codegen for the shape
+// while the kernel makes the final call-by-call decision.
+constexpr uint32_t kGatherInnerBurstCutoff = kGatherTridDepthLow;
+
+}  // namespace conv3d_gather_tuning

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/conv3d_weight_share.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/conv3d_weight_share.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <stdint.h>
+
+// Shared between conv3d_program_factory (host) and writer.cpp (kernel). The kernel receives
+// the role as a uint32_t runtime arg and casts back to this enum; cast direction is host →
+// kernel via SetRuntimeArgs/get_arg_val. The fixed underlying type makes the wire format
+// stable.
+//
+// Single weight-share strategy enum used as a compile-time arg (`weight_share_mode`).
+enum class WeightShareMode : uint32_t {
+    Disabled = 0,  // single-core group: each active core reads its own weight slice from DRAM
+    Chain = 1,     // per-group chain forwarding (SDPA-style hop chain)
+    Mcast = 2,     // per-group hardware multicast over a row-strip bbox
+};
+
+// Per-core role within the weight-share machinery. `Local` is also used for cores that have
+// no work or whose group is single-core; the kernel's outer (c_in, c_out) loop simply does
+// not execute for those.
+enum class WeightMcastRole : uint32_t {
+    Local = 0,          // no participation: read DRAM directly (or empty work — kernel exits)
+    ChainInjector = 1,  // chain head: read DRAM, forward to successor
+    ChainMiddle = 2,    // chain middle: receive from pred, forward to succ
+    ChainTail = 3,      // chain tail: receive from pred only
+    McastSender = 4,    // mcast sender: read DRAM, multicast over bbox
+    McastReceiver = 5,  // mcast active receiver: ack sender, wait VALID, has compute work
+    McastPassive = 6,   // mcast passive: in bbox but no work; participates only in the handshake
+};

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/conv3d_weight_share.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/conv3d_weight_share.hpp
@@ -21,7 +21,7 @@ enum class WeightShareMode : uint32_t {
 // Per-core role within the weight-share machinery. `Local` is also used for cores that have
 // no work or whose group is single-core; the kernel's outer (c_in, c_out) loop simply does
 // not execute for those.
-enum class WeightMcastRole : uint32_t {
+enum class WeightShareRole : uint32_t {
     Local = 0,          // no participation: read DRAM directly (or empty work — kernel exits)
     ChainInjector = 1,  // chain head: read DRAM, forward to successor
     ChainMiddle = 2,    // chain middle: receive from pred, forward to succ

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+#include <ttnn/operations/experimental/conv3d/device/kernels/conv3d_gather_tuning.hpp>
 
 // Pre-zero CB pages via NOC DMA from MEM_ZEROS so tile-alignment padding is zero.
 // Uses MEM_ZEROS_SIZE-aligned transactions (same pattern as zero_out_tiles in conv_reader_common.hpp).
@@ -160,6 +161,28 @@ struct ChunkWriter {
     }
 };
 
+template <uint32_t C_in_block_bytes>
+struct CoalescedRowLayout {
+    uint32_t slot_chunk_offset[NUM_DRAM_BANKS];
+    uint32_t slot_chunk_pages[NUM_DRAM_BANKS];
+
+    FORCE_INLINE void compute(uint32_t W_shard_cur) {
+        uint32_t offset = 0;
+        for (uint32_t slot = 0; slot < NUM_DRAM_BANKS; slot++) {
+            slot_chunk_offset[slot] = offset;
+            const uint32_t pages = slot < W_shard_cur ? ((W_shard_cur - 1 - slot) / NUM_DRAM_BANKS) + 1 : 0;
+            slot_chunk_pages[slot] = pages;
+            offset += pages * C_in_block_bytes;
+        }
+    }
+
+    FORCE_INLINE uint32_t offset_for_w(uint32_t w_natural) const {
+        const uint32_t slot = w_natural % NUM_DRAM_BANKS;
+        const uint32_t local_idx = w_natural / NUM_DRAM_BANKS;
+        return slot_chunk_offset[slot] + local_idx * C_in_block_bytes;
+    }
+};
+
 // Copy one (t, h) row of patches from the L1 shard into the vol2col CB.
 // Iterates over w positions in [w_block, w_block_end), extracting kT×kH×kW patches
 // via one_packet NOC reads.  Calls chunk.advance() after each patch.
@@ -237,6 +260,20 @@ void shift_retained_w_columns(
 // Gather rows from DRAM into the L1 shard buffer.
 // When check_padding=false, all positions are known to be in-bounds — skip per-position
 // boundary checks and clamp/zeroPad logic (~3-6 RISC-V cycles saved per position).
+//
+// Trid pipeline: each issued read is tagged with `trid = (issued % N_TRIDS) + 1`.  Once
+// `issued >= N_TRIDS`, issuing read `i` first blocks on trid `((i - N_TRIDS) % N_TRIDS) + 1`
+// to free that slot.  After the loop, drain by barriering on each in-flight trid.  This
+// bounds NoC outstanding reads to N_TRIDS and replaces the single trailing barrier with
+// per-trid waits so later reads continue while earlier ones drain.
+//
+// Per-call fast path: when this gather call has fewer than `kGatherFastPathReadCutoff`
+// reads it issues untagged + single trailing barrier (the original behavior).  In that
+// regime the ring overhead would dominate.  Note this is independent from the host gate:
+// the host decides whether N_TRIDS is non-zero for the whole shape; this decides whether
+// any individual call (e.g. a small slice along the h boundary) skips the ring locally.
+// trid is reset to 0 before returning so callers using untagged reads see clean cmd_buf
+// state.
 template <
     uint32_t C_in_block_bytes,
     bool is_padding_zeros,
@@ -248,6 +285,7 @@ template <
     uint32_t H_in_W_in,
     uint32_t in_row_size_bytes,
     bool check_padding,
+    uint32_t N_TRIDS,
     typename Reader,
     typename ShardCB>
 void gather_rows_to_shard(
@@ -264,6 +302,29 @@ void gather_rows_to_shard(
     int32_t w_shard_start,
     uint32_t w_col_start,
     uint32_t w_count) {
+    // N_TRIDS == 0 is a compile-time sentinel: the host-side classifier disabled the trid
+    // ring for this shape (compute-bound regime — see conv3d_program_factory.cpp).  In that
+    // case all ring code is constexpr-elided and the function reduces to issue-all + single
+    // trailing barrier.  When non-zero, N_TRIDS is always conv3d_gather_tuning::
+    // kGatherTridDepth (the host wires this in); the upper bound matches the underlying NoC
+    // trid-id range.
+    static_assert(
+        N_TRIDS == 0 || N_TRIDS == conv3d_gather_tuning::kGatherTridDepthLow ||
+        N_TRIDS == conv3d_gather_tuning::kGatherTridDepthHigh);
+    static_assert(conv3d_gather_tuning::kGatherTridDepthHigh <= 8, "trid id range exceeded");
+    auto trid_for = [](uint32_t i) -> uint32_t {
+        if constexpr (N_TRIDS == 0) {
+            return 0;  // unused
+        } else {
+            return (i % N_TRIDS) + 1;
+        }
+    };
+    // Per-call fast path: if this call won't fill at least two ring cycles, the
+    // post-loop drain of N_TRIDS barriers is wasted.  Floor at 2 * N_TRIDS reads.
+    constexpr uint32_t kGatherFastPathReadCutoff = 2 * N_TRIDS;
+    const uint32_t total_reads_estimate = T_shard_cur * (h_end - h_start) * w_count;
+    [[maybe_unused]] const bool use_ring = (N_TRIDS != 0) && (total_reads_estimate >= kGatherFastPathReadCutoff);
+    [[maybe_unused]] uint32_t issued = 0;
     for (uint32_t t_local = 0; t_local < T_shard_cur; t_local++) {
         const int32_t t_in = t_shard_start + static_cast<int32_t>(t_local);
         [[maybe_unused]] const bool t_outside = check_padding && (t_in < 0 || t_in >= static_cast<int32_t>(T_in));
@@ -278,6 +339,18 @@ void gather_rows_to_shard(
                 (t_local * H_shard_max_W_shard_max + h_local * W_shard_max + w_col_start) * C_in_block_bytes;
             for (uint32_t w_idx = 0; w_idx < w_count; w_idx++) {
                 const int32_t w_in = w_shard_start + static_cast<int32_t>(w_col_start + w_idx);
+                // Trid ring: free this slot if it's been used N_TRIDS reads ago, then tag the
+                // upcoming read with this iteration's trid.  Both N_TRIDS==0 (host-disabled)
+                // and use_ring=false (small-burst fallback) bypass; the constexpr branch keeps
+                // the disabled binary clean.
+                if constexpr (N_TRIDS != 0) {
+                    if (use_ring) {
+                        if (issued >= N_TRIDS) {
+                            experimental::async_read_barrier_with_trid(noc, trid_for(issued - N_TRIDS));
+                        }
+                        experimental::set_read_trid(noc, trid_for(issued));
+                    }
+                }
                 if constexpr (check_padding) {
                     const bool w_outside = (w_in < 0 || w_in >= static_cast<int32_t>(W_in));
                     const bool in_padding = t_outside || h_outside || w_outside;
@@ -326,41 +399,258 @@ void gather_rows_to_shard(
                         shard_offset,
                         C_in_block_bytes);
                 }
+                if constexpr (N_TRIDS != 0) {
+                    if (use_ring) {
+                        issued++;
+                    }
+                }
                 shard_offset += C_in_block_bytes;
             }
         }
     }
-    noc.async_read_barrier();
+    if constexpr (N_TRIDS != 0) {
+        if (use_ring) {
+            // Drain the in-flight trids in issue order.  After the loop, the most recently
+            // issued read used trid_for(issued-1), and the oldest still in flight used
+            // trid_for(issued - to_drain).
+            const uint32_t to_drain = issued < N_TRIDS ? issued : N_TRIDS;
+            for (uint32_t k = 0; k < to_drain; k++) {
+                experimental::async_read_barrier_with_trid(noc, trid_for(issued - to_drain + k));
+            }
+            // Restore untagged state so vol2col / pre_zero / shift reads (which use trid 0)
+            // don't get accounted against a stale per-trid counter.
+            experimental::set_read_trid(noc, 0);
+        } else {
+            // Small-burst fallback: ring code never set a trid this call, so no reset needed.
+            noc.async_read_barrier();
+        }
+    } else {
+        // Host-disabled: ring code is fully constexpr-elided, trid was never touched.
+        noc.async_read_barrier();
+    }
 }
 
-// Dispatch to fast or slow gather based on runtime bounds check.
-#define GATHER_ROWS(all_in_bounds, ...)  \
-    do {                                 \
-        if (all_in_bounds)               \
-            gather_rows_to_shard<        \
-                C_in_block_bytes,        \
-                is_padding_zeros,        \
-                H_shard_max_W_shard_max, \
-                W_shard_max,             \
-                T_in,                    \
-                H_in,                    \
-                W_in,                    \
-                H_in_W_in,               \
-                in_row_size_bytes,       \
-                false>(__VA_ARGS__);     \
-        else                             \
-            gather_rows_to_shard<        \
-                C_in_block_bytes,        \
-                is_padding_zeros,        \
-                H_shard_max_W_shard_max, \
-                W_shard_max,             \
-                T_in,                    \
-                H_in,                    \
-                W_in,                    \
-                H_in_W_in,               \
-                in_row_size_bytes,       \
-                true>(__VA_ARGS__);      \
-    } while (0)
+// Coalesced shard gather reads each logical row into scratch in bank-major chunks, then
+// deinterleaves scratch back into the natural shard layout with local L1->L1 copies.  The
+// extra L1 traffic is intentional: perf sweeps showed the win comes from replacing
+// many small DRAM reads with larger per-bank bursts and then paying a local reorder pass.
+template <
+    uint32_t C_in_block_bytes,
+    uint32_t H_shard_max_W_shard_max,
+    uint32_t W_shard_max,
+    uint32_t W_in,
+    uint32_t H_in_W_in,
+    uint32_t GatherTrids,
+    typename Reader,
+    typename ShardCB>
+void gather_rows_to_shard_coalesced(
+    experimental::Noc noc,
+    const Reader& in_reader,
+    const ShardCB& shard_cb,
+    uint32_t shard_l1_base,
+    uint32_t scratch_row_offset,
+    uint32_t batch_page_base,
+    [[maybe_unused]] uint32_t c_in_offset_bytes,
+    int32_t t_shard_start,
+    uint32_t T_shard_cur,
+    int32_t h_shard_start,
+    uint32_t h_start,
+    uint32_t h_end,
+    int32_t w_shard_start,
+    uint32_t w_col_start,
+    uint32_t w_count,
+    uint32_t scratch_rows) {
+    static_assert(Reader::DSpec::is_interleaved && Reader::DSpec::is_dram);
+    static_assert(GatherTrids == 0, "Coalesced shard reads require gather trid ring disabled");
+    ASSERT(c_in_offset_bytes == 0);
+    ASSERT(h_end > h_start);
+    ASSERT(w_count > NUM_DRAM_BANKS);
+    ASSERT(scratch_rows > 0);
+
+    CoalescedRowLayout<C_in_block_bytes> row_layout;
+    row_layout.compute(w_count);
+
+    const uint32_t h_count = h_end - h_start;
+    const uint32_t total_rows = T_shard_cur * h_count;
+    const uint32_t scratch_row_bytes = W_shard_max * C_in_block_bytes;
+
+    for (uint32_t row_start = 0; row_start < total_rows; row_start += scratch_rows) {
+        const uint32_t rows_cur = std::min(scratch_rows, total_rows - row_start);
+
+        for (uint32_t scratch_row = 0; scratch_row < rows_cur; scratch_row++) {
+            const uint32_t row_linear = row_start + scratch_row;
+            const uint32_t t_local = row_linear / h_count;
+            const uint32_t h_local = h_start + row_linear - t_local * h_count;
+            const int32_t t_in = t_shard_start + static_cast<int32_t>(t_local);
+            const int32_t h_in = h_shard_start + static_cast<int32_t>(h_local);
+            const uint32_t page_base = batch_page_base + static_cast<uint32_t>(t_in) * H_in_W_in +
+                                       static_cast<uint32_t>(h_in) * W_in + static_cast<uint32_t>(w_shard_start);
+            const uint32_t scratch_base = scratch_row_offset + scratch_row * scratch_row_bytes;
+
+            for (uint32_t slot = 0; slot < NUM_DRAM_BANKS; slot++) {
+                const uint32_t pages = row_layout.slot_chunk_pages[slot];
+                if (pages == 0) {
+                    continue;
+                }
+                noc.async_read(
+                    in_reader,
+                    shard_cb,
+                    pages * C_in_block_bytes,
+                    {.page_id = page_base + w_col_start + slot, .offset_bytes = 0},
+                    {.offset_bytes = scratch_base + row_layout.slot_chunk_offset[slot]});
+            }
+        }
+        noc.async_read_barrier();
+
+        if constexpr (C_in_block_bytes <= NOC_MAX_BURST_SIZE) {
+            experimental::set_read_state<C_in_block_bytes>(noc, shard_l1_base + scratch_row_offset);
+        }
+
+        for (uint32_t scratch_row = 0; scratch_row < rows_cur; scratch_row++) {
+            const uint32_t row_linear = row_start + scratch_row;
+            const uint32_t t_local = row_linear / h_count;
+            const uint32_t h_local = h_start + row_linear - t_local * h_count;
+            const uint32_t row_base = (t_local * H_shard_max_W_shard_max + h_local * W_shard_max) * C_in_block_bytes;
+            const uint32_t scratch_base = scratch_row_offset + scratch_row * scratch_row_bytes;
+            for (uint32_t w_idx = 0; w_idx < w_count; w_idx++) {
+                const uint32_t src_l1_addr = shard_l1_base + scratch_base + row_layout.offset_for_w(w_idx);
+                const uint32_t dst_offset = row_base + (w_col_start + w_idx) * C_in_block_bytes;
+                if constexpr (C_in_block_bytes <= NOC_MAX_BURST_SIZE) {
+                    experimental::read_with_state(noc, shard_cb, src_l1_addr, {.offset_bytes = dst_offset});
+                } else {
+                    experimental::UnicastEndpoint self_ep;
+                    noc.async_read(
+                        self_ep,
+                        shard_cb,
+                        C_in_block_bytes,
+                        experimental::local_addr(src_l1_addr, noc.get_noc_id()),
+                        {.offset_bytes = dst_offset});
+                }
+            }
+        }
+        noc.async_read_barrier();
+    }
+}
+
+// Dispatch to coalesced, in-bounds, or padded gather from one call site shape. This keeps the
+// first-W incremental gather and the later H-incremental gather wired identically.
+template <
+    uint32_t C_in_block_bytes,
+    bool is_padding_zeros,
+    uint32_t H_shard_max_W_shard_max,
+    uint32_t W_shard_max,
+    uint32_t T_in,
+    uint32_t H_in,
+    uint32_t W_in,
+    uint32_t H_in_W_in,
+    uint32_t in_row_size_bytes,
+    uint32_t GatherTrids,
+    bool EnableCoalescedShardReads,
+    typename Reader,
+    typename ShardCB>
+void gather_rows_to_shard_selected(
+    experimental::Noc noc,
+    const Reader& in_reader,
+    const ShardCB& shard_cb,
+    [[maybe_unused]] uint32_t shard_l1_base,
+    [[maybe_unused]] uint32_t coalesced_scratch_offset,
+    bool all_in_bounds,
+    [[maybe_unused]] bool use_coalesced,
+    uint32_t batch_page_base,
+    uint32_t c_in_offset_bytes,
+    int32_t t_shard_start,
+    uint32_t T_shard_cur,
+    int32_t h_shard_start,
+    uint32_t h_start,
+    uint32_t h_end,
+    int32_t w_shard_start,
+    uint32_t w_col_start,
+    uint32_t w_count,
+    [[maybe_unused]] uint32_t coalesced_scratch_rows) {
+    if constexpr (EnableCoalescedShardReads) {
+        if (use_coalesced) {
+            ASSERT(all_in_bounds);
+            gather_rows_to_shard_coalesced<
+                C_in_block_bytes,
+                H_shard_max_W_shard_max,
+                W_shard_max,
+                W_in,
+                H_in_W_in,
+                GatherTrids>(
+                noc,
+                in_reader,
+                shard_cb,
+                shard_l1_base,
+                coalesced_scratch_offset,
+                batch_page_base,
+                c_in_offset_bytes,
+                t_shard_start,
+                T_shard_cur,
+                h_shard_start,
+                h_start,
+                h_end,
+                w_shard_start,
+                w_col_start,
+                w_count,
+                coalesced_scratch_rows);
+            return;
+        }
+    }
+
+    if (all_in_bounds) {
+        gather_rows_to_shard<
+            C_in_block_bytes,
+            is_padding_zeros,
+            H_shard_max_W_shard_max,
+            W_shard_max,
+            T_in,
+            H_in,
+            W_in,
+            H_in_W_in,
+            in_row_size_bytes,
+            false,
+            GatherTrids>(
+            noc,
+            in_reader,
+            shard_cb,
+            batch_page_base,
+            c_in_offset_bytes,
+            t_shard_start,
+            T_shard_cur,
+            h_shard_start,
+            h_start,
+            h_end,
+            w_shard_start,
+            w_col_start,
+            w_count);
+    } else {
+        gather_rows_to_shard<
+            C_in_block_bytes,
+            is_padding_zeros,
+            H_shard_max_W_shard_max,
+            W_shard_max,
+            T_in,
+            H_in,
+            W_in,
+            H_in_W_in,
+            in_row_size_bytes,
+            true,
+            GatherTrids>(
+            noc,
+            in_reader,
+            shard_cb,
+            batch_page_base,
+            c_in_offset_bytes,
+            t_shard_start,
+            T_shard_cur,
+            h_shard_start,
+            h_start,
+            h_end,
+            w_shard_start,
+            w_col_start,
+            w_count);
+    }
+}
 
 void kernel_main() {
     constexpr uint32_t cb_vol2col = get_compile_time_arg_val(0);
@@ -402,6 +692,10 @@ void kernel_main() {
 
     // Padding bytes to append after each patch row to reach tile-aligned CB page width
     constexpr uint32_t patch_pad_bytes = get_compile_time_arg_val(35);
+    // Trid-ring depth for gather_rows_to_shard.  See plan in conv3d_gather_trid_pipeline_plan.md.
+    constexpr uint32_t gather_trids = get_compile_time_arg_val(36);
+    constexpr bool enable_coalesced_shard_reads = get_compile_time_arg_val(37) == 1;
+    constexpr uint32_t coalesced_scratch_rows = get_compile_time_arg_val(38);
     constexpr uint32_t padded_page_bytes = kT * kH * kW * C_in_block_bytes + patch_pad_bytes;
 
     // Load input/output addresses and range parameters
@@ -419,7 +713,7 @@ void kernel_main() {
     const uint32_t w_out_end = get_arg_val<uint32_t>(argidx++);
 
     // Tensor accessor for input tensor
-    constexpr auto in_args = TensorAccessorArgs<36>();
+    constexpr auto in_args = TensorAccessorArgs<39>();
     const auto in_reader = TensorAccessor(in_args, in_addr);
 
     experimental::Noc noc;
@@ -438,7 +732,9 @@ void kernel_main() {
     uint32_t shard_l1_base = 0;
     if constexpr (use_l1_prefetch) {
         constexpr uint32_t shard_total = T_shard_max * H_shard_max_W_shard_max;
-        shard_cb.reserve_back(shard_total);
+        constexpr uint32_t coalesced_scratch_pages =
+            enable_coalesced_shard_reads ? coalesced_scratch_rows * W_shard_max : 0;
+        shard_cb.reserve_back(shard_total + coalesced_scratch_pages);
         shard_l1_base = shard_cb.get_write_ptr();
     }
 
@@ -483,6 +779,10 @@ void kernel_main() {
                                 const bool shard_all_in_bounds = th_in_bounds && w_shard_start >= 0 &&
                                                                  (w_shard_start + static_cast<int32_t>(W_shard_cur) -
                                                                   1) < static_cast<int32_t>(W_in);
+                                const bool coalesce_this_block =
+                                    enable_coalesced_shard_reads && shard_all_in_bounds && W_shard_cur > NUM_DRAM_BANKS;
+                                constexpr uint32_t coalesced_scratch_offset =
+                                    T_shard_max * H_shard_max_W_shard_max * C_in_block_bytes;
 
                                 // --- SLIDING WINDOW W + H-ROW INTERLEAVED GATHER ---
                                 // For w_block > first: shift retained kW-1 columns to shard start,
@@ -509,11 +809,25 @@ void kernel_main() {
 
                                     // Gather new W columns for existing h-rows
                                     const uint32_t new_w_cols = W_shard_cur - overlap_w;
-                                    GATHER_ROWS(
-                                        shard_all_in_bounds,
+                                    gather_rows_to_shard_selected<
+                                        C_in_block_bytes,
+                                        is_padding_zeros,
+                                        H_shard_max_W_shard_max,
+                                        W_shard_max,
+                                        T_in,
+                                        H_in,
+                                        W_in,
+                                        H_in_W_in,
+                                        in_row_size_bytes,
+                                        gather_trids,
+                                        enable_coalesced_shard_reads>(
                                         noc,
                                         in_reader,
                                         shard_cb,
+                                        shard_l1_base,
+                                        coalesced_scratch_offset,
+                                        shard_all_in_bounds,
+                                        shard_all_in_bounds && new_w_cols > NUM_DRAM_BANKS,
                                         batch_page_base,
                                         c_in_offset_bytes,
                                         t_shard_start,
@@ -523,7 +837,8 @@ void kernel_main() {
                                         h_rows_gathered,
                                         w_shard_start,
                                         overlap_w,
-                                        new_w_cols);
+                                        new_w_cols,
+                                        coalesced_scratch_rows);
                                 }
 
                                 ChunkWriter<cb_vol2col, padded_page_bytes, patch_pad_bytes> chunk(noc);
@@ -537,11 +852,25 @@ void kernel_main() {
                                         // Gather shard rows needed for this output h (incremental)
                                         const uint32_t h_needed = h_base + kH;
                                         if (h_needed > h_rows_gathered) {
-                                            GATHER_ROWS(
-                                                shard_all_in_bounds,
+                                            gather_rows_to_shard_selected<
+                                                C_in_block_bytes,
+                                                is_padding_zeros,
+                                                H_shard_max_W_shard_max,
+                                                W_shard_max,
+                                                T_in,
+                                                H_in,
+                                                W_in,
+                                                H_in_W_in,
+                                                in_row_size_bytes,
+                                                gather_trids,
+                                                enable_coalesced_shard_reads>(
                                                 noc,
                                                 in_reader,
                                                 shard_cb,
+                                                shard_l1_base,
+                                                coalesced_scratch_offset,
+                                                shard_all_in_bounds,
+                                                coalesce_this_block,
                                                 batch_page_base,
                                                 c_in_offset_bytes,
                                                 t_shard_start,
@@ -551,11 +880,13 @@ void kernel_main() {
                                                 h_needed,
                                                 w_shard_start,
                                                 0u,
-                                                W_shard_cur);
+                                                W_shard_cur,
+                                                coalesced_scratch_rows);
                                             h_rows_gathered = h_needed;
                                         }
 
-                                        // Vol2col for this (t, h) across all w
+                                        // Coalesced gather reorders through scratch into the same natural shard layout,
+                                        // so vol2col always keeps the contiguous kW-row fast path.
                                         vol2col_shard_to_cb<
                                             kT,
                                             kH,

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <type_traits>
 #include "api/dataflow/dataflow_api.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 #include <ttnn/operations/experimental/conv3d/device/kernels/conv3d_gather_tuning.hpp>
@@ -597,58 +598,41 @@ void gather_rows_to_shard_selected(
         }
     }
 
+    // check_padding is a template arg on gather_rows_to_shard (compile-time elision of the
+    // padding bounds-check + clamp/zero-pad branch in the hot inner loop), so it must be
+    // dispatched as a constant. Generic lambda + bool-constant lifts the runtime
+    // `all_in_bounds` to a compile-time value once and shares the call site.
+    const auto do_gather = [&](auto check_padding_v) {
+        gather_rows_to_shard<
+            C_in_block_bytes,
+            is_padding_zeros,
+            H_shard_max_W_shard_max,
+            W_shard_max,
+            T_in,
+            H_in,
+            W_in,
+            H_in_W_in,
+            in_row_size_bytes,
+            decltype(check_padding_v)::value,
+            GatherTrids>(
+            noc,
+            in_reader,
+            shard_cb,
+            batch_page_base,
+            c_in_offset_bytes,
+            t_shard_start,
+            T_shard_cur,
+            h_shard_start,
+            h_start,
+            h_end,
+            w_shard_start,
+            w_col_start,
+            w_count);
+    };
     if (all_in_bounds) {
-        gather_rows_to_shard<
-            C_in_block_bytes,
-            is_padding_zeros,
-            H_shard_max_W_shard_max,
-            W_shard_max,
-            T_in,
-            H_in,
-            W_in,
-            H_in_W_in,
-            in_row_size_bytes,
-            false,
-            GatherTrids>(
-            noc,
-            in_reader,
-            shard_cb,
-            batch_page_base,
-            c_in_offset_bytes,
-            t_shard_start,
-            T_shard_cur,
-            h_shard_start,
-            h_start,
-            h_end,
-            w_shard_start,
-            w_col_start,
-            w_count);
+        do_gather(std::false_type{});
     } else {
-        gather_rows_to_shard<
-            C_in_block_bytes,
-            is_padding_zeros,
-            H_shard_max_W_shard_max,
-            W_shard_max,
-            T_in,
-            H_in,
-            W_in,
-            H_in_W_in,
-            in_row_size_bytes,
-            true,
-            GatherTrids>(
-            noc,
-            in_reader,
-            shard_cb,
-            batch_page_base,
-            c_in_offset_bytes,
-            t_shard_start,
-            T_shard_cur,
-            h_shard_start,
-            h_start,
-            h_end,
-            w_shard_start,
-            w_col_start,
-            w_count);
+        do_gather(std::true_type{});
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
@@ -4,9 +4,35 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
-#include "hostdevcommon/common_values.hpp"
+#include <tt-metalium/constants.hpp>
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 #include "experimental/noc_semaphore.h"
+#include "ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/conv3d_weight_share.hpp"
+
+template <
+    uint32_t tile_bytes,
+    uint32_t matmul_K_t,
+    uint32_t matmul_N_t,
+    uint32_t C_out_t,
+    typename WeightReader,
+    typename WeightCB>
+FORCE_INLINE void read_weight_block(
+    experimental::Noc noc,
+    const WeightReader& weight_reader,
+    const WeightCB& cb_weight,
+    uint32_t c_in_offset_t,
+    uint32_t c_out_offset_t) {
+    uint32_t weight_write_offset = 0;
+    for (uint32_t row = c_in_offset_t; row < c_in_offset_t + matmul_K_t; row++) {
+        for (uint32_t col = c_out_offset_t; col < c_out_offset_t + matmul_N_t; col++) {
+            const uint32_t weight_idx = row * C_out_t + col;
+            noc.async_read(
+                weight_reader, cb_weight, tile_bytes, {.page_id = weight_idx}, {.offset_bytes = weight_write_offset});
+            weight_write_offset += tile_bytes;
+        }
+    }
+    noc.async_read_barrier();
+}
 
 void kernel_main() {
     constexpr uint32_t cb_matmul_result_rm = get_compile_time_arg_val(0);
@@ -30,7 +56,14 @@ void kernel_main() {
     constexpr uint32_t C_out_block_bytes = get_compile_time_arg_val(19);
     constexpr bool use_bias = get_compile_time_arg_val(20) == 1;
     constexpr uint32_t semaphore_id = get_compile_time_arg_val(21);
-    constexpr uint32_t cb_zero_tiled = get_compile_time_arg_val(22);
+    // weight_share_mode (see WeightShareMode in conv3d_weight_share.hpp): Disabled, Chain, or Mcast.
+    constexpr WeightShareMode weight_share_mode = static_cast<WeightShareMode>(get_compile_time_arg_val(22));
+    constexpr bool enable_weight_chain = weight_share_mode == WeightShareMode::Chain;
+    constexpr bool enable_weight_mcast = weight_share_mode == WeightShareMode::Mcast;
+    constexpr uint32_t weights_mcast_sender_sem_id = get_compile_time_arg_val(23);
+    constexpr uint32_t weights_mcast_receiver_sem_id = get_compile_time_arg_val(24);
+    constexpr uint32_t enable_streaming_output_arg_idx = 25;
+    constexpr bool enable_streaming_output = get_compile_time_arg_val(enable_streaming_output_arg_idx) == 1;
 
     uint32_t argidx = 0;
     const uint32_t out_addr = get_arg_val<uint32_t>(argidx++);
@@ -47,6 +80,21 @@ void kernel_main() {
     const uint32_t w_out_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t w_out_end = get_arg_val<uint32_t>(argidx++);
     const uint32_t is_reducer = get_arg_val<uint32_t>(argidx++);
+    // weight_mcast_role: see WeightMcastRole in conv3d_weight_share.hpp.
+    const WeightMcastRole weight_mcast_role = static_cast<WeightMcastRole>(get_arg_val<uint32_t>(argidx++));
+    // Chain pred (roles 2,3) doubles as mcast sender NoC coord (roles 5,6).
+    const uint32_t pred_noc_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t pred_noc_y = get_arg_val<uint32_t>(argidx++);
+    // Chain succ (roles 1,2). Unused otherwise.
+    const uint32_t succ_noc_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t succ_noc_y = get_arg_val<uint32_t>(argidx++);
+    // Mcast bbox + counts. Only mcast sender (role 4) needs the bbox; passive (role 6) needs iters.
+    const uint32_t mcast_bbox_start_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t mcast_bbox_start_y = get_arg_val<uint32_t>(argidx++);
+    const uint32_t mcast_bbox_end_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t mcast_bbox_end_y = get_arg_val<uint32_t>(argidx++);
+    const uint32_t mcast_num_dests = get_arg_val<uint32_t>(argidx++);
+    const uint32_t mcast_num_iters = get_arg_val<uint32_t>(argidx++);
     const uint32_t num_workers = get_arg_val<uint32_t>(argidx++);
 
     experimental::Noc noc;
@@ -57,6 +105,8 @@ void kernel_main() {
     experimental::CB cb_reduction(cb_reduction_tiled);
     experimental::CB cb_ack(cb_worker_ack_back);
     experimental::Semaphore<> sem(semaphore_id);
+    experimental::Semaphore<> weights_mcast_sender_sem(weights_mcast_sender_sem_id);
+    experimental::Semaphore<> weights_mcast_receiver_sem(weights_mcast_receiver_sem_id);
 
     // Reducer coordinates and worker core coordinates are only present when num_workers > 0
     uint32_t reducer_core_x = 0, reducer_core_y = 0;
@@ -72,7 +122,8 @@ void kernel_main() {
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_weight_tiled);
     constexpr uint32_t partials_tile_bytes = get_tile_size(cb_matmul_interm_tiled);
-    constexpr auto out_args = TensorAccessorArgs<23>();
+    constexpr uint32_t tensor_accessor_args_offset = enable_streaming_output_arg_idx + 1;
+    constexpr auto out_args = TensorAccessorArgs<tensor_accessor_args_offset>();
     constexpr auto weight_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
     constexpr auto bias_args = TensorAccessorArgs<weight_args.next_compile_time_args_offset()>();
     const auto out_writer = TensorAccessor(out_args, out_addr);
@@ -84,34 +135,20 @@ void kernel_main() {
     constexpr uint32_t C_out_t = C_out_num_blocks * matmul_N_t;
     constexpr uint32_t T_out_H_out_W_out = T_out * H_out * W_out;
 
-    // Zero-fill the zero CB for FPU accumulate reduction (DST += tile + 0).
-    // The zero tile stays resident for the lifetime of the kernel.
-    // Clamp index to avoid constexpr OOB when cb_zero_tiled==32 (fp32 reduction disabled).
-    // The if constexpr discards this branch, but WH's compiler still evaluates get_tile_size.
-    constexpr uint32_t cb_zero_safe = cb_zero_tiled < 32 ? cb_zero_tiled : 0;
-    if constexpr (cb_zero_tiled < 32) {
-        experimental::CB cb_zero(cb_zero_tiled);
-        cb_zero.reserve_back(1);
-        constexpr uint32_t zero_tile_bytes = get_tile_size(cb_zero_safe);
-        uint32_t zero_offset = 0;
-        uint32_t remaining = zero_tile_bytes;
-        experimental::set_read_state<MEM_ZEROS_SIZE>(noc, MEM_ZEROS_BASE);
-        while (remaining >= MEM_ZEROS_SIZE) {
-            experimental::read_with_state(noc, cb_zero, MEM_ZEROS_BASE, {.offset_bytes = zero_offset});
-            zero_offset += MEM_ZEROS_SIZE;
-            remaining -= MEM_ZEROS_SIZE;
+    // Mcast passive participant: this core sits inside the mcast bbox but has no work. It exists
+    // only to satisfy the multicast handshake (sender's wait depends on every core in the bbox
+    // ack'ing). Run mcast_num_iters handshakes (matching active receivers' iteration count) and
+    // exit before any work-dependent code below.
+    if constexpr (enable_weight_mcast) {
+        if (weight_mcast_role == WeightMcastRole::McastPassive) {
+            for (uint32_t i = 0; i < mcast_num_iters; i++) {
+                weights_mcast_sender_sem.up(noc, pred_noc_x, pred_noc_y, 1);
+                weights_mcast_receiver_sem.wait(1);
+                weights_mcast_receiver_sem.set(0);
+            }
+            noc.async_atomic_barrier();
+            return;
         }
-        if (remaining > 0) {
-            experimental::UnicastEndpoint self_ep;
-            noc.async_read(
-                self_ep,
-                cb_zero,
-                remaining,
-                experimental::local_addr(MEM_ZEROS_BASE, noc.get_noc_id()),
-                {.offset_bytes = zero_offset});
-        }
-        noc.async_read_barrier();
-        cb_zero.push_back(1);
     }
 
     // Process each batch element
@@ -122,24 +159,108 @@ void kernel_main() {
             for (uint32_t c_out_block = c_out_block_start; c_out_block < c_out_block_end; c_out_block++) {
                 const uint32_t c_out_offset_t = c_out_block * matmul_N_t;
 
-                // Read weights and bias for this block
-                cb_weight.reserve_back(weight_tiles);
-                uint32_t weight_write_offset = 0;
+                // Read weights for this block. Strategy depends on weight_share_mode:
+                //   - chain (1): each non-injector receives from pred, each non-tail forwards to succ
+                //   - mcast (2): sender DRAM-reads then multicasts over the bbox; receivers wait
+                //   - off (0): every core reads from DRAM independently
+                if constexpr (enable_weight_chain) {
+                    cb_weight.reserve_back(weight_tiles);
+                    if (weight_mcast_role == WeightMcastRole::Local) {
+                        // Local DRAM read (single-core group inside a chain-mode program).
+                        read_weight_block<tile_bytes, matmul_K_t, matmul_N_t, C_out_t>(
+                            noc, weight_reader, cb_weight, c_in_offset_t, c_out_offset_t);
+                    } else {
+                        if (weight_mcast_role == WeightMcastRole::ChainInjector) {
+                            read_weight_block<tile_bytes, matmul_K_t, matmul_N_t, C_out_t>(
+                                noc, weight_reader, cb_weight, c_in_offset_t, c_out_offset_t);
+                        } else {
+                            weights_mcast_sender_sem.up(noc, pred_noc_x, pred_noc_y, 1);
+                            weights_mcast_receiver_sem.wait(1);
+                            weights_mcast_receiver_sem.set(0);
+                        }
+                        if (weight_mcast_role != WeightMcastRole::ChainTail) {
+                            weights_mcast_sender_sem.wait(1);
+                            weights_mcast_sender_sem.set(0);
 
-                for (uint32_t row = c_in_offset_t; row < c_in_offset_t + matmul_K_t; row++) {
-                    for (uint32_t col = c_out_offset_t; col < c_out_offset_t + matmul_N_t; col++) {
-                        uint32_t weight_idx = row * C_out_t + col;
-                        noc.async_read(
-                            weight_reader,
-                            cb_weight,
-                            tile_bytes,
-                            {.page_id = weight_idx},
-                            {.offset_bytes = weight_write_offset});
-                        weight_write_offset += tile_bytes;
+                            const uint32_t weight_block_bytes = weight_tiles * tile_bytes;
+                            const uint32_t local_addr = cb_weight.get_write_ptr();
+                            experimental::UnicastEndpoint ep;
+                            noc.async_write(
+                                experimental::use<experimental::CircularBuffer::AddrSelector::WRITE_PTR>(cb_weight),
+                                ep,
+                                weight_block_bytes,
+                                {.offset_bytes = 0},
+                                {.noc_x = succ_noc_x, .noc_y = succ_noc_y, .addr = local_addr});
+                            noc.async_write_barrier();
+
+                            weights_mcast_receiver_sem.up(noc, succ_noc_x, succ_noc_y, 1);
+                            noc.async_atomic_barrier();
+                        }
                     }
+                    cb_weight.push_back(weight_tiles);
+                } else if constexpr (enable_weight_mcast) {
+                    cb_weight.reserve_back(weight_tiles);
+                    if (weight_mcast_role == WeightMcastRole::McastSender) {
+                        // Sender: DRAM read into local L1, then hardware multicast over the
+                        // bbox. The mcast call below uses EXCLUDE_SRC; sender keeps the
+                        // DRAM-read copy in cb_weight so it doesn't need to receive its own
+                        // multicast.
+                        read_weight_block<tile_bytes, matmul_K_t, matmul_N_t, C_out_t>(
+                            noc, weight_reader, cb_weight, c_in_offset_t, c_out_offset_t);
+
+                        // mcast_num_dests is the number of receivers (= number of acks expected
+                        // = num_dests passed to EXCLUDE_SRC mcast API). Host always places the
+                        // sender inside the bbox, so mcast_num_dests = bbox_cores - 1.
+                        weights_mcast_sender_sem.wait(mcast_num_dests);
+                        weights_mcast_sender_sem.set(0);
+
+                        // EXCLUDE_SRC: sender already has the data from its DRAM read, so don't
+                        // loopback. linked=true lets the API's internal burst-splitting
+                        // (~324 KiB → ~20 × 16 KiB on BH) amortize per-burst setup.
+                        const uint32_t weight_block_bytes = weight_tiles * tile_bytes;
+                        const uint32_t local_addr = cb_weight.get_write_ptr();
+                        experimental::MulticastEndpoint mcast_dst;
+                        noc.async_write_multicast<experimental::Noc::McastMode::EXCLUDE_SRC>(
+                            experimental::use<experimental::CircularBuffer::AddrSelector::WRITE_PTR>(cb_weight),
+                            mcast_dst,
+                            weight_block_bytes,
+                            mcast_num_dests,
+                            {},
+                            {.noc_x_start = mcast_bbox_start_x,
+                             .noc_y_start = mcast_bbox_start_y,
+                             .noc_x_end = mcast_bbox_end_x,
+                             .noc_y_end = mcast_bbox_end_y,
+                             .addr = local_addr},
+                            /*linked=*/true);
+
+                        // No write_barrier between data and flag mcast (per conv2d pattern):
+                        // both go through the same NoC and VC (NOC_CMD_STATIC_VC), so the flag
+                        // can never overtake the data on any receiver. Sender's push_back is
+                        // also correct without a barrier — EXCLUDE_SRC means sender's own L1 is
+                        // not a destination, so the data already in cb_weight from the DRAM read
+                        // is what compute consumes.
+                        weights_mcast_receiver_sem.set(VALID);
+                        weights_mcast_receiver_sem.set_multicast<experimental::Noc::McastMode::EXCLUDE_SRC>(
+                            noc,
+                            mcast_bbox_start_x,
+                            mcast_bbox_start_y,
+                            mcast_bbox_end_x,
+                            mcast_bbox_end_y,
+                            mcast_num_dests,
+                            false);
+                    } else if (weight_mcast_role == WeightMcastRole::McastReceiver) {
+                        // Active receiver: ack sender, wait for VALID, reset for next iteration.
+                        weights_mcast_sender_sem.up(noc, pred_noc_x, pred_noc_y, 1);
+                        weights_mcast_receiver_sem.wait(1);
+                        weights_mcast_receiver_sem.set(0);
+                    }
+                    cb_weight.push_back(weight_tiles);
+                } else {
+                    cb_weight.reserve_back(weight_tiles);
+                    read_weight_block<tile_bytes, matmul_K_t, matmul_N_t, C_out_t>(
+                        noc, weight_reader, cb_weight, c_in_offset_t, c_out_offset_t);
+                    cb_weight.push_back(weight_tiles);
                 }
-                noc.async_read_barrier();
-                cb_weight.push_back(weight_tiles);
 
                 if constexpr (use_bias) {
                     if (is_reducer) {
@@ -167,62 +288,69 @@ void kernel_main() {
 
                             if (!is_reducer) {
                                 // I'm a worker.
-                                // Wait for compute to finish
+                                // Wait for compute to finish.
                                 cb_reduction.wait_front(output_tiles);
 
-                                // Reset our semaphore
+                                // Reset our semaphore.
                                 sem.set(0);
 
-                                // Signal to reducer that we have data ready
+                                // Signal to reducer that we have data ready.
                                 sem.up(noc, reducer_core_x, reducer_core_y, 1);
 
-                                // Wait for reducer to ack that it has read our data
+                                // Wait for reducer to ack that it has read our data.
                                 sem.wait(1);
 
-                                // Handshake with compute so it can continue
+                                // Handshake with compute so it can continue.
                                 cb_reduction.pop_front(output_tiles);
                                 cb_ack.reserve_back(1);
                                 cb_ack.push_back(1);
                             } else {
                                 // I'm a reducer.
-                                // Wait for all workers to finish
-                                sem.wait(num_workers);
+                                if (num_workers > 0) {
+                                    // Wait for all workers to finish.
+                                    sem.wait(num_workers);
 
-                                // Reset our semaphore
-                                sem.set(0);
+                                    // Reset our semaphore.
+                                    sem.set(0);
 
-                                const uint32_t worker_output_read_ptr = cb_interm.get_read_ptr();
-                                for (uint32_t worker_idx = 0; worker_idx < num_workers; worker_idx++) {
-                                    // Read data from worker into reduction buffer
-                                    // Stall if compute has not cleared buffer
-                                    cb_reduction.reserve_back(output_tiles);
-                                    uint32_t reduction_offset = 0;
-                                    const uint16_t worker_x = worker_core_xs[worker_idx];
-                                    const uint16_t worker_y = worker_core_ys[worker_idx];
-                                    for (uint32_t tile = 0; tile < output_tiles; tile++) {
+                                    const uint32_t worker_output_read_ptr = cb_interm.get_read_ptr();
+                                    for (uint32_t worker_idx = 0; worker_idx < num_workers; worker_idx++) {
+                                        // Read data from worker into reduction buffer.
+                                        cb_reduction.reserve_back(output_tiles);
+                                        const uint16_t worker_x = worker_core_xs[worker_idx];
+                                        const uint16_t worker_y = worker_core_ys[worker_idx];
                                         experimental::UnicastEndpoint ep;
                                         noc.async_read(
                                             ep,
                                             cb_reduction,
-                                            partials_tile_bytes,
-                                            {.noc_x = worker_x,
-                                             .noc_y = worker_y,
-                                             .addr = worker_output_read_ptr + tile * partials_tile_bytes},
-                                            {.offset_bytes = reduction_offset});
-                                        reduction_offset += partials_tile_bytes;
-                                    }
-                                    noc.async_read_barrier();
-                                    cb_reduction.push_back(output_tiles);
+                                            output_tiles * partials_tile_bytes,
+                                            {.noc_x = worker_x, .noc_y = worker_y, .addr = worker_output_read_ptr},
+                                            {.offset_bytes = 0});
+                                        noc.async_read_barrier();
+                                        cb_reduction.push_back(output_tiles);
 
-                                    sem.up(noc, worker_x, worker_y, 1);
+                                        sem.up(noc, worker_x, worker_y, 1);
+                                    }
                                 }
 
-                                cb_out.wait_front(output_tiles);
+                                // Streaming output drains one single-tile C_out row at a time to overlap writes with
+                                // the remaining compute tail.
+                                constexpr uint32_t row_tiles = matmul_N_t;
+                                if constexpr (!enable_streaming_output) {
+                                    cb_out.wait_front(output_tiles);
+                                }
+                                uint32_t patch_idx = 0;
                                 uint32_t cb_read_offset = 0;
-
+                                uint32_t rows_waited = 0;
                                 for (uint32_t t = t_block; t < t_block_end; ++t) {
                                     for (uint32_t h = h_block; h < h_block_end; ++h) {
                                         for (uint32_t w = w_block; w < w_block_end; ++w) {
+                                            if constexpr (enable_streaming_output) {
+                                                if (patch_idx % tt::constants::TILE_HEIGHT == 0) {
+                                                    rows_waited++;
+                                                    cb_out.wait_front(rows_waited * row_tiles);
+                                                }
+                                            }
                                             uint32_t out_page_idx =
                                                 batch_idx * T_out_H_out_W_out + t * H_out * W_out + h * W_out + w;
                                             noc.async_write(
@@ -233,6 +361,9 @@ void kernel_main() {
                                                 {.page_id = out_page_idx,
                                                  .offset_bytes = c_out_block * C_out_block_bytes});
                                             cb_read_offset += C_out_block_bytes;
+                                            if constexpr (enable_streaming_output) {
+                                                patch_idx++;
+                                            }
                                         }
                                     }
                                 }

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
@@ -62,8 +62,7 @@ void kernel_main() {
     constexpr bool enable_weight_mcast = weight_share_mode == WeightShareMode::Mcast;
     constexpr uint32_t weights_mcast_sender_sem_id = get_compile_time_arg_val(23);
     constexpr uint32_t weights_mcast_receiver_sem_id = get_compile_time_arg_val(24);
-    constexpr uint32_t enable_streaming_output_arg_idx = 25;
-    constexpr bool enable_streaming_output = get_compile_time_arg_val(enable_streaming_output_arg_idx) == 1;
+    constexpr bool enable_streaming_output = get_compile_time_arg_val(25) == 1;
 
     uint32_t argidx = 0;
     const uint32_t out_addr = get_arg_val<uint32_t>(argidx++);
@@ -120,8 +119,7 @@ void kernel_main() {
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_weight_tiled);
     constexpr uint32_t partials_tile_bytes = get_tile_size(cb_matmul_interm_tiled);
-    constexpr uint32_t tensor_accessor_args_offset = enable_streaming_output_arg_idx + 1;
-    constexpr auto out_args = TensorAccessorArgs<tensor_accessor_args_offset>();
+    constexpr auto out_args = TensorAccessorArgs<26>();
     constexpr auto weight_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
     constexpr auto bias_args = TensorAccessorArgs<weight_args.next_compile_time_args_offset()>();
     const auto out_writer = TensorAccessor(out_args, out_addr);

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
@@ -80,14 +80,12 @@ void kernel_main() {
     const uint32_t w_out_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t w_out_end = get_arg_val<uint32_t>(argidx++);
     const uint32_t is_reducer = get_arg_val<uint32_t>(argidx++);
-    // weight_mcast_role: see WeightMcastRole in conv3d_weight_share.hpp.
-    const WeightMcastRole weight_mcast_role = static_cast<WeightMcastRole>(get_arg_val<uint32_t>(argidx++));
-    // Chain pred (roles 2,3) doubles as mcast sender NoC coord (roles 5,6).
-    const uint32_t pred_noc_x = get_arg_val<uint32_t>(argidx++);
-    const uint32_t pred_noc_y = get_arg_val<uint32_t>(argidx++);
-    // Chain succ (roles 1,2). Unused otherwise.
-    const uint32_t succ_noc_x = get_arg_val<uint32_t>(argidx++);
-    const uint32_t succ_noc_y = get_arg_val<uint32_t>(argidx++);
+    // weight_share_role: see WeightShareRole in conv3d_weight_share.hpp.
+    const WeightShareRole weight_share_role = static_cast<WeightShareRole>(get_arg_val<uint32_t>(argidx++));
+    const uint32_t weight_src_noc_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t weight_src_noc_y = get_arg_val<uint32_t>(argidx++);
+    const uint32_t chain_succ_noc_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t chain_succ_noc_y = get_arg_val<uint32_t>(argidx++);
     // Mcast bbox + counts. Only mcast sender (role 4) needs the bbox; passive (role 6) needs iters.
     const uint32_t mcast_bbox_start_x = get_arg_val<uint32_t>(argidx++);
     const uint32_t mcast_bbox_start_y = get_arg_val<uint32_t>(argidx++);
@@ -140,9 +138,9 @@ void kernel_main() {
     // ack'ing). Run mcast_num_iters handshakes (matching active receivers' iteration count) and
     // exit before any work-dependent code below.
     if constexpr (enable_weight_mcast) {
-        if (weight_mcast_role == WeightMcastRole::McastPassive) {
+        if (weight_share_role == WeightShareRole::McastPassive) {
             for (uint32_t i = 0; i < mcast_num_iters; i++) {
-                weights_mcast_sender_sem.up(noc, pred_noc_x, pred_noc_y, 1);
+                weights_mcast_sender_sem.up(noc, weight_src_noc_x, weight_src_noc_y, 1);
                 weights_mcast_receiver_sem.wait(1);
                 weights_mcast_receiver_sem.set(0);
             }
@@ -165,20 +163,20 @@ void kernel_main() {
                 //   - off (0): every core reads from DRAM independently
                 if constexpr (enable_weight_chain) {
                     cb_weight.reserve_back(weight_tiles);
-                    if (weight_mcast_role == WeightMcastRole::Local) {
+                    if (weight_share_role == WeightShareRole::Local) {
                         // Local DRAM read (single-core group inside a chain-mode program).
                         read_weight_block<tile_bytes, matmul_K_t, matmul_N_t, C_out_t>(
                             noc, weight_reader, cb_weight, c_in_offset_t, c_out_offset_t);
                     } else {
-                        if (weight_mcast_role == WeightMcastRole::ChainInjector) {
+                        if (weight_share_role == WeightShareRole::ChainInjector) {
                             read_weight_block<tile_bytes, matmul_K_t, matmul_N_t, C_out_t>(
                                 noc, weight_reader, cb_weight, c_in_offset_t, c_out_offset_t);
                         } else {
-                            weights_mcast_sender_sem.up(noc, pred_noc_x, pred_noc_y, 1);
+                            weights_mcast_sender_sem.up(noc, weight_src_noc_x, weight_src_noc_y, 1);
                             weights_mcast_receiver_sem.wait(1);
                             weights_mcast_receiver_sem.set(0);
                         }
-                        if (weight_mcast_role != WeightMcastRole::ChainTail) {
+                        if (weight_share_role != WeightShareRole::ChainTail) {
                             weights_mcast_sender_sem.wait(1);
                             weights_mcast_sender_sem.set(0);
 
@@ -190,17 +188,17 @@ void kernel_main() {
                                 ep,
                                 weight_block_bytes,
                                 {.offset_bytes = 0},
-                                {.noc_x = succ_noc_x, .noc_y = succ_noc_y, .addr = local_addr});
+                                {.noc_x = chain_succ_noc_x, .noc_y = chain_succ_noc_y, .addr = local_addr});
                             noc.async_write_barrier();
 
-                            weights_mcast_receiver_sem.up(noc, succ_noc_x, succ_noc_y, 1);
+                            weights_mcast_receiver_sem.up(noc, chain_succ_noc_x, chain_succ_noc_y, 1);
                             noc.async_atomic_barrier();
                         }
                     }
                     cb_weight.push_back(weight_tiles);
                 } else if constexpr (enable_weight_mcast) {
                     cb_weight.reserve_back(weight_tiles);
-                    if (weight_mcast_role == WeightMcastRole::McastSender) {
+                    if (weight_share_role == WeightShareRole::McastSender) {
                         // Sender: DRAM read into local L1, then hardware multicast over the
                         // bbox. The mcast call below uses EXCLUDE_SRC; sender keeps the
                         // DRAM-read copy in cb_weight so it doesn't need to receive its own
@@ -248,9 +246,9 @@ void kernel_main() {
                             mcast_bbox_end_y,
                             mcast_num_dests,
                             false);
-                    } else if (weight_mcast_role == WeightMcastRole::McastReceiver) {
+                    } else if (weight_share_role == WeightShareRole::McastReceiver) {
                         // Active receiver: ack sender, wait for VALID, reset for next iteration.
-                        weights_mcast_sender_sem.up(noc, pred_noc_x, pred_noc_y, 1);
+                        weights_mcast_sender_sem.up(noc, weight_src_noc_x, weight_src_noc_y, 1);
                         weights_mcast_receiver_sem.wait(1);
                         weights_mcast_receiver_sem.set(0);
                     }

--- a/ttnn/cpp/ttnn/operations/pool/device/kernels/experimental_device_api.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/device/kernels/experimental_device_api.hpp
@@ -74,6 +74,18 @@ FORCE_INLINE void read_with_state(Noc noc, const Dst& dst, uint32_t src_addr) {
     noc.async_read_with_state<Noc::VcSelection::DEFAULT, 1>(ep, dst, 0, local_addr(src_addr, noc.get_noc_id()), {});
 }
 
+// Set the active transaction id (NOC_PACKET_TAG) for subsequent async_read* calls on this
+// Noc's read cmd_buf.  Trid persists across set_read_state / read_with_state (those write
+// different cmd_buf registers).  Pair with async_read_barrier_with_trid to wait on just
+// this batch of reads.  Pass trid=0 to clear (untagged reads = no per-trid accounting).
+FORCE_INLINE void set_read_trid(Noc noc, uint32_t trid) { noc_async_read_set_trid(trid, noc.get_noc_id()); }
+
+// Block until reads tagged `trid` on this noc are flushed.  Other in-flight reads with
+// different trids continue independently.
+FORCE_INLINE void async_read_barrier_with_trid(Noc noc, uint32_t trid) {
+    noc.template async_read_barrier<Noc::BarrierMode::TXN_ID>(trid);
+}
+
 #endif
 
 }  // namespace experimental


### PR DESCRIPTION
## Summary

This PR optimizes experimental conv3d data movement paths, primarily for activation/weight movement bottlenecks observed in the conv3d profile suite.

Main changes:
- Add coalesced DRAM shard reads for eligible conv3d shapes, with L1 scratch deinterleave to trade local L1 traffic for larger DRAM-side bursts.
- Add gather tuning helpers and gating for trid-ring gather behavior.
- Add weight sharing modes for local, chain-injector, and multicast sender roles.
- Add streaming output support for small-write output cases where compute/writer overlap is beneficial.
- Refactor conv3d program factory, reader, writer, and compute plumbing around these gated paths.

## Gating / Scope

The new paths are gated in program factory rather than enabled globally. The important constraints are:
- Coalesced shard reads require DRAM interleaved input, one C-in block, full C-in row reads, enough W shard columns to amortize the L1 reorder pass, and enough L1 scratch space.
- Gather trid-ring tuning remains disabled when coalesced shard reads are active.
- Streaming output is restricted to cases where the extra compute-side init/reconfig cost is expected to be repaid by writer overlap.
- Weight sharing is selected by the host work assignment and remains isolated from non-sharing cases.

## Perf

Full Tracy perf reports are in this gist:

https://gist.github.com/pavlejosipovic/800e5355941d9a316f672837304b78dd

Included reports:
- `conv3d_current_vs_main_fpu.md`: current branch vs recorded `origin/main` baseline, with FPU util.
- `conv3d_current_hifi2_vs_hifi4_fpu.md`: current branch HiFi2 vs HiFi4, with FPU util.

Headline from the current-vs-main report: 94 shared cases total `315.902 ms -> 283.711 ms` (`-10.19%`), faster in `85/94` shared cases, with `5` shared cases slower by more than `1%`.

## Validation

Local:
- ./build_metal.sh --release passed
- git diff --check passed
- Fresh Tracy conv3d profile runs completed for current HiFi2 and HiFi4

Triggered CI on branch d9161e8cfd4be16546f01f45eecdc86b1eb53070:
- Nightly L2 conv-only: https://github.com/tenstorrent/tt-metal/actions/runs/25320936676
- Sanity tests: https://github.com/tenstorrent/tt-metal/actions/runs/25320940923
- Blackhole post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/25320945536

Draft until the dispatched CI finishes and any PR feedback is addressed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=conv3d-strip-mcast-on-autotune)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:conv3d-strip-mcast-on-autotune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=conv3d-strip-mcast-on-autotune)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:conv3d-strip-mcast-on-autotune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=conv3d-strip-mcast-on-autotune)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:conv3d-strip-mcast-on-autotune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=conv3d-strip-mcast-on-autotune)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:conv3d-strip-mcast-on-autotune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=conv3d-strip-mcast-on-autotune)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:conv3d-strip-mcast-on-autotune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=conv3d-strip-mcast-on-autotune)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:conv3d-strip-mcast-on-autotune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=conv3d-strip-mcast-on-autotune)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:conv3d-strip-mcast-on-autotune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=conv3d-strip-mcast-on-autotune)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:conv3d-strip-mcast-on-autotune)
