### PR TITLE
test(sdpa): add Blackhole SDPA perf-tests CI job

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -87,9 +87,8 @@ jobs:
             cmd: pytest tests/nightly/blackhole/sdpa/ -svv
             timeout: 60
             test-type: slow
-          - name: sdpa perf tests
+          - name: ring sdpa perf tests
             cmd: |
-              SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py::test_sdpa_perf_check -svv
               SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_joint_attention_perf_check -svv
               SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py::test_exp_ring_joint_attention_perf_check -svv
             timeout: 60

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -87,6 +87,13 @@ jobs:
             cmd: pytest tests/nightly/blackhole/sdpa/ -svv
             timeout: 60
             test-type: slow
+          - name: sdpa perf tests
+            cmd: |
+              SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py::test_sdpa_perf_check -svv
+              SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_joint_attention_perf_check -svv
+              SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py::test_exp_ring_joint_attention_perf_check -svv
+            timeout: 60
+            test-type: slow
           - name: fabric infra unit tests
             cmd: |
               TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -91,7 +91,7 @@ jobs:
             cmd: |
               SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_joint_attention_perf_check -svv
               SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py::test_exp_ring_joint_attention_perf_check -svv
-            timeout: 60
+            timeout: 10
             test-type: slow
           - name: fabric infra unit tests
             cmd: |

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -65,7 +65,8 @@ jobs:
             "efficientnetb0": false,
             "panoptic-deeplab": false,
             "non-civ2": false,
-            "ops-perf-tests": false
+            "ops-perf-tests": false,
+            "sdpa-perf-checks": false
           }'
 
           if [[ "$requested_models" == "all" ]]; then
@@ -135,7 +136,7 @@ jobs:
             "N300 WH B0 not yet ported": ["non-civ2"],
             "N300 WH B0 Set 1": ["stable-diffusion-xl", "stable-diffusion-1-4", "distilbert", "vgg", "bert-tiny", "squeezebert", "vgg-unet", "resnet50", "ufld-v2", "sentence-bert", "vit"],
             "N300 WH B0 Set 2": ["metal-bert-large-11", "mobilenetv2", "vanilla-unet", "swin-v2", "swin-s", "vovnet", "efficientnetb0", "ops-perf-tests"],
-            "P150 BH": ["stable-diffusion-xl", "stable-diffusion-1-4", "vgg-unet", "resnet50", "ufld-v2", "sentence-bert", "vit", "panoptic-deeplab", "ops-perf-tests"]
+            "P150 BH": ["stable-diffusion-xl", "stable-diffusion-1-4", "vgg-unet", "resnet50", "ufld-v2", "sentence-bert", "vit", "panoptic-deeplab", "ops-perf-tests", "sdpa-perf-checks"]
           }'
 
           # Original matrix definition
@@ -409,6 +410,15 @@ jobs:
           commands: |
             pytest tests/ttnn/perf_tests/operations/conv -m models_device_performance_bare_metal --timeout=300
         if: ${{ !cancelled() && matrix.test-info.civ2-compatible && (!matrix.test-info.job-set1 || matrix.test-info.job-blackhole-set1) && fromJSON(needs.define-models.outputs.models-to-run)['ops-perf-tests'] }}
+        timeout-minutes: ${{ matrix.test-info.timeout }}
+
+      - name: sdpa perf checks
+        uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main
+        with:
+          device_perf_model_name: "sdpa-perf-checks"
+          commands: |
+            SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py::test_sdpa_perf_check -svv
+        if: ${{ !cancelled() && matrix.test-info.civ2-compatible && matrix.test-info.job-blackhole-set1 && fromJSON(needs.define-models.outputs.models-to-run)['sdpa-perf-checks'] }}
         timeout-minutes: ${{ matrix.test-info.timeout }}
 
       - name: Merge test reports

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -65,8 +65,7 @@ jobs:
             "efficientnetb0": false,
             "panoptic-deeplab": false,
             "non-civ2": false,
-            "ops-perf-tests": false,
-            "sdpa-perf-checks": false
+            "ops-perf-tests": false
           }'
 
           if [[ "$requested_models" == "all" ]]; then
@@ -136,7 +135,7 @@ jobs:
             "N300 WH B0 not yet ported": ["non-civ2"],
             "N300 WH B0 Set 1": ["stable-diffusion-xl", "stable-diffusion-1-4", "distilbert", "vgg", "bert-tiny", "squeezebert", "vgg-unet", "resnet50", "ufld-v2", "sentence-bert", "vit"],
             "N300 WH B0 Set 2": ["metal-bert-large-11", "mobilenetv2", "vanilla-unet", "swin-v2", "swin-s", "vovnet", "efficientnetb0", "ops-perf-tests"],
-            "P150 BH": ["stable-diffusion-xl", "stable-diffusion-1-4", "vgg-unet", "resnet50", "ufld-v2", "sentence-bert", "vit", "panoptic-deeplab", "ops-perf-tests", "sdpa-perf-checks"]
+            "P150 BH": ["stable-diffusion-xl", "stable-diffusion-1-4", "vgg-unet", "resnet50", "ufld-v2", "sentence-bert", "vit", "panoptic-deeplab", "ops-perf-tests"]
           }'
 
           # Original matrix definition
@@ -409,16 +408,8 @@ jobs:
           device_perf_model_name: "ops-perf-tests"
           commands: |
             pytest tests/ttnn/perf_tests/operations/conv -m models_device_performance_bare_metal --timeout=300
+            ${{ matrix.test-info.arch == 'blackhole' && 'SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py::test_sdpa_perf_check -svv' || '' }}
         if: ${{ !cancelled() && matrix.test-info.civ2-compatible && (!matrix.test-info.job-set1 || matrix.test-info.job-blackhole-set1) && fromJSON(needs.define-models.outputs.models-to-run)['ops-perf-tests'] }}
-        timeout-minutes: ${{ matrix.test-info.timeout }}
-
-      - name: sdpa perf checks
-        uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main
-        with:
-          device_perf_model_name: "sdpa-perf-checks"
-          commands: |
-            SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py::test_sdpa_perf_check -svv
-        if: ${{ !cancelled() && matrix.test-info.civ2-compatible && matrix.test-info.job-blackhole-set1 && fromJSON(needs.define-models.outputs.models-to-run)['sdpa-perf-checks'] }}
         timeout-minutes: ${{ matrix.test-info.timeout }}
 
       - name: Merge test reports

--- a/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
@@ -819,8 +819,11 @@ def test_exp_ring_joint_attention_perf_check(ring_size_expected, max_payload_siz
     local_seq_len = total_seq // sp_size
 
     subdir = "ttnn_exp_ring_joint_sdpa_perf_check"
+    # CI=false override: subprocess inherits CI=true under GitHub Actions, which would
+    # trigger the @skipif on test_exp_ring_joint_attention_sdpa_sweep_perf_impl and leave
+    # the profiler with no ops.
     command = (
-        f"pytest tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py::"
+        f"CI=false pytest tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py::"
         f"test_exp_ring_joint_attention_sdpa_sweep_perf_impl"
         f"[{config_id}-bf16-{payload_id}]"
     )
@@ -833,11 +836,18 @@ def test_exp_ring_joint_attention_perf_check(ring_size_expected, max_payload_siz
         subdir, float_columns=float_cols, columns=cols, op_name="", sum_vals=False, has_signposts=False
     )
 
-    measured_core_count = int(r["CORE COUNT"][0]) if len(r["CORE COUNT"]) > 0 else 0
-    duration_ns = int(r["DEVICE KERNEL DURATION [ns]"].max()) if len(r["DEVICE KERNEL DURATION [ns]"]) > 0 else 0
+    assert (
+        len(r["CORE COUNT"]) > 0 and len(r["DEVICE KERNEL DURATION [ns]"]) > 0
+    ), "profiler returned no SDPA ops — inner test was skipped or did not produce a kernel run"
+
+    measured_core_count = int(r["CORE COUNT"][0])
+    duration_ns = int(r["DEVICE KERNEL DURATION [ns]"].max())
 
     # Match perf-table effective_cores rounding (ignore non-multiple-of-10 strays)
     effective_cores = measured_core_count - measured_core_count % 10
+    assert (
+        effective_cores > 0
+    ), f"effective_cores=0 (measured_core_count={measured_core_count}) — profiler output incomplete"
 
     utilization = compute_math_utilization(
         local_seq_len, total_seq, d, d, local_nh, duration_ns, effective_cores, is_causal=False

--- a/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
@@ -779,3 +779,80 @@ def test_exp_ring_joint_attention_create_perf_table(b, nh, total_seq, d, q_chunk
         print(f"  Total coordination: {ring_size} devices x {best['ccl_cores']} CCL cores each")
 
     print(f"{'='*190}\n")
+
+
+# === TEST 5: PERFORMANCE CHECK (CI-gated by SDPA_PERF_CHECKS=1) ===
+# Symmetric +/- band — catches both regressions and unexpected speedups.
+EXP_RING_JOINT_PERF_MARGIN = 0.005
+
+EXP_RING_JOINT_PERF_CHECK_CONFIGS = [
+    # (ring_size_expected, max_payload_size, payload_id, expected_util)
+    # 4-device ring (QuietBox, 4xGalaxy analog)
+    (4, 4096, "4k", 65.1),
+    (4, 8192, "8k", 65.0),
+]
+
+
+@pytest.mark.skipif(
+    os.environ.get("SDPA_PERF_CHECKS") != "1",
+    reason="Set SDPA_PERF_CHECKS=1 to run (CI: sdpa perf tests job)",
+)
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize(
+    "ring_size_expected, max_payload_size, payload_id, expected_util",
+    EXP_RING_JOINT_PERF_CHECK_CONFIGS,
+    ids=[f"ring{cfg[0]}-{cfg[2]}" for cfg in EXP_RING_JOINT_PERF_CHECK_CONFIGS],
+)
+def test_exp_ring_joint_attention_perf_check(ring_size_expected, max_payload_size, payload_id, expected_util):
+    """Measure exp ring joint SDPA math utilization via tracy and assert within +/- EXP_RING_JOINT_PERF_MARGIN."""
+    from tracy.process_model_log import run_device_profiler
+
+    num_devices = detect_devices_without_opening()
+    sp_size, tp_size, arch_type = calculate_mesh_config(num_devices)
+
+    if sp_size != ring_size_expected:
+        pytest.skip(f"Expected ring size {ring_size_expected}, current topology has ring size {sp_size}")
+
+    b, nh, total_seq, d, q_chunk_size, k_chunk_size = TEST_CONFIGS[0]
+    config_id = TEST_CONFIG_IDS[0]
+    local_nh = nh // tp_size
+    local_seq_len = total_seq // sp_size
+
+    subdir = "ttnn_exp_ring_joint_sdpa_perf_check"
+    command = (
+        f"pytest tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py::"
+        f"test_exp_ring_joint_attention_sdpa_sweep_perf_impl"
+        f"[{config_id}-bf16-{payload_id}]"
+    )
+
+    float_cols = ["CORE COUNT", "DEVICE KERNEL DURATION [ns]"]
+    cols = ["ATTRIBUTES"]
+
+    run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
+    r = post_process_ops_log(
+        subdir, float_columns=float_cols, columns=cols, op_name="", sum_vals=False, has_signposts=False
+    )
+
+    measured_core_count = int(r["CORE COUNT"][0]) if len(r["CORE COUNT"]) > 0 else 0
+    duration_ns = int(r["DEVICE KERNEL DURATION [ns]"].max()) if len(r["DEVICE KERNEL DURATION [ns]"]) > 0 else 0
+
+    # Match perf-table effective_cores rounding (ignore non-multiple-of-10 strays)
+    effective_cores = measured_core_count - measured_core_count % 10
+
+    utilization = compute_math_utilization(
+        local_seq_len, total_seq, d, d, local_nh, duration_ns, effective_cores, is_causal=False
+    )
+
+    lower = expected_util * (1 - EXP_RING_JOINT_PERF_MARGIN)
+    upper = expected_util * (1 + EXP_RING_JOINT_PERF_MARGIN)
+
+    logger.info(
+        f"Exp ring joint SDPA perf check ring{ring_size_expected}-{payload_id}: "
+        f"duration={duration_ns/1e6:.3f} ms, math_util={utilization:.2f}% "
+        f"(expected {expected_util:.2f}%, band [{lower:.2f}, {upper:.2f}])"
+    )
+
+    assert lower <= utilization <= upper, (
+        f"Math utilization {utilization:.2f}% outside band [{lower:.2f}, {upper:.2f}] "
+        f"(expected {expected_util:.2f}%, margin +/- {EXP_RING_JOINT_PERF_MARGIN*100:.1f}%)"
+    )

--- a/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
@@ -15,6 +15,8 @@ Perf tests are included but skipped on CI.
 
 import math
 import os
+from unittest import mock
+
 import torch
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 import ttnn
@@ -819,11 +821,8 @@ def test_exp_ring_joint_attention_perf_check(ring_size_expected, max_payload_siz
     local_seq_len = total_seq // sp_size
 
     subdir = "ttnn_exp_ring_joint_sdpa_perf_check"
-    # CI=false override: subprocess inherits CI=true under GitHub Actions, which would
-    # trigger the @skipif on test_exp_ring_joint_attention_sdpa_sweep_perf_impl and leave
-    # the profiler with no ops.
     command = (
-        f"CI=false pytest tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py::"
+        f"pytest tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py::"
         f"test_exp_ring_joint_attention_sdpa_sweep_perf_impl"
         f"[{config_id}-bf16-{payload_id}]"
     )
@@ -831,7 +830,8 @@ def test_exp_ring_joint_attention_perf_check(ring_size_expected, max_payload_siz
     float_cols = ["CORE COUNT", "DEVICE KERNEL DURATION [ns]"]
     cols = ["ATTRIBUTES"]
 
-    run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
+    with mock.patch.dict(os.environ, {"CI": "false"}):
+        run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
     r = post_process_ops_log(
         subdir, float_columns=float_cols, columns=cols, op_name="", sum_vals=False, has_signposts=False
     )

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -20,6 +20,8 @@ BH adaptation: uses init_device_compute_kernel_config instead of WormholeCompute
 """
 import os
 import math
+from unittest import mock
+
 import torch
 from dataclasses import dataclass, field
 from itertools import product
@@ -1217,11 +1219,8 @@ def test_ring_joint_attention_perf_check(model_name, q_chunk_size, k_chunk_size,
     local_nhq = model.nhq
 
     subdir = "ttnn_ring_joint_sdpa_perf_check"
-    # CI=false override: subprocess inherits CI=true under GitHub Actions, which would
-    # trigger the @skipif on test_ring_joint_attention_sdpa_sweep_perf_impl and leave the
-    # profiler with no ops.
     command = (
-        f"CI=false pytest tests/nightly/blackhole/sdpa/"
+        f"pytest tests/nightly/blackhole/sdpa/"
         f"test_ring_joint_sdpa.py::test_ring_joint_attention_sdpa_sweep_perf_impl"
         f"[{config_id}]"
     )
@@ -1229,7 +1228,8 @@ def test_ring_joint_attention_perf_check(model_name, q_chunk_size, k_chunk_size,
     float_cols = ["CORE COUNT", "DEVICE KERNEL DURATION [ns]"]
     cols = ["ATTRIBUTES"]
 
-    run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
+    with mock.patch.dict(os.environ, {"CI": "false"}):
+        run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
     r = post_process_ops_log(
         subdir, float_columns=float_cols, columns=cols, op_name="", sum_vals=False, has_signposts=False
     )

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -1175,3 +1175,82 @@ def test_ring_joint_attention_create_perf_table(model_name):
         print(f"  Total coordination: {ring_size} devices x {best['ccl_cores']} CCL cores each")
 
     print(f"{'='*190}\n")
+
+
+# === TEST 5: PERFORMANCE CHECK (CI-gated by SDPA_PERF_CHECKS=1) ===
+# Symmetric +/- band — catches both regressions and unexpected speedups.
+RING_JOINT_PERF_MARGIN = 0.005
+
+RING_JOINT_PERF_CHECK_CONFIGS = [
+    # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
+    # 4-device ring (QuietBox)
+    ("wan2_2_1xGLX", 288, 512, 4, 68.9),
+    ("mla_100k", 160, 320, 4, 58.4),
+]
+
+
+@pytest.mark.skipif(
+    os.environ.get("SDPA_PERF_CHECKS") != "1",
+    reason="Set SDPA_PERF_CHECKS=1 to run (CI: sdpa perf tests job)",
+)
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize(
+    "model_name, q_chunk_size, k_chunk_size, ring_size_expected, expected_util",
+    RING_JOINT_PERF_CHECK_CONFIGS,
+    ids=[f"{cfg[0]}-q{cfg[1]}-k{cfg[2]}-ring{cfg[3]}" for cfg in RING_JOINT_PERF_CHECK_CONFIGS],
+)
+def test_ring_joint_attention_perf_check(model_name, q_chunk_size, k_chunk_size, ring_size_expected, expected_util):
+    """Measure ring joint SDPA math utilization via tracy and assert within +/- RING_JOINT_PERF_MARGIN."""
+    from tracy.process_model_log import run_device_profiler
+
+    if MESH_CONFIG.sp_size != ring_size_expected:
+        pytest.skip(f"Expected ring size {ring_size_expected}, current topology has ring size {MESH_CONFIG.sp_size}")
+
+    if model_name not in MODEL_CONFIGS:
+        pytest.skip(f"Model {model_name} not available for current mesh config")
+
+    model = MODEL_CONFIGS[model_name]
+    config_id = get_test_case_id(model, q_chunk_size, k_chunk_size)
+
+    sq = model.seq_len * MESH_CONFIG.sp_size
+    local_seq_len = model.seq_len
+    local_nhq = model.nhq
+
+    subdir = "ttnn_ring_joint_sdpa_perf_check"
+    command = (
+        f"pytest tests/nightly/blackhole/sdpa/"
+        f"test_ring_joint_sdpa.py::test_ring_joint_attention_sdpa_sweep_perf_impl"
+        f"[{config_id}]"
+    )
+
+    float_cols = ["CORE COUNT", "DEVICE KERNEL DURATION [ns]"]
+    cols = ["ATTRIBUTES"]
+
+    run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
+    r = post_process_ops_log(
+        subdir, float_columns=float_cols, columns=cols, op_name="", sum_vals=False, has_signposts=False
+    )
+
+    measured_core_count = int(r["CORE COUNT"][0]) if len(r["CORE COUNT"]) > 0 else 0
+    duration_ns = int(r["DEVICE KERNEL DURATION [ns]"].max()) if len(r["DEVICE KERNEL DURATION [ns]"]) > 0 else 0
+
+    # Match perf-table effective_cores rounding (ignore non-multiple-of-10 strays)
+    effective_cores = measured_core_count - measured_core_count % 10
+
+    utilization = compute_ring_joint_utilization(
+        local_seq_len, sq, model.d_q, model.d_v, local_nhq, duration_ns, effective_cores, model.is_causal
+    )
+
+    lower = expected_util * (1 - RING_JOINT_PERF_MARGIN)
+    upper = expected_util * (1 + RING_JOINT_PERF_MARGIN)
+
+    logger.info(
+        f"Ring joint SDPA perf check {config_id}: "
+        f"duration={duration_ns/1e6:.3f} ms, math_util={utilization:.2f}% "
+        f"(expected {expected_util:.2f}%, band [{lower:.2f}, {upper:.2f}])"
+    )
+
+    assert lower <= utilization <= upper, (
+        f"Math utilization {utilization:.2f}% outside band [{lower:.2f}, {upper:.2f}] "
+        f"(expected {expected_util:.2f}%, margin +/- {RING_JOINT_PERF_MARGIN*100:.1f}%)"
+    )

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -1217,8 +1217,11 @@ def test_ring_joint_attention_perf_check(model_name, q_chunk_size, k_chunk_size,
     local_nhq = model.nhq
 
     subdir = "ttnn_ring_joint_sdpa_perf_check"
+    # CI=false override: subprocess inherits CI=true under GitHub Actions, which would
+    # trigger the @skipif on test_ring_joint_attention_sdpa_sweep_perf_impl and leave the
+    # profiler with no ops.
     command = (
-        f"pytest tests/nightly/blackhole/sdpa/"
+        f"CI=false pytest tests/nightly/blackhole/sdpa/"
         f"test_ring_joint_sdpa.py::test_ring_joint_attention_sdpa_sweep_perf_impl"
         f"[{config_id}]"
     )
@@ -1231,11 +1234,18 @@ def test_ring_joint_attention_perf_check(model_name, q_chunk_size, k_chunk_size,
         subdir, float_columns=float_cols, columns=cols, op_name="", sum_vals=False, has_signposts=False
     )
 
-    measured_core_count = int(r["CORE COUNT"][0]) if len(r["CORE COUNT"]) > 0 else 0
-    duration_ns = int(r["DEVICE KERNEL DURATION [ns]"].max()) if len(r["DEVICE KERNEL DURATION [ns]"]) > 0 else 0
+    assert (
+        len(r["CORE COUNT"]) > 0 and len(r["DEVICE KERNEL DURATION [ns]"]) > 0
+    ), "profiler returned no SDPA ops — inner test was skipped or did not produce a kernel run"
+
+    measured_core_count = int(r["CORE COUNT"][0])
+    duration_ns = int(r["DEVICE KERNEL DURATION [ns]"].max())
 
     # Match perf-table effective_cores rounding (ignore non-multiple-of-10 strays)
     effective_cores = measured_core_count - measured_core_count % 10
+    assert (
+        effective_cores > 0
+    ), f"effective_cores=0 (measured_core_count={measured_core_count}) — profiler output incomplete"
 
     utilization = compute_ring_joint_utilization(
         local_seq_len, sq, model.d_q, model.d_v, local_nhq, duration_ns, effective_cores, model.is_causal

--- a/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
+++ b/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
@@ -4,6 +4,8 @@
 
 import os
 import math
+from unittest import mock
+
 import torch
 from itertools import product
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
@@ -443,10 +445,8 @@ def test_sdpa_perf_check(shape_id, q_chunk_size, k_chunk_size, expected_util):
 
     subdir = "ttnn_sdpa_perf_check"
     test_id = f"k{k_chunk_size}-q{q_chunk_size}-bf16"
-    # CI=false override: subprocess inherits CI=true under GitHub Actions, which would
-    # trigger the @skipif on test_sdpa_sweep_perf_impl and leave the profiler with no ops.
     command = (
-        f"CI=false pytest tests/nightly/blackhole/sdpa/"
+        f"pytest tests/nightly/blackhole/sdpa/"
         f"test_scaled_dot_product_attention_sprint.py::test_sdpa_sweep_perf_impl"
         f"[{shape_id}-{test_id}]"
     )
@@ -454,7 +454,8 @@ def test_sdpa_perf_check(shape_id, q_chunk_size, k_chunk_size, expected_util):
     float_cols = ["CORE COUNT", "DEVICE KERNEL DURATION [ns]"]
     cols = ["ATTRIBUTES"]
 
-    run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
+    with mock.patch.dict(os.environ, {"CI": "false"}):
+        run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
     r = post_process_ops_log(
         subdir, float_columns=float_cols, columns=cols, op_name="", sum_vals=False, has_signposts=False
     )

--- a/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
+++ b/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
@@ -443,8 +443,10 @@ def test_sdpa_perf_check(shape_id, q_chunk_size, k_chunk_size, expected_util):
 
     subdir = "ttnn_sdpa_perf_check"
     test_id = f"k{k_chunk_size}-q{q_chunk_size}-bf16"
+    # CI=false override: subprocess inherits CI=true under GitHub Actions, which would
+    # trigger the @skipif on test_sdpa_sweep_perf_impl and leave the profiler with no ops.
     command = (
-        f"pytest tests/nightly/blackhole/sdpa/"
+        f"CI=false pytest tests/nightly/blackhole/sdpa/"
         f"test_scaled_dot_product_attention_sprint.py::test_sdpa_sweep_perf_impl"
         f"[{shape_id}-{test_id}]"
     )
@@ -456,6 +458,10 @@ def test_sdpa_perf_check(shape_id, q_chunk_size, k_chunk_size, expected_util):
     r = post_process_ops_log(
         subdir, float_columns=float_cols, columns=cols, op_name="", sum_vals=False, has_signposts=False
     )
+
+    assert (
+        len(r["CORE COUNT"]) > 0 and len(r["DEVICE KERNEL DURATION [ns]"]) > 0
+    ), "profiler returned no SDPA ops — inner test was skipped or did not produce a kernel run"
 
     core_count = int(r["CORE COUNT"][0])
     duration_ns = int(r["DEVICE KERNEL DURATION [ns]"].min())

--- a/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
+++ b/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
@@ -412,3 +412,65 @@ def test_sdpa_create_perf_table(b, nh, s, d):
             f"{best['total_waste_pct']:.1f}% pad waste, {best['slot_waste_pct']:.1f}% slot waste)"
         )
     print(f"{'='*170}\n")
+
+
+# === TEST 5: PERFORMANCE CHECK (CI-gated by SDPA_PERF_CHECKS=1) ===
+# Symmetric +/- band — catches both regressions and unexpected speedups.
+SDPA_PERF_MARGIN = 0.007
+
+SDPA_PERF_CHECK_CONFIGS = [
+    # (shape_id, q_chunk_size, k_chunk_size, expected_util)
+    ("wan2_2_1xGLX_analog", 288, 512, 70.0),
+    ("wan2_2_4xGLX_analog", 224, 512, 57.5),
+]
+
+
+@pytest.mark.skipif(
+    os.environ.get("SDPA_PERF_CHECKS") != "1",
+    reason="Set SDPA_PERF_CHECKS=1 to run (CI: sdpa perf tests job)",
+)
+@pytest.mark.parametrize(
+    "shape_id, q_chunk_size, k_chunk_size, expected_util",
+    SDPA_PERF_CHECK_CONFIGS,
+    ids=[f"{cfg[0]}-q{cfg[1]}-k{cfg[2]}" for cfg in SDPA_PERF_CHECK_CONFIGS],
+)
+def test_sdpa_perf_check(shape_id, q_chunk_size, k_chunk_size, expected_util):
+    """Measure single-chip SDPA math utilization via tracy and assert within +/- SDPA_PERF_MARGIN."""
+    from tracy.process_model_log import run_device_profiler
+
+    idx = INPUT_IDS.index(shape_id)
+    _b, nh, s, d = INPUT_SHAPES[idx]
+
+    subdir = "ttnn_sdpa_perf_check"
+    test_id = f"k{k_chunk_size}-q{q_chunk_size}-bf16"
+    command = (
+        f"pytest tests/nightly/blackhole/sdpa/"
+        f"test_scaled_dot_product_attention_sprint.py::test_sdpa_sweep_perf_impl"
+        f"[{shape_id}-{test_id}]"
+    )
+
+    float_cols = ["CORE COUNT", "DEVICE KERNEL DURATION [ns]"]
+    cols = ["ATTRIBUTES"]
+
+    run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
+    r = post_process_ops_log(
+        subdir, float_columns=float_cols, columns=cols, op_name="", sum_vals=False, has_signposts=False
+    )
+
+    core_count = int(r["CORE COUNT"][0])
+    duration_ns = int(r["DEVICE KERNEL DURATION [ns]"].min())
+    utilization = compute_sdpa_utilization(s, d, nh, duration_ns, core_count)
+
+    lower = expected_util * (1 - SDPA_PERF_MARGIN)
+    upper = expected_util * (1 + SDPA_PERF_MARGIN)
+
+    logger.info(
+        f"SDPA perf check {shape_id}-q{q_chunk_size}-k{k_chunk_size}: "
+        f"duration={duration_ns/1e6:.3f} ms, math_util={utilization:.2f}% "
+        f"(expected {expected_util:.2f}%, band [{lower:.2f}, {upper:.2f}])"
+    )
+
+    assert lower <= utilization <= upper, (
+        f"Math utilization {utilization:.2f}% outside band [{lower:.2f}, {upper:.2f}] "
+        f"(expected {expected_util:.2f}%, margin +/- {SDPA_PERF_MARGIN*100:.1f}%)"
+    )


### PR DESCRIPTION
## Summary

Adds a dedicated Blackhole SDPA perf-tests CI job that guards against math-utilization regressions and unexpected speedups in single-chip SDPA, the ring-joint variant, and the experimental ring-joint op. Pass bands are calibrated from a QuietBox sweep; the job is gated by `SDPA_PERF_CHECKS=1` so it runs alongside — without disturbing — the existing nightly SDPA tests.

The intent is to catch perf drift before it lands and to flag both directions of change (drops or unexpected jumps both warrant a look) on every nightly run.

The single-chip check runs on the existing **(Single-card) Device perf regressions** pipeline (P150 BH leg) — that pipeline already builds with tracy and is the natural home for op-level device perf. The two ring-joint checks live on the **Blackhole multi-card unit-tests** workflow because they need a multi-chip ring topology and there is no dedicated BH multi-chip perf pipeline today; once one lands they are a natural candidate to migrate.

## Thresholds

Each test asserts measured math utilization sits within a symmetric `expected × (1 ± margin)` band. Margins are sized just above observed run-to-run noise from the calibration sweep:

- single-chip: ±0.7% relative (wider — `wan2_2_4xGLX_analog` is the noisiest config)
- ring-joint: ±0.5% relative
- exp ring-joint: ±0.5% relative

Symmetric on purpose — unexpected speedups get the same scrutiny as regressions.

## Test plan

- [x] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=skrstic/sdpa-perf-tests)](https://github.com/tenstorrent/tt-metal/actions/runs/25344677309)
- [x] [![(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=skrstic/sdpa-perf-tests)](https://github.com/tenstorrent/tt-metal/actions/runs/25375543896)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/sdpa-perf-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/sdpa-perf-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/sdpa-perf-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/sdpa-perf-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/sdpa-perf-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/sdpa-perf-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/sdpa-perf-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/sdpa-perf-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/sdpa-perf-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/sdpa-perf-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/sdpa-perf-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/sdpa-perf-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/sdpa-perf-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/sdpa-perf-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/sdpa-perf-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/sdpa-perf-tests)