### PR TITLE
[cleanup] Remove mutable storage access from metal tensors

### DIFF
--- a/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
@@ -183,7 +183,7 @@ TEST_F(MeshTensorDeviceTest, MoveConstructionTransfersOwnership) {
     auto topology = TensorTopology();
 
     MeshTensor original(mesh_buffer, std::move(spec), std::move(topology));
-    auto* buffer_ptr = &original.mesh_buffer();
+    const auto* buffer_ptr = &original.mesh_buffer();
 
     MeshTensor moved(std::move(original));
 
@@ -205,7 +205,7 @@ TEST_F(MeshTensorDeviceTest, MoveAssignmentTransfersOwnership) {
     MeshTensor tensor1(mesh_buffer1, std::move(spec1), TensorTopology());
     MeshTensor tensor2(mesh_buffer2, std::move(spec2), TensorTopology());
 
-    auto* buffer1_ptr = &tensor1.mesh_buffer();
+    const auto* buffer1_ptr = &tensor1.mesh_buffer();
 
     tensor2 = std::move(tensor1);
 

--- a/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
@@ -93,18 +93,6 @@ TEST(MeshTensorTest, ConstructionWithNullMeshBufferFails) {
     EXPECT_ANY_THROW(MeshTensor(nullptr, std::move(spec), std::move(topology)));
 }
 
-TEST(MeshTensorTest, MoveConstructionWithNewSpecFromDefaultConstructedFails) {
-    MeshTensor default_tensor;
-
-    auto page_config = PageConfig(Layout::ROW_MAJOR);
-    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    auto tensor_layout = TensorLayout(DataType::BFLOAT16, page_config, memory_config);
-    auto new_spec = TensorSpec(Shape{4, 32}, tensor_layout);
-    auto new_topology = TensorTopology();
-
-    EXPECT_ANY_THROW(MeshTensor(std::move(default_tensor), std::move(new_spec), std::move(new_topology)));
-}
-
 // Device-based tests using GenericMeshDeviceFixture
 using MeshTensorDeviceTest = GenericMeshDeviceFixture;
 
@@ -223,27 +211,6 @@ TEST_F(MeshTensorDeviceTest, MoveAssignmentTransfersOwnership) {
 
     EXPECT_EQ(&tensor2.mesh_buffer(), buffer1_ptr);
     EXPECT_EQ(tensor2.logical_shape(), Shape({1, 32}));
-}
-
-TEST_F(MeshTensorDeviceTest, MoveConstructionWithNewSpecAndTopology) {
-    auto page_config = PageConfig(Layout::ROW_MAJOR);
-    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    auto tensor_layout = TensorLayout(DataType::BFLOAT16, page_config, memory_config);
-    auto spec = TensorSpec(Shape{2, 64}, tensor_layout);
-
-    auto mesh_buffer = create_mesh_buffer(*mesh_device_, spec);
-    MeshTensor original(mesh_buffer, std::move(spec), TensorTopology());
-    auto* buffer_ptr = &original.mesh_buffer();
-
-    auto new_tensor_layout = TensorLayout(DataType::FLOAT32, page_config, memory_config);
-    auto new_spec = TensorSpec(Shape{4, 32}, new_tensor_layout);
-    auto new_topology = TensorTopology();
-
-    MeshTensor moved(std::move(original), std::move(new_spec), std::move(new_topology));
-
-    EXPECT_EQ(&moved.mesh_buffer(), buffer_ptr);
-    EXPECT_EQ(moved.logical_shape(), Shape({4, 32}));
-    EXPECT_EQ(moved.dtype(), DataType::FLOAT32);
 }
 
 TEST_F(MeshTensorDeviceTest, TensorProperties) {

--- a/tt_metal/api/tt-metalium/README.md
+++ b/tt_metal/api/tt-metalium/README.md
@@ -1,3 +1,0 @@
-# Runtime host side api
-
-## PR review criteria

--- a/tt_metal/api/tt-metalium/README.md
+++ b/tt_metal/api/tt-metalium/README.md
@@ -1,0 +1,3 @@
+# Runtime host side api
+
+## PR review criteria

--- a/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
@@ -65,15 +65,6 @@ public:
      */
     explicit HostTensor(HostBuffer buffer, TensorSpec spec, TensorTopology topology);
 
-    /**
-     * Move constructor with new spec and topology.
-     * Moves the buffer from other and uses the provided spec/topology.
-     * This is meant for transition as TTNN-Tensor currently has a two-step construction for HostTensor.
-     *
-     * pre-condition: other must not be in a default-constructed or moved-from state.
-     */
-    HostTensor(HostTensor&& other, TensorSpec spec, TensorTopology topology);
-
     ~HostTensor();
 
     /**

--- a/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
@@ -65,6 +65,15 @@ public:
      */
     explicit HostTensor(HostBuffer buffer, TensorSpec spec, TensorTopology topology);
 
+    /**
+     * Move constructor with new spec and topology.
+     * Moves the buffer from other and uses the provided spec/topology.
+     * This is meant for transition as TTNN-Tensor currently has a two-step construction for HostTensor.
+     *
+     * pre-condition: other must not be in a default-constructed or moved-from state.
+     */
+    HostTensor(HostTensor&& other, TensorSpec spec, TensorTopology topology);
+
     ~HostTensor();
 
     /**

--- a/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
@@ -45,16 +45,6 @@ class HostTensorImpl;
  * - Initialized: The HostTensor holds some tensor configurations and associated HostBuffer.
  */
 class HostTensor {
-    /*
-     * Refactoring Notes:
-     * To avoid disruption to existing users, HostTensor will deviate very little from the existing (host) Tensor
-     * semantics. The only significant changes are:
-     * - Eliminating implicit data movement APIs.
-     * - Remove transformation methods like to_layout and pad from the class methods. These seem better as free
-     *   functions that operate on a HostTensor than as methods of HostTensor. (Separation of data storage and data
-     *   manipulation.) In the existing Tensor, these are already duplicated as both methods and free functions.
-     */
-
 public:
     using volume_type = std::uint64_t;
 
@@ -203,8 +193,6 @@ public:
     std::size_t element_size() const;
 
     Strides strides() const;
-
-    // Questionables:
 
     // Applies a transformation function to each host buffer across devices in parallel, returning a new HostTensor.
     HostTensor transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const;

--- a/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
@@ -41,7 +41,7 @@ class HostTensorImpl;
  * Invariants of HostTensor:
  * - Default constructed: This is a valueless state, where any access to any member function outside of assignment and
  *   move construction will be UB. This exists to allow for default constructed HostTensor. Incompatible member function
- *   call to this state is checked by TT_ASSERT (enabled at debug build) in accessors. This is mirrors MeshTensor.
+ *   call to this state is checked by TT_FATAL in accessors. This is mirrors MeshTensor.
  * - Initialized: The HostTensor holds some tensor configurations and associated HostBuffer.
  */
 class HostTensor {
@@ -180,11 +180,6 @@ public:
      */
     const DistributedHostBuffer& buffer() const;
 
-    // TODO(#40348): This should be removed.
-    // We need to maintain invariant of this buffer.
-    // Giving out mutable reference allows user to assign into it.
-    DistributedHostBuffer& buffer();
-
     // Derivables:
 
     DataType dtype() const;
@@ -217,8 +212,16 @@ public:
     // Updates the topology of the HostTensor post construction.
     void update_tensor_topology(TensorTopology tensor_topology);
 
+    /**
+     * Access to the implementation.
+     *
+     * pre-condition: The HostTensor must be engaged.
+     */
+    HostTensorImpl& impl();
+    const HostTensorImpl& impl() const;
+
 private:
-    std::unique_ptr<HostTensorImpl> impl;
+    std::unique_ptr<HostTensorImpl> impl_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
@@ -40,8 +40,7 @@ class HostTensorImpl;
  *
  * Invariants of HostTensor:
  * - Default constructed: This is a valueless state, where any access to any member function outside of assignment and
- *   move construction will be UB. This exists to allow for default constructed HostTensor. Incompatible member function
- *   call to this state is checked by TT_FATAL in accessors. This is mirrors MeshTensor.
+ *   move construction will be UB. This exists to allow for default constructed HostTensor. This is mirrors MeshTensor.
  * - Initialized: The HostTensor holds some tensor configurations and associated HostBuffer.
  */
 class HostTensor {

--- a/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
@@ -40,7 +40,7 @@ class HostTensorImpl;
  *
  * Invariants of HostTensor:
  * - Default constructed: This is a valueless state, where any access to any member function outside of assignment and
- *   move construction will be UB. This exists to allow for default constructed HostTensor. This is mirrors MeshTensor.
+ *   move construction will be UB. This exists to allow for default constructed HostTensor. This mirrors MeshTensor.
  * - Initialized: The HostTensor holds some tensor configurations and associated HostBuffer.
  */
 class HostTensor {
@@ -202,7 +202,7 @@ public:
     /**
      * Access to the implementation.
      *
-     * pre-condition: The HostTensor must be engaged.
+     * pre-condition: The HostTensor must be initialized.
      */
     HostTensorImpl& impl();
     const HostTensorImpl& impl() const;

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -69,13 +69,6 @@ public:
     explicit MeshTensor(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, TensorSpec spec, TensorTopology topology);
 
     /**
-     * Move constructor with new spec and topology.
-     * Moves the buffer from other and uses the provided spec/topology.
-     * This is meant for transition as TTNN-Tensor current has a two-step construction for MeshTensor.
-     */
-    MeshTensor(MeshTensor&& other, TensorSpec spec, TensorTopology topology);
-
-    /**
      * Release ownership of the underlying device memory.
      * Whether or not the device memory is actually deallocated depends on the destructor semantics of the underlying
      * MeshBuffer.

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -116,9 +116,11 @@ public:
      *
      * pre-condition: The device tensor must not be in a default constructed state.
      */
-    distributed::MeshBuffer& mesh_buffer() const;
+    const distributed::MeshBuffer& mesh_buffer() const;
 
     /**
+     * THIS IS INTERNAL FUNCTION AND WILL BE DELETED ASAP, DO NOT USE, DO NOT RELY.
+     *
      * Wider API compatible mesh_buffer() that returns a shared ownership to the underlying storage.
      *
      * Note: Prefer mesh_buffer() wherever possible, as it breaks unique ownership semantics easily.
@@ -187,11 +189,19 @@ public:
     // Is a MeshTensor with a new tensor topology fundamentally different?
     void update_tensor_topology(TensorTopology tensor_topology);
 
+    /**
+     * Access to the implementation.
+     *
+     * pre-condition: The MeshTensor must not be in a default constructed state.
+     */
+    MeshTensorImpl& impl();
+    const MeshTensorImpl& impl() const;
+
 private:
-    // impl could be a nullptr if MeshTensor is in a default constructed state.
-    // Avoid using impl pointer directly, use the accessors instead.
+    // impl_ could be a nullptr if MeshTensor is in a default constructed state.
+    // Avoid using impl_ pointer directly, use the accessors instead.
     // Otherwise, please add manual TT_ASSERT checks for nullptr.
-    std::unique_ptr<MeshTensorImpl> impl;
+    std::unique_ptr<MeshTensorImpl> impl_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -178,12 +178,22 @@ public:
     const MeshTensorImpl& impl() const;
 
 private:
-    // This will be deleted after DeviceStorage no longer needs to keep a shared_ptr of the MeshBuffer.
+    // TODO(#43693): Remove once DeviceStorage no longer keeps a shared_ptr<MeshBuffer>
+    // in its DeallocatedTombStone state.
+    // DeviceStorage is the sole caller — it uses mesh_buffer_invariant_breaking() to
+    // populate the tombstone when a tensor is deallocated, so the device pointer
+    // remains accessible on aliased tensors (e.g. after a zero-copy reshape).
+    // This breaks MeshTensor's core invariant: that it is the sole owner of the
+    // underlying MeshBuffer. Shared ownership leaks out, allowing the MeshBuffer to
+    // outlive the MeshTensor.
     friend struct DeviceStorage;
 
     /**
-     * Wider API compatible mesh_buffer() that returns a shared ownership to the underlying storage.
-     * Access is only used by DeviceStorage.
+     * Returns shared ownership of the underlying MeshBuffer.
+     *
+     * WARNING: Breaks MeshTensor's sole-ownership invariant. The caller becomes a
+     * shared owner of the MeshBuffer, which can outlive the MeshTensor.
+     * Only accessible to DeviceStorage. See #43693 for removal plan.
      */
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer_invariant_breaking() const;
 

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -21,6 +21,7 @@ namespace tt::tt_metal {
 
 // Implementation details for MeshTensor
 class MeshTensorImpl;
+struct DeviceStorage;
 
 namespace distributed {
 class MeshDevice;
@@ -111,19 +112,6 @@ public:
     const distributed::MeshBuffer& mesh_buffer() const;
 
     /**
-     * THIS IS INTERNAL FUNCTION AND WILL BE DELETED ASAP, DO NOT USE, DO NOT RELY.
-     *
-     * Wider API compatible mesh_buffer() that returns a shared ownership to the underlying storage.
-     *
-     * Note: Prefer mesh_buffer() wherever possible, as it breaks unique ownership semantics easily.
-     * A core invariant of MeshTensor is that it is the sole owner of the underlying MeshBuffer,
-     * one can get the underlying shared_ptr of the MeshBuffer and break the invariant.
-     *
-     * See: #38691, #38375
-     */
-    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_invariant_breaking() const;
-
-    /**
      * Get the device the allocated device memory is on.
      *
      * pre-condition: The device tensor must not be in a default constructed state.
@@ -190,6 +178,15 @@ public:
     const MeshTensorImpl& impl() const;
 
 private:
+    // This will be deleted after DeviceStorage no longer needs to keep a shared_ptr of the MeshBuffer.
+    friend struct DeviceStorage;
+
+    /**
+     * Wider API compatible mesh_buffer() that returns a shared ownership to the underlying storage.
+     * Access is only used by DeviceStorage.
+     */
+    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_invariant_breaking() const;
+
     // impl_ could be a nullptr if MeshTensor is in a default constructed state.
     // Avoid using impl_ pointer directly, use the accessors instead.
     // Otherwise, please add manual TT_ASSERT checks for nullptr.

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -43,8 +43,7 @@ class MeshDevice;
  *
  * Invariants of MeshTensor:
  * - Default constructed: This is a valueless state, where any access to any member function outside of assignment and
- *   move construction will be UB. This exists to allow for default constructed MeshTensor. Incompatible member function
- *   call to this state is checked by TT_ASSERT (enabled at debug build) in accessors. This is mirrors HostTensor.
+ *   move construction will be UB. This exists to allow for default constructed MeshTensor. This mirrors HostTensor.
  * - Allocated: The device memory is allocated and **solely owned** by MeshTensor, user is able to get non-null
  *   pointers to the underlying storage and associated MeshDevice. Please note that this invariant isn't guaranteed
  *   currently, see: #38375

--- a/tt_metal/impl/experimental/core_subset_write/tensor.cpp
+++ b/tt_metal/impl/experimental/core_subset_write/tensor.cpp
@@ -6,6 +6,8 @@
 #include <tt-metalium/experimental/core_subset_write/tensor.hpp>
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 
+#include "tt_metal/impl/tensor/mesh_tensor_impl.hpp"
+
 namespace tt::tt_metal::experimental::core_subset_write {
 
 void enqueue_write_tensor(
@@ -24,7 +26,8 @@ void enqueue_write_tensor(
 
     // Pure data write into the device tensor's existing buffer; spec/topology of the device tensor
     // are intentionally not modified by a partial host->device copy.
-    enqueue_write(cq, device_tensor.mesh_buffer(), host_tensor.buffer(), /*blocking=*/false, logical_core_filter);
+    enqueue_write(
+        cq, *device_tensor.impl().raw_mesh_buffer(), host_tensor.buffer(), /*blocking=*/false, logical_core_filter);
 }
 
 }  // namespace tt::tt_metal::experimental::core_subset_write

--- a/tt_metal/impl/tensor/host_tensor.cpp
+++ b/tt_metal/impl/tensor/host_tensor.cpp
@@ -30,12 +30,6 @@ HostTensor::HostTensor(HostBuffer buffer, TensorSpec spec, TensorTopology topolo
         std::move(spec),
         std::move(topology))) {}
 
-HostTensor::HostTensor(HostTensor&& other, TensorSpec spec, TensorTopology topology) {
-    TT_FATAL(other.impl_ != nullptr, "Cannot move from a default-constructed or moved-from HostTensor.");
-    impl_ = std::make_unique<HostTensorImpl>(std::move(*other.impl_), std::move(spec), std::move(topology));
-}
-
-
 HostTensor::HostTensor(const HostTensor& other) :
     impl_(other.impl_ ? std::make_unique<HostTensorImpl>(*other.impl_) : nullptr) {}
 

--- a/tt_metal/impl/tensor/host_tensor.cpp
+++ b/tt_metal/impl/tensor/host_tensor.cpp
@@ -4,36 +4,15 @@
 
 #include <tt-metalium/experimental/tensor/host_tensor.hpp>
 
+#include "host_tensor_impl.hpp"
+
 namespace tt::tt_metal {
 
-class HostTensorImpl {
-public:
-    HostTensorImpl(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology) :
-        buffer_(std::move(buffer)), spec_(std::move(spec)), topology_(std::move(topology)) {}
-
-    HostTensorImpl(const HostTensorImpl& other) = default;
-    HostTensorImpl(HostTensorImpl&& other) noexcept = default;
-    HostTensorImpl& operator=(const HostTensorImpl& other) = default;
-    HostTensorImpl& operator=(HostTensorImpl&& other) noexcept = default;
-    ~HostTensorImpl() = default;
-
-    const DistributedHostBuffer& buffer() const& { return buffer_; }
-    DistributedHostBuffer& buffer() & { return buffer_; }
-    DistributedHostBuffer buffer() const&& { return buffer_; }
-    const TensorSpec& spec() const { return spec_; }
-    const TensorTopology& topology() const { return topology_; }
-    void update_topology(TensorTopology topology) { topology_ = std::move(topology); }
-
-private:
-    DistributedHostBuffer buffer_;
-    TensorSpec spec_;
-    TensorTopology topology_;
-};
 
 HostTensor::HostTensor() = default;
 
 HostTensor::HostTensor(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology) :
-    impl(std::make_unique<HostTensorImpl>(std::move(buffer), std::move(spec), std::move(topology))) {}
+    impl_(std::make_unique<HostTensorImpl>(std::move(buffer), std::move(spec), std::move(topology))) {}
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
@@ -46,49 +25,60 @@ DistributedHostBuffer create_unit_distributed_host_buffer(HostBuffer buffer) {
 };  // namespace
 
 HostTensor::HostTensor(HostBuffer buffer, TensorSpec spec, TensorTopology topology) :
-    impl(std::make_unique<HostTensorImpl>(
+    impl_(std::make_unique<HostTensorImpl>(
         CMAKE_UNIQUE_NAMESPACE::create_unit_distributed_host_buffer(std::move(buffer)),
         std::move(spec),
         std::move(topology))) {}
 
+HostTensor::HostTensor(HostTensor&& other, TensorSpec spec, TensorTopology topology) {
+    TT_FATAL(other.impl_ != nullptr, "Cannot move from a default-constructed or moved-from HostTensor.");
+    impl_ = std::make_unique<HostTensorImpl>(std::move(*other.impl_), std::move(spec), std::move(topology));
+}
+
+
 HostTensor::HostTensor(const HostTensor& other) :
-    impl(other.impl ? std::make_unique<HostTensorImpl>(*other.impl) : nullptr) {}
+    impl_(other.impl_ ? std::make_unique<HostTensorImpl>(*other.impl_) : nullptr) {}
 
 HostTensor& HostTensor::operator=(const HostTensor& other) {
     if (this == &other) {
         return *this;
     }
-    impl = other.impl ? std::make_unique<HostTensorImpl>(*other.impl) : nullptr;
+    impl_ = other.impl_ ? std::make_unique<HostTensorImpl>(*other.impl_) : nullptr;
     return *this;
 }
 
-HostTensor::HostTensor(HostTensor&& other) noexcept : impl(std::move(other.impl)) {}
+HostTensor::HostTensor(HostTensor&& other) noexcept : impl_(std::move(other.impl_)) {}
 
 HostTensor& HostTensor::operator=(HostTensor&& other) noexcept {
-    impl = std::move(other.impl);
+    impl_ = std::move(other.impl_);
     return *this;
 }
 
 HostTensor::~HostTensor() = default;
 
+HostTensorImpl& HostTensor::impl() {
+    TT_FATAL(impl_ != nullptr, "HostTensor is in default constructed state.");
+    return *impl_;
+}
+
+const HostTensorImpl& HostTensor::impl() const {
+    TT_FATAL(impl_ != nullptr, "HostTensor is in default constructed state.");
+    return *impl_;
+}
+
 const TensorSpec& HostTensor::tensor_spec() const {
-    TT_ASSERT(impl != nullptr, "HostTensor is in default constructed state.");
-    return impl->spec();
+    TT_FATAL(impl_ != nullptr, "HostTensor is in default constructed state.");
+    return impl_->spec();
 }
 
 const TensorTopology& HostTensor::tensor_topology() const {
-    TT_ASSERT(impl != nullptr, "HostTensor is in default constructed state.");
-    return impl->topology();
+    TT_FATAL(impl_ != nullptr, "HostTensor is in default constructed state.");
+    return impl_->topology();
 }
 
 const DistributedHostBuffer& HostTensor::buffer() const {
-    TT_ASSERT(impl != nullptr, "HostTensor is in default constructed state.");
-    return impl->buffer();
-}
-
-DistributedHostBuffer& HostTensor::buffer() {
-    TT_FATAL(impl != nullptr, "HostTensor is in default constructed state.");
-    return impl->buffer();
+    TT_FATAL(impl_ != nullptr, "HostTensor is in default constructed state.");
+    return impl_->buffer();
 }
 
 DataType HostTensor::dtype() const { return tensor_spec().tensor_layout().get_data_type(); }
@@ -134,8 +124,8 @@ HostTensor HostTensor::transform(const std::function<HostBuffer(const HostBuffer
 }
 
 void HostTensor::update_tensor_topology(TensorTopology tensor_topology) {
-    TT_ASSERT(impl != nullptr, "HostTensor is in default constructed state.");
-    impl->update_topology(std::move(tensor_topology));
+    TT_FATAL(impl_ != nullptr, "HostTensor is in default constructed state.");
+    impl_->update_topology(std::move(tensor_topology));
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/host_tensor_impl.hpp
+++ b/tt_metal/impl/tensor/host_tensor_impl.hpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <utility>
+
+#include <tt-metalium/distributed_host_buffer.hpp>
+#include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
+#include <tt-metalium/experimental/tensor/topology/tensor_topology.hpp>
+
+/**
+ * Internal implementation header for HostTensor.
+ *
+ * This header exposes HostTensorImpl so that translation units within tt_metal (e.g. tensor_apis.cpp)
+ * can operate directly on the implementation without going through the public HostTensor accessors.
+ * It is private to tt_metal and is not part of the installed public API.
+ */
+
+namespace tt::tt_metal {
+
+class HostTensorImpl {
+public:
+    HostTensorImpl(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology) :
+        buffer_(std::move(buffer)), spec_(std::move(spec)), topology_(std::move(topology)) {}
+
+    HostTensorImpl(const HostTensorImpl& other) = default;
+    HostTensorImpl(HostTensorImpl&& other) noexcept = default;
+    HostTensorImpl& operator=(const HostTensorImpl& other) = default;
+    HostTensorImpl& operator=(HostTensorImpl&& other) noexcept = default;
+    ~HostTensorImpl() = default;
+
+    // Two step construction for HostTensor,
+    // for transiet purpose.
+    HostTensorImpl(HostTensorImpl&& other, TensorSpec spec, TensorTopology topology) :
+        buffer_(std::move(other.buffer_)), spec_(std::move(spec)), topology_(std::move(topology)) {}
+
+    const DistributedHostBuffer& buffer() const& { return buffer_; }
+    DistributedHostBuffer& buffer() & { return buffer_; }
+    DistributedHostBuffer buffer() const&& { return buffer_; }
+    const TensorSpec& spec() const { return spec_; }
+    const TensorTopology& topology() const { return topology_; }
+    void update_topology(TensorTopology topology) { topology_ = std::move(topology); }
+
+private:
+    DistributedHostBuffer buffer_;
+    TensorSpec spec_;
+    TensorTopology topology_;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/host_tensor_impl.hpp
+++ b/tt_metal/impl/tensor/host_tensor_impl.hpp
@@ -32,7 +32,7 @@ public:
     ~HostTensorImpl() = default;
 
     // Two step construction for HostTensor,
-    // for transiet purpose.
+    // for transient purpose.
     HostTensorImpl(HostTensorImpl&& other, TensorSpec spec, TensorTopology topology) :
         buffer_(std::move(other.buffer_)), spec_(std::move(spec)), topology_(std::move(topology)) {}
 

--- a/tt_metal/impl/tensor/host_tensor_impl.hpp
+++ b/tt_metal/impl/tensor/host_tensor_impl.hpp
@@ -31,11 +31,6 @@ public:
     HostTensorImpl& operator=(HostTensorImpl&& other) noexcept = default;
     ~HostTensorImpl() = default;
 
-    // Two step construction for HostTensor,
-    // for transient purpose.
-    HostTensorImpl(HostTensorImpl&& other, TensorSpec spec, TensorTopology topology) :
-        buffer_(std::move(other.buffer_)), spec_(std::move(spec)), topology_(std::move(topology)) {}
-
     const DistributedHostBuffer& buffer() const& { return buffer_; }
     DistributedHostBuffer& buffer() & { return buffer_; }
     DistributedHostBuffer buffer() const&& { return buffer_; }

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -18,11 +18,6 @@ MeshTensor& MeshTensor::operator=(MeshTensor&& other) noexcept = default;
 MeshTensor::MeshTensor(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, TensorSpec spec, TensorTopology topology) :
     impl_(std::make_unique<MeshTensorImpl>(std::move(mesh_buffer), std::move(spec), std::move(topology))) {}
 
-MeshTensor::MeshTensor(MeshTensor&& other, TensorSpec spec, TensorTopology topology) {
-    TT_FATAL(other.is_initialized(), "Cannot move from a default-constructed or moved-from MeshTensor.");
-    impl_ = std::make_unique<MeshTensorImpl>(std::move(*other.impl_), std::move(spec), std::move(topology));
-}
-
 MeshTensor::~MeshTensor() = default;
 
 MeshTensorImpl& MeshTensor::impl() {

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -4,55 +4,10 @@
 
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 #include <tt-metalium/experimental/tensor/impl/tensor_impl.hpp>
+
+#include "mesh_tensor_impl.hpp"
+
 namespace tt::tt_metal {
-
-class MeshTensorImpl {
-public:
-    MeshTensorImpl(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, TensorSpec spec, TensorTopology topology) :
-        MeshTensorImpl(std::move(mesh_buffer), std::move(spec), std::move(topology), nullptr) {}
-
-    MeshTensorImpl(
-        std::shared_ptr<distributed::MeshBuffer> mesh_buffer,
-        TensorSpec spec,
-        TensorTopology topology,
-        std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer) :
-        mesh_buffer_(std::move(mesh_buffer)),
-        spec_(std::move(spec)),
-        topology_(std::move(topology)),
-        root_mesh_buffer_(std::move(root_mesh_buffer)) {
-        TT_FATAL(mesh_buffer_ != nullptr, "MeshBuffer cannot be nullptr.");
-        TT_FATAL(mesh_buffer_->is_allocated(), "MeshBuffer must be allocated.");
-        TT_FATAL(
-            mesh_buffer_->size() >= spec_.compute_packed_buffer_size_bytes(),
-            "MeshBuffer must be large enough to hold the tensor.");
-    }
-
-    // Two step construction for MeshTensor,
-    // for transiet purpose.
-    MeshTensorImpl(MeshTensorImpl&& other, TensorSpec spec, TensorTopology topology) :
-        mesh_buffer_(std::move(other.mesh_buffer_)),
-        spec_(std::move(spec)),
-        topology_(std::move(topology)),
-        root_mesh_buffer_(std::move(other.root_mesh_buffer_)) {}
-
-    const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer() const { return mesh_buffer_; }
-    const TensorSpec& spec() const { return spec_; }
-    const TensorTopology& topology() const { return topology_; }
-    void update_topology(TensorTopology topology) { topology_ = std::move(topology); }
-
-private:
-    // Invariant:
-    // 1. Cannot be nullptr and must be allocated.
-    // 2. Must be large enough to hold a tensor describale with spec_
-    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_;
-    TensorSpec spec_;
-    // TODO(river): What is the invariant of topology?
-    TensorTopology topology_;
-
-    // Experimental feature: Accomodates #38101
-    // This keeps mesh_buffer_ alive in limited cases.
-    std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer_;
-};
 
 MeshTensor::MeshTensor() = default;
 
@@ -61,35 +16,38 @@ MeshTensor::MeshTensor(MeshTensor&& other) noexcept = default;
 MeshTensor& MeshTensor::operator=(MeshTensor&& other) noexcept = default;
 
 MeshTensor::MeshTensor(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, TensorSpec spec, TensorTopology topology) :
-    impl(std::make_unique<MeshTensorImpl>(std::move(mesh_buffer), std::move(spec), std::move(topology))) {}
+    impl_(std::make_unique<MeshTensorImpl>(std::move(mesh_buffer), std::move(spec), std::move(topology))) {}
 
 MeshTensor::MeshTensor(MeshTensor&& other, TensorSpec spec, TensorTopology topology) {
     TT_FATAL(other.is_initialized(), "Cannot move from a default-constructed or moved-from MeshTensor.");
-    impl = std::make_unique<MeshTensorImpl>(std::move(*other.impl), std::move(spec), std::move(topology));
+    impl_ = std::make_unique<MeshTensorImpl>(std::move(*other.impl_), std::move(spec), std::move(topology));
 }
 
 MeshTensor::~MeshTensor() = default;
 
-distributed::MeshBuffer& MeshTensor::mesh_buffer() const { return *mesh_buffer_invariant_breaking(); }
+MeshTensorImpl& MeshTensor::impl() {
+    TT_FATAL(impl_ != nullptr, "MeshTensor is in default constructed state.");
+    return *impl_;
+}
+
+const MeshTensorImpl& MeshTensor::impl() const {
+    TT_FATAL(impl_ != nullptr, "MeshTensor is in default constructed state.");
+    return *impl_;
+}
+
+const distributed::MeshBuffer& MeshTensor::mesh_buffer() const { return impl().mesh_buffer(); }
 
 std::shared_ptr<distributed::MeshBuffer> MeshTensor::mesh_buffer_invariant_breaking() const {
-    TT_FATAL(is_initialized(), "MeshTensor is in default constructed state.");
-    return impl->mesh_buffer();
+    return impl().raw_mesh_buffer();
 }
 
 distributed::MeshDevice& MeshTensor::device() const { return *mesh_buffer().device(); }
 
-bool MeshTensor::is_initialized() const { return impl != nullptr; }
+bool MeshTensor::is_initialized() const { return impl_ != nullptr; }
 
-const TensorSpec& MeshTensor::tensor_spec() const {
-    TT_FATAL(is_initialized(), "MeshTensor is in default constructed state.");
-    return impl->spec();
-}
+const TensorSpec& MeshTensor::tensor_spec() const { return impl().spec(); }
 
-const TensorTopology& MeshTensor::tensor_topology() const {
-    TT_FATAL(is_initialized(), "MeshTensor is in default constructed state.");
-    return impl->topology();
-}
+const TensorTopology& MeshTensor::tensor_topology() const { return impl().topology(); }
 
 DeviceAddr MeshTensor::address() const { return mesh_buffer().address(); }
 
@@ -130,8 +88,7 @@ std::size_t MeshTensor::element_size() const {
 Strides MeshTensor::strides() const { return tensor_spec().tensor_layout().compute_strides(logical_shape()); }
 
 void MeshTensor::update_tensor_topology(TensorTopology tensor_topology) {
-    TT_FATAL(is_initialized(), "MeshTensor is in default constructed state.");
-    impl->update_topology(std::move(tensor_topology));
+    impl().update_topology(std::move(tensor_topology));
 }
 
 MeshTensor MeshTensor::allocate_on_device(

--- a/tt_metal/impl/tensor/mesh_tensor_impl.hpp
+++ b/tt_metal/impl/tensor/mesh_tensor_impl.hpp
@@ -25,17 +25,7 @@ namespace tt::tt_metal {
 class MeshTensorImpl {
 public:
     MeshTensorImpl(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, TensorSpec spec, TensorTopology topology) :
-        MeshTensorImpl(std::move(mesh_buffer), std::move(spec), std::move(topology), nullptr) {}
-
-    MeshTensorImpl(
-        std::shared_ptr<distributed::MeshBuffer> mesh_buffer,
-        TensorSpec spec,
-        TensorTopology topology,
-        std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer) :
-        mesh_buffer_(std::move(mesh_buffer)),
-        spec_(std::move(spec)),
-        topology_(std::move(topology)),
-        root_mesh_buffer_(std::move(root_mesh_buffer)) {
+        mesh_buffer_(std::move(mesh_buffer)), spec_(std::move(spec)), topology_(std::move(topology)) {
         TT_FATAL(mesh_buffer_ != nullptr, "MeshBuffer cannot be nullptr.");
         TT_FATAL(mesh_buffer_->is_allocated(), "MeshBuffer must be allocated.");
         TT_FATAL(
@@ -46,10 +36,7 @@ public:
     // Two step construction for MeshTensor,
     // for transiet purpose.
     MeshTensorImpl(MeshTensorImpl&& other, TensorSpec spec, TensorTopology topology) :
-        mesh_buffer_(std::move(other.mesh_buffer_)),
-        spec_(std::move(spec)),
-        topology_(std::move(topology)),
-        root_mesh_buffer_(std::move(other.root_mesh_buffer_)) {}
+        mesh_buffer_(std::move(other.mesh_buffer_)), spec_(std::move(spec)), topology_(std::move(topology)) {}
 
     const distributed::MeshBuffer& mesh_buffer() const { return *raw_mesh_buffer(); }
     const std::shared_ptr<distributed::MeshBuffer>& raw_mesh_buffer() const { return mesh_buffer_; }
@@ -65,10 +52,6 @@ private:
     TensorSpec spec_;
     // TODO(river): What is the invariant of topology?
     TensorTopology topology_;
-
-    // Experimental feature: Accomodates #38101
-    // This keeps mesh_buffer_ alive in limited cases.
-    std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/mesh_tensor_impl.hpp
+++ b/tt_metal/impl/tensor/mesh_tensor_impl.hpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
+#include <tt-metalium/experimental/tensor/topology/tensor_topology.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+#include <tt_stl/assert.hpp>
+
+/**
+ * Internal implementation header for MeshTensor.
+ *
+ * This header exposes MeshTensorImpl so that translation units within tt_metal (e.g. tensor_apis.cpp)
+ * can operate directly on the implementation without going through the public MeshTensor compatibility accessors.
+ * It is private to tt_metal and is not part of the installed public API.
+ */
+
+namespace tt::tt_metal {
+
+class MeshTensorImpl {
+public:
+    MeshTensorImpl(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, TensorSpec spec, TensorTopology topology) :
+        MeshTensorImpl(std::move(mesh_buffer), std::move(spec), std::move(topology), nullptr) {}
+
+    MeshTensorImpl(
+        std::shared_ptr<distributed::MeshBuffer> mesh_buffer,
+        TensorSpec spec,
+        TensorTopology topology,
+        std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer) :
+        mesh_buffer_(std::move(mesh_buffer)),
+        spec_(std::move(spec)),
+        topology_(std::move(topology)),
+        root_mesh_buffer_(std::move(root_mesh_buffer)) {
+        TT_FATAL(mesh_buffer_ != nullptr, "MeshBuffer cannot be nullptr.");
+        TT_FATAL(mesh_buffer_->is_allocated(), "MeshBuffer must be allocated.");
+        TT_FATAL(
+            mesh_buffer_->size() >= spec_.compute_packed_buffer_size_bytes(),
+            "MeshBuffer must be large enough to hold the tensor.");
+    }
+
+    // Two step construction for MeshTensor,
+    // for transiet purpose.
+    MeshTensorImpl(MeshTensorImpl&& other, TensorSpec spec, TensorTopology topology) :
+        mesh_buffer_(std::move(other.mesh_buffer_)),
+        spec_(std::move(spec)),
+        topology_(std::move(topology)),
+        root_mesh_buffer_(std::move(other.root_mesh_buffer_)) {}
+
+    const distributed::MeshBuffer& mesh_buffer() const { return *raw_mesh_buffer(); }
+    const std::shared_ptr<distributed::MeshBuffer>& raw_mesh_buffer() const { return mesh_buffer_; }
+    const TensorSpec& spec() const { return spec_; }
+    const TensorTopology& topology() const { return topology_; }
+    void update_topology(TensorTopology topology) { topology_ = std::move(topology); }
+
+private:
+    // Invariant:
+    // 1. Cannot be nullptr and must be allocated.
+    // 2. Must be large enough to hold a tensor describale with spec_
+    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_;
+    TensorSpec spec_;
+    // TODO(river): What is the invariant of topology?
+    TensorTopology topology_;
+
+    // Experimental feature: Accomodates #38101
+    // This keeps mesh_buffer_ alive in limited cases.
+    std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer_;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/mesh_tensor_impl.hpp
+++ b/tt_metal/impl/tensor/mesh_tensor_impl.hpp
@@ -33,11 +33,6 @@ public:
             "MeshBuffer must be large enough to hold the tensor.");
     }
 
-    // Two step construction for MeshTensor,
-    // for transiet purpose.
-    MeshTensorImpl(MeshTensorImpl&& other, TensorSpec spec, TensorTopology topology) :
-        mesh_buffer_(std::move(other.mesh_buffer_)), spec_(std::move(spec)), topology_(std::move(topology)) {}
-
     const distributed::MeshBuffer& mesh_buffer() const { return *raw_mesh_buffer(); }
     const std::shared_ptr<distributed::MeshBuffer>& raw_mesh_buffer() const { return mesh_buffer_; }
     const TensorSpec& spec() const { return spec_; }

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -8,6 +8,7 @@
 #include <unordered_set>
 
 #include "host_tensor_impl.hpp"
+#include "mesh_tensor_impl.hpp"
 
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor/impl/tensor_impl.hpp>
@@ -41,7 +42,7 @@ bool is_uniform_write(const HostTensor& host_tensor, const distributed::MeshDevi
 // ======================================================================================
 
 HostTensor enqueue_read_tensor(distributed::MeshCommandQueue& cq, const MeshTensor& device_tensor, bool blocking) {
-    auto mesh_buffer = device_tensor.mesh_buffer_invariant_breaking();
+    auto mesh_buffer = device_tensor.impl().raw_mesh_buffer();
     auto& device = device_tensor.device();
 
     auto distributed_host_buffer = DistributedHostBuffer::create(device.get_view());
@@ -91,7 +92,7 @@ void enqueue_read_tensor(
         host_tensor.tensor_spec().page_config() == device_tensor.tensor_spec().page_config(),
         "Host tensor has different page config");
 
-    auto mesh_buffer = device_tensor.mesh_buffer_invariant_breaking();
+    auto mesh_buffer = device_tensor.impl().raw_mesh_buffer();
 
     cq.enqueue_read(mesh_buffer, host_tensor.impl().buffer(), /*shards=*/std::nullopt, blocking);
     host_tensor.update_tensor_topology(device_tensor.tensor_topology());
@@ -108,7 +109,7 @@ void enqueue_write_tensor(distributed::MeshCommandQueue& cq, const HostTensor& h
         host_tensor.tensor_spec().page_config() == device_tensor.tensor_spec().page_config(),
         "Host tensor has different page config");
 
-    const auto& mesh_buffer = device_tensor.mesh_buffer_invariant_breaking();
+    auto mesh_buffer = device_tensor.impl().raw_mesh_buffer();
 
     // Uniform H2D copy.
     cq.enqueue_write(mesh_buffer, host_tensor.buffer(), /*blocking=*/false);
@@ -133,7 +134,7 @@ void enqueue_read_tensor(
         distributed::ShardDataTransfer{*distributed::MeshCoordinateRange(queue.device()->shape()).begin()}
             .host_data(dst)
             .region(region)};
-    queue.enqueue_read_shards(shard_data_transfers, device_tensor.mesh_buffer_invariant_breaking(), blocking);
+    queue.enqueue_read_shards(shard_data_transfers, device_tensor.impl().raw_mesh_buffer(), blocking);
 }
 
 void enqueue_write_tensor(
@@ -146,7 +147,7 @@ void enqueue_write_tensor(
         distributed::ShardDataTransfer{*distributed::MeshCoordinateRange(queue.device()->shape()).begin()}
             .host_data(const_cast<std::byte*>(src))
             .region(region)};
-    queue.enqueue_write_shards(device_tensor.mesh_buffer_invariant_breaking(), shard_data_transfers, false);
+    queue.enqueue_write_shards(device_tensor.impl().raw_mesh_buffer(), shard_data_transfers, false);
 }
 
 // ======================================================================================
@@ -210,7 +211,7 @@ void enqueue_read_tensor(
     }
 
     std::unordered_set<distributed::MeshCoordinate> shard_set(coords.begin(), coords.end());
-    cq.enqueue_read(device_tensor.mesh_buffer_invariant_breaking(), dst_distributed_host_buffer, shard_set, blocking);
+    cq.enqueue_read(device_tensor.impl().raw_mesh_buffer(), dst_distributed_host_buffer, shard_set, blocking);
 
     host_tensor = HostTensor(
         std::move(dst_distributed_host_buffer), device_tensor.tensor_spec(), device_tensor.tensor_topology());
@@ -250,7 +251,7 @@ void h2d_as_replicate_tensor_on_1x1_mesh(
         input_size_bytes,
         expected_packed_buffer_size_bytes);
 
-    auto mesh_buffer = device_tensor.mesh_buffer_invariant_breaking();
+    auto mesh_buffer = device_tensor.impl().raw_mesh_buffer();
     command_queue.enqueue_write_mesh_buffer(mesh_buffer, data_to_write.data(), /*blocking=*/false);
 
     const auto& mesh_device_shape = mesh_buffer->device()->shape();
@@ -283,7 +284,7 @@ std::vector<distributed::MeshCoordinate> enqueue_write_tensor(
         return {range.begin(), range.end()};
     }
 
-    auto mesh_buffer = device_tensor.mesh_buffer_invariant_breaking();
+    auto mesh_buffer = device_tensor.impl().raw_mesh_buffer();
     cq.enqueue_write(mesh_buffer, host_tensor.buffer(), /*blocking=*/false);
 
     // DistributedHostBuffer may not cover the entire MeshDevice, must preserve coords here.

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -7,6 +7,8 @@
 #include <functional>
 #include <unordered_set>
 
+#include "host_tensor_impl.hpp"
+
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor/impl/tensor_impl.hpp>
 
@@ -91,7 +93,7 @@ void enqueue_read_tensor(
 
     auto mesh_buffer = device_tensor.mesh_buffer_invariant_breaking();
 
-    cq.enqueue_read(mesh_buffer, host_tensor.buffer(), /*shards=*/std::nullopt, blocking);
+    cq.enqueue_read(mesh_buffer, host_tensor.impl().buffer(), /*shards=*/std::nullopt, blocking);
     host_tensor.update_tensor_topology(device_tensor.tensor_topology());
 }
 


### PR DESCRIPTION
### PR Type
Cleanup

### Summary
Closes #43580

`HostTensor` and `MeshTensor` both have invariants that tie tensor metadata to the backing storage. Public mutable access to that storage can let callers construct a valid tensor and later put it into an invalid state, such as replacing the storage with one that is too small for the tensor spec.

This PR removes public mutable access to `HostTensor`'s underlying `DistributedHostBuffer` and makes `MeshTensor::mesh_buffer()` return a const reference. Internal TT-Metal paths that still need mutable or shared buffer access now go through internal `HostTensorImpl` / `MeshTensorImpl` APIs.

This PR also pimplifies both tensor wrapper classes by extracting `HostTensorImpl` and `MeshTensorImpl` into internal implementation headers. Internal TT-Metal code can use these implementation types for mutable/raw storage access without exposing those access paths as normal public tensor APIs.

`mesh_buffer_invariant_breaking()` has also been moved from the public API to a private `friend`-accessible method, accessible only to `DeviceStorage`. This eliminates the last public escape hatch for raw shared buffer ownership while preserving the one internal caller that still needs it.

### Notes for reviewers
Please focus on the public API behavior changes:
- `HostTensor::buffer()` no longer has a mutable overload.
- `MeshTensor::mesh_buffer()` is now const-only.
- Internal read/write paths use `impl()` accessors for the cases that still need mutable/raw buffer access.
- `mesh_buffer_invariant_breaking()` has been demoted from public to private. It is now only accessible to `DeviceStorage` (via `friend struct DeviceStorage`), which is the sole remaining internal caller. The deletion note in the comment remains — once `DeviceStorage` no longer needs a shared `MeshBuffer` pointer this method goes away entirely.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/host-tensor-invariant)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/host-tensor-invariant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/host-tensor-invariant)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/host-tensor-invariant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/host-tensor-invariant)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/host-tensor-invariant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/host-tensor-invariant)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/host-tensor-invariant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/host-tensor-invariant)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/host-tensor-invariant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/host-tensor-invariant)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/host-tensor-invariant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/host-tensor-invariant)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/host-tensor-invariant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/host-tensor-invariant)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/host-tensor-invariant)
