### PR TITLE
Cleanup ttnn::Tensor scaffolding result from metal tensor migration

### DIFF
--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
@@ -183,14 +183,6 @@ TEST(HostTensorTest, CopyAssignmentFromDefaultConstructed) {
     // tensor should now be in default-constructed state (no assertions, just shouldn't crash)
 }
 
-TEST(HostTensorTest, MoveConstructionWithNewSpecFromDefaultConstructedFails) {
-    HostTensor default_tensor;
-    auto new_spec = create_simple_spec(Shape{4, 32}, DataType::FLOAT32);
-    auto new_topology = TensorTopology();
-
-    EXPECT_ANY_THROW(HostTensor(std::move(default_tensor), std::move(new_spec), std::move(new_topology)));
-}
-
 TEST(HostTensorTest, TensorSpecAccess) {
     Shape shape{4, 32};
     auto tensor = create_simple_host_tensor(shape, DataType::FLOAT32);
@@ -246,20 +238,6 @@ TEST(HostTensorTest, BufferAccess) {
     const auto& buffer = tensor.buffer();
     // Buffer should have shape {1} (single device)
     EXPECT_EQ(buffer.shape().dims(), 1);
-}
-
-TEST(HostTensorTest, MoveConstructionWithNewSpecAndTopology) {
-    Shape original_shape{2, 64};
-    auto tensor = create_simple_host_tensor(original_shape);
-
-    Shape new_shape{4, 32};
-    auto new_spec = create_simple_spec(new_shape, DataType::FLOAT32);
-    auto new_topology = TensorTopology();
-
-    HostTensor new_tensor(std::move(tensor), std::move(new_spec), std::move(new_topology));
-
-    EXPECT_EQ(new_tensor.logical_shape(), new_shape);
-    EXPECT_EQ(new_tensor.dtype(), DataType::FLOAT32);
 }
 
 TEST(HostTensorTest, PaddedShape) {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
@@ -177,7 +177,8 @@ TYPED_TEST(BorrowedStorageVectorConversionTest, Roundtrip) {
         EXPECT_EQ(ctor_count, 1);
         EXPECT_EQ(dtor_count, 0);
         {
-            Tensor copy(tensor.host_storage(), tensor.tensor_spec(), tensor.tensor_topology());
+            Tensor copy(tt::tt_metal::HostTensor(
+                tensor.host_storage().buffer(), tensor.tensor_spec(), tensor.tensor_topology()));
             EXPECT_EQ(ctor_count, 2);
             EXPECT_EQ(dtor_count, 0);
         }
@@ -209,7 +210,8 @@ TYPED_TEST(BorrowedStorageVectorConversionTest, Callbacks) {
     EXPECT_EQ(ctor_count, 1);
     EXPECT_EQ(dtor_count, 0);
     {
-        Tensor copy(tensor.host_storage(), tensor.tensor_spec(), tensor.tensor_topology());
+        Tensor copy(
+            tt::tt_metal::HostTensor(tensor.host_storage().buffer(), tensor.tensor_spec(), tensor.tensor_topology()));
         EXPECT_EQ(ctor_count, 2);
         EXPECT_EQ(dtor_count, 0);
     }

--- a/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
@@ -76,13 +76,6 @@ public:
      */
     explicit HostTensor(HostBuffer buffer, TensorSpec spec, TensorTopology topology);
 
-    /**
-     * Move constructor with new spec and topology.
-     * Moves the buffer from other and uses the provided spec/topology.
-     * This is meant for transition as TTNN-Tensor current has a two-step construction for HostTensor.
-     */
-    HostTensor(HostTensor&& other, TensorSpec spec, TensorTopology topology);
-
     ~HostTensor();
 
     /**

--- a/tt_metal/impl/tensor/host_tensor.cpp
+++ b/tt_metal/impl/tensor/host_tensor.cpp
@@ -17,11 +17,6 @@ public:
     HostTensorImpl& operator=(HostTensorImpl&& other) noexcept = default;
     ~HostTensorImpl() = default;
 
-    // Two step construction for HostTensor,
-    // for transiet purpose.
-    HostTensorImpl(HostTensorImpl&& other, TensorSpec spec, TensorTopology topology) :
-        buffer_(std::move(other.buffer_)), spec_(std::move(spec)), topology_(std::move(topology)) {}
-
     const DistributedHostBuffer& buffer() const& { return buffer_; }
     DistributedHostBuffer& buffer() & { return buffer_; }
     DistributedHostBuffer buffer() const&& { return buffer_; }
@@ -55,11 +50,6 @@ HostTensor::HostTensor(HostBuffer buffer, TensorSpec spec, TensorTopology topolo
         CMAKE_UNIQUE_NAMESPACE::create_unit_distributed_host_buffer(std::move(buffer)),
         std::move(spec),
         std::move(topology))) {}
-
-HostTensor::HostTensor(HostTensor&& other, TensorSpec spec, TensorTopology topology) {
-    TT_FATAL(other.impl != nullptr, "Cannot move from a default-constructed or moved-from HostTensor.");
-    impl = std::make_unique<HostTensorImpl>(std::move(*other.impl), std::move(spec), std::move(topology));
-}
 
 HostTensor::HostTensor(const HostTensor& other) :
     impl(other.impl ? std::make_unique<HostTensorImpl>(*other.impl) : nullptr) {}

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -333,9 +333,11 @@ HostTensor to_layout_impl(const HostTensor& tensor, Layout target_layout) {
         TT_THROW("Unreachable");
     };
 
-    auto transformed_tensor = tensor.transform([&](const HostBuffer& buffer) { return HostBuffer(convert(buffer)); });
+    auto transformed_buffer = tensor.buffer().transform(
+        [&](const HostBuffer& buffer) { return HostBuffer(convert(buffer)); },
+        DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
     return HostTensor(
-        transformed_tensor.buffer(),
+        std::move(transformed_buffer),
         TensorSpec(
             tensor.logical_shape(),
             TensorLayout::fromPaddedShape(
@@ -636,9 +638,11 @@ HostTensor pad_impl(
         return output_buffer;
     };
 
-    auto transformed_tensor = tensor.transform([&](const HostBuffer& buffer) { return HostBuffer(pad(buffer)); });
+    auto transformed_buffer = tensor.buffer().transform(
+        [&](const HostBuffer& buffer) { return HostBuffer(pad(buffer)); },
+        DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
     return HostTensor(
-        transformed_tensor.buffer(),
+        std::move(transformed_buffer),
         TensorSpec(
             tensor.logical_shape(),
             TensorLayout::fromPaddedShape(
@@ -712,9 +716,11 @@ HostTensor unpad_impl(
         return output_buffer;
     };
 
-    auto transformed_tensor = tensor.transform([&](const HostBuffer& buffer) { return HostBuffer(unpad(buffer)); });
+    auto transformed_buffer = tensor.buffer().transform(
+        [&](const HostBuffer& buffer) { return HostBuffer(unpad(buffer)); },
+        DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
     return HostTensor(
-        transformed_tensor.buffer(),
+        std::move(transformed_buffer),
         TensorSpec(
             tt::tt_metal::Shape(output_shape),
             tt::tt_metal::TensorLayout(

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -333,8 +333,9 @@ HostTensor to_layout_impl(const HostTensor& tensor, Layout target_layout) {
         TT_THROW("Unreachable");
     };
 
+    auto transformed_tensor = tensor.transform([&](const HostBuffer& buffer) { return HostBuffer(convert(buffer)); });
     return HostTensor(
-        tensor.transform([&](const HostBuffer& buffer) { return HostBuffer(convert(buffer)); }),
+        transformed_tensor.buffer(),
         TensorSpec(
             tensor.logical_shape(),
             TensorLayout::fromPaddedShape(
@@ -635,8 +636,9 @@ HostTensor pad_impl(
         return output_buffer;
     };
 
+    auto transformed_tensor = tensor.transform([&](const HostBuffer& buffer) { return HostBuffer(pad(buffer)); });
     return HostTensor(
-        tensor.transform([&](const HostBuffer& buffer) { return HostBuffer(pad(buffer)); }),
+        transformed_tensor.buffer(),
         TensorSpec(
             tensor.logical_shape(),
             TensorLayout::fromPaddedShape(
@@ -710,8 +712,9 @@ HostTensor unpad_impl(
         return output_buffer;
     };
 
+    auto transformed_tensor = tensor.transform([&](const HostBuffer& buffer) { return HostBuffer(unpad(buffer)); });
     return HostTensor(
-        tensor.transform([&](const HostBuffer& buffer) { return HostBuffer(unpad(buffer)); }),
+        transformed_tensor.buffer(),
         TensorSpec(
             tt::tt_metal::Shape(output_shape),
             tt::tt_metal::TensorLayout(

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -24,24 +24,8 @@ namespace tt::tt_metal {
 
 class HostStorage {
 public:
-    // Creates HostStorage distributed over a mesh that matches `buffer` shape.
-    [[deprecated("Use HostStorage(HostTensor tensor) instead")]]
-    explicit HostStorage(DistributedHostBuffer buffer);
-
-    // Creates HostStorage distributed over 1x1 mesh.
-    [[deprecated("Use HostStorage(HostTensor tensor) instead")]]
-    explicit HostStorage(HostBuffer buffer);
-
     // Creates HostStorage from a HostTensor.
     explicit HostStorage(HostTensor tensor);
-
-    // Transitional constructors: accept a pre-transition HostStorage (constructed
-    // without TensorSpec and TensorTopology) and assign them during construction.
-    // Overrides any existing spec/topology in the HostStorage.
-    //
-    // TODO(#40348): Remove these.
-    HostStorage(const HostStorage& other, TensorSpec spec, TensorTopology topology);
-    HostStorage(HostStorage&& other, TensorSpec spec, TensorTopology topology);
 
     // Returns the distributed host buffer.
     const DistributedHostBuffer& buffer() const;

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -51,15 +51,6 @@ public:
     Tensor& operator=(Tensor&& other) noexcept;
     ~Tensor();
 
-    // Transitional constructor: use Tensor(HostTensor) instead.
-    //
-    // Accepts a pre-transition HostStorage (constructed without TensorSpec and
-    // TensorTopology) and assigns them during Tensor construction.
-    // Overrides any existing spec/topology in the HostStorage.
-    //
-    // TODO(#40348): Remove this.
-    [[nodiscard]] Tensor(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
-
     [[nodiscard]] explicit Tensor(DeviceStorage storage);
 
     [[nodiscard]] explicit Tensor(HostTensor tensor);

--- a/ttnn/api/ttnn/tensor/tensor_attributes.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_attributes.hpp
@@ -7,8 +7,6 @@
 #include <memory>
 
 #include "ttnn/tensor/storage.hpp"
-#include "ttnn/tensor/tensor_spec.hpp"
-#include "ttnn/distributed/tensor_topology.hpp"
 
 namespace tt::tt_metal {
 
@@ -16,23 +14,6 @@ class TensorAttributes : public std::enable_shared_from_this<TensorAttributes> {
 public:
     TensorAttributes(HostStorage storage);
     TensorAttributes(DeviceStorage storage);
-
-    // Transitional constructor: use TensorAttributes(HostStorage) instead.
-    //
-    // Accepts a pre-transition HostStorage (constructed without TensorSpec and
-    // TensorTopology) and assigns them during TensorAttributes construction.
-    // Overrides any existing spec/topology in the HostStorage.
-    //
-    // e.g. This protects this usage:
-    // HostStorage storage(buffer);
-    // Tensor(storage, tensor_spec, tensor_topology);
-    //
-    // (after transition, should be):
-    // HostStorage storage(HostTensor(buffer, tensor_spec, tensor_topology));
-    // Tensor(storage);
-    //
-    // TODO(#40348): Remove this.
-    TensorAttributes(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
 
     TensorAttributes(const TensorAttributes&) = default;
     TensorAttributes(TensorAttributes&&) = default;

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <algorithm>
-#include <numeric>
 #include <functional>
 #include <tt-logger/tt-logger.hpp>
 #include <set>
@@ -39,32 +38,10 @@ void validate_mesh_coordinates(
     }
 }
 
-DistributedHostBuffer create_unit_distributed_host_buffer(HostBuffer buffer) {
-    auto distributed_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
-    distributed_buffer.emplace_shard(distributed::MeshCoordinate(0, 0), [&buffer]() { return std::move(buffer); });
-    return distributed_buffer;
-}
-
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
-HostStorage::HostStorage(HostBuffer buffer) : HostStorage(CMAKE_UNIQUE_NAMESPACE::create_unit_distributed_host_buffer(std::move(buffer))) {}
-
-HostTensor create_dummy_host_tensor(DistributedHostBuffer buffer) {
-    TensorSpec spec{Shape{}, TensorLayout{DataType::BFLOAT16, PageConfig{Layout::ROW_MAJOR}, MemoryConfig{}}};
-    TensorTopology topology;
-    return HostTensor(std::move(buffer), std::move(spec), std::move(topology));
-}
-
-HostStorage::HostStorage(DistributedHostBuffer buffer) : tensor(create_dummy_host_tensor(std::move(buffer))) {}
-
 HostStorage::HostStorage(HostTensor tensor) : tensor(std::move(tensor)) {}
-
-HostStorage::HostStorage(const HostStorage& other, TensorSpec spec, TensorTopology topology) :
-    tensor(HostTensor(other.buffer(), std::move(spec), std::move(topology))) {}
-
-HostStorage::HostStorage(HostStorage&& other, TensorSpec spec, TensorTopology topology) :
-    tensor(HostTensor(std::move(other.tensor), std::move(spec), std::move(topology))) {}
 
 const DistributedHostBuffer& HostStorage::buffer() const { return tensor.buffer(); }
 

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -79,11 +79,6 @@ Tensor::Tensor(
 Tensor::Tensor(HostBuffer buffer, TensorSpec tensor_spec) :
     Tensor(HostTensor(std::move(buffer), std::move(tensor_spec), TensorTopology{})) {}
 
-Tensor::Tensor(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
-    tensor_id(Tensor::next_tensor_id()),
-    tensor_attributes(
-        std::make_shared<TensorAttributes>(std::move(storage), std::move(tensor_spec), std::move(tensor_topology))) {}
-
 Tensor::Tensor(HostTensor tensor) :
     tensor_id(Tensor::next_tensor_id()),
     tensor_attributes(std::make_shared<TensorAttributes>(HostStorage(std::move(tensor)))) {}

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -4,18 +4,12 @@
 
 #include "ttnn/tensor/storage.hpp"
 #include "ttnn/tensor/tensor_attributes.hpp"
-#include "ttnn/tensor/tensor_spec.hpp"
 
 namespace tt::tt_metal {
 
 TensorAttributes::TensorAttributes(HostStorage storage) : storage_(std::move(storage)) {}
 
 TensorAttributes::TensorAttributes(DeviceStorage storage) : storage_(std::move(storage)) {}
-
-// Transitional: assumes a HostStorage constructed without proper TensorSpec and TensorTopology.
-// Overrides the existing spec and topology in the HostStorage.
-TensorAttributes::TensorAttributes(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
-    storage_(HostStorage(std::move(storage), std::move(tensor_spec), std::move(tensor_topology))) {}
 
 const Storage& TensorAttributes::get_storage() const { return storage_; }
 Storage& TensorAttributes::get_storage() { return storage_; }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -147,7 +147,8 @@ static tt::tt_metal::HostBuffer create_host_buffer_for_conv_weight(
 template <typename T, typename Fn>
 Tensor convert_tensor(const Tensor& input_tensor, const Fn& compute, const TensorSpec& output_spec) {
     TT_FATAL(is_cpu_tensor(input_tensor), "convert_tensor only supports cpu tensors");
-    return Tensor(input_tensor.host_storage().transform(compute), output_spec, input_tensor.tensor_topology());
+    auto transformed_tensor = input_tensor.host_tensor().transform(compute);
+    return Tensor(tt::tt_metal::HostTensor(transformed_tensor.buffer(), output_spec, input_tensor.tensor_topology()));
 }
 
 template <typename Func, typename... Args>
@@ -959,7 +960,7 @@ static Tensor to_folded_weight_layout(const Tensor& conv_weight_tensor, std::arr
         {out_channels, in_channels * stride[0] * stride[1], padded_kernel_h / stride[0], padded_kernel_w / stride[1]});
 
     auto fold_weights = [&]<typename T>(const tt::tt_metal::HostStorage& storage) {
-        auto folded_storage = storage.transform([&](const tt::tt_metal::HostBuffer& input_host_buffer) {
+        auto folded_tensor = storage.host_tensor().transform([&](const tt::tt_metal::HostBuffer& input_host_buffer) {
             auto input_buffer = tt::tt_metal::host_buffer::get_as<T>(input_host_buffer);
 
             std::vector<T> output_buffer(output_shape.volume(), T(0));
@@ -1004,12 +1005,12 @@ static Tensor to_folded_weight_layout(const Tensor& conv_weight_tensor, std::arr
 
             return tt::tt_metal::HostBuffer(std::move(output_buffer));
         });
-        return Tensor(
-            std::move(folded_storage),
+        return Tensor(tt::tt_metal::HostTensor(
+            folded_tensor.buffer(),
             TensorSpec(
                 output_shape,
                 tt::tt_metal::TensorLayout(dtype, tt::tt_metal::PageConfig(Layout::ROW_MAJOR), MemoryConfig{})),
-            conv_weight_tensor.tensor_topology());
+            conv_weight_tensor.tensor_topology()));
     };
 
     const auto& storage = conv_weight_tensor.host_storage();

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -147,8 +147,9 @@ static tt::tt_metal::HostBuffer create_host_buffer_for_conv_weight(
 template <typename T, typename Fn>
 Tensor convert_tensor(const Tensor& input_tensor, const Fn& compute, const TensorSpec& output_spec) {
     TT_FATAL(is_cpu_tensor(input_tensor), "convert_tensor only supports cpu tensors");
-    auto transformed_tensor = input_tensor.host_tensor().transform(compute);
-    return Tensor(tt::tt_metal::HostTensor(transformed_tensor.buffer(), output_spec, input_tensor.tensor_topology()));
+    auto transformed_buffer = input_tensor.host_storage().buffer().transform(
+        compute, tt::tt_metal::DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
+    return Tensor(tt::tt_metal::HostTensor(std::move(transformed_buffer), output_spec, input_tensor.tensor_topology()));
 }
 
 template <typename Func, typename... Args>
@@ -960,53 +961,56 @@ static Tensor to_folded_weight_layout(const Tensor& conv_weight_tensor, std::arr
         {out_channels, in_channels * stride[0] * stride[1], padded_kernel_h / stride[0], padded_kernel_w / stride[1]});
 
     auto fold_weights = [&]<typename T>(const tt::tt_metal::HostStorage& storage) {
-        auto folded_tensor = storage.host_tensor().transform([&](const tt::tt_metal::HostBuffer& input_host_buffer) {
-            auto input_buffer = tt::tt_metal::host_buffer::get_as<T>(input_host_buffer);
+        auto folded_buffer = storage.buffer().transform(
+            [&](const tt::tt_metal::HostBuffer& input_host_buffer) {
+                auto input_buffer = tt::tt_metal::host_buffer::get_as<T>(input_host_buffer);
 
-            std::vector<T> output_buffer(output_shape.volume(), T(0));
-            int new_h = padded_kernel_h / stride[0];
-            int new_w = padded_kernel_w / stride[1];
-            WeightLayoutThreader::parallel_for_channels(
-                out_channels,
-                in_channels,
-                16,  // Minimum work per thread
-                [&](uint32_t /*out_t*/,
-                    uint32_t /*in_t*/,
-                    uint32_t out_start,
-                    uint32_t out_end,
-                    uint32_t in_start,
-                    uint32_t in_end) {
-                    for (auto oc = out_start; oc < out_end; oc++) {
-                        for (auto ic = in_start; ic < in_end; ic++) {
-                            for (auto kh = 0; kh < kernel_h; kh++) {
-                                for (auto kw = 0; kw < kernel_w; kw++) {
-                                    uint32_t src_idx = ((((oc * in_channels + ic) * kernel_h) + kh) * kernel_w) + kw;
+                std::vector<T> output_buffer(output_shape.volume(), T(0));
+                int new_h = padded_kernel_h / stride[0];
+                int new_w = padded_kernel_w / stride[1];
+                WeightLayoutThreader::parallel_for_channels(
+                    out_channels,
+                    in_channels,
+                    16,  // Minimum work per thread
+                    [&](uint32_t /*out_t*/,
+                        uint32_t /*in_t*/,
+                        uint32_t out_start,
+                        uint32_t out_end,
+                        uint32_t in_start,
+                        uint32_t in_end) {
+                        for (auto oc = out_start; oc < out_end; oc++) {
+                            for (auto ic = in_start; ic < in_end; ic++) {
+                                for (auto kh = 0; kh < kernel_h; kh++) {
+                                    for (auto kw = 0; kw < kernel_w; kw++) {
+                                        uint32_t src_idx =
+                                            ((((oc * in_channels + ic) * kernel_h) + kh) * kernel_w) + kw;
 
-                                    int sh = kh % stride[0];
-                                    int sw = kw % stride[1];
+                                        int sh = kh % stride[0];
+                                        int sw = kw % stride[1];
 
-                                    // Calculate new y,x coordinates
-                                    int y = kh / stride[0];
-                                    int x = kw / stride[1];
+                                        // Calculate new y,x coordinates
+                                        int y = kh / stride[0];
+                                        int x = kw / stride[1];
 
-                                    // Calculate folded input channel index
-                                    int folded_ic_idx = ((sh * stride[1] + sw) * in_channels) + ic;
+                                        // Calculate folded input channel index
+                                        int folded_ic_idx = ((sh * stride[1] + sw) * in_channels) + ic;
 
-                                    // Calculate final destination index
-                                    int dst_idx = (oc * in_channels * stride[0] * stride[1] * new_h * new_w) +
-                                                  (folded_ic_idx * new_h * new_w) + (y * new_w) + x;
+                                        // Calculate final destination index
+                                        int dst_idx = (oc * in_channels * stride[0] * stride[1] * new_h * new_w) +
+                                                      (folded_ic_idx * new_h * new_w) + (y * new_w) + x;
 
-                                    output_buffer[dst_idx] = input_buffer[src_idx];
+                                        output_buffer[dst_idx] = input_buffer[src_idx];
+                                    }
                                 }
                             }
                         }
-                    }
-                });
+                    });
 
-            return tt::tt_metal::HostBuffer(std::move(output_buffer));
-        });
+                return tt::tt_metal::HostBuffer(std::move(output_buffer));
+            },
+            tt::tt_metal::DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
         return Tensor(tt::tt_metal::HostTensor(
-            folded_tensor.buffer(),
+            std::move(folded_buffer),
             TensorSpec(
                 output_shape,
                 tt::tt_metal::TensorLayout(dtype, tt::tt_metal::PageConfig(Layout::ROW_MAJOR), MemoryConfig{})),

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
@@ -133,8 +133,9 @@ ttnn::Tensor _transform_weights_for_conv_transpose2d(const Tensor& conv_weight_t
         tt::tt_metal::TensorLayout(
             conv_weight_tensor.dtype(), tt::tt_metal::PageConfig(Layout::ROW_MAJOR), MemoryConfig{}));
 
+    auto transformed_tensor = conv_weight_tensor.host_tensor().transform(compute);
     return Tensor(
-        conv_weight_tensor.host_storage().transform(compute), output_spec, conv_weight_tensor.tensor_topology());
+        tt::tt_metal::HostTensor(transformed_tensor.buffer(), output_spec, conv_weight_tensor.tensor_topology()));
 }
 
 Tensor transform_weights_for_conv_transpose2d(const Tensor& conv_weight_tensor, bool mirror_kernel) {

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
@@ -133,9 +133,10 @@ ttnn::Tensor _transform_weights_for_conv_transpose2d(const Tensor& conv_weight_t
         tt::tt_metal::TensorLayout(
             conv_weight_tensor.dtype(), tt::tt_metal::PageConfig(Layout::ROW_MAJOR), MemoryConfig{}));
 
-    auto transformed_tensor = conv_weight_tensor.host_tensor().transform(compute);
+    auto transformed_buffer = conv_weight_tensor.host_storage().buffer().transform(
+        compute, tt::tt_metal::DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
     return Tensor(
-        tt::tt_metal::HostTensor(transformed_tensor.buffer(), output_spec, conv_weight_tensor.tensor_topology()));
+        tt::tt_metal::HostTensor(std::move(transformed_buffer), output_spec, conv_weight_tensor.tensor_topology()));
 }
 
 Tensor transform_weights_for_conv_transpose2d(const Tensor& conv_weight_tensor, bool mirror_kernel) {

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
@@ -30,15 +30,13 @@ static Tensor manual_insertion(
         logical_shape.volume(),
         input_tensor.logical_volume());
     auto cpu_tensor = input_tensor.cpu();
-    auto output =
-        Tensor(
-            cpu_tensor.host_storage(),
-            TensorSpec(
-                logical_shape,
-                TensorLayout::fromPaddedShape(
-                    DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)),
-            cpu_tensor.tensor_topology())
-            .to_layout(Layout::ROW_MAJOR);
+    auto output_spec = TensorSpec(
+        logical_shape,
+        TensorLayout::fromPaddedShape(
+            DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape));
+    auto output = Tensor(tt::tt_metal::HostTensor(
+                             cpu_tensor.host_storage().buffer(), std::move(output_spec), cpu_tensor.tensor_topology()))
+                      .to_layout(Layout::ROW_MAJOR);
     if (device != nullptr) {
         output = output.to_device(device, output_mem_config);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.cpp
@@ -23,7 +23,8 @@ namespace ttnn::operations::experimental::conv3d {
 template <typename T, typename Fn>
 Tensor convert_tensor(const Tensor& input_tensor, const Fn& compute, const TensorSpec& output_spec) {
     TT_FATAL(is_cpu_tensor(input_tensor), "convert_tensor only supports cpu tensors");
-    return Tensor(input_tensor.host_storage().transform(compute), output_spec, input_tensor.tensor_topology());
+    auto transformed_tensor = input_tensor.host_tensor().transform(compute);
+    return Tensor(tt::tt_metal::HostTensor(transformed_tensor.buffer(), output_spec, input_tensor.tensor_topology()));
 }
 
 template <typename Func, typename... Args>

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.cpp
@@ -23,8 +23,9 @@ namespace ttnn::operations::experimental::conv3d {
 template <typename T, typename Fn>
 Tensor convert_tensor(const Tensor& input_tensor, const Fn& compute, const TensorSpec& output_spec) {
     TT_FATAL(is_cpu_tensor(input_tensor), "convert_tensor only supports cpu tensors");
-    auto transformed_tensor = input_tensor.host_tensor().transform(compute);
-    return Tensor(tt::tt_metal::HostTensor(transformed_tensor.buffer(), output_spec, input_tensor.tensor_topology()));
+    auto transformed_buffer = input_tensor.host_storage().buffer().transform(
+        compute, tt::tt_metal::DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
+    return Tensor(tt::tt_metal::HostTensor(std::move(transformed_buffer), output_spec, input_tensor.tensor_topology()));
 }
 
 template <typename Func, typename... Args>

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_prepare_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_prepare_grid.cpp
@@ -196,8 +196,9 @@ Tensor convert_grid_tensor(
 
     TT_FATAL(is_cpu_tensor(input_tensor), "Prepare_grid_sample_grid only supports host tensors");
 
-    auto transformed_tensor = input_tensor.host_tensor().transform(compute);
-    return Tensor(tt::tt_metal::HostTensor(transformed_tensor.buffer(), output_spec, input_tensor.tensor_topology()));
+    auto transformed_buffer = input_tensor.host_storage().buffer().transform(
+        compute, tt::tt_metal::DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
+    return Tensor(tt::tt_metal::HostTensor(std::move(transformed_buffer), output_spec, input_tensor.tensor_topology()));
 }
 
 }  // anonymous namespace

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_prepare_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_prepare_grid.cpp
@@ -196,7 +196,8 @@ Tensor convert_grid_tensor(
 
     TT_FATAL(is_cpu_tensor(input_tensor), "Prepare_grid_sample_grid only supports host tensors");
 
-    return Tensor(input_tensor.host_storage().transform(compute), output_spec, input_tensor.tensor_topology());
+    auto transformed_tensor = input_tensor.host_tensor().transform(compute);
+    return Tensor(tt::tt_metal::HostTensor(transformed_tensor.buffer(), output_spec, input_tensor.tensor_topology()));
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
### PR Category
Cleanup.

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Close #43581 .

During tensor lowering https://github.com/tenstorrent/tt-metal/pull/40127 , some scaffolding was left in `ttnn::Tensor` to ease transition.

This PR removes these scaffolding and improve code quality.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

The scaffolding is specifically to maintain this constructor:

```C++
HostStorage storage(buffer);
Tensor tensor(storage, tensor_spec, tensor_topology);
```

Where we are moving towards this construction instead:

```C++
HostTensor storage(buffer, tensor_spec, tensor_topology);
Tensor tensor(storage);
```

This migration was not done to keep the original PR small.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/transiet-constructor-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/transiet-constructor-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/transiet-constructor-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/transiet-constructor-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/transiet-constructor-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/transiet-constructor-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/transiet-constructor-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/transiet-constructor-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/transiet-constructor-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/transiet-constructor-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/transiet-constructor-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/transiet-constructor-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/transiet-constructor-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/transiet-constructor-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/transiet-constructor-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/transiet-constructor-cleanup)