### PR TITLE
[Cleanup] Require MeshDevice for Program construction in Metal 2.0

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -7,6 +7,8 @@
 // Shared test utilities for Metal 2.0 Host API tests.
 // These helpers create minimal valid spec objects for testing.
 
+#include <cstdlib>
+#include <optional>
 #include <string>
 #include <variant>
 #include <vector>
@@ -24,6 +26,36 @@
 // recommended patterns for constructing ProgramSpec objects in production code.
 
 namespace tt::tt_metal::experimental::metal2_host_api::test_helpers {
+
+// ============================================================================
+// Test environment helpers
+// ============================================================================
+
+// Saves and overrides TT_METAL_SLOW_DISPATCH_MODE on construction;
+// restores to its prior state (set or unset) on destruction.
+// (Unit test need SLOW_DISPATCH_MODE=1 to make a MeshDevice successfully.)
+class ScopedSlowDispatchOverride {
+public:
+    ScopedSlowDispatchOverride() {
+        if (const char* prev = std::getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
+            prev_value_.emplace(prev);
+        }
+        setenv("TT_METAL_SLOW_DISPATCH_MODE", "1", /*overwrite=*/1);
+    }
+    ~ScopedSlowDispatchOverride() {
+        if (prev_value_) {
+            setenv("TT_METAL_SLOW_DISPATCH_MODE", prev_value_->c_str(), /*overwrite=*/1);
+        } else {
+            unsetenv("TT_METAL_SLOW_DISPATCH_MODE");
+        }
+    }
+
+    ScopedSlowDispatchOverride(const ScopedSlowDispatchOverride&) = delete;
+    ScopedSlowDispatchOverride& operator=(const ScopedSlowDispatchOverride&) = delete;
+
+private:
+    std::optional<std::string> prev_value_;
+};
 
 // ============================================================================
 // Constants

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -33,6 +33,7 @@
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_params.hpp>
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/context/metal_env.hpp>
 #include <tt-metalium/experimental/mock_device.hpp>
 
@@ -57,14 +58,29 @@ using NumVarargsPerNode = KernelSpec::RuntimeArgSchema::NumVarargsPerNode;
 // Test Fixtures
 // ============================================================================
 
-// Test fixture for ProgramRunParams on Quasar - uses Quasar mock device
+// Test fixture for ProgramRunParams on Quasar - uses Quasar mock device.
+//
+// Forces TT_METAL_SLOW_DISPATCH_MODE so that MeshDevice::create() succeeds against the
+// mock cluster (mock Quasar has no dispatch-core reservation in its descriptor). These
+// tests exercise pure API behavior, so slow dispatch is functionally fine.
 class ProgramRunParamsTestQuasar : public ::testing::Test {
 protected:
     void SetUp() override {
+        setenv("TT_METAL_SLOW_DISPATCH_MODE", "1", /*overwrite=*/1);
         //  Configure global mock mode for Quasar
         experimental::configure_mock_mode(tt::ARCH::QUASAR, 1);
+        mesh_device_ = distributed::MeshDevice::create(distributed::MeshDeviceConfig(distributed::MeshShape{1, 1}));
     }
-    void TearDown() override { experimental::disable_mock_mode(); }
+    void TearDown() override {
+        if (mesh_device_) {
+            mesh_device_->close();
+            mesh_device_.reset();
+        }
+        experimental::disable_mock_mode();
+        unsetenv("TT_METAL_SLOW_DISPATCH_MODE");
+    }
+
+    std::shared_ptr<distributed::MeshDevice> mesh_device_;
 };
 
 // ============================================================================
@@ -139,7 +155,7 @@ inline ProgramRunParams MakeRunParamsForMinimalSpec(
 TEST_F(ProgramRunParamsTestQuasar, UnknownKernelNameFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
     params.kernel_run_params.push_back({
@@ -158,7 +174,7 @@ TEST_F(ProgramRunParamsTestQuasar, InvalidNodeForKernelFails) {
     NodeCoord node{0, 0};
     NodeCoord wrong_node{1, 1};  // Kernel doesn't run on this node
     ProgramSpec spec = MakeSpecWithRTAs(node, 2, 0);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
     params.kernel_run_params.push_back({
@@ -177,7 +193,7 @@ TEST_F(ProgramRunParamsTestQuasar, InvalidNodeForKernelFails) {
 TEST_F(ProgramRunParamsTestQuasar, WrongRuntimeArgsCountFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/3, /*num_common_rtas=*/0);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     // Provide wrong count (2 instead of 3)
     auto params = MakeRunParamsForMinimalSpec(node, {1, 2}, {});
@@ -191,7 +207,7 @@ TEST_F(ProgramRunParamsTestQuasar, WrongRuntimeArgsCountFails) {
 TEST_F(ProgramRunParamsTestQuasar, WrongCommonRuntimeArgsCountFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/0, /*num_common_rtas=*/2);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     // Provide wrong common args count (3 instead of 2)
     auto params = MakeRunParamsForMinimalSpec(node, {}, {1, 2, 3});
@@ -207,7 +223,7 @@ TEST_F(ProgramRunParamsTestQuasar, WrongCommonRuntimeArgsCountFails) {
 TEST_F(ProgramRunParamsTestQuasar, MissingKernelParamsFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     // Only provide params for dm_kernel, missing compute_kernel
     ProgramRunParams params;
@@ -223,7 +239,7 @@ TEST_F(ProgramRunParamsTestQuasar, MissingKernelParamsFails) {
 TEST_F(ProgramRunParamsTestQuasar, DuplicateKernelParamsFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     // Provide params for dm_kernel twice
     ProgramRunParams params;
@@ -239,7 +255,7 @@ TEST_F(ProgramRunParamsTestQuasar, DuplicateKernelParamsFails) {
 TEST_F(ProgramRunParamsTestQuasar, MissingNodeRTAsFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/2, /*num_common_rtas=*/0);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     // Don't provide the per-node RTAs (empty runtime_varargs)
     ProgramRunParams params;
@@ -260,7 +276,7 @@ TEST_F(ProgramRunParamsTestQuasar, MissingNodeRTAsFails) {
 TEST_F(ProgramRunParamsTestQuasar, DFBSizeOverrideFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     auto params = MakeRunParamsForMinimalSpec(node, {}, {});
 
@@ -280,7 +296,7 @@ TEST_F(ProgramRunParamsTestQuasar, DFBSizeOverrideFails) {
 TEST_F(ProgramRunParamsTestQuasar, DFBNumEntriesOverrideFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     auto params = MakeRunParamsForMinimalSpec(node, {}, {});
 
@@ -299,7 +315,7 @@ TEST_F(ProgramRunParamsTestQuasar, DFBNumEntriesOverrideFails) {
 TEST_F(ProgramRunParamsTestQuasar, DuplicateDFBParamsFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     auto params = MakeRunParamsForMinimalSpec(node, {}, {});
 
@@ -315,7 +331,7 @@ TEST_F(ProgramRunParamsTestQuasar, DuplicateDFBParamsFails) {
 TEST_F(ProgramRunParamsTestQuasar, DuplicateNodeCoordInRuntimeArgsFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/2, /*num_common_rtas=*/0);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     // Provide runtime_varargs with duplicate node_coord entries
     ProgramRunParams params;
@@ -339,7 +355,7 @@ TEST_F(ProgramRunParamsTestQuasar, DuplicateNodeCoordInRuntimeArgsFails) {
 TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_ZeroRTAs) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/0, /*num_common_rtas=*/0);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     auto params = MakeRunParamsForMinimalSpec(node, {}, {});
 
@@ -349,7 +365,7 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_ZeroRTAs) {
 TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_PerNodeRTAsOnly) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/3, /*num_common_rtas=*/0);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     auto params = MakeRunParamsForMinimalSpec(node, {100, 200, 300}, {});
 
@@ -359,7 +375,7 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_PerNodeRTAsOnly) {
 TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_CommonRTAsOnly) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/0, /*num_common_rtas=*/2);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     auto params = MakeRunParamsForMinimalSpec(node, {}, {10, 20});
 
@@ -369,7 +385,7 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_CommonRTAsOnly) {
 TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_BothRTATypes) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/3, /*num_common_rtas=*/2);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     auto params = MakeRunParamsForMinimalSpec(node, {100, 200, 300}, {10, 20});
 
@@ -384,7 +400,7 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_BothKernelsWithRTAs) {
         /*dm_common_rtas=*/1,
         /*compute_per_node_rtas=*/3,
         /*compute_common_rtas=*/2);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     auto params = MakeRunParamsForMinimalSpec(
         node,
@@ -399,7 +415,7 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_BothKernelsWithRTAs) {
 TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_DFBRunParamsWithNoOverrides) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     auto params = MakeRunParamsForMinimalSpec(node, {}, {});
 
@@ -419,7 +435,7 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_DFBRunParamsWithNoOverri
 TEST_F(ProgramRunParamsTestQuasar, SetRunParamsTwice_SameValuesSucceeds) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/2, /*num_common_rtas=*/1);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     auto params = MakeRunParamsForMinimalSpec(node, {100, 200}, {10});
 
@@ -432,7 +448,7 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsTwice_SameValuesSucceeds) {
 TEST_F(ProgramRunParamsTestQuasar, SetRunParamsTwice_DifferentValuesSucceeds) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/2, /*num_common_rtas=*/1);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     auto params1 = MakeRunParamsForMinimalSpec(node, {100, 200}, {10});
     auto params2 = MakeRunParamsForMinimalSpec(node, {300, 400}, {20});  // Different values
@@ -446,7 +462,7 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsTwice_DifferentValuesSucceeds) {
 TEST_F(ProgramRunParamsTestQuasar, SetRunParamsTwice_ChangingCommonRTACountFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/0, /*num_common_rtas=*/2);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     // First call with 2 common RTAs (matches schema)
     auto params1 = MakeRunParamsForMinimalSpec(node, {}, {10, 20});
@@ -469,7 +485,7 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsTwice_ChangingCommonRTACountFails
 TEST_F(ProgramRunParamsTestQuasar, SetRunParamsMultipleTimes_Succeeds) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/2, /*num_common_rtas=*/2);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     // Call SetProgramRunParameters multiple times with varying values
     for (uint32_t i = 0; i < 5; i++) {
@@ -511,7 +527,7 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_MultiNodeKernel) {
     spec.dataflow_buffers = {dfb};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", all_nodes, {"producer", "consumer"})};
 
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     // Create run params with per-node RTAs for both nodes
     ProgramRunParams params;
@@ -555,7 +571,7 @@ TEST_F(ProgramRunParamsTestQuasar, MultiNode_MissingOneNodeFails) {
     spec.dataflow_buffers = {dfb};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", all_nodes, {"producer", "consumer"})};
 
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     // Only provide RTAs for node0, missing node1
     ProgramRunParams params;
@@ -601,7 +617,7 @@ inline ProgramSpec MakeSpecWithNamedArgs(
 TEST_F(ProgramRunParamsTestQuasar, NamedRTAsAndCRTAsSucceed) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {"input_ptr", "output_ptr"}, {"tile_count"});
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
     params.kernel_run_params.push_back({
@@ -617,7 +633,7 @@ TEST_F(ProgramRunParamsTestQuasar, NamedRTAsAndCRTAsSucceed) {
 TEST_F(ProgramRunParamsTestQuasar, MissingNamedRTAForNodeFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {"input_ptr"}, {});
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
     params.kernel_run_params.push_back({
@@ -635,7 +651,7 @@ TEST_F(ProgramRunParamsTestQuasar, MissingNamedRTAForNodeFails) {
 TEST_F(ProgramRunParamsTestQuasar, MissingDeclaredNamedRTANameFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {"input_ptr", "output_ptr"}, {});
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
     params.kernel_run_params.push_back({
@@ -654,7 +670,7 @@ TEST_F(ProgramRunParamsTestQuasar, MissingDeclaredNamedRTANameFails) {
 TEST_F(ProgramRunParamsTestQuasar, UndeclaredNamedRTAFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {"input_ptr"}, {});
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
     params.kernel_run_params.push_back({
@@ -672,7 +688,7 @@ TEST_F(ProgramRunParamsTestQuasar, UndeclaredNamedRTAFails) {
 TEST_F(ProgramRunParamsTestQuasar, NamedCRTACountMismatchFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {}, {"tile_count", "scale"});
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
     params.kernel_run_params.push_back({
@@ -712,7 +728,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyMultiNodeDifferingCountsSucceeds) {
     kernel.runtime_arguments_schema.num_runtime_varargs_per_node = NumVarargsPerNode{{node_a, 2}, {node_b, 5}};
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", nodes, {"dm_kernel"})};
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
     params.kernel_run_params.push_back({
@@ -743,7 +759,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargPerNodeOverrideMixedEntryTypesSucceeds)
     kernel.runtime_arguments_schema.num_runtime_varargs_per_node = NumVarargsPerNode{{ab, 3}, {node_c, 5}};
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", all_nodes, {"dm_kernel"})};
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
     params.kernel_run_params.push_back({
@@ -772,7 +788,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargScalarDefaultWithSparseOverrideSucceeds
         NumVarargsPerNode{{node_c, 5}};  // node_c is the exception
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", all_nodes, {"dm_kernel"})};
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
     params.kernel_run_params.push_back({
@@ -804,7 +820,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargSparseOverrideZeroErasesScalarDefault) 
         NumVarargsPerNode{{node_b, 0}};  // node_b: no varargs despite scalar default
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", both, {"dm_kernel"})};
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     // node_b is treated as having no varargs — run-params needs no entry for it.
     ProgramRunParams params;
@@ -824,7 +840,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyAcrossMultipleKernelsSucceeds) {
     spec.kernels[0].runtime_arguments_schema.num_common_runtime_varargs = 1;
     spec.kernels[1].runtime_arguments_schema.num_runtime_varargs = 2;
     spec.kernels[1].runtime_arguments_schema.num_common_runtime_varargs = 2;
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
     params.kernel_run_params.push_back(MakeKernelRunParams("dm_kernel", node, {1, 2, 3}, {99}));
@@ -845,7 +861,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyRTAsMissingNodeCoverageFails) {
     kernel.runtime_arguments_schema.num_runtime_varargs = 2;  // uniform across both nodes
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", nodes, {"dm_kernel"})};
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
     params.kernel_run_params.push_back({
@@ -863,7 +879,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyUnknownNodeFails) {
     NodeCoord wrong_node{3, 3};
     ProgramSpec spec = MakeMinimalValidProgramSpec();
     spec.kernels[0].runtime_arguments_schema.num_runtime_varargs = 1;
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
     params.kernel_run_params.push_back({
@@ -888,7 +904,7 @@ TEST_F(ProgramRunParamsTestQuasar, AllEmptySchemaSucceeds) {
     // spec.kernels already default to empty named_runtime_args / named_common_runtime_args /
     // compile_time_arg_bindings, num_runtime_varargs = 0, num_common_runtime_varargs = 0,
     // num_runtime_varargs_per_node = nullopt.
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
     params.kernel_run_params.push_back({.kernel_spec_name = "dm_kernel"});
@@ -903,7 +919,7 @@ TEST_F(ProgramRunParamsTestQuasar, NamedAndVarargRTAsCoexistSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
     spec.kernels[0].runtime_arguments_schema.named_runtime_args = {"input_ptr"};
     spec.kernels[0].runtime_arguments_schema.num_runtime_varargs = 3;
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
     params.kernel_run_params.push_back({
@@ -922,8 +938,21 @@ TEST_F(ProgramRunParamsTestQuasar, NamedAndVarargRTAsCoexistSucceeds) {
 
 class ProgramRunParamsTestGen1 : public ::testing::Test {
 protected:
-    void SetUp() override { experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 1); }
-    void TearDown() override { experimental::disable_mock_mode(); }
+    void SetUp() override {
+        setenv("TT_METAL_SLOW_DISPATCH_MODE", "1", /*overwrite=*/1);
+        experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 1);
+        mesh_device_ = distributed::MeshDevice::create(distributed::MeshDeviceConfig(distributed::MeshShape{1, 1}));
+    }
+    void TearDown() override {
+        if (mesh_device_) {
+            mesh_device_->close();
+            mesh_device_.reset();
+        }
+        experimental::disable_mock_mode();
+        unsetenv("TT_METAL_SLOW_DISPATCH_MODE");
+    }
+
+    std::shared_ptr<distributed::MeshDevice> mesh_device_;
 };
 
 // Create a gen1 ProgramSpec with a specified RTA schema on the DM kernel
@@ -941,7 +970,7 @@ inline ProgramSpec MakeGen1SpecWithRTAs(const NodeCoord& /*node*/, size_t num_pe
 TEST_F(ProgramRunParamsTestGen1, SetRunParamsSucceeds_ZeroRTAs) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeGen1SpecWithRTAs(node, 0, 0);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     auto params = MakeRunParamsForMinimalSpec(node, {}, {});
 
@@ -951,7 +980,7 @@ TEST_F(ProgramRunParamsTestGen1, SetRunParamsSucceeds_ZeroRTAs) {
 TEST_F(ProgramRunParamsTestGen1, SetRunParamsSucceeds_PerNodeAndCommonRTAs) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeGen1SpecWithRTAs(node, /*num_per_node_rtas=*/3, /*num_common_rtas=*/2);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     auto params = MakeRunParamsForMinimalSpec(node, {100, 200, 300}, {10, 20});
 
@@ -961,7 +990,7 @@ TEST_F(ProgramRunParamsTestGen1, SetRunParamsSucceeds_PerNodeAndCommonRTAs) {
 TEST_F(ProgramRunParamsTestGen1, WrongRuntimeArgsCountFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeGen1SpecWithRTAs(node, /*num_per_node_rtas=*/3, /*num_common_rtas=*/0);
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     // Provide wrong count (2 instead of 3)
     auto params = MakeRunParamsForMinimalSpec(node, {1, 2}, {});

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -28,6 +28,7 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <optional>
 
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
@@ -49,6 +50,7 @@ using test_helpers::MakeMinimalDMKernel;
 using test_helpers::MakeMinimalGen1ValidProgramSpec;
 using test_helpers::MakeMinimalValidProgramSpec;
 using test_helpers::MakeMinimalWorkUnit;
+using test_helpers::ScopedSlowDispatchOverride;
 
 // Shorthand for the per-node-override vararg type (needed at call sites because
 // std::optional<T> can't be brace-init from an initializer-list of T's elements).
@@ -66,7 +68,7 @@ using NumVarargsPerNode = KernelSpec::RuntimeArgSchema::NumVarargsPerNode;
 class ProgramRunParamsTestQuasar : public ::testing::Test {
 protected:
     void SetUp() override {
-        setenv("TT_METAL_SLOW_DISPATCH_MODE", "1", /*overwrite=*/1);
+        slow_dispatch_override_.emplace();
         //  Configure global mock mode for Quasar
         experimental::configure_mock_mode(tt::ARCH::QUASAR, 1);
         mesh_device_ = distributed::MeshDevice::create(distributed::MeshDeviceConfig(distributed::MeshShape{1, 1}));
@@ -77,10 +79,11 @@ protected:
             mesh_device_.reset();
         }
         experimental::disable_mock_mode();
-        unsetenv("TT_METAL_SLOW_DISPATCH_MODE");
+        slow_dispatch_override_.reset();
     }
 
     std::shared_ptr<distributed::MeshDevice> mesh_device_;
+    std::optional<ScopedSlowDispatchOverride> slow_dispatch_override_;
 };
 
 // ============================================================================
@@ -939,7 +942,7 @@ TEST_F(ProgramRunParamsTestQuasar, NamedAndVarargRTAsCoexistSucceeds) {
 class ProgramRunParamsTestGen1 : public ::testing::Test {
 protected:
     void SetUp() override {
-        setenv("TT_METAL_SLOW_DISPATCH_MODE", "1", /*overwrite=*/1);
+        slow_dispatch_override_.emplace();
         experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 1);
         mesh_device_ = distributed::MeshDevice::create(distributed::MeshDeviceConfig(distributed::MeshShape{1, 1}));
     }
@@ -949,10 +952,11 @@ protected:
             mesh_device_.reset();
         }
         experimental::disable_mock_mode();
-        unsetenv("TT_METAL_SLOW_DISPATCH_MODE");
+        slow_dispatch_override_.reset();
     }
 
     std::shared_ptr<distributed::MeshDevice> mesh_device_;
+    std::optional<ScopedSlowDispatchOverride> slow_dispatch_override_;
 };
 
 // Create a gen1 ProgramSpec with a specified RTA schema on the DM kernel

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -29,6 +29,7 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <optional>
 #include <type_traits>
 
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
@@ -56,6 +57,7 @@ using test_helpers::MakeMinimalGen1DMKernel;
 using test_helpers::MakeMinimalGen1ValidProgramSpec;
 using test_helpers::MakeMinimalValidProgramSpec;
 using test_helpers::MakeMinimalWorkUnit;
+using test_helpers::ScopedSlowDispatchOverride;
 
 // ============================================================================
 // Test Fixtures
@@ -69,7 +71,7 @@ using test_helpers::MakeMinimalWorkUnit;
 class ProgramSpecTestQuasar : public ::testing::Test {
 protected:
     void SetUp() override {
-        setenv("TT_METAL_SLOW_DISPATCH_MODE", "1", /*overwrite=*/1);
+        slow_dispatch_override_.emplace();
         //  Configure global mock mode for Quasar
         //  This way, the HAL is initialized for arch check and Program creation.
         experimental::configure_mock_mode(tt::ARCH::QUASAR, 1);
@@ -81,10 +83,11 @@ protected:
             mesh_device_.reset();
         }
         experimental::disable_mock_mode();
-        unsetenv("TT_METAL_SLOW_DISPATCH_MODE");
+        slow_dispatch_override_.reset();
     }
 
     std::shared_ptr<distributed::MeshDevice> mesh_device_;
+    std::optional<ScopedSlowDispatchOverride> slow_dispatch_override_;
 };
 
 // ============================================================================
@@ -1829,7 +1832,7 @@ TEST(AggregateSpecTypes, NestedStructsDesignatedInitializers) {
 class ProgramSpecTestGen1 : public ::testing::Test {
 protected:
     void SetUp() override {
-        setenv("TT_METAL_SLOW_DISPATCH_MODE", "1", /*overwrite=*/1);
+        slow_dispatch_override_.emplace();
         experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 1);
         mesh_device_ = distributed::MeshDevice::create(distributed::MeshDeviceConfig(distributed::MeshShape{1, 1}));
     }
@@ -1839,10 +1842,11 @@ protected:
             mesh_device_.reset();
         }
         experimental::disable_mock_mode();
-        unsetenv("TT_METAL_SLOW_DISPATCH_MODE");
+        slow_dispatch_override_.reset();
     }
 
     std::shared_ptr<distributed::MeshDevice> mesh_device_;
+    std::optional<ScopedSlowDispatchOverride> slow_dispatch_override_;
 };
 
 TEST_F(ProgramSpecTestGen1, MinimalValidProgramSpecSucceeds) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -38,6 +38,7 @@
 #include <tt-metalium/hal.hpp>
 #include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
+#include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/context/metal_env.hpp>
 #include <tt-metalium/experimental/mock_device.hpp>
 
@@ -60,15 +61,30 @@ using test_helpers::MakeMinimalWorkUnit;
 // Test Fixtures
 // ============================================================================
 
-// Test fixture for ProgramSpec on Quasar - uses Quasar mock device
+// Test fixture for ProgramSpec on Quasar - uses Quasar mock device.
+//
+// Forces TT_METAL_SLOW_DISPATCH_MODE so that MeshDevice::create() succeeds against the
+// mock cluster (mock Quasar has no dispatch-core reservation in its descriptor). These
+// tests exercise pure API behavior, so slow dispatch is functionally fine.
 class ProgramSpecTestQuasar : public ::testing::Test {
 protected:
     void SetUp() override {
+        setenv("TT_METAL_SLOW_DISPATCH_MODE", "1", /*overwrite=*/1);
         //  Configure global mock mode for Quasar
         //  This way, the HAL is initialized for arch check and Program creation.
         experimental::configure_mock_mode(tt::ARCH::QUASAR, 1);
+        mesh_device_ = distributed::MeshDevice::create(distributed::MeshDeviceConfig(distributed::MeshShape{1, 1}));
     }
-    void TearDown() override { experimental::disable_mock_mode(); }
+    void TearDown() override {
+        if (mesh_device_) {
+            mesh_device_->close();
+            mesh_device_.reset();
+        }
+        experimental::disable_mock_mode();
+        unsetenv("TT_METAL_SLOW_DISPATCH_MODE");
+    }
+
+    std::shared_ptr<distributed::MeshDevice> mesh_device_;
 };
 
 // ============================================================================
@@ -87,7 +103,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateKernelNameFails) {
     spec.kernels.push_back(duplicate_kernel);
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Duplicate KernelSpec name 'dm_kernel'")));
 }
 
@@ -99,7 +115,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateDFBNameFails) {
     spec.dataflow_buffers.push_back(duplicate_dfb);
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("Duplicate DataflowBufferSpec name 'dfb_0'")));
 }
@@ -119,7 +135,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateSemaphoreNameFails) {
     spec.semaphores = {sem1, sem2};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Duplicate SemaphoreSpec name 'sem_0'")));
 }
 
@@ -141,7 +157,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateWorkUnitNameFails) {
     spec.work_units = std::vector<WorkUnitSpec>{work_unit0, work_unit1};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Duplicate WorkUnitSpec name 'same_name'")));
 }
 
@@ -164,7 +180,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateLocalAccessorNameFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("Kernel 'kernel' has duplicate local_accessor_name 'same_accessor'")));
 }
@@ -200,7 +216,7 @@ TEST_F(ProgramSpecTestQuasar, InvalidLocalAccessorNameFails) {
         spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
         EXPECT_THAT(
-            [&] { MakeProgramFromSpec(spec); },
+            [&] { MakeProgramFromSpec(*mesh_device_, spec); },
             ::testing::ThrowsMessage<std::runtime_error>(
                 ::testing::HasSubstr("DFB local_accessor_name '" + bad_name + "' must be a valid C++ identifier")))
             << "Expected rejection for name: '" << bad_name << "'";
@@ -221,7 +237,7 @@ TEST_F(ProgramSpecTestQuasar, KernelReferencesUnknownDFBFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("Kernel 'kernel' references unknown DFB 'nonexistent_dfb'")));
 }
@@ -243,7 +259,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithNoBindingsFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("DFB 'orphan_dfb' is defined but not bound by any kernel")));
 }
@@ -265,7 +281,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithOnlyProducerFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB 'dfb' has no consumer")));
 }
 
@@ -286,7 +302,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithOnlyConsumerFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB 'dfb' has no producer")));
 }
 
@@ -314,7 +330,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersFails) {
         std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer1", "producer2", "consumer"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB 'dfb' has multiple producers")));
 }
 
@@ -342,7 +358,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersFails) {
         std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer1", "consumer2"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB 'dfb' has multiple consumers")));
 }
 
@@ -356,7 +372,7 @@ TEST_F(ProgramSpecTestQuasar, EmptyKernelsFails) {
     spec.work_units = std::vector<WorkUnitSpec>{};  // Empty work_units too
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("A ProgramSpec must have at least one KernelSpec")));
 }
@@ -372,7 +388,7 @@ TEST_F(ProgramSpecTestQuasar, KernelWithZeroThreadsFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("KernelSpec 'kernel' has no threads")));
 }
 
@@ -388,7 +404,7 @@ TEST_F(ProgramSpecTestQuasar, DMKernelExceedingMaxThreadsFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("KernelSpec 'kernel' has too many data movement threads")));
 }
@@ -405,7 +421,7 @@ TEST_F(ProgramSpecTestQuasar, ComputeKernelExceedingMaxThreadsFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
             "KernelSpec 'kernel' has too many threads. The architecture supports up to 4 for compute kernels")));
 }
@@ -432,7 +448,7 @@ TEST_F(ProgramSpecTestQuasar, DMKernelWithoutGen2ConfigFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("KernelSpec 'kernel' must specify a Gen2 DM config when targeting Quasar")));
 }
@@ -453,7 +469,7 @@ TEST_F(ProgramSpecTestQuasar, DMKernelWithNoConfigAtAllFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("KernelSpec 'kernel' must specify a DM config for Gen1, Gen2, or both")));
 }
@@ -483,7 +499,7 @@ TEST_F(ProgramSpecTestQuasar, RemoteDFBNotYetSupportedAtRuntime) {
     };
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("not yet supported")));
 }
 
@@ -508,7 +524,7 @@ TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("DFB 'dfb' uses borrowed memory, but this feature is not yet implemented")));
 }
@@ -534,7 +550,7 @@ TEST_F(ProgramSpecTestQuasar, DFBAliasingFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("DFB 'dfb' has a non-empty alias_with, but DFB aliasing is not yet implemented")));
 }
@@ -547,7 +563,7 @@ TEST_F(ProgramSpecTestQuasar, SemaphoresSucceed) {
     sem.target_nodes = NodeCoord{0, 0};
     spec.semaphores = {sem};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingsSucceed) {
@@ -563,7 +579,7 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingsSucceed) {
     binding.accessor_name = "my_sem";
     spec.kernels[0].semaphore_bindings = {binding};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, SemaphoreBoundToComputeKernelFailsOnQuasar) {
@@ -582,7 +598,7 @@ TEST_F(ProgramSpecTestQuasar, SemaphoreBoundToComputeKernelFailsOnQuasar) {
         KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "done_flag"}};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("Semaphore bindings are not currently supported for compute kernels.")));
 }
@@ -596,7 +612,7 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingUnknownSemaphoreFails) {
     spec.kernels[0].semaphore_bindings = {binding};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("references unknown semaphore 'missing_sem'")));
 }
@@ -615,7 +631,7 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingInvalidAccessorFails) {
     spec.kernels[0].semaphore_bindings = {binding};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("semaphore accessor_name 'has-dash' must be a valid C++ identifier")));
 }
@@ -638,7 +654,7 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingDuplicateAccessorFails) {
         KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_1", .accessor_name = "same"}};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("duplicate semaphore accessor_name 'same'")));
 }
 
@@ -652,7 +668,7 @@ TEST_F(ProgramSpecTestQuasar, SemaphoreNonZeroInitialValueFailsOnQuasar) {
     spec.semaphores = {sem};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("has initial_value=1 but only zero is supported on Quasar")));
 }
@@ -665,7 +681,7 @@ TEST_F(ProgramSpecTestQuasar, NamedRuntimeArgsSucceeds) {
     spec.kernels[0].runtime_arguments_schema.named_common_runtime_args = {"tile_count"};
     spec.kernels[0].compile_time_arg_bindings = {{"block_size", 64}};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, InvalidNamedRtaIdentifierFails) {
@@ -673,7 +689,7 @@ TEST_F(ProgramSpecTestQuasar, InvalidNamedRtaIdentifierFails) {
     spec.kernels[0].runtime_arguments_schema.named_runtime_args = {"int"};  // C++ keyword
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("named RTA name 'int' is not a valid C++ identifier")));
 }
@@ -683,7 +699,7 @@ TEST_F(ProgramSpecTestQuasar, InvalidNamedCrtaIdentifierFails) {
     spec.kernels[0].runtime_arguments_schema.named_common_runtime_args = {"has-dash"};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("named CRTA name 'has-dash' is not a valid C++ identifier")));
 }
@@ -695,7 +711,7 @@ TEST_F(ProgramSpecTestQuasar, NamedRtaCrtaCollisionFails) {
     spec.kernels[0].runtime_arguments_schema.named_common_runtime_args = {"count"};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("naming collision: 'count' is declared as both a named RTA and a named CRTA")));
 }
@@ -706,7 +722,7 @@ TEST_F(ProgramSpecTestQuasar, NamedRtaCtaCollisionFails) {
     spec.kernels[0].compile_time_arg_bindings = {{"block_size", 64}};  // same name as CTA
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("naming collision: 'block_size' is declared as both a named RTA and a named CTA")));
 }
@@ -717,7 +733,7 @@ TEST_F(ProgramSpecTestQuasar, DifferentKernelsMayReuseArgNames) {
     spec.kernels[0].runtime_arguments_schema.named_runtime_args = {"shared_name"};
     spec.kernels[1].runtime_arguments_schema.named_runtime_args = {"shared_name"};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, DFBWithComputeEndpointRequiresDataFormat) {
@@ -739,7 +755,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithComputeEndpointRequiresDataFormat) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("DFB 'dfb' is used by a compute kernel, but no data_format_metadata is specified")));
 }
@@ -768,7 +784,7 @@ TEST_F(ProgramSpecTestQuasar, ComputeConfigUnpackToDestModeReferencesUnknownDFBF
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("Kernel 'consumer' unpack_to_dest_mode references unknown DFB 'nonexistent_dfb'")));
 }
@@ -794,7 +810,7 @@ TEST_F(ProgramSpecTestQuasar, DataFormatNotSupportedOnTargetArchitectureFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB 'dfb' has data format")));
 }
 
@@ -825,7 +841,7 @@ TEST_F(ProgramSpecTestQuasar, TooManyDFBsFailsValidation) {
 
     const std::string expected_substr = "too many DataflowBufferSpecs (" + std::to_string(too_many) + ")";
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(expected_substr)));
 }
 
@@ -842,7 +858,7 @@ TEST_F(ProgramSpecTestQuasar, EmptyWorkUnitSpecsFails) {
     spec.work_units = std::vector<WorkUnitSpec>{};  // Empty!
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("Kernel 'kernel' is not referenced by any WorkUnitSpec")));
 }
@@ -863,7 +879,7 @@ TEST_F(ProgramSpecTestQuasar, WorkUnitSpecWithNoKernelsFails) {
     spec.work_units = std::vector<WorkUnitSpec>{work_unit};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("Kernel 'kernel' is not referenced by any WorkUnitSpec")));
 }
@@ -881,7 +897,7 @@ TEST_F(ProgramSpecTestQuasar, WorkUnitSpecReferencesUnknownKernelFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"nonexistent_kernel"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("WorkUnitSpec 'work_unit' references unknown kernel 'nonexistent_kernel'")));
 }
@@ -902,7 +918,7 @@ TEST_F(ProgramSpecTestQuasar, OverlappingWorkUnitSpecsFails) {
         MakeMinimalWorkUnit("work_unit1", node, {"kernel1"}), MakeMinimalWorkUnit("work_unit2", node, {"kernel2"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("overlap in target nodes")));
 }
 
@@ -919,7 +935,7 @@ TEST_F(ProgramSpecTestQuasar, KernelNotInAnyWorkUnitSpecFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel1"})};  // Only kernel1
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("Kernel 'kernel2' is not referenced by any WorkUnitSpec")));
 }
@@ -939,7 +955,7 @@ TEST_F(ProgramSpecTestQuasar, WorkUnitExceedsDMCoreBudgetFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm1", "dm2", "dm3"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("WorkUnitSpec 'work_unit' requests 9 data movement cores")));
 }
@@ -959,7 +975,7 @@ TEST_F(ProgramSpecTestQuasar, WorkUnitExceedsComputeCoreBudgetFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"compute1", "compute2"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("WorkUnitSpec 'work_unit' needs 6 Tensix engines")));
 }
@@ -978,7 +994,7 @@ TEST_F(ProgramSpecTestQuasar, WorkUnitWithMultipleComputeKernelsFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"compute1", "compute2"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("WorkUnitSpec 'work_unit' has more than one compute kernel")));
 }
@@ -1008,7 +1024,7 @@ TEST_F(ProgramSpecTestQuasar, LocalDFBProducerConsumerWorkUnitMembershipMismatch
     };
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("do not share identical WorkUnitSpec membership")));
 }
@@ -1024,7 +1040,7 @@ TEST_F(ProgramSpecTestQuasar, LocalDFBProducerConsumerWorkUnitMembershipMismatch
 TEST_F(ProgramSpecTestQuasar, MinimalValidProgramSpecSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, DMOnlyProgramSucceeds) {
@@ -1046,7 +1062,7 @@ TEST_F(ProgramSpecTestQuasar, DMOnlyProgramSucceeds) {
     spec.dataflow_buffers = {dfb};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, MultiNodeProgramSucceeds) {
@@ -1067,7 +1083,7 @@ TEST_F(ProgramSpecTestQuasar, MultiNodeProgramSucceeds) {
     spec.dataflow_buffers = {dfb};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", nodes, {"producer", "consumer"})};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, MultipleWorkUnitsOnDifferentNodesSucceeds) {
@@ -1087,7 +1103,7 @@ TEST_F(ProgramSpecTestQuasar, MultipleWorkUnitsOnDifferentNodesSucceeds) {
     spec.work_units = std::vector<WorkUnitSpec>{
         MakeMinimalWorkUnit("work_unit0", node0, {"kernel"}), MakeMinimalWorkUnit("work_unit1", node1, {"kernel"})};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, MaxDMThreadsSucceeds) {
@@ -1109,7 +1125,7 @@ TEST_F(ProgramSpecTestQuasar, MaxDMThreadsSucceeds) {
     spec.dataflow_buffers = {dfb};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, MaxComputeThreadsSucceeds) {
@@ -1133,7 +1149,7 @@ TEST_F(ProgramSpecTestQuasar, MaxComputeThreadsSucceeds) {
     spec.dataflow_buffers = {dfb};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm", "compute"})};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, MultipleDFBsSucceeds) {
@@ -1159,7 +1175,7 @@ TEST_F(ProgramSpecTestQuasar, MultipleDFBsSucceeds) {
     spec.dataflow_buffers = {dfb1, dfb2};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, CompilerOptionsDefinesSucceeds) {
@@ -1168,7 +1184,7 @@ TEST_F(ProgramSpecTestQuasar, CompilerOptionsDefinesSucceeds) {
     // Add some defines
     spec.kernels[0].compiler_options.defines = {{"MY_DEFINE", "42"}, {"ANOTHER_DEFINE", "foo"}};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, CompileTimeArgBindingsSucceeds) {
@@ -1177,7 +1193,7 @@ TEST_F(ProgramSpecTestQuasar, CompileTimeArgBindingsSucceeds) {
     // Add compile-time arg bindings
     spec.kernels[0].compile_time_arg_bindings = {{"arg1", 100}, {"arg2", 200}};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, RuntimeArgsSchemaSucceeds) {
@@ -1187,7 +1203,7 @@ TEST_F(ProgramSpecTestQuasar, RuntimeArgsSchemaSucceeds) {
     spec.kernels[0].runtime_arguments_schema.num_runtime_varargs = 3;
     spec.kernels[0].runtime_arguments_schema.num_common_runtime_varargs = 2;
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, VarargPerNodeOverlapFails) {
@@ -1207,7 +1223,7 @@ TEST_F(ProgramSpecTestQuasar, VarargPerNodeOverlapFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", both, {"dm_kernel"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("overlapping entries")));
 }
 
@@ -1233,7 +1249,7 @@ TEST_F(ProgramSpecTestQuasar, NodeRangeSetTargetNodesSucceeds) {
     spec.dataflow_buffers = {dfb};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", nodes, {"producer", "consumer"})};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, SourceCodeKernelSucceeds) {
@@ -1242,7 +1258,7 @@ TEST_F(ProgramSpecTestQuasar, SourceCodeKernelSucceeds) {
     // Change to inline source code
     spec.kernels[0].source = KernelSpec::SourceCode{"void kernel_main() {}"};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, ComputeConfigMathFidelitySucceeds) {
@@ -1258,7 +1274,7 @@ TEST_F(ProgramSpecTestQuasar, ComputeConfigMathFidelitySucceeds) {
         }
     }
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, ValidUnpackToDestModeSucceeds) {
@@ -1272,7 +1288,7 @@ TEST_F(ProgramSpecTestQuasar, ValidUnpackToDestModeSucceeds) {
         }
     }
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestQuasar, UnpackToDestModePlacedAtDfbIdSlot) {
@@ -1306,7 +1322,7 @@ TEST_F(ProgramSpecTestQuasar, UnpackToDestModePlacedAtDfbIdSlot) {
     spec.dataflow_buffers = {dfb0, dfb1};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     // Inspect the constructed compute kernel's QuasarComputeConfig:
     //  - vector must be sized to max_cbs (so JIT's iteration up to max_cbs is in-bounds)
@@ -1437,12 +1453,12 @@ TEST_F(ProgramSpecTestQuasar, BacktrackingSolverFindsAssignment_RegardlessOfOrde
     // All kernel permutations should succeed with all work_unit permutations.
     for (const auto& kernel_perm : kernel_permutations) {
         for (const auto& work_unit_perm : work_unit_permutations1) {
-            EXPECT_NO_THROW(MakeProgramFromSpec(make_spec("", kernel_perm, work_unit_perm)));
+            EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, make_spec("", kernel_perm, work_unit_perm)));
         }
     }
     for (const auto& kernel_perm : kernel_permutations) {
         for (const auto& work_unit_perm : work_unit_permutations2) {
-            EXPECT_NO_THROW(MakeProgramFromSpec(make_spec("", kernel_perm, work_unit_perm)));
+            EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, make_spec("", kernel_perm, work_unit_perm)));
         }
     }
 }
@@ -1501,7 +1517,7 @@ TEST_F(ProgramSpecTestQuasar, SimplifyingAssumptionViolation_OverlappingMultiNod
 
     // EXPECTED BEHAVIOR: FAILS due to simplifying assumption violation.
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("Failed to find valid processor assignments for DM kernels")));
 }
@@ -1812,13 +1828,26 @@ TEST(AggregateSpecTypes, NestedStructsDesignatedInitializers) {
 // Test fixture for ProgramSpec on Wormhole - uses WORMHOLE_B0 mock device
 class ProgramSpecTestGen1 : public ::testing::Test {
 protected:
-    void SetUp() override { experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 1); }
-    void TearDown() override { experimental::disable_mock_mode(); }
+    void SetUp() override {
+        setenv("TT_METAL_SLOW_DISPATCH_MODE", "1", /*overwrite=*/1);
+        experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 1);
+        mesh_device_ = distributed::MeshDevice::create(distributed::MeshDeviceConfig(distributed::MeshShape{1, 1}));
+    }
+    void TearDown() override {
+        if (mesh_device_) {
+            mesh_device_->close();
+            mesh_device_.reset();
+        }
+        experimental::disable_mock_mode();
+        unsetenv("TT_METAL_SLOW_DISPATCH_MODE");
+    }
+
+    std::shared_ptr<distributed::MeshDevice> mesh_device_;
 };
 
 TEST_F(ProgramSpecTestGen1, MinimalValidProgramSpecSucceeds) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestGen1, DMOnlyProgramSucceeds) {
@@ -1839,7 +1868,7 @@ TEST_F(ProgramSpecTestGen1, DMOnlyProgramSucceeds) {
     spec.dataflow_buffers = {dfb};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestGen1, TwoDMKernelsDifferentProcessorsSucceeds) {
@@ -1855,7 +1884,7 @@ TEST_F(ProgramSpecTestGen1, TwoDMKernelsDifferentProcessorsSucceeds) {
     spec.kernels = {k0, k1};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"k0", "k1"})};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestGen1, MultiThreadedDMKernelFails) {
@@ -1871,7 +1900,7 @@ TEST_F(ProgramSpecTestGen1, MultiThreadedDMKernelFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("does not support multi-threaded kernels")));
 }
 
@@ -1888,7 +1917,7 @@ TEST_F(ProgramSpecTestGen1, MultiThreadedComputeKernelFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"compute_kernel"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("does not support multi-threaded kernels")));
 }
 
@@ -1906,7 +1935,7 @@ TEST_F(ProgramSpecTestGen1, DMKernelWithGen2ConfigFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("must specify a Gen1 DM config")));
 }
 
@@ -1924,7 +1953,7 @@ TEST_F(ProgramSpecTestGen1, ProcessorConflictFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"k0", "k1"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("both claim the same DM processor")));
 }
 
@@ -1949,7 +1978,7 @@ TEST_F(ProgramSpecTestGen1, KernelTargetsNodeBeyondGridYFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", oob_node, {"dm_kernel"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("out of bounds")));
 }
 
@@ -1965,7 +1994,7 @@ TEST_F(ProgramSpecTestGen1, KernelTargetsOutOfBoundsNodeFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", oob_node, {"dm_kernel"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("out of bounds")));
 }
 
@@ -1984,7 +2013,7 @@ TEST_F(ProgramSpecTestGen1, SemaphoreBoundToComputeKernelFailsOnGen1) {
         KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "done_flag"}};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("Semaphore bindings are not currently supported for compute kernels.")));
 }
@@ -2003,7 +2032,7 @@ TEST_F(ProgramSpecTestGen1, SemaphoreBoundToDMKernelSucceedsOnGen1) {
     spec.kernels[0].semaphore_bindings = {
         KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "done_flag"}};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestGen1, SemaphoresWithNonZeroInitialValueSucceedOnGen1) {
@@ -2019,7 +2048,7 @@ TEST_F(ProgramSpecTestGen1, SemaphoresWithNonZeroInitialValueSucceedOnGen1) {
     spec.kernels[0].semaphore_bindings = {
         KernelSpec::SemaphoreBinding{.semaphore_spec_name = "sem_0", .accessor_name = "done_flag"}};
 
-    EXPECT_NO_THROW(MakeProgramFromSpec(spec));
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestGen1, DuplicateKernelNameFails) {
@@ -2036,7 +2065,7 @@ TEST_F(ProgramSpecTestGen1, DuplicateKernelNameFails) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
 
     EXPECT_THAT(
-        [&] { MakeProgramFromSpec(spec); },
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Duplicate KernelSpec name")));
 }
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -121,7 +121,7 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
     // -------------------------------------------------------
     // Create Program
     // -------------------------------------------------------
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device, spec);
 
     // -------------------------------------------------------
     // Set runtime args
@@ -258,7 +258,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     spec.dataflow_buffers = {dfb};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", node, {"producer", "consumer"})};
 
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device, spec);
 
     // Vararg values picked so both kernels' XOR sums equal the same non-trivial S.
     // The kernels fold this into the first word of each DFB entry; S ^ S = 0, so data
@@ -378,7 +378,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
     spec.dataflow_buffers = {out_dfb};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", node, {"compute", "consumer"})};
 
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device, spec);
 
     // Pick non-trivial bits so a wrong-offset read is unlikely to coincidentally
     // produce the same XOR. The compute kernel's sum is:
@@ -503,7 +503,7 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
         .work_units = std::vector<WorkUnitSpec>{work_unit},
     };
 
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device, spec);
     detail::LaunchProgram(device, program);
     // If we got here, both kernels resolved their sem accessors to the same ID.
 }

--- a/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
@@ -114,7 +114,7 @@ TEST_F(KernelThreadSyncTest, BarrierSynchronizesThreads) {
     for (const auto& cfg : kernel_configs) { spec.kernels.push_back(cfg.spec); }
     spec.work_units = {MakeMinimalWorkUnit("work_unit_0", node, work_unit_kernel_names)};
 
-    Program program = MakeProgramFromSpec(spec);
+    Program program = MakeProgramFromSpec(*mesh_device, spec);
 
     uint32_t total_zeros = 0;
     for (const auto& cfg : kernel_configs) { total_zeros += cfg.layout.total_words; }

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <tt-metalium/program.hpp>
+#include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_params.hpp>
 
@@ -17,7 +18,8 @@ namespace tt::tt_metal::experimental::metal2_host_api {
 
 // Create a Program object from a ProgramSpec
 // (This will become a constructor for the Program class)
-Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation = false);
+Program MakeProgramFromSpec(
+    const distributed::MeshDevice& mesh_device, const ProgramSpec& spec, bool skip_validation = false);
 
 // Configure the mutable parameters of an existing Program
 // (This will become a member function for the Program class)

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1471,7 +1471,9 @@ std::set<experimental::quasar::QuasarComputeProcessor> GetComputeProcessorSet(Co
 // Public Entry Point
 // ============================================================================
 
-Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation) {
+Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const ProgramSpec& spec, bool skip_validation) {
+    // The mesh_device argument is required for forthcoming work but is not yet consumed.
+    (void)mesh_device;
     log_debug(tt::LogMetal, "Creating Program from ProgramSpec ({})", spec.program_id);
 
     // Step 1a: Collect derived data (builds lookup tables, checks structural invariants)


### PR DESCRIPTION
## Issue
https://github.com/tenstorrent/tt-metal/issues/41249

## Summary
Currently, the (temporary free function) API to construct a `Program` object in Metal 2.0 is:
```C++
Program MakeProgramFromSpec(const ProgramSpec& spec, bool skip_validation = false);
```

This PR changes the construction semantics to:
```C++
Program MakeProgramFromSpec(
    const distributed::MeshDevice& mesh_device, const ProgramSpec& spec, bool skip_validation = false);
```

**Why?**

- We already had this in-plan (for when `MetalContext` is no longer a singleton)
- It turns out I need the `MeshDevice` to implement Metal 2.0 Tensor bindings (in the next PR)

(I now sorely regret not making this change when I merged the initial Metal 2.0 APIs, as a smart review suggested at the time...)

## Notes to Reviewers
This is exactly as straightforward as it looks. With one small wrinkle: I'm now also forcing SLOW_DISPATCH_MODE=1 for my Quasar mock device-based unit tests (and restoring the envvar after the test is done). This wasn't necessary previously, but now that I'm calling `MeshDevice::create()` being called, I get a crash without it. Can remove once Quasar has fast dispatch support.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/require-meshdevice-for-program-creation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/require-meshdevice-for-program-creation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/require-meshdevice-for-program-creation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/require-meshdevice-for-program-creation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/require-meshdevice-for-program-creation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/require-meshdevice-for-program-creation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/require-meshdevice-for-program-creation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/require-meshdevice-for-program-creation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/require-meshdevice-for-program-creation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/require-meshdevice-for-program-creation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/require-meshdevice-for-program-creation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/require-meshdevice-for-program-creation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/require-meshdevice-for-program-creation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/require-meshdevice-for-program-creation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/require-meshdevice-for-program-creation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/require-meshdevice-for-program-creation)