### PR TITLE
Add DeepSeek V3 B1 model test to SP4 Superpod pipeline 

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -101,7 +101,7 @@ scaleout:
     wh_galaxy: 100
     bh_galaxy: 60
     bh_sp1: 90
-    bh_sp4: 120
+    bh_sp4: 150
 
 runtime:
   sanity:

--- a/tests/pipeline_reorg/demo_sp_multihost_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_multihost_tests.yaml
@@ -85,3 +85,34 @@
   owner_id: U08RL15T4N8
   team: scaleout
   sp_config: sp4
+
+- name: "Pipeline Test (DeepSeek V3 B1 Superpod 4)"
+  cmd: |
+    PIPELINE_HOSTS=$(awk '{printf "%s:4,", $1}' /ci/ttrun/hostfile | sed 's/,$//')
+    PIPELINE_DIR=/ci/pipeline-${GITHUB_RUN_ID}
+    mkdir -p $PIPELINE_DIR
+
+    echo "=== SP4 superpod: running generate_blitz_decode_pipeline_configs ==="
+    python3 /ci/tt-metal/models/demos/deepseek_v3_b1/scaleout_configs/generate_blitz_decode_pipeline_configs.py \
+      --mpi-user user \
+      --hostfile /ci/ttrun/hostfile \
+      --worker-tt-metal-home /home/user/tt-metal \
+      --output-dir $PIPELINE_DIR \
+      /ci/tt-metal/models/demos/deepseek_v3_b1/scaleout_configs/blitz_pipeline_config_superpod_ci.yaml
+
+    echo "=== SP4 superpod: running tt-run ==="
+    TT_METAL_SLOW_DISPATCH_MODE=1 tt-run \
+      --mpi-args "--map-by rankfile:file=blitz_decode_pipeline_rank_file_superpod_ci --bind-to hwt:overload-allowed --host $PIPELINE_HOSTS --tag-output" \
+      --rank-binding blitz_decode_pipeline_rank_binding_superpod_ci.yaml \
+      python -m models.demos.deepseek_v3_b1.demo.cli \
+        --max-new-tokens 2048 \
+        --weights real \
+        --cache-path /home/esmal/cache \
+        --prompt "Solve this step by step: Design a cache for sharded LLM weights across multiple hosts with local NVMe and shared NFS. Minimize startup latency, avoid duplicate reads, support cache invalidation, and explain tradeoffs between per-host caches, content-addressable storage, and pre-sharded artifacts." \
+        --model-path /mnt/models/deepseek-ai/DeepSeek-R1-0528-dequantized
+  skus:
+    bh_sp4:
+      timeout: 120
+  owner_id: U08E1JCMAJF
+  team: scaleout
+  sp_config: sp4


### PR DESCRIPTION
### Summary
- Increase the SP4 Superpod scaleout time budget from 120 to 150 minutes.
- Add a DeepSeek V3 B1 Superpod 4 pipeline test entry for `bh_sp4` with the generated blitz decode pipeline config flow.

### Notes for reviewers
- The new pipeline test uses slow dispatch and a long prompt against `/mnt/models/deepseek-ai/DeepSeek-R1-0528-dequantized`.
- Not run locally; this is a CI configuration change intended to be validated by the target SP4 infrastructure.


Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gongyu/blaze_ci_sp4)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gongyu/blaze_ci_sp4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gongyu/blaze_ci_sp4)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gongyu/blaze_ci_sp4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gongyu/blaze_ci_sp4)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gongyu/blaze_ci_sp4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gongyu/blaze_ci_sp4)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gongyu/blaze_ci_sp4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=gongyu/blaze_ci_sp4)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:gongyu/blaze_ci_sp4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gongyu/blaze_ci_sp4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gongyu/blaze_ci_sp4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gongyu/blaze_ci_sp4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gongyu/blaze_ci_sp4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gongyu/blaze_ci_sp4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gongyu/blaze_ci_sp4)