### PR TITLE
[feature] Add MeshTensor overloads to TensorAccessArgs

### DIFF
--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
@@ -16,6 +16,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/buffer_distribution_spec.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/api/ttnn/distributed/api.hpp"
@@ -1093,3 +1094,65 @@ INSTANTIATE_TEST_SUITE_P(
                                    .orientation = ShardOrientation::COL_MAJOR,
                                },
                        }}));
+
+class TensorAccessorArgsConstructorTests : public GenericMeshDeviceFixture {};
+
+TEST_F(TensorAccessorArgsConstructorTests, MeshTensorConstructorEquivalentToMeshBuffer) {
+    MemoryConfig mem_config = MemoryConfig(
+        BufferType::L1,
+        NdShardSpec{
+            .shard_shape = tt::tt_metal::Shape{32, 32},
+            .grid = CoreRangeSet(CoreRange({0, 0}, {1, 1})),
+            .orientation = ShardOrientation::ROW_MAJOR,
+        });
+
+    tt::tt_metal::TensorSpec tensor_spec(
+        tt::tt_metal::Shape{64, 64},
+        tt::tt_metal::TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_config));
+
+    auto mesh_tensor = MeshTensor::allocate_on_device(tensor_spec, mesh_device_.get());
+
+    const auto args_from_mesh_tensor = TensorAccessorArgs(mesh_tensor);
+    const auto args_from_mesh_buffer = TensorAccessorArgs(*mesh_tensor.mesh_buffer());
+
+    EXPECT_EQ(args_from_mesh_tensor.get_compile_time_args(), args_from_mesh_buffer.get_compile_time_args());
+    EXPECT_EQ(args_from_mesh_tensor.get_common_runtime_args(), args_from_mesh_buffer.get_common_runtime_args());
+}
+
+TEST_F(TensorAccessorArgsConstructorTests, MeshTensorConstructorEquivalentToMeshBufferInterleaved) {
+    MemoryConfig mem_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
+
+    tt::tt_metal::TensorSpec tensor_spec(
+        tt::tt_metal::Shape{64, 128},
+        tt::tt_metal::TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_config));
+
+    auto mesh_tensor = MeshTensor::allocate_on_device(tensor_spec, mesh_device_.get());
+
+    const auto args_from_mesh_tensor = TensorAccessorArgs(mesh_tensor);
+    const auto args_from_mesh_buffer = TensorAccessorArgs(*mesh_tensor.mesh_buffer());
+
+    EXPECT_EQ(args_from_mesh_tensor.get_compile_time_args(), args_from_mesh_buffer.get_compile_time_args());
+    EXPECT_EQ(args_from_mesh_tensor.get_common_runtime_args(), args_from_mesh_buffer.get_common_runtime_args());
+}
+
+TEST_F(TensorAccessorArgsConstructorTests, MeshTensorConstructorEquivalentToMeshBufferHigherRank) {
+    MemoryConfig mem_config = MemoryConfig(
+        BufferType::L1,
+        NdShardSpec{
+            .shard_shape = tt::tt_metal::Shape{1, 2, 32, 32},
+            .grid = CoreRangeSet(CoreRange({0, 0}, {2, 2})),
+            .orientation = ShardOrientation::COL_MAJOR,
+        });
+
+    tt::tt_metal::TensorSpec tensor_spec(
+        tt::tt_metal::Shape{4, 6, 64, 64},
+        tt::tt_metal::TensorLayout(DataType::UINT16, PageConfig(Layout::TILE), mem_config));
+
+    auto mesh_tensor = MeshTensor::allocate_on_device(tensor_spec, mesh_device_.get());
+
+    const auto args_from_mesh_tensor = TensorAccessorArgs(mesh_tensor);
+    const auto args_from_mesh_buffer = TensorAccessorArgs(*mesh_tensor.mesh_buffer());
+
+    EXPECT_EQ(args_from_mesh_tensor.get_compile_time_args(), args_from_mesh_buffer.get_compile_time_args());
+    EXPECT_EQ(args_from_mesh_tensor.get_common_runtime_args(), args_from_mesh_buffer.get_common_runtime_args());
+}

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
@@ -1110,10 +1110,10 @@ TEST_F(TensorAccessorArgsConstructorTests, MeshTensorConstructorEquivalentToMesh
         tt::tt_metal::Shape{64, 64},
         tt::tt_metal::TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_config));
 
-    auto mesh_tensor = MeshTensor::allocate_on_device(tensor_spec, mesh_device_.get());
+    auto mesh_tensor = MeshTensor::allocate_on_device(*mesh_device_, tensor_spec, TensorTopology());
 
     const auto args_from_mesh_tensor = TensorAccessorArgs(mesh_tensor);
-    const auto args_from_mesh_buffer = TensorAccessorArgs(*mesh_tensor.mesh_buffer());
+    const auto args_from_mesh_buffer = TensorAccessorArgs(mesh_tensor.mesh_buffer());
 
     EXPECT_EQ(args_from_mesh_tensor.get_compile_time_args(), args_from_mesh_buffer.get_compile_time_args());
     EXPECT_EQ(args_from_mesh_tensor.get_common_runtime_args(), args_from_mesh_buffer.get_common_runtime_args());
@@ -1126,10 +1126,10 @@ TEST_F(TensorAccessorArgsConstructorTests, MeshTensorConstructorEquivalentToMesh
         tt::tt_metal::Shape{64, 128},
         tt::tt_metal::TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_config));
 
-    auto mesh_tensor = MeshTensor::allocate_on_device(tensor_spec, mesh_device_.get());
+    auto mesh_tensor = MeshTensor::allocate_on_device(*mesh_device_, tensor_spec, TensorTopology());
 
     const auto args_from_mesh_tensor = TensorAccessorArgs(mesh_tensor);
-    const auto args_from_mesh_buffer = TensorAccessorArgs(*mesh_tensor.mesh_buffer());
+    const auto args_from_mesh_buffer = TensorAccessorArgs(mesh_tensor.mesh_buffer());
 
     EXPECT_EQ(args_from_mesh_tensor.get_compile_time_args(), args_from_mesh_buffer.get_compile_time_args());
     EXPECT_EQ(args_from_mesh_tensor.get_common_runtime_args(), args_from_mesh_buffer.get_common_runtime_args());
@@ -1148,10 +1148,10 @@ TEST_F(TensorAccessorArgsConstructorTests, MeshTensorConstructorEquivalentToMesh
         tt::tt_metal::Shape{4, 6, 64, 64},
         tt::tt_metal::TensorLayout(DataType::UINT16, PageConfig(Layout::TILE), mem_config));
 
-    auto mesh_tensor = MeshTensor::allocate_on_device(tensor_spec, mesh_device_.get());
+    auto mesh_tensor = MeshTensor::allocate_on_device(*mesh_device_, tensor_spec, TensorTopology());
 
     const auto args_from_mesh_tensor = TensorAccessorArgs(mesh_tensor);
-    const auto args_from_mesh_buffer = TensorAccessorArgs(*mesh_tensor.mesh_buffer());
+    const auto args_from_mesh_buffer = TensorAccessorArgs(mesh_tensor.mesh_buffer());
 
     EXPECT_EQ(args_from_mesh_tensor.get_compile_time_args(), args_from_mesh_buffer.get_compile_time_args());
     EXPECT_EQ(args_from_mesh_tensor.get_common_runtime_args(), args_from_mesh_buffer.get_common_runtime_args());

--- a/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
+++ b/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
@@ -6,6 +6,7 @@
 
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 #include <hostdevcommon/tensor_accessor/arg_config.hpp>
 
 #include <cstdint>
@@ -31,6 +32,10 @@ public:
         tensor_accessor::ArgsConfig args_config = tensor_accessor::ArgConfig::None);
     explicit TensorAccessorArgs(
         const std::shared_ptr<distributed::MeshBuffer>& buffer,
+        tensor_accessor::ArgsConfig args_config = tensor_accessor::ArgConfig::None);
+
+    explicit TensorAccessorArgs(
+        const MeshTensor& tensor,
         tensor_accessor::ArgsConfig args_config = tensor_accessor::ArgConfig::None);
 
     static TensorAccessorArgs create_dram_interleaved();

--- a/tt_metal/impl/buffers/tensor_accessor_args.cpp
+++ b/tt_metal/impl/buffers/tensor_accessor_args.cpp
@@ -117,6 +117,9 @@ TensorAccessorArgs::TensorAccessorArgs(
     const std::shared_ptr<distributed::MeshBuffer>& buffer, tensor_accessor::ArgsConfig args_config) :
     TensorAccessorArgs(buffer.get(), args_config) {}
 
+TensorAccessorArgs::TensorAccessorArgs(const MeshTensor& tensor, tensor_accessor::ArgsConfig args_config) :
+    TensorAccessorArgs(tensor.mesh_buffer(), args_config) {}
+
 TensorAccessorArgs TensorAccessorArgs::create_dram_interleaved() {
     TensorAccessorArgs args;
     args.args_config_ = tensor_accessor::ArgConfig::IsDram;


### PR DESCRIPTION
### PR Category

Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Metal Tensor is Runtime's new first class data storage data structure.

TensorAccessArgs simplifies how tensor is accessed on the ops side.

This PR adds a MeshTensor overload to TensorAccessArgs.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Note:
1. metal tensor is still in experimental, however TensorAccessArgs is an API in the stable directory. It is a smell for an official API to have an overload of an experimental concept, this is to be tolerated as we'll be deprecating this overload in the near future, after Metal 2.0 migration. For more infomation please contact @akerteszTT .
2. While this is a runtime (tt_metal) only change, it updates tests in the ttnn land. This is due to tensor migration currently being incomplete, specifically unit test migration has not finished. This will be addressed in the future.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/tensor-accessor)