### PR TITLE
Revert selective_reduce_combine regression from #42982

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/kernels/dataflow/reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/kernels/dataflow/reader.cpp
@@ -81,7 +81,6 @@ void kernel_main() {
     constexpr uint32_t noc_y_start = get_named_compile_time_arg_val("noc_y_start");
     constexpr uint32_t noc_x_end = get_named_compile_time_arg_val("noc_x_end");
     constexpr uint32_t noc_y_end = get_named_compile_time_arg_val("noc_y_end");
-    constexpr uint32_t worker_bounding_box_size = get_named_compile_time_arg_val("worker_bounding_box_size");
 
     constexpr uint32_t aligned_activations_page_size = aligned_token_activations_page_size_bytes / sizeof(uint32_t);
 
@@ -113,7 +112,7 @@ void kernel_main() {
         noc_semaphore_set_multicast(
             sync_semaphore_addr,
             semaphore_mc_addr,
-            worker_bounding_box_size - 1,
+            num_token_parallel_cores * num_data_parallel_cores - 1,
             /*linked=*/false,
             /*noc=*/1);
         noc_async_writes_flushed(/*noc=*/1);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -295,17 +295,9 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
     const auto token_segment_buffer_size_bytes =
         *std::max_element(data_parallel_sizes_bytes.begin(), data_parallel_sizes_bytes.end());
 
-    // slightly awkward. we want the token dimension but the underlying shape might not represent the data layout.
-    //  This is in line with the assumption that tokens are split across the entirety of the shard, regardless of
-    //  number of tokens
+    const auto expert_token_segment_buffer_block_size_bytes =
+        token_segment_buffer_size_bytes * total_tokens / num_token_parallel_cores;
     constexpr auto double_buffer = 2;
-
-    const auto input_shards = input_tensor.memory_config().shard_spec()->grid.num_cores();
-    const auto token_expert_row_offset = input_tensor.logical_shape().volume() / input_shards /
-                                         (hidden_size / num_data_parallel_cores / double_buffer) /
-                                         num_token_parallel_cores;
-
-    const auto expert_token_segment_buffer_block_size_bytes = token_segment_buffer_size_bytes * token_expert_row_offset;
     const auto buffer_size_bytes = expert_token_segment_buffer_block_size_bytes * double_buffer;
 
     const auto input_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
@@ -405,7 +397,6 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
         {"noc_y_start", start_coord.y},
         {"noc_x_end", end_coord.x},
         {"noc_y_end", end_coord.y},
-        {"worker_bounding_box_size", needed_worker_core_bounding_box.size()},
     };
 
     std::vector<uint32_t> reader_compile_time_args;


### PR DESCRIPTION
## Summary

- Reverts buffer sizing in `selective_reduce_combine_program_factory.cpp` back to `total_tokens / num_token_parallel_cores`
- Reverts semaphore multicast count in `reader.cpp` back to `num_token_parallel_cores * num_data_parallel_cores - 1`
- Removes `worker_bounding_box_size` compile-time arg that is no longer needed

PR #42982 changed these calculations in a way that computes incorrect values for GPT-OSS shapes (128 experts, K=4, hidden_size=2880, EP=4, TP=8 on 4x8 Galaxy), dropping real-weight decode PCC from 0.987 to 0.0019. Only the `selective_reduce_combine` changes are reverted; the rest of #42982's `moe_compute` work is unaffected.

Fixes #43552

## Test plan

- [x] `test_model[1_layer-mesh_4x8-decode_b128_s1]` with real weights: PCC 0.9969 (was 0.0019)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sraizada/fix-selective-reduce-combine-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sraizada/fix-selective-reduce-combine-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sraizada/fix-selective-reduce-combine-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sraizada/fix-selective-reduce-combine-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sraizada/fix-selective-reduce-combine-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sraizada/fix-selective-reduce-combine-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sraizada/fix-selective-reduce-combine-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sraizada/fix-selective-reduce-combine-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sraizada/fix-selective-reduce-combine-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sraizada/fix-selective-reduce-combine-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sraizada/fix-selective-reduce-combine-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sraizada/fix-selective-reduce-combine-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sraizada/fix-selective-reduce-combine-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sraizada/fix-selective-reduce-combine-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sraizada/fix-selective-reduce-combine-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sraizada/fix-selective-reduce-combine-regression)