### PR TITLE
[Test + Bug Fix]: Extending DFB test coverage 

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <tuple>
 #include <vector>
@@ -40,6 +41,9 @@ static std::string ImplicitSyncParamName(const ::testing::TestParamInfo<bool>& i
     return info.param ? "ImplicitSyncTrue" : "ImplicitSyncFalse";
 }
 
+// expected_output, when set, is compared against the device output instead of input.
+// This is used for Tensix→DM ring-pressure tests where the device cycles through fewer
+// unique ring slots than entries_per_core, so output != input by design.
 void execute_program_and_verify(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     Program& program,
@@ -47,7 +51,8 @@ void execute_program_and_verify(
     const std::shared_ptr<distributed::MeshBuffer>& out_buffer,
     distributed::MeshCoordinate& zero_coord,
     std::vector<uint32_t>& input,
-    bool verify_output = true) {
+    bool verify_output = true,
+    std::optional<std::vector<uint32_t>> expected_output = std::nullopt) {
     distributed::WriteShard(mesh_device->mesh_command_queue(), in_buffer, input, zero_coord, true);
 
     if (mesh_device->get_devices()[0]->arch() == ARCH::QUASAR) {
@@ -70,9 +75,10 @@ void execute_program_and_verify(
     distributed::ReadShard(mesh_device->mesh_command_queue(), output, out_buffer, zero_coord, true);
 
     if (verify_output) {
-        if (input != output) {
-            log_info(tt::LogTest, "Printing input");
-            for (auto i : input) {
+        const std::vector<uint32_t>& expected = expected_output ? *expected_output : input;
+        if (expected != output) {
+            log_info(tt::LogTest, "Printing expected");
+            for (auto i : expected) {
                 std::cout << i << " ";
             }
             std::cout << std::endl;
@@ -81,7 +87,7 @@ void execute_program_and_verify(
                 std::cout << i << " ";
             }
         }
-        EXPECT_EQ(input, output);
+        EXPECT_EQ(expected, output);
     }
 }
 
@@ -138,13 +144,16 @@ void run_single_dfb_program(
     log_info(tt::LogTest, "In Buffer:  [address: {} B, size: {} B]", in_buffer->address(), in_buffer->size());
     log_info(tt::LogTest, "Out Buffer: [address: {} B, size: {} B]", out_buffer->address(), out_buffer->size());
 
-    uint32_t num_entries_per_producer = entries_per_core / dfb_config.num_producers;
+    // Ceiling division so every producer gets a loop bound that covers the largest slice.
+    // Producers whose page_id would exceed entries_per_core use the runtime bounds
+    // check in the kernel to skip the out-of-range iteration.
+    uint32_t num_entries_per_producer =
+        (entries_per_core + dfb_config.num_producers - 1) / dfb_config.num_producers;
     const bool is_all = (dfb_config.cap == dfb::AccessPattern::ALL);
     std::vector<uint32_t> producer_cta = {
         (uint32_t)in_buffer->address(),
         num_entries_per_producer,
-        (uint32_t)dfb_config.enable_implicit_sync,
-        (uint32_t)is_all};
+        (uint32_t)dfb_config.enable_implicit_sync};
     tt::tt_metal::TensorAccessorArgs(in_buffer).append_to(producer_cta);
 
     KernelHandle producer_kernel;
@@ -179,7 +188,9 @@ void run_single_dfb_program(
         }
     }
 
-    uint32_t num_entries_per_consumer = is_all ? entries_per_core : entries_per_core / dfb_config.num_consumers;
+    uint32_t num_entries_per_consumer = is_all
+                                            ? entries_per_core
+                                            : (entries_per_core + dfb_config.num_consumers - 1) / dfb_config.num_consumers;
     std::vector<uint32_t> consumer_cta = {
         (uint32_t)out_buffer->address(),
         num_entries_per_consumer,
@@ -243,10 +254,10 @@ void run_single_dfb_program(
             for (auto x = cr.start_coord.x; x <= cr.end_coord.x; x++) {
                 const CoreCoord core(x, y);
                 const uint32_t chunk_offset = core_to_chunk_offset.at(core);
-                SetRuntimeArgs(program, producer_kernel, core, {producer_mask, chunk_offset});
+                SetRuntimeArgs(program, producer_kernel, core, {producer_mask, chunk_offset, entries_per_core});
                 SetRuntimeArgs(
                     program, consumer_kernel, core,
-                    {consumer_mask, (uint32_t)logical_dfb_id, chunk_offset});
+                    {consumer_mask, (uint32_t)logical_dfb_id, chunk_offset, entries_per_core});
             }
         }
     }
@@ -255,25 +266,92 @@ void run_single_dfb_program(
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, total_buffer_size / sizeof(uint32_t));
 
     IDevice* device = mesh_device->get_devices()[0];
-    const uint32_t words_per_core = entries_per_core * entry_size / sizeof(uint32_t);
+    // const uint32_t words_per_core = entries_per_core * entry_size / sizeof(uint32_t);
 
     // For Tensix → DM: pre-fill each core's DFB L1 with its input chunk so the
     // Tensix producer kernel can read from L1 while DM consumer drains to DRAM.
     //
     // l1_by_core addresses are not populated until allocate_dataflow_buffers() runs
     // during program compilation. Since this is a single-DFB test it is always placed at the L1 base allocator address.
+    //
+    // IMPORTANT: the slice written to L1 must be exactly the physical ring size
+    // (dfb->total_size() bytes = num_entries * entry_size). Writing more than the ring
+    // size would corrupt L1 beyond the ring (kernel stack, config structures, etc.).
+    // For ring-pressure tests (entries_per_core > num_entries) only the first
+    // num_entries slots are filled; the producer kernel cycles through those same
+    // slots repeatedly, which is the expected behaviour.
     if (producer_type == DFBPorCType::TENSIX) {
         const uint32_t dfb_l1_addr =
             static_cast<uint32_t>(device->allocator()->get_base_allocator_addr(HalMemType::L1));
+        const uint32_t ring_words = dfb->total_size() / sizeof(uint32_t);
         for (const CoreRange& cr : core_range_set.ranges()) {
             for (auto y = cr.start_coord.y; y <= cr.end_coord.y; y++) {
                 for (auto x = cr.start_coord.x; x <= cr.end_coord.x; x++) {
                     const CoreCoord core(x, y);
                     const uint32_t co = core_to_chunk_offset.at(core);
-                    std::vector<uint32_t> slice(
-                        input.begin() + co * entry_size / sizeof(uint32_t),
-                        input.begin() + co * entry_size / sizeof(uint32_t) + words_per_core);
+                    const uint32_t wpe = entry_size / sizeof(uint32_t);
+                    std::vector<uint32_t> slice(ring_words, 0);
+                    for (uint32_t p = 0; p < dfb_config.num_producers; p++) {
+                        for (uint32_t e = 0; e < num_entries_per_producer; e++) {
+                            const uint32_t page_id = co + e * dfb_config.num_producers + p;
+                            if (page_id >= co + entries_per_core) {
+                                break;
+                            }
+                            // Ring layout depends on stride_in_entries, which is set by the
+                            // consumer access pattern:
+                            //   STRIDED: stride = num_producers → interleaved (slot = e*P + p)
+                            //   ALL: stride = 1 → TC-first   (slot = p*E + e)
+                            const uint32_t dst_slot =
+                                (dfb_config.cap == dfb::AccessPattern::ALL)
+                                    ? (p * num_entries_per_producer + e)
+                                    : (e * dfb_config.num_producers + p);
+
+                            // Stop once all physical ring slots are filled; for ring-pressure
+                            // tests the remaining iterations would alias back to already-filled
+                            // slots, so there is nothing new to write.
+                            if (dst_slot >= dfb_config.num_entries) {
+                                break;
+                            }
+
+                            std::copy(
+                                input.begin() + page_id * wpe,
+                                input.begin() + page_id * wpe + wpe,
+                                slice.begin() + dst_slot * wpe);
+                        }
+                    }
                     detail::WriteToDeviceL1(device, core, dfb_l1_addr, slice);
+                }
+            }
+        }
+    }
+
+    // For Tensix → DM ring-pressure tests (entries_per_core > num_entries), the
+    // Tensix producer cycles through the same num_entries ring slots indefinitely.
+    // Each STRIDED consumer c always reads ring slot (c % num_entries), which was
+    // pre-filled with input page c.  The expected out_buffer page p therefore
+    // contains the data from ring slot (p % num_consumers) % num_entries, not
+    // input[p].  Build the corrected expected vector so the verification is sound.
+    std::optional<std::vector<uint32_t>> tensix_dm_expected;
+    if (producer_type == DFBPorCType::TENSIX && consumer_type == DFBPorCType::DM &&
+        entries_per_core > dfb_config.num_entries &&
+        dfb_config.cap == dfb::AccessPattern::STRIDED) {
+        const uint32_t wpe = entry_size / sizeof(uint32_t);
+        tensix_dm_expected.emplace(num_cores * entries_per_core * wpe, 0u);
+        for (const CoreRange& cr : core_range_set.ranges()) {
+            for (auto y = cr.start_coord.y; y <= cr.end_coord.y; y++) {
+                for (auto x = cr.start_coord.x; x <= cr.end_coord.x; x++) {
+                    const CoreCoord core(x, y);
+                    const uint32_t co = core_to_chunk_offset.at(core);
+                    for (uint32_t p = 0; p < entries_per_core; p++) {
+                        // Consumer c = p % num_consumers always reads the ring slot it
+                        // was assigned (slot = c % num_entries), which holds input[co + c].
+                        const uint32_t ring_slot =
+                            (p % dfb_config.num_consumers) % dfb_config.num_entries;
+                        std::copy(
+                            input.begin() + (co + ring_slot) * wpe,
+                            input.begin() + (co + ring_slot + 1) * wpe,
+                            tensix_dm_expected->begin() + (co + p) * wpe);
+                    }
                 }
             }
         }
@@ -284,7 +362,8 @@ void run_single_dfb_program(
     execute_program_and_verify(
         mesh_device, program, in_buffer, out_buffer, zero_coord,
         input,
-        /*verify_output=*/(consumer_type == DFBPorCType::DM));
+        /*verify_output=*/(consumer_type == DFBPorCType::DM),
+        tensix_dm_expected);
 
     // For DM → Tensix: verify each core's DFB L1 against the expected input chunk.
     if (consumer_type == DFBPorCType::TENSIX) {
@@ -293,9 +372,44 @@ void run_single_dfb_program(
                 const uint32_t co = core_to_chunk_offset.at(core);
                 std::vector<uint32_t> l1_data;
                 detail::ReadFromDeviceL1(device, core, alloc_addr, dfb->total_size(), l1_data);
-                std::vector<uint32_t> expected(
-                    input.begin() + co * entry_size / sizeof(uint32_t),
-                    input.begin() + co * entry_size / sizeof(uint32_t) + words_per_core);
+                const uint32_t wpe_v = entry_size / sizeof(uint32_t);
+                // Physical ring holds dfb_config.num_entries entries; for ring-pressure
+                // tests (entries_per_core > dfb_config.num_entries) the ring wraps and
+                // only the last ring_capacity writes per producer survive in L1.
+                // Size expected to l1_data so the comparison is against what is actually there.
+                const uint32_t total_ring_words = dfb->total_size() / sizeof(uint32_t);
+                std::vector<uint32_t> expected(total_ring_words, 0);
+                if (dfb_config.cap == dfb::AccessPattern::ALL) {
+                    // ALL consumer: ring is TC-first (stride_in_entries=1).
+                    // Each producer p has ring_capacity consecutive ring slots.
+                    // After wrapping, only the last ring_capacity entries from each
+                    // producer survive: e in [num_entries_per_producer - ring_capacity, ...).
+                    const uint32_t ring_capacity = dfb_config.num_entries / dfb_config.num_producers;
+                    const uint32_t last_e_base = num_entries_per_producer - ring_capacity;
+                    for (uint32_t p = 0; p < dfb_config.num_producers; p++) {
+                        for (uint32_t c = 0; c < ring_capacity; c++) {
+                            const uint32_t ring_slot = p * ring_capacity + c;
+                            const uint32_t e = last_e_base + c;
+                            const uint32_t page_id = co + e * dfb_config.num_producers + p;
+                            if (page_id >= co + entries_per_core) {
+                                break;
+                            }
+                            std::copy(
+                                input.begin() + page_id * wpe_v,
+                                input.begin() + page_id * wpe_v + wpe_v,
+                                expected.begin() + ring_slot * wpe_v);
+                        }
+                    }
+                } else {
+                    // STRIDED consumer: ring is interleaved, matching sequential input order.
+                    // For ring-pressure tests (entries_per_core > dfb_config.num_entries) only
+                    // the last dfb_config.num_entries entries survive in L1; copy that suffix.
+                    const uint32_t ring_start_page = co + entries_per_core - dfb_config.num_entries;
+                    std::copy(
+                        input.begin() + ring_start_page * wpe_v,
+                        input.begin() + ring_start_page * wpe_v + total_ring_words,
+                        expected.begin());
+                }
                 if (expected != l1_data) {
                     std::cout << "expected: ";
                     for (const auto& e : expected) {
@@ -312,6 +426,389 @@ void run_single_dfb_program(
                     << "DFB L1 mismatch on core (" << core.x << "," << core.y << ")";
             }
         }
+    }
+}
+
+// =====================================================================================
+// Gap 7 harness – concurrent DFBs on the same core (TC allocator stress)
+//
+// Runs `num_dfbs` independent 1Sx1S DM→DM DFBs simultaneously on core (0,0).
+//
+// Thread assignment (Quasar has 8 DM threads total):
+//   Producer threads : DM[0 .. num_dfbs-1]  (combined_producer_mask = low  num_dfbs bits)
+//   Consumer threads : DM[num_dfbs .. 2*num_dfbs-1] (combined_consumer_mask = next num_dfbs bits)
+//
+// All num_dfbs DFBs are created in a single Program so their TCs are allocated
+// simultaneously, stressing the TC allocator.  Each DFB is bound to the same
+// multi-producer and multi-consumer kernel; each DM thread derives its DFB ID from
+// its position in the combined mask (via mhartid) and owns a contiguous slice of
+// the shared DRAM buffers.
+//
+// num_dfbs must satisfy: 2 * num_dfbs <= 8 (Quasar DM thread limit).
+// dfb_config must use num_producers=1, num_consumers=1 (1Sx1S).
+// =====================================================================================
+void run_concurrent_dfbs_program(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    uint32_t num_dfbs,
+    experimental::dfb::DataflowBufferConfig& dfb_config) {
+    TT_FATAL(
+        mesh_device->get_devices()[0]->arch() == ARCH::QUASAR,
+        "Concurrent DFB tests require Quasar (multi-threaded DM)");
+    TT_FATAL(
+        dfb_config.num_producers == 1 && dfb_config.num_consumers == 1,
+        "run_concurrent_dfbs_program requires 1Sx1S per DFB");
+    TT_FATAL(2 * num_dfbs <= 6, "2*num_dfbs must fit in the 6 available Quasar DM threads (DM0 reserved for dispatch)");
+
+    const CoreCoord core(0, 0);
+    const CoreRangeSet core_range_set(CoreRange(core, core));
+
+    const uint32_t entry_size      = dfb_config.entry_size;
+    const uint32_t entries_per_dfb = dfb_config.num_entries;
+    const uint32_t total_buf_size  = num_dfbs * entries_per_dfb * entry_size;
+
+    distributed::DeviceLocalBufferConfig local_cfg{.page_size = entry_size, .buffer_type = BufferType::DRAM};
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto in_buffer  = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = total_buf_size}, local_cfg, mesh_device.get());
+    auto out_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = total_buf_size}, local_cfg, mesh_device.get());
+
+    log_info(
+        tt::LogTest,
+        "Gap7: {} concurrent 1Sx1S DFBs, {} entries/DFB, total {}B in/out buffers",
+        num_dfbs, entries_per_dfb, total_buf_size);
+
+    Program program = CreateProgram();
+
+    // Create one producer kernel instance and one consumer kernel instance per DFB,
+    // each running on a single DM thread.  Encoding dfb_id and chunk_offset in the CTA
+    // makes each instance unique so the runtime allocates a distinct DM thread to it.
+    // This ensures BindDataflowBufferToProducerConsumerKernels registers exactly 1 DM
+    // thread as producer and 1 as consumer for each DFB – matching num_producers=1 /
+    // num_consumers=1 in the DFB config.  A shared N-thread kernel bound to N DFBs
+    // would erroneously register all N threads as producers for every DFB, causing the
+    // consumer to wait for N acks that never arrive (hang).
+    std::vector<KernelHandle> producer_kernels, consumer_kernels;
+    for (uint32_t i = 0; i < num_dfbs; ++i) {
+        const uint32_t chunk_offset = i * entries_per_dfb;
+
+        std::vector<uint32_t> prod_cta = {
+            entries_per_dfb,
+            (uint32_t)dfb_config.enable_implicit_sync,
+            (uint32_t)in_buffer->address(),
+            i,             // dfb_id
+            chunk_offset}; // chunk_offset
+        tt::tt_metal::TensorAccessorArgs(in_buffer).append_to(prod_cta);
+
+        producer_kernels.push_back(experimental::quasar::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_producer.cpp",
+            core_range_set,
+            experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1, .compile_args = prod_cta}));
+
+        std::vector<uint32_t> cons_cta = {
+            entries_per_dfb,
+            (uint32_t)dfb_config.enable_implicit_sync,
+            (uint32_t)out_buffer->address(),
+            i,             // dfb_id
+            chunk_offset}; // chunk_offset
+        tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(cons_cta);
+
+        consumer_kernels.push_back(experimental::quasar::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer.cpp",
+            core_range_set,
+            experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1, .compile_args = cons_cta}));
+    }
+
+    // All DFBs created in the same Program so TCs are allocated simultaneously.
+    for (uint32_t i = 0; i < num_dfbs; ++i) {
+        auto dfb_id = experimental::dfb::CreateDataflowBuffer(program, core_range_set, dfb_config);
+        experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program, dfb_id, producer_kernels[i], consumer_kernels[i]);
+    }
+
+    // No runtime args needed: dfb_id and chunk_offset are already in each kernel's CTA.
+
+    auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(
+        0, 100, total_buf_size / sizeof(uint32_t));
+    execute_program_and_verify(mesh_device, program, in_buffer, out_buffer, zero_coord, input);
+}
+
+// =====================================================================================
+// Tensix→DM concurrent DFBs
+//
+// Runs num_dfbs independent 1Sx1S Tensix→DM DFBs on core (0,0) with a single
+// Neo thread looping through all DFBs sequentially and num_dfbs DM consumer threads
+// running concurrently (each draining its own DFB the moment entries arrive).
+//
+// Using a sequential Tensix kernel (dfb_t6_seq_producer.cpp) avoids any dependency
+// on Neo hartid values: the single Neo thread signals DFB_0 fully, waits for acks,
+// then moves to DFB_1.  DM consumer threads start simultaneously but block on
+// wait_front until their DFB has entries.
+// =====================================================================================
+void run_concurrent_tensix_dm_dfbs_program(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    uint32_t num_dfbs,
+    experimental::dfb::DataflowBufferConfig& dfb_config) {
+    TT_FATAL(
+        mesh_device->get_devices()[0]->arch() == ARCH::QUASAR,
+        "Concurrent Tensix→DM DFB tests require Quasar");
+    TT_FATAL(
+        dfb_config.num_producers == 1 && dfb_config.num_consumers == 1,
+        "run_concurrent_tensix_dm_dfbs_program requires 1Sx1S per DFB");
+    TT_FATAL(num_dfbs <= 6, "num_dfbs must fit in the 6 available Quasar DM threads (DM0 reserved for dispatch)");
+
+    const CoreCoord core(0, 0);
+    const CoreRangeSet core_range_set(CoreRange(core, core));
+    IDevice* device = mesh_device->get_devices()[0];
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+
+    const uint32_t entry_size     = dfb_config.entry_size;
+    const uint32_t entries_per_dfb = dfb_config.num_entries;
+    const uint32_t wpe             = entry_size / sizeof(uint32_t);
+    const uint32_t buf_size        = entries_per_dfb * entry_size;
+
+    // Separate DRAM out_buffer per DFB (DM consumers write here).
+    std::vector<std::shared_ptr<distributed::MeshBuffer>> out_buffers;
+    distributed::DeviceLocalBufferConfig local_cfg{.page_size = entry_size, .buffer_type = BufferType::DRAM};
+    for (uint32_t i = 0; i < num_dfbs; ++i) {
+        distributed::ReplicatedBufferConfig buf_cfg{.size = buf_size};
+        out_buffers.push_back(distributed::MeshBuffer::create(buf_cfg, local_cfg, mesh_device.get()));
+    }
+
+    // Generate input – each DFB gets its own slice (entries_per_dfb entries).
+    const uint32_t total_words = num_dfbs * entries_per_dfb * wpe;
+    auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, total_words);
+
+    Program program = CreateProgram();
+
+    // Tensix sequential producer: 1 Neo thread, loops through num_dfbs DFBs.
+    std::vector<uint32_t> producer_cta = {num_dfbs, entries_per_dfb};
+    auto producer_kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_seq_producer.cpp",
+        core_range_set,
+        experimental::quasar::QuasarComputeConfig{
+            .num_threads_per_cluster = 1, .compile_args = producer_cta});
+
+    // DM concurrent consumers: one 1-thread kernel instance per DFB.
+    // Encoding dfb_id and the per-DFB dst_addr in each instance's CTA makes each
+    // instance unique, so the runtime allocates a separate DM thread to it and
+    // BindDataflowBufferToProducerConsumerKernels registers exactly 1 consumer per
+    // DFB – matching num_consumers=1 in the DFB config.
+    const uint32_t num_entries_per_consumer = entries_per_dfb;  // 1Sx1S: sole consumer gets all
+
+    std::vector<KernelHandle> consumer_kernels;
+    for (uint32_t i = 0; i < num_dfbs; ++i) {
+        std::vector<uint32_t> cons_cta = {
+            num_entries_per_consumer,
+            (uint32_t)dfb_config.enable_implicit_sync,
+            (uint32_t)out_buffers[i]->address(),
+            i}; // dfb_id
+        tt::tt_metal::TensorAccessorArgs(out_buffers[i]).append_to(cons_cta);
+
+        consumer_kernels.push_back(experimental::quasar::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer_sep.cpp",
+            core_range_set,
+            experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1, .compile_args = cons_cta}));
+    }
+
+    // Create all DFBs in the same Program (simultaneous TC allocation).
+    std::vector<uint32_t> dfb_ids;
+    for (uint32_t i = 0; i < num_dfbs; ++i) {
+        auto dfb_id = experimental::dfb::CreateDataflowBuffer(program, core_range_set, dfb_config);
+        experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program, dfb_id, producer_kernel, consumer_kernels[i]);
+        dfb_ids.push_back(dfb_id);
+    }
+
+    // Producer runtime args: nothing extra needed (loop bounds are in CTA).
+    SetRuntimeArgs(program, producer_kernel, core, {});
+    // No consumer runtime args: dfb_id and dst_addr are in each instance's CTA.
+
+    // Pre-fill each DFB's L1 ring with its input slice.
+    // DFBs are allocated consecutively starting at the base L1 allocator address.
+    auto dfb0 = program.impl().get_dataflow_buffer(dfb_ids[0]);
+    const uint32_t l1_base   = static_cast<uint32_t>(
+        device->allocator()->get_base_allocator_addr(HalMemType::L1));
+    const uint32_t ring_stride = dfb0->total_size();  // bytes; same for all identical configs
+    const uint32_t ring_words  = ring_stride / sizeof(uint32_t);
+
+    for (uint32_t i = 0; i < num_dfbs; ++i) {
+        const uint32_t dfb_l1_addr = l1_base + i * ring_stride;
+        std::vector<uint32_t> slice(ring_words, 0u);
+        for (uint32_t e = 0; e < entries_per_dfb; ++e) {
+            const uint32_t src = (i * entries_per_dfb + e) * wpe;
+            std::copy(input.begin() + src, input.begin() + src + wpe, slice.begin() + e * wpe);
+        }
+        detail::WriteToDeviceL1(device, core, dfb_l1_addr, slice);
+    }
+
+    // Launch program (slow dispatch; same pattern as execute_program_and_verify).
+    detail::LaunchProgram(device, program, true /*wait_until_cores_done*/);
+
+    // Verify: each out_buffer must match its DFB's L1 pre-fill slice.
+    for (uint32_t i = 0; i < num_dfbs; ++i) {
+        std::vector<uint32_t> output;
+        distributed::ReadShard(
+            mesh_device->mesh_command_queue(), output, out_buffers[i], zero_coord, true);
+
+        std::vector<uint32_t> expected(entries_per_dfb * wpe);
+        for (uint32_t e = 0; e < entries_per_dfb; ++e) {
+            const uint32_t src = (i * entries_per_dfb + e) * wpe;
+            std::copy(input.begin() + src, input.begin() + src + wpe, expected.begin() + e * wpe);
+        }
+        EXPECT_EQ(expected, output) << "TensixDM concurrent DFB " << i << " output mismatch";
+    }
+}
+
+// =====================================================================================
+// Gap 7 harness – sequential DM→DM DFBs
+//
+// N DM producer threads and N DM consumer threads cooperate sequentially through
+// num_dfbs DFBs
+//
+// Producer threads: DM[0..num_producers-1]
+// Consumer threads: DM[num_producers..num_producers+num_consumers-1]
+// =====================================================================================
+void run_sequential_dfbs_program(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const std::vector<experimental::dfb::DataflowBufferConfig>& configs) {
+    TT_FATAL(!configs.empty(), "configs must not be empty");
+    TT_FATAL(
+        mesh_device->get_devices()[0]->arch() == ARCH::QUASAR,
+        "Sequential multi-DFB TC-exhaustion tests require Quasar");
+
+    const uint32_t num_dfbs      = static_cast<uint32_t>(configs.size());
+    const uint32_t num_producers = configs[0].num_producers;
+    const uint32_t num_consumers = configs[0].num_consumers;
+    const uint32_t num_entries   = configs[0].num_entries;
+    const uint32_t entry_size    = configs[0].entry_size;
+
+    for (const auto& c : configs) {
+        TT_FATAL(c.num_producers == num_producers && c.num_consumers == num_consumers &&
+                     c.num_entries == num_entries && c.entry_size == entry_size,
+            "All DFB configs must share num_producers/num_consumers/num_entries/entry_size");
+    }
+
+    // Producer DM threads: low num_producers bits; consumer threads: next num_consumers bits.
+    TT_FATAL(
+        num_producers + num_consumers <= 6,
+        "num_producers + num_consumers must fit in 6 available Quasar DM threads (DM0 reserved for dispatch)");
+
+    const uint32_t producer_mask =  (1u << num_producers) - 1u;
+    const uint32_t consumer_mask = ((1u << num_consumers) - 1u) << num_producers;
+
+    const CoreCoord core(0, 0);
+    const CoreRangeSet core_range_set(CoreRange(core, core));
+    IDevice* device = mesh_device->get_devices()[0];
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+
+    const uint32_t buf_size = num_entries * entry_size;
+
+    // Separate in_buffer and out_buffer per DFB.
+    std::vector<std::shared_ptr<distributed::MeshBuffer>> in_buffers, out_buffers;
+    distributed::DeviceLocalBufferConfig local_cfg{.page_size = entry_size, .buffer_type = BufferType::DRAM};
+    for (uint32_t i = 0; i < num_dfbs; ++i) {
+        distributed::ReplicatedBufferConfig buf_cfg{.size = buf_size};
+        in_buffers.push_back(distributed::MeshBuffer::create(buf_cfg, local_cfg, mesh_device.get()));
+        out_buffers.push_back(distributed::MeshBuffer::create(buf_cfg, local_cfg, mesh_device.get()));
+    }
+
+    // Generate and write input data for each DFB's in_buffer.
+    std::vector<std::vector<uint32_t>> inputs(num_dfbs);
+    for (uint32_t i = 0; i < num_dfbs; ++i) {
+        inputs[i] = tt::test_utils::generate_uniform_random_vector<uint32_t>(
+            0, 100, buf_size / sizeof(uint32_t));
+        distributed::WriteShard(
+            mesh_device->mesh_command_queue(), in_buffers[i], inputs[i], zero_coord, true);
+    }
+
+    if (mesh_device->get_devices()[0]->arch() == ARCH::QUASAR) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        for (uint32_t i = 0; i < num_dfbs; ++i) {
+            std::vector<uint32_t> rdback;
+            distributed::ReadShard(
+                mesh_device->mesh_command_queue(), rdback, in_buffers[i], zero_coord, true);
+            tt_driver_atomics::mfence();
+            EXPECT_EQ(rdback, inputs[i]) << "in_buffer[" << i << "] DRAM write verify failed";
+        }
+    }
+
+    Program program = CreateProgram();
+
+    const uint32_t num_entries_per_producer =
+        (num_entries + num_producers - 1) / num_producers;  // ceiling; all configs share this
+
+    // Sequential DM producer kernel.
+    std::vector<uint32_t> prod_cta = {
+        num_entries_per_producer,
+        (uint32_t)configs[0].enable_implicit_sync};
+    tt::tt_metal::TensorAccessorArgs(in_buffers[0]).append_to(prod_cta);
+
+    auto producer_kernel = experimental::quasar::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_producer.cpp",
+        core_range_set,
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = num_producers, .compile_args = prod_cta});
+
+    // Sequential DM consumer kernel.
+    std::vector<uint32_t> cons_cta = {(uint32_t)configs[0].enable_implicit_sync};
+    tt::tt_metal::TensorAccessorArgs(out_buffers[0]).append_to(cons_cta);
+
+    auto consumer_kernel = experimental::quasar::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_consumer.cpp",
+        core_range_set,
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = num_consumers, .compile_args = cons_cta});
+
+    // Create all DFBs in the same Program (simultaneous TC allocation stress).
+    std::vector<uint32_t> dfb_ids;
+    for (uint32_t i = 0; i < num_dfbs; ++i) {
+        auto cfg_copy = configs[i];  // CreateDataflowBuffer takes by const ref; copy is fine
+        auto dfb_id = experimental::dfb::CreateDataflowBuffer(program, core_range_set, cfg_copy);
+        experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program, dfb_id, producer_kernel, consumer_kernel);
+        dfb_ids.push_back(dfb_id);
+    }
+
+    // Producer runtime args: mask | num_dfbs | src_addr[0..N-1]
+    std::vector<uint32_t> prod_rta = {producer_mask, num_dfbs};
+    for (uint32_t i = 0; i < num_dfbs; ++i) {
+        prod_rta.push_back(static_cast<uint32_t>(in_buffers[i]->address()));
+    }
+    SetRuntimeArgs(program, producer_kernel, core, prod_rta);
+
+    // Consumer runtime args: mask | num_dfbs | dst_addr[0..N-1] | epc[0..N-1] | is_all[0..N-1]
+    std::vector<uint32_t> cons_rta = {consumer_mask, num_dfbs};
+    for (uint32_t i = 0; i < num_dfbs; ++i) {
+        cons_rta.push_back(static_cast<uint32_t>(out_buffers[i]->address()));
+    }
+    for (uint32_t i = 0; i < num_dfbs; ++i) {
+        const bool is_all = (configs[i].cap == dfb::AccessPattern::ALL);
+        const uint32_t epc = is_all ? num_entries : (num_entries + num_consumers - 1) / num_consumers;
+        cons_rta.push_back(epc);
+    }
+    for (uint32_t i = 0; i < num_dfbs; ++i) {
+        cons_rta.push_back(configs[i].cap == dfb::AccessPattern::ALL ? 1u : 0u);
+    }
+    SetRuntimeArgs(program, consumer_kernel, core, cons_rta);
+
+    detail::LaunchProgram(device, program, true /*wait_until_cores_done*/);
+
+    // Verify: out_buffer[i] should equal in_buffer[i] (strided and all alike).
+    for (uint32_t i = 0; i < num_dfbs; ++i) {
+        std::vector<uint32_t> output;
+        distributed::ReadShard(
+            mesh_device->mesh_command_queue(), output, out_buffers[i], zero_coord, true);
+        EXPECT_EQ(inputs[i], output) << "Sequential DFB " << i << " output mismatch";
     }
 }
 
@@ -402,55 +899,81 @@ void run_in_dfb_out_dfb_program(
     execute_program_and_verify(mesh_device, program, in_buffer, out_buffer, zero_coord, input);
 }
 
-TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB1Sx1S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR and GetParam()) {
-        GTEST_SKIP();
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 1,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 1,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
+// =====================================================================================
+// Single-DFB test macros
+//
+// WH/BH supports only 1 DM producer (BRISC) + 1 DM consumer (NCRISC) and no implicit_sync,
+// so 1x1 configurations may run there with implicit_sync=false; everything else is Quasar-only.
+// =====================================================================================
 
-    uint32_t num_entries_in_buffer = 18;
-    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, core_range_set, num_entries_in_buffer);
+#define DFB_SKIP_IF_UNSUPPORTED(num_p, num_c)                                                           \
+    if (devices_.at(0)->arch() != ARCH::QUASAR && (GetParam() || (num_p) > 1 || (num_c) > 1)) {        \
+        GTEST_SKIP();                                                                                   \
+    }
+
+// DM -> ALL DM is unsupported with implicit_sync today.
+#define DFB_SKIP_DM_DM_ALL_IMPLICIT_SYNC                                                             \
+    if (GetParam()) {                                                                                \
+        GTEST_SKIP() << "Skipping DM to ALL DM with implicit sync until support is added";          \
+    }
+
+#define DFB_NO_EXTRA_SKIP ((void)0)
+
+constexpr uint32_t dfb_default_num_entries(uint32_t num_p, uint32_t num_c) {
+    const uint32_t m = (num_p / std::gcd(num_p, num_c)) * num_c;
+    return ((16u + m - 1u) / m) * m;
 }
 
-TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB1Sx1S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR and GetParam()) {
-        GTEST_SKIP();
+// Single-DFB test on a single core with default ring derived from (num_p, num_c)
+// and entry_size=1024.
+//   prefix       e.g. DM, DMTensix, TensixDM
+//   suffix       e.g. 3Sx1S, 6Sx2B
+//   p_kind/c_kind   DM | TENSIX
+//   num_p/num_c     1..6 (DM); 1..4 (TENSIX)
+//   pap_kind/cap_kind   STRIDED | ALL
+//   extra_skip      DFB_NO_EXTRA_SKIP or DFB_SKIP_DM_DM_ALL_IMPLICIT_SYNC
+#define DFB_TEST(prefix, suffix, p_kind, c_kind, num_p, pap_kind, num_c, cap_kind, extra_skip)          \
+    TEST_P(DFBImplicitSyncParamFixture, prefix##Test1xDFB##suffix) {                                    \
+        DFB_SKIP_IF_UNSUPPORTED((num_p), (num_c));                                                      \
+        extra_skip;                                                                                     \
+        experimental::dfb::DataflowBufferConfig config{                                                 \
+            .entry_size = 1024,                                                                         \
+            .num_entries = dfb_default_num_entries((num_p), (num_c)),                                   \
+            .num_producers = (num_p),                                                                   \
+            .pap = dfb::AccessPattern::pap_kind,                                                        \
+            .num_consumers = (num_c),                                                                   \
+            .cap = dfb::AccessPattern::cap_kind,                                                        \
+            .enable_implicit_sync = GetParam()};                                                        \
+        run_single_dfb_program(                                                                         \
+            this->devices_.at(0), config, DFBPorCType::p_kind, DFBPorCType::c_kind);                    \
     }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 1,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 1,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
 
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB1Sx1S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR and GetParam()) {
-        GTEST_SKIP();
+// Variant for DM->DM tests that pass an explicit num_entries_in_buffer (forces wraparound
+// when the requested total exceeds the ring size).
+#define DFB_TEST_BUF(prefix, suffix, p_kind, c_kind, num_p, pap_kind, num_c, cap_kind, extra_skip, n_buf) \
+    TEST_P(DFBImplicitSyncParamFixture, prefix##Test1xDFB##suffix) {                                    \
+        DFB_SKIP_IF_UNSUPPORTED((num_p), (num_c));                                                      \
+        extra_skip;                                                                                     \
+        experimental::dfb::DataflowBufferConfig config{                                                 \
+            .entry_size = 1024,                                                                         \
+            .num_entries = dfb_default_num_entries((num_p), (num_c)),                                   \
+            .num_producers = (num_p), .pap = dfb::AccessPattern::pap_kind,                              \
+            .num_consumers = (num_c), .cap = dfb::AccessPattern::cap_kind,                              \
+            .enable_implicit_sync = GetParam()};                                                        \
+        CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));                       \
+        run_single_dfb_program(                                                                         \
+            this->devices_.at(0), config, DFBPorCType::p_kind, DFBPorCType::c_kind,                     \
+            core_range_set, (n_buf));                                                                   \
     }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 1,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 1,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
 
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
-}
+// =====================================================================================
+// Strided
+// =====================================================================================
+
+// 1x1 (DM->DM uses num_entries_in_buffer=18 to exercise wraparound)
+DFB_TEST_BUF(DM,       1Sx1S, DM,     DM,     1, STRIDED, 1, STRIDED, DFB_NO_EXTRA_SKIP, 18)
+DFB_TEST    (DMTensix, 1Sx1S, DM,     TENSIX, 1, STRIDED, 1, STRIDED, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (TensixDM, 1Sx1S, TENSIX, DM,     1, STRIDED, 1, STRIDED, DFB_NO_EXTRA_SKIP)
 
 // TEST_F(MeshDeviceFixture, DMTensixDMTest2xDFB1Sx1S) {
 //     if (devices_.at(0)->arch() != ARCH::QUASAR) {
@@ -527,476 +1050,197 @@ TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB1Sx1S) {
 //     run_in_dfb_out_dfb_program(this->devices_.at(0), dm2tensix_config, tensix2dm_config);
 // }
 
-TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB1Sx4S) {
+DFB_TEST    (DM,       1Sx4S, DM,     DM,     1, STRIDED, 4, STRIDED, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (DMTensix, 1Sx4S, DM,     TENSIX, 1, STRIDED, 4, STRIDED, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (TensixDM, 1Sx4S, TENSIX, DM,     1, STRIDED, 4, STRIDED, DFB_NO_EXTRA_SKIP)
+
+DFB_TEST    (DM,       4Sx1S, DM,     DM,     4, STRIDED, 1, STRIDED, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (DMTensix, 4Sx1S, DM,     TENSIX, 4, STRIDED, 1, STRIDED, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (TensixDM, 4Sx1S, TENSIX, DM,     4, STRIDED, 1, STRIDED, DFB_NO_EXTRA_SKIP)
+
+DFB_TEST_BUF(DM,       4Sx4S, DM,     DM,     4, STRIDED, 4, STRIDED, DFB_NO_EXTRA_SKIP, 29)
+DFB_TEST    (DMTensix, 4Sx4S, DM,     TENSIX, 4, STRIDED, 4, STRIDED, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (TensixDM, 4Sx4S, TENSIX, DM,     4, STRIDED, 4, STRIDED, DFB_NO_EXTRA_SKIP)
+
+DFB_TEST_BUF(DM,       2Sx4S, DM,     DM,     2, STRIDED, 4, STRIDED, DFB_NO_EXTRA_SKIP, 21)
+DFB_TEST    (DMTensix, 2Sx4S, DM,     TENSIX, 2, STRIDED, 4, STRIDED, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (TensixDM, 2Sx4S, TENSIX, DM,     2, STRIDED, 4, STRIDED, DFB_NO_EXTRA_SKIP)
+
+DFB_TEST    (DM,       4Sx2S, DM,     DM,     4, STRIDED, 2, STRIDED, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (DMTensix, 4Sx2S, DM,     TENSIX, 4, STRIDED, 2, STRIDED, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (TensixDM, 4Sx2S, TENSIX, DM,     4, STRIDED, 2, STRIDED, DFB_NO_EXTRA_SKIP)
+
+// DM->DM strided: power-of-2 (1Sx2S, 2Sx1S, 2Sx2S)
+DFB_TEST    (DM,       1Sx2S, DM,     DM,     1, STRIDED, 2, STRIDED, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (DM,       2Sx1S, DM,     DM,     2, STRIDED, 1, STRIDED, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (DM,       2Sx2S, DM,     DM,     2, STRIDED, 2, STRIDED, DFB_NO_EXTRA_SKIP)
+
+// DM->DM strided: 3-DM consumer column
+DFB_TEST    (DM,       1Sx3S, DM,     DM,     1, STRIDED, 3, STRIDED, DFB_NO_EXTRA_SKIP)
+// DFB_TEST    (DM,       2Sx3S, DM,     DM,     2, STRIDED, 3, STRIDED, DFB_NO_EXTRA_SKIP) // needs ALL access pattern
+
+DFB_TEST    (DM,       3Sx1S, DM,     DM,     3, STRIDED, 1, STRIDED, DFB_NO_EXTRA_SKIP)
+// DFB_TEST    (DM,       3Sx2S, DM,     DM,     3, STRIDED, 2, STRIDED, DFB_NO_EXTRA_SKIP) // needs ALL access pattern
+DFB_TEST    (DM,       3Sx3S, DM,     DM,     3, STRIDED, 3, STRIDED, DFB_NO_EXTRA_SKIP)
+
+DFB_TEST    (DM,       1Sx5S, DM,     DM,     1, STRIDED, 5, STRIDED, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (DM,       5Sx1S, DM,     DM,     5, STRIDED, 1, STRIDED, DFB_NO_EXTRA_SKIP)
+
+// DM->Tensix strided (Tensix consumers limited to {1,2,4})
+// Power-of-2 gaps
+DFB_TEST    (DMTensix, 1Sx2S, DM,     TENSIX, 1, STRIDED, 2, STRIDED, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (DMTensix, 2Sx1S, DM,     TENSIX, 2, STRIDED, 1, STRIDED, DFB_NO_EXTRA_SKIP)
+// 3-DM producer
+DFB_TEST    (DMTensix, 3Sx1S, DM,     TENSIX, 3, STRIDED, 1, STRIDED, DFB_NO_EXTRA_SKIP)
+// DFB_TEST    (DMTensix, 3Sx2S, DM,     TENSIX, 3, STRIDED, 2, STRIDED, DFB_NO_EXTRA_SKIP) // needs BLOCKED access pattern
+// DFB_TEST    (DMTensix, 3Sx4S, DM,     TENSIX, 3, STRIDED, 4, STRIDED, DFB_NO_EXTRA_SKIP) // needs BLOCKED access pattern
+// 6-DM producer
+DFB_TEST    (DMTensix, 6Sx1S, DM,     TENSIX, 6, STRIDED, 1, STRIDED, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (DMTensix, 6Sx2S, DM,     TENSIX, 6, STRIDED, 2, STRIDED, DFB_NO_EXTRA_SKIP)
+// DFB_TEST    (DMTensix, 6Sx4S, DM,     TENSIX, 6, STRIDED, 4, STRIDED, DFB_NO_EXTRA_SKIP) // needs BLOCKED access pattern
+
+// Tensix->DM strided (Tensix producers limited to {1,2,4})
+// Power-of-2 gaps
+DFB_TEST    (TensixDM, 2Sx1S, TENSIX, DM,     2, STRIDED, 1, STRIDED, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (TensixDM, 1Sx2S, TENSIX, DM,     1, STRIDED, 2, STRIDED, DFB_NO_EXTRA_SKIP)
+// 3-DM consumer
+DFB_TEST    (TensixDM, 1Sx3S, TENSIX, DM,     1, STRIDED, 3, STRIDED, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (TensixDM, 2Sx3S, TENSIX, DM,     2, STRIDED, 3, STRIDED, DFB_NO_EXTRA_SKIP)
+// DFB_TEST    (TensixDM, 4Sx3S, TENSIX, DM,     4, STRIDED, 3, STRIDED, DFB_NO_EXTRA_SKIP) // needs BLOCKED access pattern
+// 6-DM consumer
+DFB_TEST    (TensixDM, 1Sx6S, TENSIX, DM,     1, STRIDED, 6, STRIDED, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (TensixDM, 2Sx6S, TENSIX, DM,     2, STRIDED, 6, STRIDED, DFB_NO_EXTRA_SKIP)
+// DFB_TEST    (TensixDM, 4Sx6S, TENSIX, DM,     4, STRIDED, 6, STRIDED, DFB_NO_EXTRA_SKIP) // needs BLOCKED access pattern
+
+// =====================================================================================
+// ALL
+// =====================================================================================
+
+DFB_TEST    (DM,       1Sx4A, DM,     DM,     1, STRIDED, 4, ALL, DFB_SKIP_DM_DM_ALL_IMPLICIT_SYNC)
+DFB_TEST    (DMTensix, 1Sx4A, DM,     TENSIX, 1, STRIDED, 4, ALL, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (TensixDM, 1Sx4A, TENSIX, DM,     1, STRIDED, 4, ALL, DFB_NO_EXTRA_SKIP)
+
+DFB_TEST    (DM,       4Sx1A, DM,     DM,     4, STRIDED, 1, ALL, DFB_SKIP_DM_DM_ALL_IMPLICIT_SYNC)
+DFB_TEST    (DMTensix, 4Sx1A, DM,     TENSIX, 4, STRIDED, 1, ALL, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (TensixDM, 4Sx1A, TENSIX, DM,     4, STRIDED, 1, ALL, DFB_NO_EXTRA_SKIP)
+
+DFB_TEST    (DM,       4Sx4A, DM,     DM,     4, STRIDED, 4, ALL, DFB_SKIP_DM_DM_ALL_IMPLICIT_SYNC)
+DFB_TEST    (DMTensix, 4Sx4A, DM,     TENSIX, 4, STRIDED, 4, ALL, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (TensixDM, 4Sx4A, TENSIX, DM,     4, STRIDED, 4, ALL, DFB_NO_EXTRA_SKIP)
+
+DFB_TEST    (DM,       4Sx2A, DM,     DM,     4, STRIDED, 2, ALL, DFB_SKIP_DM_DM_ALL_IMPLICIT_SYNC)
+DFB_TEST    (DMTensix, 4Sx2A, DM,     TENSIX, 4, STRIDED, 2, ALL, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (TensixDM, 4Sx2A, TENSIX, DM,     4, STRIDED, 2, ALL, DFB_NO_EXTRA_SKIP)
+
+DFB_TEST    (DM,       2Sx4A, DM,     DM,     2, STRIDED, 4, ALL, DFB_SKIP_DM_DM_ALL_IMPLICIT_SYNC)
+DFB_TEST    (DMTensix, 2Sx4A, DM,     TENSIX, 2, STRIDED, 4, ALL, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (TensixDM, 2Sx4A, TENSIX, DM,     2, STRIDED, 4, ALL, DFB_NO_EXTRA_SKIP)
+
+// DM->DM ALL: 3-DM producer
+DFB_TEST    (DM,       3Sx1A, DM,     DM,     3, STRIDED, 1, ALL, DFB_SKIP_DM_DM_ALL_IMPLICIT_SYNC)
+DFB_TEST    (DM,       3Sx2A, DM,     DM,     3, STRIDED, 2, ALL, DFB_SKIP_DM_DM_ALL_IMPLICIT_SYNC)
+DFB_TEST    (DM,       3Sx3A, DM,     DM,     3, STRIDED, 3, ALL, DFB_SKIP_DM_DM_ALL_IMPLICIT_SYNC)
+
+// DM->DM ALL: 3-DM consumer
+DFB_TEST    (DM,       1Sx3A, DM,     DM,     1, STRIDED, 3, ALL, DFB_SKIP_DM_DM_ALL_IMPLICIT_SYNC)
+DFB_TEST    (DM,       2Sx3A, DM,     DM,     2, STRIDED, 3, ALL, DFB_SKIP_DM_DM_ALL_IMPLICIT_SYNC)
+
+// DM->Tensix ALL (Tensix consumers limited to {1,2,4})
+DFB_TEST    (DMTensix, 3Sx1A, DM,     TENSIX, 3, STRIDED, 1, ALL, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (DMTensix, 3Sx2A, DM,     TENSIX, 3, STRIDED, 2, ALL, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (DMTensix, 3Sx4A, DM,     TENSIX, 3, STRIDED, 4, ALL, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (DMTensix, 6Sx1A, DM,     TENSIX, 6, STRIDED, 1, ALL, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (DMTensix, 6Sx2A, DM,     TENSIX, 6, STRIDED, 2, ALL, DFB_NO_EXTRA_SKIP)
+DFB_TEST    (DMTensix, 6Sx4A, DM,     TENSIX, 6, STRIDED, 4, ALL, DFB_NO_EXTRA_SKIP)
+
+// Tensix->DM ALL (Tensix producers limited to {1,2,4}).
+// DFB_TEST    (TensixDM, 1Sx3A, TENSIX, DM,     1, STRIDED, 3, ALL, DFB_NO_EXTRA_SKIP) // revisit the 3A Tensix consumer
+// DFB_TEST    (TensixDM, 2Sx3A, TENSIX, DM,     2, STRIDED, 3, ALL, DFB_NO_EXTRA_SKIP)
+// DFB_TEST    (TensixDM, 4Sx3A, TENSIX, DM,     4, STRIDED, 3, ALL, DFB_NO_EXTRA_SKIP)
+// DFB_TEST    (TensixDM, 1Sx6A, TENSIX, DM,     1, STRIDED, 6, ALL, DFB_NO_EXTRA_SKIP) // revisit more than 4 ALL consumers
+// DFB_TEST    (TensixDM, 2Sx6A, TENSIX, DM,     2, STRIDED, 6, ALL, DFB_NO_EXTRA_SKIP)
+// DFB_TEST    (TensixDM, 4Sx6A, TENSIX, DM,     4, STRIDED, 6, ALL, DFB_NO_EXTRA_SKIP)
+
+// 1 strided DM producer, 1 strided DM consumer, num_entries=4.
+// Ring wraps 16x; baseline to confirm wraparound logic with minimum participants.
+TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB_RingPressure_1Sx1S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+        GTEST_SKIP() << "Skipping DFB ring-pressure test for WH/BH until DFB is backported";
     }
+    DFB_SKIP_IF_UNSUPPORTED(1, 1);
     experimental::dfb::DataflowBufferConfig config{
         .entry_size = 1024,
-        .num_entries = 16,
+        .num_entries = 4,
         .num_producers = 1,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 4,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
-
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB1Sx4S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 1,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 4,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB1Sx4S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 1,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 4,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx1S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 4,
         .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
         .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
-
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
+    run_single_dfb_program(
+        this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM,
+        CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0))), /*num_entries_in_buffer=*/64);
 }
 
-TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx1S) {
+// 4 strided DM producers, 4 strided DM consumers, num_entries=4 -> capacity=1.
+// Each producer stalls after every push; ring wraps 64x per producer.
+TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB_RingPressure_4Sx4S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+        GTEST_SKIP() << "Skipping DFB ring-pressure test for WH/BH until DFB is backported";
     }
+    DFB_SKIP_IF_UNSUPPORTED(4, 4);
     experimental::dfb::DataflowBufferConfig config{
         .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 4,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 1,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB4Sx1S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 4,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 1,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx4S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
+        .num_entries = 4,
         .num_producers = 4,
         .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
-
-    uint32_t num_entries_in_buffer = 29;
-    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, core_range_set, num_entries_in_buffer);
+    run_single_dfb_program(
+        this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM,
+        CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0))), /*num_entries_in_buffer=*/64);
 }
 
-TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx4S) {
+// 4 DM producers (STRIDED), 4 Tensix consumers (ALL), num_entries=4 -> capacity=1.
+// Every push stalls until all 4 ALL Tensix consumers ack; ring wraps 64x per producer.
+// Exercises remapper fan-out on the DM->Tensix path under maximum ring pressure.
+TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB_RingPressure_4Sx4A) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+        GTEST_SKIP() << "Skipping DFB ring-pressure test for WH/BH until DFB is backported";
     }
+    DFB_SKIP_IF_UNSUPPORTED(4, 4);
     experimental::dfb::DataflowBufferConfig config{
         .entry_size = 1024,
-        .num_entries = 16,
+        .num_entries = 4,  // tight ring: capacity = num_entries / num_producers = 1
         .num_producers = 4,
         .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = dfb::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::ALL,
         .enable_implicit_sync = GetParam()};
-
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
+    run_single_dfb_program(
+        this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX,
+        CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0))), /*num_entries_in_buffer=*/64);
 }
 
-TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB4Sx4S) {
+// 2 Tensix producers (STRIDED), 4 DM consumers (STRIDED), num_entries=4 -> capacity=1.
+// Ring wraps 64x per producer; exercises the Tensix->DM path with asymmetric P:C ratio
+// under tight ring pressure (num_consumers > num_producers).
+TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB_RingPressure_2Sx4S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+        GTEST_SKIP() << "Skipping DFB ring-pressure test for WH/BH until DFB is backported";
     }
+    DFB_SKIP_IF_UNSUPPORTED(2, 4);
     experimental::dfb::DataflowBufferConfig config{
         .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 4,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 4,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB2Sx4S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
+        .num_entries = 4,  // tight ring: capacity = num_entries / max(num_p, num_c) = 1
         .num_producers = 2,
         .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
-
-    uint32_t num_entries_in_buffer = 21;
-    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, core_range_set, num_entries_in_buffer);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB2Sx4S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 2,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 4,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB2Sx4S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 2,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 4,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx2S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 4,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 2,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
-
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx2S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 4,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 2,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB4Sx2S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 4,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 2,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
-}
-
-// AccessPattern::ALL
-
-TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB1Sx4B) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 1,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 4,
-        .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = GetParam()};
-
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB1Sx4B) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 1,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 4,
-        .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = GetParam()};
-
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB1Sx4B) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 1,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 4,
-        .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = GetParam()};
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx1B) { // mismatching
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 4,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 1,
-        .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = GetParam()};
-
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx1B) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 4,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 1,
-        .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = GetParam()};
-
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB4Sx1B) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 4,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 1,
-        .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = GetParam()};
-
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx4B) { // mismatching
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 4,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 4,
-        .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = GetParam()};
-
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx4B) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 4,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 4,
-        .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = GetParam()};
-
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB4Sx4B) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 4,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 4,
-        .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = GetParam()};
-
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx2B) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 4,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 2,
-        .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = GetParam()};
-
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx2B) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 4,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 2,
-        .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = GetParam()};
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB4Sx2B) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 4,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 2,
-        .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = GetParam()};
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB2Sx4B) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 2,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 4,
-        .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = GetParam()};
-
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB2Sx4B) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 2,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 4,
-        .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = GetParam()};
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
-}
-
-TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB2Sx4B) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 2,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 4,
-        .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = GetParam()};
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
+    run_single_dfb_program(
+        this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM,
+        CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0))), /*num_entries_in_buffer=*/64);
 }
 
 TEST_P(DFBImplicitSyncParamFixture, MultiCoreDMTest2Core_1Sx1S) {
@@ -1033,7 +1277,7 @@ TEST_P(DFBImplicitSyncParamFixture, MultiCoreDMTest2Core_2Sx2S) {
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, core_range_set);
 }
 
-TEST_P(DFBImplicitSyncParamFixture, MultiCoreDMTest2Core_1Sx4B) {
+TEST_P(DFBImplicitSyncParamFixture, MultiCoreDMTest2Core_1Sx4A) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -1048,6 +1292,108 @@ TEST_P(DFBImplicitSyncParamFixture, MultiCoreDMTest2Core_1Sx4B) {
 
     CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(1, 0)));
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, core_range_set);
+}
+
+// =====================================================================================
+// Concurrent DFBs on Same Core (TC Allocator Stress)
+//
+//
+// TensixDMTest4xDFB_1Sx1S
+//   4 concurrent 1Sx1S Tensix→DM DFBs.  Single Neo thread fills DFBs sequentially;
+//   4 DM consumer threads drain each DFB as soon as entries arrive.
+//   Harness: run_concurrent_tensix_dm_dfbs_program
+//            + dfb_t6_seq_producer.cpp + dfb_multi_consumer_sep.cpp
+//
+// DMTest4xDFB_3Sx3S
+//   4× 3Sx3S DFBs = 12 TCs total: stresses TC allocator across 6 DM threads.
+//   DM threads 0..2 cooperate on each DFB in sequence as producers; DM threads 3..5 consume.
+//   All 12 TCs allocated simultaneously in one Program.
+//   Harness: run_sequential_dfbs_program + dfb_seq_producer.cpp + dfb_seq_consumer.cpp
+//
+// DMTest4xDFB_Mixed
+//   2× 3Sx3S (strided) + 2× 3Sx3ALL (ALL) on the same core.
+//   Mixed TC allocation (strided TCs + remapper-backed ALL TCs) across 6 DM threads.
+//   Harness: run_sequential_dfbs_program + dfb_seq_producer.cpp + dfb_seq_consumer.cpp
+// =====================================================================================
+
+TEST_P(DFBImplicitSyncParamFixture, DMTest3xDFB_1Sx1S) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping: concurrent DFB test requires Quasar multi-threaded DM";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size    = 1024,
+        .num_entries   = 16,
+        .num_producers = 1,
+        .pap           = dfb::AccessPattern::STRIDED,
+        .num_consumers = 1,
+        .cap           = dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = GetParam()};
+    run_concurrent_dfbs_program(this->devices_.at(0), /*num_dfbs=*/3, config);
+}
+
+TEST_P(DFBImplicitSyncParamFixture, TensixDMTest4xDFB_1Sx1S) {
+    // 4 concurrent 1Sx1S DFBs: single Neo thread produces to all 4 sequentially while
+    // 4 DM consumer threads drain their DFBs as soon as entries become available.
+    // Uses dfb_t6_seq_producer.cpp + dfb_multi_consumer_sep.cpp.
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping: Tensix concurrent DFB test requires Quasar";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size    = 1024,
+        .num_entries   = 16,
+        .num_producers = 1,
+        .pap           = dfb::AccessPattern::STRIDED,
+        .num_consumers = 1,
+        .cap           = dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = GetParam()};
+    run_concurrent_tensix_dm_dfbs_program(this->devices_.at(0), /*num_dfbs=*/4, config);
+}
+
+TEST_P(DFBImplicitSyncParamFixture, DMTest4xDFB_3Sx3S) {
+    // 4 DFBs × 3Sx3S = 12 TCs: stresses TC allocator across 6 DM threads.
+    // DM threads 0..2 cooperatively produce all 4 DFBs in sequence; DM threads 3..5
+    // cooperatively consume all 4 DFBs in sequence.
+    // Uses dfb_seq_producer.cpp + dfb_seq_consumer.cpp.
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping: sequential multi-DFB TC exhaustion test requires Quasar";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size    = 1024,
+        .num_entries   = 16,
+        .num_producers = 3,
+        .pap           = dfb::AccessPattern::STRIDED,
+        .num_consumers = 3,
+        .cap           = dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = GetParam()};
+    run_sequential_dfbs_program(this->devices_.at(0), {config, config, config, config});
+}
+
+TEST_P(DFBImplicitSyncParamFixture, DMTest4xDFB_Mixed) {
+    // 2× 3Sx3S (strided consumers) + 2× 3Sx3B (ALL consumers) on the same core.
+    // Mixed TC allocation exercises both plain strided TCs and remapper-backed ALL TCs
+    // simultaneously across 6 DM threads (DM threads 0..2 produce, 3..5 consume).
+    // Uses dfb_seq_producer.cpp + dfb_seq_consumer.cpp with per-DFB is_all flags.
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping: mixed multi-DFB TC exhaustion test requires Quasar";
+    }
+    experimental::dfb::DataflowBufferConfig strided_cfg{
+        .entry_size    = 1024,
+        .num_entries   = 16,
+        .num_producers = 3,
+        .pap           = dfb::AccessPattern::STRIDED,
+        .num_consumers = 3,
+        .cap           = dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = GetParam()};
+    experimental::dfb::DataflowBufferConfig all_cfg{
+        .entry_size    = 1024,
+        .num_entries   = 16,
+        .num_producers = 3,
+        .pap           = dfb::AccessPattern::STRIDED,
+        .num_consumers = 3,
+        .cap           = dfb::AccessPattern::ALL,
+        .enable_implicit_sync = GetParam()};
+    run_sequential_dfbs_program(
+        this->devices_.at(0), {strided_cfg, strided_cfg, all_cfg, all_cfg});
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_seq_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_seq_producer.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: � 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Sequential Tensix producer for concurrent DFB stress tests (Gap 7).
+//
+// A single Neo thread loops through num_dfbs DFBs in order, signaling entries for
+// each one.  The host pre-fills every DFB's L1 ring before the program is launched.
+// Running on one Neo thread avoids any dependency on Neo hartid values while still
+// creating all num_dfbs DFBs in a single Program (so their TCs are allocated
+// simultaneously), which is the TC-allocator stress this test exercises.
+//
+// Synchronisation: after each dfb.finish() the producer has verified that all
+// consumers of that DFB have acked every entry, so it is safe to move on to the
+// next DFB.  Concurrent DM consumers therefore drain each DFB as soon as entries
+// arrive, then block on the next DFB until the Neo fills it.
+//
+// Compile-time args:
+//   [0]: num_dfbs                  � number of DFBs to loop through
+//   [1]: num_entries_per_producer  � entries to signal per DFB (same for all)
+
+#include "experimental/dataflow_buffer.h"
+
+void kernel_main() {
+    constexpr uint32_t num_dfbs               = get_compile_time_arg_val(0);
+    const uint32_t     num_entries_per_producer = get_compile_time_arg_val(1);
+
+    for (uint32_t dfb_id = 0; dfb_id < num_dfbs; dfb_id++) {
+        experimental::DataflowBuffer dfb(dfb_id);
+        for (uint32_t tile_id = 0; tile_id < num_entries_per_producer; tile_id++) {
+            dfb.reserve_back(1);
+            dfb.push_back(1);
+        }
+        // Blocks until all consumers of this DFB have acked every entry.
+        dfb.finish();
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
@@ -19,6 +19,9 @@ void kernel_main() {
     // Base page offset for this core's slice of the global buffer.
     // Single-core callers pass 0; multi-core callers pass core_idx * entries_per_core.
     const uint32_t chunk_offset = get_arg_val<uint32_t>(2);
+    // Total entries in this core's slice; used to clamp the last consumer when
+    // entries_per_core is not a multiple of num_consumers.
+    const uint32_t entries_per_core = get_arg_val<uint32_t>(3);
     const uint32_t num_consumers = static_cast<uint32_t>(__builtin_popcount(consumer_mask));
 
     experimental::DataflowBuffer dfb(logical_dfb_id);
@@ -45,6 +48,11 @@ void kernel_main() {
             page_id = chunk_offset + tile_id;
         } else {
             page_id = chunk_offset + tile_id * num_consumers + consumer_idx;
+        }
+        // Skip if this consumer's slice overshoots the actual buffer size (happens when
+        // entries_per_core is not a multiple of num_consumers).
+        if (page_id >= chunk_offset + entries_per_core) {
+            break;
         }
         // DPRINT << "consumer tile id " << tile_id << " page id " << page_id << ENDL();
         // DEVICE_PRINT("consumer tile id {} page id {}\n", tile_id, page_id);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Single-DFB consumer kernel for concurrent DFB stress tests (Gap 7).
+//
+// Each instance handles exactly one DFB (identified by dfb_id in the CTA) and
+// drains entries to its chunk of a shared DRAM out_buffer (offset by chunk_offset).
+// The harness creates one instance per DFB so each DFB gets exactly one consumer
+// thread – matching num_consumers=1 in the DFB config.
+//
+// Compile-time args:
+//   [0]: num_entries_per_consumer  – entries this instance consumes
+//   [1]: implicit_sync             – 0 or 1
+//   [2]: dst_addr_base             – shared DRAM out_buffer base address
+//   [3]: dfb_id                    – logical DFB ID this instance handles
+//   [4]: chunk_offset              – page offset into the shared DRAM buffer
+//   [5..]: TensorAccessorArgs      – shared DRAM layout descriptor
+
+#include "experimental/dataflow_buffer.h"
+#include "experimental/noc.h"
+#include "experimental/tensor.h"
+
+void kernel_main() {
+    const uint32_t num_entries_per_consumer = get_compile_time_arg_val(0);
+    constexpr uint32_t implicit_sync        = get_compile_time_arg_val(1);
+    const uint32_t dst_addr_base            = get_compile_time_arg_val(2);
+    const uint32_t dfb_id                   = get_compile_time_arg_val(3);
+    const uint32_t chunk_offset             = get_compile_time_arg_val(4);
+    constexpr auto dst_args                 = TensorAccessorArgs<5>();
+
+    experimental::DataflowBuffer dfb(dfb_id);
+    experimental::Noc noc;
+    const uint32_t entry_size  = dfb.get_entry_size();
+    const auto tensor_accessor = TensorAccessor(dst_args, dst_addr_base, entry_size);
+
+
+    for (uint32_t tile_id = 0; tile_id < num_entries_per_consumer; tile_id++) {
+        const uint32_t page_id = chunk_offset + tile_id;
+        if constexpr (implicit_sync) {
+#ifdef ARCH_QUASAR
+            noc.async_write<experimental::Noc::TxnIdMode::ENABLED>(
+                dfb, tensor_accessor, {}, {.page_id = page_id});
+#endif
+        } else {
+            DPRINT << "consumer wait page id: " << page_id << ENDL();
+            dfb.wait_front(1);
+            noc.async_write(dfb, tensor_accessor, entry_size, {}, {.page_id = page_id});
+            noc.async_write_barrier();
+            dfb.pop_front(1);
+        }
+    }
+    DPRINT << "consumer before finish" << ENDL();
+    dfb.finish();
+    DPRINT << "at end of kernel_main b4 write barrier" << ENDL();
+    dfb.write_barrier(noc);
+    DPRINT << "finished write barrier" << ENDL();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer_sep.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer_sep.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Single-DFB consumer kernel with a separate DRAM output buffer per DFB (Gap 7).
+//
+// Like dfb_multi_consumer.cpp but each instance writes to its own independent DRAM
+// output buffer (dst_addr_base is per-instance) rather than a shared buffer + offset.
+// Used for TensixDMTest4xDFB_1Sx1S where the host verifies each out_buffer separately.
+//
+// Compile-time args:
+//   [0]: num_entries_per_consumer  – entries this instance consumes
+//   [1]: implicit_sync             – 0 or 1
+//   [2]: dst_addr_base             – this DFB's own DRAM out_buffer base address
+//   [3]: dfb_id                    – logical DFB ID this instance handles
+//   [4..]: TensorAccessorArgs      – shared DRAM layout descriptor
+
+#include "experimental/dataflow_buffer.h"
+#include "experimental/noc.h"
+#include "experimental/tensor.h"
+
+void kernel_main() {
+    const uint32_t num_entries_per_consumer = get_compile_time_arg_val(0);
+    constexpr uint32_t implicit_sync        = get_compile_time_arg_val(1);
+    const uint32_t dst_addr_base            = get_compile_time_arg_val(2);
+    const uint32_t dfb_id                   = get_compile_time_arg_val(3);
+    constexpr auto dst_args                 = TensorAccessorArgs<4>();
+
+    experimental::DataflowBuffer dfb(dfb_id);
+    experimental::Noc noc;
+    const uint32_t entry_size  = dfb.get_entry_size();
+    const auto tensor_accessor = TensorAccessor(dst_args, dst_addr_base, entry_size);
+
+    // 1Sx1S sole consumer: pages are sequential starting from 0.
+    for (uint32_t tile_id = 0; tile_id < num_entries_per_consumer; tile_id++) {
+        if constexpr (implicit_sync) {
+#ifdef ARCH_QUASAR
+            noc.async_write<experimental::Noc::TxnIdMode::ENABLED>(
+                dfb, tensor_accessor, {}, {.page_id = tile_id});
+#endif
+        } else {
+            dfb.wait_front(1);
+            noc.async_write(dfb, tensor_accessor, entry_size, {}, {.page_id = tile_id});
+            noc.async_write_barrier();
+            dfb.pop_front(1);
+        }
+    }
+    dfb.finish();
+    dfb.write_barrier(noc);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_producer.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Single-DFB producer kernel for concurrent DFB stress tests (Gap 7).
+//
+// Each instance of this kernel runs as a single DM thread and handles exactly one
+// DFB, identified by the dfb_id compile-time arg.  The harness creates one kernel
+// instance per DFB (with a unique dfb_id and chunk_offset in the CTA), so each DFB
+// gets precisely one producer thread – matching num_producers=1 in the DFB config.
+//
+// Encoding dfb_id and chunk_offset in the CTA (rather than deriving them from
+// mhartid at runtime) avoids any dependency on the DM thread assignment order and
+// makes each kernel instance distinct so the runtime allocates a separate DM thread
+// to each one.
+//
+// Compile-time args:
+//   [0]: num_entries_per_producer  – entries this instance produces
+//   [1]: implicit_sync             – 0 or 1
+//   [2]: src_addr_base             – shared DRAM in_buffer base address
+//   [3]: dfb_id                    – logical DFB ID this instance handles
+//   [4]: chunk_offset              – page offset into the shared DRAM buffer
+//   [5..]: TensorAccessorArgs      – shared DRAM layout descriptor
+
+#include "experimental/dataflow_buffer.h"
+#include "experimental/noc.h"
+#include "experimental/tensor.h"
+
+void kernel_main() {
+    const uint32_t num_entries_per_producer = get_compile_time_arg_val(0);
+    constexpr uint32_t implicit_sync        = get_compile_time_arg_val(1);
+    const uint32_t src_addr_base            = get_compile_time_arg_val(2);
+    const uint32_t dfb_id                   = get_compile_time_arg_val(3);
+    const uint32_t chunk_offset             = get_compile_time_arg_val(4);
+    constexpr auto src_args                 = TensorAccessorArgs<5>();
+
+    experimental::DataflowBuffer dfb(dfb_id);
+    experimental::Noc noc;
+    const uint32_t entry_size  = dfb.get_entry_size();
+    const auto tensor_accessor = TensorAccessor(src_args, src_addr_base, entry_size);
+
+
+    for (uint32_t tile_id = 0; tile_id < num_entries_per_producer; tile_id++) {
+        const uint32_t page_id = chunk_offset + tile_id;
+        if constexpr (implicit_sync) {
+#ifdef ARCH_QUASAR
+            noc.async_read<experimental::Noc::TxnIdMode::ENABLED>(
+                tensor_accessor, dfb, {.page_id = page_id}, {});
+#endif
+        } else {
+            dfb.reserve_back(1);
+            noc.async_read(tensor_accessor, dfb, entry_size, {.page_id = page_id}, {});
+            noc.async_read_barrier();
+            dfb.push_back(1);
+        }
+    }
+    DPRINT << "producer before finish" << ENDL();
+    dfb.finish();
+    DPRINT << "producer after finish" << ENDL();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
@@ -11,18 +11,15 @@ void kernel_main() {
     const uint32_t src_addr_base = get_compile_time_arg_val(0);
     const uint32_t num_entries_per_producer = get_compile_time_arg_val(1);
     constexpr uint32_t implicit_sync = get_compile_time_arg_val(2);
-    // ALL consumer does contiguous reads (TC0 fully exhausted before TC1, etc.), so the DFB
-    // uses a contiguous layout per producer. Producer i must write pages [i*N .. i*N+(N-1)]
-    // so that each consumer TC sees a contiguous, in-order slice.
-    // STRIDED consumer reads in round-robin (TC0, TC1, ..., TC0, ...), so the DFB uses an
-    // interleaved layout and producer i writes pages [i, i+P, i+2P, ...].
-    constexpr uint32_t consume_all = get_compile_time_arg_val(3);
-    constexpr auto src_args = TensorAccessorArgs<4>();
+    constexpr auto src_args = TensorAccessorArgs<3>();
 
     uint32_t producer_mask = get_arg_val<uint32_t>(0);
     // Base page offset for this core's slice of the global buffer.
     // Single-core callers pass 0; multi-core callers pass core_idx * entries_per_core.
     const uint32_t chunk_offset = get_arg_val<uint32_t>(1);
+    // Total entries in this core's slice; used to clamp the last producer when
+    // num_entries_in_buffer is not a multiple of num_producers.
+    const uint32_t entries_per_core = get_arg_val<uint32_t>(2);
     const uint32_t num_producers = static_cast<uint32_t>(__builtin_popcount(producer_mask));
 
     experimental::DataflowBuffer dfb(0);
@@ -41,8 +38,13 @@ void kernel_main() {
     const auto tensor_accessor = TensorAccessor(src_args, src_addr_base);
 
     for (uint32_t tile_id = 0; tile_id < num_entries_per_producer; tile_id++) {
-        const uint32_t page_id = consume_all ? chunk_offset + producer_idx * num_entries_per_producer + tile_id
-                                                  : chunk_offset + tile_id * num_producers + producer_idx;
+        // Strided access: producer i owns pages i, i+P, i+2P, ...
+        const uint32_t page_id = chunk_offset + tile_id * num_producers + producer_idx;
+        // Skip if this producer's slice overshoots the actual buffer size (happens when
+        // entries_per_core is not a multiple of num_producers).
+        if (page_id >= chunk_offset + entries_per_core) {
+            break;
+        }
         // DPRINT << "producer tile id " << tile_id << " page id " << page_id << ENDL();
         // DEVICE_PRINT("producer tile id {} page id {}\n", tile_id, page_id);
         if constexpr (implicit_sync) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_consumer.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: � 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Sequential cooperative DM consumer for multi-DFB TC-exhaustion tests (Gap 7).
+//
+// All N consumer threads cooperate on DFB_0, then DFB_1, and so on.  Each DFB
+// has its own independent DRAM output buffer.  Both STRIDED and BLOCKED access
+// patterns are supported on a per-DFB basis (controlled by the is_blocked runtime
+// arg for each DFB).
+//
+// Compile-time args:
+//   [0]: implicit_sync             � 0 or 1
+//   [1..]: TensorAccessorArgs      � shared DRAM layout (same page_size for all bufs)
+//
+// Runtime args (per-core):
+//   [0]: consumer_mask             � bitmask of DM consumer threads
+//   [1]: num_dfbs                  � number of DFBs to loop through
+//   [2 .. 2+M-1]:     dst_addr[i]             � DRAM base address of out_buffer_i
+//   [2+M .. 2+2M-1]:  entries_per_consumer[i] � loop count per thread for DFB_i
+//   [2+2M .. 2+3M-1]: is_blocked[i]           � 1 for BLOCKED, 0 for STRIDED
+
+#include "experimental/dataflow_buffer.h"
+#include "experimental/noc.h"
+#include "experimental/tensor.h"
+
+void kernel_main() {
+    constexpr uint32_t implicit_sync = get_compile_time_arg_val(0);
+    constexpr auto dst_args          = TensorAccessorArgs<1>();
+
+    const uint32_t consumer_mask = get_arg_val<uint32_t>(0);
+    const uint32_t num_dfbs      = get_arg_val<uint32_t>(1);
+
+#ifdef ARCH_QUASAR
+    std::uint64_t hartid;
+    asm volatile("csrr %0, mhartid" : "=r"(hartid));
+    const uint32_t consumer_idx =
+        static_cast<uint32_t>(__builtin_popcount(consumer_mask & ((1u << hartid) - 1u)));
+#else
+    const uint32_t consumer_idx = 0;
+#endif
+    const uint32_t num_consumers = static_cast<uint32_t>(__builtin_popcount(consumer_mask));
+
+    experimental::Noc noc;
+
+    for (uint32_t dfb_id = 0; dfb_id < num_dfbs; dfb_id++) {
+        const uint32_t dst_addr            = get_arg_val<uint32_t>(2 + dfb_id);
+        const uint32_t entries_per_consumer = get_arg_val<uint32_t>(2 + num_dfbs + dfb_id);
+        const uint32_t is_blocked          = get_arg_val<uint32_t>(2 + 2 * num_dfbs + dfb_id);
+
+        experimental::DataflowBuffer dfb(dfb_id);
+        const uint32_t entry_size  = dfb.get_entry_size();
+        const auto tensor_accessor = TensorAccessor(dst_args, dst_addr, entry_size);
+
+        for (uint32_t tile_id = 0; tile_id < entries_per_consumer; tile_id++) {
+            // BLOCKED: each consumer reads all entries sequentially (broadcast).
+            // STRIDED: interleaved, consumer i reads pages i, i+C, i+2C, ...
+            const uint32_t page_id = is_blocked
+                ? tile_id
+                : tile_id * num_consumers + consumer_idx;
+
+            if constexpr (implicit_sync) {
+#ifdef ARCH_QUASAR
+                noc.async_write<experimental::Noc::TxnIdMode::ENABLED>(
+                    dfb, tensor_accessor, {}, {.page_id = page_id});
+#endif
+            } else {
+                dfb.wait_front(1);
+                noc.async_write(dfb, tensor_accessor, entry_size, {}, {.page_id = page_id});
+                noc.async_write_barrier();
+                dfb.pop_front(1);
+            }
+        }
+        // All consumers of this DFB must finish before moving to the next DFB.
+        dfb.finish();
+        dfb.write_barrier(noc);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_producer.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: � 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Sequential cooperative DM producer for multi-DFB TC-exhaustion tests (Gap 7).
+//
+// All N producer threads cooperate on DFB_0 (each handling its own strided slice),
+// then cooperate on DFB_1, and so on.  Every DFB has its own independent DRAM
+// source buffer whose base address is supplied as a runtime arg.
+//
+// After all producers call dfb.finish() for DFB_i, the barrier ensures they have
+// all completed before any of them advances to DFB_i+1.  The consumer kernel uses
+// the symmetric dfb_seq_consumer.cpp pattern so both sides stay in lock-step.
+//
+// Compile-time args:
+//   [0]: num_entries_per_producer  � per DFB, same for all DFBs
+//   [1]: implicit_sync             � 0 or 1
+//   [2..]: TensorAccessorArgs      � shared DRAM layout (same page_size for all bufs)
+//
+// Runtime args (per-core):
+//   [0]: producer_mask             � bitmask of DM producer threads
+//   [1]: num_dfbs                  � number of DFBs to loop through
+//   [2 .. 2+num_dfbs-1]: src_addr[i] � DRAM base address of in_buffer_i
+
+#include "experimental/dataflow_buffer.h"
+#include "experimental/noc.h"
+#include "experimental/tensor.h"
+
+void kernel_main() {
+    const uint32_t num_entries_per_producer = get_compile_time_arg_val(0);
+    constexpr uint32_t implicit_sync        = get_compile_time_arg_val(1);
+    constexpr auto src_args                 = TensorAccessorArgs<2>();
+
+    const uint32_t producer_mask = get_arg_val<uint32_t>(0);
+    const uint32_t num_dfbs      = get_arg_val<uint32_t>(1);
+
+#ifdef ARCH_QUASAR
+    std::uint64_t hartid;
+    asm volatile("csrr %0, mhartid" : "=r"(hartid));
+    const uint32_t producer_idx =
+        static_cast<uint32_t>(__builtin_popcount(producer_mask & ((1u << hartid) - 1u)));
+#else
+    const uint32_t producer_idx = 0;
+#endif
+    const uint32_t num_producers = static_cast<uint32_t>(__builtin_popcount(producer_mask));
+
+    experimental::Noc noc;
+
+    for (uint32_t dfb_id = 0; dfb_id < num_dfbs; dfb_id++) {
+        // Each DFB has its own source buffer; address comes from runtime args.
+        const uint32_t src_addr = get_arg_val<uint32_t>(2 + dfb_id);
+
+        experimental::DataflowBuffer dfb(dfb_id);
+        const uint32_t entry_size    = dfb.get_entry_size();
+        const auto tensor_accessor   = TensorAccessor(src_args, src_addr, entry_size);
+
+        for (uint32_t tile_id = 0; tile_id < num_entries_per_producer; tile_id++) {
+            // Strided: producer i owns pages i, i+P, i+2P, ...
+            const uint32_t page_id = tile_id * num_producers + producer_idx;
+            if constexpr (implicit_sync) {
+#ifdef ARCH_QUASAR
+                noc.async_read<experimental::Noc::TxnIdMode::ENABLED>(
+                    tensor_accessor, dfb, {.page_id = page_id}, {});
+#endif
+            } else {
+                dfb.reserve_back(1);
+                noc.async_read(tensor_accessor, dfb, entry_size, {.page_id = page_id}, {});
+                noc.async_read_barrier();
+                dfb.push_back(1);
+            }
+        }
+        // All producers of this DFB must finish before moving to the next DFB.
+        dfb.finish();
+    }
+}

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -168,12 +168,15 @@ inline void run_triscs(uint32_t enables) {
     }
 }
 
-inline void start_subordinate_kernel_run_early(uint32_t enables) {
+inline bool start_subordinate_kernel_run_early(uint32_t enables) {
+    bool subordinates_run_kernel = false;
     for (int i = 1; i < NUM_DM_CORES; i++) {  // start from 1 to skip DM0
         if (enables & (1u << i)) {
+            subordinates_run_kernel = true;
             *((volatile uint8_t*)&(subordinate_sync->dm1) + i - 1) = RUN_SYNC_MSG_GO;
         }
     }
+    return subordinates_run_kernel;
 }
 
 inline void wait_subordinates() {
@@ -318,14 +321,17 @@ extern "C" uint32_t _start1() {
                 for (uint32_t i = 0; i < MaxDMProcessorsPerCoreType; i++) {
                     mailboxes->shared_globals_ready[i] = SHARED_GLOBALS_READY_WAIT;
                 }
-                start_subordinate_kernel_run_early(enables);
+                bool subordinates_run_kernel = start_subordinate_kernel_run_early(enables);
 
-                // Run the kernel
-                WAYPOINT("R");
                 int index = static_cast<std::underlying_type<TensixProcessorTypes>::type>(TensixProcessorTypes::DM0);
-                if (enables & (1u << index)) {
+                if (subordinates_run_kernel) {
+                    // If subordinates run kernel they could be using DFBs. DM0 needs to setup DFBs to program implicit synchronization.
                     uint32_t num_local_dfbs = launch_msg_address->kernel_config.local_cb_mask;
                     setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
+                }
+                // Run the kernel
+                WAYPOINT("R");
+                if (enables & (1u << index)) {
                     uint32_t kernel_lma =
                         (kernel_config_base + launch_msg_address->kernel_config.kernel_text_offset[index]);
                     asm("FENCE.i");

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
@@ -16,16 +16,19 @@
 #endif
 #endif
 
+#include "api/kernel_thread_globals.h"
+
 namespace experimental {
 
 inline DataflowBuffer::DataflowBuffer(uint16_t logical_dfb_id)
-    : local_dfb_interface_(get_local_dfb_interface(logical_dfb_id)), logical_dfb_id_(logical_dfb_id) {}
+    : local_dfb_interface_(g_dfb_interface[logical_dfb_id]), logical_dfb_id_(logical_dfb_id) {}
 
 inline uint32_t DataflowBuffer::get_entry_size() const { return local_dfb_interface_.entry_size; }
 
 inline uint32_t DataflowBuffer::get_stride_size() const { return local_dfb_interface_.stride_size; }
 
 inline void DataflowBuffer::reserve_back_impl(uint16_t num_entries) {
+    WAYPOINT("RBW");
     dfb::PackedTileCounter packed_tc =
         local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
     uint8_t tc_id = dfb::get_counter_id(packed_tc);
@@ -53,6 +56,7 @@ inline void DataflowBuffer::reserve_back_impl(uint16_t num_entries) {
         while (llk_intf_get_free_space(tensix_id, tc_id) < num_entries);
     }
 #endif
+    WAYPOINT("RBD");
 }
 
 inline void DataflowBuffer::push_back_impl(uint16_t num_entries) {
@@ -89,6 +93,7 @@ inline void DataflowBuffer::push_back_impl(uint16_t num_entries) {
 }
 
 inline void DataflowBuffer::wait_front_impl(uint16_t num_entries) {
+    WAYPOINT("WFW");
     dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
     uint8_t tc_id = dfb::get_counter_id(packed_tc);
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
@@ -102,6 +107,7 @@ inline void DataflowBuffer::wait_front_impl(uint16_t num_entries) {
     ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
     while (llk_intf_get_occupancy(tensix_id, tc_id) < num_entries);
 #endif
+    WAYPOINT("WFD");
 }
 
 inline void DataflowBuffer::pop_front_impl(uint16_t num_entries) {
@@ -206,14 +212,7 @@ inline void DataflowBuffer::handle_final_credits(uint16_t transactions_issued, u
         }
     };
 
-    uint64_t threshold;
-    if constexpr (is_producer) {
-        threshold = GET_TILES_TO_PROCESS_THRES_TR_ACK(tail_txn_id);
-    } else {
-        threshold = GET_TILES_TO_PROCESS_THRES_WR_SENT(tail_txn_id);
-    }
-
-    // Wait until this DM's tail reads have completed.
+    // Wait until this DM's tail transactions have been picked up by the NoC.
     // A transaction passes through three observable states:
     //   not dispatched → tack == 0, tiles == 0
     //   in-flight      → tack >  0
@@ -229,11 +228,28 @@ inline void DataflowBuffer::handle_final_credits(uint16_t transactions_issued, u
             tack  = CMDBUF_WR_SENT_TRID(OVERLAY_WR_CMD_BUF, tail_txn_id);
             tiles = CMDBUF_READ_TILES_TO_PROCESS_WR_SENT(OVERLAY_WR_CMD_BUF, tail_txn_id);
         }
-        if (tack == 0 && tiles > 0) break;
+        if (tack == 0 && tiles > 0) {
+            break;
+        }
     }
 
-    // Transactions are completed. Spin giving the ISR a chance to fire.
-    // Break when tiles < threshold which is a genuine partial tail the ISR can never handle.
+    // Rendezvous: every participating DM has now issued its tail transaction and seen
+    // the NoC pick it up. This must be unconditional — gating the barrier on
+    // read_actual_slot0() < expected_slot0 is racy because the ISR can fire between
+    // different threads' checks, causing some to enter the barrier and others to skip
+    // it. Once past this point, tiles_to_process on the tail txn_id reflects the
+    // contributions of all producers / consumers for this collective batch.
+    sync_threads();
+
+    // ISR already handled the collective batch
+    if (read_actual_slot0() >= expected_slot0) {
+        return;
+    }
+
+    // Spin giving the ISR a chance to fire. Break when the tail txn_id's tiles_to_process
+    // is a genuine partial batch (below the global ISR-programmed threshold). The ISR will
+    // never post credits for it, so we fall through to the manual posting below.
+    uint16_t global_threshold = local_dfb_interface_.threshold;
     WAYPOINT("WTP2");
     while (read_actual_slot0() < expected_slot0) {
         uint64_t tiles;
@@ -242,7 +258,9 @@ inline void DataflowBuffer::handle_final_credits(uint16_t transactions_issued, u
         } else {
             tiles = CMDBUF_READ_TILES_TO_PROCESS_WR_SENT(OVERLAY_WR_CMD_BUF, tail_txn_id);
         }
-        if (tiles > 0 && tiles < threshold) break;
+        if (tiles > 0 && tiles < global_threshold) {
+            break;
+        }
     }
 
     // Manually post missing credits if ISR did not fire.
@@ -285,18 +303,19 @@ inline void DataflowBuffer::write_barrier_impl(const Noc &noc) const {
 // Preamble for implicit-sync read: spin until previous reads are posted and there is space in the tile counters.
 // Returns the txn_id to stamp on the next NOC read.
 inline uint32_t DataflowBuffer::prepare_implicit_read() {
-    ASSERT(local_dfb_interface_.num_txn_ids > 0);
     dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
     uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
     uint8_t tc_id = dfb::get_counter_id(packed_tc);
+    const uint32_t txn_id = local_dfb_interface_.txn_ids[ptxn_id_index_];
+    WAYPOINT("PIRW");
     while (fast_llk_intf_read_posted(tensix_id, tc_id) < (ptxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
     while (fast_llk_intf_get_free_space(tensix_id, tc_id) < 1);
-    return local_dfb_interface_.txn_ids[ptxn_id_index_];
+    WAYPOINT("PIRD");
+    return txn_id;
 }
 
 // Postamble for implicit-sync read: advance wr_ptr, tile/txn counters, and tc_idx.
 inline void DataflowBuffer::commit_implicit_read() {
-    ASSERT(local_dfb_interface_.num_txn_ids > 0);
     local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr += local_dfb_interface_.stride_size;
     if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr >=
         local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
@@ -314,18 +333,19 @@ inline void DataflowBuffer::commit_implicit_read() {
 // Preamble for implicit-sync write: spin until previous writes are acked and data is available in the tile counters.
 // Returns the txn_id to stamp on the next NOC write.
 inline uint32_t DataflowBuffer::prepare_implicit_write() {
-    ASSERT(local_dfb_interface_.num_txn_ids > 0);
     dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
     uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
     uint8_t tc_id = dfb::get_counter_id(packed_tc);
+    const uint32_t txn_id = local_dfb_interface_.txn_ids[ctxn_id_index_];
+    WAYPOINT("PIWW");
     while (fast_llk_intf_read_acked(tensix_id, tc_id) < (ctxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
     while (fast_llk_intf_get_occupancy(tensix_id, tc_id) < 1);
-    return local_dfb_interface_.txn_ids[ctxn_id_index_];
+    WAYPOINT("PIWD");
+    return txn_id;
 }
 
 // Postamble for implicit-sync write: advance rd_ptr, tile/txn counters, and tc_idx.
 inline void DataflowBuffer::commit_implicit_write() {
-    ASSERT(local_dfb_interface_.num_txn_ids > 0);
     local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr += local_dfb_interface_.stride_size;
     if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr >=
         local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
@@ -354,9 +374,10 @@ Noc::async_read(
     uint32_t txn_id = dst.prepare_implicit_read();
     noc_async_read_set_trid(txn_id, noc_id_);
     while (noc_available_transactions(noc_id_, txn_id) < ((NOC_MAX_TRANSACTION_ID_COUNT + 1) / 2));
+    // DPRINT << "Issue the read" << ENDL();
     noc_async_read<NOC_MAX_BURST_SIZE + 1, true>(
         get_src_ptr<AddressType::NOC>(src, src_args),
-        get_dst_ptr<AddressType::LOCAL_L1>(dst, dst_args),
+        dst.get_write_ptr(),
         dst.get_entry_size(),
         noc_id_,
         NOC_UNICAST_WRITE_VC);
@@ -371,10 +392,11 @@ Noc::async_write(
     const DataflowBufferArgs& src_args,
     const typename noc_traits_t<Dst>::dst_args_type& dst_args) const {
     uint32_t txn_id = src.prepare_implicit_write();
-    auto src_addr = get_src_ptr<AddressType::LOCAL_L1>(src, src_args);
+    auto src_addr = src.get_read_ptr();
     auto dst_noc_addr = get_dst_ptr<AddressType::NOC>(dst, dst_args);
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID, src_addr, dst_noc_addr, size_bytes, -1, posted, noc_id_);
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_id_, dst_noc_addr, src_addr, src.get_entry_size());
+    // DPRINT << "Issue the write" << ENDL();
     ncrisc_noc_fast_write_any_len<noc_mode, true, /*one_packet*/false>(
         noc_id_,
         write_cmd_buf,

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
@@ -26,7 +26,7 @@ constexpr uint8_t NUM_TENSIX_TILE_COUNTERS_FOR_DM = 16;
 constexpr uint8_t TC_TENSIX_POOL_START = NUM_TENSIX_TILE_COUNTERS_FOR_DM;  // = 16
 constexpr uint8_t NUM_REMAPPER_PAIRINGS = 64;
 constexpr uint8_t NUM_TXN_IDS = 4;
-constexpr uint8_t MAX_NUM_TILE_COUNTERS_TO_RR = 4;
+constexpr uint8_t MAX_NUM_TILE_COUNTERS_TO_RR = 6;
 
 constexpr uint16_t TENSIX_RISC_OFFSET = 8; // First 8 represent DMs
 
@@ -66,7 +66,7 @@ inline __attribute__((always_inline)) constexpr uint8_t get_counter_id(PackedTil
     | dfb_initializer_per_risc_t | risc 0
     | dfb_initializer_per_risc_t | risc 1
     ...
-    (36 + (44 * 12)) * 16 = 8336 bytes
+    (36 + (62 * 12)) * 16 = 12480 bytes
 */
 struct dfb_txn_id_descriptor_t {
     uint8_t txn_ids[dfb::NUM_TXN_IDS];
@@ -90,17 +90,18 @@ struct dfb_initializer_t {  // 36 bytes
     dfb_txn_id_descriptor_t producer_txn_descriptor;
     dfb_txn_id_descriptor_t consumer_txn_descriptor;
     uint8_t num_producers;
-    uint8_t padding[3];
+    uint8_t implicit_sync_configured; // 0: init state, 1: configured
+    uint8_t padding[2];
 } __attribute__((packed));
 
-struct dfb_initializer_per_risc_t {  // 44 bytes
+struct dfb_initializer_per_risc_t {  // 62 bytes
     uint32_t base_addr[dfb::MAX_NUM_TILE_COUNTERS_TO_RR];
     uint32_t limit[dfb::MAX_NUM_TILE_COUNTERS_TO_RR];
     uint32_t consumer_tcs;  // used to program remapper, for a L:R mapping contains all the TCs on the consumer side
                             // (R). TC can be value between 0 and 31 (5 bits, max of 4 TCs)
     dfb::PackedTileCounter packed_tile_counter[dfb::MAX_NUM_TILE_COUNTERS_TO_RR];
     struct {
-        uint8_t num_tcs_to_rr : 4;   // 0..8, number of TCs to round-robin (max 4 but keeping space)
+        uint8_t num_tcs_to_rr : 4;   // 0..15, number of TCs to round-robin (max 6 for 6 user-programmable DM cores)
         uint8_t tc_init_done : 1;
         uint8_t broadcast_tc : 1;    // DM-DM ALL: producer posts to all TCs instead of round-robin
         uint8_t reserved : 2;
@@ -128,5 +129,5 @@ struct dfb_initializer_intra_tensix_t {  // 24 bytes
 } __attribute__((packed));
 
 static_assert(sizeof(dfb_initializer_t) == 36, "dfb_initializer_t size is incorrect");
-static_assert(sizeof(dfb_initializer_per_risc_t) == 44, "dfb_initializer_per_risc_t size is incorrect");
+static_assert(sizeof(dfb_initializer_per_risc_t) == 62, "dfb_initializer_per_risc_t size is incorrect");
 static_assert(sizeof(dfb_initializer_intra_tensix_t) == 24, "dfb_initializer_intra_tensix_t size is incorrect");

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
@@ -19,6 +19,44 @@
 
 #include "api/debug/dprint.h"
 
+
+FORCE_INLINE void wait_all_tcs_initialized(uint32_t tt_l1_ptr* dfb_config_base, uint32_t num_dfbs, uint64_t hartid) {
+    WAYPOINT("TCIW");
+    bool all_tcs_initialized = false;
+    while (!all_tcs_initialized) {
+        all_tcs_initialized = true;
+        volatile uint8_t* base_ptr = reinterpret_cast<volatile uint8_t*>(dfb_config_base);
+
+        for (uint32_t logical_dfb_id = 0; logical_dfb_id < num_dfbs; logical_dfb_id++) {
+            volatile dfb_initializer_t* init_ptr = reinterpret_cast<volatile dfb_initializer_t*>(base_ptr);
+
+            if (hartid == 0) {
+                // At this point DM0 configured the ISR. Other DMs need to ensure that the ISR is configured before they start running kernels.
+                init_ptr->implicit_sync_configured = 1;
+            }
+
+            uint16_t risc_mask = (init_ptr->risc_mask_bits.tensix_mask << 8) | init_ptr->risc_mask_bits.dm_mask;
+            uint8_t num_riscs = static_cast<uint8_t>(__builtin_popcount(risc_mask));
+
+            volatile dfb_initializer_per_risc_t* per_risc_base =
+                reinterpret_cast<volatile dfb_initializer_per_risc_t*>(base_ptr + sizeof(dfb_initializer_t));
+
+            // Loop over per_risc: count producers that have set tc_init_done (each per_risc is separate cache line)
+            uint8_t producers_done = 0;
+            for (uint8_t i = 0; i < num_riscs; i++) {
+                if (per_risc_base[i].flags.is_producer && per_risc_base[i].num_tcs_and_init.tc_init_done) {
+                    producers_done++;
+                }
+            }
+            all_tcs_initialized &= ((producers_done == init_ptr->num_producers) && (init_ptr->implicit_sync_configured == 1));
+
+            base_ptr += sizeof(dfb_initializer_t) + (num_riscs * sizeof(dfb_initializer_per_risc_t));
+        }
+    }
+    WAYPOINT("TCID");
+    // DPRINT << "all_tcs_initialized" << ENDL();
+}
+
 FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base, uint32_t local_dfb_mask) {
     uint64_t hartid;
 #ifdef COMPILE_FOR_TRISC
@@ -131,6 +169,7 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
 #ifndef COMPILE_FOR_TRISC
             if (per_risc_ptr->flags.is_producer) {
                 dfb_interface.num_txn_ids = init_ptr->producer_txn_descriptor.num_txn_ids;
+                dfb_interface.threshold = init_ptr->producer_txn_descriptor.num_entries_to_process_threshold;
                 dfb_interface.num_entries_per_txn_id = init_ptr->producer_txn_descriptor.num_entries_per_txn_id;
                 dfb_interface.num_entries_per_txn_id_per_tc =
                     init_ptr->producer_txn_descriptor.num_entries_per_txn_id_per_tc;
@@ -139,6 +178,7 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
                 }
             } else {
                 dfb_interface.num_txn_ids = init_ptr->consumer_txn_descriptor.num_txn_ids;
+                dfb_interface.threshold = init_ptr->consumer_txn_descriptor.num_entries_to_process_threshold;
                 dfb_interface.num_entries_per_txn_id = init_ptr->consumer_txn_descriptor.num_entries_per_txn_id;
                 dfb_interface.num_entries_per_txn_id_per_tc =
                     init_ptr->consumer_txn_descriptor.num_entries_per_txn_id_per_tc;
@@ -171,9 +211,9 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
                 reinterpret_cast<volatile dfb_initializer_per_risc_t*>(base_ptr + sizeof(dfb_initializer_t));
 
             uint8_t num_producer_tcs = 0;
-            uint8_t producer_tcs[dfb::MAX_NUM_TILE_COUNTERS_TO_RR] = {};
+            uint8_t producer_tcs[16] = {};
             uint8_t num_consumer_tcs = 0;
-            uint8_t consumer_tcs[dfb::MAX_NUM_TILE_COUNTERS_TO_RR] = {};
+            uint8_t consumer_tcs[16] = {};
             for (uint8_t i = 0; i < num_riscs; i++) {
                 volatile dfb_initializer_per_risc_t* per_risc_ptr = per_risc_base + i;
 
@@ -290,6 +330,7 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
         } else {
             disable_dfb_tile_isr();
         }
+
     }  // end if (hartid == 0)
 #endif
 
@@ -342,32 +383,6 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
     }
 
     // After setting up g_dfb_interface, wait for all TCs to be initialized
-    bool all_tcs_initialized = false;
-    while (!all_tcs_initialized) {
-        all_tcs_initialized = true;
-        base_ptr = reinterpret_cast<volatile uint8_t*>(dfb_config_base);
-
-        for (uint32_t logical_dfb_id = 0; logical_dfb_id < num_dfbs; logical_dfb_id++) {
-            volatile dfb_initializer_t* init_ptr = reinterpret_cast<volatile dfb_initializer_t*>(base_ptr);
-
-            uint16_t risc_mask = (init_ptr->risc_mask_bits.tensix_mask << 8) | init_ptr->risc_mask_bits.dm_mask;
-            uint8_t num_riscs = static_cast<uint8_t>(__builtin_popcount(risc_mask));
-
-            volatile dfb_initializer_per_risc_t* per_risc_base =
-                reinterpret_cast<volatile dfb_initializer_per_risc_t*>(base_ptr + sizeof(dfb_initializer_t));
-
-            // Loop over per_risc: count producers that have set tc_init_done (each per_risc is separate cache line)
-            uint8_t producers_done = 0;
-            for (uint8_t i = 0; i < num_riscs; i++) {
-                if (per_risc_base[i].flags.is_producer && per_risc_base[i].num_tcs_and_init.tc_init_done) {
-                    producers_done++;
-                }
-            }
-            all_tcs_initialized &= (producers_done == init_ptr->num_producers);
-
-            base_ptr += sizeof(dfb_initializer_t) + (num_riscs * sizeof(dfb_initializer_per_risc_t));
-        }
-    }
-    // DPRINT << "all_tcs_initialized" << ENDL();
+    wait_all_tcs_initialized(dfb_config_base, num_dfbs, hartid);
     // DEVICE_PRINT("all_tcs_initialized\n");
 }

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
@@ -49,7 +49,7 @@ struct LocalDFBInterface {
 } __attribute__((packed));
 
 static_assert(sizeof(DFBTCSlot) == 13, "DFBTCSlot (pack TRISC) size is incorrect");
-static_assert(sizeof(LocalDFBInterface) == 61, "LocalDFBInterface (pack TRISC) size is incorrect");
+static_assert(sizeof(LocalDFBInterface) == 87, "LocalDFBInterface (pack TRISC) size is incorrect");
 
 #elif defined(COMPILE_FOR_TRISC)
 
@@ -73,7 +73,7 @@ struct LocalDFBInterface {
 } __attribute__((packed));
 
 static_assert(sizeof(DFBTCSlot) == 13, "DFBTCSlot (unpack TRISC) size is incorrect");
-static_assert(sizeof(LocalDFBInterface) == 60, "LocalDFBInterface (unpack TRISC) size is incorrect");
+static_assert(sizeof(LocalDFBInterface) == 86, "LocalDFBInterface (unpack TRISC) size is incorrect");
 
 #else
 
@@ -95,6 +95,7 @@ struct LocalDFBInterface {
     uint8_t tc_idx;
 
     uint8_t txn_ids[dfb::NUM_TXN_IDS];
+    uint8_t threshold;         // When this value is met, ISR to post/ack credits will fire. Used when last reads don't meet this value.
     uint8_t
         num_entries_per_txn_id;
     uint8_t num_entries_per_txn_id_per_tc;
@@ -105,7 +106,7 @@ struct LocalDFBInterface {
 } __attribute__((packed));
 
 static_assert(sizeof(DFBTCSlot) == 17, "DFBTCSlot size is incorrect");
-static_assert(sizeof(LocalDFBInterface) == 86, "LocalDFBInterface size is incorrect");
+static_assert(sizeof(LocalDFBInterface) == 121, "LocalDFBInterface size is incorrect");
 
 #endif
 
@@ -121,7 +122,7 @@ inline LocalDFBInterface& get_local_dfb_interface(uint32_t logical_dfb_id) {
 // It is used by the ISR to understand which tile counters need to update which credits (post/ack)
 struct TxnDFBDescriptor {
     uint8_t num_counters;
-    dfb::PackedTileCounter tile_counters[dfb::MAX_NUM_TILE_COUNTERS_TO_RR];
+    dfb::PackedTileCounter tile_counters[18];
     union {
         uint8_t tiles_to_post;
         uint8_t tiles_to_ack;

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <fmt/ranges.h>
 #include <tt_stl/fmt.hpp>
 #include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
 
@@ -182,35 +183,47 @@ uint8_t ClientTypeAllocator::allocate_for_consumer(uint8_t producer_client_type,
 
 // Computes dfb_txn_id_descriptor_t for either the producer or consumer side of a DFB.
 static dfb_txn_id_descriptor_t compute_txn_descriptor(
-    uint16_t capacity,
+    uint16_t num_entries,
     uint8_t num_producers,
     uint8_t num_consumers,
     bool is_producer,
     const std::vector<uint8_t>& txn_ids,
-    uint8_t num_tcs_per_risc) {
+    uint8_t num_tcs_per_risc,
+    ::dfb::AccessPattern access_pattern) {
     uint8_t num_prods_or_cons = is_producer ? num_producers : num_consumers;
     uint8_t num_txn_ids = static_cast<uint8_t>(txn_ids.size());
+
+    // Each ALL consumer needs to issue the transaction before the ISR can fire
+    const bool consumes_all = !is_producer && (access_pattern == ::dfb::AccessPattern::ALL);
+    const uint32_t required_divisor =
+        consumes_all ? (num_txn_ids * num_tcs_per_risc)
+                            : (num_txn_ids * num_prods_or_cons * num_tcs_per_risc);
+    TT_FATAL(
+        num_entries % required_divisor == 0,
+        "DFB num_entries {} must be divisible by {} to ensure equal credits per TC per ISR cycle",
+        num_entries,
+        required_divisor);
 
     // threshold is the number of transactions that each txn ID needs to process before posting/acking
     // for reads the transaction needs to be committed to dst, for writes the transaction needs to be sent out
     uint8_t threshold;
-    if (num_producers == 1 && num_consumers == 1) {
-        TT_FATAL(
-            capacity % num_txn_ids == 0,
-            "DFB capacity {} must be divisible by num_txn_ids {} for implicit sync",
-            capacity,
-            num_txn_ids);
-        threshold = static_cast<uint8_t>(capacity / num_txn_ids);
+    uint8_t per_txn;
+    if (consumes_all) {
+        // wr_sent is a global counter shared across all DMs. Each of the num_consumers DMs writes
+        // per_txn entries per txn_id, so the ISR must not fire until all consumers have finished
+        // their batch: threshold = num_consumers × per_txn.
+        per_txn = static_cast<uint8_t>(num_entries / num_txn_ids);
+        threshold = static_cast<uint8_t>(num_prods_or_cons * per_txn);
     } else {
-        threshold = num_prods_or_cons * num_tcs_per_risc;
+        threshold = static_cast<uint8_t>(num_entries / num_txn_ids);
+        // Defensive assertion — guaranteed by the upfront check above.
+        TT_FATAL(
+            threshold % num_prods_or_cons == 0,
+            "num_entries_to_process_threshold {} must be divisible by num_prods_or_cons {}",
+            threshold,
+            num_prods_or_cons);
+        per_txn = threshold / num_prods_or_cons;
     }
-
-    TT_FATAL(
-        threshold % num_prods_or_cons == 0,
-        "num_entries_to_process_threshold {} must be divisible by num_prods_or_cons {}",
-        threshold,
-        num_prods_or_cons);
-    uint8_t per_txn = threshold / num_prods_or_cons;
 
     TT_FATAL(
         per_txn % num_tcs_per_risc == 0,
@@ -228,6 +241,29 @@ static dfb_txn_id_descriptor_t compute_txn_descriptor(
         desc.txn_ids[i] = txn_ids[i];
     }
     return desc;
+}
+
+// Returns the smallest n in (1, NUM_TXN_IDS] satisfying the divisibility constraint that
+// compute_txn_descriptor() enforces:
+//   ALL consumer:  num_entries % (n * num_tcs_per_risc) == 0
+//   all other cases:   num_entries % (n * num_prods_or_cons * num_tcs_per_risc) == 0
+// Falls back to 1 if no n > 1 satisfies the constraint.
+// If even n=1 does not satisfy the constraint the configuration is invalid
+// and compute_txn_descriptor() will catch it with a TT_FATAL.
+static uint8_t compute_optimal_txn_id_count(
+    uint16_t num_entries,
+    uint8_t num_prods_or_cons,
+    uint8_t num_tcs_per_risc,
+    bool consumes_all) {
+    for (uint8_t n = 2; n <= ::dfb::NUM_TXN_IDS; n++) {
+        uint32_t divisor = consumes_all
+            ? static_cast<uint32_t>(n) * num_tcs_per_risc
+            : static_cast<uint32_t>(n) * num_prods_or_cons * num_tcs_per_risc;
+        if (num_entries % divisor == 0) {
+            return n;
+        }
+    }
+    return 1;
 }
 
 bool has_dm_risc(uint16_t risc_mask) { return (risc_mask & 0xFF) != 0; }
@@ -359,6 +395,7 @@ std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& cor
     init.num_producers = this->config.num_producers;
     init.producer_txn_descriptor = this->producer_txn_descriptor;
     init.consumer_txn_descriptor = this->consumer_txn_descriptor;
+    init.implicit_sync_configured = 0;
 
     log_debug(
         tt::LogMetal,
@@ -1233,46 +1270,49 @@ void ProgramImpl::finalize_single_dfb_config(
 
     // Allocate transaction IDs and compute ISR descriptor fields when implicit sync is enabled.
     // Only done on the first core processed for this DFB because txn IDs are core-invariant
-    // Two txn IDs per side for double buffering.
     if (config.enable_implicit_sync && dfb->groups.empty()) {
-        constexpr uint8_t TXN_IDS_PER_SIDE = 2;
-
         if (!producer_is_tensix_only) {
-            auto producer_txn_ids = txn_id_allocator_.allocate(TXN_IDS_PER_SIDE);
+            uint8_t num_prod_txn_ids = compute_optimal_txn_id_count(
+                config.num_entries, config.num_producers, num_producer_tcs,
+                /*consumes_all=*/false);
+            auto producer_txn_ids = txn_id_allocator_.allocate(num_prod_txn_ids);
             dfb->producer_txn_descriptor = compute_txn_descriptor(
-                dfb->capacity,
+                config.num_entries,
                 config.num_producers,
                 config.num_consumers,
                 /*is_producer=*/true,
                 producer_txn_ids,
-                num_producer_tcs);
-            log_debug(
+                num_producer_tcs,
+                config.pap);
+            log_info(
                 tt::LogMetal,
-                "DFB {} implicit sync: producer txn_ids=[{},{}] threshold={} per_txn={} per_tc={}",
+                "DFB {} implicit sync: producer txn_ids=[{}] threshold={} per_txn={} per_tc={}",
                 dfb->id,
-                dfb->producer_txn_descriptor.txn_ids[0],
-                dfb->producer_txn_descriptor.txn_ids[1],
+                fmt::join(producer_txn_ids, ","),
                 dfb->producer_txn_descriptor.num_entries_to_process_threshold,
                 dfb->producer_txn_descriptor.num_entries_per_txn_id,
                 dfb->producer_txn_descriptor.num_entries_per_txn_id_per_tc);
         }
 
         if (!consumer_is_tensix_only) {
-            auto consumer_txn_ids = txn_id_allocator_.allocate(TXN_IDS_PER_SIDE);
+            const bool consumes_all = (config.cap == ::dfb::AccessPattern::ALL);
+            uint8_t num_cons_txn_ids = compute_optimal_txn_id_count(
+                config.num_entries, config.num_consumers, num_consumer_tcs,
+                /*consumes_all=*/consumes_all);
+            auto consumer_txn_ids = txn_id_allocator_.allocate(num_cons_txn_ids);
             dfb->consumer_txn_descriptor = compute_txn_descriptor(
-                dfb->capacity,
+                config.num_entries,
                 config.num_producers,
                 config.num_consumers,
                 /*is_producer=*/false,
                 consumer_txn_ids,
-                num_consumer_tcs);
-            log_debug(
+                num_consumer_tcs,
+                config.cap);
+            log_info(
                 tt::LogMetal,
-                "DFB {} implicit sync: "
-                "consumer txn_ids=[{},{}] threshold={} per_txn={} per_tc={}",
+                "DFB {} implicit sync: consumer txn_ids=[{}] threshold={} per_txn={} per_tc={}",
                 dfb->id,
-                dfb->consumer_txn_descriptor.txn_ids[0],
-                dfb->consumer_txn_descriptor.txn_ids[1],
+                fmt::join(consumer_txn_ids, ","),
                 dfb->consumer_txn_descriptor.num_entries_to_process_threshold,
                 dfb->consumer_txn_descriptor.num_entries_per_txn_id,
                 dfb->consumer_txn_descriptor.num_entries_per_txn_id_per_tc);

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -26,9 +26,9 @@ namespace tt::tt_metal::experimental::dfb::detail {
 
 // Per-risc config matching dfb_initializer_per_risc_t
 struct LocalDFBInterfaceHost {
-    std::array<uint32_t, 4> base_addr = {0};
-    std::array<uint32_t, 4> limit = {0};
-    std::array<::dfb::PackedTileCounter, 4> packed_tile_counter = {0};
+    std::array<uint32_t, ::dfb::MAX_NUM_TILE_COUNTERS_TO_RR> base_addr = {0};
+    std::array<uint32_t, ::dfb::MAX_NUM_TILE_COUNTERS_TO_RR> limit = {0};
+    std::array<::dfb::PackedTileCounter, ::dfb::MAX_NUM_TILE_COUNTERS_TO_RR> packed_tile_counter = {0};
     uint8_t num_tcs_to_rr = 1;
     bool broadcast_tc = false;  // DM-DM ALL producer: post to all TCs instead of round-robin
     uint8_t remapper_pair_index = 0;


### PR DESCRIPTION
### Summary
Adding some additional DFB test cases and bug fixes that came out of trying to successfully run 
- Added some missing num producer x num consumer tests (focusing on non-power of 2 counts)
- Tests where buffer is small to exercise wraparound cases
- Fixed the manual "last push" implicit sync case by added DM barrier to ensure all DMs have issued their last noc transactions before manually posting/acking credits to ensure that the collective last push would be a partial 
- Update DM0 fw to setup dfbs even if DM0 isn't running any kernels and ensure that subordinates waits until DM0 has programmed the txn id interrupt registers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/dfb-fixes-rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/dfb-fixes-rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/dfb-fixes-rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/dfb-fixes-rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abhullar/dfb-fixes-rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/dfb-fixes-rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/dfb-fixes-rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/dfb-fixes-rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/dfb-fixes-rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/dfb-fixes-rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/dfb-fixes-rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/dfb-fixes-rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/dfb-fixes-rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/dfb-fixes-rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/dfb-fixes-rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/dfb-fixes-rebased)