### PR TITLE
Preprogram noc registers while waiting for data

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -2381,7 +2381,7 @@ void kernel_main() {
                 // ================================================================
                 {
                     DeviceZoneScopedN("QNOPE/MATMUL3");
-                    deepseek_b1_ops::Matmul::Op<Matmul3CTArgs, Core::is_qnope_core, true, false> matmul3;
+                    deepseek_b1_ops::Matmul::Op<Matmul3CTArgs, Core::is_qnope_core, true, false, true> matmul3;
                     matmul3(matmul3_args);
                 }
 

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_custom_mm_compressed_common.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_custom_mm_compressed_common.h
@@ -258,7 +258,6 @@ inline void custom_mm_compressed_block_init_short(
     const uint32_t in0_cb_id, const uint32_t in1_cb_id, const uint32_t out_cb_id) {
     llk_unpack_AB_custom_mm_compressed_init<use_barrier, ct_dim>(in0_cb_id, in1_cb_id);
     MATH((llk_math_custom_mm_init<false, split_acc, dense_packing>(in0_cb_id, in1_cb_id, ct_dim)));
-    PACK((llk_pack_init<false, false>(out_cb_id)));
     if constexpr (dense_packing) {
         PACK((cfg_reg_rmw_tensix<PCK0_ADDR_CTRL_ZW_REG_0_Wstride_RMW>(
             (TILE_NUM_FACES / 2) * FACE_C_DIM * FACE_R_DIM * 2)));

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/compressed_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/compressed_custom_mm.h
@@ -99,7 +99,6 @@ ALWI void compressed_custom_mm_block_init_short(
 
     MATH((llk_math_compressed_custom_mm_init<transpose, split_acc, dense_packing>(in0_cb_id, in1_cb_id)));
 
-    PACK((llk_pack_init<false, false>(out_cb_id)));
     if constexpr (dense_packing) {
         // Reduce packing stride from tile to tile to 32 rows instead of 64
         PACK((cfg_reg_rmw_tensix<PCK0_ADDR_CTRL_ZW_REG_0_Wstride_RMW>(

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h
@@ -101,7 +101,6 @@ ALWI void custom_mm_block_init_short(
 
     MATH((llk_math_custom_mm_init<transpose, split_acc, dense_packing>(in0_cb_id, in1_cb_id, ct_dim)));
 
-    PACK((llk_pack_init<false, false>(out_cb_id)));
     if constexpr (dense_packing) {
         // Reduce packing stride from tile to tile to 32 rows instead of 64
         PACK((cfg_reg_rmw_tensix<PCK0_ADDR_CTRL_ZW_REG_0_Wstride_RMW>(

--- a/models/demos/deepseek_v3_b1/unified_kernels/create_q_heads.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/create_q_heads.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "dataflow_utils.hpp"
 #include "kernel_op_api.hpp"
 #include "kernel_utils.hpp"
 
@@ -186,10 +187,6 @@ struct CreateQHeads {
                 unified_kernels::setup_sharded_buffer(src_cb, args.src_num_pages);
             }
 
-            // Wait for source CB data to be ready
-            cb_wait_front(src_cb, args.src_num_pages);
-
-            // Get source address from CB
             uint32_t src_addr = get_read_ptr(src_cb);
 
             if (is_qnope_core) {
@@ -204,16 +201,28 @@ struct CreateQHeads {
                 // First half: tight row-major packing
                 uint32_t dst_offset_0 = my_col * half_qnope_data_size_bytes;
                 uint64_t dst_data_noc_addr_0 = dst_noc_coord | (uint64_t)(args.receiver_data_addr + dst_offset_0);
-                noc_async_write<half_qnope_data_size_bytes, true, /*posted=*/true>(
+                unified_kernels::unicast_write_set_state<true, true, true, true, false, write_cmd_buf>(
                     src_addr, dst_data_noc_addr_0, half_qnope_data_size_bytes, WRITE_NOC);
-                noc_semaphore_inc(phase1_semaphore_noc_addr, 1, WRITE_NOC);
+                unified_kernels::unicast_atomic_inc_set_state<false, true, true, false, write_at_cmd_buf>(
+                    phase1_semaphore_noc_addr, 1, 31, WRITE_NOC);
+
+                // Wait for source CB data to be ready
+                cb_wait_front(src_cb, args.src_num_pages);
+                unified_kernels::unicast_write_increment_counters<true>(2, WRITE_NOC);
+
+                unified_kernels::noc_async_write_issue_txn<true, false>(WRITE_NOC);
+                unified_kernels::unicast_atomic_inc_increment_counters<false>(2, WRITE_NOC);
+                unified_kernels::noc_async_atomic_inc_issue_txn<false, false>(WRITE_NOC);
 
                 // Second half: continues after first block
                 uint32_t dst_offset_1 = (args.qnope_cols * half_qnope_data_size_bytes) + dst_offset_0;
                 uint64_t dst_data_noc_addr_1 = dst_noc_coord | (uint64_t)(args.receiver_data_addr + dst_offset_1);
-                noc_async_write<half_qnope_data_size_bytes, true, /*posted=*/true>(
+                unified_kernels::unicast_write_set_state<true, false, true, false, false, write_cmd_buf>(
                     src_addr + half_qnope_data_size_bytes, dst_data_noc_addr_1, half_qnope_data_size_bytes, WRITE_NOC);
-                noc_semaphore_inc(phase2_semaphore_noc_addr, 1, WRITE_NOC);
+                unified_kernels::noc_async_write_issue_txn<true, false>(WRITE_NOC);
+                unified_kernels::unicast_atomic_inc_set_state<false, true, false, false, write_at_cmd_buf>(
+                    phase2_semaphore_noc_addr, 1, 31, WRITE_NOC);
+                unified_kernels::noc_async_atomic_inc_issue_txn<false, false>(WRITE_NOC);
             } else {
                 // QROPE core: Write 2 heads × 64 elements = 128 elements
                 // Memory layout: after all QNOPE data, QROPE is packed row-major [8, 64]
@@ -224,9 +233,16 @@ struct CreateQHeads {
                     (args.qnope_cols * CTArgs::qnope_data_size_bytes) + (2 * qrope_col * CTArgs::qrope_head_size_bytes);
                 uint64_t dst_data_noc_addr = dst_noc_coord | (uint64_t)(args.receiver_data_addr + dst_offset);
                 constexpr uint32_t double_qrope_head_size_bytes = CTArgs::qrope_head_size_bytes * 2;
-                noc_async_write<double_qrope_head_size_bytes, true, /*posted=*/true>(
+                unified_kernels::noc_async_write_preprogram_all_state<true>(
                     src_addr, dst_data_noc_addr, double_qrope_head_size_bytes, WRITE_NOC);
-                noc_semaphore_inc(rope_semaphore_noc_addr, 1, WRITE_NOC);
+                unified_kernels::noc_async_atomic_inc_preprogram_all_state<false>(
+                    rope_semaphore_noc_addr, 1, 31, WRITE_NOC);
+
+                // Wait for source CB data to be ready
+                cb_wait_front(src_cb, args.src_num_pages);
+
+                unified_kernels::noc_async_write_issue_txn<true>(WRITE_NOC);
+                unified_kernels::noc_async_atomic_inc_issue_txn<false>(WRITE_NOC);
             }
 
             if constexpr (!is_receiver_same_risc) {
@@ -256,23 +272,23 @@ struct CreateQHeads {
             volatile tt_l1_ptr uint32_t* rope_semaphore_ptr = (volatile tt_l1_ptr uint32_t*)args.rope_semaphore_addr;
 
             if (args.num_nope_senders > 0) {
+                cb_reserve_back(args.receiver_in_cb, args.nope_tiles);
                 noc_semaphore_wait(phase1_semaphore_ptr, args.num_nope_senders);
                 noc_semaphore_set(phase1_semaphore_ptr, 0);
-                cb_reserve_back(args.receiver_in_cb, args.nope_tiles);
                 cb_push_back(args.receiver_in_cb, args.nope_tiles);
             }
 
             if (args.num_nope_senders > 0) {
+                cb_reserve_back(args.receiver_in_cb, args.nope_tiles);
                 noc_semaphore_wait(phase2_semaphore_ptr, args.num_nope_senders);
                 noc_semaphore_set(phase2_semaphore_ptr, 0);
-                cb_reserve_back(args.receiver_in_cb, args.nope_tiles);
                 cb_push_back(args.receiver_in_cb, args.nope_tiles);
             }
 
             if (args.num_rope_senders > 0) {
+                cb_reserve_back(args.receiver_in_cb, args.rope_tiles);
                 noc_semaphore_wait(rope_semaphore_ptr, args.num_rope_senders);
                 noc_semaphore_set(rope_semaphore_ptr, 0);
-                cb_reserve_back(args.receiver_in_cb, args.rope_tiles);
                 cb_push_back(args.receiver_in_cb, args.rope_tiles);
             }
             if constexpr (is_sender_same_risc) {

--- a/models/demos/deepseek_v3_b1/unified_kernels/dataflow_utils.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dataflow_utils.hpp
@@ -1,0 +1,398 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
+#include "api/dataflow/dataflow_api.h"
+#endif
+
+namespace unified_kernels {
+
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
+
+template <bool posted>
+FORCE_INLINE void unicast_write_increment_counters(uint32_t count = 1, uint8_t noc = noc_index) {
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        if constexpr (posted) {
+            inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, count);
+        } else {
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, count);
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, count);
+        }
+    }
+
+    if constexpr (noc_mode == DM_DEDICATED_NOC) {
+        if constexpr (posted) {
+            noc_posted_writes_num_issued[noc] += count;
+        } else {
+            noc_nonposted_writes_num_issued[noc] += count;
+            noc_nonposted_writes_acked[noc] += count;
+        }
+    }
+}
+
+template <bool posted>
+FORCE_INLINE void unicast_atomic_inc_increment_counters(uint32_t count = 1, uint8_t noc = noc_index) {
+#ifdef ARCH_BLACKHOLE
+    static_assert(!posted, "Blackhole does not support posted atomics");
+#endif
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        if constexpr (!posted) {
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(noc, count);
+        }
+    }
+
+    if constexpr (noc_mode == DM_DEDICATED_NOC) {
+        if constexpr (!posted) {
+            noc_nonposted_atomics_acked[noc] += count;
+        }
+    }
+}
+
+FORCE_INLINE void noc_async_read_increment_counters(uint32_t count = 1, uint8_t noc = noc_index) {
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        inc_noc_counter_val<proc_type, NocBarrierType::READS_NUM_ISSUED>(noc, count);
+    }
+
+    if constexpr (noc_mode == DM_DEDICATED_NOC) {
+        noc_reads_num_issued[noc] += count;
+    }
+}
+
+template <bool set_noc_coord, bool set_addresses, bool set_size, bool increment_counters, uint8_t cmd_buf>
+FORCE_INLINE void unicast_read_set_state(
+    uint64_t src_noc_addr, uint32_t dst_local_addr, uint32_t len_bytes, uint8_t noc = noc_index, uint8_t vc = 1) {
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
+
+    if constexpr (increment_counters) {
+        noc_async_read_increment_counters(1, noc);
+    }
+
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        uint32_t noc_rd_cmd_field =
+            NOC_CMD_CPY | NOC_CMD_RD | NOC_CMD_RESP_MARKED | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_rd_cmd_field);
+    }
+    if constexpr (set_noc_coord) {
+        NOC_CMD_BUF_WRITE_REG(
+            noc,
+            cmd_buf,
+            NOC_TARG_ADDR_COORDINATE,
+            (uint32_t)(src_noc_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
+    }
+    if constexpr (set_size) {
+        ASSERT(len_bytes <= NOC_MAX_BURST_SIZE);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, len_bytes);
+    }
+    if constexpr (set_addresses) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)src_noc_addr);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, dst_local_addr);
+    }
+}
+
+template <bool set_addresses, bool set_size, bool wait_cmd_buf_ready, bool increment_counters, uint8_t cmd_buf>
+FORCE_INLINE void unicast_read_with_state(
+    uint32_t src_local_addr, uint32_t dst_local_addr, uint32_t len_bytes, uint8_t noc = noc_index) {
+    if constexpr (increment_counters) {
+        noc_async_read_increment_counters(1, noc);
+    }
+
+    if constexpr (wait_cmd_buf_ready) {
+        while (!noc_cmd_buf_ready(noc, cmd_buf));
+    }
+    if constexpr (set_size) {
+        ASSERT(len_bytes <= NOC_MAX_BURST_SIZE);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, len_bytes);
+    }
+    if constexpr (set_addresses) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_local_addr);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, dst_local_addr);
+    }
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+}
+
+template <bool increment_counters = false, uint8_t cmd_buf = read_cmd_buf>
+FORCE_INLINE void noc_async_read_preprogram_all_state(
+    uint64_t src_noc_addr, uint32_t dst_local_addr, uint32_t len_bytes, uint8_t noc = noc_index, uint8_t vc = 1) {
+    unicast_read_set_state<true, true, true, increment_counters, cmd_buf>(
+        src_noc_addr, dst_local_addr, len_bytes, noc, vc);
+}
+
+template <bool increment_counters = true, uint8_t cmd_buf = read_cmd_buf>
+FORCE_INLINE void noc_async_read_issue_txn(uint8_t noc = noc_index) {
+    unicast_read_with_state<false, false, false, increment_counters, cmd_buf>(0, 0, 0, noc);
+}
+
+template <bool posted, bool set_noc_coord, bool set_addresses, bool set_size, bool increment_counters, uint8_t cmd_buf>
+FORCE_INLINE void unicast_write_set_state(
+    uint32_t src_local_addr,
+    uint64_t dst_noc_addr,
+    uint32_t len_bytes,
+    uint8_t noc = noc_index,
+    uint8_t vc = NOC_UNICAST_WRITE_VC) {
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
+
+    if constexpr (increment_counters) {
+        unicast_write_increment_counters<posted>(1, noc);
+    }
+
+    uint32_t noc_cmd_field =
+        NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) | (posted ? 0 : NOC_CMD_RESP_MARKED);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
+    if constexpr (set_noc_coord) {
+        NOC_CMD_BUF_WRITE_REG(
+            noc,
+            cmd_buf,
+            NOC_RET_ADDR_COORDINATE,
+            (uint32_t)(dst_noc_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
+    }
+    if constexpr (set_size) {
+        ASSERT(len_bytes <= NOC_MAX_BURST_SIZE);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, len_bytes);
+    }
+    if constexpr (set_addresses) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_local_addr);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr);
+    }
+}
+
+template <
+    bool posted,
+    bool set_addresses,
+    bool set_size,
+    bool wait_cmd_buf_ready,
+    bool increment_counters,
+    uint8_t cmd_buf>
+FORCE_INLINE void unicast_write_with_state(
+    uint32_t src_local_addr, uint32_t dst_local_addr, uint32_t len_bytes, uint8_t noc = noc_index) {
+    if constexpr (increment_counters) {
+        unicast_write_increment_counters<posted>(1, noc);
+    }
+
+    if constexpr (wait_cmd_buf_ready) {
+        while (!noc_cmd_buf_ready(noc, cmd_buf));
+    }
+    if constexpr (set_size) {
+        ASSERT(len_bytes <= NOC_MAX_BURST_SIZE);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, len_bytes);
+    }
+    if constexpr (set_addresses) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_local_addr);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, dst_local_addr);
+    }
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+}
+
+template <bool posted, bool increment_counters = false, uint8_t cmd_buf = write_cmd_buf>
+FORCE_INLINE void noc_async_write_preprogram_all_state(
+    uint32_t src_local_addr,
+    uint64_t dst_noc_addr,
+    uint32_t len_bytes,
+    uint8_t noc = noc_index,
+    uint8_t vc = NOC_UNICAST_WRITE_VC) {
+    unicast_write_set_state<posted, true, true, true, increment_counters, cmd_buf>(
+        src_local_addr, dst_noc_addr, len_bytes, noc, vc);
+}
+
+template <bool posted, bool increment_counters = true, uint8_t cmd_buf = write_cmd_buf>
+FORCE_INLINE void noc_async_write_issue_txn(uint8_t noc = noc_index) {
+    unicast_write_with_state<posted, false, false, false, increment_counters, cmd_buf>(0, 0, 0, noc);
+}
+
+template <bool posted>
+FORCE_INLINE void multicast_write_increment_counters(uint32_t num_dests, uint8_t noc = noc_index) {
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        if constexpr (posted) {
+            inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
+        } else {
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, num_dests);
+        }
+    }
+
+    if constexpr (noc_mode == DM_DEDICATED_NOC) {
+        if constexpr (posted) {
+            noc_posted_writes_num_issued[noc] += 1;
+        } else {
+            noc_nonposted_writes_num_issued[noc] += 1;
+            noc_nonposted_writes_acked[noc] += num_dests;
+        }
+    }
+}
+
+template <bool posted, bool set_noc_coord, bool set_addresses, bool set_size, bool increment_counters, uint8_t cmd_buf>
+FORCE_INLINE void multicast_write_set_state(
+    uint32_t src_local_addr,
+    uint64_t dst_noc_addr_multicast,
+    uint32_t len_bytes,
+    uint32_t num_dests,
+    bool multicast_path_reserve = true,
+    bool linked = false,
+    uint8_t noc = noc_index,
+    uint8_t vc = NOC_MULTICAST_WRITE_VC) {
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
+
+    if constexpr (increment_counters) {
+        multicast_write_increment_counters<posted>(num_dests, noc);
+    }
+
+    uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) |
+                             (linked ? NOC_CMD_VC_LINKED : 0x0) |
+                             (multicast_path_reserve ? NOC_CMD_PATH_RESERVE : 0x0) | NOC_CMD_BRCST_PACKET |
+                             (posted ? 0 : NOC_CMD_RESP_MARKED);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
+    if constexpr (set_noc_coord) {
+        NOC_CMD_BUF_WRITE_REG(
+            noc,
+            cmd_buf,
+            NOC_RET_ADDR_COORDINATE,
+            (uint32_t)(dst_noc_addr_multicast >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
+    }
+    if constexpr (set_size) {
+        ASSERT(len_bytes <= NOC_MAX_BURST_SIZE);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, len_bytes);
+    }
+    if constexpr (set_addresses) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_local_addr);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr_multicast);
+    }
+}
+
+template <
+    bool posted,
+    bool set_addresses,
+    bool set_size,
+    bool wait_cmd_buf_ready,
+    bool increment_counters,
+    uint8_t cmd_buf>
+FORCE_INLINE void multicast_write_with_state(
+    uint32_t src_local_addr, uint32_t dst_local_addr, uint32_t len_bytes, uint32_t num_dests, uint8_t noc = noc_index) {
+    if constexpr (increment_counters) {
+        multicast_write_increment_counters<posted>(num_dests, noc);
+    }
+
+    if constexpr (wait_cmd_buf_ready) {
+        while (!noc_cmd_buf_ready(noc, cmd_buf));
+    }
+    if constexpr (set_size) {
+        ASSERT(len_bytes <= NOC_MAX_BURST_SIZE);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, len_bytes);
+    }
+    if constexpr (set_addresses) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_local_addr);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, dst_local_addr);
+    }
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+}
+
+template <bool posted, bool increment_counters = false, uint8_t cmd_buf = write_cmd_buf>
+FORCE_INLINE void noc_async_write_multicast_preprogram_all_state(
+    uint32_t src_local_addr,
+    uint64_t dst_noc_addr_multicast,
+    uint32_t len_bytes,
+    uint32_t num_dests,
+    bool multicast_path_reserve = true,
+    bool linked = false,
+    uint8_t noc = noc_index,
+    uint8_t vc = NOC_MULTICAST_WRITE_VC) {
+    multicast_write_set_state<posted, true, true, true, increment_counters, cmd_buf>(
+        src_local_addr, dst_noc_addr_multicast, len_bytes, num_dests, multicast_path_reserve, linked, noc, vc);
+}
+
+template <bool posted, bool increment_counters = true, uint8_t cmd_buf = write_cmd_buf>
+FORCE_INLINE void noc_async_write_multicast_issue_txn(uint32_t num_dests, uint8_t noc = noc_index) {
+    multicast_write_with_state<posted, false, false, false, increment_counters, cmd_buf>(0, 0, 0, num_dests, noc);
+}
+
+template <bool posted, bool set_addr, bool set_incr, bool increment_counters, uint8_t cmd_buf>
+FORCE_INLINE void unicast_atomic_inc_set_state(
+    uint64_t addr,
+    uint32_t incr,
+    uint32_t wrap = 31,
+    uint8_t noc = noc_index,
+    uint8_t vc = NOC_UNICAST_WRITE_VC,
+    uint32_t atomic_ret_val = MEM_NOC_ATOMIC_RET_VAL_ADDR) {
+#ifdef ARCH_BLACKHOLE
+    static_assert(!posted, "Blackhole does not support posted atomics");
+#endif
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
+    if constexpr (increment_counters) {
+        unicast_atomic_inc_increment_counters<posted>(1, noc);
+    }
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        uint32_t noc_id_reg = NOC_CMD_BUF_READ_REG(noc, 0, NOC_NODE_ID);
+        uint32_t my_x = noc_id_reg & NOC_NODE_ID_MASK;
+        uint32_t my_y = (noc_id_reg >> NOC_ADDR_NODE_ID_BITS) & NOC_NODE_ID_MASK;
+        uint64_t atomic_ret_addr = NOC_XY_ADDR(my_x, my_y, atomic_ret_val);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)(atomic_ret_addr & 0xFFFFFFFF));
+    }
+    if constexpr (set_addr) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(addr & 0xFFFFFFFF));
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(addr >> NOC_ADDR_COORD_SHIFT));
+        NOC_CMD_BUF_WRITE_REG(
+            noc,
+            cmd_buf,
+            NOC_AT_LEN_BE,
+            NOC_AT_INS(NOC_AT_INS_INCR_GET) | NOC_AT_WRAP(wrap) | NOC_AT_IND_32((addr >> 2) & 0x3) |
+                NOC_AT_IND_32_SRC(0));
+    }
+    if constexpr (set_incr) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, incr);
+    }
+    NOC_CMD_BUF_WRITE_REG(
+        noc,
+        cmd_buf,
+        NOC_CTRL,
+        NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) | (posted ? 0 : NOC_CMD_RESP_MARKED) | NOC_CMD_AT);
+}
+
+template <bool posted, bool set_addr, bool set_incr, bool wait_cmd_buf_ready, bool increment_counters, uint8_t cmd_buf>
+FORCE_INLINE void unicast_atomic_inc_with_state(
+    uint64_t addr, uint32_t incr, uint32_t wrap = 31, uint8_t noc = noc_index) {
+#ifdef ARCH_BLACKHOLE
+    static_assert(!posted, "Blackhole does not support posted atomics");
+#endif
+    if constexpr (increment_counters) {
+        unicast_atomic_inc_increment_counters<posted>(1, noc);
+    }
+
+    if constexpr (wait_cmd_buf_ready) {
+        while (!noc_cmd_buf_ready(noc, cmd_buf));
+    }
+    if constexpr (set_addr) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(addr & 0xFFFFFFFF));
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(addr >> NOC_ADDR_COORD_SHIFT));
+        NOC_CMD_BUF_WRITE_REG(
+            noc,
+            cmd_buf,
+            NOC_AT_LEN_BE,
+            NOC_AT_INS(NOC_AT_INS_INCR_GET) | NOC_AT_WRAP(wrap) | NOC_AT_IND_32((addr >> 2) & 0x3) |
+                NOC_AT_IND_32_SRC(0));
+    }
+    if constexpr (set_incr) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, incr);
+    }
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+}
+
+template <bool posted, bool increment_counters = false, uint8_t cmd_buf = write_at_cmd_buf>
+FORCE_INLINE void noc_async_atomic_inc_preprogram_all_state(
+    uint64_t addr,
+    uint32_t incr,
+    uint32_t wrap = 31,
+    uint8_t noc = noc_index,
+    uint8_t vc = NOC_UNICAST_WRITE_VC,
+    uint32_t atomic_ret_val = MEM_NOC_ATOMIC_RET_VAL_ADDR) {
+    unicast_atomic_inc_set_state<posted, true, true, increment_counters, cmd_buf>(
+        addr, incr, wrap, noc, vc, atomic_ret_val);
+}
+
+template <bool posted, bool increment_counters = true, uint8_t cmd_buf = write_at_cmd_buf>
+FORCE_INLINE void noc_async_atomic_inc_issue_txn(uint8_t noc = noc_index) {
+    unicast_atomic_inc_with_state<posted, false, false, false, increment_counters, cmd_buf>(0, 0, 31, noc);
+}
+
+#endif  // defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
+
+}  // namespace unified_kernels

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_experts_matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_experts_matmul.hpp
@@ -13,7 +13,6 @@
 #include <cstdint>
 #include "api/compute/tile_move_copy.h"
 #include "../kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h"
-#include "../kernel_includes/tt_metal/include/compute_kernel_api/deepseek_compute_kernel_hw_startup.h"
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/reconfig_data_format.h"
 #include "api/compute/pack.h"
@@ -157,6 +156,32 @@ struct DRAMStreamingExpertsMatmul {
             constexpr uint32_t dram_bank_id = CTArgs::bank_id;
             constexpr uint32_t vc = CTArgs::vc;
 
+            // Setup DRAM read for in1 — issued before the indexing block so the NOC
+            // cmd-buf register writes overlap with the cb_wait_front on the index CB.
+            uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, CTArgs::in1_tensor_addr);
+
+            // Previous multicasts could have put trids into a non-zero state, so reset the barrier counter
+            reset_noc_trid_barrier_counter(NOC_CLEAR_OUTSTANDING_REQ_MASK, noc_index);
+
+            // Set up NOC state for page reads
+            noc_async_read_one_packet_set_state<true>(in1_base_addr, CTArgs::in1_page_size, vc);
+
+            // Triple-buffering with transaction IDs for pipelining
+            constexpr uint32_t num_buffers = 3;
+            constexpr uint32_t extra_blocks_in_flight = 1;
+
+            cb_reserve_back(CTArgs::cb_in1, CTArgs::subblock_k * (extra_blocks_in_flight + 1));
+            uint32_t l1_write_addr_in1 = get_write_ptr(CTArgs::cb_in1);
+
+            // CB base for boundary wrapping: compile-time addr when looping, runtime addr otherwise
+            uint32_t cb_in1_base;
+            if constexpr (ResetCBIn1) {
+                cb_in1_base = CBIn1ResetAddr;
+            } else {
+                cb_in1_base = l1_write_addr_in1;  // fresh kernel: get_write_ptr == CB base
+            }
+            uint32_t cb_in1_end = cb_in1_base + num_buffers * CTArgs::in1_block_size_bytes;
+
             // Expert indexing: compute DRAM offsets for all selected experts
             constexpr uint32_t k_tiles = CTArgs::num_subblocks_k * CTArgs::subblock_k;
             constexpr uint32_t bytes_per_tile = CTArgs::in1_block_size_bytes / CTArgs::subblock_k;
@@ -184,34 +209,9 @@ struct DRAMStreamingExpertsMatmul {
                 }
             }
 
-            // Previous multicasts could have put trids into a non-zero state, so reset the barrier counter
-            reset_noc_trid_barrier_counter(NOC_CLEAR_OUTSTANDING_REQ_MASK, noc_index);
-
-            // Setup DRAM read for in1
-            uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, CTArgs::in1_tensor_addr);
-            uint32_t l1_write_addr_in1;
-
-            // Set up NOC state for page reads
-            noc_async_read_one_packet_set_state<true>(in1_base_addr, CTArgs::in1_page_size, vc);
-
-            // Triple-buffering with transaction IDs for pipelining
-            constexpr uint32_t num_buffers = 3;
-            constexpr uint32_t extra_blocks_in_flight = 1;
             uint32_t num_free_blocks_in_buffer = num_buffers;
             uint32_t curr_block_trid = 1;
             uint32_t block_trid_to_wait = 1;
-
-            cb_reserve_back(CTArgs::cb_in1, CTArgs::subblock_k * (extra_blocks_in_flight + 1));
-            l1_write_addr_in1 = get_write_ptr(CTArgs::cb_in1);
-
-            // CB base for boundary wrapping: compile-time addr when looping, runtime addr otherwise
-            uint32_t cb_in1_base;
-            if constexpr (ResetCBIn1) {
-                cb_in1_base = CBIn1ResetAddr;
-            } else {
-                cb_in1_base = l1_write_addr_in1;  // fresh kernel: get_write_ptr == CB base
-            }
-            uint32_t cb_in1_end = cb_in1_base + num_buffers * CTArgs::in1_block_size_bytes;
 
             // Outer loop over experts, inner loop streams one expert's weight tiles.
             // Pipeline state (trid, free blocks, L1 write addr) flows continuously;
@@ -272,16 +272,17 @@ struct DRAMStreamingExpertsMatmul {
             constexpr bool split_acc = true;
             constexpr bool dense_packing = false;
 
+            reconfig_data_format<false, true>(CTArgs::cb_in1, CTArgs::cb_in0);
+            pack_reconfig_data_format<true>(CTArgs::cb_out);
+            custom_mm_block_init_short<transpose, split_acc, dense_packing>(
+                CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
             if constexpr (CTArgs::fp32_dest_acc_en != DST_ACCUM_MODE) {
-                custom_mm_block_init<transpose, split_acc, dense_packing, CTArgs::fp32_dest_acc_en>(
-                    CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
-            } else {
-                reconfig_data_format<false, true>(CTArgs::cb_in1, CTArgs::cb_in0);
-                pack_reconfig_data_format<true>(CTArgs::cb_out);
-                custom_mm_block_init_short<transpose, split_acc, dense_packing>(
-                    CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
+                if constexpr (CTArgs::fp32_dest_acc_en) {
+                    enable_fp32_dest_acc();
+                } else {
+                    disable_fp32_dest_acc();
+                }
             }
-
             if constexpr (CTArgs::fuse_silu) {
                 PACK((llk_math_eltwise_unary_sfpu_silu_init<false>()));
             }
@@ -317,10 +318,10 @@ struct DRAMStreamingExpertsMatmul {
                         tile_regs_commit();
 
                         // Run SiLU on PACK thread
-                        TTI_SEMWAIT(
+                        PACK(TTI_SEMWAIT(
                             p_stall::STALL_TDMA | p_stall::STALL_CFG,
                             semaphore::t6_sem(semaphore::MATH_PACK),
-                            p_stall::STALL_ON_ZERO);
+                            p_stall::STALL_ON_ZERO));
                         PACK(TT_SETC16(
                             DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, ckernel::packer::get_packer_dest_offset()));
 
@@ -377,7 +378,11 @@ struct DRAMStreamingExpertsMatmul {
             custom_mm_block_uninit<dense_packing>();
             // Reset FP32 accum mode if different from DST_ACCUM_MODE
             if constexpr (CTArgs::fp32_dest_acc_en != DST_ACCUM_MODE) {
-                deepseek_compute_kernel_hw_startup<DST_ACCUM_MODE>(CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
+                if constexpr (CTArgs::fp32_dest_acc_en) {
+                    disable_fp32_dest_acc();
+                } else {
+                    enable_fp32_dest_acc();
+                }
             }
 
             if constexpr (PopIn0) {

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_experts_matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_experts_matmul.hpp
@@ -272,17 +272,16 @@ struct DRAMStreamingExpertsMatmul {
             constexpr bool split_acc = true;
             constexpr bool dense_packing = false;
 
-            reconfig_data_format<false, true>(CTArgs::cb_in1, CTArgs::cb_in0);
-            pack_reconfig_data_format<true>(CTArgs::cb_out);
-            custom_mm_block_init_short<transpose, split_acc, dense_packing>(
-                CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
             if constexpr (CTArgs::fp32_dest_acc_en != DST_ACCUM_MODE) {
-                if constexpr (CTArgs::fp32_dest_acc_en) {
-                    enable_fp32_dest_acc();
-                } else {
-                    disable_fp32_dest_acc();
-                }
+                custom_mm_block_init<transpose, split_acc, dense_packing, CTArgs::fp32_dest_acc_en>(
+                    CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
+            } else {
+                reconfig_data_format<false, true>(CTArgs::cb_in1, CTArgs::cb_in0);
+                pack_reconfig_data_format<true>(CTArgs::cb_out);
+                custom_mm_block_init_short<transpose, split_acc, dense_packing>(
+                    CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
             }
+
             if constexpr (CTArgs::fuse_silu) {
                 PACK((llk_math_eltwise_unary_sfpu_silu_init<false>()));
             }
@@ -378,11 +377,7 @@ struct DRAMStreamingExpertsMatmul {
             custom_mm_block_uninit<dense_packing>();
             // Reset FP32 accum mode if different from DST_ACCUM_MODE
             if constexpr (CTArgs::fp32_dest_acc_en != DST_ACCUM_MODE) {
-                if constexpr (CTArgs::fp32_dest_acc_en) {
-                    disable_fp32_dest_acc();
-                } else {
-                    enable_fp32_dest_acc();
-                }
+                deepseek_compute_kernel_hw_startup<DST_ACCUM_MODE>(CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
             }
 
             if constexpr (PopIn0) {

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul.hpp
@@ -13,7 +13,6 @@
 #include <cstdint>
 #include "api/compute/tile_move_copy.h"
 #include "../kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h"
-#include "../kernel_includes/tt_metal/include/compute_kernel_api/deepseek_compute_kernel_hw_startup.h"
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/reconfig_data_format.h"
 #include "api/compute/pack.h"
@@ -152,6 +151,33 @@ struct DRAMStreamingMatmul {
             constexpr uint32_t dram_bank_id = CTArgs::bank_id;
             constexpr uint32_t vc = CTArgs::vc;
 
+            // Setup DRAM read for in1 — issued before the indexing block so the NOC
+            // cmd-buf register writes overlap with the cb_wait_front on the index CB.
+            uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, CTArgs::in1_tensor_addr);
+
+            // Previous multicasts could have put trids into a non-zero state, so reset the barrier counter
+            reset_noc_trid_barrier_counter(NOC_CLEAR_OUTSTANDING_REQ_MASK, noc_index);
+
+            // Set up NOC state for page reads
+            noc_async_read_one_packet_set_state<true>(in1_base_addr, CTArgs::in1_page_size, vc);
+
+            constexpr uint32_t num_buffers = NumBuffers;
+            static_assert(num_buffers >= 2, "Need at least double buffering");
+            constexpr uint32_t extra_blocks_in_flight = (num_buffers >= 3) ? 1 : 0;
+
+            cb_reserve_back(CTArgs::cb_in1, CTArgs::subblock_k * (extra_blocks_in_flight + 1));
+            uint32_t l1_write_addr_in1 = get_write_ptr(CTArgs::cb_in1);
+
+            // CB base for boundary wrapping: compile-time addr when looping, runtime addr otherwise
+            uint32_t cb_in1_base;
+            if constexpr (ResetCBIn1) {
+                cb_in1_base = CBIn1ResetAddr;
+            } else {
+                auto& cb_in1_iface = get_local_cb_interface(CTArgs::cb_in1);
+                cb_in1_base = cb_in1_iface.fifo_limit - cb_in1_iface.fifo_size;
+            }
+            uint32_t cb_in1_end = cb_in1_base + num_buffers * CTArgs::in1_block_size_bytes;
+
             // Expert indexing: compute DRAM offset based on expert index.
             // Contract: for a given projection (gate/up/down), all expert weight tensors must
             // be packed contiguously in DRAM starting at in1_tensor_addr (base of expert 0).
@@ -182,36 +208,11 @@ struct DRAMStreamingMatmul {
                 expert_offset_bytes = expert_idx * expert_size_bytes;
             }
 
-            // Previous multicasts could have put trids into a non-zero state, so reset the barrier counter
-            reset_noc_trid_barrier_counter(NOC_CLEAR_OUTSTANDING_REQ_MASK, noc_index);
-
-            // Setup DRAM read for in1
-            uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, CTArgs::in1_tensor_addr);
-            uint32_t l1_write_addr_in1;
             uint32_t l1_read_addr_in1 = expert_offset_bytes;
 
-            // Set up NOC state for page reads
-            noc_async_read_one_packet_set_state<true>(in1_base_addr, CTArgs::in1_page_size, vc);
-
-            constexpr uint32_t num_buffers = NumBuffers;
-            static_assert(num_buffers >= 2, "Need at least double buffering");
-            constexpr uint32_t extra_blocks_in_flight = (num_buffers >= 3) ? 1 : 0;
             uint32_t num_free_blocks_in_buffer = num_buffers;
             uint32_t curr_block_trid = 1;
             uint32_t block_trid_to_wait = 1;
-
-            cb_reserve_back(CTArgs::cb_in1, CTArgs::subblock_k * (extra_blocks_in_flight + 1));
-            l1_write_addr_in1 = get_write_ptr(CTArgs::cb_in1);
-
-            // CB base for boundary wrapping: compile-time addr when looping, runtime addr otherwise
-            uint32_t cb_in1_base;
-            if constexpr (ResetCBIn1) {
-                cb_in1_base = CBIn1ResetAddr;
-            } else {
-                auto& cb_in1_iface = get_local_cb_interface(CTArgs::cb_in1);
-                cb_in1_base = cb_in1_iface.fifo_limit - cb_in1_iface.fifo_size;
-            }
-            uint32_t cb_in1_end = cb_in1_base + num_buffers * CTArgs::in1_block_size_bytes;
 
             // Read in1: for each N column, read num_subblocks_k K subblocks
             for (uint32_t n = 0; n < num_iterations; ++n) {
@@ -267,16 +268,17 @@ struct DRAMStreamingMatmul {
             constexpr bool split_acc = true;
             constexpr bool dense_packing = false;
 
+            reconfig_data_format<false, true>(CTArgs::cb_in1, CTArgs::cb_in0);
+            pack_reconfig_data_format<true>(CTArgs::cb_out);
+            custom_mm_block_init_short<transpose, split_acc, dense_packing>(
+                CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
             if constexpr (CTArgs::fp32_dest_acc_en != DST_ACCUM_MODE) {
-                custom_mm_block_init<transpose, split_acc, dense_packing, CTArgs::fp32_dest_acc_en>(
-                    CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
-            } else {
-                reconfig_data_format<false, true>(CTArgs::cb_in1, CTArgs::cb_in0);
-                pack_reconfig_data_format<true>(CTArgs::cb_out);
-                custom_mm_block_init_short<transpose, split_acc, dense_packing>(
-                    CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
+                if constexpr (CTArgs::fp32_dest_acc_en) {
+                    enable_fp32_dest_acc();
+                } else {
+                    disable_fp32_dest_acc();
+                }
             }
-
             if constexpr (CTArgs::fuse_silu) {
                 PACK((llk_math_eltwise_unary_sfpu_silu_init<true>()));
             } else {
@@ -314,10 +316,10 @@ struct DRAMStreamingMatmul {
                         tile_regs_commit();
 
                         // Run SiLU on PACK thread
-                        TTI_SEMWAIT(
+                        PACK(TTI_SEMWAIT(
                             p_stall::STALL_TDMA | p_stall::STALL_CFG,
                             semaphore::t6_sem(semaphore::MATH_PACK),
-                            p_stall::STALL_ON_ZERO);
+                            p_stall::STALL_ON_ZERO));
                         PACK(TT_SETC16(
                             DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, ckernel::packer::get_packer_dest_offset()));
 
@@ -369,7 +371,11 @@ struct DRAMStreamingMatmul {
             custom_mm_block_uninit<dense_packing>();
             // Reset FP32 accum mode if different from DST_ACCUM_MODE
             if constexpr (CTArgs::fp32_dest_acc_en != DST_ACCUM_MODE) {
-                deepseek_compute_kernel_hw_startup<DST_ACCUM_MODE>(CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
+                if constexpr (CTArgs::fp32_dest_acc_en) {
+                    disable_fp32_dest_acc();
+                } else {
+                    enable_fp32_dest_acc();
+                }
             }
 
             if constexpr (PopIn0) {

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul.hpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include "api/compute/tile_move_copy.h"
 #include "../kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h"
+#include "../kernel_includes/tt_metal/include/compute_kernel_api/deepseek_compute_kernel_hw_startup.h"
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/reconfig_data_format.h"
 #include "api/compute/pack.h"
@@ -268,17 +269,16 @@ struct DRAMStreamingMatmul {
             constexpr bool split_acc = true;
             constexpr bool dense_packing = false;
 
-            reconfig_data_format<false, true>(CTArgs::cb_in1, CTArgs::cb_in0);
-            pack_reconfig_data_format<true>(CTArgs::cb_out);
-            custom_mm_block_init_short<transpose, split_acc, dense_packing>(
-                CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
             if constexpr (CTArgs::fp32_dest_acc_en != DST_ACCUM_MODE) {
-                if constexpr (CTArgs::fp32_dest_acc_en) {
-                    enable_fp32_dest_acc();
-                } else {
-                    disable_fp32_dest_acc();
-                }
+                custom_mm_block_init<transpose, split_acc, dense_packing, CTArgs::fp32_dest_acc_en>(
+                    CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
+            } else {
+                reconfig_data_format<false, true>(CTArgs::cb_in1, CTArgs::cb_in0);
+                pack_reconfig_data_format<true>(CTArgs::cb_out);
+                custom_mm_block_init_short<transpose, split_acc, dense_packing>(
+                    CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
             }
+
             if constexpr (CTArgs::fuse_silu) {
                 PACK((llk_math_eltwise_unary_sfpu_silu_init<true>()));
             } else {
@@ -371,11 +371,7 @@ struct DRAMStreamingMatmul {
             custom_mm_block_uninit<dense_packing>();
             // Reset FP32 accum mode if different from DST_ACCUM_MODE
             if constexpr (CTArgs::fp32_dest_acc_en != DST_ACCUM_MODE) {
-                if constexpr (CTArgs::fp32_dest_acc_en) {
-                    disable_fp32_dest_acc();
-                } else {
-                    enable_fp32_dest_acc();
-                }
+                deepseek_compute_kernel_hw_startup<DST_ACCUM_MODE>(CTArgs::cb_in0, CTArgs::cb_in1, CTArgs::cb_out);
             }
 
             if constexpr (PopIn0) {

--- a/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul_compressed.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/dram_streaming_matmul_compressed.hpp
@@ -13,7 +13,6 @@
 #include <cstdint>
 #include "api/compute/tile_move_copy.h"
 #include "../kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h"
-#include "../kernel_includes/tt_metal/include/compute_kernel_api/deepseek_compute_kernel_hw_startup.h"
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/reconfig_data_format.h"
 #include "api/compute/pack.h"
@@ -145,17 +144,13 @@ struct DRAMStreamingMatmulCompressed {
             uint64_t next_noc_addr = get_noc_addr(CTArgs::next_core_noc_x, CTArgs::next_core_noc_y, 0);
             uint64_t next_sem_noc_addr = next_noc_addr | (uint64_t)next_sem_l1;
 
-            // --- Wait for previous core before first batch ---
-            if constexpr (CTArgs::core_in_bank_idx > 0) {
-                noc_semaphore_wait(sem_ptr, 1);
-                noc_semaphore_set(sem_ptr, 0);
-            }
-
             reset_noc_trid_barrier_counter(NOC_CLEAR_OUTSTANDING_REQ_MASK, noc_index);
 
             uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, CTArgs::in1_tensor_addr);
-            uint32_t l1_write_addr_in1;
             uint32_t dram_read_offset = CTArgs::dram_start_offset;
+
+            noc_async_read_one_packet_set_state<true>(in1_base_addr, max_page_size, vc);
+            uint32_t programmed_size = max_page_size;
 
             // Triple-buffering with transaction IDs
             constexpr uint32_t num_buffers = 3;
@@ -165,12 +160,18 @@ struct DRAMStreamingMatmulCompressed {
             uint32_t block_trid_to_wait = 1;
             // Reserve initial space
             cb_reserve_back(CTArgs::cb_in1, CTArgs::subblock_k * (extra_blocks_in_flight + 1));
-            l1_write_addr_in1 = get_write_ptr(CTArgs::cb_in1);
+            uint32_t l1_write_addr_in1 = get_write_ptr(CTArgs::cb_in1);
 
             uint32_t cb_in1_base = l1_write_addr_in1;
             uint32_t cb_in1_end = cb_in1_base + CTArgs::cb_in1_size_bytes;
 
             constexpr uint32_t max_subblock_bytes = CTArgs::cb_in1_size_bytes / num_buffers;
+
+            // --- Wait for previous core before first batch ---
+            if constexpr (CTArgs::core_in_bank_idx > 0) {
+                noc_semaphore_wait(sem_ptr, 1);
+                noc_semaphore_set(sem_ptr, 0);
+            }
 
             uint32_t iter = 0;
             while (iter < num_iterations) {
@@ -185,7 +186,13 @@ struct DRAMStreamingMatmulCompressed {
                     uint32_t remaining = block_size;
                     while (remaining > 0) {
                         uint32_t chunk = (remaining > max_page_size) ? max_page_size : remaining;
-                        noc_async_read_one_packet_set_state<true>(in1_base_addr, chunk, vc);
+                        // Re-program size only when it differs from what's currently
+                        // in the cmd-buf (i.e. trailing partial packet, or first
+                        // packet of the next block after a partial trailer).
+                        if (chunk != programmed_size) {
+                            noc_async_read_one_packet_set_state<true>(in1_base_addr, chunk, vc);
+                            programmed_size = chunk;
+                        }
                         noc_async_read_one_packet_with_state_with_trid(
                             in1_base_addr, dram_read_offset, l1_write_addr_in1, curr_block_trid);
                         dram_read_offset += chunk;

--- a/models/demos/deepseek_v3_b1/unified_kernels/eltwise_mul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/eltwise_mul.hpp
@@ -17,7 +17,6 @@
 #include "api/compute/compute_kernel_hw_startup.h"
 #include "api/compute/bcast.h"
 #include "../kernel_includes/tt_metal/include/compute_kernel_api/eltwise_mul_scalar.h"
-#include "../kernel_includes/tt_metal/include/compute_kernel_api/deepseek_compute_kernel_hw_startup.h"
 using namespace ckernel;
 #endif
 
@@ -161,15 +160,16 @@ struct EltwiseMul {
 
             if constexpr (CTArgs::enable_scalar) {
                 // ---- 3-way multiply: in0 * scalar -> dest, then dest * in1 -> dest ----
-                if constexpr (CTArgs::fp32_dest_acc_en != DST_ACCUM_MODE) {
-                    deepseek_compute_kernel_hw_startup<CTArgs::fp32_dest_acc_en>(
-                        CTArgs::cb_in0, CTArgs::cb_scalar, CTArgs::cb_out);
-                } else {
-                    reconfig_data_format<false, true>(CTArgs::cb_in0, CTArgs::cb_scalar);
-                    pack_reconfig_data_format<true>(CTArgs::cb_out);
-                }
+                reconfig_data_format<false, true>(CTArgs::cb_in0, CTArgs::cb_scalar);
+                pack_reconfig_data_format<true>(CTArgs::cb_out);
                 deepseek_mul_tiles_bcast_scalar_init_short(CTArgs::cb_in0, CTArgs::cb_scalar);
-
+                if constexpr (CTArgs::fp32_dest_acc_en != DST_ACCUM_MODE) {
+                    if constexpr (CTArgs::fp32_dest_acc_en) {
+                        enable_fp32_dest_acc();
+                    } else {
+                        disable_fp32_dest_acc();
+                    }
+                }
                 tile_regs_acquire();
 
                 // Step 1: cb_in0 * scalar -> dest (using scalar broadcast)
@@ -215,7 +215,11 @@ struct EltwiseMul {
             }
             // Reset FP32 accum mode if different from DST_ACCUM_MODE
             if constexpr (CTArgs::enable_scalar && CTArgs::fp32_dest_acc_en != DST_ACCUM_MODE) {
-                deepseek_compute_kernel_hw_startup<DST_ACCUM_MODE>(CTArgs::cb_in0, CTArgs::cb_scalar, CTArgs::cb_out);
+                if constexpr (CTArgs::fp32_dest_acc_en) {
+                    disable_fp32_dest_acc();
+                } else {
+                    enable_fp32_dest_acc();
+                }
             }
 #endif
         }

--- a/models/demos/deepseek_v3_b1/unified_kernels/eltwise_mul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/eltwise_mul.hpp
@@ -17,6 +17,7 @@
 #include "api/compute/compute_kernel_hw_startup.h"
 #include "api/compute/bcast.h"
 #include "../kernel_includes/tt_metal/include/compute_kernel_api/eltwise_mul_scalar.h"
+#include "../kernel_includes/tt_metal/include/compute_kernel_api/deepseek_compute_kernel_hw_startup.h"
 using namespace ckernel;
 #endif
 
@@ -160,16 +161,14 @@ struct EltwiseMul {
 
             if constexpr (CTArgs::enable_scalar) {
                 // ---- 3-way multiply: in0 * scalar -> dest, then dest * in1 -> dest ----
-                reconfig_data_format<false, true>(CTArgs::cb_in0, CTArgs::cb_scalar);
-                pack_reconfig_data_format<true>(CTArgs::cb_out);
-                deepseek_mul_tiles_bcast_scalar_init_short(CTArgs::cb_in0, CTArgs::cb_scalar);
                 if constexpr (CTArgs::fp32_dest_acc_en != DST_ACCUM_MODE) {
-                    if constexpr (CTArgs::fp32_dest_acc_en) {
-                        enable_fp32_dest_acc();
-                    } else {
-                        disable_fp32_dest_acc();
-                    }
+                    deepseek_compute_kernel_hw_startup<CTArgs::fp32_dest_acc_en>(
+                        CTArgs::cb_in0, CTArgs::cb_scalar, CTArgs::cb_out);
+                } else {
+                    reconfig_data_format<false, true>(CTArgs::cb_in0, CTArgs::cb_scalar);
+                    pack_reconfig_data_format<true>(CTArgs::cb_out);
                 }
+                deepseek_mul_tiles_bcast_scalar_init_short(CTArgs::cb_in0, CTArgs::cb_scalar);
                 tile_regs_acquire();
 
                 // Step 1: cb_in0 * scalar -> dest (using scalar broadcast)
@@ -215,11 +214,7 @@ struct EltwiseMul {
             }
             // Reset FP32 accum mode if different from DST_ACCUM_MODE
             if constexpr (CTArgs::enable_scalar && CTArgs::fp32_dest_acc_en != DST_ACCUM_MODE) {
-                if constexpr (CTArgs::fp32_dest_acc_en) {
-                    disable_fp32_dest_acc();
-                } else {
-                    enable_fp32_dest_acc();
-                }
+                deepseek_compute_kernel_hw_startup<DST_ACCUM_MODE>(CTArgs::cb_in0, CTArgs::cb_scalar, CTArgs::cb_out);
             }
 #endif
         }

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -9,9 +9,11 @@
 #if defined(COMPILE_FOR_BRISC)
 #include "api/dataflow/dataflow_api.h"
 #include "mcast.hpp"
+#include "dataflow_utils.hpp"
 #elif defined(COMPILE_FOR_NCRISC)
 #include "api/dataflow/dataflow_api.h"
 #include "mcast.hpp"
+#include "dataflow_utils.hpp"
 #include "api/debug/assert.h"
 #elif defined(COMPILE_FOR_TRISC)
 #include <cstdint>
@@ -311,6 +313,12 @@ struct FlashMLADecode {
             // Only the core handling the last chunk needs to wait for the KV cache cur pos ready
             bool wait_for_kv_cache_ready = k_chunk_end == k_num_chunks;
             uint32_t loop_iter = 0;
+            if (is_mcast_sender && BRISC_MCAST_LOOPS > 0) {
+                noc_semaphore_set(mcast_semaphore_ptr, MCAST_VALID);
+            } else if (!is_mcast_sender) {
+                unified_kernels::unicast_atomic_inc_set_state<false, true, true, false, write_at_cmd_buf>(
+                    sender_receiver_ready_noc_addr, 1, 31, ATOMIC_NOC_INDEX);
+            }
             for (uint32_t k_chunk = k_chunk_start; k_chunk < k_chunk_end; k_chunk += args.num_cores_per_head) {
                 {
                     DeviceZoneScopedN("reader-k-read");
@@ -349,7 +357,6 @@ struct FlashMLADecode {
                                 false,
                                 MCAST_NOC_INDEX);
 
-                            noc_semaphore_set(mcast_semaphore_ptr, MCAST_VALID);
                             noc_semaphore_set_multicast(
                                 args.mcast_semaphore_addr,
                                 brisc_mcast_sem_addr,
@@ -369,13 +376,22 @@ struct FlashMLADecode {
                             reset_noc_trid_barrier_counter(NOC_CLEAR_OUTSTANDING_REQ_MASK, READ_NOC_INDEX);
                         }
 
-                        constexpr uint32_t NUM_TRIDS = NOC_MAX_TRANSACTION_ID - 1;
+                        // Cycle through the free trid range owned by user-defined transactions.
+                        // Reserved trids for built-in writes/atomics/reads are declared in
+                        // unified_kernels::{write,write_reg,write_at,read}_trid (see dataflow_common.hpp).
+                        constexpr uint32_t TRID_MIN = 1;
+                        constexpr uint32_t NUM_TRIDS = NOC_MAX_TRANSACTION_ID - TRID_MIN + 1;
+                        constexpr uint32_t TRID_MAX = TRID_MIN + NUM_TRIDS - 1;
+                        static_assert(TRID_MIN >= 1, "trid 0 is reserved");
+                        static_assert(TRID_MAX <= NOC_MAX_TRANSACTION_ID);
+                        static_assert(NUM_TRIDS >= 1);
+
                         uint32_t src_base_addr = (uint32_t)(k_src_noc_addr & 0xFFFFFFFF);
                         uint32_t src_offset = 0;
                         uint32_t dst_addr = k_write_ptr;
 
-                        uint32_t curr_trid = 1;
-                        uint32_t wait_trid = 1;
+                        uint32_t curr_trid = TRID_MIN;
+                        uint32_t wait_trid = TRID_MIN;
                         uint32_t pages_issued = 0;
                         uint32_t pages_completed = 0;
                         if (wait_for_kv_cache_ready && (k_chunk + args.num_cores_per_head) >= k_chunk_end) {
@@ -385,20 +401,20 @@ struct FlashMLADecode {
 
                         noc_semaphore_wait(ncrisc_brisc_sync_curr_ptr, 0);
                         *k_write_curr_ptr_shared = k_write_ptr;
+                        noc_semaphore_set(ncrisc_brisc_sync_curr_ptr, 1);
                         for (uint32_t i = 0; i < NUM_TRIDS && pages_issued < args.k_num_pages; ++i) {
                             noc_async_read_set_trid(curr_trid, READ_NOC_INDEX);
                             noc_async_read_one_packet_with_state_with_trid(
                                 src_base_addr, src_offset, dst_addr, curr_trid, READ_NOC_INDEX);
                             src_offset += args.k_page_size;
                             dst_addr += args.k_page_size;
-                            curr_trid = (curr_trid % NUM_TRIDS) + 1;
+                            curr_trid = (curr_trid == TRID_MAX) ? TRID_MIN : (curr_trid + 1);
                             pages_issued++;
                         }
 
                         while (pages_completed < args.k_num_pages) {
                             noc_async_read_barrier_with_trid(wait_trid, READ_NOC_INDEX);
-                            *ncrisc_brisc_sync_curr_ptr += 1;
-                            pages_completed++;
+                            noc_semaphore_set(ncrisc_brisc_sync_curr_ptr, ++pages_completed + 1);
 
                             if (pages_issued < args.k_num_pages) {
                                 noc_async_read_set_trid(curr_trid, READ_NOC_INDEX);
@@ -406,18 +422,20 @@ struct FlashMLADecode {
                                     src_base_addr, src_offset, dst_addr, curr_trid, READ_NOC_INDEX);
                                 src_offset += args.k_page_size;
                                 dst_addr += args.k_page_size;
-                                curr_trid = (curr_trid % NUM_TRIDS) + 1;
+                                curr_trid = (curr_trid == TRID_MAX) ? TRID_MIN : (curr_trid + 1);
                                 pages_issued++;
                             }
 
-                            wait_trid = (wait_trid % NUM_TRIDS) + 1;
+                            wait_trid = (wait_trid == TRID_MAX) ? TRID_MIN : (wait_trid + 1);
                         }
 
                         std::swap(ncrisc_brisc_sync_curr_ptr, ncrisc_brisc_sync_next_ptr);
                         std::swap(k_write_curr_ptr_shared, k_write_next_ptr_shared);
                     } else {
                         DeviceZoneScopedN("mcast-receiver-signal-ready");
-                        noc_semaphore_inc(sender_receiver_ready_noc_addr, 1, ATOMIC_NOC_INDEX);
+                        unified_kernels::
+                            unicast_atomic_inc_with_state<false, false, false, true, true, write_at_cmd_buf>(
+                                0, 0, 31, ATOMIC_NOC_INDEX);
 
                         noc_semaphore_wait(mcast_semaphore_ptr, MCAST_VALID);
                         noc_semaphore_set(mcast_semaphore_ptr, MCAST_INVALID);
@@ -427,7 +445,11 @@ struct FlashMLADecode {
                 }
                 loop_iter++;
             }
-            noc_async_write_barrier(MCAST_NOC_INDEX);
+            if (is_mcast_sender && BRISC_MCAST_LOOPS > 0) {
+                noc_async_write_barrier(MCAST_NOC_INDEX);
+            } else if (!is_mcast_sender) {
+                noc_async_atomic_barrier(ATOMIC_NOC_INDEX);
+            }
 // ====================================================================
 // NCRISC (Writer)
 // ====================================================================
@@ -443,6 +465,8 @@ struct FlashMLADecode {
             constexpr uint32_t tile_bytes_intermed = get_tile_size(cb_out_o);
             constexpr uint32_t o_write_size = out_chunk_tiles * tile_bytes_intermed;
             constexpr uint32_t ms_write_size = tile_bytes_intermed;
+            static_assert(ms_write_size <= NOC_MAX_BURST_SIZE);
+            static_assert(o_write_size <= NOC_MAX_BURST_SIZE);
             constexpr uint32_t q_mcast_vc =
                 CTArgs::use_alt_mcast_vc ? NOC_DISPATCH_MULTICAST_WRITE_VC : NOC_MULTICAST_WRITE_VC;
 
@@ -474,9 +498,6 @@ struct FlashMLADecode {
                         noc_semaphore_inc_multicast(
                             q_input_mcast_sem_noc_addr, 1, args.full_grid_mcast_num_dests, MCAST_NOC_INDEX, q_mcast_vc);
                         mask_last_chunk(args.cb_mask, args.k_chunk_size, cur_pos, k_chunk_end, k_num_chunks);
-                        // This is needed because we need to wait for all transactions before resetting the trids
-                        // Could move it later but don't think it makes much difference
-                        noc_async_atomic_barrier(MCAST_NOC_INDEX);
                     } else {
                         const uint64_t sender_receiver_ready_noc_addr = get_noc_addr(
                             args.mcast_start_x,
@@ -485,7 +506,6 @@ struct FlashMLADecode {
                             ATOMIC_NOC_INDEX);
                         noc_semaphore_inc(sender_receiver_ready_noc_addr, 1, ATOMIC_NOC_INDEX);
                         mask_last_chunk(args.cb_mask, args.k_chunk_size, cur_pos, k_chunk_end, k_num_chunks);
-                        noc_async_atomic_barrier(ATOMIC_NOC_INDEX);
                         noc_semaphore_wait(q_input_mcast_semaphore_ptr, 1);
                     }
                 } else if (k_chunk_start == k_chunk_end) {
@@ -494,10 +514,13 @@ struct FlashMLADecode {
                     // wait for 8 q heads
                     uint64_t q_noc_addr = get_noc_addr(
                         args.output_core_noc_x, args.output_core_noc_y, get_read_ptr(args.cb_q_in), READ_NOC_INDEX);
-                    cb_reserve_back(args.cb_q_in, q_chunk_tiles);
-                    noc_semaphore_wait(q_input_mcast_semaphore_ptr, 1);
-                    noc_async_read(q_noc_addr, get_write_ptr(args.cb_q_in), args.q_chunk_size_bytes, READ_NOC_INDEX);
                     mask_last_chunk(args.cb_mask, args.k_chunk_size, cur_pos, k_chunk_end, k_num_chunks);
+                    cb_reserve_back(args.cb_q_in, q_chunk_tiles);
+                    uint32_t q_write_addr = get_write_ptr(args.cb_q_in);
+                    unified_kernels::noc_async_read_preprogram_all_state(
+                        q_noc_addr, q_write_addr, args.q_chunk_size_bytes, READ_NOC_INDEX);
+                    noc_semaphore_wait(q_input_mcast_semaphore_ptr, 1);
+                    unified_kernels::noc_async_read_issue_txn(READ_NOC_INDEX);
                     noc_async_read_barrier(READ_NOC_INDEX);
                     cb_push_back(args.cb_q_in, q_chunk_tiles);
                 }
@@ -541,34 +564,65 @@ struct FlashMLADecode {
                      k_chunk += args.num_cores_per_head) {
                     DeviceZoneScopedN("mcast-sender-multicast");
 
+                    // Safe to pre-increment here since brisc signals that it's in flash mla
                     noc_semaphore_wait_min(ncrisc_brisc_sync_curr_ptr, 1);
+                    // TODO: Make compile time
+                    mcast_increment_counters_runtime<false>(
+                        args.num_mcast_dests, args.k_num_pages + 1, MCAST_NOC_INDEX);
+
                     invalidate_l1_cache();
                     uint32_t page_addr = *k_write_curr_ptr_shared;
 
                     uint64_t mcast_dest_addr = mcast_noc_addr | page_addr;
-
+                    mcast_send_set_state_runtime<false, false, true, true, true, false, write_cmd_buf>(
+                        page_addr, mcast_dest_addr, k_page_size, args.num_mcast_dests, MCAST_NOC_INDEX);
+                    if constexpr (!mcast_is_shared_write_cmd_buf) {
+                        mcast_send_set_state_runtime<false, false, true, true, true, false, write_reg_cmd_buf>(
+                            args.mcast_semaphore_addr,
+                            mcast_sem_addr,
+                            sizeof(uint32_t),
+                            args.num_mcast_dests,
+                            MCAST_NOC_INDEX);
+                    }
+                    noc_semaphore_wait_min(ncrisc_brisc_sync_curr_ptr, 2);
                     noc_semaphore_wait(receiver_ready_semaphore_ptr, args.num_mcast_dests);
                     noc_semaphore_set(receiver_ready_semaphore_ptr, 0);
 
-                    noc_async_write_multicast<k_page_size>(
-                        page_addr, mcast_dest_addr, k_page_size, args.num_mcast_dests, false, MCAST_NOC_INDEX);
+                    mcast_send_issue_txn<write_cmd_buf>(MCAST_NOC_INDEX);
 
                     for (uint32_t page = 1; page < args.k_num_pages; ++page) {
                         page_addr += k_page_size;
                         mcast_dest_addr = mcast_noc_addr | page_addr;
-                        noc_semaphore_wait_min(ncrisc_brisc_sync_curr_ptr, page + 1);
-                        noc_async_write_multicast<k_page_size>(
-                            page_addr, mcast_dest_addr, k_page_size, args.num_mcast_dests, false, MCAST_NOC_INDEX);
+                        mcast_send_set_state_runtime<false, false, false, true, false, false, write_cmd_buf>(
+                            page_addr, mcast_dest_addr, 0, args.num_mcast_dests, MCAST_NOC_INDEX);
+                        noc_semaphore_wait_min(ncrisc_brisc_sync_curr_ptr, page + 2);
+                        mcast_send_issue_txn<write_cmd_buf>(MCAST_NOC_INDEX);
                     }
 
-                    noc_semaphore_set_multicast(
-                        args.mcast_semaphore_addr, mcast_sem_addr, args.num_mcast_dests, false, MCAST_NOC_INDEX);
+                    if constexpr (mcast_is_shared_write_cmd_buf) {
+                        mcast_send_set_state_runtime<false, false, false, true, true, false, write_reg_cmd_buf>(
+                            args.mcast_semaphore_addr,
+                            mcast_sem_addr,
+                            sizeof(uint32_t),
+                            args.num_mcast_dests,
+                            MCAST_NOC_INDEX);
+                    }
+                    mcast_send_issue_txn<write_reg_cmd_buf>(MCAST_NOC_INDEX);
                     noc_async_writes_flushed(MCAST_NOC_INDEX);
                     *ncrisc_brisc_sync_curr_ptr = 0;
                     std::swap(ncrisc_brisc_sync_curr_ptr, ncrisc_brisc_sync_next_ptr);
                     std::swap(k_write_curr_ptr_shared, k_write_next_ptr_shared);
                 }
                 noc_async_write_barrier(MCAST_NOC_INDEX);
+            }
+
+            // Defer the Q-input signal barrier until the K streaming/mcast work has completed.
+            if (is_output_core) {
+                if (is_mcast_sender) {
+                    noc_async_atomic_barrier(MCAST_NOC_INDEX);
+                } else {
+                    noc_async_atomic_barrier(ATOMIC_NOC_INDEX);
+                }
             }
 
             // =================================================================
@@ -604,17 +658,26 @@ struct FlashMLADecode {
                         uint32_t inc_value = step_semaphore_inc<bits_per_step>(step, ms_sub_bit);
                         uint64_t output_write_coord = get_noc_addr(partner_x, partner_y, 0, WRITE_NOC_INDEX);
                         uint64_t partner_semaphore_addr = output_write_coord | args.reducer_semaphore_addr;
+                        // Should be safe to pre-increment here
+                        unified_kernels::unicast_write_increment_counters<true>(2, WRITE_NOC_INDEX);
+                        unified_kernels::unicast_atomic_inc_increment_counters<false>(2, WRITE_NOC_INDEX);
                         uint64_t output_write_addr = output_write_coord | (cb_ms_in_base_addr + step * ms_write_size);
-                        cb_wait_front(args.cb_out_ms, 1);
-                        noc_async_write<ms_write_size, false, /*posted=*/true>(
+                        unified_kernels::unicast_write_set_state<true, true, true, true, false, write_cmd_buf>(
                             get_read_ptr(args.cb_out_ms), output_write_addr, ms_write_size, WRITE_NOC_INDEX);
-                        noc_semaphore_inc(partner_semaphore_addr, inc_value, WRITE_NOC_INDEX);
+                        unified_kernels::unicast_atomic_inc_set_state<false, true, true, false, write_at_cmd_buf>(
+                            partner_semaphore_addr, inc_value, 31, WRITE_NOC_INDEX);
+                        cb_wait_front(args.cb_out_ms, 1);
+                        unified_kernels::noc_async_write_issue_txn<true, false>(WRITE_NOC_INDEX);
+                        unified_kernels::noc_async_atomic_inc_issue_txn<false, false>(WRITE_NOC_INDEX);
                         inc_value = step_semaphore_inc<bits_per_step>(step, o_sub_bit);
                         output_write_addr = output_write_coord | (cb_out_in_base_addr + step * o_write_size);
-                        cb_wait_front(cb_out_o, out_chunk_tiles);
-                        noc_async_write<o_write_size, false, /*posted=*/true>(
+                        unified_kernels::unicast_write_set_state<true, false, true, true, false, write_cmd_buf>(
                             get_read_ptr(cb_out_o), output_write_addr, o_write_size, WRITE_NOC_INDEX);
-                        noc_semaphore_inc(partner_semaphore_addr, inc_value, WRITE_NOC_INDEX);
+                        unified_kernels::unicast_atomic_inc_set_state<false, false, true, false, write_at_cmd_buf>(
+                            partner_semaphore_addr, inc_value, 31, WRITE_NOC_INDEX);
+                        cb_wait_front(cb_out_o, out_chunk_tiles);
+                        unified_kernels::noc_async_write_issue_txn<true, false>(WRITE_NOC_INDEX);
+                        unified_kernels::noc_async_atomic_inc_issue_txn<false, false>(WRITE_NOC_INDEX);
 
                         noc_async_posted_writes_flushed(WRITE_NOC_INDEX);
                         cb_pop_front(args.cb_out_ms, 1);

--- a/models/demos/deepseek_v3_b1/unified_kernels/gather.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/gather.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "dataflow_utils.hpp"
 #include "kernel_op_api.hpp"
 #include "kernel_utils.hpp"
 
@@ -121,12 +122,15 @@ struct Gather {
             uint64_t dst_data_noc_addr = dst_noc_coord | (uint64_t)(s.receiver_data_addr + offset);
             uint64_t dst_semaphore_noc_addr = dst_noc_coord | (uint64_t)s.receiver_semaphore_addr;
 
+            uint32_t input_data_addr = get_read_ptr(s.src_cb);
+            unified_kernels::noc_async_write_preprogram_all_state<true>(
+                input_data_addr, dst_data_noc_addr, s.data_size_bytes, s.noc);
+            unified_kernels::noc_async_atomic_inc_preprogram_all_state<false>(dst_semaphore_noc_addr, 1, 31, s.noc);
             cb_wait_front(s.src_cb, s.src_num_pages);
 
-            uint32_t input_data_addr = get_read_ptr(s.src_cb);
-            noc_async_write_one_packet<true, true>(input_data_addr, dst_data_noc_addr, s.data_size_bytes, s.noc);
+            unified_kernels::noc_async_write_issue_txn<true>(s.noc);
             // BH does not support posted atomics due to a bug
-            noc_semaphore_inc(dst_semaphore_noc_addr, 1, s.noc);
+            unified_kernels::noc_async_atomic_inc_issue_txn<false>(s.noc);
 
             if constexpr (pop_src) {
                 noc_async_posted_writes_flushed(s.noc);

--- a/models/demos/deepseek_v3_b1/unified_kernels/gather_reduce.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/gather_reduce.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "dataflow_utils.hpp"
 #include "kernel_op_api.hpp"
 #include "kernel_utils.hpp"
 
@@ -158,15 +159,16 @@ struct GatherReduce {
                 uint64_t dst_data_noc_addr = dst_noc_coord | (uint64_t)(dst_base_addr + dst_offset);
                 uint64_t dst_sem_noc_addr = dst_noc_coord | (uint64_t)args.receiver_semaphore_addr;
 
+                uint32_t src_addr = get_read_ptr(args.src_cb);
+                unified_kernels::noc_async_write_preprogram_all_state<true>(
+                    src_addr, dst_data_noc_addr, args.data_size_bytes, args.noc);
+                unified_kernels::noc_async_atomic_inc_preprogram_all_state<false>(dst_sem_noc_addr, 1, 31, args.noc);
                 // Wait for source CB data to be ready
                 cb_wait_front(args.src_cb, args.src_num_pages);
 
-                // Get source address from CB
-                uint32_t src_addr = get_read_ptr(args.src_cb);
-
-                noc_async_write_one_packet<true, true>(src_addr, dst_data_noc_addr, args.data_size_bytes, args.noc);
+                unified_kernels::noc_async_write_issue_txn<true>(args.noc);
                 // BH does not support posted atomics due to a bug
-                noc_semaphore_inc(dst_sem_noc_addr, 1, args.noc);
+                unified_kernels::noc_async_atomic_inc_issue_txn<false>(args.noc);
 
                 // Pop the source CB after sending
                 if constexpr (pop_src) {

--- a/models/demos/deepseek_v3_b1/unified_kernels/kn_sliced_matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kn_sliced_matmul.hpp
@@ -116,12 +116,12 @@ struct KNSlicedMatmul {
             pack_block_contiguous_init(args.out_cb);
 
             // Wait for all activation tiles and weight tiles
-            cb_wait_front(args.act_cb, args.act_total_tiles);
             if (args.weights_address_override > 0) {
                 UNPACK(({ unified_kernels::override_cb_rd_ptr(args.weights_cb, args.weights_address_override); }));
             } else {
                 cb_wait_front(args.weights_cb, args.k_per_core);
             }
+            cb_wait_front(args.act_cb, args.act_total_tiles);
 
             // Reserve output tile
             cb_reserve_back(args.out_cb, out_w);
@@ -132,6 +132,7 @@ struct KNSlicedMatmul {
 
             tile_regs_wait();
             pack_block_contiguous(0, args.out_cb, out_w);
+            cb_push_back(args.out_cb, out_w);
             tile_regs_release();
 
             custom_mm_block_uninit<dense_packing>();
@@ -143,8 +144,6 @@ struct KNSlicedMatmul {
             if constexpr (pop_weights) {
                 cb_pop_front(args.weights_cb, args.k_per_core);
             }
-
-            cb_push_back(args.out_cb, out_w);
 #endif
         }
     };  // class Op

--- a/models/demos/deepseek_v3_b1/unified_kernels/kv_cache_update.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kv_cache_update.hpp
@@ -5,6 +5,7 @@
 
 #include "kernel_op_api.hpp"
 #include "kernel_utils.hpp"
+#include "dataflow_utils.hpp"
 #include "mcast.hpp"
 
 #if defined(COMPILE_FOR_BRISC)
@@ -147,39 +148,76 @@ struct KVCacheUpdate {
             // ============================================================
 #if defined(COMPILE_FOR_NCRISC)
             if constexpr (IsNopeSenderCore) {
+                constexpr uint32_t MCAST_NOC_INDEX = 0;
+                static_assert(
+                    noc_mode == DM_DYNAMIC_NOC || MCAST_NOC_INDEX == noc_index, "Custom noc requires DM_DYNAMIC_NOC");
+                constexpr uint32_t SEMAPHORE_SIZE_BYTES = 4;
+                uint32_t data_addr = get_read_ptr(args.kv_rmsnorm_output_cb);
+
+                volatile tt_l1_ptr uint32_t* sender_sem_ptr =
+                    (volatile tt_l1_ptr uint32_t*)args.nope_mcast_sender_semaphore_addr;
+                noc_semaphore_set(sender_sem_ptr, VALID);
+
+                uint64_t mcast_noc_addr = get_noc_multicast_addr<0>(
+                    args.nope_mcast_dest_noc_start_x,
+                    args.nope_mcast_dest_noc_start_y,
+                    args.nope_mcast_dest_noc_end_x,
+                    args.nope_mcast_dest_noc_end_y,
+                    MCAST_NOC_INDEX);
+
+                unified_kernels::noc_async_write_multicast_preprogram_all_state</*posted=*/false>(
+                    data_addr,
+                    mcast_noc_addr | data_addr,
+                    args.nope_mcast_data_size_bytes,
+                    args.nope_mcast_num_dests,
+                    /*multicast_path_reserve=*/true,
+                    /*linked=*/false,
+                    /*noc=*/MCAST_NOC_INDEX,
+                    NOC_DISPATCH_MULTICAST_WRITE_VC);
+
+                if constexpr (!mcast_is_shared_write_cmd_buf) {
+                    unified_kernels::noc_async_write_multicast_preprogram_all_state<
+                        /*posted=*/false,
+                        /*increment_counters=*/false,
+                        write_reg_cmd_buf>(
+                        args.nope_mcast_sender_semaphore_addr,
+                        mcast_noc_addr | args.nope_mcast_receiver_semaphore_addr,
+                        SEMAPHORE_SIZE_BYTES,
+                        args.nope_mcast_num_dests,
+                        /*multicast_path_reserve=*/true,
+                        /*linked=*/false,
+                        /*noc=*/MCAST_NOC_INDEX,
+                        NOC_DISPATCH_MULTICAST_WRITE_VC);
+                }
+
                 cb_wait_front(args.kv_rmsnorm_output_cb, args.kv_rmsnorm_num_tiles);
 
                 {
                     DeviceZoneScopedN("MCAST_RMSNORM");
-                    uint32_t data_addr = get_read_ptr(args.kv_rmsnorm_output_cb);
+                    unified_kernels::noc_async_write_multicast_issue_txn</*posted=*/false>(
+                        args.nope_mcast_num_dests, /*noc=*/MCAST_NOC_INDEX);
 
-                    volatile tt_l1_ptr uint32_t* sender_sem_ptr =
-                        (volatile tt_l1_ptr uint32_t*)args.nope_mcast_sender_semaphore_addr;
-                    noc_semaphore_set(sender_sem_ptr, VALID);
+                    if constexpr (mcast_is_shared_write_cmd_buf) {
+                        unified_kernels::multicast_write_with_state<
+                            /*posted=*/false,
+                            /*set_addresses=*/true,
+                            /*set_size=*/true,
+                            /*wait_cmd_buf_ready=*/true,
+                            /*increment_counters=*/true,
+                            write_cmd_buf>(
+                            args.nope_mcast_sender_semaphore_addr,
+                            (uint32_t)(mcast_noc_addr | args.nope_mcast_receiver_semaphore_addr),
+                            SEMAPHORE_SIZE_BYTES,
+                            args.nope_mcast_num_dests,
+                            MCAST_NOC_INDEX);
+                    } else {
+                        unified_kernels::noc_async_write_multicast_issue_txn<
+                            /*posted=*/false,
+                            /*increment_counters=*/true,
+                            write_reg_cmd_buf>(args.nope_mcast_num_dests, /*noc=*/MCAST_NOC_INDEX);
+                    }
 
-                    uint64_t mcast_noc_addr = get_noc_multicast_addr<0>(
-                        args.nope_mcast_dest_noc_start_x,
-                        args.nope_mcast_dest_noc_start_y,
-                        args.nope_mcast_dest_noc_end_x,
-                        args.nope_mcast_dest_noc_end_y,
-                        0);
-                    noc_async_write_multicast(
-                        data_addr,
-                        mcast_noc_addr | data_addr,
-                        args.nope_mcast_data_size_bytes,
-                        args.nope_mcast_num_dests,
-                        false,
-                        0,
-                        NOC_DISPATCH_MULTICAST_WRITE_VC);
-                    noc_semaphore_set_multicast(
-                        args.nope_mcast_sender_semaphore_addr,
-                        mcast_noc_addr | args.nope_mcast_receiver_semaphore_addr,
-                        args.nope_mcast_num_dests,
-                        false,
-                        0,
-                        NOC_DISPATCH_MULTICAST_WRITE_VC);
-
-                    noc_async_write_barrier();
+                    noc_async_write_barrier(MCAST_NOC_INDEX);
                 }
             } else if constexpr (IsNopeCore) {
                 {
@@ -258,6 +296,10 @@ struct KVCacheUpdate {
                 uint32_t write_addr_offset = offset_in_page * num_bytes_per_chunk;
 
                 for (uint32_t chunk = 0; chunk < NUM_CHUNKS; chunk++) {
+                    uint32_t write_addr = get_read_ptr(kv_cache_intermed_cb) + write_addr_offset;
+                    unified_kernels::noc_async_write_preprogram_all_state<false>(
+                        src_addr, get_noc_addr(write_addr), num_bytes_per_chunk);
+
                     {
                         DeviceZoneScopedN("WAIT_UNTILIZE");
                         cb_reserve_back(kv_cache_intermed_sync_cb, CHUNK_SIZE);
@@ -266,8 +308,7 @@ struct KVCacheUpdate {
 
                     {
                         DeviceZoneScopedN("UPDATE_NEW_CACHE");
-                        uint32_t write_addr = get_read_ptr(kv_cache_intermed_cb) + write_addr_offset;
-                        noc_async_write(src_addr, get_noc_addr(write_addr), num_bytes_per_chunk);
+                        unified_kernels::noc_async_write_issue_txn<false>();
                         noc_async_write_barrier();
                     }
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/matmul.hpp
@@ -101,7 +101,7 @@ struct Matmul {
     //   pop_in0 - whether to pop in0 after compute (default true)
     //   pop_in1 - whether to pop in1 after compute (default true)
     // ========================================================================
-    template <typename CTArgs, bool IsActiveCore, bool pop_in0, bool pop_in1>
+    template <typename CTArgs, bool IsActiveCore, bool pop_in0, bool pop_in1, bool skip_reconfig = false>
     class Op {
     public:
         void operator()(const RTArgs& args) {
@@ -123,22 +123,23 @@ struct Matmul {
             constexpr bool finalize = split_acc && true;
             constexpr bool read_transposed = transpose && true;
             constexpr bool fuse_activation = CTArgs::fuse_sigmoid || CTArgs::fuse_silu;
-
-            reconfig_data_format<false, true>(args.in1, args.in0);
-            pack_reconfig_data_format<true>(args.out);
+            if constexpr (!skip_reconfig) {
+                reconfig_data_format<false, true>(args.in1, args.in0);
+                pack_reconfig_data_format<true>(args.out);
+            }
             custom_mm_block_init_short<transpose, split_acc, dense_packing>(args.in0, args.in1, args.out, out_w);
-            if constexpr (!fuse_activation) {
+            if constexpr (!fuse_activation && !skip_reconfig) {
                 pack_block_contiguous_init(args.out);
             }
 
             // Wait for all input tiles (both from sharded tensors in L1)
             // in1 has num_tiles * out_w tiles (K tiles for each output column)
-            cb_wait_front(args.in0, args.k_num_tiles);
             if (args.in1_address_override > 0) {
                 UNPACK(({ unified_kernels::override_cb_rd_ptr(args.in1, args.in1_address_override); }));
             } else {
                 cb_wait_front(args.in1, args.k_num_tiles * out_w);
             }
+            cb_wait_front(args.in0, args.k_num_tiles);
 
             // Reserve output tiles
             cb_reserve_back(args.out, out_w);
@@ -160,10 +161,10 @@ struct Matmul {
                     tile_regs_commit();
 
                     // Run activation on PACK thread
-                    TTI_SEMWAIT(
+                    PACK(TTI_SEMWAIT(
                         p_stall::STALL_TDMA | p_stall::STALL_CFG,
                         semaphore::t6_sem(semaphore::MATH_PACK),
-                        p_stall::STALL_ON_ZERO);
+                        p_stall::STALL_ON_ZERO));
                     PACK(TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, ckernel::packer::get_packer_dest_offset()));
 
                     // Use 2 iterations for 1x32 tiny tiles
@@ -193,6 +194,7 @@ struct Matmul {
                 pack_block_contiguous(0, args.out, out_w);
                 tile_regs_release();
             }
+            cb_push_back(args.out, out_w);
 
             custom_mm_block_uninit<dense_packing>();
 
@@ -203,8 +205,6 @@ struct Matmul {
             if constexpr (pop_in1) {
                 cb_pop_front(args.in1, args.k_num_tiles * out_w);
             }
-
-            cb_push_back(args.out, out_w);
 #endif
         }
     };  // class Op

--- a/models/demos/deepseek_v3_b1/unified_kernels/matmul_expert_compressed_dram.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/matmul_expert_compressed_dram.hpp
@@ -37,7 +37,6 @@
 #include "api/compute/compute_kernel_api.h"
 #include "../kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h"
 #include "../kernel_includes/tt_metal/include/compute_kernel_api/compressed_custom_mm.h"
-#include "../kernel_includes/tt_metal/include/compute_kernel_api/deepseek_compute_kernel_hw_startup.h"
 using namespace ckernel;
 #ifdef TRISC_PACK
 #include "llk_math_eltwise_unary_sfpu_silu.h"
@@ -823,10 +822,10 @@ struct MatmulExpertCompressedDRAM {
 
                         tile_regs_commit();
                         if constexpr (CTArgs::fuse_silu) {
-                            TTI_SEMWAIT(
+                            PACK(TTI_SEMWAIT(
                                 p_stall::STALL_TDMA | p_stall::STALL_CFG,
                                 semaphore::t6_sem(semaphore::MATH_PACK),
-                                p_stall::STALL_ON_ZERO);
+                                p_stall::STALL_ON_ZERO));
                             PACK(TT_SETC16(
                                 DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, ckernel::packer::get_packer_dest_offset()));
                             for (uint32_t sn = 0; sn < CTArgs::subblock_n; sn++) {

--- a/models/demos/deepseek_v3_b1/unified_kernels/matmul_expert_compressed_sram.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/matmul_expert_compressed_sram.hpp
@@ -21,7 +21,6 @@
 #include "api/compute/compute_kernel_api.h"
 #include "../kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h"
 #include "../kernel_includes/tt_metal/include/compute_kernel_api/compressed_custom_mm.h"
-#include "../kernel_includes/tt_metal/include/compute_kernel_api/deepseek_compute_kernel_hw_startup.h"
 using namespace ckernel;
 #ifdef TRISC_PACK
 #include "llk_math_eltwise_unary_sfpu_silu.h"

--- a/models/demos/deepseek_v3_b1/unified_kernels/mcast.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/mcast.hpp
@@ -19,6 +19,52 @@ namespace deepseek_b1_ops {
 
 constexpr bool mcast_is_shared_write_cmd_buf = write_cmd_buf == write_reg_cmd_buf;
 
+template <uint32_t mcast_num_cores, bool loopback, bool is_part_of_receiver_grid, bool posted>
+FORCE_INLINE void mcast_increment_counters() {
+    constexpr uint32_t noc = noc_index;
+    constexpr uint32_t num_dests =
+        loopback ? mcast_num_cores : (is_part_of_receiver_grid ? mcast_num_cores - 1 : mcast_num_cores);
+
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        if constexpr (posted) {
+            inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
+        } else {
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, num_dests);
+        }
+    }
+
+    if constexpr (noc_mode == DM_DEDICATED_NOC) {
+        if constexpr (posted) {
+            noc_posted_writes_num_issued[noc] += 1;
+        } else {
+            noc_nonposted_writes_num_issued[noc] += 1;
+            noc_nonposted_writes_acked[noc] += num_dests;
+        }
+    }
+}
+
+template <bool posted>
+FORCE_INLINE void mcast_increment_counters_runtime(uint32_t num_dests, uint32_t count = 1, uint8_t noc = noc_index) {
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        if constexpr (posted) {
+            inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, count);
+        } else {
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, count);
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, num_dests * count);
+        }
+    }
+
+    if constexpr (noc_mode == DM_DEDICATED_NOC) {
+        if constexpr (posted) {
+            noc_posted_writes_num_issued[noc] += count;
+        } else {
+            noc_nonposted_writes_num_issued[noc] += count;
+            noc_nonposted_writes_acked[noc] += num_dests * count;
+        }
+    }
+}
+
 template <uint8_t noc>
 FORCE_INLINE uint64_t get_noc_multicast_addr(
     uint32_t noc_x_start, uint32_t noc_y_start, uint32_t noc_x_end, uint32_t noc_y_end, uint32_t addr) {
@@ -40,6 +86,57 @@ FORCE_INLINE uint64_t get_noc_multicast_addr(
 }
 
 template <
+    bool posted,
+    bool linked,
+    bool set_noc_coord,
+    bool set_addresses,
+    bool set_size,
+    bool increment_counters,
+    uint8_t cmd_buf>
+FORCE_INLINE void mcast_send_set_state_runtime(
+    uint32_t src_local_addr,
+    uint64_t dst_noc_addr,
+    uint32_t len_bytes,
+    uint32_t num_dests,
+    uint8_t noc = noc_index,
+    uint8_t vc = NOC_MULTICAST_WRITE_VC) {
+    constexpr bool multicast_path_reserve = true;
+
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
+    if constexpr (increment_counters) {
+        mcast_increment_counters_runtime<posted>(num_dests, 1, noc);
+    }
+
+    uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) |
+                             (linked ? NOC_CMD_VC_LINKED : 0x0) | (multicast_path_reserve ? NOC_CMD_PATH_RESERVE : 0) |
+                             NOC_CMD_BRCST_PACKET | (posted ? 0 : NOC_CMD_RESP_MARKED);
+
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
+    if constexpr (set_noc_coord) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(dst_noc_addr >> 32) & NOC_PCIE_MASK);
+        NOC_CMD_BUF_WRITE_REG(
+            noc,
+            cmd_buf,
+            NOC_RET_ADDR_COORDINATE,
+            (uint32_t)(dst_noc_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
+    }
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_BRCST_EXCLUDE, 0);
+    if constexpr (set_size) {
+        ASSERT(len_bytes <= NOC_MAX_BURST_SIZE);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, len_bytes);
+    }
+    if constexpr (set_addresses) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_local_addr);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr);
+    }
+}
+
+template <uint8_t cmd_buf>
+FORCE_INLINE void mcast_send_issue_txn(uint8_t noc = noc_index) {
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+}
+
+template <
     uint32_t mcast_num_cores,
     bool loopback,
     bool is_part_of_receiver_grid,
@@ -48,6 +145,7 @@ template <
     bool set_noc_coord,
     bool set_addresses,
     bool set_size,
+    bool increment_counters,
     uint8_t cmd_buf>
 FORCE_INLINE void mcast_send_set_state(uint32_t src_local_addr, uint64_t dst_noc_addr, uint32_t len_bytes = 0) {
     constexpr uint32_t noc = noc_index;
@@ -55,6 +153,10 @@ FORCE_INLINE void mcast_send_set_state(uint32_t src_local_addr, uint64_t dst_noc
     constexpr bool multicast_path_reserve = true;
 
     while (!noc_cmd_buf_ready(noc, cmd_buf));
+    if constexpr (increment_counters) {
+        mcast_increment_counters<mcast_num_cores, loopback, is_part_of_receiver_grid, posted>();
+    }
+
     uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) |
                              (linked ? NOC_CMD_VC_LINKED : 0x0) | (multicast_path_reserve ? NOC_CMD_PATH_RESERVE : 0) |
                              (loopback ? NOC_CMD_BRCST_SRC_INCLUDE : 0) | NOC_CMD_BRCST_PACKET |
@@ -89,25 +191,22 @@ template <
     bool posted,
     bool set_addresses,
     bool set_size,
+    bool wait_cmd_buf_ready,
+    bool increment_counters,
     uint8_t cmd_buf>
 FORCE_INLINE void mcast_send_with_state(uint32_t src_local_addr, uint32_t dst_local_addr, uint32_t len_bytes = 0) {
     constexpr uint32_t noc = noc_index;
     if constexpr (loopback) {
         static_assert(is_part_of_receiver_grid, "Loopback mode is only supported for receiver grid");
     }
-    constexpr uint32_t num_dests =
-        loopback ? mcast_num_cores : (is_part_of_receiver_grid ? mcast_num_cores - 1 : mcast_num_cores);
 
-    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-        if constexpr (posted) {
-            inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
-        } else {
-            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
-            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, num_dests);
-        }
+    if constexpr (increment_counters) {
+        mcast_increment_counters<mcast_num_cores, loopback, is_part_of_receiver_grid, posted>();
     }
 
-    while (!noc_cmd_buf_ready(noc, cmd_buf));
+    if constexpr (wait_cmd_buf_ready) {
+        while (!noc_cmd_buf_ready(noc, cmd_buf));
+    }
 
     if constexpr (set_size) {
         ASSERT(len_bytes <= NOC_MAX_BURST_SIZE);
@@ -118,15 +217,6 @@ FORCE_INLINE void mcast_send_with_state(uint32_t src_local_addr, uint32_t dst_lo
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, dst_local_addr);
     }
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
-
-    if constexpr (noc_mode == DM_DEDICATED_NOC) {
-        if constexpr (posted) {
-            noc_posted_writes_num_issued[noc] += 1;
-        } else {
-            noc_nonposted_writes_num_issued[noc] += 1;
-            noc_nonposted_writes_acked[noc] += num_dests;
-        }
-    }
 }
 
 template <uint32_t mcast_num_cores, bool loopback, bool is_part_of_receiver_grid, bool linked, bool posted>
@@ -140,6 +230,7 @@ FORCE_INLINE void init_persistent_mcast_sender(uint64_t mcast_flag_noc_addr, uin
         true,
         false,
         false,
+        false,
         write_cmd_buf>(0, mcast_flag_noc_addr, 0);
     if constexpr (!mcast_is_shared_write_cmd_buf) {
         mcast_send_set_state<
@@ -148,6 +239,7 @@ FORCE_INLINE void init_persistent_mcast_sender(uint64_t mcast_flag_noc_addr, uin
             is_part_of_receiver_grid,
             linked,
             posted,
+            true,
             true,
             true,
             true,
@@ -160,6 +252,8 @@ FORCE_INLINE void init_persistent_mcast_sender(uint64_t mcast_flag_noc_addr, uin
         linked,
         posted,
         mcast_is_shared_write_cmd_buf,
+        mcast_is_shared_write_cmd_buf,
+        false,
         mcast_is_shared_write_cmd_buf,
         write_reg_cmd_buf>(data_sender_semaphore_addr, mcast_flag_noc_addr, 4);
     noc_async_posted_writes_flushed();
@@ -176,6 +270,7 @@ FORCE_INLINE void teardown_persistent_mcast_sender(uint32_t data_sender_semaphor
         false,
         false,
         false,
+        true,
         write_reg_cmd_buf>(0, 0, 0);
     mcast_send_with_state<
         mcast_num_cores,
@@ -185,6 +280,8 @@ FORCE_INLINE void teardown_persistent_mcast_sender(uint32_t data_sender_semaphor
         false,
         true,
         mcast_is_shared_write_cmd_buf,
+        false,
+        false,
         write_reg_cmd_buf>(data_sender_semaphore_addr, data_sender_semaphore_addr, 4);
     noc_async_write_barrier();
     riscv_wait(10000);  // This is just to guarantee safety due to posted mcast hw bug
@@ -345,6 +442,38 @@ struct Mcast {
     private:
 #if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
         static void sender_impl(const SenderArgs& s) {
+            // Due to a HW bug, only mcast txns can be sent on the same NOC while linked, so it's safe to pre-increment
+            mcast_send_set_state<
+                CTArgsT::mcast_num_cores,
+                CTArgsT::loopback,
+                CTArgsT::is_part_of_receiver_grid,
+                linked,
+                posted,
+                false,
+                true,
+                true,
+                true,
+                write_cmd_buf>(s.input_data_addr, s.mcast_receiver_data_addr, s.data_size_bytes);
+            if constexpr (!mcast_is_shared_write_cmd_buf) {
+                mcast_send_set_state<
+                    CTArgsT::mcast_num_cores,
+                    CTArgsT::loopback,
+                    CTArgsT::is_part_of_receiver_grid,
+                    linked,
+                    posted,
+                    false,
+                    true,
+                    false,
+                    true,
+                    write_reg_cmd_buf>(s.data_sender_semaphore_addr, s.data_receiver_semaphore_addr, 4);
+            } else {
+                mcast_increment_counters<
+                    CTArgsT::mcast_num_cores,
+                    CTArgsT::loopback,
+                    CTArgsT::is_part_of_receiver_grid,
+                    posted>();
+            }
+
             cb_wait_front(s.src_cb, s.src_num_pages);
 
             mcast_send_with_state<
@@ -353,17 +482,21 @@ struct Mcast {
                 CTArgsT::is_part_of_receiver_grid,
                 linked,
                 posted,
-                true,
-                true,
-                write_cmd_buf>(s.input_data_addr, s.mcast_receiver_data_addr, s.data_size_bytes);
+                false,
+                false,
+                false,
+                false,
+                write_cmd_buf>(0, 0, 0);
             mcast_send_with_state<
                 CTArgsT::mcast_num_cores,
                 CTArgsT::loopback,
                 CTArgsT::is_part_of_receiver_grid,
                 linked,
                 posted,
-                true,
                 mcast_is_shared_write_cmd_buf,
+                mcast_is_shared_write_cmd_buf,
+                mcast_is_shared_write_cmd_buf,
+                false,
                 write_reg_cmd_buf>(s.data_sender_semaphore_addr, s.data_receiver_semaphore_addr, 4);
 
             noc_async_posted_writes_flushed();

--- a/models/demos/deepseek_v3_b1/unified_kernels/moe_gather.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/moe_gather.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "dataflow_utils.hpp"
 #include "kernel_op_api.hpp"
 #include "kernel_utils.hpp"
 
@@ -121,14 +122,16 @@ struct MoeGather {
                 uint64_t dst_data_noc_addr = dst_noc_coord | (uint64_t)(args.receiver_data_addr + offset);
                 uint64_t dst_semaphore_noc_addr = dst_noc_coord | (uint64_t)args.receiver_semaphore_addr;
 
+                uint32_t input_data_addr = get_read_ptr(args.src_cb);
+                unified_kernels::noc_async_write_preprogram_all_state<true>(
+                    input_data_addr, dst_data_noc_addr, args.data_size_bytes);
+                unified_kernels::noc_async_atomic_inc_preprogram_all_state<false>(dst_semaphore_noc_addr, 1);
                 // Wait for source CB data to be ready
                 cb_wait_front(args.src_cb, args.src_num_pages);
 
-                // Get source address from CB
-                uint32_t input_data_addr = get_read_ptr(args.src_cb);
-                noc_async_write_one_packet<true, true>(input_data_addr, dst_data_noc_addr, args.data_size_bytes);
+                unified_kernels::noc_async_write_issue_txn<true>();
                 // BH does not support posted atomics due to a bug
-                noc_semaphore_inc(dst_semaphore_noc_addr, 1);
+                unified_kernels::noc_async_atomic_inc_issue_txn<false>();
 
                 // Pop the source CB after sending
                 if constexpr (pop_src) {

--- a/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_one_b1.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_one_b1.hpp
@@ -25,6 +25,7 @@
 #if defined(COMPILE_FOR_BRISC)
 #include <type_traits>
 #include "api/dataflow/dataflow_api.h"
+#include "dataflow_utils.hpp"
 #include "api/socket_api.h"
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
@@ -33,6 +34,7 @@
 
 #elif defined(COMPILE_FOR_NCRISC)
 #include "api/dataflow/dataflow_api.h"
+#include "dataflow_utils.hpp"
 
 #elif defined(COMPILE_FOR_TRISC)
 #include "api/compute/compute_kernel_api.h"
@@ -398,22 +400,27 @@ struct ReduceToOneB1 {
             // ROOT1: gather all shards to output tensor; each worker sends its shard downstream
             if constexpr (CTArgs::device_role == MESH_ROOT1) {
                 // Notify the aggregator (or persistent forwarder) that this worker is done.
-                // Issued between socket_notify_receiver and socket_barrier in the socket branch
-                // so the downstream consumer can wake up while we wait for the socket ack.
-                auto signal_aggregator = [&]() __attribute__((always_inline)) {
+                auto prepare_signal_aggregator = [&]() __attribute__((always_inline)) {
                     if (args.persistent_enable != 0) {
-                        volatile tt_l1_ptr uint32_t* agg_sem_ptr =
-                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.agg_sem_l1_addr);
                         uint64_t fc_sem = get_noc_addr(
                             args.persistent_dst_noc_x, args.persistent_dst_noc_y, args.persistent_dst_sem_addr);
-                        noc_semaphore_wait_min(agg_sem_ptr, CTArgs::total_num_workers - 1);
-                        noc_semaphore_set(agg_sem_ptr, 0);
-                        noc_semaphore_inc(fc_sem, 1);
-                        noc_async_atomic_barrier();
+                        unified_kernels::noc_async_atomic_inc_preprogram_all_state</*posted=*/false>(fc_sem, 1);
                     } else if (args.agg_sem_l1_addr != 0) {
                         uint64_t agg_sem_noc =
                             get_noc_addr(args.agg_core_noc_x, args.agg_core_noc_y, args.agg_sem_l1_addr);
-                        noc_semaphore_inc(agg_sem_noc, 1);
+                        unified_kernels::noc_async_atomic_inc_preprogram_all_state</*posted=*/false>(agg_sem_noc, 1);
+                    }
+                };
+                auto complete_signal_aggregator = [&]() __attribute__((always_inline)) {
+                    if (args.persistent_enable != 0) {
+                        volatile tt_l1_ptr uint32_t* agg_sem_ptr =
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.agg_sem_l1_addr);
+                        noc_semaphore_wait_min(agg_sem_ptr, CTArgs::total_num_workers - 1);
+                        noc_semaphore_set(agg_sem_ptr, 0);
+                        unified_kernels::noc_async_atomic_inc_issue_txn</*posted=*/false>();
+                        noc_async_atomic_barrier();
+                    } else if (args.agg_sem_l1_addr != 0) {
+                        unified_kernels::noc_async_atomic_inc_issue_txn</*posted=*/false>();
                         noc_async_atomic_barrier();
                     }
                 };
@@ -435,25 +442,40 @@ struct ReduceToOneB1 {
                             downstream_enc.d2d.downstream_noc_x,
                             downstream_enc.d2d.downstream_noc_y,
                             sender_socket.write_ptr + sender_socket.downstream_fifo_addr);
-                        cb_wait_front(CTArgs::scratch_cb, CTArgs::num_tiles);
+
+                        static_assert(
+                            useful_per_shard <= NOC_MAX_BURST_SIZE,
+                            "useful_per_shard exceeds NOC_MAX_BURST_SIZE; preprogrammed single-packet path "
+                            "cannot handle multi-packet writes");
                         uint32_t src_addr = get_read_ptr(CTArgs::scratch_cb);
-                        // Socket barrier means receiver has received and acknowledged the write, so we can use posted
-                        // writes here
-                        noc_async_write<useful_per_shard, true, /*posted=*/true>(src_addr, fifo_dst, useful_per_shard);
+                        unified_kernels::noc_async_write_preprogram_all_state</*posted=*/true>(
+                            src_addr, fifo_dst, useful_per_shard);
+                        cb_wait_front(CTArgs::scratch_cb, CTArgs::num_tiles);
+                        unified_kernels::noc_async_write_issue_txn</*posted=*/true>();
 
                         if constexpr (is_last_worker_metadata_forwarder) {
                             if (is_last_worker) {
-                                noc_async_write<CTArgs::forward_metadata_size_bytes, true, /*posted=*/true>(
+                                static_assert(
+                                    CTArgs::forward_metadata_size_bytes <= NOC_MAX_BURST_SIZE,
+                                    "forward_metadata_size_bytes exceeds NOC_MAX_BURST_SIZE; "
+                                    "partial-reprogram path cannot handle multi-packet writes");
+                                unified_kernels::unicast_write_with_state<
+                                    /*posted=*/true,
+                                    /*set_addresses=*/true,
+                                    /*set_size=*/true,
+                                    /*wait_cmd_buf_ready=*/true,
+                                    /*increment_counters=*/true,
+                                    write_cmd_buf>(
                                     args.metadata_addr,
-                                    fifo_dst + useful_per_shard,
+                                    (uint32_t)(fifo_dst + useful_per_shard),
                                     CTArgs::forward_metadata_size_bytes);
                             }
                         }
-                        noc_async_posted_writes_flushed();
-
                         socket_push_pages(sender_socket, 1);
+                        noc_async_posted_writes_flushed();
                         socket_notify_receiver(sender_socket);
-                        signal_aggregator();
+                        prepare_signal_aggregator();
+                        complete_signal_aggregator();
                         socket_barrier(sender_socket);
                         update_socket_config(sender_socket);
                     }
@@ -461,11 +483,18 @@ struct ReduceToOneB1 {
                     uint32_t dst_addr_0 = args.output_base_addr + args.shard_idx * CTArgs::payload_size_bytes;
                     uint64_t dst_noc_addr_0 =
                         get_noc_addr(CTArgs::output_core_noc_x, CTArgs::output_core_noc_y, dst_addr_0);
-                    cb_wait_front(CTArgs::scratch_cb, CTArgs::num_tiles);
+                    static_assert(
+                        CTArgs::payload_size_bytes <= NOC_MAX_BURST_SIZE,
+                        "payload_size_bytes exceeds NOC_MAX_BURST_SIZE; preprogrammed single-packet path "
+                        "cannot handle multi-packet writes");
                     uint32_t src_addr = get_read_ptr(CTArgs::scratch_cb);
-                    noc_async_write<CTArgs::payload_size_bytes>(src_addr, dst_noc_addr_0, CTArgs::payload_size_bytes);
+                    unified_kernels::noc_async_write_preprogram_all_state</*posted=*/false>(
+                        src_addr, dst_noc_addr_0, CTArgs::payload_size_bytes);
+                    prepare_signal_aggregator();
+                    cb_wait_front(CTArgs::scratch_cb, CTArgs::num_tiles);
+                    unified_kernels::noc_async_write_issue_txn</*posted=*/false>();
                     noc_async_write_barrier();
-                    signal_aggregator();
+                    complete_signal_aggregator();
                 }
 
                 cb_pop_front(CTArgs::scratch_cb, CTArgs::num_tiles);
@@ -505,6 +534,15 @@ struct ReduceToOneB1 {
             // Source CB: LEAF uses local_cb, others use scratch_cb
             constexpr uint32_t source_cb = (CTArgs::device_role == MESH_LEAF) ? CTArgs::local_cb : CTArgs::scratch_cb;
 
+            uint32_t data_addr = get_read_ptr(source_cb);
+            unified_kernels::noc_async_write_preprogram_all_state</*posted=*/true>(
+                reinterpret_cast<uint32_t>(packet_header),
+                header_noc_addr,
+                packet_header_size_bytes,
+                worker_to_forwarder_noc);
+            unified_kernels::noc_async_atomic_inc_preprogram_all_state</*posted=*/false>(
+                arrival_sem_noc_addr, 1u << args.my_slot_idx, /*wrap=*/31, worker_to_forwarder_noc);
+
             // Wait for data
             // - LEAF: when fused (SkipLocalCbPush=true), previous op pushed to local_cb, so we wait
             //         when standalone (SkipLocalCbPush=false), data is already in-place, no wait needed
@@ -516,21 +554,23 @@ struct ReduceToOneB1 {
             } else {
                 cb_wait_front(source_cb, CTArgs::num_tiles);
             }
-            uint32_t data_addr = get_read_ptr(source_cb);
 
-            // Send header and payload to fabric core
-            noc_async_write<packet_header_size_bytes, /*enable_noc_tracing=*/false, /*posted=*/true>(
-                reinterpret_cast<uint32_t>(packet_header),
-                header_noc_addr,
-                packet_header_size_bytes,
-                worker_to_forwarder_noc);
-            noc_async_write<CTArgs::payload_size_bytes, /*enable_noc_tracing=*/false, /*posted=*/true>(
-                data_addr, payload_noc_addr, CTArgs::payload_size_bytes, worker_to_forwarder_noc);
+            static_assert(
+                CTArgs::payload_size_bytes <= NOC_MAX_BURST_SIZE,
+                "payload_size_bytes exceeds NOC_MAX_BURST_SIZE; partial-reprogram path "
+                "cannot handle multi-packet writes");
+            unified_kernels::noc_async_write_issue_txn</*posted=*/true>(worker_to_forwarder_noc);
+            unified_kernels::unicast_write_with_state<
+                /*posted=*/true,
+                /*set_addresses=*/true,
+                /*set_size=*/true,
+                /*wait_cmd_buf_ready=*/true,
+                /*increment_counters=*/true,
+                write_cmd_buf>(
+                data_addr, (uint32_t)payload_noc_addr, CTArgs::payload_size_bytes, worker_to_forwarder_noc);
 
-            // Ensure the staged packet is visible before advertising the slot as ready.
-            noc_async_posted_writes_flushed(worker_to_forwarder_noc);
-            noc_semaphore_inc(arrival_sem_noc_addr, 1u << args.my_slot_idx, worker_to_forwarder_noc);
-            noc_async_atomic_barrier();
+            unified_kernels::noc_async_atomic_inc_issue_txn</*posted=*/false>(worker_to_forwarder_noc);
+            noc_async_atomic_barrier(worker_to_forwarder_noc);
 
             // Pop source_cb to free it for the next iteration.
             // Must match the wait_front guard: LEAF standalone (SkipLocalCbPush=false)

--- a/models/demos/deepseek_v3_b1/unified_kernels/residual_add.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/residual_add.hpp
@@ -65,15 +65,14 @@ struct ResidualAdd {
 #if defined(COMPILE_FOR_TRISC)
             constexpr uint32_t out_w = CTArgs::out_w;
 
-            cb_wait_front(args.in0_cb, out_w);
-            cb_wait_front(args.in1_cb, args.total_in1_tiles);
-
             if constexpr (SkipAdd) {
                 // Pass-through: copy in0 to out, discard in1
                 reconfig_data_format<false, true>(args.in0_cb, args.in0_cb);
                 pack_reconfig_data_format<true>(args.out_cb);
                 pack_block_contiguous_init(args.out_cb);
                 copy_tile_to_dst_init_short(args.in0_cb);
+                cb_wait_front(args.in0_cb, out_w);
+                cb_wait_front(args.in1_cb, args.total_in1_tiles);
                 cb_reserve_back(args.out_cb, out_w);
                 tile_regs_acquire();
                 for (uint32_t j = 0; j < out_w; j++) {
@@ -90,7 +89,8 @@ struct ResidualAdd {
                 pack_block_contiguous_init(args.out_cb);
 
                 add_tiles_init(args.in0_cb, args.in1_cb);
-
+                cb_wait_front(args.in0_cb, out_w);
+                cb_wait_front(args.in1_cb, args.total_in1_tiles);
                 cb_reserve_back(args.out_cb, out_w);
                 tile_regs_acquire();
                 for (uint32_t j = 0; j < out_w; j++) {

--- a/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
@@ -5,6 +5,7 @@
 
 #include "kernel_op_api.hpp"
 #include "kernel_utils.hpp"
+#include "dataflow_utils.hpp"
 
 // =============================================================================
 // Per-RISC includes
@@ -753,24 +754,50 @@ struct SdpaReduceWorker {
                     scatter_dest_noc_y[i] = scatter_dest_coords[i * 2 + 1];
                 }
 
-                cb_wait_front(CTArgs::cb_l_out, CTArgs::scatter_num_tiles);
+                constexpr uint32_t scatter_payload_bytes = CTArgs::scatter_num_tiles * CTArgs::scatter_dst_tile_size;
+                static_assert(scatter_payload_bytes <= NOC_MAX_BURST_SIZE);
+                constexpr bool posted = CTArgs::scatter_arrival_enabled;
                 uint32_t src_addr = get_read_ptr(CTArgs::cb_l_out);
 
-                constexpr uint32_t scatter_payload_bytes = CTArgs::scatter_num_tiles * CTArgs::scatter_dst_tile_size;
+                uint64_t dest_noc_addr =
+                    get_noc_addr(scatter_dest_noc_x[0], scatter_dest_noc_y[0], args.scatter_dest_l1_addr);
+                unified_kernels::unicast_write_set_state<posted, true, true, true, false, write_cmd_buf>(
+                    src_addr, dest_noc_addr, scatter_payload_bytes);
 
-                for (uint32_t row = 0; row < CTArgs::scatter_num_rows; row++) {
+                if constexpr (CTArgs::scatter_arrival_enabled) {
+                    uint64_t sem_addr =
+                        get_noc_addr(scatter_dest_noc_x[0], scatter_dest_noc_y[0], args.scatter_arrival_sem_addr);
+                    unified_kernels::unicast_atomic_inc_set_state<false, true, true, false, write_at_cmd_buf>(
+                        sem_addr, 1);
+                }
+
+                cb_wait_front(CTArgs::cb_l_out, CTArgs::scatter_num_tiles);
+                unified_kernels::unicast_write_increment_counters<posted>(CTArgs::scatter_num_rows);
+                unified_kernels::noc_async_write_issue_txn<posted, false>();
+                if constexpr (CTArgs::scatter_arrival_enabled) {
+                    unified_kernels::unicast_atomic_inc_increment_counters<false>(CTArgs::scatter_num_rows);
+                    unified_kernels::noc_async_atomic_inc_issue_txn<false, false>();
+                }
+                src_addr += scatter_payload_bytes;
+
+                for (uint32_t row = 1; row < CTArgs::scatter_num_rows; row++) {
                     uint64_t dest_noc_addr =
                         get_noc_addr(scatter_dest_noc_x[row], scatter_dest_noc_y[row], args.scatter_dest_l1_addr);
-                    noc_async_write(src_addr, dest_noc_addr, scatter_payload_bytes);
-                    src_addr += scatter_payload_bytes;
+                    unified_kernels::unicast_write_set_state<posted, true, true, false, false, write_cmd_buf>(
+                        src_addr, dest_noc_addr, scatter_payload_bytes);
+
+                    unified_kernels::noc_async_write_issue_txn<posted, false>();
 
                     // Signal scatter arrival on destination core (used by fused ops
                     // to synchronize downstream stages like matmul1)
                     if constexpr (CTArgs::scatter_arrival_enabled) {
                         uint64_t sem_addr = get_noc_addr(
                             scatter_dest_noc_x[row], scatter_dest_noc_y[row], args.scatter_arrival_sem_addr);
-                        noc_semaphore_inc(sem_addr, 1);
+                        unified_kernels::unicast_atomic_inc_set_state<false, true, false, false, write_at_cmd_buf>(
+                            sem_addr, 1);
+                        unified_kernels::noc_async_atomic_inc_issue_txn<false, false>();
                     }
+                    src_addr += scatter_payload_bytes;
                 }
                 if constexpr (CTArgs::scatter_arrival_enabled) {
                     noc_async_atomic_barrier();


### PR DESCRIPTION
### Summary
We waste cycles by waiting for data to arrive via cb or semaphore before we program the noc registers.
This change preprograms the noc registers before waiting. In some cases, we will also pre-increment the noc counters before waiting. This is not safe in the general case in dynamic noc mode because the counters are shared between riscs so it could cause a deadlock depending on ordering, so only enable in a few select locations. In dedicated noc mode this should be safe to pre-increment in all cases since we have dedicated counters.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aho/noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aho/noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aho/noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aho/noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/noc)