### PR TITLE
[fw] Initialize PACK_DONE alongside other tensix semaphores

### DIFF
--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/c_tensix_core.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/c_tensix_core.h
@@ -418,6 +418,7 @@ inline void c_tensix_core::initialize_tensix_semaphores(vptr_uint instrn_buf) {
     ex_sem_init(ckernel::semaphore::MATH_PACK, 1, 0, instrn_buf);
     ex_sem_init(ckernel::semaphore::UNPACK_TO_DEST, 1, 0, instrn_buf);
     ex_sem_init(ckernel::semaphore::MATH_DONE, 1, 0, instrn_buf);
+    ex_sem_init(ckernel::semaphore::PACK_DONE, 1, 0, instrn_buf);
 }
 
 inline void c_tensix_core::noc_copy(

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/c_tensix_core.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/c_tensix_core.h
@@ -276,6 +276,7 @@ inline void c_tensix_core::initialize_tensix_semaphores(vptr_uint instrn_buf) {
     ex_sem_init(ckernel::semaphore::MATH_PACK, 1, 0, instrn_buf);
     ex_sem_init(ckernel::semaphore::UNPACK_TO_DEST, 1, 0, instrn_buf);
     ex_sem_init(ckernel::semaphore::MATH_DONE, 1, 0, instrn_buf);
+    ex_sem_init(ckernel::semaphore::PACK_DONE, 1, 0, instrn_buf);
 }
 
 // NOC API

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
@@ -55,7 +55,7 @@
 
 /////////////
 // Firmware/kernel code holes
-#define MEM_BRISC_FIRMWARE_SIZE (6 * 1024)
+#define MEM_BRISC_FIRMWARE_SIZE (6 * 1024 + 32)
 // TODO: perhaps put NCRISC FW in the scratch area and free 1.5K after init (GS/WH)
 #define MEM_NCRISC_FIRMWARE_SIZE 2048
 #define MEM_TRISC0_FIRMWARE_SIZE 1536


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
PACK_DONE is used by D2M `unpack_stall_on_pack` LLK helper for unpack/pack synchronization but was never initialized at kernel startup, requiring a workaround init inside the helper itself [tt-mlir issue #8144](https://github.com/tenstorrent/tt-mlir/issues/8144). Initialize it once in
`c_tensix_core::initialize_tensix_semaphores` next to MATH_PACK, UNPACK_TO_DEST, and MATH_DONE so the helper can drop its inline init and only post/wait on the hot path.

Quasar's `c_tensix_core::initialize_tensix_semaphores` is left alone: its semaphore enum does not yet define PACK_DONE (or UNPACK_TO_DEST / MATH_DONE that the existing block also references).
### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=xchin/packer-done-sem)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:xchin/packer-done-sem)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=xchin/packer-done-sem)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:xchin/packer-done-sem)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=xchin/packer-done-sem)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:xchin/packer-done-sem)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=xchin/packer-done-sem)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:xchin/packer-done-sem)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=xchin/packer-done-sem)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:xchin/packer-done-sem)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=xchin/packer-done-sem)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:xchin/packer-done-sem)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=xchin/packer-done-sem)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:xchin/packer-done-sem)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=xchin/packer-done-sem)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:xchin/packer-done-sem)