### PR TITLE
[cleanup] Harden pre-condition checks for HostTensor ops

### DIFF
--- a/tests/ttnn/unit_tests/tensor/test_tensor_ranks.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_ranks.py
@@ -28,7 +28,6 @@ def test_tensor_ranks(shape, device):
     tt_tensor = tt_tensor.to(device)
     tt_tensor = tt_tensor.cpu()
     tt_tensor = tt_tensor.to(ttnn.ROW_MAJOR_LAYOUT)
-    tt_tensor = tt_tensor.unpad_from_tile(shape)
 
     assert tt_tensor.shape.rank == len(shape)
 

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -745,12 +745,7 @@ HostTensor pad(
     const tt::tt_metal::Shape& output_padded_shape,
     const tt::tt_metal::Shape& input_tensor_start,
     float pad_value) {
-    // TODO(#40993): Flip to assert when we remove use cases in python and c++
-    if (tensor.layout() != Layout::ROW_MAJOR) {
-        log_warning(
-            tt::LogOp, "Tensor layout {} must be ROW_MAJOR for padding! Returning original tensor!", tensor.layout());
-        return tensor;
-    }
+    TT_FATAL(tensor.layout() == Layout::ROW_MAJOR, "Tensor layout must be ROW_MAJOR for padding");
     return tensor_impl::dispatch(tensor.dtype(), [&]<typename T>() {
         return CMAKE_UNIQUE_NAMESPACE::pad_impl<T>(tensor, output_padded_shape, input_tensor_start, pad_value);
     });
@@ -786,8 +781,7 @@ HostTensor unpad(
     const HostTensor& tensor,
     const tt::tt_metal::Shape& output_tensor_start,
     const tt::tt_metal::Shape& output_tensor_end) {
-    // TODO(#40993): This should be a FATAL
-    TT_ASSERT(tensor.layout() == Layout::ROW_MAJOR && "Tensor layout must be ROW_MAJOR for unpadding");
+    TT_FATAL(tensor.layout() == Layout::ROW_MAJOR, "Tensor layout must be ROW_MAJOR for unpadding");
     return tensor_impl::dispatch(tensor.dtype(), [&]<typename T>() {
         return CMAKE_UNIQUE_NAMESPACE::unpad_impl<T>(tensor, output_tensor_start, output_tensor_end);
     });

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -350,6 +350,11 @@ template <typename T>
 HostTensor to_layout_bfloat_impl(const HostTensor& tensor, Layout target_layout) {
     static_assert(
         std::is_same_v<T, tensor_impl::bfloat8_b> || std::is_same_v<T, tensor_impl::bfloat4_b>, "Invalid type T");
+    // TODO(#43763):
+    // Flipping this assert to TT_FATAL triggers multiple failures in **sanity** test suite.
+    // This silent fail has a high impact area and should be studied and addressed asap.
+    //
+    // Original comment:
     // TODO: Flip to assert when we remove use cases in python and c++
     if (tensor.layout() != target_layout or tensor.layout() != Layout::TILE) {
         log_warning(

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -788,17 +788,16 @@ HostTensor unpad(
 }
 
 HostTensor unpad_from_tile(const HostTensor& tensor, const tt::tt_metal::Shape& output_tensor_shape) {
-    // TODO(#40993): These asserts should be FATAL
     for (auto index = -3; index >= -static_cast<int>(tensor.padded_shape().rank()); index--) {
-        TT_ASSERT(
+        TT_FATAL(
             tensor.logical_shape()[index] == output_tensor_shape[index],
             "Input shape must match output shape apart from last 2 dims");
     }
-    TT_ASSERT(
+    TT_FATAL(
         tensor.padded_shape()[-2] % constants::TILE_HEIGHT == 0 &&
             tensor.padded_shape()[-1] % constants::TILE_WIDTH == 0,
         "Last 2 dims of input shape must be multiples of 32");
-    TT_ASSERT(
+    TT_FATAL(
         tensor.padded_shape()[-2] < output_tensor_shape[-2] + constants::TILE_HEIGHT &&
             tensor.padded_shape()[-1] < output_tensor_shape[-1] + constants::TILE_WIDTH,
         "Last 2 dims of output must be within range to have been padded to input");


### PR DESCRIPTION
### PR Category
Cleanup

### Summary

Part of #40993

Several pad/unpad host tensor operations do not report failed invariant checks as `TT_FATAL`, making these functions error-prone as bugs won't be easily discovered.

This PR changes respective `TT_ASSERT`/silent fails to explicit `TT_FATAL`s.

### Notes for reviewers

Not all silent fails in #40993 are addressed in this PR. Specifically, the `to_layout_bfloat_impl` silent fail was attempted but reverted — enforcing it as a `TT_FATAL` breaks sanity tests, indicating it is exercised by existing code paths with potentially high impact. That case requires further investigation before it can be hardened.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/enforce-pad-unpad-rm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/enforce-pad-unpad-rm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/enforce-pad-unpad-rm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/enforce-pad-unpad-rm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/enforce-pad-unpad-rm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/enforce-pad-unpad-rm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/enforce-pad-unpad-rm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/enforce-pad-unpad-rm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/enforce-pad-unpad-rm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/enforce-pad-unpad-rm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/enforce-pad-unpad-rm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/enforce-pad-unpad-rm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/enforce-pad-unpad-rm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/enforce-pad-unpad-rm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/enforce-pad-unpad-rm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/enforce-pad-unpad-rm)
