### PR TITLE
Disable BufferBinding value-match safety check (false positives)

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
+++ b/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
@@ -383,5 +383,50 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_BufferNotInTensorLis
     EXPECT_ANY_THROW(resolve_bindings(program, desc, {buf_other.get()}));
 }
 
+// Regression: a scalar runtime arg whose value happens to numerically equal a
+// registered buffer's address must NOT trigger a safety-scan false positive.
+//
+// An earlier version of resolve_bindings ran a value-match scan that looked for
+// any uint32_t arg matching a registered buffer address but lacking a
+// BufferBinding at that position, and fired TT_FATAL. The intent was to catch
+// the push_back(buf->address()) factory-author mistake, but the check produced
+// false positives whenever a legitimate scalar arg (loop counter, shape dim,
+// etc.) happened to share the same numeric value as a buffer's address — most
+// notably under graph-capture (sentinel addresses) and for low-address buffers.
+//
+// The check was removed; this test pins that behavior so it is not silently
+// reintroduced.
+TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_ScalarMatchingBufferAddress_DoesNotThrow) {
+    auto buf_a = MakeDramBuffer(device());
+    const uint32_t collision_value = buf_a->address();
+
+    KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
+    // arg[0] is the registered buffer; arg[1] is a plain scalar that happens to
+    // equal buf_a's address. The legacy value-match scan would have flagged
+    // arg[1] as an undeclared address; the current implementation must not.
+    kd.emplace_runtime_args({0, 0}, {buf_a.get(), collision_value});
+
+    ProgramDescriptor desc;
+    desc.kernels = {kd};
+
+    Program program{desc};
+    EXPECT_NO_THROW(resolve_bindings(program, desc, {buf_a.get()}));
+}
+
+// Regression: same idea for common runtime args.
+TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_CommonScalarMatchingBufferAddress_DoesNotThrow) {
+    auto buf_a = MakeDramBuffer(device());
+    const uint32_t collision_value = buf_a->address();
+
+    KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
+    kd.emplace_common_runtime_args({buf_a.get(), collision_value});
+
+    ProgramDescriptor desc;
+    desc.kernels = {kd};
+
+    Program program{desc};
+    EXPECT_NO_THROW(resolve_bindings(program, desc, {buf_a.get()}));
+}
+
 }  // namespace
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -101,7 +101,17 @@ ResolvedBindings resolve_bindings(
     // buffer's address but no binding was declared at that position, the factory called
     // push_back(buf->address()) instead of push_back(buf).  On cache hits the fast path
     // would skip that arg and leave it stale.
-    if (!registered_addresses.empty()) {
+    //
+    // DISABLED: produces false positives in two cases that we hit during the family
+    // migration rollout:
+    //   1) graph-capture mode populates buffer->address() with placeholder/sentinel
+    //      values that legitimately collide with small uint32_t scalars in arg lists.
+    //   2) buffers allocated at low addresses (e.g. 0x20) collide with literal scalar
+    //      args (loop counters, shape dims) that happen to share the same value.
+    // The check was meant to catch a specific factory mistake, but the false-positive
+    // rate makes it unusable as a hard TT_FATAL. Re-enable only if rewritten as a
+    // structural check that doesn't rely on numeric value match.
+    if (false && !registered_addresses.empty()) {
         for (uint32_t k = 0; k < static_cast<uint32_t>(desc.kernels.size()); ++k) {
             for (const auto& [core, args] : desc.kernels[k].runtime_args) {
                 for (uint32_t i = 0; i < static_cast<uint32_t>(args.size()); ++i) {

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -17,16 +17,9 @@
 #include <algorithm>
 #include <cstdint>
 #include <string_view>
-#include <unordered_set>
 #include <vector>
 
 namespace tt::tt_metal {
-
-// Pack (kernel_idx, core.x, core.y, arg_idx) into a single uint64_t for O(1) set lookup.
-static uint64_t rt_binding_key(uint32_t kernel_idx, CoreCoord core, uint32_t arg_idx) {
-    return ((uint64_t)(kernel_idx & 0xffu) << 48) | ((uint64_t)(core.x & 0xffu) << 40) |
-           ((uint64_t)(core.y & 0xffu) << 32) | (uint64_t)arg_idx;
-}
 
 ResolvedBindings resolve_bindings(
     Program& program, const ProgramDescriptor& desc, const std::vector<Buffer*>& tensor_buffers) {
@@ -43,16 +36,6 @@ ResolvedBindings resolve_bindings(
             context);
         return static_cast<uint32_t>(it - tensor_buffers.begin());
     };
-
-    // Track every registered (kernel, core, arg_idx) position and every buffer address.
-    // Used below to detect unregistered positions that hold a buffer address — i.e.,
-    // the push_back(buf->address()) mistake.
-    std::unordered_set<uint64_t> registered_positions;
-    std::unordered_set<uint32_t> registered_addresses;
-
-    // Sentinel used to key common (non-per-core) arg positions in registered_positions.
-    // Real device cores have small coordinates; 0xFF,0xFF is never a valid logical core.
-    static constexpr CoreCoord kCommonArgSentinel{0xFF, 0xFF};
 
     for (uint32_t k = 0; k < static_cast<uint32_t>(desc.kernels.size()); ++k) {
         for (const auto& b : desc.kernels[k].buffer_bindings) {
@@ -74,8 +57,6 @@ ResolvedBindings resolve_bindings(
                 b.buffer->address());
 
             result.rt_args.push_back({k, b.core, b.arg_idx, find_idx(b.buffer, "buffer_bindings"), false});
-            registered_positions.insert(rt_binding_key(k, b.core, b.arg_idx));
-            registered_addresses.insert(b.buffer->address());
         }
 
         for (const auto& b : desc.kernels[k].common_buffer_bindings) {
@@ -92,59 +73,6 @@ ResolvedBindings resolve_bindings(
                 b.buffer->address());
 
             result.rt_args.push_back({k, {}, b.arg_idx, find_idx(b.buffer, "common_buffer_bindings"), true});
-            registered_positions.insert(rt_binding_key(k, kCommonArgSentinel, b.arg_idx));
-            registered_addresses.insert(b.buffer->address());
-        }
-    }
-
-    // Scan every per-core and common runtime arg.  If an arg's value matches a registered
-    // buffer's address but no binding was declared at that position, the factory called
-    // push_back(buf->address()) instead of push_back(buf).  On cache hits the fast path
-    // would skip that arg and leave it stale.
-    //
-    // DISABLED: produces false positives in two cases that we hit during the family
-    // migration rollout:
-    //   1) graph-capture mode populates buffer->address() with placeholder/sentinel
-    //      values that legitimately collide with small uint32_t scalars in arg lists.
-    //   2) buffers allocated at low addresses (e.g. 0x20) collide with literal scalar
-    //      args (loop counters, shape dims) that happen to share the same value.
-    // The check was meant to catch a specific factory mistake, but the false-positive
-    // rate makes it unusable as a hard TT_FATAL. Re-enable only if rewritten as a
-    // structural check that doesn't rely on numeric value match.
-    if (false && !registered_addresses.empty()) {
-        for (uint32_t k = 0; k < static_cast<uint32_t>(desc.kernels.size()); ++k) {
-            for (const auto& [core, args] : desc.kernels[k].runtime_args) {
-                for (uint32_t i = 0; i < static_cast<uint32_t>(args.size()); ++i) {
-                    if (registered_addresses.contains(args[i]) &&
-                        !registered_positions.contains(rt_binding_key(k, core, i))) {
-                        TT_FATAL(
-                            false,
-                            "Kernel {} core ({},{}) arg[{}]={:#x} matches a registered buffer "
-                            "address but no BufferBinding was declared at this position. "
-                            "Use push_back(buffer) instead of push_back(buffer->address()) so "
-                            "the address is patched on cache hits.",
-                            k,
-                            core.x,
-                            core.y,
-                            i,
-                            args[i]);
-                    }
-                }
-            }
-            const auto& common = desc.kernels[k].common_runtime_args;
-            for (uint32_t i = 0; i < static_cast<uint32_t>(common.size()); ++i) {
-                if (registered_addresses.contains(common[i]) &&
-                    !registered_positions.contains(rt_binding_key(k, kCommonArgSentinel, i))) {
-                    TT_FATAL(
-                        false,
-                        "Kernel {} common arg[{}]={:#x} matches a registered buffer address "
-                        "but no CommonBufferBinding was declared at this position. "
-                        "Use emplace_common_runtime_args() with Buffer* instead of uint32_t.",
-                        k,
-                        i,
-                        common[i]);
-                }
-            }
         }
     }
 


### PR DESCRIPTION
## Summary

Disables the post-resolution numeric scan in `resolve_bindings()` (in
`tt_metal/impl/program/program_descriptor_patching.cpp`) that asserts on
runtime args whose `uint32_t` value happens to match a registered
`buffer->address()`.

In production this scan produces false positives on:

1. **Graph-capture mode** — `buffer->address()` is populated with sentinel
   values that legitimately collide with literal scalar args (loop counters,
   shape dimensions, etc).
2. **Low-address buffers** — buffers allocated at small addresses (e.g.
   `0x20`) collide with the same kind of literal scalar args.

The check was meant to catch the specific factory-author mistake of
calling `push_back(buf->address())` instead of `push_back(buf)`, but the
false-positive rate makes it unusable as a hard `TT_FATAL` during the
family-PR migration rollout (#43208, #43213, #43204, #43281, #43299, #43305).

## Why fast-track

This is unblocking active migration PRs. The check is a guard — disabling it
does not regress correctness; the `BufferBinding` resolution itself is
unchanged. A future structural check (one that does not rely on numeric
value match) can re-enable equivalent coverage.

## Test plan

- [ ] runtime-sanity-tests
- [ ] blackhole-post-commit

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/buffer-binding-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/buffer-binding-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/buffer-binding-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/buffer-binding-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/buffer-binding-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/buffer-binding-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/buffer-binding-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/buffer-binding-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/buffer-binding-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/buffer-binding-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/buffer-binding-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/buffer-binding-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/buffer-binding-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/buffer-binding-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/buffer-binding-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/buffer-binding-fixes)