### PR TITLE
[Cleanup] Move ttnn Tensor infrastructure to ttnn namespace

### DIFF
--- a/tests/tt_eager/ops/test_bcast_op.cpp
+++ b/tests/tt_eager/ops/test_bcast_op.cpp
@@ -29,6 +29,7 @@
 using namespace tt;
 using namespace tt_metal;
 using namespace constants;
+using ttnn::Tensor;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does

--- a/tests/tt_eager/ops/test_bmm_op.cpp
+++ b/tests/tt_eager/ops/test_bmm_op.cpp
@@ -28,6 +28,7 @@ class IDevice;
 using namespace tt;
 using namespace tt_metal;
 using namespace constants;
+using ttnn::Tensor;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does

--- a/tests/tt_eager/ops/test_eltwise_binary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_binary_op.cpp
@@ -20,8 +20,8 @@
 
 using tt::tt_metal::DataType;
 using tt::tt_metal::Layout;
-using tt::tt_metal::Tensor;
 using tt::tt_metal::distributed::MeshDevice;
+using ttnn::Tensor;
 
 template <typename BinaryFunction>
 Tensor host_function(const Tensor& input_tensor_a, const Tensor& input_tensor_b) {

--- a/tests/tt_eager/ops/test_eltwise_binary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_binary_op.cpp
@@ -25,8 +25,8 @@ using ttnn::Tensor;
 
 template <typename BinaryFunction>
 Tensor host_function(const Tensor& input_tensor_a, const Tensor& input_tensor_b) {
-    auto input_a_buffer = tt::tt_metal::host_buffer::get_as<bfloat16>(input_tensor_a);
-    auto input_b_buffer = tt::tt_metal::host_buffer::get_as<bfloat16>(input_tensor_b);
+    auto input_a_buffer = ttnn::host_buffer::get_as<bfloat16>(input_tensor_a);
+    auto input_b_buffer = ttnn::host_buffer::get_as<bfloat16>(input_tensor_b);
 
     auto output_buffer = std::vector<bfloat16>(input_tensor_a.physical_volume());
 

--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -33,7 +33,7 @@ using tt::tt_metal::DataType;
 using tt::tt_metal::distributed::MeshDevice;
 
 using tt::tt_metal::Layout;
-using tt::tt_metal::Tensor;
+using ttnn::Tensor;
 
 namespace detail {
 float sqrt(float x) { return std::sqrt(x); }
@@ -183,7 +183,7 @@ void test_shape_padding() {
 namespace tt::tt_metal {
 template <bool approx_value = false>
 struct exp_with_param {
-    static Tensor fn(const tt::tt_metal::Tensor& t) {
+    static Tensor fn(const Tensor& t) {
         return ttnn::exp(t, approx_value, tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
     }
 };

--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -52,7 +52,7 @@ Tensor gelu_slow(const Tensor& t) { return ttnn::gelu(t, false); }
 
 template <auto UnaryFunction>
 Tensor host_function(const Tensor& input_tensor) {
-    auto input_buffer = tt::tt_metal::host_buffer::get_as<bfloat16>(input_tensor);
+    auto input_buffer = ttnn::host_buffer::get_as<bfloat16>(input_tensor);
 
     auto output_buffer = std::vector<bfloat16>(input_tensor.physical_volume());
 

--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -166,10 +166,10 @@ void test_shape_padding() {
     ttnn::SetDefaultDevice(device);
 
     ttnn::Shape input_shape({1, 1, 13, 18});
-    tt::tt_metal::Array4D padded_input_shape = {1, 1, TILE_HEIGHT, TILE_WIDTH};
+    ttnn::Array4D padded_input_shape = {1, 1, TILE_HEIGHT, TILE_WIDTH};
     auto input_tensor = ttnn::random::uniform(bfloat16(0), bfloat16(1), input_shape);
 
-    auto padded_input_tensor = ttnn::pad(input_tensor, padded_input_shape, tt::tt_metal::Array4D({0, 0, 0, 0}), 0);
+    auto padded_input_tensor = ttnn::pad(input_tensor, padded_input_shape, ttnn::Array4D({0, 0, 0, 0}), 0);
 
     padded_input_tensor = padded_input_tensor.to_layout(Layout::TILE);
     padded_input_tensor = padded_input_tensor.to_device(device);

--- a/tests/tt_eager/ops/test_layernorm_op.cpp
+++ b/tests/tt_eager/ops/test_layernorm_op.cpp
@@ -23,6 +23,7 @@ class IDevice;
 using namespace tt;
 using namespace tt::tt_metal;
 using namespace constants;
+using ttnn::Tensor;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does

--- a/tests/tt_eager/ops/test_softmax_op.cpp
+++ b/tests/tt_eager/ops/test_softmax_op.cpp
@@ -16,6 +16,7 @@
 using namespace tt;
 using namespace tt::tt_metal;
 using namespace constants;
+using ttnn::Tensor;
 
 void run_softmax(distributed::MeshDevice* device, const ttnn::Shape& shape) {
     Tensor input_tensor = ttnn::random::random(shape).to_layout(Layout::TILE).to_device(device);

--- a/tests/tt_eager/tensors/test_copy_and_move.cpp
+++ b/tests/tt_eager/tensors/test_copy_and_move.cpp
@@ -34,6 +34,7 @@ class IDevice;
 using namespace tt;
 using namespace tt_metal;
 using namespace constants;
+using ttnn::Tensor;
 
 void test_tensor_copy_semantics(distributed::MeshDevice* device) {
     ttnn::Shape single_tile_shape({1, 1, TILE_HEIGHT, TILE_WIDTH});

--- a/tests/tt_eager/tensors/test_copy_and_move.cpp
+++ b/tests/tt_eager/tensors/test_copy_and_move.cpp
@@ -69,7 +69,7 @@ void test_tensor_copy_semantics(distributed::MeshDevice* device) {
     // host tensor updated with dev tensor copy assignment
     Tensor host_d_copy = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE);
     host_d_copy = dev_a;
-    TT_FATAL(host_d_copy.storage_type() == StorageType::DEVICE, "Test Failed");
+    TT_FATAL(host_d_copy.storage_type() == ttnn::StorageType::DEVICE, "Test Failed");
     auto host_d_copy_on_host = host_d_copy.cpu();
     auto host_d_copy_data = host_buffer::get_as<bfloat16>(host_d_copy_on_host);
     TT_FATAL(std::equal(dev_a_data.begin(), dev_a_data.end(), host_d_copy_data.begin()), "Test Failed");
@@ -78,7 +78,7 @@ void test_tensor_copy_semantics(distributed::MeshDevice* device) {
     Tensor host_e = ttnn::ones(single_tile_shape, DataType::BFLOAT16, Layout::TILE);
     Tensor dev_e_copy = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device);
     dev_e_copy = host_e;
-    TT_FATAL(dev_e_copy.storage_type() == StorageType::HOST, "Test Failed");
+    TT_FATAL(dev_e_copy.storage_type() == ttnn::StorageType::HOST, "Test Failed");
     auto host_e_data = host_buffer::get_as<bfloat16>(host_e);
     auto dev_e_copy_data = host_buffer::get_as<bfloat16>(dev_e_copy);
     TT_FATAL(std::equal(host_e_data.begin(), host_e_data.end(), dev_e_copy_data.begin()), "Test Failed");
@@ -87,7 +87,7 @@ void test_tensor_copy_semantics(distributed::MeshDevice* device) {
     Tensor dev_b = ttnn::ones(single_tile_shape, DataType::BFLOAT16, Layout::TILE, *device);
     Tensor dev_b_copy = ttnn::zeros(single_tile_shape, DataType::BFLOAT16, Layout::TILE, *device);
     dev_b_copy = dev_b;
-    TT_FATAL(dev_b_copy.storage_type() == StorageType::DEVICE, "Test Failed");
+    TT_FATAL(dev_b_copy.storage_type() == ttnn::StorageType::DEVICE, "Test Failed");
     auto dev_b_on_host = dev_b.cpu();
     auto dev_b_copy_on_host = dev_b_copy.cpu();
     auto dev_b_data = host_buffer::get_as<bfloat16>(dev_b_on_host);
@@ -141,7 +141,7 @@ void test_tensor_move_semantics(distributed::MeshDevice* device) {
     // host tensor updated with dev tensor move assignment
     Tensor host_d_copy = host_c_copy;
     host_d_copy = std::move(dev_a_copy);
-    TT_FATAL(host_d_copy.storage_type() == StorageType::DEVICE, "Test Failed");
+    TT_FATAL(host_d_copy.storage_type() == ttnn::StorageType::DEVICE, "Test Failed");
     auto host_d_copy_on_host = host_d_copy.cpu();
     auto host_d_copy_data = host_buffer::get_as<bfloat16>(host_d_copy_on_host);
     TT_FATAL(std::equal(host_d_copy_data.begin(), host_d_copy_data.end(), bfloat_data.begin()), "Test Failed");
@@ -152,7 +152,7 @@ void test_tensor_move_semantics(distributed::MeshDevice* device) {
     Tensor host_e = random_tensor_four;
     Tensor dev_e_copy = host_c_copy.to_device(device);
     dev_e_copy = std::move(host_e);
-    TT_FATAL(dev_e_copy.storage_type() == StorageType::HOST, "Test Failed");
+    TT_FATAL(dev_e_copy.storage_type() == ttnn::StorageType::HOST, "Test Failed");
     auto dev_e_copy_data = host_buffer::get_as<bfloat16>(dev_e_copy);
     TT_FATAL(std::equal(dev_e_copy_data.begin(), dev_e_copy_data.end(), bfloat_data_four.begin()), "Test Failed");
 
@@ -162,7 +162,7 @@ void test_tensor_move_semantics(distributed::MeshDevice* device) {
     Tensor dev_b = random_tensor_four.to_device(device);
     Tensor dev_b_copy = dev_e_copy.to_device(device);
     dev_b_copy = std::move(dev_b);
-    TT_FATAL(dev_b_copy.storage_type() == StorageType::DEVICE, "Test Failed");
+    TT_FATAL(dev_b_copy.storage_type() == ttnn::StorageType::DEVICE, "Test Failed");
     auto dev_b_copy_on_host = dev_b_copy.cpu();
     auto dev_b_copy_data = host_buffer::get_as<bfloat16>(dev_b_copy_on_host);
     TT_FATAL(std::equal(dev_b_copy_data.begin(), dev_b_copy_data.end(), bfloat_data_five.begin()), "Test Failed");

--- a/tests/tt_eager/tensors/test_copy_and_move.cpp
+++ b/tests/tt_eager/tensors/test_copy_and_move.cpp
@@ -42,8 +42,8 @@ void test_tensor_copy_semantics(distributed::MeshDevice* device) {
     // host tensor to host tensor copy constructor
     Tensor host_a = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE);
     Tensor host_a_copy = host_a;
-    auto host_a_data = host_buffer::get_as<bfloat16>(host_a);
-    auto host_a_copy_data = host_buffer::get_as<bfloat16>(host_a_copy);
+    auto host_a_data = ttnn::host_buffer::get_as<bfloat16>(host_a);
+    auto host_a_copy_data = ttnn::host_buffer::get_as<bfloat16>(host_a_copy);
     TT_FATAL(std::equal(host_a_data.begin(), host_a_data.end(), host_a_copy_data.begin()), "Test Failed");
 
     // dev tensor to dev tensor copy constructor
@@ -52,8 +52,8 @@ void test_tensor_copy_semantics(distributed::MeshDevice* device) {
     Tensor dev_a_copy = dev_a;
     auto dev_a_on_host = dev_a.cpu();
     auto dev_a_copy_on_host = dev_a_copy.cpu();
-    auto dev_a_data = host_buffer::get_as<bfloat16>(dev_a_on_host);
-    auto dev_a_copy_data = host_buffer::get_as<bfloat16>(dev_a_copy_on_host);
+    auto dev_a_data = ttnn::host_buffer::get_as<bfloat16>(dev_a_on_host);
+    auto dev_a_copy_data = ttnn::host_buffer::get_as<bfloat16>(dev_a_copy_on_host);
     TT_FATAL(std::equal(dev_a_data.begin(), dev_a_data.end(), dev_a_copy_data.begin()), "Test Failed");
 
     // host tensor updated with host tensor copy assignment
@@ -62,8 +62,8 @@ void test_tensor_copy_semantics(distributed::MeshDevice* device) {
                         .to_layout(Layout::TILE);
     Tensor host_c_copy = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE);
     host_c_copy = host_c;
-    auto host_c_data = host_buffer::get_as<bfloat16>(host_c);
-    auto host_c_copy_data = host_buffer::get_as<bfloat16>(host_c_copy);
+    auto host_c_data = ttnn::host_buffer::get_as<bfloat16>(host_c);
+    auto host_c_copy_data = ttnn::host_buffer::get_as<bfloat16>(host_c_copy);
     TT_FATAL(std::equal(host_c_data.begin(), host_c_data.end(), host_c_copy_data.begin()), "Test Failed");
 
     // host tensor updated with dev tensor copy assignment
@@ -71,7 +71,7 @@ void test_tensor_copy_semantics(distributed::MeshDevice* device) {
     host_d_copy = dev_a;
     TT_FATAL(host_d_copy.storage_type() == ttnn::StorageType::DEVICE, "Test Failed");
     auto host_d_copy_on_host = host_d_copy.cpu();
-    auto host_d_copy_data = host_buffer::get_as<bfloat16>(host_d_copy_on_host);
+    auto host_d_copy_data = ttnn::host_buffer::get_as<bfloat16>(host_d_copy_on_host);
     TT_FATAL(std::equal(dev_a_data.begin(), dev_a_data.end(), host_d_copy_data.begin()), "Test Failed");
 
     // dev tensor updated with host tensor copy assignment
@@ -79,8 +79,8 @@ void test_tensor_copy_semantics(distributed::MeshDevice* device) {
     Tensor dev_e_copy = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device);
     dev_e_copy = host_e;
     TT_FATAL(dev_e_copy.storage_type() == ttnn::StorageType::HOST, "Test Failed");
-    auto host_e_data = host_buffer::get_as<bfloat16>(host_e);
-    auto dev_e_copy_data = host_buffer::get_as<bfloat16>(dev_e_copy);
+    auto host_e_data = ttnn::host_buffer::get_as<bfloat16>(host_e);
+    auto dev_e_copy_data = ttnn::host_buffer::get_as<bfloat16>(dev_e_copy);
     TT_FATAL(std::equal(host_e_data.begin(), host_e_data.end(), dev_e_copy_data.begin()), "Test Failed");
 
     // dev tensor updated with dev tensor copy assignment
@@ -90,8 +90,8 @@ void test_tensor_copy_semantics(distributed::MeshDevice* device) {
     TT_FATAL(dev_b_copy.storage_type() == ttnn::StorageType::DEVICE, "Test Failed");
     auto dev_b_on_host = dev_b.cpu();
     auto dev_b_copy_on_host = dev_b_copy.cpu();
-    auto dev_b_data = host_buffer::get_as<bfloat16>(dev_b_on_host);
-    auto dev_b_copy_data = host_buffer::get_as<bfloat16>(dev_b_copy_on_host);
+    auto dev_b_data = ttnn::host_buffer::get_as<bfloat16>(dev_b_on_host);
+    auto dev_b_copy_data = ttnn::host_buffer::get_as<bfloat16>(dev_b_copy_on_host);
     TT_FATAL(std::equal(dev_b_data.begin(), dev_b_data.end(), dev_b_copy_data.begin()), "Test Failed");
 }
 
@@ -99,7 +99,7 @@ void test_tensor_move_semantics(distributed::MeshDevice* device) {
     ttnn::Shape single_tile_shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
 
     auto random_tensor = ttnn::random::uniform(bfloat16(-1.0f), bfloat16(1.0f), single_tile_shape);
-    auto bfloat_data = host_buffer::get_as<bfloat16>(random_tensor);
+    auto bfloat_data = ttnn::host_buffer::get_as<bfloat16>(random_tensor);
 
     // host tensor to host tensor move constructor
     Tensor host_a = Tensor(
@@ -108,7 +108,7 @@ void test_tensor_move_semantics(distributed::MeshDevice* device) {
         DataType::BFLOAT16,
         Layout::TILE);
     Tensor host_a_copy = std::move(host_a);
-    auto host_a_copy_data = host_buffer::get_as<bfloat16>(host_a_copy);
+    auto host_a_copy_data = ttnn::host_buffer::get_as<bfloat16>(host_a_copy);
     TT_FATAL(std::equal(host_a_copy_data.begin(), host_a_copy_data.end(), bfloat_data.begin()), "Test Failed");
 
     // dev tensor to dev tensor move constructor
@@ -122,12 +122,12 @@ void test_tensor_move_semantics(distributed::MeshDevice* device) {
     Tensor dev_a_copy = std::move(dev_a);
     TT_FATAL(dev_a_copy.buffer() == og_buffer_a, "Test Failed");
     auto dev_a_copy_on_host = dev_a_copy.cpu();
-    auto dev_a_copy_data = host_buffer::get_as<bfloat16>(dev_a_copy_on_host);
+    auto dev_a_copy_data = ttnn::host_buffer::get_as<bfloat16>(dev_a_copy_on_host);
     TT_FATAL(std::equal(dev_a_copy_data.begin(), dev_a_copy_data.end(), bfloat_data.begin()), "Test Failed");
 
     // host tensor updated with host tensor move assignment
     auto random_tensor_three = ttnn::random::uniform(bfloat16(-1.0f), bfloat16(1.0f), single_tile_shape);
-    auto bfloat_data_three = host_buffer::get_as<bfloat16>(random_tensor_three);
+    auto bfloat_data_three = ttnn::host_buffer::get_as<bfloat16>(random_tensor_three);
     Tensor host_c = Tensor(
         HostBuffer(std::vector<bfloat16>(bfloat_data_three.begin(), bfloat_data_three.end())),
         single_tile_shape,
@@ -135,7 +135,7 @@ void test_tensor_move_semantics(distributed::MeshDevice* device) {
         Layout::TILE);
     Tensor host_c_copy = dev_a_copy_on_host;
     host_c_copy = std::move(host_c);
-    auto host_c_copy_data = host_buffer::get_as<bfloat16>(host_c_copy);
+    auto host_c_copy_data = ttnn::host_buffer::get_as<bfloat16>(host_c_copy);
     TT_FATAL(std::equal(host_c_copy_data.begin(), host_c_copy_data.end(), bfloat_data_three.begin()), "Test Failed");
 
     // host tensor updated with dev tensor move assignment
@@ -143,28 +143,28 @@ void test_tensor_move_semantics(distributed::MeshDevice* device) {
     host_d_copy = std::move(dev_a_copy);
     TT_FATAL(host_d_copy.storage_type() == ttnn::StorageType::DEVICE, "Test Failed");
     auto host_d_copy_on_host = host_d_copy.cpu();
-    auto host_d_copy_data = host_buffer::get_as<bfloat16>(host_d_copy_on_host);
+    auto host_d_copy_data = ttnn::host_buffer::get_as<bfloat16>(host_d_copy_on_host);
     TT_FATAL(std::equal(host_d_copy_data.begin(), host_d_copy_data.end(), bfloat_data.begin()), "Test Failed");
 
     // dev tensor updated with host tensor copy assignment
     auto random_tensor_four = ttnn::random::uniform(bfloat16(-1.0f), bfloat16(1.0f), single_tile_shape);
-    auto bfloat_data_four = host_buffer::get_as<bfloat16>(random_tensor_four);
+    auto bfloat_data_four = ttnn::host_buffer::get_as<bfloat16>(random_tensor_four);
     Tensor host_e = random_tensor_four;
     Tensor dev_e_copy = host_c_copy.to_device(device);
     dev_e_copy = std::move(host_e);
     TT_FATAL(dev_e_copy.storage_type() == ttnn::StorageType::HOST, "Test Failed");
-    auto dev_e_copy_data = host_buffer::get_as<bfloat16>(dev_e_copy);
+    auto dev_e_copy_data = ttnn::host_buffer::get_as<bfloat16>(dev_e_copy);
     TT_FATAL(std::equal(dev_e_copy_data.begin(), dev_e_copy_data.end(), bfloat_data_four.begin()), "Test Failed");
 
     // dev tensor updated with dev tensor copy assignment
     auto random_tensor_five = ttnn::random::uniform(bfloat16(-1.0f), bfloat16(1.0f), single_tile_shape);
-    auto bfloat_data_five = host_buffer::get_as<bfloat16>(random_tensor_five);
+    auto bfloat_data_five = ttnn::host_buffer::get_as<bfloat16>(random_tensor_five);
     Tensor dev_b = random_tensor_four.to_device(device);
     Tensor dev_b_copy = dev_e_copy.to_device(device);
     dev_b_copy = std::move(dev_b);
     TT_FATAL(dev_b_copy.storage_type() == ttnn::StorageType::DEVICE, "Test Failed");
     auto dev_b_copy_on_host = dev_b_copy.cpu();
-    auto dev_b_copy_data = host_buffer::get_as<bfloat16>(dev_b_copy_on_host);
+    auto dev_b_copy_data = ttnn::host_buffer::get_as<bfloat16>(dev_b_copy_on_host);
     TT_FATAL(std::equal(dev_b_copy_data.begin(), dev_b_copy_data.end(), bfloat_data_five.begin()), "Test Failed");
 }
 

--- a/tests/tt_eager/tensors/test_host_device_loopback.cpp
+++ b/tests/tt_eager/tensors/test_host_device_loopback.cpp
@@ -34,8 +34,8 @@ bool test_single_tile_single_dram_bank_loopback(distributed::MeshDevice* device)
     Tensor host_a = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE);
     Tensor device_a = host_a.to_device(device);
     Tensor loopbacked_a = device_a.cpu();
-    auto host_a_data = host_buffer::get_as<bfloat16>(host_a);
-    auto loopbacked_a_data = host_buffer::get_as<bfloat16>(loopbacked_a);
+    auto host_a_data = ttnn::host_buffer::get_as<bfloat16>(host_a);
+    auto loopbacked_a_data = ttnn::host_buffer::get_as<bfloat16>(loopbacked_a);
     pass &= std::equal(host_a_data.begin(), host_a_data.end(), loopbacked_a_data.begin());
 
     return pass;
@@ -48,8 +48,8 @@ bool test_multi_tile_multi_dram_bank_loopback(distributed::MeshDevice* device) {
     Tensor host_a = ttnn::random::random(multi_tile_shape).to_layout(Layout::TILE);
     Tensor device_a = host_a.to_device(device);
     Tensor loopbacked_a = device_a.cpu();
-    auto host_a_data = host_buffer::get_as<bfloat16>(host_a);
-    auto loopbacked_a_data = host_buffer::get_as<bfloat16>(loopbacked_a);
+    auto host_a_data = ttnn::host_buffer::get_as<bfloat16>(host_a);
+    auto loopbacked_a_data = ttnn::host_buffer::get_as<bfloat16>(loopbacked_a);
     pass &= std::equal(host_a_data.begin(), host_a_data.end(), loopbacked_a_data.begin());
     return pass;
 }

--- a/tests/tt_eager/tensors/test_host_device_loopback.cpp
+++ b/tests/tt_eager/tensors/test_host_device_loopback.cpp
@@ -25,6 +25,7 @@ class IDevice;
 using namespace tt;
 using namespace tt_metal;
 using namespace constants;
+using ttnn::Tensor;
 
 bool test_single_tile_single_dram_bank_loopback(distributed::MeshDevice* device) {
     bool pass = true;

--- a/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
+++ b/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
@@ -96,7 +96,7 @@ void test_raw_host_memory_pointer() {
     // Set every value of tt Tensor to the same non-zero number
     bfloat16 a_value = 4.0f;
 
-    for (auto& element : tt::tt_metal::host_buffer::get_as<bfloat16>(a_cpu)) {
+    for (auto& element : ttnn::host_buffer::get_as<bfloat16>(a_cpu)) {
         element = a_value;
     }
 
@@ -113,13 +113,13 @@ void test_raw_host_memory_pointer() {
     Tensor c_dev = ttnn::sqrt(a_dev);
 
     {
-        auto dst_host_buffer = tt::tt_metal::host_buffer::get_host_buffer(tensor_for_printing);
+        auto dst_host_buffer = ttnn::host_buffer::get_host_buffer(tensor_for_printing);
         tt::tt_metal::copy_to_host(c_dev.device()->mesh_command_queue(), c_dev, dst_host_buffer.view_bytes().data());
     }
 
     // Check that cpu tensor has correct data
     bfloat16 output_value = 2.0f;
-    for (auto& element : tt::tt_metal::host_buffer::get_as<bfloat16>(tensor_for_printing)) {
+    for (auto& element : ttnn::host_buffer::get_as<bfloat16>(tensor_for_printing)) {
         TT_FATAL(element == output_value, "Element does not match expected output_value");
     }
 
@@ -143,7 +143,7 @@ void test_raw_host_memory_pointer() {
         Tensor(std::move(alternative_tensor_for_printing_buffer), shape, DataType::BFLOAT16, Layout::TILE);
     std::cout << ttnn::to_string(alternative_tensor_for_printing) << "\n";
 
-    for (auto& element : tt::tt_metal::host_buffer::get_as<bfloat16>(alternative_tensor_for_printing)) {
+    for (auto& element : ttnn::host_buffer::get_as<bfloat16>(alternative_tensor_for_printing)) {
         TT_FATAL(element == output_value, "Element does not match expected output_value");
     }
 
@@ -157,20 +157,20 @@ void test_raw_host_memory_pointer() {
     Tensor d_cpu = Tensor(std::move(d_data_buffer), shape, DataType::BFLOAT16, Layout::TILE);
 
     bfloat16 d_value = 8.0f;
-    for (auto& element : tt::tt_metal::host_buffer::get_as<bfloat16>(d_cpu)) {
+    for (auto& element : ttnn::host_buffer::get_as<bfloat16>(d_cpu)) {
         element = d_value;
     }
 
     Tensor d_dev = a_dev;
-    auto d_cpu_buffer = tt::tt_metal::host_buffer::get_host_buffer(d_cpu);
+    auto d_cpu_buffer = ttnn::host_buffer::get_host_buffer(d_cpu);
     tt::tt_metal::copy_to_device(d_dev.device()->mesh_command_queue(), d_cpu_buffer.view_bytes().data(), d_dev);
 
     Tensor e_dev = ttnn::add(c_dev, d_dev);
 
-    auto dst_host_buffer = tt::tt_metal::host_buffer::get_host_buffer(tensor_for_printing);
+    auto dst_host_buffer = ttnn::host_buffer::get_host_buffer(tensor_for_printing);
     tt::tt_metal::copy_to_host(e_dev.device()->mesh_command_queue(), e_dev, dst_host_buffer.view_bytes().data());
 
-    for (auto& element : tt::tt_metal::host_buffer::get_as<bfloat16>(tensor_for_printing)) {
+    for (auto& element : ttnn::host_buffer::get_as<bfloat16>(tensor_for_printing)) {
         TT_FATAL(element == bfloat16(10.0f), "Element does not match expected bfloat16(10.0f)");
     }
 }

--- a/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
+++ b/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
@@ -68,7 +68,7 @@ void test_raw_host_memory_pointer() {
     using tt::tt_metal::DataType;
     using tt::tt_metal::HostBuffer;
     using tt::tt_metal::Layout;
-    using tt::tt_metal::Tensor;
+    using ttnn::Tensor;
 
     int device_id = 0;
     auto device = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);

--- a/tests/ttnn/benchmark/cpp/benchmark_host_alloc_on_tensor_readback.cpp
+++ b/tests/ttnn/benchmark/cpp/benchmark_host_alloc_on_tensor_readback.cpp
@@ -17,7 +17,7 @@ ttnn::distributed::MeshDevice* device = nullptr;
 
 void BM_host_alloc_on_tensor_readback(benchmark::State& state) {
     const size_t global_tensor_size = state.range(0);
-    tt::tt_metal::Tensor device_tensor = tt::tt_metal::create_device_tensor(
+    ttnn::Tensor device_tensor = tt::tt_metal::create_device_tensor(
         tt::tt_metal::TensorSpec(
             ttnn::Shape({global_tensor_size / sizeof(float) / device->num_devices()}),
             tt::tt_metal::TensorLayout(

--- a/tests/ttnn/benchmark/cpp/benchmark_host_dtype_conversion.cpp
+++ b/tests/ttnn/benchmark/cpp/benchmark_host_dtype_conversion.cpp
@@ -23,14 +23,14 @@ ttnn::distributed::MeshDevice* device = nullptr;
 void BM_host_bfloat8_conversion(benchmark::State& state) {
     const auto tensor_shape = ttnn::Shape{state.range(0), constants::TILE_HEIGHT, constants::TILE_WIDTH};
 
-    std::vector<Tensor> tensors;
+    std::vector<ttnn::Tensor> tensors;
     for (int i = 0; i < device->num_devices(); i++) {
         std::vector<bfloat16> host_data;
         host_data.reserve(tensor_shape.volume());
         for (int j = 0; j < tensor_shape.volume(); j++) {
             host_data.push_back(bfloat16(j));
         }
-        tensors.push_back(Tensor::from_vector(
+        tensors.push_back(ttnn::Tensor::from_vector(
             std::move(host_data),
             TensorSpec(tensor_shape, TensorLayout(DataType::BFLOAT16, Layout::ROW_MAJOR, MemoryConfig{}))));
     }

--- a/tests/ttnn/benchmark/cpp/operations/ternary/benchmark_where.cpp
+++ b/tests/ttnn/benchmark/cpp/operations/ternary/benchmark_where.cpp
@@ -16,7 +16,7 @@ namespace {
 
 // Will be replaced with ttnn::rand
 template <typename ElemType>
-tt::tt_metal::Tensor genRandomTensor(const ttnn::Shape& shape, const tt::tt_metal::Layout layout) {
+ttnn::Tensor genRandomTensor(const ttnn::Shape& shape, const tt::tt_metal::Layout layout) {
     constexpr ttnn::DataType data_type = tt::tt_metal::convert_to_data_type<ElemType>();
     ttnn::TensorSpec spec(shape, ttnn::TensorLayout(data_type, ttnn::PageConfig(layout), tt::tt_metal::MemoryConfig{}));
     auto output_buffer = std::vector<ElemType>(spec.padded_shape().volume());
@@ -30,7 +30,7 @@ tt::tt_metal::Tensor genRandomTensor(const ttnn::Shape& shape, const tt::tt_meta
     const size_t total = output_buffer.size();
     if (total < 256 * 256) {
         std::ranges::for_each(output_buffer, init_rand_elem);
-        return tt::tt_metal::Tensor(tt::tt_metal::HostBuffer(std::move(output_buffer)), spec);
+        return ttnn::Tensor(tt::tt_metal::HostBuffer(std::move(output_buffer)), spec);
     } else {
         tf::Executor executor;
         tf::Taskflow taskflow;
@@ -39,7 +39,7 @@ tt::tt_metal::Tensor genRandomTensor(const ttnn::Shape& shape, const tt::tt_meta
         executor.run(taskflow).wait();
     }
 
-    return tt::tt_metal::Tensor(tt::tt_metal::HostBuffer(std::move(output_buffer)), spec);
+    return ttnn::Tensor(tt::tt_metal::HostBuffer(std::move(output_buffer)), spec);
 }
 
 void BM_where_bf16_ttt(benchmark::State& state) {

--- a/tests/ttnn/benchmark/cpp/padding/pad_rm.cpp
+++ b/tests/ttnn/benchmark/cpp/padding/pad_rm.cpp
@@ -32,7 +32,7 @@ ttnn::Tensor GenInputTensor(const ttnn::SmallVector<uint32_t>& shape) {
     for (size_t i = 0; i < volume; ++i) {
         input_data.push_back(static_cast<T>(dist(gen)));
     }
-    return Tensor(HostBuffer{input_data}, ttnn::Shape(shape), DataType::BFLOAT16, Layout::ROW_MAJOR);
+    return ttnn::Tensor(HostBuffer{input_data}, ttnn::Shape(shape), DataType::BFLOAT16, Layout::ROW_MAJOR);
 }
 
 void BM_pad_rm_2d_last_dim_right(benchmark::State& state) {

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -420,8 +420,8 @@ bool RunPipelinedWorkersTest(
 
     // Allocate the tensors - pull to function
     const size_t num_tensors = num_stages + 1;
-    std::vector<Tensor> host_tensors;
-    std::vector<Tensor> device_tensors;
+    std::vector<ttnn::Tensor> host_tensors;
+    std::vector<ttnn::Tensor> device_tensors;
     host_tensors.reserve(num_tensors);
     device_tensors.reserve(num_tensors);
     auto num_elems = std::reduce(tensor_shape.cbegin(), tensor_shape.cend(), 1, std::multiplies<uint32_t>());

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -642,10 +642,10 @@ bool RunPipelinedWorkersTest(
         auto input_cpu = device_tensors[0].cpu();
         auto final_out_cpu = device_tensors.back().cpu();
 
-        auto in_tensor_copyback = tt::tt_metal::host_buffer::get_as<uint32_t>(input_cpu);
-        auto out_tensor_copyback = tt::tt_metal::host_buffer::get_as<uint32_t>(final_out_cpu);
+        auto in_tensor_copyback = ttnn::host_buffer::get_as<uint32_t>(input_cpu);
+        auto out_tensor_copyback = ttnn::host_buffer::get_as<uint32_t>(final_out_cpu);
 
-        auto in_tensor_data = tt::tt_metal::host_buffer::get_as<uint32_t>(host_tensors[0]);
+        auto in_tensor_data = ttnn::host_buffer::get_as<uint32_t>(host_tensors[0]);
 
         bool input_copyback_check_passed = run_output_check(in_tensor_data, in_tensor_copyback) == Correctness::Correct;
         TT_FATAL(input_copyback_check_passed, "Input 0 copyback check failed");

--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -58,7 +58,8 @@ TEST_F(MeshDevice1x4Fixture, AllGatherReturnedTensor) {
         ttnn::Shape({1, 8, 1024, 768}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
         std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(dev_idx)));
-        tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
+        tensors.push_back(
+            ttnn::Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
     }
 
     auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
@@ -94,10 +95,11 @@ TEST_F(MeshDevice1x4Fixture, AllGatherPersistentOutput) {
         ttnn::Shape({4, 8, 1024, 768}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
         std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(dev_idx)));
-        tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
+        tensors.push_back(
+            ttnn::Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
         std::vector<bfloat16> output_data(output_tensor_spec.logical_shape().volume(), bfloat16(0));
-        output_tensors.push_back(
-            Tensor::from_vector(std::move(output_data), output_tensor_spec).to_device(mesh_devices[dev_idx].get()));
+        output_tensors.push_back(ttnn::Tensor::from_vector(std::move(output_data), output_tensor_spec)
+                                     .to_device(mesh_devices[dev_idx].get()));
     }
 
     auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
@@ -137,10 +139,10 @@ TEST_F(MeshDevice1x4Fixture, ReduceScatter) {
         ttnn::Shape({1, 8, 1024, 192}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
     for (auto& mesh_device : mesh_devices) {
         std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(1)));
-        tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_device.get()));
+        tensors.push_back(ttnn::Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_device.get()));
         std::vector<bfloat16> output_data(output_tensor_spec.logical_shape().volume(), bfloat16(0));
         output_tensors.push_back(
-            Tensor::from_vector(std::move(output_data), output_tensor_spec).to_device(mesh_device.get()));
+            ttnn::Tensor::from_vector(std::move(output_data), output_tensor_spec).to_device(mesh_device.get()));
     }
     auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
     auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
@@ -175,7 +177,7 @@ TEST_F(MeshDevice1x4Fixture, AllReduce) {
         ttnn::Shape({1, 8, 1024, 768}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
     for (auto& mesh_device : mesh_devices) {
         std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(1)));
-        tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_device.get()));
+        tensors.push_back(ttnn::Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_device.get()));
     }
 
     auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);

--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -62,7 +62,7 @@ TEST_F(MeshDevice1x4Fixture, AllGatherReturnedTensor) {
             ttnn::Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
     }
 
-    auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
+    auto aggregated_tensor = ttnn::experimental::unit_mesh::aggregate(tensors);
 
     // Quiesce parent mesh before all gather
     mesh_device_->quiesce_devices();
@@ -74,7 +74,7 @@ TEST_F(MeshDevice1x4Fixture, AllGatherReturnedTensor) {
     // Quiesce parent mesh after all gather
     mesh_device_->quiesce_devices();
 
-    auto disaggregated_output_tensors = tt::tt_metal::experimental::unit_mesh::disaggregate(all_gathered_tensor);
+    auto disaggregated_output_tensors = ttnn::experimental::unit_mesh::disaggregate(all_gathered_tensor);
     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
         auto data = disaggregated_output_tensors[dev_idx].to_vector<bfloat16>();
         for (int i = 0; i < data.size(); i++) {
@@ -102,8 +102,8 @@ TEST_F(MeshDevice1x4Fixture, AllGatherPersistentOutput) {
                                      .to_device(mesh_devices[dev_idx].get()));
     }
 
-    auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
-    auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
+    auto aggregated_tensor = ttnn::experimental::unit_mesh::aggregate(tensors);
+    auto aggregated_output_tensor = ttnn::experimental::unit_mesh::aggregate(output_tensors);
 
     // Quiesce parent mesh before all gather
     mesh_device_->quiesce_devices();
@@ -144,8 +144,8 @@ TEST_F(MeshDevice1x4Fixture, ReduceScatter) {
         output_tensors.push_back(
             ttnn::Tensor::from_vector(std::move(output_data), output_tensor_spec).to_device(mesh_device.get()));
     }
-    auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
-    auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
+    auto aggregated_tensor = ttnn::experimental::unit_mesh::aggregate(tensors);
+    auto aggregated_output_tensor = ttnn::experimental::unit_mesh::aggregate(output_tensors);
 
     // Quiesce parent mesh before reduce scatter
     mesh_device_->quiesce_devices();
@@ -180,7 +180,7 @@ TEST_F(MeshDevice1x4Fixture, AllReduce) {
         tensors.push_back(ttnn::Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_device.get()));
     }
 
-    auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
+    auto aggregated_tensor = ttnn::experimental::unit_mesh::aggregate(tensors);
 
     // Quiesce parent mesh before all reduce
     mesh_device_->quiesce_devices();
@@ -190,7 +190,7 @@ TEST_F(MeshDevice1x4Fixture, AllReduce) {
     // Quiesce parent mesh after all reduce
     mesh_device_->quiesce_devices();
 
-    auto disaggregated_output_tensors = tt::tt_metal::experimental::unit_mesh::disaggregate(all_reduced_tensor);
+    auto disaggregated_output_tensors = ttnn::experimental::unit_mesh::disaggregate(all_reduced_tensor);
     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
         auto data = disaggregated_output_tensors[dev_idx].to_vector<bfloat16>();
         for (auto val : data) {

--- a/tests/ttnn/unit_tests/gtests/ccl/test_persistent_fabric_ccl_ops.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_persistent_fabric_ccl_ops.cpp
@@ -53,7 +53,7 @@ TEST(CclAsyncOp, ReduceScatterSmall_PersistentFabric) {
     // INPUT TENSOR setup
 
     // Replicate the tensor across (1, num_devices) submesh.
-    const Tensor input_mesh_tensor = ttnn::distributed::distribute_tensor(
+    const ttnn::Tensor input_mesh_tensor = ttnn::distributed::distribute_tensor(
         ttnn::experimental::view(ttnn::arange(0, num_elems, 1, DataType::BFLOAT16), input_shape).to_layout(layout),
         *ttnn::distributed::create_mesh_mapper(
             *test_fixture.mesh_device_,

--- a/tests/ttnn/unit_tests/gtests/ccl/test_send_recv_ops.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_send_recv_ops.cpp
@@ -56,7 +56,7 @@ void test_send_recv_async_(
     auto layout = tensor_spec.layout();
     auto dtype = tensor_spec.data_type();
     // Replicate the tensor across (1, num_devices) submesh.
-    const Tensor md0_input_tensor =
+    const ttnn::Tensor md0_input_tensor =
         ttnn::distributed::distribute_tensor(
             ttnn::experimental::view(ttnn::arange(seed, seed + num_elems, 1, dtype), input_shape).to_layout(layout),
             *ttnn::distributed::replicate_tensor_to_mesh_mapper(*md0),

--- a/tests/ttnn/unit_tests/gtests/emitc/test_sanity.cpp
+++ b/tests/ttnn/unit_tests/gtests/emitc/test_sanity.cpp
@@ -39,7 +39,7 @@ TEST(EmitC, Sanity) {
     ttnn::Tensor v1;
     ttnn::Tensor v2;
     std::tie(v1, v2) = create_inputs_for_add();
-    ttnn::Tensor v3 = add(v1, v2);
+    Tensor v3 = ttnn::test::add(v1, v2);
 }
 
 }  // namespace ttnn::test

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -145,8 +145,8 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0) {
 
         log_info(LogTest, "Enqueue AllGather");
 
-        auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(device_tensors);
-        auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
+        auto aggregated_tensor = experimental::unit_mesh::aggregate(device_tensors);
+        auto aggregated_output_tensor = experimental::unit_mesh::aggregate(output_tensors);
         // Quiesce parent mesh before all gather
         mesh_device_->quiesce_devices();
 
@@ -313,8 +313,8 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0CQ1) {
 
         log_info(LogTest, "Enqueue AllGather");
 
-        auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(device_tensors);
-        auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
+        auto aggregated_tensor = experimental::unit_mesh::aggregate(device_tensors);
+        auto aggregated_output_tensor = experimental::unit_mesh::aggregate(output_tensors);
 
         // Quiesce parent mesh before all gather
         mesh_device_->quiesce_devices();
@@ -507,8 +507,8 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksMultithreadCQ0) {
 
         log_info(LogTest, "Enqueue AllGather");
 
-        auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(device_tensors);
-        auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
+        auto aggregated_tensor = experimental::unit_mesh::aggregate(device_tensors);
+        auto aggregated_output_tensor = experimental::unit_mesh::aggregate(output_tensors);
 
         // Quiesce parent mesh before all gather
         mesh_device_->quiesce_devices();

--- a/tests/ttnn/unit_tests/gtests/multiprocess/test_host_all_gather.cpp
+++ b/tests/ttnn/unit_tests/gtests/multiprocess/test_host_all_gather.cpp
@@ -58,7 +58,7 @@ TEST_F(BigMeshDualRankTest2x4, HostAllGather) {
 
     // Perform all-gather on host and validate the data at each host.
     auto all_gather_tensor = host_ccl::all_gather(sharded_tensor);
-    EXPECT_EQ(all_gather_tensor.storage_type(), tt::tt_metal::StorageType::HOST);
+    EXPECT_EQ(all_gather_tensor.storage_type(), StorageType::HOST);
     EXPECT_EQ(count_local_buffers(all_gather_tensor), kNumDevices);
 
     auto composer = concat_mesh_to_tensor_composer(*mesh_device_, /*dim=*/0);
@@ -67,7 +67,7 @@ TEST_F(BigMeshDualRankTest2x4, HostAllGather) {
 
     // Calling `all_gather` again should be a no-op.
     all_gather_tensor = host_ccl::all_gather(all_gather_tensor);
-    EXPECT_EQ(all_gather_tensor.storage_type(), tt::tt_metal::StorageType::HOST);
+    EXPECT_EQ(all_gather_tensor.storage_type(), StorageType::HOST);
     EXPECT_EQ(count_local_buffers(all_gather_tensor), kNumDevices);
 
     EXPECT_THAT(aggregate_tensor(all_gather_tensor, *composer).to_vector<float>(), Pointwise(FloatEq(), test_data));

--- a/tests/ttnn/unit_tests/gtests/multiprocess/test_host_all_gather.cpp
+++ b/tests/ttnn/unit_tests/gtests/multiprocess/test_host_all_gather.cpp
@@ -26,9 +26,9 @@ using ::tt::tt_fabric::MeshHostRankId;
 using ::tt::tt_metal::DataType;
 using ::tt::tt_metal::Layout;
 using ::tt::tt_metal::MemoryConfig;
-using ::tt::tt_metal::Tensor;
 using ::tt::tt_metal::TensorLayout;
 using ::tt::tt_metal::TensorSpec;
+using ::ttnn::Tensor;
 
 using BigMeshDualRankTest2x4 = tt::tt_metal::MeshDevice2x4Fixture;
 

--- a/tests/ttnn/unit_tests/gtests/multiprocess/test_send_recv_ops.cpp
+++ b/tests/ttnn/unit_tests/gtests/multiprocess/test_send_recv_ops.cpp
@@ -86,7 +86,7 @@ void test_send_recv_async_(
     auto layout = tensor_spec.layout();
     auto dtype = tensor_spec.data_type();
     if (*(distributed_context->rank()) == *sender_rank) {
-        const Tensor input_tensor =
+        const ttnn::Tensor input_tensor =
             ttnn::distributed::distribute_tensor(
                 ttnn::experimental::view(ttnn::arange(seed, seed + num_elems, 1, dtype), input_shape).to_layout(layout),
                 *ttnn::distributed::replicate_tensor_to_mesh_mapper(*mesh_device),

--- a/tests/ttnn/unit_tests/gtests/multiprocess/test_send_recv_pipeline.cpp
+++ b/tests/ttnn/unit_tests/gtests/multiprocess/test_send_recv_pipeline.cpp
@@ -206,7 +206,7 @@ TEST_F(MeshDevice4StagePipelineSendRecvFixture, TestSendRecvPipeline) {
     const bool is_pipeline_end = (*distributed_context->rank() == *pipeline_end_rank);
     const bool is_intermediate = !is_pipeline_start && !is_pipeline_end;
 
-    Tensor intermediate_tensor = tt::tt_metal::create_device_tensor(tensor_spec, mesh_device_.get());
+    ttnn::Tensor intermediate_tensor = tt::tt_metal::create_device_tensor(tensor_spec, mesh_device_.get());
 
     if (is_pipeline_start) {
         // Pipeline start: Copy data from start coord to exit node using an intermediate socket
@@ -294,7 +294,7 @@ TEST_F(MeshDevice4StagePipelineSendRecvFixture, TestSendRecvPipeline) {
             auto run_receiver_step = [&](uint32_t i) {
                 ttnn::experimental::recv_async(intermediate_tensor, recv_socket);
                 ttnn::experimental::send_async(intermediate_tensor, intermed_send);
-                Tensor output_tensor = tt::tt_metal::create_device_tensor(tensor_spec, mesh_device_.get());
+                ttnn::Tensor output_tensor = tt::tt_metal::create_device_tensor(tensor_spec, mesh_device_.get());
                 ttnn::experimental::recv_async(output_tensor, intermed_recv);
                 auto composer = ttnn::distributed::concat_mesh_to_tensor_composer(*mesh_device_, /*dim=*/0);
                 auto output_data = ttnn::distributed::aggregate_tensor(output_tensor, *composer).to_vector<uint32_t>();

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
@@ -59,7 +59,7 @@ void run_create_tensor_test(tt::tt_metal::distributed::MeshDevice* device, const
     ASSERT_EQ(input_buf_size_datums * datum_size_bytes, tensor_spec.compute_packed_buffer_size_bytes());
     auto input_buffer = tt::tt_metal::tensor_impl::allocate_device_buffer(device, tensor_spec);
 
-    Tensor input_tensor(tt::tt_metal::MeshTensor(input_buffer, tensor_spec, TensorTopology{}));
+    ttnn::Tensor input_tensor(tt::tt_metal::MeshTensor(input_buffer, tensor_spec, TensorTopology{}));
 
     ttnn::write_buffer(io_cq, input_tensor, {host_data});
 
@@ -260,7 +260,7 @@ TEST_F(TensorFromDeallocatedStorageTest, ConstructingTensorFromDeallocatedStorag
     TensorSpec tensor_spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg));
 
     // Step 1: Create initial tensor on device
-    Tensor tensor_a = create_device_tensor(tensor_spec, device_);
+    ttnn::Tensor tensor_a = create_device_tensor(tensor_spec, device_);
 
     ASSERT_NE(tensor_a.device(), nullptr) << "Tensor A should have valid device";
     ASSERT_TRUE(tensor_a.is_allocated()) << "Tensor A should be allocated";
@@ -268,7 +268,7 @@ TEST_F(TensorFromDeallocatedStorageTest, ConstructingTensorFromDeallocatedStorag
     // Step 2: Copy the DeviceStorage (simulating what view() does internally)
     // This creates a separate DeviceStorage with a copy of the shared_ptr<MeshBuffer>
     auto storage_copy = tensor_a.device_storage();  // Makes a copy, not a reference
-    Tensor tensor_b = Tensor(storage_copy);
+    ttnn::Tensor tensor_b = ttnn::Tensor(storage_copy);
 
     ASSERT_NE(tensor_b.device(), nullptr) << "Tensor B should have valid device";
     ASSERT_TRUE(tensor_b.is_allocated()) << "Tensor B should be allocated";
@@ -288,7 +288,7 @@ TEST_F(TensorFromDeallocatedStorageTest, ConstructingTensorFromDeallocatedStorag
     // Step 4: Create tensor C from B's storage (simulating another view() call)
     // This is where the bug manifests - if Tensor constructor uses is_allocated(),
     // mesh_device_ won't be set because is_allocated() returns false
-    Tensor tensor_c = Tensor(storage_b);
+    ttnn::Tensor tensor_c = ttnn::Tensor(storage_b);
 
     // THE KEY ASSERTION: tensor C must have valid device pointer
     // This is the workaround - without it, device() returns nullptr and causes segfaults

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_multi_device.cpp
@@ -27,8 +27,8 @@ using ::testing::SizeIs;
 using ::tt::tt_metal::BufferType;
 using ::tt::tt_metal::Layout;
 using ::tt::tt_metal::MemoryConfig;
-using ::tt::tt_metal::StorageType;
 using ::tt::tt_metal::TensorMemoryLayout;
+using ::ttnn::StorageType;
 
 using MultiDeviceTensorCreationTest = GenericMeshDeviceFixture;
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
@@ -22,9 +22,9 @@ using tt::tt_metal::DeviceStorage;
 using tt::tt_metal::Layout;
 using tt::tt_metal::MemoryConfig;
 using tt::tt_metal::MeshDevice1x2Fixture;
-using tt::tt_metal::Tensor;
 using tt::tt_metal::TensorLayout;
 using tt::tt_metal::TensorSpec;
+using ttnn::Tensor;
 
 using DeviceStorageOwnershipTest = MeshDevice1x2Fixture;
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
@@ -18,13 +18,11 @@ namespace {
 using ::testing::SizeIs;
 
 using tt::tt_metal::DataType;
-using tt::tt_metal::DeviceStorage;
 using tt::tt_metal::Layout;
 using tt::tt_metal::MemoryConfig;
 using tt::tt_metal::MeshDevice1x2Fixture;
 using tt::tt_metal::TensorLayout;
 using tt::tt_metal::TensorSpec;
-using ttnn::Tensor;
 
 using DeviceStorageOwnershipTest = MeshDevice1x2Fixture;
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
@@ -498,7 +498,7 @@ TEST_F(TensorDistribution2x4Test, BorrowedDistributedTensors) {
     auto check_borrow = []<typename T>(const Tensor& distributed, const T* src, size_t count) {
         auto shards = get_device_tensors(distributed);
         for (const auto& shard : shards) {
-            auto buf = tt::tt_metal::host_buffer::get_host_buffer(shard);
+            auto buf = host_buffer::get_host_buffer(shard);
             auto span = buf.view_as<T>();
             if (span.data() < src || span.data() + span.size() > src + count) {
                 return false;

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -376,7 +376,7 @@ TEST_F(MeshTensorTest2x4, CombineDeviceTensorsWithDifferentShardDims) {
 }
 
 TEST_F(MeshTensorTest, DefaultConstructedDeviceStorageGetters) {
-    tt::tt_metal::DeviceStorage storage;
+    DeviceStorage storage;
 
     EXPECT_THAT(([&]() { storage.get_buffer(); }), ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
     EXPECT_THAT(([&]() { storage.get_mesh_buffer(); }), ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));

--- a/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
@@ -31,10 +31,10 @@ namespace ttnn {
 namespace {
 
 using ::testing::SizeIs;
-using ::tt::tt_metal::experimental::xtensor::chunk;
-using ::tt::tt_metal::experimental::xtensor::chunk_ndim;
-using ::tt::tt_metal::experimental::xtensor::concat;
-using ::tt::tt_metal::experimental::xtensor::concat_ndim;
+using ::ttnn::experimental::xtensor::chunk;
+using ::ttnn::experimental::xtensor::chunk_ndim;
+using ::ttnn::experimental::xtensor::concat;
+using ::ttnn::experimental::xtensor::concat_ndim;
 
 TEST(PartitionTest, ChunkBasicNonDivisible3) {
     // Create a 1D tensor: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -261,8 +261,7 @@ TEST(PartitionTest, ChunkDoesNotAccessData) {
         for (const auto& chunked_xexpr : chunks) {
             EXPECT_THAT(chunked_xexpr, SizeIs(kDim0Size * page_size));
             EXPECT_EQ(
-                tt::tt_metal::experimental::xtensor::get_shape_from_xarray(chunked_xexpr),
-                ttnn::Shape({kDim0Size, 1, page_size}));
+                experimental::xtensor::get_shape_from_xarray(chunked_xexpr), ttnn::Shape({kDim0Size, 1, page_size}));
         }
     } else {
         FAIL() << "segfault occurred when calling `chunk`";

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
@@ -130,7 +130,7 @@ TEST_P(NDShardingTests, RegionWriteReadTest) {
         data[i] = static_cast<uint16_t>(i);
     }
     auto data_tensor = ttnn::Tensor::from_vector(data, tensor_spec);
-    auto tensor_data_span = host_buffer::get_as<uint16_t>(data_tensor);
+    auto tensor_data_span = ttnn::host_buffer::get_as<uint16_t>(data_tensor);
     auto tensor_data = std::vector<uint16_t>(tensor_data_span.begin(), tensor_data_span.end());
 
     std::vector<uint16_t> empty_data(volume);

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
@@ -111,7 +111,7 @@ TEST_P(NDShardingTests, LoopbackTest) {
         data[i] = static_cast<uint16_t>(i);
     }
 
-    auto tensor = Tensor::from_vector(data, tensor_spec, device_);
+    auto tensor = ttnn::Tensor::from_vector(data, tensor_spec, device_);
     EXPECT_TRUE(tensor.buffer()->buffer_distribution_spec().has_value());
     auto readback_data = tensor.to_vector<uint16_t>();
 
@@ -129,12 +129,12 @@ TEST_P(NDShardingTests, RegionWriteReadTest) {
     for (size_t i = 0; i < data.size(); i++) {
         data[i] = static_cast<uint16_t>(i);
     }
-    auto data_tensor = Tensor::from_vector(data, tensor_spec);
+    auto data_tensor = ttnn::Tensor::from_vector(data, tensor_spec);
     auto tensor_data_span = host_buffer::get_as<uint16_t>(data_tensor);
     auto tensor_data = std::vector<uint16_t>(tensor_data_span.begin(), tensor_data_span.end());
 
     std::vector<uint16_t> empty_data(volume);
-    auto tensor = Tensor::from_vector(empty_data, tensor_spec, device_);
+    auto tensor = ttnn::Tensor::from_vector(empty_data, tensor_spec, device_);
 
     const auto& buffer = tensor.mesh_buffer();
 
@@ -229,7 +229,7 @@ TEST_F(BufferDistributionSpecCreationTests, LegacyAndNdShardSpecCreateBufferDist
         TensorLayout tensor_layout(DataType::UINT16, PageConfig(Layout::TILE), memory_config);
         TensorSpec tensor_spec(shape, tensor_layout);
 
-        auto tensor = Tensor::from_vector(data, tensor_spec, device_);
+        auto tensor = ttnn::Tensor::from_vector(data, tensor_spec, device_);
         EXPECT_TRUE(tensor.buffer()->buffer_distribution_spec().has_value());
     }
 
@@ -238,7 +238,7 @@ TEST_F(BufferDistributionSpecCreationTests, LegacyAndNdShardSpecCreateBufferDist
         TensorLayout tensor_layout(DataType::UINT16, PageConfig(Layout::TILE), memory_config);
         TensorSpec tensor_spec(shape, tensor_layout);
 
-        auto tensor = Tensor::from_vector(data, tensor_spec, device_);
+        auto tensor = ttnn::Tensor::from_vector(data, tensor_spec, device_);
         EXPECT_TRUE(tensor.buffer()->buffer_distribution_spec().has_value());
     }
 }
@@ -261,11 +261,11 @@ TEST_P(NdShardingOpCompatTests, TestAdd) {
     for (size_t i = 0; i < volume; i++) {
         data[i] = static_cast<float>(i);
     }
-    auto tensor_a = Tensor::from_vector(data, tensor_spec, device_);
+    auto tensor_a = ttnn::Tensor::from_vector(data, tensor_spec, device_);
     for (auto& elem : data) {
         elem *= 2;
     }
-    auto tensor_b = Tensor::from_vector(data, tensor_spec, device_);
+    auto tensor_b = ttnn::Tensor::from_vector(data, tensor_spec, device_);
 
     auto sum_tensor = ttnn::add(tensor_a, tensor_b);
 
@@ -292,7 +292,7 @@ TEST_F(NDShardingPerfTests, TestBatchShardingPerf) {
     }
 
     auto measure_to_device_time_ns = [&](const TensorSpec& tensor_spec) -> double {
-        auto tensor = Tensor::from_vector(data, tensor_spec);
+        auto tensor = ttnn::Tensor::from_vector(data, tensor_spec);
 
         auto start = std::chrono::high_resolution_clock::now();
         auto device_tensor = tensor.to_device(device_, tensor_spec.memory_config());
@@ -344,7 +344,7 @@ TEST_P(NDShardingBufferSizeTests, TestBufferSize) {
 
     size_t volume = params.shape.volume();
     std::vector<uint8_t> data(volume);
-    auto tensor = Tensor::from_vector(data, tensor_spec, device_);
+    auto tensor = ttnn::Tensor::from_vector(data, tensor_spec, device_);
 
     auto* buffer = tensor.buffer();
     EXPECT_EQ(buffer->size(), params.expected_buffer_size);

--- a/tests/ttnn/unit_tests/gtests/tensor/test_unchecked_reinterpret_layout.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_unchecked_reinterpret_layout.cpp
@@ -29,10 +29,10 @@ TEST_F(UncheckedReinterpretLayoutDeviceTest, TileToRowMajorPreservesShapeAndDtyp
     ttnn::Shape shape({1, 1, 32, 32});
     TensorSpec spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg));
 
-    Tensor tile_tensor = create_device_tensor(spec, device_);
+    ttnn::Tensor tile_tensor = create_device_tensor(spec, device_);
     ASSERT_EQ(tile_tensor.layout(), Layout::TILE);
 
-    Tensor rm_tensor = unchecked_reinterpret_layout(tile_tensor, Layout::ROW_MAJOR);
+    ttnn::Tensor rm_tensor = unchecked_reinterpret_layout(tile_tensor, Layout::ROW_MAJOR);
 
     EXPECT_EQ(rm_tensor.layout(), Layout::ROW_MAJOR);
     EXPECT_EQ(rm_tensor.logical_shape(), tile_tensor.logical_shape());
@@ -45,10 +45,10 @@ TEST_F(UncheckedReinterpretLayoutDeviceTest, RowMajorToTilePreservesShapeAndDtyp
     ttnn::Shape shape({1, 1, 32, 32});
     TensorSpec spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), mem_cfg));
 
-    Tensor rm_tensor = create_device_tensor(spec, device_);
+    ttnn::Tensor rm_tensor = create_device_tensor(spec, device_);
     ASSERT_EQ(rm_tensor.layout(), Layout::ROW_MAJOR);
 
-    Tensor tile_tensor = unchecked_reinterpret_layout(rm_tensor, Layout::TILE);
+    ttnn::Tensor tile_tensor = unchecked_reinterpret_layout(rm_tensor, Layout::TILE);
 
     EXPECT_EQ(tile_tensor.layout(), Layout::TILE);
     EXPECT_EQ(tile_tensor.logical_shape(), rm_tensor.logical_shape());
@@ -62,10 +62,10 @@ TEST_F(UncheckedReinterpretLayoutDeviceTest, PreservesNonDefaultTile) {
     ttnn::Shape shape({1, 1, 16, 32});
     TensorSpec spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, custom_tile), mem_cfg));
 
-    Tensor original = create_device_tensor(spec, device_);
+    ttnn::Tensor original = create_device_tensor(spec, device_);
     ASSERT_EQ(original.tensor_spec().tile(), custom_tile);
 
-    Tensor reinterpreted = unchecked_reinterpret_layout(original, Layout::ROW_MAJOR);
+    ttnn::Tensor reinterpreted = unchecked_reinterpret_layout(original, Layout::ROW_MAJOR);
 
     EXPECT_EQ(reinterpreted.layout(), Layout::ROW_MAJOR);
     EXPECT_EQ(reinterpreted.tensor_spec().tile(), custom_tile);
@@ -76,8 +76,8 @@ TEST_F(UncheckedReinterpretLayoutDeviceTest, AliasesTheSameDeviceAddress) {
     ttnn::Shape shape({1, 1, 32, 32});
     TensorSpec spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg));
 
-    Tensor original = create_device_tensor(spec, device_);
-    Tensor reinterpreted = unchecked_reinterpret_layout(original, Layout::ROW_MAJOR);
+    ttnn::Tensor original = create_device_tensor(spec, device_);
+    ttnn::Tensor reinterpreted = unchecked_reinterpret_layout(original, Layout::ROW_MAJOR);
 
     EXPECT_EQ(
         original.device_storage().get_mesh_buffer().address(),
@@ -89,8 +89,8 @@ TEST_F(UncheckedReinterpretLayoutDeviceTest, SameLayoutIsIdentity) {
     ttnn::Shape shape({1, 1, 32, 32});
     TensorSpec spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg));
 
-    Tensor original = create_device_tensor(spec, device_);
-    Tensor reinterpreted = unchecked_reinterpret_layout(original, Layout::TILE);
+    ttnn::Tensor original = create_device_tensor(spec, device_);
+    ttnn::Tensor reinterpreted = unchecked_reinterpret_layout(original, Layout::TILE);
 
     EXPECT_EQ(reinterpreted.layout(), Layout::TILE);
     EXPECT_EQ(reinterpreted.tensor_spec(), original.tensor_spec());
@@ -104,9 +104,9 @@ TEST_F(UncheckedReinterpretLayoutDeviceTest, OriginalTensorStaysAliveAfterReinte
     ttnn::Shape shape({1, 1, 32, 32});
     TensorSpec spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg));
 
-    Tensor original = create_device_tensor(spec, device_);
+    ttnn::Tensor original = create_device_tensor(spec, device_);
     {
-        Tensor reinterpreted = unchecked_reinterpret_layout(original, Layout::ROW_MAJOR);
+        ttnn::Tensor reinterpreted = unchecked_reinterpret_layout(original, Layout::ROW_MAJOR);
         ASSERT_TRUE(reinterpreted.is_allocated());
     }
     EXPECT_TRUE(original.is_allocated());
@@ -124,10 +124,10 @@ TEST_F(UncheckedReinterpretLayoutHostTest, TileToRowMajorOnHost) {
 
     auto num_elements = shape.volume();
     std::vector<bfloat16> data(num_elements, bfloat16(1.0f));
-    Tensor host_tensor(HostBuffer(data), spec);
+    ttnn::Tensor host_tensor(HostBuffer(data), spec);
     ASSERT_EQ(host_tensor.layout(), Layout::TILE);
 
-    Tensor reinterpreted = unchecked_reinterpret_layout(host_tensor, Layout::ROW_MAJOR);
+    ttnn::Tensor reinterpreted = unchecked_reinterpret_layout(host_tensor, Layout::ROW_MAJOR);
 
     EXPECT_EQ(reinterpreted.layout(), Layout::ROW_MAJOR);
     EXPECT_EQ(reinterpreted.logical_shape(), host_tensor.logical_shape());
@@ -142,10 +142,10 @@ TEST_F(UncheckedReinterpretLayoutHostTest, PreservesNonDefaultTileOnHost) {
 
     auto num_elements = shape.volume();
     std::vector<bfloat16> data(num_elements, bfloat16(1.0f));
-    Tensor host_tensor(HostBuffer(data), spec);
+    ttnn::Tensor host_tensor(HostBuffer(data), spec);
     ASSERT_EQ(host_tensor.tensor_spec().tile(), custom_tile);
 
-    Tensor reinterpreted = unchecked_reinterpret_layout(host_tensor, Layout::ROW_MAJOR);
+    ttnn::Tensor reinterpreted = unchecked_reinterpret_layout(host_tensor, Layout::ROW_MAJOR);
 
     EXPECT_EQ(reinterpreted.layout(), Layout::ROW_MAJOR);
     EXPECT_EQ(reinterpreted.tensor_spec().tile(), custom_tile);
@@ -157,10 +157,10 @@ TEST_F(UncheckedReinterpretLayoutHostTest, RowMajorToTileOnHost) {
 
     auto num_elements = shape.volume();
     std::vector<bfloat16> data(num_elements, bfloat16(2.0f));
-    Tensor host_tensor(HostBuffer(data), spec);
+    ttnn::Tensor host_tensor(HostBuffer(data), spec);
     ASSERT_EQ(host_tensor.layout(), Layout::ROW_MAJOR);
 
-    Tensor reinterpreted = unchecked_reinterpret_layout(host_tensor, Layout::TILE);
+    ttnn::Tensor reinterpreted = unchecked_reinterpret_layout(host_tensor, Layout::TILE);
 
     EXPECT_EQ(reinterpreted.layout(), Layout::TILE);
     EXPECT_EQ(reinterpreted.logical_shape(), host_tensor.logical_shape());

--- a/tests/ttnn/unit_tests/gtests/tensor/test_unit_mesh_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_unit_mesh_utils.cpp
@@ -18,7 +18,7 @@
 #include "ttnn/tensor/unit_mesh/unit_mesh_utils.hpp"
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 
-namespace tt::tt_metal::experimental::unit_mesh {
+namespace ttnn::experimental::unit_mesh {
 namespace {
 
 using ::testing::HasSubstr;
@@ -232,4 +232,4 @@ TEST_F(UnitMeshUtils2x4Test, DisaggregateWithoutSubmeshes) {
 }
 
 }  // namespace
-}  // namespace tt::tt_metal::experimental::unit_mesh
+}  // namespace ttnn::experimental::unit_mesh

--- a/tests/ttnn/unit_tests/gtests/tensor/test_unit_mesh_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_unit_mesh_utils.cpp
@@ -53,7 +53,7 @@ TEST_F(UnitMeshUtils2x4Test, AggregateAndDisaggregate) {
     auto layout = tt::tt_metal::Layout::TILE;
 
     // Create tensors on each unit mesh at the same address, assuming deterministic lock-step allocation.
-    std::vector<Tensor> unit_tensors;
+    std::vector<ttnn::Tensor> unit_tensors;
     unit_tensors.reserve(unit_meshes.size());
 
     for (const auto& unit_mesh : unit_meshes) {
@@ -97,7 +97,7 @@ TEST_F(UnitMeshUtils2x4Test, AggregateAndDisaggregate) {
 }
 
 TEST_F(UnitMeshUtils2x4Test, AggregateEmptyVector) {
-    std::vector<Tensor> empty_tensors;
+    std::vector<ttnn::Tensor> empty_tensors;
     EXPECT_THAT(
         ([&]() { aggregate(empty_tensors); }),
         ThrowsMessage<std::runtime_error>(HasSubstr("Cannot aggregate empty tensor vector")));
@@ -109,7 +109,7 @@ TEST_F(UnitMeshUtils2x4Test, AggregateNonUnitMeshes) {
     auto dtype = tt::tt_metal::DataType::BFLOAT16;
     auto layout = tt::tt_metal::Layout::TILE;
 
-    std::vector<Tensor> tensors;
+    std::vector<ttnn::Tensor> tensors;
     tensors.reserve(non_unit_meshes.size());
     for (const auto& non_unit_mesh : non_unit_meshes) {
         tensors.push_back(create_device_tensor(
@@ -129,7 +129,7 @@ TEST_F(UnitMeshUtils2x4Test, AggregateMismatchedTensorSpecs) {
     auto shape1 = ttnn::Shape(std::array<uint32_t, 2>{32, 32});
     auto shape2 = ttnn::Shape(std::array<uint32_t, 2>{64, 64});
 
-    std::vector<Tensor> tensors;
+    std::vector<ttnn::Tensor> tensors;
     tensors.reserve(unit_meshes.size());
     for (int i = 0; i < unit_meshes.size(); i++) {
         if (i % 2 == 0) {
@@ -173,7 +173,7 @@ TEST_F(UnitMeshUtils2x4Test, AggregateMismatchedAddresses) {
                 tt::tt_metal::MemoryConfig())),
         unit_meshes[0].get());
 
-    std::vector<Tensor> tensors;
+    std::vector<ttnn::Tensor> tensors;
     tensors.reserve(unit_meshes.size());
     for (const auto& unit_mesh : unit_meshes) {
         tensors.push_back(create_device_tensor(
@@ -206,7 +206,7 @@ TEST_F(UnitMeshUtils2x4Test, AggregateWrongNumberOfTensors) {
                 tt::tt_metal::MemoryConfig())),
         unit_meshes[0].get());
 
-    std::vector<Tensor> tensors = {tensor};
+    std::vector<ttnn::Tensor> tensors = {tensor};
     EXPECT_THAT(
         ([&]() { aggregate(tensors); }),
         ThrowsMessage<std::runtime_error>(HasSubstr("Input tensors must span the entire parent mesh")));

--- a/tests/ttnn/unit_tests/gtests/tensor/test_xtensor_adapter.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_xtensor_adapter.cpp
@@ -17,7 +17,7 @@ namespace ttnn {
 namespace {
 
 using ::testing::ElementsAre;
-using ::tt::tt_metal::experimental::xtensor::XtensorAdapter;
+using ::ttnn::experimental::xtensor::XtensorAdapter;
 
 TEST(XtensorAdapterTest, BasicConstruction) {
     std::vector<float> data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};

--- a/tests/ttnn/unit_tests/gtests/tensor/test_xtensor_conversion.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_xtensor_conversion.cpp
@@ -32,11 +32,11 @@ namespace {
 
 using ::testing::ElementsAre;
 using ::testing::Eq;
-using ::tt::tt_metal::experimental::xtensor::from_xtensor;
-using ::tt::tt_metal::experimental::xtensor::get_shape_from_xarray;
-using ::tt::tt_metal::experimental::xtensor::span_to_xtensor_view;
-using ::tt::tt_metal::experimental::xtensor::to_xtensor;
-using ::tt::tt_metal::experimental::xtensor::xtensor_to_span;
+using ::ttnn::experimental::xtensor::from_xtensor;
+using ::ttnn::experimental::xtensor::get_shape_from_xarray;
+using ::ttnn::experimental::xtensor::span_to_xtensor_view;
+using ::ttnn::experimental::xtensor::to_xtensor;
+using ::ttnn::experimental::xtensor::xtensor_to_span;
 
 TensorSpec get_tensor_spec(const ttnn::Shape& shape) {
     return TensorSpec(

--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -65,7 +65,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncPreallocatedOutputs) {
     ttnn::Tensor np_out = ttnn::moreh_sum(np_tensor, reduce_dims, false, std::nullopt, std::nullopt, std::nullopt);
     ttnn::Tensor np_out_host = np_out.cpu();
     const ttnn::Tensor reference_tensor = ttnn::distributed::get_device_tensors(np_out_host).front();
-    auto golden_output = host_buffer::get_as<bfloat16>(reference_tensor);
+    auto golden_output = ttnn::host_buffer::get_as<bfloat16>(reference_tensor);
     // Events for host - device synchronization
     // Running sum-reduce with preallocated output
     // Preallocate Input and Output Tensors on Device

--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -60,11 +60,11 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncPreallocatedOutputs) {
         host_data[i] = bfloat16(static_cast<float>(1));
     }
     // Create golden data using tt_eager APIs
-    Tensor np_tensor = ttnn::full(input_shape, static_cast<float>(1), DataType::BFLOAT16, Layout::TILE, *device_);
+    ttnn::Tensor np_tensor = ttnn::full(input_shape, static_cast<float>(1), DataType::BFLOAT16, Layout::TILE, *device_);
     ttnn::SmallVector<int64_t> reduce_dims = {3};
-    Tensor np_out = ttnn::moreh_sum(np_tensor, reduce_dims, false, std::nullopt, std::nullopt, std::nullopt);
-    Tensor np_out_host = np_out.cpu();
-    const Tensor reference_tensor = ttnn::distributed::get_device_tensors(np_out_host).front();
+    ttnn::Tensor np_out = ttnn::moreh_sum(np_tensor, reduce_dims, false, std::nullopt, std::nullopt, std::nullopt);
+    ttnn::Tensor np_out_host = np_out.cpu();
+    const ttnn::Tensor reference_tensor = ttnn::distributed::get_device_tensors(np_out_host).front();
     auto golden_output = host_buffer::get_as<bfloat16>(reference_tensor);
     // Events for host - device synchronization
     // Running sum-reduce with preallocated output
@@ -130,7 +130,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeAllocatedBuffers) {
             ttnn::wait_for_event(device_->mesh_command_queue(*workload_dispatch_cq), write_event);
 
             // Run operation on cq 0
-            Tensor output_tensor;
+            ttnn::Tensor output_tensor;
             ttnn::with_command_queue_id(workload_dispatch_cq, [&]() { output_tensor = ttnn::sqrt(input_tensor); });
 
             auto dummy_buffer_0 =

--- a/tests/ttnn/unit_tests/gtests/test_gelu_bw_main_ulp.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_gelu_bw_main_ulp.cpp
@@ -417,8 +417,8 @@ TEST_F(GeluBwMainUlpTest, ComprehensiveULPByRegion) {
         tt::tt_metal::TensorLayout(
             DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), tt::tt_metal::MemoryConfig{}));
 
-    auto input_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
-    auto grad_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
+    auto input_tensor = Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
+    auto grad_tensor = Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
 
     // Run GELU backward once on entire tensor
     auto results = ttnn::gelu_bw(grad_tensor, input_tensor, "none");
@@ -577,8 +577,8 @@ TEST_F(GeluBwMainUlpTest, CumulativeULPDistribution) {
         tt::tt_metal::TensorLayout(
             DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), tt::tt_metal::MemoryConfig{}));
 
-    auto input_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
-    auto grad_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
+    auto input_tensor = Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
+    auto grad_tensor = Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
 
     auto results = ttnn::gelu_bw(grad_tensor, input_tensor, "none");
     auto result = results[0].value();
@@ -951,8 +951,8 @@ TEST_F(GeluBwMainPolyTest, ComprehensiveULPAnalysis) {
         tt::tt_metal::TensorLayout(
             DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), tt::tt_metal::MemoryConfig{}));
 
-    auto input_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
-    auto grad_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
+    auto input_tensor = Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
+    auto grad_tensor = Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
 
     // Run GELU backward with polynomial approximation
     auto results = ttnn::gelu_bw(grad_tensor, input_tensor, "none");
@@ -1130,8 +1130,8 @@ TEST_F(GeluBwMainPolyTest, DetailedSegmentAnalysis) {
         tt::tt_metal::TensorLayout(
             DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), tt::tt_metal::MemoryConfig{}));
 
-    auto input_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
-    auto grad_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
+    auto input_tensor = Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
+    auto grad_tensor = Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
 
     auto results = ttnn::gelu_bw(grad_tensor, input_tensor, "none");
     auto result = results[0].value();
@@ -1317,8 +1317,8 @@ TEST_F(GeluBwMainPolyTest, ExpBasedRegionFullDump) {
         tt::tt_metal::TensorLayout(
             DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), tt::tt_metal::MemoryConfig{}));
 
-    auto input_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
-    auto grad_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
+    auto input_tensor = Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
+    auto grad_tensor = Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
 
     auto results = ttnn::gelu_bw(grad_tensor, input_tensor, "none");
     auto result = results[0].value();
@@ -1439,8 +1439,8 @@ TEST_F(GeluBwMainPolyTest, DeepNegativeRegionAnalysis) {
         tt::tt_metal::TensorLayout(
             DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), tt::tt_metal::MemoryConfig{}));
 
-    auto input_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
-    auto grad_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
+    auto input_tensor = Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
+    auto grad_tensor = Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
 
     auto results = ttnn::gelu_bw(grad_tensor, input_tensor, "none");
     auto result = results[0].value();
@@ -1703,8 +1703,8 @@ TEST_F(GeluBwMainPolyTest, SaturationThresholdResearch) {
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
                 tt::tt_metal::MemoryConfig{}));
 
-        auto in_t = tt::tt_metal::Tensor::from_vector(std::move(inputs), spec).to_device(device_);
-        auto gr_t = tt::tt_metal::Tensor::from_vector(std::move(grads), spec).to_device(device_);
+        auto in_t = Tensor::from_vector(std::move(inputs), spec).to_device(device_);
+        auto gr_t = Tensor::from_vector(std::move(grads), spec).to_device(device_);
 
         auto res_vec = ttnn::gelu_bw(gr_t, in_t, "none");
         auto res = res_vec[0].value();

--- a/tests/ttnn/unit_tests/gtests/test_gelu_bw_ulp.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_gelu_bw_ulp.cpp
@@ -417,8 +417,8 @@ TEST_F(GeluBwUlpTest, ComprehensiveULPByRegion) {
         tt::tt_metal::TensorLayout(
             DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), tt::tt_metal::MemoryConfig{}));
 
-    auto input_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
-    auto grad_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
+    auto input_tensor = Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
+    auto grad_tensor = Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
 
     // Run GELU backward once on entire tensor
     auto result = ttnn::experimental::gelu_bw(grad_tensor, input_tensor, "none");
@@ -576,8 +576,8 @@ TEST_F(GeluBwUlpTest, CumulativeULPDistribution) {
         tt::tt_metal::TensorLayout(
             DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), tt::tt_metal::MemoryConfig{}));
 
-    auto input_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
-    auto grad_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
+    auto input_tensor = Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
+    auto grad_tensor = Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
 
     auto result = ttnn::experimental::gelu_bw(grad_tensor, input_tensor, "none");
     auto output_cpu = ttnn::from_device(result);
@@ -949,8 +949,8 @@ TEST_F(GeluBwPolyTest, ComprehensiveULPAnalysis) {
         tt::tt_metal::TensorLayout(
             DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), tt::tt_metal::MemoryConfig{}));
 
-    auto input_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
-    auto grad_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
+    auto input_tensor = Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
+    auto grad_tensor = Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
 
     // Run experimental GELU backward with polynomial approximation
     auto result = ttnn::experimental::gelu_bw(grad_tensor, input_tensor, "none");
@@ -1127,8 +1127,8 @@ TEST_F(GeluBwPolyTest, DetailedSegmentAnalysis) {
         tt::tt_metal::TensorLayout(
             DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), tt::tt_metal::MemoryConfig{}));
 
-    auto input_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
-    auto grad_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
+    auto input_tensor = Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
+    auto grad_tensor = Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
 
     auto result = ttnn::experimental::gelu_bw(grad_tensor, input_tensor, "none");
     auto output_cpu = ttnn::from_device(result);
@@ -1313,8 +1313,8 @@ TEST_F(GeluBwPolyTest, ExpBasedRegionFullDump) {
         tt::tt_metal::TensorLayout(
             DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), tt::tt_metal::MemoryConfig{}));
 
-    auto input_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
-    auto grad_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
+    auto input_tensor = Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
+    auto grad_tensor = Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
 
     auto result = ttnn::experimental::gelu_bw(grad_tensor, input_tensor, "none");
     auto output_cpu = ttnn::from_device(result);
@@ -1434,8 +1434,8 @@ TEST_F(GeluBwPolyTest, DeepNegativeRegionAnalysis) {
         tt::tt_metal::TensorLayout(
             DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), tt::tt_metal::MemoryConfig{}));
 
-    auto input_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
-    auto grad_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
+    auto input_tensor = Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
+    auto grad_tensor = Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device_);
 
     auto result = ttnn::experimental::gelu_bw(grad_tensor, input_tensor, "none");
     auto output_cpu = ttnn::from_device(result);
@@ -1697,8 +1697,8 @@ TEST_F(GeluBwPolyTest, SaturationThresholdResearch) {
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
                 tt::tt_metal::MemoryConfig{}));
 
-        auto in_t = tt::tt_metal::Tensor::from_vector(std::move(inputs), spec).to_device(device_);
-        auto gr_t = tt::tt_metal::Tensor::from_vector(std::move(grads), spec).to_device(device_);
+        auto in_t = Tensor::from_vector(std::move(inputs), spec).to_device(device_);
+        auto gr_t = Tensor::from_vector(std::move(grads), spec).to_device(device_);
 
         auto res = ttnn::experimental::gelu_bw(gr_t, in_t, "none");
         auto out = ttnn::from_device(res).to_vector<::bfloat16>();

--- a/tests/ttnn/unit_tests/gtests/test_gelu_fw_ulp.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_gelu_fw_ulp.cpp
@@ -346,7 +346,7 @@ TEST_F(GeluFwUlpTest, ComprehensiveULPByRegion) {
         tt::tt_metal::TensorLayout(
             DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), tt::tt_metal::MemoryConfig{}));
 
-    auto input_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
+    auto input_tensor = Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
 
     // Run forward GELU once on entire tensor
     auto result = ttnn::gelu(input_tensor, false);
@@ -491,7 +491,7 @@ TEST_F(GeluFwUlpTest, CumulativeULPDistribution) {
         tt::tt_metal::TensorLayout(
             DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), tt::tt_metal::MemoryConfig{}));
 
-    auto input_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
+    auto input_tensor = Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
 
     auto result = ttnn::gelu(input_tensor, false);
     auto output_cpu = ttnn::from_device(result);
@@ -709,7 +709,7 @@ TEST_F(GeluFwUlpTest, SaturationBoundaryVerification) {
         tt::tt_metal::TensorLayout(
             DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), tt::tt_metal::MemoryConfig{}));
 
-    auto input_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
+    auto input_tensor = Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
     auto result_tensor = ttnn::gelu(input_tensor, false);
     auto output_cpu = ttnn::from_device(result_tensor);
     auto output_vec = output_cpu.to_vector<::bfloat16>();
@@ -815,7 +815,7 @@ TEST_F(GeluFwUlpTest, LocateULP2Values) {
         tt::tt_metal::TensorLayout(
             DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), tt::tt_metal::MemoryConfig{}));
 
-    auto input_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
+    auto input_tensor = Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device_);
     auto result = ttnn::gelu(input_tensor, false);
     auto output_cpu = ttnn::from_device(result);
     auto output_vec = output_cpu.to_vector<::bfloat16>();

--- a/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
@@ -1187,8 +1187,8 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
             Tensor::from_vector(std::move(out_data), output_tensor_spec).to_device(submeshes.back().get()));
     }
 
-    auto input_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(input_tensors);
-    auto output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
+    auto input_tensor = ttnn::experimental::unit_mesh::aggregate(input_tensors);
+    auto output_tensor = ttnn::experimental::unit_mesh::aggregate(output_tensors);
 
     mesh_device_->quiesce_devices();
 
@@ -1492,7 +1492,7 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
     ttnn::generic_op(std::vector<Tensor>{input_tensor, output_tensor}, mesh_program_descriptor);
     mesh_device_->quiesce_devices();
 
-    auto disaggregated_output = tt::tt_metal::experimental::unit_mesh::disaggregate(output_tensor);
+    auto disaggregated_output = ttnn::experimental::unit_mesh::disaggregate(output_tensor);
     for (uint32_t dev_idx = 0; dev_idx < ring_size; dev_idx++) {
         auto data = disaggregated_output[dev_idx].to_vector<bfloat16>();
         for (size_t i = 0; i < data.size(); i++) {

--- a/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
@@ -108,8 +108,8 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Values(
             // AddOpGraphTestParam instances for different test cases
             AddOpGraphTestParam{
-                .a_Shape = ttnn::Shape(tt::tt_metal::Array4D{1, 3, 32, 32}),
-                .b_Shape = ttnn::Shape(tt::tt_metal::Array4D{1, 3, 32, 32}),
+                .a_Shape = ttnn::Shape(Array4D{1, 3, 32, 32}),
+                .b_Shape = ttnn::Shape(Array4D{1, 3, 32, 32}),
                 .memory_config = ttnn::L1_MEMORY_CONFIG,
                 .expected_calltrace =
                     {"BinaryNgDeviceOperation", "tt::tt_metal::create_device_tensor", "Tensor::deallocate"},
@@ -119,12 +119,10 @@ INSTANTIATE_TEST_SUITE_P(
                 .expected_l1_output_per_core = 2048,
                 .expected_l1_peak_per_core = 2048,
                 .expected_output_info = {graph::TensorInfo{
-                    .shape = ttnn::Shape(tt::tt_metal::Array4D{1, 3, 32, 32}),
-                    .size = 6144,
-                    .type = tt::tt_metal::BufferType::L1}}},
+                    .shape = ttnn::Shape(Array4D{1, 3, 32, 32}), .size = 6144, .type = tt::tt_metal::BufferType::L1}}},
             AddOpGraphTestParam{
-                .a_Shape = ttnn::Shape(tt::tt_metal::Array4D{4, 3, 32, 32}),
-                .b_Shape = ttnn::Shape(tt::tt_metal::Array4D{1, 3, 32, 32}),
+                .a_Shape = ttnn::Shape(Array4D{4, 3, 32, 32}),
+                .b_Shape = ttnn::Shape(Array4D{1, 3, 32, 32}),
                 .memory_config = ttnn::L1_MEMORY_CONFIG,
                 .expected_calltrace =
                     {"BinaryNgDeviceOperation", "tt::tt_metal::create_device_tensor", "Tensor::deallocate"},
@@ -134,13 +132,11 @@ INSTANTIATE_TEST_SUITE_P(
                 .expected_l1_output_per_core = 2048,
                 .expected_l1_peak_per_core = 2048,
                 .expected_output_info = {graph::TensorInfo{
-                    .shape = ttnn::Shape(tt::tt_metal::Array4D{4, 3, 32, 32}),
-                    .size = 24576,
-                    .type = tt::tt_metal::BufferType::L1}},
+                    .shape = ttnn::Shape(Array4D{4, 3, 32, 32}), .size = 24576, .type = tt::tt_metal::BufferType::L1}},
             },
             AddOpGraphTestParam{
-                .a_Shape = ttnn::Shape(tt::tt_metal::Array4D{3, 1, 32 * 32, 32 * 32}),
-                .b_Shape = ttnn::Shape(tt::tt_metal::Array4D{3, 1, 32 * 32, 32 * 32}),
+                .a_Shape = ttnn::Shape(Array4D{3, 1, 32 * 32, 32 * 32}),
+                .b_Shape = ttnn::Shape(Array4D{3, 1, 32 * 32, 32 * 32}),
                 .memory_config =
                     tt::tt_metal::MemoryConfig{
                         tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
@@ -157,7 +153,7 @@ INSTANTIATE_TEST_SUITE_P(
                 .expected_l1_output_per_core = 2 * (3 * 32 * 32 * 32 * 32) / 16,
                 .expected_l1_peak_per_core = 2 * (3 * 32 * 32 * 32 * 32) / 16,
                 .expected_output_info = {graph::TensorInfo{
-                    .shape = ttnn::Shape(tt::tt_metal::Array4D{3, 1, 32 * 32, 32 * 32}),
+                    .shape = ttnn::Shape(Array4D{3, 1, 32 * 32, 32 * 32}),
                     .size = 2 * (3 * 32 * 32 * 32 * 32),
                     .type = tt::tt_metal::BufferType::L1}}}),
         ::testing::Values(

--- a/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
@@ -133,8 +133,7 @@ INSTANTIATE_TEST_SUITE_P(
     BufferTestFixture,
     ::testing::Combine(
         ::testing::Values(BufferTestParam{
-            .shape_a = ttnn::Shape(tt::tt_metal::Array4D{1, 1, 32, 32}),
-            .shape_b = ttnn::Shape(tt::tt_metal::Array4D{32, 1, 32, 32})}),
+            .shape_a = ttnn::Shape(Array4D{1, 1, 32, 32}), .shape_b = ttnn::Shape(Array4D{32, 1, 32, 32})}),
         ::testing::Values(
             tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH, tt::tt_metal::IGraphProcessor::RunMode::NORMAL)),
     [](const testing::TestParamInfo<std::tuple<BufferTestParam, tt::tt_metal::IGraphProcessor::RunMode>>& info) {
@@ -159,7 +158,7 @@ TEST_F(TestScopedGraphCapture, ScopedGraphCapture) {
 
     auto operation = [&device](tt::tt_metal::DataType datatype) {
         const auto input_a = ttnn::TensorSpec(
-            ttnn::Shape(tt::tt_metal::Array4D{1, 4, 512, 512}),
+            ttnn::Shape(ttnn::Array4D{1, 4, 512, 512}),
             tt::tt_metal::TensorLayout(
                 datatype, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), ttnn::L1_MEMORY_CONFIG));
         const auto input_tensor_a = tt::tt_metal::create_device_tensor(input_a, device);
@@ -238,7 +237,7 @@ TEST_F(TestScopedGraphCapture, OrderOfArgsTest) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+        ttnn::Shape(ttnn::Array2D{32, 64}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -313,7 +312,7 @@ TEST_F(TestScopedGraphCapture, SameTensorMultipleTimesTest) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+        ttnn::Shape(ttnn::Array2D{32, 64}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -362,7 +361,7 @@ TEST_F(TestScopedGraphCapture, TernaryOpDifferentOrderTest) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+        ttnn::Shape(ttnn::Array2D{32, 64}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -437,7 +436,7 @@ TEST_F(TestScopedGraphCapture, TernaryOpRepeatedTensorsTest) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+        ttnn::Shape(ttnn::Array2D{32, 64}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -506,7 +505,7 @@ TEST_F(TestScopedGraphCapture, MatmulDifferentOrdersTest) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{64, 64}),
+        ttnn::Shape(ttnn::Array2D{64, 64}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -587,7 +586,7 @@ TEST_F(TestScopedGraphCapture, SubtractArgumentOrderWithCapturedTensorsTest) {
     auto operation = [&device]() {
         // Create tensors INSIDE the capture
         const auto tensor_spec = ttnn::TensorSpec(
-            ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+            ttnn::Shape(ttnn::Array2D{32, 64}),
             tt::tt_metal::TensorLayout(
                 tt::tt_metal::DataType::BFLOAT16,
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -673,7 +672,7 @@ TEST_P(DurationTrackingTest, DurationTracking) {
         auto capture = ttnn::graph::ScopedGraphCapture(run_mode);
 
         const auto tensor_spec = ttnn::TensorSpec(
-            ttnn::Shape(tt::tt_metal::Array4D{1, 4, 512, 512}),
+            ttnn::Shape(ttnn::Array4D{1, 4, 512, 512}),
             tt::tt_metal::TensorLayout(
                 tt::tt_metal::DataType::BFLOAT16,
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -742,7 +741,7 @@ TEST_P(TensorInfoTest, FullTensorInfoCaptured) {
         auto capture = ttnn::graph::ScopedGraphCapture(run_mode);
 
         const auto tensor_spec = ttnn::TensorSpec(
-            ttnn::Shape(tt::tt_metal::Array4D{1, 1, 32, 32}),
+            ttnn::Shape(ttnn::Array4D{1, 1, 32, 32}),
             tt::tt_metal::TensorLayout(
                 tt::tt_metal::DataType::BFLOAT16,
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -817,7 +816,7 @@ TEST_F(TestScopedGraphCapture, ReportContainsClusterDescriptor) {
         auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
 
         const auto tensor_spec = ttnn::TensorSpec(
-            ttnn::Shape(tt::tt_metal::Array4D{1, 1, 32, 32}),
+            ttnn::Shape(ttnn::Array4D{1, 1, 32, 32}),
             tt::tt_metal::TensorLayout(
                 tt::tt_metal::DataType::BFLOAT16,
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -849,7 +848,7 @@ TEST_F(TestScopedGraphCapture, ExactBufferTypeAndMaxSizePerBankTest) {
         auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
 
         const auto tensor_spec = ttnn::TensorSpec(
-            ttnn::Shape(tt::tt_metal::Array4D{1, 1, 32, 32}),
+            ttnn::Shape(ttnn::Array4D{1, 1, 32, 32}),
             tt::tt_metal::TensorLayout(
                 tt::tt_metal::DataType::BFLOAT16,
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -885,7 +884,7 @@ TEST_F(TestScopedGraphCapture, PerOperationBuffersInReportTest) {
         auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NORMAL);
 
         const auto tensor_spec = ttnn::TensorSpec(
-            ttnn::Shape(tt::tt_metal::Array4D{1, 1, 32, 32}),
+            ttnn::Shape(ttnn::Array4D{1, 1, 32, 32}),
             tt::tt_metal::TensorLayout(
                 tt::tt_metal::DataType::BFLOAT16,
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -927,7 +926,7 @@ TEST_F(TestScopedGraphCapture, DeallocateContainsBufferTypeTest) {
         auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NORMAL);
 
         const auto tensor_spec = ttnn::TensorSpec(
-            ttnn::Shape(tt::tt_metal::Array4D{1, 1, 32, 32}),
+            ttnn::Shape(ttnn::Array4D{1, 1, 32, 32}),
             tt::tt_metal::TensorLayout(
                 tt::tt_metal::DataType::BFLOAT16,
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -107,7 +107,7 @@ static std::ostream& operator<<(std::ostream& os, const ttnn::Shape& shape) {
 // ============================================================================
 
 const auto g_height_shard_3_1_1024_1024_tiled_to_16_cores = ttnn::TensorSpec(
-    ttnn::Shape(tt::tt_metal::Array4D{3, 1, 32 * 32, 32 * 32}),
+    ttnn::Shape(Array4D{3, 1, 32 * 32, 32 * 32}),
     tt::tt_metal::TensorLayout(
         tt::tt_metal::DataType::BFLOAT16,
         tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -120,7 +120,7 @@ const auto g_height_shard_3_1_1024_1024_tiled_to_16_cores = ttnn::TensorSpec(
                 ShardOrientation::ROW_MAJOR}}));
 
 const auto g_height_shard_1_1_1024_32_tiled_to_32_cores = ttnn::TensorSpec(
-    ttnn::Shape(tt::tt_metal::Array4D{1, 1, 32 * 32, 64}),
+    ttnn::Shape(Array4D{1, 1, 32 * 32, 64}),
     tt::tt_metal::TensorLayout(
         tt::tt_metal::DataType::BFLOAT16,
         tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -133,49 +133,49 @@ const auto g_height_shard_1_1_1024_32_tiled_to_32_cores = ttnn::TensorSpec(
                 ShardOrientation::ROW_MAJOR}}));
 
 const auto g_interleaved_1_1_1024_1024_tiled = ttnn::TensorSpec(
-    ttnn::Shape(tt::tt_metal::Array4D{1, 1, 64, 128}),
+    ttnn::Shape(Array4D{1, 1, 64, 128}),
     tt::tt_metal::TensorLayout(
         tt::tt_metal::DataType::BFLOAT16,
         tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
         ttnn::L1_MEMORY_CONFIG));
 
 const auto g_interleave_4_2_160_244_tiled = ttnn::TensorSpec(
-    ttnn::Shape(tt::tt_metal::Array4D{4, 2, 5 * 32, 7 * 32}),
+    ttnn::Shape(Array4D{4, 2, 5 * 32, 7 * 32}),
     tt::tt_metal::TensorLayout(
         tt::tt_metal::DataType::BFLOAT16,
         tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
         ttnn::L1_MEMORY_CONFIG));
 
 const auto g_interleave_1_2_160_244_tiled = ttnn::TensorSpec(
-    ttnn::Shape(tt::tt_metal::Array4D{1, 1, 5 * 32, 7 * 32}),
+    ttnn::Shape(Array4D{1, 1, 5 * 32, 7 * 32}),
     tt::tt_metal::TensorLayout(
         tt::tt_metal::DataType::BFLOAT16,
         tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
         ttnn::L1_MEMORY_CONFIG));
 
 const auto g_interleave_1_1_160_244_tiled = ttnn::TensorSpec(
-    ttnn::Shape(tt::tt_metal::Array4D{1, 1, 5 * 32, 7 * 32}),
+    ttnn::Shape(Array4D{1, 1, 5 * 32, 7 * 32}),
     tt::tt_metal::TensorLayout(
         tt::tt_metal::DataType::BFLOAT16,
         tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
         ttnn::L1_MEMORY_CONFIG));
 
 const auto g_interleaved_1_1_2048_64_tiled = ttnn::TensorSpec(
-    ttnn::Shape(tt::tt_metal::Array4D{1, 1, 2048, 64}),
+    ttnn::Shape(Array4D{1, 1, 2048, 64}),
     tt::tt_metal::TensorLayout(
         tt::tt_metal::DataType::BFLOAT16,
         tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
         ttnn::L1_MEMORY_CONFIG));
 
 const auto g_interleaved_1_1_245_1024_tiled = ttnn::TensorSpec(
-    ttnn::Shape(tt::tt_metal::Array4D{1, 1, 256, 1024}),
+    ttnn::Shape(Array4D{1, 1, 256, 1024}),
     tt::tt_metal::TensorLayout(
         tt::tt_metal::DataType::BFLOAT16,
         tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
         ttnn::L1_MEMORY_CONFIG));
 
 const auto g_width_shard_1_1_64_2048_tiled_to_32_cores = ttnn::TensorSpec(
-    ttnn::Shape(tt::tt_metal::Array4D{1, 1, 64, 2048}),
+    ttnn::Shape(Array4D{1, 1, 64, 2048}),
     tt::tt_metal::TensorLayout(
         tt::tt_metal::DataType::BFLOAT16,
         tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -188,7 +188,7 @@ const auto g_width_shard_1_1_64_2048_tiled_to_32_cores = ttnn::TensorSpec(
                 ShardOrientation::ROW_MAJOR}}));
 
 const auto g_block_shard_1_1_1600_256_tiled_to_32_cores = ttnn::TensorSpec(
-    ttnn::Shape(tt::tt_metal::Array4D{1, 1, 1600, 256}),
+    ttnn::Shape(Array4D{1, 1, 1600, 256}),
     tt::tt_metal::TensorLayout(
         tt::tt_metal::DataType::BFLOAT16,
         tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -747,7 +747,7 @@ TEST_P(MatmulOpIfTest, Matmul) {
         tt::tt_metal::distributed::MeshDevice* device = device_;
 
         const auto output_spec = ttnn::TensorSpec(
-            ttnn::Shape(tt::tt_metal::Array4D{
+            ttnn::Shape(Array4D{
                 input_spec_a.logical_shape()[0],
                 input_spec_a.logical_shape()[1],
                 input_spec_a.logical_shape()[-2],
@@ -1308,7 +1308,7 @@ TYPED_TEST(DistributedTensorOpIfTest, FusedRmsMinimalWithShardedTopology) {
     const tt::tt_metal::MemoryConfig shard_mem_cfg{TensorMemoryLayout::WIDTH_SHARDED, BufferType::L1, shard_spec};
 
     const auto input_spec = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array4D{1, 1, kTileHeight, kN}),
+        ttnn::Shape(ttnn::Array4D{1, 1, kTileHeight, kN}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), shard_mem_cfg));
 
@@ -1319,7 +1319,7 @@ TYPED_TEST(DistributedTensorOpIfTest, FusedRmsMinimalWithShardedTopology) {
     // Weight: ROW_MAJOR, padded_shape[-1]==32 (tile width), volume==N.
     // Shape (1,1,N/32,32): padded[-1]=32, volume=N
     const auto weight_spec = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array4D{1, 1, kN / kTileWidth, kTileWidth}),
+        ttnn::Shape(ttnn::Array4D{1, 1, kN / kTileWidth, kTileWidth}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR),
@@ -1334,7 +1334,7 @@ TYPED_TEST(DistributedTensorOpIfTest, FusedRmsMinimalWithShardedTopology) {
         CoreRangeSet{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}}, {kTileHeight, kN}, ShardOrientation::ROW_MAJOR};
     const tt::tt_metal::MemoryConfig stats_mem_cfg{TensorMemoryLayout::WIDTH_SHARDED, BufferType::L1, stats_shard_spec};
     const auto stats_spec = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array4D{1, 1, kTileHeight, kN}),
+        ttnn::Shape(ttnn::Array4D{1, 1, kTileHeight, kN}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), stats_mem_cfg));
 

--- a/tests/ttnn/unit_tests/gtests/test_levelized_graph.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_levelized_graph.cpp
@@ -43,7 +43,7 @@ TEST_F(TestLevelizedGraphCapture, SimpleBinaryOp) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{64, 128}),
+        ttnn::Shape(ttnn::Array2D{64, 128}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -89,7 +89,7 @@ TEST_F(TestLevelizedGraphCapture, SimpleBinaryOp) {
     }
     EXPECT_TRUE(vertex_1.out_edges.empty());
     EXPECT_FALSE(vertex_1.output_shape.empty());
-    EXPECT_EQ(vertex_1.output_shape[0], shape_to_string(tt::tt_metal::Array2D{64, 128}));
+    EXPECT_EQ(vertex_1.output_shape[0], shape_to_string(ttnn::Array2D{64, 128}));
 
     // Now get the same graph but up to level 2:
     auto levelized_graph_2 = ttnn::graph::LevelizedGraph(ref_json_trace, 2);
@@ -115,7 +115,7 @@ TEST_F(TestLevelizedGraphCapture, ReductionOp) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{256, 128}),
+        ttnn::Shape(ttnn::Array2D{256, 128}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -152,7 +152,7 @@ TEST_F(TestLevelizedGraphCapture, ReductionOp) {
     // Basic structure checks - input tensor should have output edges
     EXPECT_TRUE(vertex_0.in_edges.empty());
     EXPECT_GE(vertex_0.out_edges.size(), 1);
-    EXPECT_EQ(vertex_0.output_shape[0], shape_to_string(tt::tt_metal::Array2D{256, 128}));
+    EXPECT_EQ(vertex_0.output_shape[0], shape_to_string(ttnn::Array2D{256, 128}));
 
     // Test level 2
     auto levelized_graph_2 = ttnn::graph::LevelizedGraph(ref_json_trace, 2);
@@ -174,7 +174,7 @@ TEST_F(TestLevelizedGraphCapture, OutputLayoutInfo) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array3D{16, 32, 64}),
+        ttnn::Shape(ttnn::Array3D{16, 32, 64}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -212,7 +212,7 @@ TEST_F(TestLevelizedGraphCapture, OutputLayoutInfo) {
     // Basic structure checks - input tensor should have output edges
     EXPECT_TRUE(vertex_0.in_edges.empty());
     EXPECT_GE(vertex_0.out_edges.size(), 1);
-    EXPECT_EQ(vertex_0.output_shape[0], shape_to_string(tt::tt_metal::Array3D{16, 32, 64}));
+    EXPECT_EQ(vertex_0.output_shape[0], shape_to_string(ttnn::Array3D{16, 32, 64}));
 
     auto has_reduction = std::ranges::any_of(
         levelized_graph.vertices(), [](const auto& v) { return v.name.find("Reduce") != std::string::npos; });
@@ -240,7 +240,7 @@ TEST_F(TestLevelizedGraphCapture, MatmulWithBiasTest) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{32, 32}),
+        ttnn::Shape(ttnn::Array2D{32, 32}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -284,7 +284,7 @@ TEST_F(TestLevelizedGraphCapture, MatmulWithBiasTest) {
     // Basic structure checks - input tensor should have output edges
     EXPECT_TRUE(vertex_0.in_edges.empty());
     EXPECT_GE(vertex_0.out_edges.size(), 1);  // feeds operations
-    EXPECT_EQ(vertex_0.output_shape[0], shape_to_string(tt::tt_metal::Array2D{32, 32}));
+    EXPECT_EQ(vertex_0.output_shape[0], shape_to_string(ttnn::Array2D{32, 32}));
 
     EXPECT_TRUE(matmul_op_it != levelized_graph.vertices().end() || add_op_it != levelized_graph.vertices().end());
 
@@ -308,7 +308,7 @@ TEST_F(TestLevelizedGraphCapture, CompositeOpTest) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{12, 19}),
+        ttnn::Shape(ttnn::Array2D{12, 19}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -347,7 +347,7 @@ TEST_F(TestLevelizedGraphCapture, CompositeOpTest) {
     // Basic structure checks - input tensor should have output edges
     EXPECT_TRUE(vertex_0.in_edges.empty());
     EXPECT_GE(vertex_0.out_edges.size(), 1);
-    EXPECT_EQ(vertex_0.output_shape[0], shape_to_string(tt::tt_metal::Array2D{12, 19}));
+    EXPECT_EQ(vertex_0.output_shape[0], shape_to_string(ttnn::Array2D{12, 19}));
 
     EXPECT_TRUE(digamma_op_it != levelized_graph.vertices().end());
 
@@ -371,7 +371,7 @@ TEST_F(TestLevelizedGraphCapture, MultiplySelfTest) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{64, 128}),
+        ttnn::Shape(ttnn::Array2D{64, 128}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -411,7 +411,7 @@ TEST_F(TestLevelizedGraphCapture, MultiplySelfTest) {
 
     EXPECT_TRUE(vertex_0.in_edges.empty());
     EXPECT_GE(vertex_0.out_edges.size(), 1);
-    EXPECT_EQ(vertex_0.output_shape[0], shape_to_string(tt::tt_metal::Array2D{64, 128}));
+    EXPECT_EQ(vertex_0.output_shape[0], shape_to_string(ttnn::Array2D{64, 128}));
 
     // Tensor dedup removed: multiply(a,a) creates two separate tensor vertices.
     EXPECT_EQ(vertex_1.in_edges.size(), 2);
@@ -421,7 +421,7 @@ TEST_F(TestLevelizedGraphCapture, MultiplySelfTest) {
     }
     EXPECT_TRUE(vertex_1.out_edges.empty());
     EXPECT_FALSE(vertex_1.output_shape.empty());
-    EXPECT_EQ(vertex_1.output_shape[0], shape_to_string(tt::tt_metal::Array2D{64, 128}));
+    EXPECT_EQ(vertex_1.output_shape[0], shape_to_string(ttnn::Array2D{64, 128}));
 
     // Test level 2
     auto levelized_graph_2 = ttnn::graph::LevelizedGraph(ref_json_trace, 2);
@@ -474,7 +474,7 @@ TEST_F(TestLevelizedGraphCapture, ForkTest) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{64, 128}),
+        ttnn::Shape(ttnn::Array2D{64, 128}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -568,13 +568,13 @@ TEST_F(TestLevelizedGraphCapture, JoinTest) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input_a = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{64, 128}),
+        ttnn::Shape(ttnn::Array2D{64, 128}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
             ttnn::L1_MEMORY_CONFIG));
     const auto input_b = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{64, 128}),
+        ttnn::Shape(ttnn::Array2D{64, 128}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -650,7 +650,7 @@ TEST_F(TestLevelizedGraphCapture, OrderOfArgs) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+        ttnn::Shape(ttnn::Array2D{32, 64}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -747,7 +747,7 @@ TEST_F(TestLevelizedGraphCapture, OrderOfArgsIntermediateTensorTest) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+        ttnn::Shape(ttnn::Array2D{32, 64}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -845,7 +845,7 @@ TEST_F(TestLevelizedGraphCapture, SameTensorMultipleTimes) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+        ttnn::Shape(ttnn::Array2D{32, 64}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -913,7 +913,7 @@ TEST_F(TestLevelizedGraphCapture, TernaryOpDifferentOrder) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+        ttnn::Shape(ttnn::Array2D{32, 64}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -1014,7 +1014,7 @@ TEST_F(TestLevelizedGraphCapture, TernaryOpRepeatedTensors) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+        ttnn::Shape(ttnn::Array2D{32, 64}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -1115,7 +1115,7 @@ TEST_F(TestLevelizedGraphCapture, MatmulDifferentOrders) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{64, 64}),
+        ttnn::Shape(ttnn::Array2D{64, 64}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -1244,7 +1244,7 @@ TEST_F(TestLevelizedGraphCapture, ExtractLevelizedGraphJsonTest) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+        ttnn::Shape(ttnn::Array2D{32, 64}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -1341,21 +1341,21 @@ TEST_F(TestLevelizedGraphCapture, MultiplyAndAddTest) {
     tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input_a = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+        ttnn::Shape(ttnn::Array2D{32, 64}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
             ttnn::L1_MEMORY_CONFIG));
     const auto input_tensor_a = tt::tt_metal::create_device_tensor(input_a, device);
     const auto input_b = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+        ttnn::Shape(ttnn::Array2D{32, 64}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
             ttnn::L1_MEMORY_CONFIG));
     const auto input_tensor_b = tt::tt_metal::create_device_tensor(input_b, device);
     const auto input_c = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+        ttnn::Shape(ttnn::Array2D{32, 64}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -1436,7 +1436,7 @@ TEST_F(TestLevelizedGraphCapture, MultiplyAndAddWithCapturedTensorsTest) {
     auto operation = [&device]() {
         // Create tensors INSIDE the capture
         const auto input_a = ttnn::TensorSpec(
-            ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+            ttnn::Shape(ttnn::Array2D{32, 64}),
             tt::tt_metal::TensorLayout(
                 tt::tt_metal::DataType::BFLOAT16,
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -1444,7 +1444,7 @@ TEST_F(TestLevelizedGraphCapture, MultiplyAndAddWithCapturedTensorsTest) {
         const auto input_tensor_a = tt::tt_metal::create_device_tensor(input_a, device);
 
         const auto input_b = ttnn::TensorSpec(
-            ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+            ttnn::Shape(ttnn::Array2D{32, 64}),
             tt::tt_metal::TensorLayout(
                 tt::tt_metal::DataType::BFLOAT16,
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -1452,7 +1452,7 @@ TEST_F(TestLevelizedGraphCapture, MultiplyAndAddWithCapturedTensorsTest) {
         const auto input_tensor_b = tt::tt_metal::create_device_tensor(input_b, device);
 
         const auto input_c = ttnn::TensorSpec(
-            ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+            ttnn::Shape(ttnn::Array2D{32, 64}),
             tt::tt_metal::TensorLayout(
                 tt::tt_metal::DataType::BFLOAT16,
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -1551,7 +1551,7 @@ TEST_F(TestLevelizedGraphCapture, SubtractArgumentOrderWithCapturedTensorsTest) 
     auto operation = [&device]() {
         // Create tensors INSIDE the capture
         const auto tensor_spec = ttnn::TensorSpec(
-            ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+            ttnn::Shape(ttnn::Array2D{32, 64}),
             tt::tt_metal::TensorLayout(
                 tt::tt_metal::DataType::BFLOAT16,
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),

--- a/tests/ttnn/unit_tests/gtests/test_matmul_sweep.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_matmul_sweep.cpp
@@ -84,8 +84,8 @@ TEST_P(MatmulSweepFixture, MatmulSweep) {
         // Dump first mismatches for debugging flaky failures
         auto c_host = ttnn::from_device(c_tensor);
         auto e_host = ttnn::from_device(expected);
-        auto c_buf = tt::tt_metal::host_buffer::get_as<::bfloat16>(c_host);
-        auto e_buf = tt::tt_metal::host_buffer::get_as<::bfloat16>(e_host);
+        auto c_buf = host_buffer::get_as<::bfloat16>(c_host);
+        auto e_buf = host_buffer::get_as<::bfloat16>(e_host);
         uint32_t total = c_buf.size();
         int printed = 0;
         for (uint32_t i = 0; i < total && printed < 20; i++) {

--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -30,8 +30,6 @@
 namespace tt::tt_metal {
 namespace {
 
-using ::tt::tt_metal::is_device_tensor;
-
 using MultiProducerCommandQueueTest = ttnn::MultiCommandQueueSingleDeviceFixture;
 
 TEST_F(MultiProducerCommandQueueTest, Stress) {
@@ -61,7 +59,7 @@ TEST_F(MultiProducerCommandQueueTest, Stress) {
     std::thread t0([&]() {
         for (int j = 0; j < kNumIterations; j++) {
             ttnn::Tensor t0_tensor = t0_host_tensor.to_device(device, mem_cfg, t0_io_cq);
-            EXPECT_TRUE(is_device_tensor(t0_tensor));
+            EXPECT_TRUE(ttnn::is_device_tensor(t0_tensor));
             EXPECT_EQ(t0_tensor.to_vector<float>(t0_io_cq), t0_host_data);
         }
     });
@@ -69,7 +67,7 @@ TEST_F(MultiProducerCommandQueueTest, Stress) {
     std::thread t1([&]() {
         for (int j = 0; j < kNumIterations; j++) {
             ttnn::Tensor t1_tensor = t1_host_tensor.to_device(device, mem_cfg, t1_io_cq);
-            EXPECT_TRUE(is_device_tensor(t1_tensor));
+            EXPECT_TRUE(ttnn::is_device_tensor(t1_tensor));
             EXPECT_EQ(t1_tensor.to_vector<float>(t1_io_cq), t1_host_data);
         }
     });
@@ -125,7 +123,7 @@ TEST_F(MultiProducerCommandQueueTest, EventSync) {
             std::iota(host_data.begin(), host_data.end(), j);
             const ttnn::Tensor host_tensor = ttnn::Tensor::from_vector(host_data, tensor_spec);
             copy_to_device(host_tensor, device_tensor, write_cq);
-            EXPECT_TRUE(is_device_tensor(device_tensor));
+            EXPECT_TRUE(ttnn::is_device_tensor(device_tensor));
 
             {
                 std::unique_lock<std::mutex> lock(event_mutex);
@@ -153,7 +151,7 @@ TEST_F(MultiProducerCommandQueueTest, EventSync) {
 
             // Read back from device and verify
             const ttnn::Tensor readback_tensor = device_tensor.cpu(/*blocking=*/true, read_cq);
-            EXPECT_FALSE(is_device_tensor(readback_tensor));
+            EXPECT_FALSE(ttnn::is_device_tensor(readback_tensor));
             std::iota(expected_readback_data.begin(), expected_readback_data.end(), j);
             EXPECT_EQ(readback_tensor.to_vector<uint32_t>(), expected_readback_data) << "At iteration " << j;
 

--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -54,13 +54,13 @@ TEST_F(MultiProducerCommandQueueTest, Stress) {
     std::iota(t0_host_data.begin(), t0_host_data.end(), 1024);
     std::iota(t1_host_data.begin(), t1_host_data.end(), 2048);
 
-    const Tensor t0_host_tensor = Tensor::from_vector(t0_host_data, tensor_spec);
-    const Tensor t1_host_tensor = Tensor::from_vector(t1_host_data, tensor_spec);
+    const ttnn::Tensor t0_host_tensor = ttnn::Tensor::from_vector(t0_host_data, tensor_spec);
+    const ttnn::Tensor t1_host_tensor = ttnn::Tensor::from_vector(t1_host_data, tensor_spec);
 
     constexpr int kNumIterations = 25;
     std::thread t0([&]() {
         for (int j = 0; j < kNumIterations; j++) {
-            Tensor t0_tensor = t0_host_tensor.to_device(device, mem_cfg, t0_io_cq);
+            ttnn::Tensor t0_tensor = t0_host_tensor.to_device(device, mem_cfg, t0_io_cq);
             EXPECT_TRUE(is_device_tensor(t0_tensor));
             EXPECT_EQ(t0_tensor.to_vector<float>(t0_io_cq), t0_host_data);
         }
@@ -68,7 +68,7 @@ TEST_F(MultiProducerCommandQueueTest, Stress) {
 
     std::thread t1([&]() {
         for (int j = 0; j < kNumIterations; j++) {
-            Tensor t1_tensor = t1_host_tensor.to_device(device, mem_cfg, t1_io_cq);
+            ttnn::Tensor t1_tensor = t1_host_tensor.to_device(device, mem_cfg, t1_io_cq);
             EXPECT_TRUE(is_device_tensor(t1_tensor));
             EXPECT_EQ(t1_tensor.to_vector<float>(t1_io_cq), t1_host_data);
         }
@@ -99,7 +99,7 @@ TEST_F(MultiProducerCommandQueueTest, EventSync) {
     std::optional<tt::tt_metal::distributed::MeshEvent> read_event;
     std::mutex event_mutex;
 
-    Tensor device_tensor = create_device_tensor(tensor_spec, device);
+    ttnn::Tensor device_tensor = create_device_tensor(tensor_spec, device);
 
     constexpr int kNumIterations = 100;
     std::thread t0([&]() {
@@ -123,7 +123,7 @@ TEST_F(MultiProducerCommandQueueTest, EventSync) {
 
             // Create tensor and transfer to device
             std::iota(host_data.begin(), host_data.end(), j);
-            const Tensor host_tensor = Tensor::from_vector(host_data, tensor_spec);
+            const ttnn::Tensor host_tensor = ttnn::Tensor::from_vector(host_data, tensor_spec);
             copy_to_device(host_tensor, device_tensor, write_cq);
             EXPECT_TRUE(is_device_tensor(device_tensor));
 
@@ -152,7 +152,7 @@ TEST_F(MultiProducerCommandQueueTest, EventSync) {
             }
 
             // Read back from device and verify
-            const Tensor readback_tensor = device_tensor.cpu(/*blocking=*/true, read_cq);
+            const ttnn::Tensor readback_tensor = device_tensor.cpu(/*blocking=*/true, read_cq);
             EXPECT_FALSE(is_device_tensor(readback_tensor));
             std::iota(expected_readback_data.begin(), expected_readback_data.end(), j);
             EXPECT_EQ(readback_tensor.to_vector<uint32_t>(), expected_readback_data) << "At iteration " << j;

--- a/tests/ttnn/unit_tests/gtests/test_tanh_bw_ulp.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_tanh_bw_ulp.cpp
@@ -242,8 +242,8 @@ std::vector<::bfloat16> run_tanh_bw_batched(
         tt::tt_metal::TensorLayout(
             DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), tt::tt_metal::MemoryConfig{}));
 
-    auto input_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device);
-    auto grad_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device);
+    auto input_tensor = Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device);
+    auto grad_tensor = Tensor::from_vector(std::move(bf16_grads), tensor_spec).to_device(device);
 
     auto results = ttnn::tanh_bw(grad_tensor, input_tensor);
     auto result = results[0].value();

--- a/tests/ttnn/unit_tests/gtests/test_tanh_fw_ulp.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_tanh_fw_ulp.cpp
@@ -269,7 +269,7 @@ std::vector<::bfloat16> run_tanh_fw_batched(
         tt::tt_metal::TensorLayout(
             DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), tt::tt_metal::MemoryConfig{}));
 
-    auto input_tensor = tt::tt_metal::Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device);
+    auto input_tensor = Tensor::from_vector(std::move(bf16_inputs), tensor_spec).to_device(device);
     auto result = ttnn::tanh(input_tensor);
     auto output_cpu = ttnn::from_device(result);
     return output_cpu.to_vector<::bfloat16>();

--- a/tt-train/sources/examples/sample_app/main.cpp
+++ b/tt-train/sources/examples/sample_app/main.cpp
@@ -13,7 +13,7 @@
 
 std::shared_ptr<tt::tt_metal::distributed::MeshDevice> device;
 
-void print_tensor(const tt::tt_metal::Tensor& tensor) {
+void print_tensor(const ttnn::Tensor& tensor) {
     // IMPORTANT. This function prints the tensor data assuming the tensor is in ROW_MAJOR layout
     // but we are using TILE layout. The printed format WILL NOT be correct. But good enough for a demo
 
@@ -68,7 +68,7 @@ int main() {
         42,
         -1));
     // Now we create a tensor with the buffer we just created
-    auto x = tt::tt_metal::Tensor(
+    auto x = ttnn::Tensor(
         // Let the tensor take ownership of the buffer
         std::move(buffer),
         // IMPORTANT: SHAPE MUST BE 4D ELSE EVERYTHING WILL BREAK during the PAD operation

--- a/tt-train/sources/examples/sample_app/main.cpp
+++ b/tt-train/sources/examples/sample_app/main.cpp
@@ -22,7 +22,7 @@ void print_tensor(const ttnn::Tensor& tensor) {
 
     // Move tensor to host and get data as a span
     auto host_tensor = tensor.cpu();
-    auto data = tt::tt_metal::host_buffer::get_as<bfloat16>(host_tensor);
+    auto data = ttnn::host_buffer::get_as<bfloat16>(host_tensor);
 
     // print the data
     for (size_t dim0 = 0; dim0 < shape[0]; dim0++) {

--- a/tt-train/sources/ttml/autograd/autocast_tensor.cpp
+++ b/tt-train/sources/ttml/autograd/autocast_tensor.cpp
@@ -12,7 +12,7 @@ static bool is_float_dtype(ttnn::DataType dtype) {
     return dtype == ttnn::DataType::FLOAT32 || dtype == ttnn::DataType::BFLOAT16;
 }
 
-void AutocastTensor::set_tensor(const tt::tt_metal::Tensor &tensor) {
+void AutocastTensor::set_tensor(const ttnn::Tensor &tensor) {
     if (tensor.dtype() == ttnn::DataType::FLOAT32) {
         m_full_precision_tensor = tensor;
         m_half_precision_tensor = ttnn::Tensor();
@@ -36,7 +36,7 @@ bool AutocastTensor::has_full() const {
     return core::is_tensor_initialized(m_full_precision_tensor);
 }
 
-const tt::tt_metal::Tensor &AutocastTensor::get_tensor(PreferredPrecision preferred_precision) const {
+const ttnn::Tensor &AutocastTensor::get_tensor(PreferredPrecision preferred_precision) const {
     // Non-float tensors (e.g. UINT32 embedding indices) are stored in the full-precision
     // slot and returned unchanged — they cannot be typecast to half/full float precision.
     if (has_full() && !is_float_dtype(m_full_precision_tensor.dtype())) {
@@ -61,7 +61,7 @@ const tt::tt_metal::Tensor &AutocastTensor::get_tensor(PreferredPrecision prefer
     return m_full_precision_tensor;
 }
 
-AutocastTensor::AutocastTensor(const tt::tt_metal::Tensor &tensor) {
+AutocastTensor::AutocastTensor(const ttnn::Tensor &tensor) {
     set_tensor(tensor);
 }
 

--- a/tt-train/sources/ttml/autograd/autocast_tensor.hpp
+++ b/tt-train/sources/ttml/autograd/autocast_tensor.hpp
@@ -12,20 +12,20 @@ namespace ttml::autograd {
 enum class PreferredPrecision : uint8_t { HALF = 0, FULL = 1 };
 
 class AutocastTensor {
-    mutable tt::tt_metal::Tensor m_half_precision_tensor{};
-    mutable tt::tt_metal::Tensor m_full_precision_tensor{};
+    mutable ttnn::Tensor m_half_precision_tensor{};
+    mutable ttnn::Tensor m_full_precision_tensor{};
 
 public:
     AutocastTensor() = default;
-    explicit AutocastTensor(const tt::tt_metal::Tensor &tensor);
+    explicit AutocastTensor(const ttnn::Tensor &tensor);
     AutocastTensor(const AutocastTensor &) = default;
     AutocastTensor(AutocastTensor &&) noexcept = default;
     AutocastTensor &operator=(const AutocastTensor &) = default;
     AutocastTensor &operator=(AutocastTensor &&) noexcept = default;
     ~AutocastTensor() = default;
 
-    void set_tensor(const tt::tt_metal::Tensor &tensor);
-    [[nodiscard]] const tt::tt_metal::Tensor &get_tensor(
+    void set_tensor(const ttnn::Tensor &tensor);
+    [[nodiscard]] const ttnn::Tensor &get_tensor(
         PreferredPrecision preferred_precision = PreferredPrecision::HALF) const;
 
     [[nodiscard]] bool has_half() const;

--- a/tt-train/sources/ttml/autograd/tensor.cpp
+++ b/tt-train/sources/ttml/autograd/tensor.cpp
@@ -29,10 +29,10 @@ void topological_sort(
 
 namespace ttml::autograd {
 
-Tensor::Tensor(const tt::tt_metal::Tensor& value, bool requires_grad) : m_value(value), m_requires_grad(requires_grad) {
+Tensor::Tensor(const ttnn::Tensor& value, bool requires_grad) : m_value(value), m_requires_grad(requires_grad) {
 }
 
-void Tensor::add_grad(const tt::tt_metal::Tensor& grad) {
+void Tensor::add_grad(const ttnn::Tensor& grad) {
     // Skip gradient addition if not required. Part of branch pruning autograd optimization.
     if (!m_requires_grad) {
         return;
@@ -110,11 +110,11 @@ void print_tensor_stats(const autograd::TensorPtr& tensor, const std::string& na
     core::print_tensor_stats(tensor->get_value(), name);
 }
 
-void Tensor::set_value(const tt::tt_metal::Tensor& value) {
+void Tensor::set_value(const ttnn::Tensor& value) {
     m_value.set_tensor(value);
 }
 
-void Tensor::set_grad(const tt::tt_metal::Tensor& grad) {
+void Tensor::set_grad(const ttnn::Tensor& grad) {
     if (core::is_tensor_initialized(grad)) {
         auto grad_shape = grad.logical_shape();
         auto value_shape = m_value.get_tensor().logical_shape();
@@ -136,15 +136,15 @@ void Tensor::set_requires_grad(bool requires_grad) {
     m_requires_grad = requires_grad;
 }
 
-const tt::tt_metal::Tensor& Tensor::get_value(PreferredPrecision preferred_precision) const {
+const ttnn::Tensor& Tensor::get_value(PreferredPrecision preferred_precision) const {
     return m_value.get_tensor(preferred_precision);
 }
 
-const tt::tt_metal::Tensor& Tensor::get_grad() const {
+const ttnn::Tensor& Tensor::get_grad() const {
     return m_grad;
 }
 
-tt::tt_metal::Tensor& Tensor::get_grad() {
+ttnn::Tensor& Tensor::get_grad() {
     return m_grad;
 }
 

--- a/tt-train/sources/ttml/autograd/tensor.hpp
+++ b/tt-train/sources/ttml/autograd/tensor.hpp
@@ -16,7 +16,7 @@ namespace ttml::autograd {
 class Tensor : public std::enable_shared_from_this<Tensor> {
 private:
     AutocastTensor m_value;
-    tt::tt_metal::Tensor m_grad;
+    ttnn::Tensor m_grad;
     bool m_requires_grad = false;
     std::optional<NodeId> m_node_id;
 
@@ -26,19 +26,19 @@ public:
     Tensor(Tensor &&) noexcept = default;
     Tensor &operator=(const Tensor &) = default;
     Tensor &operator=(Tensor &&) noexcept = default;
-    explicit Tensor(const tt::tt_metal::Tensor &value, bool requires_grad = false);
+    explicit Tensor(const ttnn::Tensor &value, bool requires_grad = false);
     ~Tensor() = default;
 
-    void set_value(const tt::tt_metal::Tensor &value);
-    void set_grad(const tt::tt_metal::Tensor &grad);
+    void set_value(const ttnn::Tensor &value);
+    void set_grad(const ttnn::Tensor &grad);
     void set_node(const std::optional<NodeId> &node);
     void clean_node();
-    void add_grad(const tt::tt_metal::Tensor &grad);
+    void add_grad(const ttnn::Tensor &grad);
     void set_requires_grad(bool requires_grad);
 
-    const tt::tt_metal::Tensor &get_value(PreferredPrecision preferred_precision = PreferredPrecision::HALF) const;
-    const tt::tt_metal::Tensor &get_grad() const;
-    tt::tt_metal::Tensor &get_grad();
+    const ttnn::Tensor &get_value(PreferredPrecision preferred_precision = PreferredPrecision::HALF) const;
+    const ttnn::Tensor &get_grad() const;
+    ttnn::Tensor &get_grad();
     bool get_requires_grad() const;
     const std::optional<NodeId> &get_node() const;
     const ttnn::Shape &get_shape() const;

--- a/tt-train/sources/ttml/core/clip_grad_norm.cpp
+++ b/tt-train/sources/ttml/core/clip_grad_norm.cpp
@@ -13,7 +13,7 @@ namespace ttml::core {
 
 autograd::TensorPtr clip_grad_norm(
     const serialization::NamedParameters& parameters, float max_norm, float p_norm_type, bool error_if_nonfinite) {
-    std::vector<tt::tt_metal::Tensor> grads;
+    std::vector<ttnn::Tensor> grads;
     grads.reserve(parameters.size());
     for (const auto& [_, tensor] : parameters) {
         if (tensor->get_requires_grad() && tensor->is_grad_initialized()) {

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -62,7 +62,7 @@ ttnn::Tensor ttml_create_owned_tensor(
 }
 
 std::vector<tt::tt_metal::HostBuffer> get_as(const ttnn::Tensor& tensor) {
-    TT_FATAL(tt::tt_metal::is_cpu_tensor(tensor), "Tensor must be on host");
+    TT_FATAL(ttnn::is_cpu_tensor(tensor), "Tensor must be on host");
     const auto& storage = tensor.host_storage();
     std::vector<tt::tt_metal::HostBuffer> buffers;
     buffers.reserve(storage.buffer().shard_coords().size());

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -31,7 +31,7 @@ T get_median(std::vector<T>& vec) {
 };
 
 template <typename T>
-void print_tensor_stats_(const tt::tt_metal::Tensor& tensor, const std::string& name) {
+void print_tensor_stats_(const ttnn::Tensor& tensor, const std::string& name) {
     auto tensor_shape = tensor.logical_shape();
     auto tensor_vec = tensor.to_vector<T>();
 
@@ -55,14 +55,14 @@ void print_tensor_stats_(const tt::tt_metal::Tensor& tensor, const std::string& 
 }
 
 template <typename T>
-tt::tt_metal::Tensor ttml_create_owned_tensor(
+ttnn::Tensor ttml_create_owned_tensor(
     std::vector<T>&& data, const ttnn::Shape& shape, tt::tt_metal::DataType data_type, tt::tt_metal::Layout layout) {
     auto buffer = tt::tt_metal::HostBuffer(std::move(data));
     return {std::move(buffer), shape, data_type, layout};
 }
 
 std::vector<tt::tt_metal::HostBuffer> get_as(const ttnn::Tensor& tensor) {
-    TT_FATAL(is_cpu_tensor(tensor), "Tensor must be on host");
+    TT_FATAL(tt::tt_metal::is_cpu_tensor(tensor), "Tensor must be on host");
     const auto& storage = tensor.host_storage();
     std::vector<tt::tt_metal::HostBuffer> buffers;
     buffers.reserve(storage.buffer().shard_coords().size());
@@ -73,33 +73,32 @@ std::vector<tt::tt_metal::HostBuffer> get_as(const ttnn::Tensor& tensor) {
 }  // namespace
 namespace ttml::core {
 
-tt::tt_metal::Tensor zeros_like(const tt::tt_metal::Tensor& tensor) {
+ttnn::Tensor zeros_like(const ttnn::Tensor& tensor) {
     return ttnn::moreh_full_like(tensor, 0.F, tensor.dtype(), tensor.layout(), tensor.memory_config());
 }
 
-tt::tt_metal::Tensor ones_like(const tt::tt_metal::Tensor& tensor) {
+ttnn::Tensor ones_like(const ttnn::Tensor& tensor) {
     return ttnn::moreh_full_like(tensor, 1.F, tensor.dtype(), tensor.layout(), tensor.memory_config());
 }
 
-tt::tt_metal::Tensor empty(
+ttnn::Tensor empty(
     const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, const ttnn::MemoryConfig& memory_config) {
     return ttnn::empty(shape, ttnn::DataType::BFLOAT16, ttnn::Layout::TILE, device, memory_config);
 }
 
-tt::tt_metal::Tensor full(
-    const ttnn::Shape& shape, float value, ttnn::distributed::MeshDevice* device, ttnn::DataType dtype) {
+ttnn::Tensor full(const ttnn::Shape& shape, float value, ttnn::distributed::MeshDevice* device, ttnn::DataType dtype) {
     return ttnn::full(shape, value, dtype, ttnn::Layout::TILE, std::ref(*device));
 }
 
-tt::tt_metal::Tensor zeros(const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, ttnn::DataType dtype) {
+ttnn::Tensor zeros(const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, ttnn::DataType dtype) {
     return core::full(shape, 0.F, device, dtype);
 }
 
-tt::tt_metal::Tensor ones(const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, ttnn::DataType dtype) {
+ttnn::Tensor ones(const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, ttnn::DataType dtype) {
     return core::full(shape, 1.F, device, dtype);
 }
 template <class VectorType, ttnn::DataType TensorType>
-tt::tt_metal::Tensor from_vector(
+ttnn::Tensor from_vector(
     const std::vector<VectorType>& buffer,
     const ttnn::Shape& shape,
     ttnn::distributed::MeshDevice* device,
@@ -145,42 +144,42 @@ tt::tt_metal::Tensor from_vector(
     return output;
 }
 
-template tt::tt_metal::Tensor from_vector<bfloat16, ttnn::DataType::BFLOAT16>(
+template ttnn::Tensor from_vector<bfloat16, ttnn::DataType::BFLOAT16>(
     const std::vector<bfloat16>&,
     const ttnn::Shape&,
     ttnn::distributed::MeshDevice*,
     ttnn::Layout,
     const ttnn::distributed::TensorToMesh*);
-template tt::tt_metal::Tensor from_vector<float, ttnn::DataType::BFLOAT16>(
+template ttnn::Tensor from_vector<float, ttnn::DataType::BFLOAT16>(
     const std::vector<float>&,
     const ttnn::Shape&,
     ttnn::distributed::MeshDevice*,
     ttnn::Layout,
     const ttnn::distributed::TensorToMesh*);
-template tt::tt_metal::Tensor from_vector<float, ttnn::DataType::FLOAT32>(
+template ttnn::Tensor from_vector<float, ttnn::DataType::FLOAT32>(
     const std::vector<float>&,
     const ttnn::Shape&,
     ttnn::distributed::MeshDevice*,
     ttnn::Layout,
     const ttnn::distributed::TensorToMesh*);
-template tt::tt_metal::Tensor from_vector<uint32_t, ttnn::DataType::UINT32>(
+template ttnn::Tensor from_vector<uint32_t, ttnn::DataType::UINT32>(
     const std::vector<uint32_t>&,
     const ttnn::Shape&,
     ttnn::distributed::MeshDevice*,
     ttnn::Layout,
     const ttnn::distributed::TensorToMesh*);
-template tt::tt_metal::Tensor from_vector<int32_t, ttnn::DataType::INT32>(
+template ttnn::Tensor from_vector<int32_t, ttnn::DataType::INT32>(
     const std::vector<int32_t>&,
     const ttnn::Shape&,
     ttnn::distributed::MeshDevice*,
     ttnn::Layout,
     const ttnn::distributed::TensorToMesh*);
 
-bool is_tensor_initialized(const tt::tt_metal::Tensor& tensor) {
+bool is_tensor_initialized(const ttnn::Tensor& tensor) {
     return tensor.tensor_attributes != nullptr;
 }
 
-void print_tensor_stats(const tt::tt_metal::Tensor& tensor, const std::string& name) {
+void print_tensor_stats(const ttnn::Tensor& tensor, const std::string& name) {
     if (tensor.dtype() == ttnn::DataType::BFLOAT16 || tensor.dtype() == ttnn::DataType::FLOAT32) {
         print_tensor_stats_<float>(tensor, name);
     } else {

--- a/tt-train/sources/ttml/core/tt_tensor_utils.hpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.hpp
@@ -51,7 +51,7 @@ template <class T = float, ttnn::DataType TensorType = ttnn::DataType::BFLOAT16>
     ttnn::distributed::MeshDevice* device,
     ttnn::Layout layout = ttnn::Layout::TILE,
     const ttnn::distributed::TensorToMesh* mesh_mapper = nullptr) {
-    auto shape = tt::tt_metal::experimental::xtensor::get_shape_from_xarray(buffer);
+    auto shape = ttnn::experimental::xtensor::get_shape_from_xarray(buffer);
     auto buffer_view = xtensor_to_span(buffer);
     return from_vector<T, TensorType>(
         std::vector<T>(buffer_view.begin(), buffer_view.end()), shape, device, layout, mesh_mapper);

--- a/tt-train/sources/ttml/core/tt_tensor_utils.hpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.hpp
@@ -13,25 +13,25 @@
 
 namespace ttml::core {
 
-void print_tensor_stats(const tt::tt_metal::Tensor& tensor, const std::string& name);
+void print_tensor_stats(const ttnn::Tensor& tensor, const std::string& name);
 
-tt::tt_metal::Tensor zeros_like(const tt::tt_metal::Tensor& tensor);
-tt::tt_metal::Tensor ones_like(const tt::tt_metal::Tensor& tensor);
+ttnn::Tensor zeros_like(const ttnn::Tensor& tensor);
+ttnn::Tensor ones_like(const ttnn::Tensor& tensor);
 
-tt::tt_metal::Tensor empty(
+ttnn::Tensor empty(
     const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, const ttnn::MemoryConfig& memory_config);
-tt::tt_metal::Tensor full(
+ttnn::Tensor full(
     const ttnn::Shape& shape,
     float value,
     ttnn::distributed::MeshDevice* device,
     ttnn::DataType dtype = ttnn::DataType::BFLOAT16);
-tt::tt_metal::Tensor zeros(
+ttnn::Tensor zeros(
     const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, ttnn::DataType dtype = ttnn::DataType::BFLOAT16);
-tt::tt_metal::Tensor ones(
+ttnn::Tensor ones(
     const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, ttnn::DataType dtype = ttnn::DataType::BFLOAT16);
 
 template <class VectorType = float, ttnn::DataType TensorType = ttnn::DataType::BFLOAT16>
-[[nodiscard]] tt::tt_metal::Tensor from_vector(
+[[nodiscard]] ttnn::Tensor from_vector(
     const std::vector<VectorType>& buffer,
     const ttnn::Shape& shape,
     ttnn::distributed::MeshDevice* device,
@@ -39,14 +39,14 @@ template <class VectorType = float, ttnn::DataType TensorType = ttnn::DataType::
     const ttnn::distributed::TensorToMesh* mesh_mapper = nullptr);
 
 template <class T = float>
-[[nodiscard]] std::vector<T> to_vector(const tt::tt_metal::Tensor& tensor) {
+[[nodiscard]] std::vector<T> to_vector(const ttnn::Tensor& tensor) {
     return tensor.to_vector<T>();
 }
 
-[[nodiscard]] bool is_tensor_initialized(const tt::tt_metal::Tensor& tensor);
+[[nodiscard]] bool is_tensor_initialized(const ttnn::Tensor& tensor);
 
 template <class T = float, ttnn::DataType TensorType = ttnn::DataType::BFLOAT16>
-[[nodiscard]] tt::tt_metal::Tensor from_xtensor(
+[[nodiscard]] ttnn::Tensor from_xtensor(
     const xt::xarray<T>& buffer,
     ttnn::distributed::MeshDevice* device,
     ttnn::Layout layout = ttnn::Layout::TILE,
@@ -58,7 +58,7 @@ template <class T = float, ttnn::DataType TensorType = ttnn::DataType::BFLOAT16>
 }
 
 template <class T = float>
-[[nodiscard]] xt::xarray<T> to_xtensor(const tt::tt_metal::Tensor& tensor) {
+[[nodiscard]] xt::xarray<T> to_xtensor(const ttnn::Tensor& tensor) {
     auto vec = tensor.to_vector<T>();
     const auto& shape = tensor.logical_shape();
     std::vector<size_t> shape_vec(shape.cbegin(), shape.cend());
@@ -70,8 +70,7 @@ std::vector<std::span<std::byte>> get_bytes_from_cpu_tensor(ttnn::Tensor& cpu_te
 
 // Converts a tensor distributed across mesh device into a single xtensor
 template <class T = float>
-[[nodiscard]] xt::xarray<T> to_xtensor(
-    const tt::tt_metal::Tensor& tensor, const ttnn::distributed::MeshToTensor& composer) {
+[[nodiscard]] xt::xarray<T> to_xtensor(const ttnn::Tensor& tensor, const ttnn::distributed::MeshToTensor& composer) {
     auto [vec, shape] = composer.compose<T>(tensor);
     std::vector<size_t> shape_vec(shape.cbegin(), shape.cend());
     return xt::adapt(vec, shape_vec);
@@ -82,7 +81,7 @@ struct IdentityComposer {};
 
 // Converts a tensor distributed across mesh device into a collection of individual xtensors
 template <class T = float>
-auto to_xtensor(const tt::tt_metal::Tensor& tensor, IdentityComposer) {
+auto to_xtensor(const ttnn::Tensor& tensor, IdentityComposer) {
     auto cpu_tensor = tensor.cpu();
     cpu_tensor = cpu_tensor.to_layout(ttnn::Layout::ROW_MAJOR);
     auto cpu_tensors = ttnn::distributed::get_device_tensors(cpu_tensor);

--- a/tt-train/sources/ttml/core/xtensor_utils.hpp
+++ b/tt-train/sources/ttml/core/xtensor_utils.hpp
@@ -58,16 +58,16 @@ set to N at compile time. xtensor_fixed<T, xshape<I, J, K> : tensor whose shape 
 namespace ttml::core {
 template <class T>
 xt::xarray<T> span_to_xtensor_view(std::span<T> vec, const ttnn::Shape& shape) {
-    return tt::tt_metal::experimental::xtensor::span_to_xtensor_view(vec, shape);
+    return ttnn::experimental::xtensor::span_to_xtensor_view(vec, shape);
 }
 template <class T>
 auto xtensor_to_span(const xt::xarray<T>& xtensor) {
-    return tt::tt_metal::experimental::xtensor::xtensor_to_span(xtensor);
+    return ttnn::experimental::xtensor::xtensor_to_span(xtensor);
 }
 
 template <typename T>
 xt::xarray<T> concat(const std::vector<xt::xarray<T>>& v, size_t axis = 0) {
-    return tt::tt_metal::experimental::xtensor::concat(v, axis).expr();
+    return ttnn::experimental::xtensor::concat(v, axis).expr();
 }
 
 }  // namespace ttml::core

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation.cpp
@@ -17,9 +17,8 @@ void CrossEntropyBackwardDeviceOperation::validate_on_program_cache_miss(
                            const std::string& name,
                            const tt::tt_metal::Layout required_layout,
                            const tt::tt_metal::DataType required_dtype) {
-
         TT_FATAL(
-            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            tensor.storage_type() == ttnn::StorageType::DEVICE,
             "CrossEntropyBackward operation requires '{}' to be on DEVICE. Got storage type: '{}'",
             name,
             enchantum::to_string(tensor.storage_type()));

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation.cpp
@@ -18,7 +18,7 @@ void CrossEntropyForwardDeviceOperation::validate_on_program_cache_miss(
                            const tt::tt_metal::Layout required_layout,
                            const tt::tt_metal::DataType required_dtype) {
         TT_FATAL(
-            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            tensor.storage_type() == ttnn::StorageType::DEVICE,
             "CrossEntropyForward operation requires '{}' to be on DEVICE. Got storage type: '{}'",
             name,
             enchantum::to_string(tensor.storage_type()));

--- a/tt-train/sources/ttml/metal/ops/frobenius_normalize/device/frobenius_normalize_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/frobenius_normalize/device/frobenius_normalize_device_operation.cpp
@@ -16,7 +16,7 @@ void FrobeniusNormalizeDeviceOperation::validate_on_program_cache_miss(
     const auto& input_tensor = tensor_args.input;
 
     TT_FATAL(
-        input_tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+        input_tensor.storage_type() == ttnn::StorageType::DEVICE,
         "FrobeniusNormalize requires input on Device. Storage type: {}",
         enchantum::to_string(input_tensor.storage_type()));
 
@@ -39,7 +39,7 @@ void FrobeniusNormalizeDeviceOperation::validate_on_program_cache_miss(
 
     if (tensor_args.preallocated_output.has_value()) {
         const auto& output = tensor_args.preallocated_output.value();
-        TT_FATAL(output.storage_type() == tt::tt_metal::StorageType::DEVICE, "Preallocated output must be on Device");
+        TT_FATAL(output.storage_type() == ttnn::StorageType::DEVICE, "Preallocated output must be on Device");
         TT_FATAL(output.layout() == tt::tt_metal::Layout::TILE, "Preallocated output must be TILE layout");
         TT_FATAL(output.dtype() == tt::tt_metal::DataType::BFLOAT16, "Preallocated output must be BFLOAT16");
         TT_FATAL(output.logical_shape() == input_tensor.logical_shape(), "Preallocated output shape must match input.");

--- a/tt-train/sources/ttml/metal/ops/layernorm_bw/device/layernorm_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_bw/device/layernorm_bw_device_operation.cpp
@@ -15,10 +15,10 @@ void LayerNormBackwardDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     auto check_tensor = [](const ttnn::Tensor& tensor, const std::string& name) {
         TT_FATAL(
-            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            tensor.storage_type() == ttnn::StorageType::DEVICE,
             "Tensor's '{}' storage type must be {}. Got storage type: {}",
             name,
-            enchantum::to_string(tt::tt_metal::StorageType::DEVICE),
+            enchantum::to_string(ttnn::StorageType::DEVICE),
             enchantum::to_string(tensor.storage_type()));
 
         TT_FATAL(tensor.buffer() != nullptr, "Tensor '{}' must be allocated on device (buffer is null).", name);

--- a/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_device_operation.cpp
@@ -15,10 +15,10 @@ void LayerNormForwardDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     auto check_tensor = [](const ttnn::Tensor& tensor, const std::string& name) {
         TT_FATAL(
-            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            tensor.storage_type() == ttnn::StorageType::DEVICE,
             "Tensor's '{}' storage type must be {}. Got storage type: {}",
             name,
-            enchantum::to_string(tt::tt_metal::StorageType::DEVICE),
+            enchantum::to_string(ttnn::StorageType::DEVICE),
             enchantum::to_string(tensor.storage_type()));
 
         TT_FATAL(tensor.buffer() != nullptr, "Tensor '{}' must be allocated on device (buffer is null).", name);

--- a/tt-train/sources/ttml/metal/ops/polynorm_fw/device/polynorm_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/polynorm_fw/device/polynorm_fw_device_operation.cpp
@@ -14,7 +14,7 @@ void PolyNorm3ForwardDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     auto check_tensor = [](const ttnn::Tensor& tensor, const std::string& name) {
         TT_FATAL(
-            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            tensor.storage_type() == ttnn::StorageType::DEVICE,
             "PolyNorm3Forward operation requires {} to be on Device. Input storage type: {}",
             name,
             enchantum::to_string(tensor.storage_type()));

--- a/tt-train/sources/ttml/metal/ops/profiler_no_op/device/profiler_no_op_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/profiler_no_op/device/profiler_no_op_device_operation.cpp
@@ -17,9 +17,8 @@ void ProfilerNoopOperation::validate_on_program_cache_miss(
                            const std::string& name,
                            const tt::tt_metal::Layout required_layout,
                            const tt::tt_metal::DataType required_dtype) {
-
         TT_FATAL(
-            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            tensor.storage_type() == ttnn::StorageType::DEVICE,
             "ProfilerNoop operation requires '{}' to be on DEVICE. Got storage type: '{}'",
             name,
             enchantum::to_string(tensor.storage_type()));

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation.cpp
@@ -15,7 +15,7 @@ void RMSNormBackwardDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     auto check_tensor = [](const ttnn::Tensor& tensor, const std::string& name) {
         TT_FATAL(
-            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            tensor.storage_type() == ttnn::StorageType::DEVICE,
             "RMSNormBackward operation requires {} to be on Device. Input storage type: {}",
             name,
             enchantum::to_string(tensor.storage_type()));

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation.cpp
@@ -15,7 +15,7 @@ void RMSNormForwardDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     auto check_tensor = [](const ttnn::Tensor& tensor, const std::string& name) {
         TT_FATAL(
-            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            tensor.storage_type() == ttnn::StorageType::DEVICE,
             "RMSNormForward operation requires {} to be on Device. Input storage type: {}",
             name,
             enchantum::to_string(tensor.storage_type()));

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_device_operation.cpp
@@ -24,7 +24,7 @@ void SDPAForwardDeviceOperation::validate_on_program_cache_miss(
                                  const tt::tt_metal::Layout required_layout,
                                  const tt::tt_metal::DataType required_dtype) {
         TT_FATAL(
-            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            tensor.storage_type() == ttnn::StorageType::DEVICE,
             "SDPAForward operation requires '{}' to be on DEVICE. Got storage type: '{}'",
             name,
             enchantum::to_string(tensor.storage_type()));

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation.cpp
@@ -15,7 +15,7 @@ void SiLUBackwardDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     auto check_tensor = [](const ttnn::Tensor& tensor, const std::string& name) {
         TT_FATAL(
-            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            tensor.storage_type() == ttnn::StorageType::DEVICE,
             "SiLUBackward operation requires {} to be on Device. Input storage type: {}",
             name,
             enchantum::to_string(tensor.storage_type()));

--- a/tt-train/sources/ttml/metal/ops/softmax/device/softmax_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax/device/softmax_device_operation.cpp
@@ -17,9 +17,8 @@ void SoftmaxDeviceOperation::validate_on_program_cache_miss(
                            const std::string& name,
                            const tt::tt_metal::Layout required_layout,
                            const tt::tt_metal::DataType required_dtype) {
-
         TT_FATAL(
-            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            tensor.storage_type() == ttnn::StorageType::DEVICE,
             "Softmax operation requires '{}' to be on DEVICE. Got storage type: '{}'",
             name,
             enchantum::to_string(tensor.storage_type()));

--- a/tt-train/sources/ttml/metal/ops/swiglu_elemwise_bw/device/swiglu_elemwise_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_elemwise_bw/device/swiglu_elemwise_bw_device_operation.cpp
@@ -15,7 +15,7 @@ void SwigluElemwiseBwDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     auto check_tensor = [](const ttnn::Tensor& tensor, const std::string& name) {
         TT_FATAL(
-            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            tensor.storage_type() == ttnn::StorageType::DEVICE,
             "SwigluElemwiseBw requires {} on Device. Storage type: {}",
             name,
             enchantum::to_string(tensor.storage_type()));

--- a/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.cpp
@@ -18,7 +18,7 @@ void AdamWDeviceOperation::validate_on_program_cache_miss(
                            const tt::tt_metal::Layout required_layout,
                            const tt::tt_metal::DataType required_dtype) {
         TT_FATAL(
-            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            tensor.storage_type() == ttnn::StorageType::DEVICE,
             "AdamW optimizer requires '{}' to be on DEVICE. Got storage type: '{}'",
             name,
             enchantum::to_string(tensor.storage_type()));

--- a/tt-train/sources/ttml/metal/optimizers/sgd/device/sgd_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/sgd/device/sgd_device_operation.cpp
@@ -18,7 +18,7 @@ void SGDDeviceOperation::validate_on_program_cache_miss(
                            const tt::tt_metal::Layout required_layout,
                            const tt::tt_metal::DataType required_dtype) {
         TT_FATAL(
-            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            tensor.storage_type() == ttnn::StorageType::DEVICE,
             "SGD optimizer requires '{}' to be on DEVICE. Got storage type: '{}'",
             name,
             enchantum::to_string(tensor.storage_type()));

--- a/tt-train/sources/ttml/models/common/transformer_common.cpp
+++ b/tt-train/sources/ttml/models/common/transformer_common.cpp
@@ -117,10 +117,10 @@ KvCache::KvCache(const KvCacheConfig& config) :
 }
 
 const uint32_t KvCache::update_prefill(
-    const tt::tt_metal::Tensor& key_tensor,
-    const tt::tt_metal::Tensor& value_tensor,
-    tt::tt_metal::Tensor& k_cache,
-    tt::tt_metal::Tensor& v_cache,
+    const ttnn::Tensor& key_tensor,
+    const ttnn::Tensor& value_tensor,
+    ttnn::Tensor& k_cache,
+    ttnn::Tensor& v_cache,
     const uint32_t new_tokens) {
     const auto kv_shape = key_tensor.logical_shape();
     TT_FATAL(
@@ -131,8 +131,8 @@ const uint32_t KvCache::update_prefill(
     const ttsl::SmallVector<uint32_t> token_start = {0, 0, 0, 0};
     const ttsl::SmallVector<uint32_t> kv_end = {kv_shape[0], kv_shape[1], new_tokens, kv_shape[3]};
 
-    const tt::tt_metal::Tensor& new_key = ttnn::slice(key_tensor, token_start, kv_end, step);
-    const tt::tt_metal::Tensor& new_value = ttnn::slice(value_tensor, token_start, kv_end, step);
+    const ttnn::Tensor& new_key = ttnn::slice(key_tensor, token_start, kv_end, step);
+    const ttnn::Tensor& new_value = ttnn::slice(value_tensor, token_start, kv_end, step);
 
     const ttsl::SmallVector<uint32_t> cache_start = {0, 0, 0, 0};
     const ttsl::SmallVector<uint32_t> cache_end = {cache_shape[0], cache_shape[1], new_tokens, cache_shape[3]};
@@ -144,10 +144,10 @@ const uint32_t KvCache::update_prefill(
 }
 
 const uint32_t KvCache::update_decode(
-    const tt::tt_metal::Tensor& key_tensor,
-    const tt::tt_metal::Tensor& value_tensor,
-    tt::tt_metal::Tensor& k_cache,
-    tt::tt_metal::Tensor& v_cache,
+    const ttnn::Tensor& key_tensor,
+    const ttnn::Tensor& value_tensor,
+    ttnn::Tensor& k_cache,
+    ttnn::Tensor& v_cache,
     const uint32_t cache_position,
     const uint32_t new_tokens) {
     const auto cache_shape = k_cache.logical_shape();
@@ -158,8 +158,8 @@ const uint32_t KvCache::update_decode(
     const ttsl::SmallVector<uint32_t> token_start = {0, 0, 0, 0};
     const ttsl::SmallVector<uint32_t> kv_end = {kv_shape[0], kv_shape[1], new_tokens, kv_shape[3]};
 
-    const tt::tt_metal::Tensor& new_key = ttnn::slice(key_tensor, token_start, kv_end, step);
-    const tt::tt_metal::Tensor& new_value = ttnn::slice(value_tensor, token_start, kv_end, step);
+    const ttnn::Tensor& new_key = ttnn::slice(key_tensor, token_start, kv_end, step);
+    const ttnn::Tensor& new_value = ttnn::slice(value_tensor, token_start, kv_end, step);
 
     const ttsl::SmallVector<uint32_t> cache_start = {0, 0, cache_position, 0};
     const ttsl::SmallVector<uint32_t> cache_end = {
@@ -173,8 +173,8 @@ const uint32_t KvCache::update_decode(
 
 const uint32_t KvCache::update(
     const uint32_t layer_idx,
-    const tt::tt_metal::Tensor& key_states,
-    const tt::tt_metal::Tensor& value_states,
+    const ttnn::Tensor& key_states,
+    const ttnn::Tensor& value_states,
     const uint32_t new_tokens) {
     TT_FATAL(layer_idx < m_kv_cache.size(), "Layer index out of range");
 

--- a/tt-train/sources/ttml/models/common/transformer_common.hpp
+++ b/tt-train/sources/ttml/models/common/transformer_common.hpp
@@ -131,8 +131,8 @@ public:
 
     const uint32_t update(
         const uint32_t layer_idx,
-        const tt::tt_metal::Tensor& key_states,
-        const tt::tt_metal::Tensor& value_states,
+        const ttnn::Tensor& key_states,
+        const ttnn::Tensor& value_states,
         const uint32_t new_tokens);
 
     /**
@@ -214,20 +214,20 @@ private:
      * @brief Update cache for prefill mode (writes entire sequence starting at position 0)
      */
     const uint32_t update_prefill(
-        const tt::tt_metal::Tensor& key_tensor,
-        const tt::tt_metal::Tensor& value_tensor,
-        tt::tt_metal::Tensor& k_cache,
-        tt::tt_metal::Tensor& v_cache,
+        const ttnn::Tensor& key_tensor,
+        const ttnn::Tensor& value_tensor,
+        ttnn::Tensor& k_cache,
+        ttnn::Tensor& v_cache,
         const uint32_t new_tokens);
 
     /**
      * @brief Update cache for decode mode (writes single token at cache_position)
      */
     const uint32_t update_decode(
-        const tt::tt_metal::Tensor& key_tensor,
-        const tt::tt_metal::Tensor& value_tensor,
-        tt::tt_metal::Tensor& k_cache,
-        tt::tt_metal::Tensor& v_cache,
+        const ttnn::Tensor& key_tensor,
+        const ttnn::Tensor& value_tensor,
+        ttnn::Tensor& k_cache,
+        ttnn::Tensor& v_cache,
         const uint32_t cache_position,
         const uint32_t new_tokens = 1);
 };

--- a/tt-train/sources/ttml/modules/grouped_query_attention.cpp
+++ b/tt-train/sources/ttml/modules/grouped_query_attention.cpp
@@ -94,8 +94,8 @@ ttml::autograd::TensorPtr GroupedQueryAttention::operator()(
     const ttsl::SmallVector<uint32_t> token_end = {
         cache_shape[0], cache_shape[1], mask->get_value().logical_shape()[-1], cache_shape[3]};
 
-    const tt::tt_metal::Tensor& k_cache_slice = ttnn::slice(k_cache, token_start, token_end, step);
-    const tt::tt_metal::Tensor& v_cache_slice = ttnn::slice(v_cache, token_start, token_end, step);
+    const ttnn::Tensor& k_cache_slice = ttnn::slice(k_cache, token_start, token_end, step);
+    const ttnn::Tensor& v_cache_slice = ttnn::slice(v_cache, token_start, token_end, step);
 
     const auto k_cache_to_process = ttml::autograd::create_tensor(k_cache_slice);
     const auto v_cache_to_process = ttml::autograd::create_tensor(v_cache_slice);

--- a/tt-train/sources/ttml/nanobind/nb_autograd.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_autograd.cpp
@@ -65,7 +65,7 @@ void py_module(nb::module_& m) {
         py_tensor.def(nb::init<>());
         py_tensor.def(nb::init<const Tensor&>());
         py_tensor.def(nb::init<Tensor&&>());
-        py_tensor.def(nb::init<const tt::tt_metal::Tensor&, bool>());
+        py_tensor.def(nb::init<const ttnn::Tensor&, bool>());
         py_tensor.def_prop_ro(
             "tensor",
             [](const TensorPtr& self) -> TensorPtr { return self; },
@@ -349,12 +349,10 @@ void py_module(nb::module_& m) {
     // Module-level create_tensor functions for creating autograd tensors
     m.def(
         "create_tensor",
-        [](const tt::tt_metal::Tensor& value, bool requires_grad) -> TensorPtr {
-            return create_tensor(value, requires_grad);
-        },
+        [](const ttnn::Tensor& value, bool requires_grad) -> TensorPtr { return create_tensor(value, requires_grad); },
         nb::arg("value"),
         nb::arg("requires_grad") = true,
-        "Create an autograd Tensor from a tt::tt_metal::Tensor");
+        "Create an autograd Tensor from a ttnn::Tensor");
 
     m.def("create_tensor", []() -> TensorPtr { return create_tensor(); }, "Create an empty autograd Tensor");
 

--- a/tt-train/sources/ttml/nanobind/nb_core.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_core.cpp
@@ -100,7 +100,7 @@ void py_module(nb::module_& m) {
 
     m.def(
         "zeros_like",
-        [](const tt::tt_metal::Tensor& tensor) -> tt::tt_metal::Tensor {
+        [](const ttnn::Tensor& tensor) -> ttnn::Tensor {
             return ttnn::moreh_full_like(tensor, 0.F, tensor.dtype(), tensor.layout(), tensor.memory_config());
         },
         nb::arg("tensor"),
@@ -108,7 +108,7 @@ void py_module(nb::module_& m) {
 
     m.def(
         "ones_like",
-        [](const tt::tt_metal::Tensor& tensor) -> tt::tt_metal::Tensor {
+        [](const ttnn::Tensor& tensor) -> ttnn::Tensor {
             return ttnn::moreh_full_like(tensor, 1.F, tensor.dtype(), tensor.layout(), tensor.memory_config());
         },
         nb::arg("tensor"),

--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -264,13 +264,12 @@ void py_module(nb::module_& m) {
             nb::arg("value"),
             nb::arg("mask") = std::nullopt);
         // Overload 2: mask as ttnn.Tensor (or None) - wrap it in autograd::Tensor
-        // ttnn.Tensor wraps tt::tt_metal::Tensor, so we accept that type
         py_attention.def(
             "scaled_dot_product_attention",
             [](const autograd::TensorPtr& query,
                const autograd::TensorPtr& key,
                const autograd::TensorPtr& value,
-               const std::optional<tt::tt_metal::Tensor>& mask) -> autograd::TensorPtr {
+               const std::optional<ttnn::Tensor>& mask) -> autograd::TensorPtr {
                 std::optional<autograd::TensorPtr> mask_ptr = std::nullopt;
                 if (mask.has_value()) {
                     mask_ptr = autograd::create_tensor(mask.value(), false);

--- a/tt-train/sources/ttml/nanobind/nb_util.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_util.cpp
@@ -122,7 +122,7 @@ auto dispatch_conversion(
 
 // Helper: Create tensor from numpy data span (common logic for both overloads)
 template <typename NumpyType, typename MetalType>
-tt::tt_metal::Tensor create_tensor_from_span(
+ttnn::Tensor create_tensor_from_span(
     std::span<const NumpyType> numpy_data_span,
     const tt::tt_metal::ShapeBase::Container& shape_container,
     tt::tt_metal::DataType tensor_data_type,
@@ -143,7 +143,7 @@ tt::tt_metal::Tensor create_tensor_from_span(
         auto row_major_tensor = (mapper != nullptr)
                                     ? ttnn::distributed::create_distributed_tensor(
                                           ttsl::make_const_span(converted_data), tensor_shape, tensor_layout, *mapper)
-                                    : tt::tt_metal::Tensor::from_vector(converted_data, tensor_spec, device);
+                                    : ttnn::Tensor::from_vector(converted_data, tensor_spec, device);
 
         if (mapper != nullptr) {
             row_major_tensor = ttnn::to_device(row_major_tensor, device, tt::tt_metal::MemoryConfig{});
@@ -157,7 +157,7 @@ tt::tt_metal::Tensor create_tensor_from_span(
         auto row_major_tensor = (mapper != nullptr)
                                     ? ttnn::distributed::create_distributed_tensor(
                                           ttsl::make_const_span(numpy_data_span), tensor_shape, tensor_layout, *mapper)
-                                    : tt::tt_metal::Tensor::from_span(numpy_data_span, tensor_spec, device);
+                                    : ttnn::Tensor::from_span(numpy_data_span, tensor_spec, device);
 
         if (mapper != nullptr) {
             row_major_tensor = ttnn::to_device(row_major_tensor, device, tt::tt_metal::MemoryConfig{});
@@ -189,7 +189,7 @@ tt::tt_metal::Tensor create_tensor_from_span(
 }
 
 nb::object make_numpy_tensor(
-    const tt::tt_metal::Tensor& t,
+    const ttnn::Tensor& t,
     std::optional<tt::tt_metal::DataType> new_type,
     const ttnn::distributed::MeshToTensor* composer) {
     // Get ml_dtypes.bfloat16 dtype for bfloat16 arrays
@@ -276,7 +276,7 @@ nb::object make_numpy_tensor(
             nb::dtype<NumpyType>()));
     };
 
-    const auto convert_to_row_major = [](const tt::tt_metal::Tensor& tensor) {
+    const auto convert_to_row_major = [](const ttnn::Tensor& tensor) {
         tt::tt_metal::Shape output_tensor_end(ttsl::SmallVector<uint32_t>(tensor.logical_shape().rank(), 0));
         int logical_rank = tensor.logical_shape().rank();
         for (int index = -1; index >= -logical_rank; --index) {
@@ -288,7 +288,7 @@ nb::object make_numpy_tensor(
 
     const auto impl = [&make_numpy_tensor_from_data,
                        &convert_to_row_major,
-                       composer]<typename MetalType, typename NumpyType>(const tt::tt_metal::Tensor& tensor) {
+                       composer]<typename MetalType, typename NumpyType>(const ttnn::Tensor& tensor) {
         if (tensor.storage_type() == ttnn::types::StorageType::HOST) {
             if (tensor.layout() != tt::tt_metal::Layout::ROW_MAJOR) {
                 const auto row_major_tensor = convert_to_row_major(tensor);
@@ -336,7 +336,7 @@ nb::object make_numpy_tensor(
 }
 
 // Fast path: standard NumPy dtypes validated by nanobind
-tt::tt_metal::Tensor make_metal_tensor(
+ttnn::Tensor make_metal_tensor(
     nb::ndarray<nb::numpy> numpy_data,
     tt::tt_metal::Layout target_layout,
     std::optional<tt::tt_metal::DataType> new_type,
@@ -431,7 +431,7 @@ tt::tt_metal::Tensor make_metal_tensor(
 
 // Custom dtype handler: only accepts custom dtypes (like ml_dtypes.bfloat16)
 // Standard dtypes should use the fast path nb::ndarray<nb::numpy> overload
-tt::tt_metal::Tensor make_metal_tensor(
+ttnn::Tensor make_metal_tensor(
     nb::object numpy_data_obj,
     tt::tt_metal::Layout target_layout,
     std::optional<tt::tt_metal::DataType> new_type,

--- a/tt-train/sources/ttml/nanobind/nb_util.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_util.cpp
@@ -289,7 +289,7 @@ nb::object make_numpy_tensor(
     const auto impl = [&make_numpy_tensor_from_data,
                        &convert_to_row_major,
                        composer]<typename MetalType, typename NumpyType>(const ttnn::Tensor& tensor) {
-        if (tensor.storage_type() == ttnn::types::StorageType::HOST) {
+        if (tensor.storage_type() == ttnn::StorageType::HOST) {
             if (tensor.layout() != tt::tt_metal::Layout::ROW_MAJOR) {
                 const auto row_major_tensor = convert_to_row_major(tensor);
                 const auto row_major_tensor_data = tt::tt_metal::host_buffer::get_as<MetalType const>(row_major_tensor);

--- a/tt-train/sources/ttml/nanobind/nb_util.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_util.cpp
@@ -292,11 +292,11 @@ nb::object make_numpy_tensor(
         if (tensor.storage_type() == ttnn::StorageType::HOST) {
             if (tensor.layout() != tt::tt_metal::Layout::ROW_MAJOR) {
                 const auto row_major_tensor = convert_to_row_major(tensor);
-                const auto row_major_tensor_data = tt::tt_metal::host_buffer::get_as<MetalType const>(row_major_tensor);
+                const auto row_major_tensor_data = ttnn::host_buffer::get_as<MetalType const>(row_major_tensor);
                 return make_numpy_tensor_from_data.template operator()<NumpyType>(
                     row_major_tensor_data, row_major_tensor.tensor_spec());
             }
-            const auto tensor_data = tt::tt_metal::host_buffer::get_as<const MetalType>(tensor);
+            const auto tensor_data = ttnn::host_buffer::get_as<const MetalType>(tensor);
             return make_numpy_tensor_from_data.template operator()<NumpyType>(tensor_data, tensor.tensor_spec());
         }
 
@@ -315,7 +315,7 @@ nb::object make_numpy_tensor(
             return make_numpy_tensor_from_data.template operator()<NumpyType>(vec, composed_spec);
         }
 
-        const auto cpu_tensor_data = tt::tt_metal::host_buffer::get_as<const MetalType>(cpu_tensor);
+        const auto cpu_tensor_data = ttnn::host_buffer::get_as<const MetalType>(cpu_tensor);
         const auto cpu_tensor_spec = cpu_tensor.tensor_spec();
         const auto cpu_tensor_strides = cpu_tensor.strides();
 

--- a/tt-train/sources/ttml/nanobind/nb_util.hpp
+++ b/tt-train/sources/ttml/nanobind/nb_util.hpp
@@ -15,19 +15,19 @@
 namespace ttml::nanobind::util {
 
 nb::object make_numpy_tensor(
-    const tt::tt_metal::Tensor& tensor,
+    const ttnn::Tensor& tensor,
     std::optional<tt::tt_metal::DataType> new_type = std::nullopt,
     const ttnn::distributed::MeshToTensor* composer = nullptr);
 
 // Fast path for standard NumPy dtypes (validated by nanobind)
-tt::tt_metal::Tensor make_metal_tensor(
+ttnn::Tensor make_metal_tensor(
     nb::ndarray<nb::numpy> data,
     tt::tt_metal::Layout layout = tt::tt_metal::Layout::TILE,
     std::optional<tt::tt_metal::DataType> new_type = std::nullopt,
     const ttnn::distributed::TensorToMesh* mapper = nullptr);
 
 // Fallback for custom dtypes (like ml_dtypes.bfloat16)
-tt::tt_metal::Tensor make_metal_tensor(
+ttnn::Tensor make_metal_tensor(
     nb::object data,
     tt::tt_metal::Layout layout = tt::tt_metal::Layout::TILE,
     std::optional<tt::tt_metal::DataType> new_type = std::nullopt,

--- a/tt-train/sources/ttml/ops/linear_op.cpp
+++ b/tt-train/sources/ttml/ops/linear_op.cpp
@@ -62,12 +62,11 @@ void moreh_linear_backward(
         tensor->get_value(),
         weight->get_value(),
         /* are required outputs */ std::vector<bool>{true, true, bias != nullptr},
-        bias != nullptr ? std::optional<tt::tt_metal::Tensor>(bias->get_value())
-                        : std::optional<tt::tt_metal::Tensor>(std::nullopt),
+        bias != nullptr ? std::optional<ttnn::Tensor>(bias->get_value()) : std::optional<ttnn::Tensor>(std::nullopt),
         tensor_grad,
         weight_grad,
-        bias ? std::optional<tt::tt_metal::Tensor>(ttnn::empty_like(bias->get_value()))
-             : std::optional<tt::tt_metal::Tensor>(std::nullopt),
+        bias ? std::optional<ttnn::Tensor>(ttnn::empty_like(bias->get_value()))
+             : std::optional<ttnn::Tensor>(std::nullopt),
         /* input_grad_mem_config */ std::nullopt,
         /* weight_grad_mem_config */ std::nullopt,
         /* bias_grad_mem_config */ std::nullopt,
@@ -98,8 +97,7 @@ autograd::TensorPtr linear_op(
     out->set_value(ttnn::linear(
         tensor->get_value(),
         weight->get_value(),
-        bias != nullptr ? std::optional<tt::tt_metal::Tensor>(bias->get_value())
-                        : std::optional<tt::tt_metal::Tensor>(std::nullopt),
+        bias != nullptr ? std::optional<ttnn::Tensor>(bias->get_value()) : std::optional<ttnn::Tensor>(std::nullopt),
         /* transpose_a */ false,
         /* tranpose_b */ true,
         /* memory_config */ std::nullopt,

--- a/tt-train/sources/ttml/ops/newton_schulz_op.cpp
+++ b/tt-train/sources/ttml/ops/newton_schulz_op.cpp
@@ -11,7 +11,7 @@
 
 namespace ttml::ops {
 
-tt::tt_metal::Tensor newtonschulz(const tt::tt_metal::Tensor& G, int steps, float eps, float a, float b, float c) {
+ttnn::Tensor newtonschulz(const ttnn::Tensor& G, int steps, float eps, float a, float b, float c) {
     ttnn::Tensor X = G;
 
     ttnn::Tensor squares = ttnn::square(X);
@@ -73,7 +73,7 @@ tt::tt_metal::Tensor newtonschulz(const tt::tt_metal::Tensor& G, int steps, floa
     return X;
 }
 
-tt::tt_metal::Tensor newtonschulz5(const tt::tt_metal::Tensor& G, int steps, float eps) {
+ttnn::Tensor newtonschulz5(const ttnn::Tensor& G, int steps, float eps) {
     return newtonschulz(G, steps, eps, 3.4445f, -4.7750f, 2.0315f);
 }
 

--- a/tt-train/sources/ttml/ops/newton_schulz_op.hpp
+++ b/tt-train/sources/ttml/ops/newton_schulz_op.hpp
@@ -7,8 +7,8 @@
 
 namespace ttml::ops {
 
-tt::tt_metal::Tensor newtonschulz5(const tt::tt_metal::Tensor& G, int steps = 5, float eps = 1e-7f);
+ttnn::Tensor newtonschulz5(const ttnn::Tensor& G, int steps = 5, float eps = 1e-7f);
 
-tt::tt_metal::Tensor newtonschulz(const tt::tt_metal::Tensor& G, int steps, float eps, float a, float b, float c);
+ttnn::Tensor newtonschulz(const ttnn::Tensor& G, int steps, float eps, float a, float b, float c);
 
 }  // namespace ttml::ops

--- a/tt-train/sources/ttml/ops/sampling_op.cpp
+++ b/tt-train/sources/ttml/ops/sampling_op.cpp
@@ -20,8 +20,7 @@ autograd::TensorPtr sample_op(
         logits->get_value(),
         temperature,
         seed,
-        logits_padding_mask == nullptr ? std::nullopt
-                                       : std::optional<tt::tt_metal::Tensor>(logits_padding_mask->get_value()));
+        logits_padding_mask == nullptr ? std::nullopt : std::optional<ttnn::Tensor>(logits_padding_mask->get_value()));
 
     auto out = autograd::create_tensor(sampled_tensor);
 

--- a/tt-train/sources/ttml/serialization/flatbuffer_file.cpp
+++ b/tt-train/sources/ttml/serialization/flatbuffer_file.cpp
@@ -205,7 +205,7 @@ void FlatBufferFile::serialize(std::string_view file_path) {
         ttnn::Tensor cpu_tensor = tensor.cpu();
 
         // Write tensor to file using tt-metal's dump function
-        tt::tt_metal::dump_tensor_flatbuffer(tensor_file.string(), cpu_tensor);
+        ttnn::dump_tensor_flatbuffer(tensor_file.string(), cpu_tensor);
     }
 
     // Build KeyValuePair for each entry in m_data (strings and vectors only)
@@ -566,7 +566,7 @@ void FlatBufferFile::deserialize(std::string_view filename) {
                         }
 
                         // Load tensor from file using tt-metal's load function
-                        ttnn::Tensor tensor = tt::tt_metal::load_tensor_flatbuffer(tensor_file.string(), nullptr);
+                        ttnn::Tensor tensor = ttnn::load_tensor_flatbuffer(tensor_file.string(), nullptr);
                         m_tensors[key] = tensor;
                     }
                 }

--- a/tt-train/sources/ttml/serialization/flatbuffer_file.cpp
+++ b/tt-train/sources/ttml/serialization/flatbuffer_file.cpp
@@ -175,7 +175,7 @@ void FlatBufferFile::put(std::string_view key, const ValueType& value) {
         value);
 }
 
-void FlatBufferFile::put(std::string_view key, const tt::tt_metal::Tensor& tensor) {
+void FlatBufferFile::put(std::string_view key, const ttnn::Tensor& tensor) {
     m_tensors[std::string(key)] = tensor;
 }
 
@@ -202,7 +202,7 @@ void FlatBufferFile::serialize(std::string_view file_path) {
         std::filesystem::path tensor_file = tensor_dir / (sanitized_key + DOT_TENSORBIN);
 
         // Convert tensor to CPU if needed
-        tt::tt_metal::Tensor cpu_tensor = tensor.cpu();
+        ttnn::Tensor cpu_tensor = tensor.cpu();
 
         // Write tensor to file using tt-metal's dump function
         tt::tt_metal::dump_tensor_flatbuffer(tensor_file.string(), cpu_tensor);
@@ -566,8 +566,7 @@ void FlatBufferFile::deserialize(std::string_view filename) {
                         }
 
                         // Load tensor from file using tt-metal's load function
-                        tt::tt_metal::Tensor tensor =
-                            tt::tt_metal::load_tensor_flatbuffer(tensor_file.string(), nullptr);
+                        ttnn::Tensor tensor = tt::tt_metal::load_tensor_flatbuffer(tensor_file.string(), nullptr);
                         m_tensors[key] = tensor;
                     }
                 }
@@ -626,7 +625,7 @@ ValueType FlatBufferFile::get_value_type(std::string_view key) const {
     }
 }
 
-tt::tt_metal::Tensor FlatBufferFile::get_tensor(std::string_view key) const {
+ttnn::Tensor FlatBufferFile::get_tensor(std::string_view key) const {
     auto it = m_tensors.find(std::string(key));
     if (it != m_tensors.end()) {
         return it->second;

--- a/tt-train/sources/ttml/serialization/flatbuffer_file.hpp
+++ b/tt-train/sources/ttml/serialization/flatbuffer_file.hpp
@@ -81,7 +81,7 @@ public:
     void put(std::string_view key, const ValueType& value);
 
     // Tensor support
-    void put(std::string_view key, const tt::tt_metal::Tensor& tensor);
+    void put(std::string_view key, const ttnn::Tensor& tensor);
 
     // Serialization method
     void serialize(std::string_view filename);
@@ -104,7 +104,7 @@ public:
     [[nodiscard]] ValueType get_value_type(std::string_view key) const;
 
     // Tensor support
-    [[nodiscard]] tt::tt_metal::Tensor get_tensor(std::string_view key) const;
+    [[nodiscard]] ttnn::Tensor get_tensor(std::string_view key) const;
 
 private:
     void deserialize_flatbuffer(std::span<const uint8_t> buffer);
@@ -124,7 +124,7 @@ private:
     }
 
     std::unordered_map<std::string, ValueType> m_data;
-    std::unordered_map<std::string, tt::tt_metal::Tensor> m_tensors;
+    std::unordered_map<std::string, ttnn::Tensor> m_tensors;
 
     // FlatBufferBuilder for incremental building - scalars are built directly
     flatbuffers::FlatBufferBuilder m_builder;

--- a/tt-train/sources/ttml/serialization/serialization.cpp
+++ b/tt-train/sources/ttml/serialization/serialization.cpp
@@ -72,7 +72,7 @@ void get_enum(FlatBufferFile& file, std::string_view name, T& value) {
     value = static_cast<T>(int_value);
 }
 
-void write_ttnn_tensor(FlatBufferFile& file, std::string_view name, const tt::tt_metal::Tensor& tensor) {
+void write_ttnn_tensor(FlatBufferFile& file, std::string_view name, const ttnn::Tensor& tensor) {
     // Store tensor in m_tensors - it will be written to file during serialize()
     // This ensures tensors are written to the correct directory
     file.put(name, tensor);
@@ -89,7 +89,7 @@ void write_ttnn_tensor(FlatBufferFile& file, std::string_view name, const tt::tt
     file.put(std::string(name) + "/storage_type", static_cast<int>(storage_type));
 }
 
-void read_ttnn_tensor(FlatBufferFile& file, std::string_view name, tt::tt_metal::Tensor& tensor) {
+void read_ttnn_tensor(FlatBufferFile& file, std::string_view name, ttnn::Tensor& tensor) {
     // Read tensor directly from m_tensors (loaded during deserialize)
     tensor = file.get_tensor(name);
 
@@ -137,7 +137,7 @@ void write_autograd_tensor(
 }
 
 void read_autograd_tensor(FlatBufferFile& file, std::string_view name, ttml::autograd::TensorPtr& tensor) {
-    tt::tt_metal::Tensor value;
+    ttnn::Tensor value;
     bool has_grads = false;
     bool requires_grads = false;
     read_ttnn_tensor(file, std::string(name) + "/value", value);
@@ -146,7 +146,7 @@ void read_autograd_tensor(FlatBufferFile& file, std::string_view name, ttml::aut
     has_grads = file.get_bool(std::string(name) + "/has_grads");
     tensor->set_requires_grad(requires_grads);
     if (has_grads) {
-        tt::tt_metal::Tensor grad;
+        ttnn::Tensor grad;
         read_ttnn_tensor(file, std::string(name) + "/grad", grad);
         tensor->set_grad(grad);
     }

--- a/tt-train/sources/ttml/serialization/serialization.cpp
+++ b/tt-train/sources/ttml/serialization/serialization.cpp
@@ -115,11 +115,10 @@ void read_ttnn_tensor(FlatBufferFile& file, std::string_view name, ttnn::Tensor&
     }
 
     // Restore storage type if needed
-    tt::tt_metal::StorageType storage_type{};
+    ttnn::StorageType storage_type{};
     get_enum(file, std::string(name) + "/storage_type", storage_type);
 
-    if (storage_type == tt::tt_metal::StorageType::DEVICE &&
-        tensor.storage_type() != tt::tt_metal::StorageType::DEVICE) {
+    if (storage_type == ttnn::StorageType::DEVICE && tensor.storage_type() != ttnn::StorageType::DEVICE) {
         tensor = tensor.to_device(&ttml::autograd::ctx().get_device());
     }
 }

--- a/tt-train/sources/ttml/serialization/serialization.hpp
+++ b/tt-train/sources/ttml/serialization/serialization.hpp
@@ -16,8 +16,8 @@ class OptimizerBase;
 namespace ttml::serialization {
 class FlatBufferFile;
 
-void write_ttnn_tensor(FlatBufferFile& file, std::string_view name, const tt::tt_metal::Tensor& tensor);
-void read_ttnn_tensor(FlatBufferFile& file, std::string_view name, tt::tt_metal::Tensor& tensor);
+void write_ttnn_tensor(FlatBufferFile& file, std::string_view name, const ttnn::Tensor& tensor);
+void read_ttnn_tensor(FlatBufferFile& file, std::string_view name, ttnn::Tensor& tensor);
 
 void write_autograd_tensor(
     FlatBufferFile& file, std::string_view name, const ttml::autograd::TensorPtr& tensor, bool save_grads = false);

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
@@ -82,8 +82,7 @@ ttnn::ccl::Topology get_topology(const std::optional<uint32_t>& cluster_axis) {
 
 }  // namespace
 
-tt::tt_metal::Tensor all_gather(
-    const tt::tt_metal::Tensor& tensor, const int dim, const std::optional<uint32_t> cluster_axis) {
+ttnn::Tensor all_gather(const ttnn::Tensor& tensor, const int dim, const std::optional<uint32_t> cluster_axis) {
     auto* mesh_device = &ttml::autograd::ctx().get_device();
     auto num_devices = mesh_device->num_devices();
     if (num_devices == 1U) {
@@ -111,7 +110,7 @@ tt::tt_metal::Tensor all_gather(
         /* barrier_semaphore */ ccl_resources.get_barrier_semaphore());
 }
 
-tt::tt_metal::Tensor all_reduce(const tt::tt_metal::Tensor& tensor, const std::optional<uint32_t> cluster_axis) {
+ttnn::Tensor all_reduce(const ttnn::Tensor& tensor, const std::optional<uint32_t> cluster_axis) {
     auto* mesh_device = &ttml::autograd::ctx().get_device();
     auto num_devices = mesh_device->num_devices();
     if (num_devices == 1U) {
@@ -163,8 +162,7 @@ tt::tt_metal::Tensor all_reduce(const tt::tt_metal::Tensor& tensor, const std::o
     }
 }
 
-tt::tt_metal::Tensor reduce_scatter(
-    const tt::tt_metal::Tensor& tensor, const int dim, const std::optional<uint32_t> cluster_axis) {
+ttnn::Tensor reduce_scatter(const ttnn::Tensor& tensor, const int dim, const std::optional<uint32_t> cluster_axis) {
     auto& ccl_resources = ttml::autograd::ctx().get_ccl_resources();
     auto& mesh_device = ttml::autograd::ctx().get_device();
     uint32_t num_links = ttnn::operations::ccl::common::get_num_links(mesh_device, /* cluster_axis */ cluster_axis);
@@ -187,10 +185,8 @@ tt::tt_metal::Tensor reduce_scatter(
         /* cluster_axis */ cluster_axis);
 }
 
-tt::tt_metal::Tensor ring_shift(
-    const tt::tt_metal::Tensor& tensor,
-    const std::optional<uint32_t> cluster_axis,
-    const RingShiftDirection direction) {
+ttnn::Tensor ring_shift(
+    const ttnn::Tensor& tensor, const std::optional<uint32_t> cluster_axis, const RingShiftDirection direction) {
     auto& ctx = ttml::autograd::ctx();
     auto& socket_manager = ctx.get_socket_manager();
     auto distributed_ctx = ctx.get_distributed_context();

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.hpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.hpp
@@ -7,12 +7,11 @@
 
 namespace ttml::ttnn_fixed::distributed {
 
-tt::tt_metal::Tensor all_gather(
-    const tt::tt_metal::Tensor& tensor, const int dim, const std::optional<uint32_t> cluster_axis = std::nullopt);
-tt::tt_metal::Tensor all_reduce(
-    const tt::tt_metal::Tensor& tensor, const std::optional<uint32_t> cluster_axis = std::nullopt);
-tt::tt_metal::Tensor reduce_scatter(
-    const tt::tt_metal::Tensor& tensor, const int dim, const std::optional<uint32_t> cluster_axis = std::nullopt);
+ttnn::Tensor all_gather(
+    const ttnn::Tensor& tensor, const int dim, const std::optional<uint32_t> cluster_axis = std::nullopt);
+ttnn::Tensor all_reduce(const ttnn::Tensor& tensor, const std::optional<uint32_t> cluster_axis = std::nullopt);
+ttnn::Tensor reduce_scatter(
+    const ttnn::Tensor& tensor, const int dim, const std::optional<uint32_t> cluster_axis = std::nullopt);
 
 /**
  * Direction for ring shift operation.
@@ -36,8 +35,8 @@ enum class RingShiftDirection {
  * @param direction Direction to shift: Forward (i -> i+1) or Backward (i -> i-1)
  * @return The tensor received from the neighbor device
  */
-tt::tt_metal::Tensor ring_shift(
-    const tt::tt_metal::Tensor& tensor,
+ttnn::Tensor ring_shift(
+    const ttnn::Tensor& tensor,
     const std::optional<uint32_t> cluster_axis = std::nullopt,
     const RingShiftDirection direction = RingShiftDirection::Forward);
 

--- a/tt-train/sources/ttml/ttnn_fixed/matmuls.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/matmuls.cpp
@@ -7,12 +7,12 @@
 #include "core/compute_kernel_config.hpp"
 
 namespace ttml::ttnn_fixed {
-tt::tt_metal::Tensor matmul(
-    const tt::tt_metal::Tensor& a,
-    const tt::tt_metal::Tensor& b,
+ttnn::Tensor matmul(
+    const ttnn::Tensor& a,
+    const ttnn::Tensor& b,
     bool transpose_a,
     bool transpose_b,
-    std::optional<tt::tt_metal::Tensor> output_tensor) {
+    std::optional<ttnn::Tensor> output_tensor) {
     const auto grid_size = a.device()->compute_with_storage_grid_size();
     auto core_grid = std::make_optional<ttnn::CoreGrid>(grid_size.x, grid_size.y);
 
@@ -32,12 +32,8 @@ tt::tt_metal::Tensor matmul(
         /* optional_output_tensor */ std::move(output_tensor));
 }
 
-std::pair<tt::tt_metal::Tensor, tt::tt_metal::Tensor> matmul_backward(
-    const tt::tt_metal::Tensor& a,
-    const tt::tt_metal::Tensor& b,
-    const tt::tt_metal::Tensor& out_grad,
-    bool transpose_a,
-    bool transpose_b) {
+std::pair<ttnn::Tensor, ttnn::Tensor> matmul_backward(
+    const ttnn::Tensor& a, const ttnn::Tensor& b, const ttnn::Tensor& out_grad, bool transpose_a, bool transpose_b) {
     auto a_shape = a.logical_shape();
     auto b_shape = b.logical_shape();
     auto grad_shape = out_grad.logical_shape();
@@ -55,27 +51,29 @@ std::pair<tt::tt_metal::Tensor, tt::tt_metal::Tensor> matmul_backward(
         // A was used as is.
         // grad_A = reshaped_grad * ( (transpose_b ? B^T : B) )^T.
         // If transpose_b is false: (B)^T = B^T, if true: (B^T)^T = B.
-        reshaped_a_grad = matmul(reshaped_grad, b, false, !transpose_b);
+        reshaped_a_grad = ttml::ttnn_fixed::matmul(reshaped_grad, b, false, !transpose_b);
     } else {
         // A was transposed in the forward pass (i.e. we used A^T).
         // Compute dA_eff = reshaped_grad * ( (transpose_b ? B^T : B) )^T.
         // Then grad_A = (dA_eff)^T = ( (transpose_b ? B^T : B) ) * reshaped_grad^T.
         if (!transpose_b)
-            reshaped_a_grad = matmul(b, reshaped_grad, false, true);  // B as is, reshaped_grad transposed.
+            reshaped_a_grad =
+                ttml::ttnn_fixed::matmul(b, reshaped_grad, false, true);  // B as is, reshaped_grad transposed.
         else
-            reshaped_a_grad = matmul(b, reshaped_grad, true, true);  // B transposed, reshaped_grad transposed.
+            reshaped_a_grad =
+                ttml::ttnn_fixed::matmul(b, reshaped_grad, true, true);  // B transposed, reshaped_grad transposed.
     }
 
     if (!transpose_b) {
         // B was used as is.
         // grad_B = ( (transpose_a ? A^T : A) )^T * d_out.
         // If transpose_a is false: (A)^T = A^T, if true: (A^T)^T = A.
-        reshaped_b_grad = matmul(reshaped_a, reshaped_grad, !transpose_a, false);
+        reshaped_b_grad = ttml::ttnn_fixed::matmul(reshaped_a, reshaped_grad, !transpose_a, false);
     } else {
         // B was transposed in the forward pass (i.e. we used B^T).
         // Compute dB_eff = ( (transpose_a ? A^T : A) )^T * d_out,
         // then grad_B = (dB_eff)^T = d_out^T * (transpose_a ? A^T : A).
-        reshaped_b_grad = matmul(reshaped_grad, reshaped_a, true, transpose_a);
+        reshaped_b_grad = ttml::ttnn_fixed::matmul(reshaped_grad, reshaped_a, true, transpose_a);
     }
     auto a_grad = ttnn::reshape(reshaped_a_grad, a_shape);
     auto b_grad = ttnn::reshape(reshaped_b_grad, b_shape);

--- a/tt-train/sources/ttml/ttnn_fixed/matmuls.hpp
+++ b/tt-train/sources/ttml/ttnn_fixed/matmuls.hpp
@@ -6,17 +6,17 @@
 #include <core/ttnn_all_includes.hpp>
 
 namespace ttml::ttnn_fixed {
-tt::tt_metal::Tensor matmul(
-    const tt::tt_metal::Tensor& a,
-    const tt::tt_metal::Tensor& b,
+ttnn::Tensor matmul(
+    const ttnn::Tensor& a,
+    const ttnn::Tensor& b,
     bool transpose_a = false,
     bool transpose_b = false,
-    std::optional<tt::tt_metal::Tensor> output_tensor = std::nullopt);
+    std::optional<ttnn::Tensor> output_tensor = std::nullopt);
 
-std::pair<tt::tt_metal::Tensor, tt::tt_metal::Tensor> matmul_backward(
-    const tt::tt_metal::Tensor& a,
-    const tt::tt_metal::Tensor& b,
-    const tt::tt_metal::Tensor& out_grad,
+std::pair<ttnn::Tensor, ttnn::Tensor> matmul_backward(
+    const ttnn::Tensor& a,
+    const ttnn::Tensor& b,
+    const ttnn::Tensor& out_grad,
     bool transpose_a = false,
     bool transpose_b = false);
 }  // namespace ttml::ttnn_fixed

--- a/tt-train/sources/ttml/ttnn_fixed/trivial_ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/trivial_ttnn_ops.cpp
@@ -22,16 +22,16 @@
 
 namespace ttml::ttnn_fixed {
 
-tt::tt_metal::Tensor sum_over_dim(const tt::tt_metal::Tensor& t, uint32_t dim) {
+ttnn::Tensor sum_over_dim(const ttnn::Tensor& t, uint32_t dim) {
     return sum_moreh(t, dim, /* keepdim */ true);
 }
 
-tt::tt_metal::Tensor sum_over_batch(const tt::tt_metal::Tensor& t) {
+ttnn::Tensor sum_over_batch(const ttnn::Tensor& t) {
     return sum_over_dim(t, /* dim */ 0);
 }
 
 // Stable log-softmax implementation
-tt::tt_metal::Tensor log_softmax(const tt::tt_metal::Tensor& t, int dim) {
+ttnn::Tensor log_softmax(const ttnn::Tensor& t, int dim) {
     auto t_max = ttnn::max(t, dim, /* keepdim */ true);
     auto t_sub_max = ttnn::subtract(t, t_max);
 
@@ -44,7 +44,7 @@ tt::tt_metal::Tensor log_softmax(const tt::tt_metal::Tensor& t, int dim) {
 
 // Stable softmax implementation
 // ttnn::softmax also exists, but it is not stable (even after max subtraction optimization)
-tt::tt_metal::Tensor softmax(const tt::tt_metal::Tensor& t, int dim) {
+ttnn::Tensor softmax(const ttnn::Tensor& t, int dim) {
     return ttnn::softmax(
         t,
         /* dim */ dim,
@@ -53,12 +53,12 @@ tt::tt_metal::Tensor softmax(const tt::tt_metal::Tensor& t, int dim) {
         /*stable*/ true);
 }
 
-tt::tt_metal::Tensor divide(const tt::tt_metal::Tensor& a, const tt::tt_metal::Tensor& b) {
+ttnn::Tensor divide(const ttnn::Tensor& a, const ttnn::Tensor& b) {
     auto inv_b = ttnn::reciprocal(b);
     return ttnn::multiply(a, inv_b);
 }
 
-tt::tt_metal::Tensor mean_moreh(const tt::tt_metal::Tensor& t, int dim, bool keep_dim) {
+ttnn::Tensor mean_moreh(const ttnn::Tensor& t, int dim, bool keep_dim) {
     auto res = ttnn::moreh_mean(
         t,
         dim,
@@ -69,11 +69,11 @@ tt::tt_metal::Tensor mean_moreh(const tt::tt_metal::Tensor& t, int dim, bool kee
         /* device_compute_kernel_config */ core::ComputeKernelConfig::precise());
     return res;
 }
-tt::tt_metal::Tensor mean_ttnn(const tt::tt_metal::Tensor& t, int dim, bool keep_dim) {
+ttnn::Tensor mean_ttnn(const ttnn::Tensor& t, int dim, bool keep_dim) {
     return ttnn::mean(t, dim, keep_dim, std::nullopt, core::ComputeKernelConfig::precise());
 }
 
-tt::tt_metal::Tensor sum_moreh(const tt::tt_metal::Tensor& t, int dim, bool keep_dim) {
+ttnn::Tensor sum_moreh(const ttnn::Tensor& t, int dim, bool keep_dim) {
     return ttnn::moreh_sum(
         t,
         dim,
@@ -82,15 +82,12 @@ tt::tt_metal::Tensor sum_moreh(const tt::tt_metal::Tensor& t, int dim, bool keep
         std::nullopt,
         /* device_compute_kernel_config */ core::ComputeKernelConfig::precise());
 }
-tt::tt_metal::Tensor sum_ttnn(const tt::tt_metal::Tensor& t, int dim, bool keep_dim) {
+ttnn::Tensor sum_ttnn(const ttnn::Tensor& t, int dim, bool keep_dim) {
     return ttnn::sum(t, dim, keep_dim, std::nullopt, core::ComputeKernelConfig::precise());
 }
 
-tt::tt_metal::Tensor sample(
-    const tt::tt_metal::Tensor& t,
-    float temperature,
-    uint32_t seed,
-    std::optional<tt::tt_metal::Tensor> logits_padding_mask) {
+ttnn::Tensor sample(
+    const ttnn::Tensor& t, float temperature, uint32_t seed, std::optional<ttnn::Tensor> logits_padding_mask) {
     auto* device = &ttml::autograd::ctx().get_device();
 
     ttnn::Tensor out = t;
@@ -121,11 +118,11 @@ tt::tt_metal::Tensor sample(
     return ttnn::argmax(ttnn::untilize(out), 3, true, std::nullopt, true);
 }
 
-tt::tt_metal::Tensor to_l1_interleaved(const tt::tt_metal::Tensor& t) {
+ttnn::Tensor to_l1_interleaved(const ttnn::Tensor& t) {
     return ttnn::to_memory_config(t, ttnn::L1_MEMORY_CONFIG);
 }
 
-tt::tt_metal::Tensor to_dram_interleaved(const tt::tt_metal::Tensor& t) {
+ttnn::Tensor to_dram_interleaved(const ttnn::Tensor& t) {
     return ttnn::to_memory_config(t, ttnn::DRAM_MEMORY_CONFIG);
 }
 

--- a/tt-train/sources/ttml/ttnn_fixed/trivial_ttnn_ops.hpp
+++ b/tt-train/sources/ttml/ttnn_fixed/trivial_ttnn_ops.hpp
@@ -9,25 +9,25 @@
 
 namespace ttml::ttnn_fixed {
 
-tt::tt_metal::Tensor sum_over_dim(const tt::tt_metal::Tensor& t, uint32_t dim);
-tt::tt_metal::Tensor sum_over_batch(const tt::tt_metal::Tensor& t);
-tt::tt_metal::Tensor log_softmax(const tt::tt_metal::Tensor& t, int dim);
-tt::tt_metal::Tensor softmax(const tt::tt_metal::Tensor& t, int dim);
-tt::tt_metal::Tensor divide(const tt::tt_metal::Tensor& a, const tt::tt_metal::Tensor& b);
+ttnn::Tensor sum_over_dim(const ttnn::Tensor& t, uint32_t dim);
+ttnn::Tensor sum_over_batch(const ttnn::Tensor& t);
+ttnn::Tensor log_softmax(const ttnn::Tensor& t, int dim);
+ttnn::Tensor softmax(const ttnn::Tensor& t, int dim);
+ttnn::Tensor divide(const ttnn::Tensor& a, const ttnn::Tensor& b);
 
-tt::tt_metal::Tensor mean_moreh(const tt::tt_metal::Tensor& t, int dim, bool keep_dim);
-tt::tt_metal::Tensor mean_ttnn(const tt::tt_metal::Tensor& t, int dim, bool keep_dim);
+ttnn::Tensor mean_moreh(const ttnn::Tensor& t, int dim, bool keep_dim);
+ttnn::Tensor mean_ttnn(const ttnn::Tensor& t, int dim, bool keep_dim);
 
-tt::tt_metal::Tensor sum_moreh(const tt::tt_metal::Tensor& t, int dim, bool keep_dim);
-tt::tt_metal::Tensor sum_ttnn(const tt::tt_metal::Tensor& t, int dim, bool keep_dim);
+ttnn::Tensor sum_moreh(const ttnn::Tensor& t, int dim, bool keep_dim);
+ttnn::Tensor sum_ttnn(const ttnn::Tensor& t, int dim, bool keep_dim);
 
-tt::tt_metal::Tensor sample(
-    const tt::tt_metal::Tensor& t,
+ttnn::Tensor sample(
+    const ttnn::Tensor& t,
     float temperature,
     uint32_t seed,
-    std::optional<tt::tt_metal::Tensor> logits_padding_mask = std::nullopt);
+    std::optional<ttnn::Tensor> logits_padding_mask = std::nullopt);
 
-tt::tt_metal::Tensor to_l1_interleaved(const tt::tt_metal::Tensor& t);
-tt::tt_metal::Tensor to_dram_interleaved(const tt::tt_metal::Tensor& t);
+ttnn::Tensor to_l1_interleaved(const ttnn::Tensor& t);
+ttnn::Tensor to_dram_interleaved(const ttnn::Tensor& t);
 
 }  // namespace ttml::ttnn_fixed

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -261,7 +261,7 @@ TEST_F(N300UtilsTest, MorehClipGradNorm) {
     auto tensor = ttml::core::from_xtensor(xtensor, device, ttnn::Layout::TILE, mapper.get());
     auto do_it = [&tensor]() {
         ttnn::moreh_clip_grad_norm(
-            std::vector<tt::tt_metal::Tensor>{tensor},
+            std::vector<ttnn::Tensor>{tensor},
             1.0F,
             2.0F,
             false,

--- a/tt-train/tests/core/tensor_utils_test.cpp
+++ b/tt-train/tests/core/tensor_utils_test.cpp
@@ -448,7 +448,7 @@ TEST_F(TensorUtilsTest, TestZeros) {
 TEST_F(TensorUtilsTest, TestIsInitialized) {
     auto* device = &ttml::autograd::ctx().get_device();
 
-    tt::tt_metal::Tensor tensor;
+    ttnn::Tensor tensor;
     EXPECT_FALSE(ttml::core::is_tensor_initialized(tensor));
 
     auto shape = ttnn::Shape({1, 2, 3, 4});

--- a/tt-train/tests/optimizers/adamw_full_precision_test.cpp
+++ b/tt-train/tests/optimizers/adamw_full_precision_test.cpp
@@ -67,7 +67,7 @@ static ttnn::Tensor to_tt_bf16(const xt::xarray<bfloat16>& x) {
 // NOTE: ttml::core::from_xtensor() performs fp32 -> bf16 conversion, that's why this function exists
 static ttnn::Tensor to_tt_fp32(const xt::xarray<float>& x) {
     auto* device = &ttml::autograd::ctx().get_device();
-    auto shape = tt::tt_metal::experimental::xtensor::get_shape_from_xarray(x);
+    auto shape = ttnn::experimental::xtensor::get_shape_from_xarray(x);
     auto buffer_span = ttml::core::xtensor_to_span(x);
 
     ttnn::MemoryConfig output_mem_config{};

--- a/tt-train/tests/serialization/flatbuffer_serializer_test.cpp
+++ b/tt-train/tests/serialization/flatbuffer_serializer_test.cpp
@@ -388,14 +388,14 @@ std::vector<T> make_serializer_fuzz_data(size_t size, uint32_t seed) {
 // storage_type: Storage type (HOST or DEVICE)
 // seed: Random seed for reproducibility
 // device: Target device for tensor creation
-tt::tt_metal::Tensor create_random_tensor(
+ttnn::Tensor create_random_tensor(
     const ttnn::Shape& shape,
     tt::tt_metal::DataType dtype,
     ttnn::Layout layout,
     tt::tt_metal::StorageType storage_type,
     uint32_t seed,
     ttnn::distributed::MeshDevice* device) {
-    tt::tt_metal::Tensor tensor;
+    ttnn::Tensor tensor;
 
     switch (dtype) {
         case tt::tt_metal::DataType::BFLOAT16: {
@@ -588,7 +588,7 @@ TEST_P(FlatBufferFileSerializationTest, ScopedTempDirWriteReadRoundTrip) {
     std::string tensor_filename_read = tensor_filename;
     ASSERT_TRUE(std::filesystem::exists(tensor_filename_read)) << "Tensor file should exist: " << tensor_filename_read;
 
-    tt::tt_metal::Tensor read_tensor;
+    ttnn::Tensor read_tensor;
     // For HOST tensors, pass nullptr to load as CPU tensor
     // For DEVICE tensors, pass device to load and then move to device
     auto* load_device = (test_case.storage_type == tt::tt_metal::StorageType::DEVICE) ? device : nullptr;

--- a/tt-train/tests/serialization/flatbuffer_serializer_test.cpp
+++ b/tt-train/tests/serialization/flatbuffer_serializer_test.cpp
@@ -523,7 +523,7 @@ TEST_P(FlatBufferFileSerializationTest, ScopedTempDirWriteReadRoundTrip) {
     std::string tensor_filename = (temp_dir / (test_case.name + ".tensorbin")).string();
 
     // Use tt-metal's dump_tensor_flatbuffer to write tensor to file
-    tt::tt_metal::dump_tensor_flatbuffer(tensor_filename, tensor);
+    ttnn::dump_tensor_flatbuffer(tensor_filename, tensor);
 
     // Store metadata in FlatBufferFile for reference
     serializer.put(test_case.name + "/tensor_file", std::string_view(tensor_filename));
@@ -590,7 +590,7 @@ TEST_P(FlatBufferFileSerializationTest, ScopedTempDirWriteReadRoundTrip) {
     // For HOST tensors, pass nullptr to load as CPU tensor
     // For DEVICE tensors, pass device to load and then move to device
     auto* load_device = (test_case.storage_type == ttnn::StorageType::DEVICE) ? device : nullptr;
-    ASSERT_NO_THROW(read_tensor = tt::tt_metal::load_tensor_flatbuffer(tensor_filename_read, load_device));
+    ASSERT_NO_THROW(read_tensor = ttnn::load_tensor_flatbuffer(tensor_filename_read, load_device));
 
     // Restore original layout if needed
     tt::tt_metal::Layout original_layout = test_case.layout;

--- a/tt-train/tests/serialization/flatbuffer_serializer_test.cpp
+++ b/tt-train/tests/serialization/flatbuffer_serializer_test.cpp
@@ -392,7 +392,7 @@ ttnn::Tensor create_random_tensor(
     const ttnn::Shape& shape,
     tt::tt_metal::DataType dtype,
     ttnn::Layout layout,
-    tt::tt_metal::StorageType storage_type,
+    ttnn::StorageType storage_type,
     uint32_t seed,
     ttnn::distributed::MeshDevice* device) {
     ttnn::Tensor tensor;
@@ -431,11 +431,9 @@ ttnn::Tensor create_random_tensor(
         default: throw std::runtime_error("Unsupported dtype for random tensor generation");
     }
 
-    if (storage_type == tt::tt_metal::StorageType::HOST && tensor.storage_type() != tt::tt_metal::StorageType::HOST) {
+    if (storage_type == ttnn::StorageType::HOST && tensor.storage_type() != ttnn::StorageType::HOST) {
         tensor = tensor.cpu();
-    } else if (
-        storage_type == tt::tt_metal::StorageType::DEVICE &&
-        tensor.storage_type() != tt::tt_metal::StorageType::DEVICE) {
+    } else if (storage_type == ttnn::StorageType::DEVICE && tensor.storage_type() != ttnn::StorageType::DEVICE) {
         tensor = tensor.to_device(device);
     }
 
@@ -445,7 +443,7 @@ ttnn::Tensor create_random_tensor(
 struct TensorTestCase {
     tt::tt_metal::DataType dtype;
     ttnn::Layout layout;
-    tt::tt_metal::StorageType storage_type;
+    ttnn::StorageType storage_type;
     std::string name;
 };
 
@@ -474,7 +472,7 @@ std::string to_string(const TensorTestCase& test_case) {
     result += "_";
 
     // Print storage type
-    result += (test_case.storage_type == tt::tt_metal::StorageType::DEVICE ? "DEVICE" : "HOST");
+    result += (test_case.storage_type == ttnn::StorageType::DEVICE ? "DEVICE" : "HOST");
 
     return result;
 }
@@ -591,7 +589,7 @@ TEST_P(FlatBufferFileSerializationTest, ScopedTempDirWriteReadRoundTrip) {
     ttnn::Tensor read_tensor;
     // For HOST tensors, pass nullptr to load as CPU tensor
     // For DEVICE tensors, pass device to load and then move to device
-    auto* load_device = (test_case.storage_type == tt::tt_metal::StorageType::DEVICE) ? device : nullptr;
+    auto* load_device = (test_case.storage_type == ttnn::StorageType::DEVICE) ? device : nullptr;
     ASSERT_NO_THROW(read_tensor = tt::tt_metal::load_tensor_flatbuffer(tensor_filename_read, load_device));
 
     // Restore original layout if needed
@@ -602,12 +600,11 @@ TEST_P(FlatBufferFileSerializationTest, ScopedTempDirWriteReadRoundTrip) {
 
     // Restore storage type if needed
     // load_tensor_flatbuffer loads tensors as HOST by default, so we need to restore device storage type
-    if (test_case.storage_type == tt::tt_metal::StorageType::DEVICE &&
-        read_tensor.storage_type() != tt::tt_metal::StorageType::DEVICE) {
+    if (test_case.storage_type == ttnn::StorageType::DEVICE &&
+        read_tensor.storage_type() != ttnn::StorageType::DEVICE) {
         read_tensor = read_tensor.to_device(device);
     } else if (
-        test_case.storage_type == tt::tt_metal::StorageType::HOST &&
-        read_tensor.storage_type() != tt::tt_metal::StorageType::HOST) {
+        test_case.storage_type == ttnn::StorageType::HOST && read_tensor.storage_type() != ttnn::StorageType::HOST) {
         // Ensure HOST tensors are on CPU
         read_tensor = read_tensor.cpu();
     }
@@ -667,69 +664,38 @@ INSTANTIATE_TEST_SUITE_P(
     FlatBufferFileSerializationTest,
     ::testing::Values(
         TensorTestCase{
-            tt::tt_metal::DataType::BFLOAT16,
-            ttnn::Layout::ROW_MAJOR,
-            tt::tt_metal::StorageType::DEVICE,
-            "bf16_row_device"},
+            tt::tt_metal::DataType::BFLOAT16, ttnn::Layout::ROW_MAJOR, ttnn::StorageType::DEVICE, "bf16_row_device"},
         TensorTestCase{
-            tt::tt_metal::DataType::BFLOAT16,
-            ttnn::Layout::TILE,
-            tt::tt_metal::StorageType::DEVICE,
-            "bf16_tile_device"},
+            tt::tt_metal::DataType::BFLOAT16, ttnn::Layout::TILE, ttnn::StorageType::DEVICE, "bf16_tile_device"},
         TensorTestCase{
-            tt::tt_metal::DataType::BFLOAT16,
-            ttnn::Layout::ROW_MAJOR,
-            tt::tt_metal::StorageType::HOST,
-            "bf16_row_host"},
+            tt::tt_metal::DataType::BFLOAT16, ttnn::Layout::ROW_MAJOR, ttnn::StorageType::HOST, "bf16_row_host"},
+        TensorTestCase{tt::tt_metal::DataType::BFLOAT16, ttnn::Layout::TILE, ttnn::StorageType::HOST, "bf16_tile_host"},
         TensorTestCase{
-            tt::tt_metal::DataType::BFLOAT16, ttnn::Layout::TILE, tt::tt_metal::StorageType::HOST, "bf16_tile_host"},
+            tt::tt_metal::DataType::FLOAT32, ttnn::Layout::ROW_MAJOR, ttnn::StorageType::DEVICE, "f32_row_device"},
         TensorTestCase{
-            tt::tt_metal::DataType::FLOAT32,
-            ttnn::Layout::ROW_MAJOR,
-            tt::tt_metal::StorageType::DEVICE,
-            "f32_row_device"},
+            tt::tt_metal::DataType::FLOAT32, ttnn::Layout::TILE, ttnn::StorageType::DEVICE, "f32_tile_device"},
         TensorTestCase{
-            tt::tt_metal::DataType::FLOAT32, ttnn::Layout::TILE, tt::tt_metal::StorageType::DEVICE, "f32_tile_device"},
+            tt::tt_metal::DataType::FLOAT32, ttnn::Layout::ROW_MAJOR, ttnn::StorageType::HOST, "f32_row_host"},
+        TensorTestCase{tt::tt_metal::DataType::FLOAT32, ttnn::Layout::TILE, ttnn::StorageType::HOST, "f32_tile_host"},
         TensorTestCase{
-            tt::tt_metal::DataType::FLOAT32, ttnn::Layout::ROW_MAJOR, tt::tt_metal::StorageType::HOST, "f32_row_host"},
+            tt::tt_metal::DataType::UINT32, ttnn::Layout::ROW_MAJOR, ttnn::StorageType::DEVICE, "u32_row_device"},
         TensorTestCase{
-            tt::tt_metal::DataType::FLOAT32, ttnn::Layout::TILE, tt::tt_metal::StorageType::HOST, "f32_tile_host"},
+            tt::tt_metal::DataType::UINT32, ttnn::Layout::TILE, ttnn::StorageType::DEVICE, "u32_tile_device"},
         TensorTestCase{
-            tt::tt_metal::DataType::UINT32,
-            ttnn::Layout::ROW_MAJOR,
-            tt::tt_metal::StorageType::DEVICE,
-            "u32_row_device"},
+            tt::tt_metal::DataType::UINT32, ttnn::Layout::ROW_MAJOR, ttnn::StorageType::HOST, "u32_row_host"},
+        TensorTestCase{tt::tt_metal::DataType::UINT32, ttnn::Layout::TILE, ttnn::StorageType::HOST, "u32_tile_host"},
         TensorTestCase{
-            tt::tt_metal::DataType::UINT32, ttnn::Layout::TILE, tt::tt_metal::StorageType::DEVICE, "u32_tile_device"},
+            tt::tt_metal::DataType::INT32, ttnn::Layout::ROW_MAJOR, ttnn::StorageType::DEVICE, "i32_row_device"},
+        TensorTestCase{tt::tt_metal::DataType::INT32, ttnn::Layout::TILE, ttnn::StorageType::DEVICE, "i32_tile_device"},
+        TensorTestCase{tt::tt_metal::DataType::INT32, ttnn::Layout::ROW_MAJOR, ttnn::StorageType::HOST, "i32_row_host"},
+        TensorTestCase{tt::tt_metal::DataType::INT32, ttnn::Layout::TILE, ttnn::StorageType::HOST, "i32_tile_host"},
         TensorTestCase{
-            tt::tt_metal::DataType::UINT32, ttnn::Layout::ROW_MAJOR, tt::tt_metal::StorageType::HOST, "u32_row_host"},
+            tt::tt_metal::DataType::BFLOAT8_B, ttnn::Layout::TILE, ttnn::StorageType::DEVICE, "bf8_tile_device"},
+        TensorTestCase{tt::tt_metal::DataType::BFLOAT8_B, ttnn::Layout::TILE, ttnn::StorageType::HOST, "bf8_tile_host"},
         TensorTestCase{
-            tt::tt_metal::DataType::UINT32, ttnn::Layout::TILE, tt::tt_metal::StorageType::HOST, "u32_tile_host"},
+            tt::tt_metal::DataType::BFLOAT4_B, ttnn::Layout::TILE, ttnn::StorageType::DEVICE, "bf4_tile_device"},
         TensorTestCase{
-            tt::tt_metal::DataType::INT32,
-            ttnn::Layout::ROW_MAJOR,
-            tt::tt_metal::StorageType::DEVICE,
-            "i32_row_device"},
-        TensorTestCase{
-            tt::tt_metal::DataType::INT32, ttnn::Layout::TILE, tt::tt_metal::StorageType::DEVICE, "i32_tile_device"},
-        TensorTestCase{
-            tt::tt_metal::DataType::INT32, ttnn::Layout::ROW_MAJOR, tt::tt_metal::StorageType::HOST, "i32_row_host"},
-        TensorTestCase{
-            tt::tt_metal::DataType::INT32, ttnn::Layout::TILE, tt::tt_metal::StorageType::HOST, "i32_tile_host"},
-        TensorTestCase{
-            tt::tt_metal::DataType::BFLOAT8_B,
-            ttnn::Layout::TILE,
-            tt::tt_metal::StorageType::DEVICE,
-            "bf8_tile_device"},
-        TensorTestCase{
-            tt::tt_metal::DataType::BFLOAT8_B, ttnn::Layout::TILE, tt::tt_metal::StorageType::HOST, "bf8_tile_host"},
-        TensorTestCase{
-            tt::tt_metal::DataType::BFLOAT4_B,
-            ttnn::Layout::TILE,
-            tt::tt_metal::StorageType::DEVICE,
-            "bf4_tile_device"},
-        TensorTestCase{
-            tt::tt_metal::DataType::BFLOAT4_B, ttnn::Layout::TILE, tt::tt_metal::StorageType::HOST, "bf4_tile_host"}),
+            tt::tt_metal::DataType::BFLOAT4_B, ttnn::Layout::TILE, ttnn::StorageType::HOST, "bf4_tile_host"}),
     [](const ::testing::TestParamInfo<TestParam>& info) {
         // Use pretty printer to generate test name from all parameters
         std::string name = to_string(info.param);

--- a/tt-train/tests/serialization/tensor_serializer_test.cpp
+++ b/tt-train/tests/serialization/tensor_serializer_test.cpp
@@ -100,7 +100,7 @@ TEST_F(TensorFileTest, SerializeDeserializeTensor) {
     deserializer.deserialize(output_dir.string());
 
     // Read tensor from file
-    tt::tt_metal::Tensor tensor_read = tensor_zeros;
+    ttnn::Tensor tensor_read = tensor_zeros;
     ttml::serialization::read_ttnn_tensor(deserializer, "tensor", tensor_read);
 
     auto read_vec = ttml::core::to_vector(tensor_read);
@@ -110,7 +110,7 @@ TEST_F(TensorFileTest, SerializeDeserializeTensor) {
     }
 }
 
-bool compare_tensors(const tt::tt_metal::Tensor& tensor1, const tt::tt_metal::Tensor& tensor2) {
+bool compare_tensors(const ttnn::Tensor& tensor1, const ttnn::Tensor& tensor2) {
     auto vec1 = ttml::core::to_vector(tensor1);
     auto vec2 = ttml::core::to_vector(tensor2);
     return vec1 == vec2;

--- a/tt-train/tests/ttnn_fixed/matmuls_test.cpp
+++ b/tt-train/tests/ttnn_fixed/matmuls_test.cpp
@@ -85,7 +85,7 @@ TEST_F(MatmulsTest, MatMulNoTranspose) {
     auto t_b = core::from_xtensor(b, &autograd::ctx().get_device());
 
     // Compute the result using the ttnn op.
-    auto t_y = matmul(t_a, t_b, false, false);
+    auto t_y = ttml::ttnn_fixed::matmul(t_a, t_b, false, false);
     xt::xarray<float> y = core::to_xtensor(t_y);
 
     // Compute the expected result using xtensor goldens.
@@ -101,7 +101,7 @@ TEST_F(MatmulsTest, MatMulTransposeA) {
     auto t_b = core::from_xtensor(b, &autograd::ctx().get_device());
 
     // Use transpose_a = true.
-    auto t_y = matmul(t_a, t_b, true, false);
+    auto t_y = ttml::ttnn_fixed::matmul(t_a, t_b, true, false);
     xt::xarray<float> y = core::to_xtensor(t_y);
 
     // Expected: (a^T) * b.
@@ -117,7 +117,7 @@ TEST_F(MatmulsTest, MatMulTransposeB) {
     auto t_b = core::from_xtensor(b, &autograd::ctx().get_device());
 
     // Use transpose_b = true.
-    auto t_y = matmul(t_a, t_b, false, true);
+    auto t_y = ttml::ttnn_fixed::matmul(t_a, t_b, false, true);
     xt::xarray<float> y = core::to_xtensor(t_y);
 
     // Expected: a * (b^T).
@@ -133,7 +133,7 @@ TEST_F(MatmulsTest, MatMulTransposeBoth) {
     auto t_b = core::from_xtensor(b, &autograd::ctx().get_device());
 
     // Use both transpositions.
-    auto t_y = matmul(t_a, t_b, true, true);
+    auto t_y = ttml::ttnn_fixed::matmul(t_a, t_b, true, true);
     xt::xarray<float> y = core::to_xtensor(t_y);
 
     // Expected: (a^T) * (b^T).

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -17,11 +17,14 @@
 // long time, it is expected for the implementation to graduate out of experimental really quickly.
 //
 // Using namespace tt::tt_metal avoids double namespace renaming for the refactoring effort.
+namespace ttnn {
+struct DeviceStorage;
+}  // namespace ttnn
+
 namespace tt::tt_metal {
 
 // Implementation details for MeshTensor
 class MeshTensorImpl;
-struct DeviceStorage;
 
 namespace distributed {
 class MeshDevice;
@@ -186,7 +189,7 @@ private:
     // This breaks MeshTensor's core invariant: that it is the sole owner of the
     // underlying MeshBuffer. Shared ownership leaks out, allowing the MeshBuffer to
     // outlive the MeshTensor.
-    friend struct DeviceStorage;
+    friend struct ttnn::DeviceStorage;
 
     /**
      * Returns shared ownership of the underlying MeshBuffer.

--- a/ttnn/api/tools/profiler/op_profiler.hpp
+++ b/ttnn/api/tools/profiler/op_profiler.hpp
@@ -32,7 +32,7 @@ namespace tt::tt_metal::op_profiler {
 
 #if defined(TRACY_ENABLE)
 
-static inline json get_tensor_json(const Tensor& tensor) {
+static inline json get_tensor_json(const ttnn::Tensor& tensor) {
     json ret;
     if (tensor.storage_type() == StorageType::DEVICE) {
         ret["storage_type"]["device_id"] = tensor.device()->id();
@@ -65,7 +65,7 @@ static inline json get_tensor_json(const Tensor& tensor) {
     return ret;
 }
 
-static inline std::vector<json> get_tensors_json(const std::vector<Tensor>& tensors) {
+static inline std::vector<json> get_tensors_json(const std::vector<ttnn::Tensor>& tensors) {
     ZoneScoped;
     std::vector<json> ret;
     ret.reserve(tensors.size());
@@ -75,7 +75,7 @@ static inline std::vector<json> get_tensors_json(const std::vector<Tensor>& tens
     return ret;
 }
 
-static inline std::vector<json> get_tensors_json(const std::vector<std::optional<const Tensor>>& tensors) {
+static inline std::vector<json> get_tensors_json(const std::vector<std::optional<const ttnn::Tensor>>& tensors) {
     ZoneScoped;
     std::vector<json> ret;
     for (const auto& tensor : tensors) {
@@ -86,7 +86,7 @@ static inline std::vector<json> get_tensors_json(const std::vector<std::optional
     return ret;
 }
 
-static inline std::vector<json> get_tensors_json(const std::vector<std::optional<Tensor>>& tensors) {
+static inline std::vector<json> get_tensors_json(const std::vector<std::optional<ttnn::Tensor>>& tensors) {
     ZoneScoped;
     std::vector<json> ret;
     for (const auto& tensor : tensors) {
@@ -101,7 +101,7 @@ template <bool IsExternal = false, typename Operation>
 inline json get_base_json(
     uint32_t opID,
     const Operation& op,
-    const std::vector<Tensor>& input_tensors,
+    const std::vector<ttnn::Tensor>& input_tensors,
     std::optional<std::reference_wrapper<typename Operation::OutputTensors>> output_tensors = std::nullopt) {
     ZoneScoped;
     json j;
@@ -139,7 +139,7 @@ inline json get_base_json(
     j["input_tensors"] = get_tensors_json(input_tensors);
 
     if (output_tensors.has_value()) {
-        j["output_tensors"] = get_tensors_json(output_tensors.value());
+        j["output_tensors"] = get_tensors_json(output_tensors.value().get());
     }
     return j;
 }
@@ -149,7 +149,7 @@ inline json get_base_json(
 inline std::string op_meta_data_serialized_json(
     [[maybe_unused]] uint32_t opID,
     [[maybe_unused]] const tt::tt_metal::operation::ExternalOperation& op,
-    [[maybe_unused]] const std::vector<Tensor>& input_tensors) {
+    [[maybe_unused]] const std::vector<ttnn::Tensor>& input_tensors) {
 #if defined(TRACY_ENABLE)
     if (!is_op_profiler_env_var_set()) {
         return {};

--- a/ttnn/api/tools/profiler/op_profiler.hpp
+++ b/ttnn/api/tools/profiler/op_profiler.hpp
@@ -34,7 +34,7 @@ namespace tt::tt_metal::op_profiler {
 
 static inline json get_tensor_json(const ttnn::Tensor& tensor) {
     json ret;
-    if (tensor.storage_type() == StorageType::DEVICE) {
+    if (tensor.storage_type() == ttnn::StorageType::DEVICE) {
         ret["storage_type"]["device_id"] = tensor.device()->id();
         ret["storage_type"]["memory_config"]["buffer_type"] =
             enchantum::to_string(tensor.memory_config().buffer_type());

--- a/ttnn/api/tools/profiler/op_profiler_serialize.hpp
+++ b/ttnn/api/tools/profiler/op_profiler_serialize.hpp
@@ -299,7 +299,7 @@ inline auto compute_program_hash(
 // make_tensor_meta — extract TensorMeta from a Tensor (no JSON)
 // ---------------------------------------------------------------------------
 
-static inline TensorMeta make_tensor_meta(const Tensor& tensor) {
+static inline TensorMeta make_tensor_meta(const ttnn::Tensor& tensor) {
     TensorMeta m;
     if (tensor.storage_type() == StorageType::DEVICE) {
         m.is_device = true;
@@ -373,11 +373,11 @@ inline std::string op_meta_data_serialized_json(
         }
 
         // Input tensors → TensorMeta (no JSON)
-        ttsl::reflection::visit_object_of_type<Tensor>(
+        ttsl::reflection::visit_object_of_type<ttnn::Tensor>(
             [&data](auto&& tensor) { data.input_tensors.push_back(make_tensor_meta(tensor)); }, tensor_args);
 
         // Output tensors → TensorMeta (no JSON)
-        ttsl::reflection::visit_object_of_type<Tensor>(
+        ttsl::reflection::visit_object_of_type<ttnn::Tensor>(
             [&data](auto&& tensor) { data.output_tensors.push_back(make_tensor_meta(tensor)); }, tensor_return_value);
 
         // Performance model — use if constexpr to avoid depending on OpPerformanceModel type

--- a/ttnn/api/tools/profiler/op_profiler_serialize.hpp
+++ b/ttnn/api/tools/profiler/op_profiler_serialize.hpp
@@ -301,7 +301,7 @@ inline auto compute_program_hash(
 
 static inline TensorMeta make_tensor_meta(const ttnn::Tensor& tensor) {
     TensorMeta m;
-    if (tensor.storage_type() == StorageType::DEVICE) {
+    if (tensor.storage_type() == ttnn::StorageType::DEVICE) {
         m.is_device = true;
         m.device_id = tensor.device()->id();
         m.buffer_type = std::string(enchantum::to_string(tensor.memory_config().buffer_type()));

--- a/ttnn/api/ttnn/core.hpp
+++ b/ttnn/api/ttnn/core.hpp
@@ -22,8 +22,8 @@ namespace ttnn {
 using OptionalConstTensors = std::vector<std::optional<const Tensor>>;
 using OptionalTensors = std::vector<std::optional<Tensor>>;
 using Tensors = std::vector<Tensor>;
-using TensorPrintProfile = tt::tt_metal::tensor_impl::TensorPrintProfile;
-using SciMode = tt::tt_metal::tensor_impl::SciMode;
+using TensorPrintProfile = tensor_impl::TensorPrintProfile;
+using SciMode = tensor_impl::SciMode;
 
 }  // namespace ttnn
 

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -447,7 +447,9 @@ typename device_operation_t::tensor_return_value_t launch(
     tt::tt_metal::GraphTracker::instance().track_function_start(operation_name, operation_attributes, input_tensors);
 
     if (!input_tensors.empty()) {
-        TT_FATAL(is_device_tensor(input_tensors.front().get()), "Device Operations expect tensor with Device storage in inputs");
+        TT_FATAL(
+            tt::tt_metal::is_device_tensor(input_tensors.front().get()),
+            "Device Operations expect tensor with Device storage in inputs");
     }
 
     auto tensor_return_value = device_operation_t::create_output_tensors(operation_attributes, tensor_args);

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -448,7 +448,7 @@ typename device_operation_t::tensor_return_value_t launch(
 
     if (!input_tensors.empty()) {
         TT_FATAL(
-            tt::tt_metal::is_device_tensor(input_tensors.front().get()),
+            is_device_tensor(input_tensors.front().get()),
             "Device Operations expect tensor with Device storage in inputs");
     }
 

--- a/ttnn/api/ttnn/device_operation_detail.hpp
+++ b/ttnn/api/ttnn/device_operation_detail.hpp
@@ -12,12 +12,13 @@
 #include <tt_stl/small_vector.hpp>
 #include <ttnn/distributed/distributed_configs.hpp>
 
-namespace tt::tt_metal {
-class Tensor;
-namespace distributed {
+namespace tt::tt_metal::distributed {
 class MeshDevice;
-}  // namespace distributed
-}  // namespace tt::tt_metal
+}  // namespace tt::tt_metal::distributed
+
+namespace ttnn {
+class Tensor;
+}  // namespace ttnn
 
 namespace ttnn::device_operation::detail {
 
@@ -33,8 +34,7 @@ namespace ttnn::device_operation::detail {
 std::pair<
     ttsl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement>,
     tt::tt_metal::distributed::MeshShape>
-compute_output_placements_and_shape(
-    const std::vector<std::reference_wrapper<const tt::tt_metal::Tensor>>& tensors);
+compute_output_placements_and_shape(const std::vector<std::reference_wrapper<const Tensor>>& tensors);
 
 /**
  * Non-template implementation of tensor coordinate extraction.
@@ -42,7 +42,7 @@ compute_output_placements_and_shape(
  * Extracts and validates mesh coordinates from a pre-extracted list of input tensors.
  */
 std::vector<tt::tt_metal::distributed::MeshCoordinate> extract_tensor_coordinates_impl(
-    const std::vector<std::reference_wrapper<const tt::tt_metal::Tensor>>& tensors,
+    const std::vector<std::reference_wrapper<const Tensor>>& tensors,
     tt::tt_metal::distributed::MeshDevice* mesh_device);
 
 }  // namespace ttnn::device_operation::detail

--- a/ttnn/api/ttnn/mesh_device_operation_utils.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_utils.hpp
@@ -59,7 +59,7 @@ TensorReturnValue filter_tensor_shards(
             }
 
             // Create new storage with filtered coords, sharing the device memory
-            return Tensor(tt::tt_metal::DeviceStorage(old_storage, std::move(filtered_coords)));
+            return Tensor(DeviceStorage(old_storage, std::move(filtered_coords)));
         },
         tensor_return_value);
 }

--- a/ttnn/api/ttnn/operation.hpp
+++ b/ttnn/api/ttnn/operation.hpp
@@ -25,9 +25,9 @@ static Hash hash_operation(const Types&... objects) {
     return ttsl::hash::hash_objects_with_default_seed(ttsl::hash::type_hash<OperationType>, objects...);
 }
 
-using Tensors = std::vector<Tensor>;
-using OptionalTensors = std::vector<std::optional<Tensor>>;
-using OptionalConstTensors = std::vector<std::optional<const Tensor>>;
+using Tensors = std::vector<ttnn::Tensor>;
+using OptionalTensors = std::vector<std::optional<ttnn::Tensor>>;
+using OptionalConstTensors = std::vector<std::optional<const ttnn::Tensor>>;
 
 template <typename... Args>
 struct last_type;

--- a/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
+++ b/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
@@ -10,12 +10,12 @@
 
 namespace tt::tt_metal::host_buffer {
 
-HostBuffer get_host_buffer(const Tensor& tensor);
+HostBuffer get_host_buffer(const ttnn::Tensor& tensor);
 
 template <typename T>
-ttsl::Span<const T> get_as(const Tensor& tensor);
+ttsl::Span<const T> get_as(const ttnn::Tensor& tensor);
 
 template <typename T>
-ttsl::Span<T> get_as(Tensor& tensor);
+ttsl::Span<T> get_as(ttnn::Tensor& tensor);
 
 }  // namespace tt::tt_metal::host_buffer

--- a/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
+++ b/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
@@ -8,14 +8,14 @@
 
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 
-namespace tt::tt_metal::host_buffer {
+namespace ttnn::host_buffer {
 
-HostBuffer get_host_buffer(const ttnn::Tensor& tensor);
-
-template <typename T>
-ttsl::Span<const T> get_as(const ttnn::Tensor& tensor);
+tt::tt_metal::HostBuffer get_host_buffer(const Tensor& tensor);
 
 template <typename T>
-ttsl::Span<T> get_as(ttnn::Tensor& tensor);
+ttsl::Span<const T> get_as(const Tensor& tensor);
 
-}  // namespace tt::tt_metal::host_buffer
+template <typename T>
+ttsl::Span<T> get_as(Tensor& tensor);
+
+}  // namespace ttnn::host_buffer

--- a/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
+++ b/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
@@ -19,3 +19,26 @@ template <typename T>
 ttsl::Span<T> get_as(Tensor& tensor);
 
 }  // namespace ttnn::host_buffer
+
+// Compatibility bridges - ttnn tensor infrastructure has moved to the ttnn namespace.
+namespace tt::tt_metal::host_buffer {
+
+template <int = 0>
+[[deprecated("use ttnn::host_buffer::get_host_buffer instead. This alias may be removed after Jun 2026.")]]
+inline tt::tt_metal::HostBuffer get_host_buffer(const ttnn::Tensor& tensor) {
+    return ttnn::host_buffer::get_host_buffer(tensor);
+}
+
+template <typename T, int = 0>
+[[deprecated("use ttnn::host_buffer::get_as instead. This alias may be removed after Jun 2026.")]]
+inline ttsl::Span<const T> get_as(const ttnn::Tensor& tensor) {
+    return ttnn::host_buffer::get_as<T>(tensor);
+}
+
+template <typename T, int = 0>
+[[deprecated("use ttnn::host_buffer::get_as instead. This alias may be removed after Jun 2026.")]]
+inline ttsl::Span<T> get_as(ttnn::Tensor& tensor) {
+    return ttnn::host_buffer::get_as<T>(tensor);
+}
+
+}  // namespace tt::tt_metal::host_buffer

--- a/ttnn/api/ttnn/tensor/overlapped_tensor.hpp
+++ b/ttnn/api/ttnn/tensor/overlapped_tensor.hpp
@@ -15,7 +15,7 @@ namespace tt::tt_metal {
 
 struct OverlappedTensorView {
     std::string name;
-    Tensor fused_tensor;
+    ttnn::Tensor fused_tensor;
     std::array<uint32_t, 2> tensor_shape;
     std::array<uint32_t, 2> shard_shape;
     CoreRangeSet core_range_set;

--- a/ttnn/api/ttnn/tensor/overlapped_tensor.hpp
+++ b/ttnn/api/ttnn/tensor/overlapped_tensor.hpp
@@ -30,3 +30,26 @@ std::vector<OverlappedTensorView> load_overlapped_tensors(
     const std::string& file_name, tt::tt_metal::distributed::MeshDevice* device = nullptr);
 
 }  // namespace ttnn
+
+// Compatibility aliases - ttnn tensor infrastructure has moved to the ttnn namespace.
+namespace tt::tt_metal {
+
+using OverlappedTensorView
+    [[deprecated("use ttnn::OverlappedTensorView instead. This alias may be removed after Jun 2026.")]] =
+        ttnn::OverlappedTensorView;
+
+template <int = 0>
+[[deprecated("use ttnn::dump_overlapped_tensors instead. This alias may be removed after Jun 2026.")]]
+inline void dump_overlapped_tensors(
+    const std::string& file_name, const std::vector<ttnn::OverlappedTensorView>& views) {
+    ttnn::dump_overlapped_tensors(file_name, views);
+}
+
+template <int = 0>
+[[deprecated("use ttnn::load_overlapped_tensors instead. This alias may be removed after Jun 2026.")]]
+inline std::vector<ttnn::OverlappedTensorView> load_overlapped_tensors(
+    const std::string& file_name, distributed::MeshDevice* device = nullptr) {
+    return ttnn::load_overlapped_tensors(file_name, device);
+}
+
+}  // namespace tt::tt_metal

--- a/ttnn/api/ttnn/tensor/overlapped_tensor.hpp
+++ b/ttnn/api/ttnn/tensor/overlapped_tensor.hpp
@@ -11,15 +11,15 @@
 
 #include "ttnn/tensor/tensor.hpp"
 
-namespace tt::tt_metal {
+namespace ttnn {
 
 struct OverlappedTensorView {
     std::string name;
     ttnn::Tensor fused_tensor;
     std::array<uint32_t, 2> tensor_shape;
     std::array<uint32_t, 2> shard_shape;
-    CoreRangeSet core_range_set;
-    DataType dtype;
+    tt::tt_metal::CoreRangeSet core_range_set;
+    tt::tt_metal::DataType dtype;
     std::array<uint32_t, 2> tile_shape;
     uint64_t byte_offset = 0;
     uint64_t total_size = 0;
@@ -27,6 +27,6 @@ struct OverlappedTensorView {
 
 void dump_overlapped_tensors(const std::string& file_name, const std::vector<OverlappedTensorView>& views);
 std::vector<OverlappedTensorView> load_overlapped_tensors(
-    const std::string& file_name, distributed::MeshDevice* device = nullptr);
+    const std::string& file_name, tt::tt_metal::distributed::MeshDevice* device = nullptr);
 
-}  // namespace tt::tt_metal
+}  // namespace ttnn

--- a/ttnn/api/ttnn/tensor/py_to_tt_tensor.hpp
+++ b/ttnn/api/ttnn/tensor/py_to_tt_tensor.hpp
@@ -13,7 +13,7 @@ namespace distributed {
 class TensorToMesh;
 }  // namespace distributed
 
-tt::tt_metal::Tensor convert_python_tensor_to_tt_tensor(
+Tensor convert_python_tensor_to_tt_tensor(
     const tt::tt_metal::Shape& tensor_shape,
     tt::tt_metal::DataType dst_dtype,
     tt::tt_metal::Layout layout,

--- a/ttnn/api/ttnn/tensor/serialization.hpp
+++ b/ttnn/api/ttnn/tensor/serialization.hpp
@@ -23,7 +23,7 @@ enum class DumpTensorMode : std::uint8_t {
 //    tensor data.
 // 2. Metadata includes data offsets and sizes for tensor / tensor shards (multi device context).
 void dump_tensor_flatbuffer(
-    const std::string& file_name, const Tensor& tensor, DumpTensorMode mode = DumpTensorMode::DISTRIBUTED_GATHER);
-Tensor load_tensor_flatbuffer(const std::string& file_name, distributed::MeshDevice* device = nullptr);
+    const std::string& file_name, const ttnn::Tensor& tensor, DumpTensorMode mode = DumpTensorMode::DISTRIBUTED_GATHER);
+ttnn::Tensor load_tensor_flatbuffer(const std::string& file_name, distributed::MeshDevice* device = nullptr);
 
 }  // namespace tt::tt_metal

--- a/ttnn/api/ttnn/tensor/serialization.hpp
+++ b/ttnn/api/ttnn/tensor/serialization.hpp
@@ -27,3 +27,26 @@ void dump_tensor_flatbuffer(
 Tensor load_tensor_flatbuffer(const std::string& file_name, tt::tt_metal::distributed::MeshDevice* device = nullptr);
 
 }  // namespace ttnn
+
+// Compatibility aliases - ttnn tensor infrastructure has moved to the ttnn namespace.
+namespace tt::tt_metal {
+
+using DumpTensorMode [[deprecated("use ttnn::DumpTensorMode instead. This alias may be removed after Jun 2026.")]] =
+    ttnn::DumpTensorMode;
+
+template <int = 0>
+[[deprecated("use ttnn::dump_tensor_flatbuffer instead. This alias may be removed after Jun 2026.")]]
+inline void dump_tensor_flatbuffer(
+    const std::string& file_name,
+    const ttnn::Tensor& tensor,
+    ttnn::DumpTensorMode mode = ttnn::DumpTensorMode::DISTRIBUTED_GATHER) {
+    ttnn::dump_tensor_flatbuffer(file_name, tensor, mode);
+}
+
+template <int = 0>
+[[deprecated("use ttnn::load_tensor_flatbuffer instead. This alias may be removed after Jun 2026.")]]
+inline ttnn::Tensor load_tensor_flatbuffer(const std::string& file_name, distributed::MeshDevice* device = nullptr) {
+    return ttnn::load_tensor_flatbuffer(file_name, device);
+}
+
+}  // namespace tt::tt_metal

--- a/ttnn/api/ttnn/tensor/serialization.hpp
+++ b/ttnn/api/ttnn/tensor/serialization.hpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace tt::tt_metal {
+namespace ttnn {
 
 enum class DumpTensorMode : std::uint8_t {
     DISTRIBUTED_GATHER = 0,
@@ -24,6 +24,6 @@ enum class DumpTensorMode : std::uint8_t {
 // 2. Metadata includes data offsets and sizes for tensor / tensor shards (multi device context).
 void dump_tensor_flatbuffer(
     const std::string& file_name, const ttnn::Tensor& tensor, DumpTensorMode mode = DumpTensorMode::DISTRIBUTED_GATHER);
-ttnn::Tensor load_tensor_flatbuffer(const std::string& file_name, distributed::MeshDevice* device = nullptr);
+Tensor load_tensor_flatbuffer(const std::string& file_name, tt::tt_metal::distributed::MeshDevice* device = nullptr);
 
-}  // namespace tt::tt_metal
+}  // namespace ttnn

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -216,3 +216,14 @@ private:
 using Storage = std::variant<HostStorage, DeviceStorage>;
 
 }  // namespace ttnn
+
+// Compatibility aliases - ttnn tensor infrastructure has moved to the ttnn namespace.
+namespace tt::tt_metal {
+
+using HostStorage [[deprecated("use ttnn::HostStorage instead. This alias may be removed after Jun 2026.")]] =
+    ttnn::HostStorage;
+using DeviceStorage [[deprecated("use ttnn::DeviceStorage instead. This alias may be removed after Jun 2026.")]] =
+    ttnn::DeviceStorage;
+using Storage [[deprecated("use ttnn::Storage instead. This alias may be removed after Jun 2026.")]] = ttnn::Storage;
+
+}  // namespace tt::tt_metal

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -19,29 +19,29 @@
 #include <ttnn/distributed/tensor_topology.hpp>
 #include "ttnn/tensor/types.hpp"
 
-
-namespace tt::tt_metal {
+namespace ttnn {
 
 class HostStorage {
 public:
     // Creates HostStorage from a HostTensor.
-    explicit HostStorage(HostTensor tensor);
+    explicit HostStorage(tt::tt_metal::HostTensor tensor);
 
     // Returns the distributed host buffer.
-    const DistributedHostBuffer& buffer() const;
+    const tt::tt_metal::DistributedHostBuffer& buffer() const;
 
     // Returns the host tensor.
-    const HostTensor& host_tensor() const;
-    HostTensor& host_tensor();
+    const tt::tt_metal::HostTensor& host_tensor() const;
+    tt::tt_metal::HostTensor& host_tensor();
 
     // Applies a transformation function to each device buffer in parallel, returning a new HostStorage.
-    HostStorage transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const;
+    HostStorage transform(
+        const std::function<tt::tt_metal::HostBuffer(const tt::tt_metal::HostBuffer&)>& callable) const;
 
     static constexpr auto attribute_names = std::forward_as_tuple();
     auto attribute_values() const { return std::forward_as_tuple(); }
 
 private:
-    HostTensor tensor;
+    tt::tt_metal::HostTensor tensor;
 };
 
 // DeviceStorage is a wrapper around the MeshTensor to fit the semantics of ttnn::Tensor.
@@ -68,11 +68,11 @@ struct DeviceStorage {
     // Constructs a DeviceStorage from a device memory
 
     // Constructs DeviceStorage with coords covering the full mesh device shape.
-    explicit DeviceStorage(MeshTensor mesh_tensor);
+    explicit DeviceStorage(tt::tt_metal::MeshTensor mesh_tensor);
 
     // Constructs DeviceStorage that is a view of the mesh_buffer_ at the given coords_.
     // Throws if the coords_ are out of bounds for the mesh_buffer_ device shape.
-    DeviceStorage(MeshTensor mesh_tensor, std::vector<distributed::MeshCoordinate> coords);
+    DeviceStorage(tt::tt_metal::MeshTensor mesh_tensor, std::vector<tt::tt_metal::distributed::MeshCoordinate> coords);
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Copys an existing DeviceStorage and share it's underlying device memory.
@@ -86,25 +86,25 @@ struct DeviceStorage {
     // Creates a copy of the DeviceStorage that shares the underlying device memory,
     // but with a different set of coords.
     // Throws if the coords_ are out of bounds for the mesh_buffer_ device shape.
-    DeviceStorage(const DeviceStorage& other, std::vector<distributed::MeshCoordinate> coords);
+    DeviceStorage(const DeviceStorage& other, std::vector<tt::tt_metal::distributed::MeshCoordinate> coords);
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Device Memory getters
 
     // Get legacy single device buffer
     // Throws if the DeviceStorage is not allocated.
-    Buffer* get_buffer() const;
+    tt::tt_metal::Buffer* get_buffer() const;
 
     // Get mesh buffer that represents the device memory
     // Throws if the DeviceStorage is deallocated.
-    const distributed::MeshBuffer& get_mesh_buffer() const;
+    const tt::tt_metal::distributed::MeshBuffer& get_mesh_buffer() const;
 
     // Get the underlying MeshTensor, throws if the DeviceStorage is deallocated.
-    const MeshTensor& get_mesh_tensor() const;
+    const tt::tt_metal::MeshTensor& get_mesh_tensor() const;
 
     // Get the underlying MeshTensor, throws if the DeviceStorage is deallocated.
     // Please do not move the MeshTensor out of the DeviceStorage using this function.
-    MeshTensor& get_mesh_tensor();
+    tt::tt_metal::MeshTensor& get_mesh_tensor();
 
     // Returns the MeshDevice associated with the underlying device memory.
     // Throws if the DeviceStorage is not constructed from a MeshTensor.
@@ -116,8 +116,7 @@ struct DeviceStorage {
     //
     // TODO: Remove this workaround once models properly manage tensor lifetimes and
     // don't operate on deallocated tensors.
-    distributed::MeshDevice* get_device_bypass_deallocate_check() const;
-
+    tt::tt_metal::distributed::MeshDevice* get_device_bypass_deallocate_check() const;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // DeviceStorage as a view of the undelrying device memory at specific coordinates:
@@ -126,7 +125,7 @@ struct DeviceStorage {
     bool is_uniform_storage() const;
 
     // Returns the coordinates the tensor spans across.
-    std::span<const distributed::MeshCoordinate> get_coords() const;
+    std::span<const tt::tt_metal::distributed::MeshCoordinate> get_coords() const;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Deallocation management
@@ -150,7 +149,7 @@ struct DeviceStorage {
     // The function also leaks the ownership of the underlying device memory out.
     // This is meant to be transitional and is to be removed.
     // Throws if the DeviceStorage is not constructed from a MeshTensor.
-    std::shared_ptr<distributed::MeshBuffer> get_mesh_buffer_leak_ownership() const;
+    std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> get_mesh_buffer_leak_ownership() const;
 
     // There are situations where we want to "reinterpret" an existing Tensor without modifying its underlying memory.
     // For example, select slice ops can be done in-place, as can select reshapes. This DeviceStorage constructor
@@ -166,7 +165,7 @@ struct DeviceStorage {
     // This is currently the recommended method to reinterpret an existing Tensor.
     // This is  internal functionality: it is not part of the public API.
     // TODO(#38093): implement a more robust mechanism for Tensor reinterpretation
-    DeviceStorage(const DeviceStorage& owning_storage, MeshTensor reinterpreted_mesh_tensor);
+    DeviceStorage(const DeviceStorage& owning_storage, tt::tt_metal::MeshTensor reinterpreted_mesh_tensor);
     // End internal functions.
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -185,10 +184,10 @@ struct DeviceStorage {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Returns the tensor spec associated with the MeshTensor.
     // Throws if the DeviceStorage is not constructed from a MeshTensor.
-    const TensorSpec& get_tensor_spec() const;
+    const tt::tt_metal::TensorSpec& get_tensor_spec() const;
     // Returns the tensor topology associated with the MeshTensor.
     // Throws if the DeviceStorage is not constructed from a MeshTensor.
-    const TensorTopology& get_tensor_topology() const;
+    const tt::tt_metal::TensorTopology& get_tensor_topology() const;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Serialization
@@ -202,11 +201,11 @@ private:
     // Main internal constructor, performs all validation
     DeviceStorage(
         std::shared_ptr<MeshTensorHolder> mesh_tensor_holder,
-        std::vector<distributed::MeshCoordinate> coords,
+        std::vector<tt::tt_metal::distributed::MeshCoordinate> coords,
         std::shared_ptr<MeshTensorHolder> root_mesh_tensor_holder);
 
     std::shared_ptr<MeshTensorHolder> mesh_tensor_holder_;
-    std::vector<distributed::MeshCoordinate> coords_;
+    std::vector<tt::tt_metal::distributed::MeshCoordinate> coords_;
 
     // Experimental features for viewing an existing DeviceStorage
     const std::shared_ptr<MeshTensorHolder>& get_root_mesh_tensor() const;
@@ -216,4 +215,4 @@ private:
 
 using Storage = std::variant<HostStorage, DeviceStorage>;
 
-}  // namespace tt::tt_metal
+}  // namespace ttnn

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -6,6 +6,9 @@
 
 #include <cstdint>
 
+#include <functional>
+#include <iosfwd>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -14,6 +17,7 @@
 
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 #include <tt-metalium/experimental/tensor/host_tensor.hpp>
+#include <tt-metalium/core_coord.hpp>
 #include "ttnn/common/queue_id.hpp"
 #include "ttnn/distributed/tensor_topology.hpp"
 #include "ttnn/tensor/storage.hpp"
@@ -24,13 +28,21 @@
 #include <tt-metalium/tile.hpp>
 
 #include <tt_stl/optional_reference.hpp>
+#include <tt_stl/span.hpp>
 
-namespace tt::tt_metal {
-
-namespace distributed {
+namespace tt::tt_metal::distributed {
 class MeshDevice;
 class MeshCommandQueue;
-}  // namespace distributed
+}  // namespace tt::tt_metal::distributed
+
+namespace ttnn {
+
+using TensorSpec = tt::tt_metal::TensorSpec;
+
+// These will be moved to ttnn namespace
+using TensorAttributes = tt::tt_metal::TensorAttributes;
+using HostStorage = tt::tt_metal::HostStorage;
+using DeviceStorage = tt::tt_metal::DeviceStorage;
 
 class Tensor {
 public:
@@ -53,25 +65,25 @@ public:
 
     [[nodiscard]] explicit Tensor(DeviceStorage storage);
 
-    [[nodiscard]] explicit Tensor(HostTensor tensor);
-    [[nodiscard]] explicit Tensor(MeshTensor tensor);
+    [[nodiscard]] explicit Tensor(tt::tt_metal::HostTensor tensor);
+    [[nodiscard]] explicit Tensor(tt::tt_metal::MeshTensor tensor);
 
     // Constructors of `Tensor` that take physical data encoded in `HostBuffer`.
     // The encoded data type and physical size of the data must match the specified tensor physical shape and data type.
     [[nodiscard]] Tensor(
-        HostBuffer buffer,
+        tt::tt_metal::HostBuffer buffer,
         const tt::tt_metal::Shape& shape,
-        DataType dtype,
-        Layout layout,
-        const std::optional<Tile>& tile = std::nullopt);
+        tt::tt_metal::DataType dtype,
+        tt::tt_metal::Layout layout,
+        const std::optional<tt::tt_metal::Tile>& tile = std::nullopt);
     [[nodiscard]] Tensor(
-        HostBuffer buffer,
+        tt::tt_metal::HostBuffer buffer,
         const tt::tt_metal::Shape& logical_shape,
         const tt::tt_metal::Shape& padded_shape,
-        DataType dtype,
-        Layout layout,
-        const std::optional<Tile>& tile = std::nullopt);
-    [[nodiscard]] Tensor(HostBuffer buffer, TensorSpec tensor_spec);
+        tt::tt_metal::DataType dtype,
+        tt::tt_metal::Layout layout,
+        const std::optional<tt::tt_metal::Tile>& tile = std::nullopt);
+    [[nodiscard]] Tensor(tt::tt_metal::HostBuffer buffer, TensorSpec tensor_spec);
 
     // Converts a buffer of elements of type `T` to a `Tensor`.
     // Elements in the buffer are assumed to be stored in row-major order. The size of the buffer and the type of the
@@ -82,7 +94,7 @@ public:
     [[nodiscard]] static Tensor from_span(
         ttsl::Span<const T> buffer,
         const TensorSpec& spec,
-        distributed::MeshDevice* device = nullptr,
+        tt::tt_metal::distributed::MeshDevice* device = nullptr,
         std::optional<tt::tt_metal::QueueId> cq_id = std::nullopt,
         T pad_value = 0);
 
@@ -107,7 +119,7 @@ public:
         ttsl::Span<T> buffer,
         const tt::tt_metal::Shape& shape,
         tt::tt_metal::MemoryPin buffer_pin,
-        const std::optional<Tile>& tile = std::nullopt);
+        const std::optional<tt::tt_metal::Tile>& tile = std::nullopt);
 
     // Overload that takes `on_creation_callback` and `on_destruction_callback` as separate arguments.
     template <typename T>
@@ -116,8 +128,9 @@ public:
         const tt::tt_metal::Shape& shape,
         const std::function<void()>& on_creation_callback,
         const std::function<void()>& on_destruction_callback,
-        const std::optional<Tile>& tile = std::nullopt) {
-        return from_borrowed_data(buffer, shape, MemoryPin(on_creation_callback, on_destruction_callback), tile);
+        const std::optional<tt::tt_metal::Tile>& tile = std::nullopt) {
+        return from_borrowed_data(
+            buffer, shape, tt::tt_metal::MemoryPin(on_creation_callback, on_destruction_callback), tile);
     }
 
     // Same as `from_span`, but operates on a vector instead.
@@ -125,7 +138,7 @@ public:
     [[nodiscard]] static Tensor from_vector(
         const std::vector<T>& buffer,
         const TensorSpec& spec,
-        distributed::MeshDevice* device = nullptr,
+        tt::tt_metal::distributed::MeshDevice* device = nullptr,
         std::optional<tt::tt_metal::QueueId> cq_id = std::nullopt,
         T pad_value = 0) {
         return from_span(ttsl::Span<const T>(buffer), spec, device, cq_id, pad_value);
@@ -137,7 +150,7 @@ public:
     [[nodiscard]] static Tensor from_vector(
         std::vector<T>&& buffer,
         const TensorSpec& spec,
-        distributed::MeshDevice* device = nullptr,
+        tt::tt_metal::distributed::MeshDevice* device = nullptr,
         std::optional<tt::tt_metal::QueueId> cq_id = std::nullopt,
         T pad_value = 0);
 
@@ -150,11 +163,11 @@ public:
     [[nodiscard]] std::vector<T> to_vector(std::optional<tt::tt_metal::QueueId> cq_id = std::nullopt) const;
 
     [[nodiscard]] Tensor to_device(
-        distributed::MeshDevice* mesh_device,
-        ttsl::optional_reference<const MemoryConfig> mem_config = std::nullopt,
+        tt::tt_metal::distributed::MeshDevice* mesh_device,
+        ttsl::optional_reference<const tt::tt_metal::MemoryConfig> mem_config = std::nullopt,
         std::optional<tt::tt_metal::QueueId> cq_id = std::nullopt) const;
 
-    [[nodiscard]] Tensor to_layout(Layout target_layout) const;
+    [[nodiscard]] Tensor to_layout(tt::tt_metal::Layout target_layout) const;
 
     [[nodiscard]] Tensor pad(
         const tt::tt_metal::Shape& output_padded_shape,
@@ -176,7 +189,7 @@ public:
     // If the tensor is on host, does nothing.
     void deallocate(bool force = false);
 
-    [[nodiscard]] Tensor extract_shard(const CoreCoord& core) const;
+    [[nodiscard]] Tensor extract_shard(const tt::tt_metal::CoreCoord& core) const;
     [[nodiscard]] Tensor extract_shard(const uint32_t& core_id) const;
 
     // ======================================================================================
@@ -186,30 +199,30 @@ public:
     [[nodiscard]] Tensor reshape(
         const tt::tt_metal::Shape& new_logical_shape, const tt::tt_metal::Shape& new_padded_shape) const;
 
-    void update_tensor_topology(const TensorTopology& tensor_topology);
+    void update_tensor_topology(const tt::tt_metal::TensorTopology& tensor_topology);
     // ======================================================================================
     //                                      Getters
     // ======================================================================================
-    DataType dtype() const;
-    Layout layout() const;
+    tt::tt_metal::DataType dtype() const;
+    tt::tt_metal::Layout layout() const;
     const tt::tt_metal::Shape& logical_shape() const;
     const tt::tt_metal::Shape& padded_shape() const;
     const TensorSpec& tensor_spec() const;
     uint64_t logical_volume() const;
     uint64_t physical_volume() const;
-    const MemoryConfig& memory_config() const;
+    const tt::tt_metal::MemoryConfig& memory_config() const;
 
     // Multi-device topology configuration - tracks how tensor is distributed across mesh devices
-    const TensorTopology& tensor_topology() const;
+    const tt::tt_metal::TensorTopology& tensor_topology() const;
 
     // For sharded tensors, at least one of ShardSpec or NdShardSpec will be provided.
-    const std::optional<ShardSpec>& shard_spec() const;
-    const std::optional<NdShardSpec>& nd_shard_spec() const;
+    const std::optional<tt::tt_metal::ShardSpec>& shard_spec() const;
+    const std::optional<tt::tt_metal::NdShardSpec>& nd_shard_spec() const;
 
     // ======================================================================================
     //                                      Extra Helper Functions
     // ======================================================================================
-    StorageType storage_type() const;
+    tt::tt_metal::StorageType storage_type() const;
     tt::tt_metal::Shape strides() const;
 
     bool is_scalar() const;
@@ -218,7 +231,7 @@ public:
 
     // Returns device `Buffer`.
     // Throws if the tensor is not allocated on a device.
-    Buffer* buffer() const;
+    tt::tt_metal::Buffer* buffer() const;
 
     // Returns device `Storage`.
     // Throws if the tensor is not on device.
@@ -233,20 +246,20 @@ public:
     const HostStorage& host_storage() const&& = delete;  // prevents dangling reference to temporaries.
 
     // Returns the associated HostTensor.
-    const HostTensor& host_tensor() const&;
-    const HostTensor& host_tensor() const&& = delete;  // prevents dangling reference to temporaries.
+    const tt::tt_metal::HostTensor& host_tensor() const&;
+    const tt::tt_metal::HostTensor& host_tensor() const&& = delete;  // prevents dangling reference to temporaries.
 
     // Returns the associated MeshTensor.
-    const MeshTensor& mesh_tensor() const&;
-    const MeshTensor& mesh_tensor() const&& = delete;  // prevents dangling reference to temporaries.
+    const tt::tt_metal::MeshTensor& mesh_tensor() const&;
+    const tt::tt_metal::MeshTensor& mesh_tensor() const&& = delete;  // prevents dangling reference to temporaries.
 
     // Returns device `MeshBuffer`.
     // Throws if the tensor is not allocated on a device.
-    const distributed::MeshBuffer& mesh_buffer() const;
+    const tt::tt_metal::distributed::MeshBuffer& mesh_buffer() const;
 
     // Returns the device the tensor is allocated on.
     // Throws if the tensor is not allocated on a device.
-    distributed::MeshDevice* device() const;
+    tt::tt_metal::distributed::MeshDevice* device() const;
 
     bool is_sharded() const;
 
@@ -267,7 +280,7 @@ private:
     // Shorthand for checking if this Tensor is allocated on MeshDevice. If set, is never nullptr.
     // If not set, the tensor can either be on host or allocated on a single device.
     // TODO: #21099 - This won't be needed after the migration to MeshDevice is complete.
-    std::optional<distributed::MeshDevice*> mesh_device_ = std::nullopt;
+    std::optional<tt::tt_metal::distributed::MeshDevice*> mesh_device_ = std::nullopt;
 
     void deallocate_impl(bool force);
 };
@@ -275,12 +288,5 @@ private:
 Tensor set_tensor_id(const Tensor& tensor);
 
 std::ostream& operator<<(std::ostream& os, const Tensor& tensor);
-
-}  // namespace tt::tt_metal
-
-namespace ttnn {
-
-using Tensor = tt::tt_metal::Tensor;
-using TensorSpec = tt::tt_metal::TensorSpec;
 
 }  // namespace ttnn

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -220,7 +220,7 @@ public:
     // ======================================================================================
     //                                      Extra Helper Functions
     // ======================================================================================
-    tt::tt_metal::StorageType storage_type() const;
+    StorageType storage_type() const;
     tt::tt_metal::Shape strides() const;
 
     bool is_scalar() const;

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -41,8 +41,6 @@ using TensorSpec = tt::tt_metal::TensorSpec;
 
 // These will be moved to ttnn namespace
 using TensorAttributes = tt::tt_metal::TensorAttributes;
-using HostStorage = tt::tt_metal::HostStorage;
-using DeviceStorage = tt::tt_metal::DeviceStorage;
 
 class Tensor {
 public:

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -39,9 +39,6 @@ namespace ttnn {
 
 using TensorSpec = tt::tt_metal::TensorSpec;
 
-// These will be moved to ttnn namespace
-using TensorAttributes = tt::tt_metal::TensorAttributes;
-
 class Tensor {
 public:
     constexpr static std::uint64_t INVALID_TENSOR_ID = std::numeric_limits<std::uint64_t>::max();

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -285,3 +285,10 @@ Tensor set_tensor_id(const Tensor& tensor);
 std::ostream& operator<<(std::ostream& os, const Tensor& tensor);
 
 }  // namespace ttnn
+
+// Compatibility alias - ttnn tensor infrastructure has moved to the ttnn namespace.
+namespace tt::tt_metal {
+
+using Tensor [[deprecated("use ttnn::Tensor instead. This alias may be removed after Jun 2026.")]] = ttnn::Tensor;
+
+}  // namespace tt::tt_metal

--- a/ttnn/api/ttnn/tensor/tensor_attributes.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_attributes.hpp
@@ -8,7 +8,7 @@
 
 #include "ttnn/tensor/storage.hpp"
 
-namespace tt::tt_metal {
+namespace ttnn {
 
 class TensorAttributes : public std::enable_shared_from_this<TensorAttributes> {
 public:
@@ -21,15 +21,15 @@ public:
     TensorAttributes& operator=(TensorAttributes&&) = default;
 
     // Getters and setters.
-    const ttnn::Storage& get_storage() const;
-    ttnn::Storage& get_storage();
-    const TensorSpec& get_tensor_spec() const;
-    const TensorTopology& get_tensor_topology() const;
+    const Storage& get_storage() const;
+    Storage& get_storage();
+    const tt::tt_metal::TensorSpec& get_tensor_spec() const;
+    const tt::tt_metal::TensorTopology& get_tensor_topology() const;
 
-    void update_tensor_topology(const TensorTopology& tensor_topology);
+    void update_tensor_topology(const tt::tt_metal::TensorTopology& tensor_topology);
 
 private:
     ttnn::Storage storage_;
 };
 
-}  // namespace tt::tt_metal
+}  // namespace ttnn

--- a/ttnn/api/ttnn/tensor/tensor_attributes.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_attributes.hpp
@@ -33,3 +33,11 @@ private:
 };
 
 }  // namespace ttnn
+
+// Compatibility alias - ttnn tensor infrastructure has moved to the ttnn namespace.
+namespace tt::tt_metal {
+
+using TensorAttributes [[deprecated("use ttnn::TensorAttributes instead. This alias may be removed after Jun 2026.")]] =
+    ttnn::TensorAttributes;
+
+}  // namespace tt::tt_metal

--- a/ttnn/api/ttnn/tensor/tensor_attributes.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_attributes.hpp
@@ -12,8 +12,8 @@ namespace tt::tt_metal {
 
 class TensorAttributes : public std::enable_shared_from_this<TensorAttributes> {
 public:
-    TensorAttributes(HostStorage storage);
-    TensorAttributes(DeviceStorage storage);
+    TensorAttributes(ttnn::HostStorage storage);
+    TensorAttributes(ttnn::DeviceStorage storage);
 
     TensorAttributes(const TensorAttributes&) = default;
     TensorAttributes(TensorAttributes&&) = default;
@@ -21,15 +21,15 @@ public:
     TensorAttributes& operator=(TensorAttributes&&) = default;
 
     // Getters and setters.
-    const Storage& get_storage() const;
-    Storage& get_storage();
+    const ttnn::Storage& get_storage() const;
+    ttnn::Storage& get_storage();
     const TensorSpec& get_tensor_spec() const;
     const TensorTopology& get_tensor_topology() const;
 
     void update_tensor_topology(const TensorTopology& tensor_topology);
 
 private:
-    Storage storage_;
+    ttnn::Storage storage_;
 };
 
 }  // namespace tt::tt_metal

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -62,3 +62,47 @@ std::string to_string(const ttnn::Tensor& tensor);
 ttnn::Tensor extract_shard(const ttnn::Tensor& tensor, const uint32_t& core_id);
 
 }  // namespace ttnn::tensor_impl
+
+// Compatibility bridges - ttnn tensor infrastructure has moved to the ttnn namespace.
+namespace tt::tt_metal::tensor_impl {
+
+using TensorPrintProfile
+    [[deprecated("use ttnn::tensor_impl::TensorPrintProfile instead. This alias may be removed after Jun 2026.")]] =
+        ttnn::tensor_impl::TensorPrintProfile;
+using SciMode [[deprecated("use ttnn::tensor_impl::SciMode instead. This alias may be removed after Jun 2026.")]] =
+    ttnn::tensor_impl::SciMode;
+using PrintOptions
+    [[deprecated("use ttnn::tensor_impl::PrintOptions instead. This alias may be removed after Jun 2026.")]] =
+        ttnn::tensor_impl::PrintOptions;
+
+[[deprecated("use ttnn::tensor_impl::TTNN_PRINT_OPTIONS instead. This alias may be removed after Jun 2026.")]]
+inline ttnn::tensor_impl::PrintOptions& TTNN_PRINT_OPTIONS = ttnn::tensor_impl::TTNN_PRINT_OPTIONS;
+
+template <int = 0>
+[[deprecated("use ttnn::tensor_impl::view instead. This alias may be removed after Jun 2026.")]]
+inline tt::tt_metal::HostTensor view(
+    const tt::tt_metal::HostTensor& tensor,
+    const tt::tt_metal::Shape& new_logical_shape,
+    const tt::tt_metal::Shape& new_padded_shape) {
+    return ttnn::tensor_impl::view(tensor, new_logical_shape, new_padded_shape);
+}
+
+template <int = 0>
+[[deprecated("use ttnn::tensor_impl::operator<< instead. This alias may be removed after Jun 2026.")]]
+inline std::ostream& operator<<(std::ostream& os, const tt::tt_metal::DataType& dtype) {
+    return ttnn::tensor_impl::operator<<(os, dtype);
+}
+
+template <int = 0>
+[[deprecated("use ttnn::tensor_impl::to_string instead. This alias may be removed after Jun 2026.")]]
+inline std::string to_string(const ttnn::Tensor& tensor) {
+    return ttnn::tensor_impl::to_string(tensor);
+}
+
+template <int = 0>
+[[deprecated("use ttnn::tensor_impl::extract_shard instead. This alias may be removed after Jun 2026.")]]
+inline ttnn::Tensor extract_shard(const ttnn::Tensor& tensor, const uint32_t& core_id) {
+    return ttnn::tensor_impl::extract_shard(tensor, core_id);
+}
+
+}  // namespace tt::tt_metal::tensor_impl

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -57,8 +57,8 @@ struct PrintOptions {
 
 extern PrintOptions TTNN_PRINT_OPTIONS;
 
-std::string to_string(const Tensor& tensor);
+std::string to_string(const ttnn::Tensor& tensor);
 
-Tensor extract_shard(const Tensor& tensor, const uint32_t& core_id);
+ttnn::Tensor extract_shard(const ttnn::Tensor& tensor, const uint32_t& core_id);
 
 }  // namespace tt::tt_metal::tensor_impl

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -16,7 +16,7 @@
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/tensor/layout/tensor_layout.hpp"
 
-namespace tt::tt_metal::tensor_impl {
+namespace ttnn::tensor_impl {
 
 // ===============================================================================================================================================
 //                                                              High Level APIs
@@ -26,8 +26,8 @@ namespace tt::tt_metal::tensor_impl {
 //                                  .view()
 // ======================================================================================
 
-HostTensor view(
-    const HostTensor& tensor,
+tt::tt_metal::HostTensor view(
+    const tt::tt_metal::HostTensor& tensor,
     const tt::tt_metal::Shape& new_logical_shape,
     const tt::tt_metal::Shape& new_padded_shape);
 
@@ -35,7 +35,7 @@ HostTensor view(
 //                                         Print
 // ======================================================================================
 
-std::ostream& operator<<(std::ostream& os, const DataType& dtype);
+std::ostream& operator<<(std::ostream& os, const tt::tt_metal::DataType& dtype);
 
 enum class TensorPrintProfile {
     Empty,
@@ -61,4 +61,4 @@ std::string to_string(const ttnn::Tensor& tensor);
 
 ttnn::Tensor extract_shard(const ttnn::Tensor& tensor, const uint32_t& core_id);
 
-}  // namespace tt::tt_metal::tensor_impl
+}  // namespace ttnn::tensor_impl

--- a/ttnn/api/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_ops.hpp
@@ -14,71 +14,78 @@ namespace tt::tt_metal::distributed {
 class MeshDevice;
 }  // namespace tt::tt_metal::distributed
 
-namespace tt::tt_metal {
+namespace ttnn {
 class Tensor;
+}  // namespace ttnn
+
+namespace tt::tt_metal {
 class MemoryConfig;
 class TensorSpec;
 
 // Allocates a tensor on host.
 // Uses `mesh_device` to allocate sufficient number of host buffers for each multi-device shard.
-Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshDevice* mesh_device);
-Tensor create_device_tensor(const TensorSpec& tensor_spec, distributed::MeshDevice* mesh_device, std::optional<TensorTopology> tensor_topology = std::nullopt);
+ttnn::Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshDevice* mesh_device);
+ttnn::Tensor create_device_tensor(
+    const TensorSpec& tensor_spec,
+    distributed::MeshDevice* mesh_device,
+    std::optional<TensorTopology> tensor_topology = std::nullopt);
 
-tt::tt_metal::Tensor to_device(
-    const tt::tt_metal::Tensor& input_tensor,
+ttnn::Tensor to_device(
+    const ttnn::Tensor& input_tensor,
     distributed::MeshDevice* mesh_device,
     ttsl::optional_reference<const MemoryConfig> mem_config = std::nullopt,
     std::optional<QueueId> cq_id = std::nullopt);
 
-void copy_to_device(const Tensor& host_tensor, Tensor& device_tensor, std::optional<QueueId> cq_id = std::nullopt);
+void copy_to_device(
+    const ttnn::Tensor& host_tensor, ttnn::Tensor& device_tensor, std::optional<QueueId> cq_id = std::nullopt);
 
 void copy_to_device(
     distributed::MeshCommandQueue& queue,
     const std::byte* src,
-    Tensor& device_tensor,
+    ttnn::Tensor& device_tensor,
     const std::optional<BufferRegion>& region = std::nullopt);
 
 void copy_to_host(
     distributed::MeshCommandQueue& queue,
-    const Tensor& device_tensor,
+    const ttnn::Tensor& device_tensor,
     std::byte* dst,
     const std::optional<BufferRegion>& region = std::nullopt,
     bool blocking = true);
 
 void copy_to_host(
-    const Tensor& device_tensor,
-    Tensor& host_tensor,
+    const ttnn::Tensor& device_tensor,
+    ttnn::Tensor& host_tensor,
     bool blocking = true,
     std::optional<QueueId> cq_id = std::nullopt);
 
-Tensor to_layout(const Tensor& input_tensor, tt::tt_metal::Layout target_layout);
+ttnn::Tensor to_layout(const ttnn::Tensor& input_tensor, tt::tt_metal::Layout target_layout);
 
-Tensor cpu(const Tensor& input_tensor, bool blocking = true, std::optional<QueueId> cq_id = std::nullopt);
+ttnn::Tensor cpu(const ttnn::Tensor& input_tensor, bool blocking = true, std::optional<QueueId> cq_id = std::nullopt);
 
-Tensor pad(
-    const Tensor& input_tensor,
+ttnn::Tensor pad(
+    const ttnn::Tensor& input_tensor,
     const tt::tt_metal::Shape& output_padded_shape,
     const tt::tt_metal::Shape& input_tensor_start,
     float pad_value);
 
-Tensor unpad(
-    const Tensor& input_tensor,
+ttnn::Tensor unpad(
+    const ttnn::Tensor& input_tensor,
     const tt::tt_metal::Shape& output_tensor_start,
     const tt::tt_metal::Shape& output_tensor_end);
 
-Tensor pad_to_tile(const Tensor& input_tensor, float pad_value);
+ttnn::Tensor pad_to_tile(const ttnn::Tensor& input_tensor, float pad_value);
 
-Tensor unpad_from_tile(const Tensor& input_tensor, const tt::tt_metal::Shape& output_tensor_shape);
+ttnn::Tensor unpad_from_tile(const ttnn::Tensor& input_tensor, const tt::tt_metal::Shape& output_tensor_shape);
 
-Tensor reshape(const Tensor& input_tensor, const tt::tt_metal::Shape& new_shape);
-Tensor reshape(
-    const Tensor& input_tensor,
+ttnn::Tensor reshape(const ttnn::Tensor& input_tensor, const tt::tt_metal::Shape& new_shape);
+ttnn::Tensor reshape(
+    const ttnn::Tensor& input_tensor,
     const tt::tt_metal::Shape& new_logical_shape,
     const tt::tt_metal::Shape& new_padded_shape);
 
-Tensor view(const Tensor& input_tensor, const tt::tt_metal::Shape& new_shape);
-Tensor view(
-    const Tensor& input_tensor,
+ttnn::Tensor view(const ttnn::Tensor& input_tensor, const tt::tt_metal::Shape& new_shape);
+ttnn::Tensor view(
+    const ttnn::Tensor& input_tensor,
     const tt::tt_metal::Shape& new_logical_shape,
     const tt::tt_metal::Shape& new_padded_shape);
 
@@ -91,10 +98,10 @@ Tensor view(
  * This function is error prone, and the caller is responsible for ensuring that the reinterpretation is semantically
  * valid.
  */
-Tensor unchecked_reinterpret_layout(const Tensor& input_tensor, Layout target_layout);
+ttnn::Tensor unchecked_reinterpret_layout(const ttnn::Tensor& input_tensor, Layout target_layout);
 
-Tensor to_dtype(const Tensor& input_tensor, DataType dtype);
+ttnn::Tensor to_dtype(const ttnn::Tensor& input_tensor, DataType dtype);
 
-std::string to_string(const Tensor& tensor);
+std::string to_string(const ttnn::Tensor& tensor);
 
 }  // namespace tt::tt_metal

--- a/ttnn/api/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_utils.hpp
@@ -13,7 +13,7 @@
 // Exports symbols
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 
-namespace tt::tt_metal {
+namespace ttnn {
 
 // Returns true if tensor has Host storage.
 bool is_cpu_tensor(const ttnn::Tensor& tensor);
@@ -23,7 +23,7 @@ bool is_device_tensor(const ttnn::Tensor& tensor);
 
 // Returns the optimal worker cores for a sharded tensor.
 std::vector<CoreCoord> get_optimal_worker_cores_for_sharded_tensor(
-    const ttnn::Tensor& tensor, NOC noc = NOC::RISCV_0_default);
+    const ttnn::Tensor& tensor, tt::tt_metal::NOC noc = tt::tt_metal::NOC::RISCV_0_default);
 
 /**
  * @brief Creates a CBDescriptor from a sharded tensor.
@@ -59,7 +59,7 @@ std::vector<CoreCoord> get_optimal_worker_cores_for_sharded_tensor(
  *   CBDescriptor cb = cb_descriptor_from_sharded_tensor(in_cb_id, device_input_tensor);
  * @endcode
  */
-CBDescriptor cb_descriptor_from_sharded_tensor(
+tt::tt_metal::CBDescriptor cb_descriptor_from_sharded_tensor(
     uint8_t cb_index,
     const ttnn::Tensor& tensor,
     uint32_t address_offset = 0,
@@ -72,11 +72,11 @@ CBDescriptor cb_descriptor_from_sharded_tensor(
  * Returns buffer->address() + address_offset when a buffer is present,
  * or just address_offset when no buffer is set (manually placed CB).
  */
-inline uint32_t get_cb_address(const CBDescriptor& desc) {
+inline uint32_t get_cb_address(const tt::tt_metal::CBDescriptor& desc) {
     if (desc.buffer == nullptr) {
         return desc.address_offset;
     }
     return desc.buffer->address() + desc.address_offset;
 }
 
-}  // namespace tt::tt_metal
+}  // namespace ttnn

--- a/ttnn/api/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_utils.hpp
@@ -80,3 +80,45 @@ inline uint32_t get_cb_address(const tt::tt_metal::CBDescriptor& desc) {
 }
 
 }  // namespace ttnn
+
+// Compatibility bridges - ttnn tensor infrastructure has moved to the ttnn namespace.
+namespace tt::tt_metal {
+
+template <int = 0>
+[[deprecated("use ttnn::is_cpu_tensor instead. This alias may be removed after Jun 2026.")]]
+inline bool is_cpu_tensor(const ttnn::Tensor& tensor) {
+    return ttnn::is_cpu_tensor(tensor);
+}
+
+template <int = 0>
+[[deprecated("use ttnn::is_device_tensor instead. This alias may be removed after Jun 2026.")]]
+inline bool is_device_tensor(const ttnn::Tensor& tensor) {
+    return ttnn::is_device_tensor(tensor);
+}
+
+template <int = 0>
+[[deprecated(
+    "use ttnn::get_optimal_worker_cores_for_sharded_tensor instead. This alias may be removed after Jun 2026.")]]
+inline std::vector<CoreCoord> get_optimal_worker_cores_for_sharded_tensor(
+    const ttnn::Tensor& tensor, NOC noc = NOC::RISCV_0_default) {
+    return ttnn::get_optimal_worker_cores_for_sharded_tensor(tensor, noc);
+}
+
+template <int = 0>
+[[deprecated("use ttnn::cb_descriptor_from_sharded_tensor instead. This alias may be removed after Jun 2026.")]]
+inline CBDescriptor cb_descriptor_from_sharded_tensor(
+    uint8_t cb_index,
+    const ttnn::Tensor& tensor,
+    uint32_t address_offset = 0,
+    uint32_t total_size = 0,
+    const std::optional<CoreRangeSet>& core_ranges = std::nullopt) {
+    return ttnn::cb_descriptor_from_sharded_tensor(cb_index, tensor, address_offset, total_size, core_ranges);
+}
+
+template <int = 0>
+[[deprecated("use ttnn::get_cb_address instead. This alias may be removed after Jun 2026.")]]
+inline uint32_t get_cb_address(const CBDescriptor& desc) {
+    return ttnn::get_cb_address(desc);
+}
+
+}  // namespace tt::tt_metal

--- a/ttnn/api/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_utils.hpp
@@ -16,14 +16,14 @@
 namespace tt::tt_metal {
 
 // Returns true if tensor has Host storage.
-bool is_cpu_tensor(const Tensor& tensor);
+bool is_cpu_tensor(const ttnn::Tensor& tensor);
 
 // Returns true if tensor is on device.
-bool is_device_tensor(const Tensor& tensor);
+bool is_device_tensor(const ttnn::Tensor& tensor);
 
 // Returns the optimal worker cores for a sharded tensor.
 std::vector<CoreCoord> get_optimal_worker_cores_for_sharded_tensor(
-    const Tensor& tensor, NOC noc = NOC::RISCV_0_default);
+    const ttnn::Tensor& tensor, NOC noc = NOC::RISCV_0_default);
 
 /**
  * @brief Creates a CBDescriptor from a sharded tensor.
@@ -61,7 +61,7 @@ std::vector<CoreCoord> get_optimal_worker_cores_for_sharded_tensor(
  */
 CBDescriptor cb_descriptor_from_sharded_tensor(
     uint8_t cb_index,
-    const Tensor& tensor,
+    const ttnn::Tensor& tensor,
     uint32_t address_offset = 0,
     uint32_t total_size = 0,
     const std::optional<CoreRangeSet>& core_ranges = std::nullopt);

--- a/ttnn/api/ttnn/tensor/to_string.hpp
+++ b/ttnn/api/ttnn/tensor/to_string.hpp
@@ -6,6 +6,6 @@
 
 namespace ttnn {
 
-std::string to_string(const tt::tt_metal::Tensor& tensor);
+std::string to_string(const Tensor& tensor);
 
 }  // namespace ttnn

--- a/ttnn/api/ttnn/tensor/types.hpp
+++ b/ttnn/api/ttnn/tensor/types.hpp
@@ -8,6 +8,7 @@
 #include "ttnn/tensor/shape/shape.hpp"
 
 namespace ttnn {
+
 enum class PyDType {
     FLOAT32,
     FLOAT64,
@@ -23,11 +24,7 @@ enum class PyDType {
     UINT64,
     BOOL
 };
-}
 
-namespace tt::tt_metal {
-
-// Specifies Tensor storage type.
 enum class StorageType {
     HOST = 0,
     DEVICE = 1,
@@ -44,4 +41,4 @@ using Array6D = std::array<uint32_t, 6>;
 using Array7D = std::array<uint32_t, 7>;
 using Array8D = std::array<uint32_t, 8>;
 
-}  // namespace tt::tt_metal
+}  // namespace ttnn

--- a/ttnn/api/ttnn/tensor/types.hpp
+++ b/ttnn/api/ttnn/tensor/types.hpp
@@ -42,3 +42,22 @@ using Array7D = std::array<uint32_t, 7>;
 using Array8D = std::array<uint32_t, 8>;
 
 }  // namespace ttnn
+
+// Compatibility aliases - ttnn tensor infrastructure has moved to the ttnn namespace.
+namespace tt::tt_metal {
+
+[[deprecated("use ttnn::MAX_NUM_DIMENSIONS instead. This alias may be removed after Jun 2026.")]]
+static constexpr std::size_t MAX_NUM_DIMENSIONS = ttnn::MAX_NUM_DIMENSIONS;
+
+using StorageType [[deprecated("use ttnn::StorageType instead. This alias may be removed after Jun 2026.")]] =
+    ttnn::StorageType;
+using Array1D [[deprecated("use ttnn::Array1D instead. This alias may be removed after Jun 2026.")]] = ttnn::Array1D;
+using Array2D [[deprecated("use ttnn::Array2D instead. This alias may be removed after Jun 2026.")]] = ttnn::Array2D;
+using Array3D [[deprecated("use ttnn::Array3D instead. This alias may be removed after Jun 2026.")]] = ttnn::Array3D;
+using Array4D [[deprecated("use ttnn::Array4D instead. This alias may be removed after Jun 2026.")]] = ttnn::Array4D;
+using Array5D [[deprecated("use ttnn::Array5D instead. This alias may be removed after Jun 2026.")]] = ttnn::Array5D;
+using Array6D [[deprecated("use ttnn::Array6D instead. This alias may be removed after Jun 2026.")]] = ttnn::Array6D;
+using Array7D [[deprecated("use ttnn::Array7D instead. This alias may be removed after Jun 2026.")]] = ttnn::Array7D;
+using Array8D [[deprecated("use ttnn::Array8D instead. This alias may be removed after Jun 2026.")]] = ttnn::Array8D;
+
+}  // namespace tt::tt_metal

--- a/ttnn/api/ttnn/tensor/unit_mesh/unit_mesh_utils.hpp
+++ b/ttnn/api/ttnn/tensor/unit_mesh/unit_mesh_utils.hpp
@@ -28,3 +28,20 @@ ttnn::Tensor aggregate(const std::vector<ttnn::Tensor>& tensors);
 std::vector<ttnn::Tensor> disaggregate(const ttnn::Tensor& tensor);
 
 }  // namespace ttnn::experimental::unit_mesh
+
+// Compatibility bridges - ttnn tensor infrastructure has moved to the ttnn namespace.
+namespace tt::tt_metal::experimental::unit_mesh {
+
+template <int = 0>
+[[deprecated("use ttnn::experimental::unit_mesh::aggregate instead. This alias may be removed after Jun 2026.")]]
+inline ttnn::Tensor aggregate(const std::vector<ttnn::Tensor>& tensors) {
+    return ttnn::experimental::unit_mesh::aggregate(tensors);
+}
+
+template <int = 0>
+[[deprecated("use ttnn::experimental::unit_mesh::disaggregate instead. This alias may be removed after Jun 2026.")]]
+inline std::vector<ttnn::Tensor> disaggregate(const ttnn::Tensor& tensor) {
+    return ttnn::experimental::unit_mesh::disaggregate(tensor);
+}
+
+}  // namespace tt::tt_metal::experimental::unit_mesh

--- a/ttnn/api/ttnn/tensor/unit_mesh/unit_mesh_utils.hpp
+++ b/ttnn/api/ttnn/tensor/unit_mesh/unit_mesh_utils.hpp
@@ -17,7 +17,7 @@ namespace tt::tt_metal::experimental::unit_mesh {
 // match the parent mesh size.
 //
 // Returns a tensor distributed across the parent mesh.
-Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors);
+ttnn::Tensor aggregate(const std::vector<ttnn::Tensor>& tensors);
 
 // Disaggregates a tensor from a parent mesh into individual tensors on unit meshes (1x1 submeshes).
 //
@@ -25,6 +25,6 @@ Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors);
 // parent mesh size, and each submesh must be a unit mesh (1x1).
 //
 // Returns a vector of tensors, one per submesh, all sharing the same buffer address.
-std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tensor);
+std::vector<ttnn::Tensor> disaggregate(const ttnn::Tensor& tensor);
 
 }  // namespace tt::tt_metal::experimental::unit_mesh

--- a/ttnn/api/ttnn/tensor/unit_mesh/unit_mesh_utils.hpp
+++ b/ttnn/api/ttnn/tensor/unit_mesh/unit_mesh_utils.hpp
@@ -8,7 +8,7 @@
 
 #include "ttnn/tensor/tensor.hpp"
 
-namespace tt::tt_metal::experimental::unit_mesh {
+namespace ttnn::experimental::unit_mesh {
 
 // Aggregates tensors from unit meshes (1x1 submeshes) into a single tensor on the parent mesh.
 //
@@ -27,4 +27,4 @@ ttnn::Tensor aggregate(const std::vector<ttnn::Tensor>& tensors);
 // Returns a vector of tensors, one per submesh, all sharing the same buffer address.
 std::vector<ttnn::Tensor> disaggregate(const ttnn::Tensor& tensor);
 
-}  // namespace tt::tt_metal::experimental::unit_mesh
+}  // namespace ttnn::experimental::unit_mesh

--- a/ttnn/api/ttnn/tensor/xtensor/conversion_utils.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/conversion_utils.hpp
@@ -123,3 +123,20 @@ xt::xarray<T> to_xtensor(const ttnn::Tensor& tensor) {
 }
 
 }  // namespace ttnn::experimental::xtensor
+
+// Compatibility bridges - ttnn tensor infrastructure has moved to the ttnn namespace.
+namespace tt::tt_metal::experimental::xtensor {
+
+template <typename T, int = 0>
+[[deprecated("use ttnn::experimental::xtensor::from_xtensor instead. This alias may be removed after Jun 2026.")]]
+inline ttnn::Tensor from_xtensor(const xt::xarray<T>& buffer, const tt::tt_metal::TensorSpec& spec) {
+    return ttnn::experimental::xtensor::from_xtensor<T>(buffer, spec);
+}
+
+template <typename T, int = 0>
+[[deprecated("use ttnn::experimental::xtensor::to_xtensor instead. This alias may be removed after Jun 2026.")]]
+inline xt::xarray<T> to_xtensor(const ttnn::Tensor& tensor) {
+    return ttnn::experimental::xtensor::to_xtensor<T>(tensor);
+}
+
+}  // namespace tt::tt_metal::experimental::xtensor

--- a/ttnn/api/ttnn/tensor/xtensor/conversion_utils.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/conversion_utils.hpp
@@ -106,17 +106,17 @@ auto xtensor_to_span(const xt::xarray<T>& xtensor) {
 // Converts an xtensor to a Tensor.
 // IMPORTANT: this copies the data into the returned Tensor, which can be an expensive operation.
 template <typename T>
-tt::tt_metal::Tensor from_xtensor(const xt::xarray<T>& buffer, const TensorSpec& spec) {
+ttnn::Tensor from_xtensor(const xt::xarray<T>& buffer, const TensorSpec& spec) {
     auto shape = get_shape_from_xarray(buffer);
     TT_FATAL(shape == spec.logical_shape(), "xtensor has a different shape than the supplied TensorSpec");
     auto buffer_view = xtensor_to_span(buffer);
-    return tt::tt_metal::Tensor::from_span<T>(buffer_view, spec);
+    return ttnn::Tensor::from_span<T>(buffer_view, spec);
 }
 
 // Converts a Tensor to an xtensor.
 // IMPORTANT: this copies the data into the returned Tensor, which can be an expensive operation.
 template <typename T>
-xt::xarray<T> to_xtensor(const tt::tt_metal::Tensor& tensor) {
+xt::xarray<T> to_xtensor(const ttnn::Tensor& tensor) {
     auto vec = tensor.to_vector<T>();
     const auto& shape = tensor.logical_shape();
     return xt::xarray<T>(span_to_xtensor_view(ttsl::Span<T>(vec.data(), vec.size()), shape));

--- a/ttnn/api/ttnn/tensor/xtensor/conversion_utils.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/conversion_utils.hpp
@@ -10,7 +10,7 @@
 #include "ttnn/tensor/tensor.hpp"
 #include <ttnn/tensor/xtensor/xtensor_all_includes.hpp>
 
-namespace tt::tt_metal::experimental::xtensor {
+namespace ttnn::experimental::xtensor {
 
 // Returns the shape of the xtensor as `tt::tt_metal::Shape`.
 template <typename E>
@@ -122,4 +122,4 @@ xt::xarray<T> to_xtensor(const ttnn::Tensor& tensor) {
     return xt::xarray<T>(span_to_xtensor_view(ttsl::Span<T>(vec.data(), vec.size()), shape));
 }
 
-}  // namespace tt::tt_metal::experimental::xtensor
+}  // namespace ttnn::experimental::xtensor

--- a/ttnn/api/ttnn/tensor/xtensor/partition.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/partition.hpp
@@ -10,7 +10,7 @@
 #include <xtensor/views/xstrided_view.hpp>
 #include "ttnn/tensor/tensor.hpp"
 
-namespace tt::tt_metal::experimental::xtensor {
+namespace ttnn::experimental::xtensor {
 namespace detail {
 
 // Helper to compute the type of an unowned strided view over an `xt::xexpression`.
@@ -59,4 +59,4 @@ XtensorAdapter<typename Expression::value_type> concat_ndim(
 // Deprecated: Use high-level APIs defined in distributed_tensor.hpp
 ttnn::Tensor concat(const std::vector<ttnn::Tensor>& tensors, int dim = 0);
 
-}  // namespace tt::tt_metal::experimental::xtensor
+}  // namespace ttnn::experimental::xtensor

--- a/ttnn/api/ttnn/tensor/xtensor/partition.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/partition.hpp
@@ -60,3 +60,14 @@ XtensorAdapter<typename Expression::value_type> concat_ndim(
 ttnn::Tensor concat(const std::vector<ttnn::Tensor>& tensors, int dim = 0);
 
 }  // namespace ttnn::experimental::xtensor
+
+// Compatibility bridge - ttnn tensor infrastructure has moved to the ttnn namespace.
+namespace tt::tt_metal::experimental::xtensor {
+
+template <int = 0>
+[[deprecated("use ttnn::experimental::xtensor::concat instead. This alias may be removed after Jun 2026.")]]
+inline ttnn::Tensor concat(const std::vector<ttnn::Tensor>& tensors, int dim = 0) {
+    return ttnn::experimental::xtensor::concat(tensors, dim);
+}
+
+}  // namespace tt::tt_metal::experimental::xtensor

--- a/ttnn/api/ttnn/tensor/xtensor/partition.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/partition.hpp
@@ -57,6 +57,6 @@ XtensorAdapter<typename Expression::value_type> concat_ndim(
 
 // Overload in terms of `Tensor`.
 // Deprecated: Use high-level APIs defined in distributed_tensor.hpp
-tt::tt_metal::Tensor concat(const std::vector<tt::tt_metal::Tensor>& tensors, int dim = 0);
+ttnn::Tensor concat(const std::vector<ttnn::Tensor>& tensors, int dim = 0);
 
 }  // namespace tt::tt_metal::experimental::xtensor

--- a/ttnn/api/ttnn/types.hpp
+++ b/ttnn/api/ttnn/types.hpp
@@ -38,7 +38,6 @@ using tt::tt_metal::Layout;
 static constexpr auto ROW_MAJOR_LAYOUT = Layout::ROW_MAJOR;
 static constexpr auto TILE_LAYOUT = Layout::TILE;
 
-using tt::tt_metal::StorageType;
 static constexpr auto DEVICE_STORAGE_TYPE = StorageType::DEVICE;
 static constexpr auto HOST_STORAGE_TYPE = StorageType::HOST;
 

--- a/ttnn/core/core.cpp
+++ b/ttnn/core/core.cpp
@@ -15,7 +15,7 @@ bool has_storage_type_of(const ttnn::Tensor& tensor, const ttnn::StorageType& st
 }
 
 std::optional<ttnn::MemoryConfig> get_memory_config(const ttnn::Tensor& tensor) {
-    if (not tensor.is_allocated() or not tt::tt_metal::is_device_tensor(tensor)) {
+    if (not tensor.is_allocated() or not is_device_tensor(tensor)) {
         return std::nullopt;
     }
     return tensor.memory_config();

--- a/ttnn/core/core.cpp
+++ b/ttnn/core/core.cpp
@@ -22,9 +22,9 @@ std::optional<ttnn::MemoryConfig> get_memory_config(const ttnn::Tensor& tensor) 
 }
 
 void set_printoptions(TensorPrintProfile print_profile, SciMode sci_mode, int precision) {
-    tt::tt_metal::tensor_impl::TTNN_PRINT_OPTIONS.profile = print_profile;
-    tt::tt_metal::tensor_impl::TTNN_PRINT_OPTIONS.sci_mode = sci_mode;
-    tt::tt_metal::tensor_impl::TTNN_PRINT_OPTIONS.precision = precision;
+    tensor_impl::TTNN_PRINT_OPTIONS.profile = print_profile;
+    tensor_impl::TTNN_PRINT_OPTIONS.sci_mode = sci_mode;
+    tensor_impl::TTNN_PRINT_OPTIONS.precision = precision;
 }
 
 void segfault_handler(int /*sig*/) {

--- a/ttnn/core/core.cpp
+++ b/ttnn/core/core.cpp
@@ -15,7 +15,7 @@ bool has_storage_type_of(const ttnn::Tensor& tensor, const ttnn::StorageType& st
 }
 
 std::optional<ttnn::MemoryConfig> get_memory_config(const ttnn::Tensor& tensor) {
-    if (not tensor.is_allocated() or not is_device_tensor(tensor)) {
+    if (not tensor.is_allocated() or not tt::tt_metal::is_device_tensor(tensor)) {
         return std::nullopt;
     }
     return tensor.memory_config();

--- a/ttnn/core/device_operation_detail.cpp
+++ b/ttnn/core/device_operation_detail.cpp
@@ -34,7 +34,7 @@ using MeshCoordinateRangeSet = tt::tt_metal::distributed::MeshCoordinateRangeSet
 // The only reason it was templated was to call visit_object_of_type<Tensor> on tensor_args.
 // Callers now extract tensors first and pass them as a vector.
 
-static bool is_fully_replicated(const tt::tt_metal::Tensor& tensor) {
+static bool is_fully_replicated(const Tensor& tensor) {
     for (const auto& placement : tensor.tensor_topology().placements()) {
         if (std::holds_alternative<tt::tt_metal::distributed::MeshMapperConfig::Shard>(placement)) {
             return false;
@@ -46,9 +46,7 @@ static bool is_fully_replicated(const tt::tt_metal::Tensor& tensor) {
 std::pair<
     ttsl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement>,
     tt::tt_metal::distributed::MeshShape>
-compute_output_placements_and_shape(
-    const std::vector<std::reference_wrapper<const tt::tt_metal::Tensor>>& tensors) {
-    using Tensor = tt::tt_metal::Tensor;
+compute_output_placements_and_shape(const std::vector<std::reference_wrapper<const Tensor>>& tensors) {
     using Placement = tt::tt_metal::distributed::MeshMapperConfig::Placement;
     using Shard = tt::tt_metal::distributed::MeshMapperConfig::Shard;
     using Replicate = tt::tt_metal::distributed::MeshMapperConfig::Replicate;
@@ -178,10 +176,8 @@ static bool is_subset_of(const std::vector<MeshCoordinate>& a, const std::vector
 }
 
 std::vector<MeshCoordinate> extract_tensor_coordinates_impl(
-    const std::vector<std::reference_wrapper<const tt::tt_metal::Tensor>>& tensors,
+    const std::vector<std::reference_wrapper<const Tensor>>& tensors,
     tt::tt_metal::distributed::MeshDevice* mesh_device) {
-    using Tensor = tt::tt_metal::Tensor;
-
     // If no tensor is found, return zero coordinate
     if (tensors.empty()) {
         if (mesh_device == nullptr) {

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -598,7 +598,7 @@ Tensor distribute_tensor(
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     std::optional<ttnn::QueueId> cq_id) {
     TT_FATAL(
-        tensor.storage_type() == tt::tt_metal::StorageType::HOST,
+        tensor.storage_type() == StorageType::HOST,
         "TensorToMesh only supports host tensors; got storage type: {}",
         tensor.storage_type());
     Tensor output = mapper(tensor);

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -121,7 +121,7 @@ public:
         config_(config) {}
 
     Tensor operator()(const Tensor& tensor) const {
-        auto extract_logical_data = [this]<typename T>(const tt::tt_metal::Tensor& tensor) -> Tensor {
+        auto extract_logical_data = [this]<typename T>(const Tensor& tensor) -> Tensor {
             const bool data_viewable = tensor.tensor_spec().layout() == tt::tt_metal::Layout::ROW_MAJOR &&
                                        tensor.tensor_spec().physical_shape() == tensor.tensor_spec().logical_2d_shape();
             tt::tt_metal::HostBuffer host_buffer = data_viewable ? tt::tt_metal::host_buffer::get_host_buffer(tensor)

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -97,7 +97,7 @@ tt::tt_metal::HostBuffer create_host_buffer_from_span(
         }
     }
 
-    return tt::tt_metal::host_buffer::get_host_buffer(Tensor::from_span(
+    return host_buffer::get_host_buffer(Tensor::from_span(
         ttsl::make_const_span(span),
         tensor_spec,
         /*device=*/nullptr,
@@ -124,8 +124,8 @@ public:
         auto extract_logical_data = [this]<typename T>(const Tensor& tensor) -> Tensor {
             const bool data_viewable = tensor.tensor_spec().layout() == tt::tt_metal::Layout::ROW_MAJOR &&
                                        tensor.tensor_spec().physical_shape() == tensor.tensor_spec().logical_2d_shape();
-            tt::tt_metal::HostBuffer host_buffer = data_viewable ? tt::tt_metal::host_buffer::get_host_buffer(tensor)
-                                                                 : tt::tt_metal::HostBuffer(tensor.to_vector<T>());
+            tt::tt_metal::HostBuffer host_buffer =
+                data_viewable ? host_buffer::get_host_buffer(tensor) : tt::tt_metal::HostBuffer(tensor.to_vector<T>());
             return (*this)(
                 host_buffer.view_as<T>(),
                 tensor.tensor_spec().logical_shape(),
@@ -347,7 +347,7 @@ private:
                             std::nullopt,
                             pad_value);
                     }
-                    auto buffer = tt::tt_metal::host_buffer::get_host_buffer(shard_tensor);
+                    auto buffer = host_buffer::get_host_buffer(shard_tensor);
                     converted_buffers.emplace(&xtensor_view->get(), buffer);
                     return buffer;
                 };

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -68,7 +68,7 @@ TensorSpec compute_tensor_spec_for_shards(
         if (!xtensor_view.has_value()) {
             continue;
         }
-        auto xtensor_shard_shape = tt::tt_metal::experimental::xtensor::get_shape_from_xarray(xtensor_view->get());
+        auto xtensor_shard_shape = experimental::xtensor::get_shape_from_xarray(xtensor_view->get());
         if (shard_shape.has_value()) {
             TT_FATAL(
                 shard_shape.value() == xtensor_shard_shape,
@@ -197,10 +197,9 @@ public:
         }
 
         // Otherwise, use xtensor to chunk the data into shards.
-        auto input_xtensor =
-            tt::tt_metal::experimental::xtensor::adapt(span, std::vector<size_t>(shape.cbegin(), shape.cend()));
+        auto input_xtensor = experimental::xtensor::adapt(span, std::vector<size_t>(shape.cbegin(), shape.cend()));
 
-        auto chunks = tt::tt_metal::experimental::xtensor::chunk_ndim(input_xtensor, num_chunks_per_dim, tensor_dims);
+        auto chunks = experimental::xtensor::chunk_ndim(input_xtensor, num_chunks_per_dim, tensor_dims);
         TT_FATAL(chunks.size() >= 1, "No chunks were produced");
         TT_FATAL(
             distribution_shape_.dims() == 1 || chunks.size() == sharded_mesh_size,
@@ -208,8 +207,7 @@ public:
             chunks.size(),
             sharded_mesh_size);
 
-        using StridedViewRef =
-            std::reference_wrapper<tt::tt_metal::experimental::xtensor::StridedView<decltype(input_xtensor)>>;
+        using StridedViewRef = std::reference_wrapper<experimental::xtensor::StridedView<decltype(input_xtensor)>>;
         tt::tt_metal::distributed::MeshContainer<std::optional<StridedViewRef>> sharded_xtensor_views(
             distribution_shape_, std::nullopt);
 
@@ -416,11 +414,11 @@ public:
         }
 
         // Convert shards into a linear buffer of xtensor views.
-        std::vector<tt::tt_metal::experimental::xtensor::AdaptedView<const T>> xtensor_views;
+        std::vector<experimental::xtensor::AdaptedView<const T>> xtensor_views;
         xtensor_views.reserve(distribution_shape_.mesh_size());
         std::vector<size_t> shard_shape(tensor.logical_shape().cbegin(), tensor.logical_shape().cend());
         dst_buffer.apply([&xtensor_views, &shard_shape](const tt::tt_metal::HostBuffer& shard) {
-            xtensor_views.push_back(tt::tt_metal::experimental::xtensor::adapt(shard.view_as<const T>(), shard_shape));
+            xtensor_views.push_back(experimental::xtensor::adapt(shard.view_as<const T>(), shard_shape));
         });
 
         ttsl::SmallVector<int> num_chunks;
@@ -441,9 +439,8 @@ public:
             }
         }
 
-        auto xtensor_adapter =
-            tt::tt_metal::experimental::xtensor::concat_ndim(xtensor_views, num_chunks, config_.dims);
-        auto&& shape = tt::tt_metal::experimental::xtensor::get_shape_from_xarray(xtensor_adapter.expr());
+        auto xtensor_adapter = experimental::xtensor::concat_ndim(xtensor_views, num_chunks, config_.dims);
+        auto&& shape = experimental::xtensor::get_shape_from_xarray(xtensor_adapter.expr());
         return {std::move(xtensor_adapter).data(), std::move(shape)};
     }
 

--- a/ttnn/core/distributed/host_ccl.cpp
+++ b/ttnn/core/distributed/host_ccl.cpp
@@ -23,7 +23,7 @@ using ::tt::tt_metal::DistributedHostBuffer;
 using ::tt::tt_metal::HostBuffer;
 
 Tensor all_gather(const Tensor& tensor) {
-    TT_FATAL(tensor.storage_type() == tt::tt_metal::StorageType::HOST, "Tensor must be on host");
+    TT_FATAL(tensor.storage_type() == StorageType::HOST, "Tensor must be on host");
     const auto& ctx = tensor.host_storage().buffer().context();
     if (*ctx->size() == 1) {
         // Single-host deployment. Validate this host has all the data.

--- a/ttnn/core/distributed/mpi_socket.cpp
+++ b/ttnn/core/distributed/mpi_socket.cpp
@@ -14,7 +14,7 @@ namespace ttnn::distributed {
 namespace {
 
 std::vector<tt::tt_metal::HostBuffer> get_as(const ttnn::Tensor& tensor) {
-    TT_FATAL(tt::tt_metal::is_cpu_tensor(tensor), "Tensor must be on host");
+    TT_FATAL(is_cpu_tensor(tensor), "Tensor must be on host");
     const auto& storage = tensor.host_storage();
     std::vector<tt::tt_metal::HostBuffer> buffers;
     buffers.reserve(storage.buffer().shard_coords().size());

--- a/ttnn/core/operation.cpp
+++ b/ttnn/core/operation.cpp
@@ -13,11 +13,11 @@ OpPerformanceModelGeneral<OutputTensorsT>::OpPerformanceModelGeneral(
     Tensors input_tensors, const OutputTensors& output_tensors, int ideal_compute_cycles) :
     ideal_compute_cycles(ideal_compute_cycles) {
     const auto& t = input_tensors.at(0);
-    const auto arch = t.storage_type() == StorageType::DEVICE ? t.device()->arch() : ARCH::WORMHOLE_B0;
+    const auto arch = t.storage_type() == ttnn::StorageType::DEVICE ? t.device()->arch() : ARCH::WORMHOLE_B0;
 
     // Get clock rate dynamically from device
     float clock_rate_ghz;
-    if (t.storage_type() == StorageType::DEVICE) {
+    if (t.storage_type() == ttnn::StorageType::DEVICE) {
         int freq_mhz = t.device()->get_clock_rate_mhz();
         clock_rate_ghz = freq_mhz / 1000.0f;
     } else {

--- a/ttnn/core/operation.cpp
+++ b/ttnn/core/operation.cpp
@@ -41,7 +41,7 @@ OpPerformanceModelGeneral<OutputTensorsT>::OpPerformanceModelGeneral(
         TT_THROW("Unsupported architecture for OpPerformanceModel");
     }
 
-    auto tensor_ns = [peak_dram_bw](const Tensor& t) {
+    auto tensor_ns = [peak_dram_bw](const ttnn::Tensor& t) {
         int size_bytes = t.physical_volume() * t.element_size();
         if (t.memory_config().is_dram()) {
             return size_bytes / peak_dram_bw / 1024 / 1024 / 1024 * 1000 * 1000 * 1000;
@@ -65,18 +65,18 @@ OpPerformanceModelGeneral<OutputTensorsT>::OpPerformanceModelGeneral(
                 this->ideal_bandwidth_ns = tensor_ns(t);
             }
         }
-    } else if constexpr (std::is_same_v<OutputTensors, Tensor>) {
+    } else if constexpr (std::is_same_v<OutputTensors, ttnn::Tensor>) {
         this->outputs_bytes.push_back(output_tensors.physical_volume() * output_tensors.element_size());
         auto output_ns = tensor_ns(output_tensors);
         if (output_ns > this->ideal_bandwidth_ns) {
             this->ideal_bandwidth_ns = output_ns;
         }
     } else if constexpr (
-        std::is_same_v<OutputTensors, std::array<std::vector<Tensor>, 2>> ||
-        std::is_same_v<OutputTensors, std::array<Tensor, 2>>) {
+        std::is_same_v<OutputTensors, std::array<std::vector<ttnn::Tensor>, 2>> ||
+        std::is_same_v<OutputTensors, std::array<ttnn::Tensor, 2>>) {
         // Handle std::array types - iterate over array elements
         for (const auto& element : output_tensors) {
-            if constexpr (std::is_same_v<decltype(element), const std::vector<Tensor>&>) {
+            if constexpr (std::is_same_v<decltype(element), const std::vector<ttnn::Tensor>&>) {
                 // Array of vectors - process each tensor in each vector
                 for (const auto& t : element) {
                     this->outputs_bytes.push_back(t.physical_volume() * t.element_size());
@@ -92,7 +92,7 @@ OpPerformanceModelGeneral<OutputTensorsT>::OpPerformanceModelGeneral(
                 }
             }
         }
-    } else if constexpr (std::is_same_v<OutputTensors, std::tuple<Tensor, Tensor>>) {
+    } else if constexpr (std::is_same_v<OutputTensors, std::tuple<ttnn::Tensor, ttnn::Tensor>>) {
         // Handle std::tuple<Tensor, Tensor>
         auto process_tuple_element = [&](const auto& t) {
             this->outputs_bytes.push_back(t.physical_volume() * t.element_size());
@@ -123,7 +123,7 @@ OpPerformanceModelGeneral<OutputTensorsT>::OpPerformanceModelGeneral(
 // get_input_bws/get_output_bws are kept inline in header to avoid needing
 // explicit instantiation for every custom result type.
 template OpPerformanceModelGeneral<Tensors>::OpPerformanceModelGeneral(Tensors, const Tensors&, int);
-template OpPerformanceModelGeneral<Tensor>::OpPerformanceModelGeneral(Tensors, const Tensor&, int);
+template OpPerformanceModelGeneral<ttnn::Tensor>::OpPerformanceModelGeneral(Tensors, const ttnn::Tensor&, int);
 template OpPerformanceModelGeneral<OptionalTensors>::OpPerformanceModelGeneral(Tensors, const OptionalTensors&, int);
 
 }  // namespace tt::tt_metal::operation

--- a/ttnn/core/tensor/flatbuffer/overlapped_tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/overlapped_tensor_flatbuffer.cpp
@@ -16,7 +16,7 @@
 namespace ttnn {
 
 flatbuffers::Offset<flatbuffer::OverlappedTensors> overlapped_tensors_to_flatbuffer(
-    const std::vector<tt::tt_metal::OverlappedTensorView>& views,
+    const std::vector<OverlappedTensorView>& views,
     flatbuffers::FlatBufferBuilder& builder,
     std::vector<tt::tt_metal::HostBuffer>& buffers) {
     TT_FATAL(!views.empty(), "Need at least one OverlappedTensorView to serialize");
@@ -47,7 +47,7 @@ flatbuffers::Offset<flatbuffer::OverlappedTensors> overlapped_tensors_to_flatbuf
     return flatbuffer::CreateOverlappedTensors(builder, fused_offset, views_vec);
 }
 
-std::vector<tt::tt_metal::OverlappedTensorView> overlapped_tensors_from_flatbuffer(
+std::vector<OverlappedTensorView> overlapped_tensors_from_flatbuffer(
     const flatbuffer::OverlappedTensors* fb,
     tt::stl::Span<std::byte> tensor_data,
     const tt::tt_metal::MemoryPin& memory_pin) {
@@ -57,10 +57,10 @@ std::vector<tt::tt_metal::OverlappedTensorView> overlapped_tensors_from_flatbuff
 
     auto fused = ttnn::from_flatbuffer(fb->fused_tensor(), tensor_data, memory_pin);
 
-    std::vector<tt::tt_metal::OverlappedTensorView> result;
+    std::vector<OverlappedTensorView> result;
     result.reserve(fb->views()->size());
     for (const auto* fb_view : *fb->views()) {
-        result.push_back(tt::tt_metal::OverlappedTensorView{
+        result.push_back(OverlappedTensorView{
             .name = fb_view->name() ? fb_view->name()->str() : std::string{},
             .fused_tensor = fused,
             .tensor_shape = {fb_view->tensor_shape_h(), fb_view->tensor_shape_w()},

--- a/ttnn/core/tensor/flatbuffer/overlapped_tensor_flatbuffer.hpp
+++ b/ttnn/core/tensor/flatbuffer/overlapped_tensor_flatbuffer.hpp
@@ -13,11 +13,11 @@
 namespace ttnn {
 
 flatbuffers::Offset<flatbuffer::OverlappedTensors> overlapped_tensors_to_flatbuffer(
-    const std::vector<tt::tt_metal::OverlappedTensorView>& views,
+    const std::vector<OverlappedTensorView>& views,
     flatbuffers::FlatBufferBuilder& builder,
     std::vector<tt::tt_metal::HostBuffer>& buffers);
 
-std::vector<tt::tt_metal::OverlappedTensorView> overlapped_tensors_from_flatbuffer(
+std::vector<OverlappedTensorView> overlapped_tensors_from_flatbuffer(
     const flatbuffer::OverlappedTensors* fb,
     tt::stl::Span<std::byte> tensor_data,
     const tt::tt_metal::MemoryPin& memory_pin);

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -161,7 +161,7 @@ tt::tt_metal::TensorTopology from_flatbuffer(const ttnn::flatbuffer::TensorTopol
 flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
     const Tensor& tensor, flatbuffers::FlatBufferBuilder& builder, std::vector<tt::tt_metal::HostBuffer>& buffers) {
     TT_FATAL(buffers.empty(), "Buffers vector must be empty");
-    TT_FATAL(!is_device_tensor(tensor), "Device tensors are not supported in flatbuffer serialization");
+    TT_FATAL(!tt::tt_metal::is_device_tensor(tensor), "Device tensors are not supported in flatbuffer serialization");
 
     auto tensor_spec_offset = ttnn::to_flatbuffer(tensor.tensor_spec(), builder);
 

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -161,7 +161,7 @@ tt::tt_metal::TensorTopology from_flatbuffer(const ttnn::flatbuffer::TensorTopol
 flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
     const Tensor& tensor, flatbuffers::FlatBufferBuilder& builder, std::vector<tt::tt_metal::HostBuffer>& buffers) {
     TT_FATAL(buffers.empty(), "Buffers vector must be empty");
-    TT_FATAL(!tt::tt_metal::is_device_tensor(tensor), "Device tensors are not supported in flatbuffer serialization");
+    TT_FATAL(!is_device_tensor(tensor), "Device tensors are not supported in flatbuffer serialization");
 
     auto tensor_spec_offset = ttnn::to_flatbuffer(tensor.tensor_spec(), builder);
 

--- a/ttnn/core/tensor/host_buffer/functions.cpp
+++ b/ttnn/core/tensor/host_buffer/functions.cpp
@@ -13,27 +13,27 @@
 
 namespace tt::tt_metal::host_buffer {
 
-HostBuffer get_host_buffer(const Tensor& tensor) {
+HostBuffer get_host_buffer(const ttnn::Tensor& tensor) {
     TT_FATAL(is_cpu_tensor(tensor), "Tensor must have on host");
     return get_host_buffer(tensor.host_tensor());
 }
 
 template <typename T>
-ttsl::Span<const T> get_as(const Tensor& tensor) {
+ttsl::Span<const T> get_as(const ttnn::Tensor& tensor) {
     return get_as<T>(tensor.host_tensor());
 }
 
 template <typename T>
-ttsl::Span<T> get_as(Tensor& tensor) {
+ttsl::Span<T> get_as(ttnn::Tensor& tensor) {
     return get_as<T>(tensor.host_storage().host_tensor());
 }
 
 // Explicit template instantiations
-#define INSTANTIATE_HOST_BUFFER_FUNCTIONS(T)                     \
-    template ttsl::Span<const T> get_as<T>(const Tensor&);       \
-    template ttsl::Span<const T> get_as<const T>(const Tensor&); \
-    template ttsl::Span<T> get_as<T>(Tensor&);                   \
-    template ttsl::Span<const T> get_as<const T>(Tensor&);
+#define INSTANTIATE_HOST_BUFFER_FUNCTIONS(T)                           \
+    template ttsl::Span<const T> get_as<T>(const ttnn::Tensor&);       \
+    template ttsl::Span<const T> get_as<const T>(const ttnn::Tensor&); \
+    template ttsl::Span<T> get_as<T>(ttnn::Tensor&);                   \
+    template ttsl::Span<const T> get_as<const T>(ttnn::Tensor&);
 
 INSTANTIATE_HOST_BUFFER_FUNCTIONS(uint32_t)
 INSTANTIATE_HOST_BUFFER_FUNCTIONS(int32_t)

--- a/ttnn/core/tensor/host_buffer/functions.cpp
+++ b/ttnn/core/tensor/host_buffer/functions.cpp
@@ -11,21 +11,21 @@
 #include <ttnn/tensor/tensor.hpp>
 #include <ttnn/tensor/tensor_utils.hpp>
 
-namespace tt::tt_metal::host_buffer {
+namespace ttnn::host_buffer {
 
-HostBuffer get_host_buffer(const ttnn::Tensor& tensor) {
+tt::tt_metal::HostBuffer get_host_buffer(const ttnn::Tensor& tensor) {
     TT_FATAL(is_cpu_tensor(tensor), "Tensor must have on host");
-    return get_host_buffer(tensor.host_tensor());
+    return tt::tt_metal::host_buffer::get_host_buffer(tensor.host_tensor());
 }
 
 template <typename T>
 ttsl::Span<const T> get_as(const ttnn::Tensor& tensor) {
-    return get_as<T>(tensor.host_tensor());
+    return tt::tt_metal::host_buffer::get_as<T>(tensor.host_tensor());
 }
 
 template <typename T>
 ttsl::Span<T> get_as(ttnn::Tensor& tensor) {
-    return get_as<T>(tensor.host_storage().host_tensor());
+    return tt::tt_metal::host_buffer::get_as<T>(tensor.host_storage().host_tensor());
 }
 
 // Explicit template instantiations
@@ -44,4 +44,4 @@ INSTANTIATE_HOST_BUFFER_FUNCTIONS(uint8_t)
 
 #undef INSTANTIATE_HOST_BUFFER_FUNCTIONS
 
-}  // namespace tt::tt_metal::host_buffer
+}  // namespace ttnn::host_buffer

--- a/ttnn/core/tensor/overlapped_serialization.cpp
+++ b/ttnn/core/tensor/overlapped_serialization.cpp
@@ -24,7 +24,7 @@
 #include "tensor/flatbuffer/overlapped_tensor_flatbuffer.hpp"
 #include "ttnn/distributed/host_ccl.hpp"
 
-namespace tt::tt_metal {
+namespace ttnn {
 namespace {
 
 void safe_fwrite(const void* buffer, size_t bytes, FILE* file, const std::string& filename, std::string_view what) {
@@ -66,8 +66,8 @@ void dump_overlapped_tensors(const std::string& file_name, const std::vector<Ove
         v.fused_tensor = cpu_tensor;
     }
 
-    const auto& ctx = distributed::multihost::DistributedContext::get_current_world();
-    if (ctx->rank() == distributed::multihost::Rank(0)) {
+    const auto& ctx = tt::tt_metal::distributed::multihost::DistributedContext::get_current_world();
+    if (ctx->rank() == tt::tt_metal::distributed::multihost::Rank(0)) {
         FILE* output_file = fopen(file_name.c_str(), "wb");
         TT_FATAL(
             output_file != nullptr,
@@ -81,7 +81,7 @@ void dump_overlapped_tensors(const std::string& file_name, const std::vector<Ove
             }
         });
 
-        std::vector<HostBuffer> buffers;
+        std::vector<tt::tt_metal::HostBuffer> buffers;
         flatbuffers::FlatBufferBuilder builder;
         auto root_offset = ttnn::overlapped_tensors_to_flatbuffer(cpu_views, builder, buffers);
         builder.Align(kOverlappedFlatbufferAlignment);
@@ -104,7 +104,7 @@ void dump_overlapped_tensors(const std::string& file_name, const std::vector<Ove
 }
 
 std::vector<OverlappedTensorView> load_overlapped_tensors(
-    const std::string& file_name, distributed::MeshDevice* device) {
+    const std::string& file_name, tt::tt_metal::distributed::MeshDevice* device) {
     int fd = open(file_name.c_str(), O_RDONLY | O_CLOEXEC);
     TT_FATAL(fd != -1, "Cannot open \"{}\": errno={} \"{}\"", file_name, errno, strerror(errno));
     auto cleanup = ttsl::make_cleanup([fd]() { close(fd); });
@@ -118,7 +118,7 @@ std::vector<OverlappedTensorView> load_overlapped_tensors(
     TT_FATAL(mmap_addr != MAP_FAILED, "Failed to mmap file \"{}\": {}", file_name, strerror(errno));
 
     std::shared_ptr<void> mmap_ptr(mmap_addr, [file_size](void* addr) { munmap(addr, file_size); });
-    MemoryPin memory_pin(mmap_ptr);
+    tt::tt_metal::MemoryPin memory_pin(mmap_ptr);
 
     auto* file_data = static_cast<std::byte*>(mmap_addr);
     uint64_t header_size = 0;
@@ -162,4 +162,4 @@ std::vector<OverlappedTensorView> load_overlapped_tensors(
     return views;
 }
 
-}  // namespace tt::tt_metal
+}  // namespace ttnn

--- a/ttnn/core/tensor/overlapped_serialization.cpp
+++ b/ttnn/core/tensor/overlapped_serialization.cpp
@@ -57,7 +57,7 @@ void dump_overlapped_tensors(const std::string& file_name, const std::vector<Ove
             i);
     }
 
-    Tensor cpu_tensor = views[0].fused_tensor.cpu();
+    ttnn::Tensor cpu_tensor = views[0].fused_tensor.cpu();
     cpu_tensor = ttnn::distributed::host_ccl::all_gather(cpu_tensor);
 
     // Build a temporary view list with the CPU-side fused tensor for serialization.

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -208,7 +208,7 @@ ttnn::Shape estimate_per_device_shard_shape(
     return ttnn::Shape(ttsl::Span<const uint32_t>(dims.data(), dims.size()));
 }
 
-Tensor create_tt_tensor_from_host_data(
+ttnn::Tensor create_tt_tensor_from_host_data(
     HostBuffer& host_buffer,
     DataType src_dtype,
     DataType dst_dtype,
@@ -229,7 +229,7 @@ Tensor create_tt_tensor_from_host_data(
         (dst_dtype == DataType::BFLOAT4_B or dst_dtype == DataType::BFLOAT8_B) ? enable_bfloat_opt : true;
 
     using namespace tt::tt_metal;
-    auto create_tensor_from_host_buffer = [&]<typename T>() -> Tensor {
+    auto create_tensor_from_host_buffer = [&]<typename T>() -> ttnn::Tensor {
         TensorLayout dst_tensor_layout(dst_dtype, PageConfig(layout, optional_tile), memory_config);
 
         const bool construct_on_device = can_construct_on_device(
@@ -288,10 +288,11 @@ Tensor create_tt_tensor_from_host_data(
                 device, src_tensor_layout, tensor_shape, src_dtype, dst_dtype, layout, memory_config, optional_tile);
 
         if (can_borrow) {
-            return Tensor::from_borrowed_data(host_buffer.view_as<T>(), tensor_shape, host_buffer.pin(), optional_tile);
+            return ttnn::Tensor::from_borrowed_data(
+                host_buffer.view_as<T>(), tensor_shape, host_buffer.pin(), optional_tile);
         }
 
-        return Tensor::from_span(
+        return ttnn::Tensor::from_span(
             ttsl::make_const_span(host_buffer.view_as<T>()),
             TensorSpec(tensor_shape, dst_tensor_layout),
             nullptr,

--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -27,7 +27,7 @@
 #include "tensor/flatbuffer/tensor_flatbuffer.hpp"
 #include "ttnn/distributed/host_ccl.hpp"
 
-namespace tt::tt_metal {
+namespace ttnn {
 namespace {
 
 void safe_fwrite_bytes(
@@ -59,7 +59,7 @@ void dump_tensor_flatbuffer_impl(const std::string& file_name, const ttnn::Tenso
         // already be fully host-local. In this latter case, host buffer context will consist of a single (local) host
         // rank, and each host will attempt to flush the serialized tensor file to disk.
         cpu_tensor = ttnn::distributed::host_ccl::all_gather(cpu_tensor);
-        const auto& ctx = distributed::multihost::DistributedContext::get_current_world();
+        const auto& ctx = tt::tt_metal::distributed::multihost::DistributedContext::get_current_world();
         if (ctx->rank() != tt::tt_metal::distributed::multihost::Rank(0)) {
             ctx->barrier();
             return;
@@ -75,7 +75,7 @@ void dump_tensor_flatbuffer_impl(const std::string& file_name, const ttnn::Tenso
         }
     });
 
-    std::vector<HostBuffer> buffers;
+    std::vector<tt::tt_metal::HostBuffer> buffers;
     flatbuffers::FlatBufferBuilder builder;
     auto tensor_offset = ttnn::to_flatbuffer(cpu_tensor, builder, buffers);
     // To be able to read flatbuffer data with `mmap` safely, make sure the serialized flatbuffer is aligned to at
@@ -97,7 +97,7 @@ void dump_tensor_flatbuffer_impl(const std::string& file_name, const ttnn::Tenso
     TT_FATAL(fflush(output_file) == 0, "Failed to flush \"{}\": errno={} \"{}\"", file_name, errno, strerror(errno));
 
     if (mode == DumpTensorMode::DISTRIBUTED_GATHER) {
-        const auto& ctx = distributed::multihost::DistributedContext::get_current_world();
+        const auto& ctx = tt::tt_metal::distributed::multihost::DistributedContext::get_current_world();
         ctx->barrier();
     }
 }
@@ -108,7 +108,7 @@ void dump_tensor_flatbuffer(const std::string& file_name, const ttnn::Tensor& te
     dump_tensor_flatbuffer_impl(file_name, tensor, mode);
 }
 
-ttnn::Tensor load_tensor_flatbuffer(const std::string& file_name, distributed::MeshDevice* device) {
+ttnn::Tensor load_tensor_flatbuffer(const std::string& file_name, tt::tt_metal::distributed::MeshDevice* device) {
     int fd = open(file_name.c_str(), O_RDONLY | O_CLOEXEC);
     TT_FATAL(fd != -1, "Cannot open \"{}\": errno={} \"{}\"", file_name, errno, strerror(errno));
     auto cleanup = ttsl::make_cleanup([fd]() { close(fd); });
@@ -123,7 +123,7 @@ ttnn::Tensor load_tensor_flatbuffer(const std::string& file_name, distributed::M
     TT_FATAL(mmap_addr != MAP_FAILED, "Failed to mmap file \"{}\": {}", file_name, strerror(errno));
 
     std::shared_ptr<void> mmap_ptr(mmap_addr, [file_size](void* addr) { munmap(addr, file_size); });
-    MemoryPin memory_pin(mmap_ptr);
+    tt::tt_metal::MemoryPin memory_pin(mmap_ptr);
 
     auto* file_data = static_cast<std::byte*>(mmap_addr);
     uint64_t header_size = 0;
@@ -160,4 +160,4 @@ ttnn::Tensor load_tensor_flatbuffer(const std::string& file_name, distributed::M
     return tensor;
 }
 
-}  // namespace tt::tt_metal
+}  // namespace ttnn

--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -50,8 +50,8 @@ void safe_fwrite_bytes(
 
 constexpr std::uint32_t kFlatbufferAlignment = alignof(std::uint64_t);
 
-void dump_tensor_flatbuffer_impl(const std::string& file_name, const Tensor& tensor, DumpTensorMode mode) {
-    Tensor cpu_tensor = tensor.cpu();
+void dump_tensor_flatbuffer_impl(const std::string& file_name, const ttnn::Tensor& tensor, DumpTensorMode mode) {
+    ttnn::Tensor cpu_tensor = tensor.cpu();
 
     if (mode == DumpTensorMode::DISTRIBUTED_GATHER) {
         // Dump tensor to disk from (global) rank 0 host.
@@ -104,11 +104,11 @@ void dump_tensor_flatbuffer_impl(const std::string& file_name, const Tensor& ten
 
 }  // namespace
 
-void dump_tensor_flatbuffer(const std::string& file_name, const Tensor& tensor, DumpTensorMode mode) {
+void dump_tensor_flatbuffer(const std::string& file_name, const ttnn::Tensor& tensor, DumpTensorMode mode) {
     dump_tensor_flatbuffer_impl(file_name, tensor, mode);
 }
 
-Tensor load_tensor_flatbuffer(const std::string& file_name, distributed::MeshDevice* device) {
+ttnn::Tensor load_tensor_flatbuffer(const std::string& file_name, distributed::MeshDevice* device) {
     int fd = open(file_name.c_str(), O_RDONLY | O_CLOEXEC);
     TT_FATAL(fd != -1, "Cannot open \"{}\": errno={} \"{}\"", file_name, errno, strerror(errno));
     auto cleanup = ttsl::make_cleanup([fd]() { close(fd); });
@@ -153,7 +153,7 @@ Tensor load_tensor_flatbuffer(const std::string& file_name, distributed::MeshDev
         (reinterpret_cast<uintptr_t>(data_region) & (kFlatbufferAlignment - 1)) == 0,
         "Tensor data pointer must be 8-byte aligned!");
 
-    Tensor tensor = ttnn::from_flatbuffer(fb_tensor, ttsl::Span<std::byte>(data_region, data_size), memory_pin);
+    ttnn::Tensor tensor = ttnn::from_flatbuffer(fb_tensor, ttsl::Span<std::byte>(data_region, data_size), memory_pin);
     if (device != nullptr) {
         tensor = tensor.to_device(device, tensor.tensor_spec().memory_config());
     }

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -14,21 +14,23 @@
 
 #include "ttnn/tensor/storage.hpp"
 
-namespace tt::tt_metal {
+namespace ttnn {
+
+namespace metal = ::tt::tt_metal;
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
-std::vector<distributed::MeshCoordinate> get_all_mesh_coordinates(const distributed::MeshDevice& device) {
-    std::vector<distributed::MeshCoordinate> coordinates;
+std::vector<metal::distributed::MeshCoordinate> get_all_mesh_coordinates(const metal::distributed::MeshDevice& device) {
+    std::vector<metal::distributed::MeshCoordinate> coordinates;
     coordinates.reserve(device.num_devices());
-    for (const auto& coord : distributed::MeshCoordinateRange(device.shape())) {
+    for (const auto& coord : metal::distributed::MeshCoordinateRange(device.shape())) {
         coordinates.push_back(coord);
     }
     return coordinates;
 }
 
 void validate_mesh_coordinates(
-    const std::vector<distributed::MeshCoordinate>& coords, const distributed::MeshDevice& device) {
-    const distributed::MeshCoordinateRange valid_range(device.shape());
+    const std::vector<metal::distributed::MeshCoordinate>& coords, const metal::distributed::MeshDevice& device) {
+    const metal::distributed::MeshCoordinateRange valid_range(device.shape());
     for (const auto& coord : coords) {
         TT_FATAL(
             valid_range.contains(coord),
@@ -41,14 +43,14 @@ void validate_mesh_coordinates(
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
-HostStorage::HostStorage(HostTensor tensor) : tensor(std::move(tensor)) {}
+HostStorage::HostStorage(metal::HostTensor tensor) : tensor(std::move(tensor)) {}
 
-const DistributedHostBuffer& HostStorage::buffer() const { return tensor.buffer(); }
+const metal::DistributedHostBuffer& HostStorage::buffer() const { return tensor.buffer(); }
 
-const HostTensor& HostStorage::host_tensor() const { return tensor; }
-HostTensor& HostStorage::host_tensor() { return tensor; }
+const metal::HostTensor& HostStorage::host_tensor() const { return tensor; }
+metal::HostTensor& HostStorage::host_tensor() { return tensor; }
 
-HostStorage HostStorage::transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const {
+HostStorage HostStorage::transform(const std::function<metal::HostBuffer(const metal::HostBuffer&)>& callable) const {
     return HostStorage(tensor.transform(callable));
 }
 
@@ -63,23 +65,23 @@ struct DeviceStorage::MeshTensorHolder {
     struct DeallocatedDefaultConstructed {};
 
     struct Allocated {
-        MeshTensor mesh_tensor_;
+        metal::MeshTensor mesh_tensor_;
     };
 
     struct DeallocatedTombStone {
-        TensorSpec tensor_spec_;
-        TensorTopology tensor_topology_;
+        metal::TensorSpec tensor_spec_;
+        metal::TensorTopology tensor_topology_;
         // Deallocated buffer kept so device() stays valid without dangling MeshDevice.
         // Remove once post-deallocation mesh_device access is no longer needed.
         // See: get_device_bypass_deallocate_check
-        std::shared_ptr<distributed::MeshBuffer> mesh_buffer_;
+        std::shared_ptr<metal::distributed::MeshBuffer> mesh_buffer_;
     };
 
     using States = std::variant<DeallocatedDefaultConstructed, Allocated, DeallocatedTombStone>;
     States state_;
 
     MeshTensorHolder() : state_(DeallocatedDefaultConstructed{}) {}
-    MeshTensorHolder(MeshTensor mesh_tensor) : state_(Allocated{std::move(mesh_tensor)}) {
+    MeshTensorHolder(metal::MeshTensor mesh_tensor) : state_(Allocated{std::move(mesh_tensor)}) {
         TT_FATAL(
             std::get<Allocated>(state_).mesh_tensor_.is_initialized(),
             "MeshTensor must not be in default constructed state.");
@@ -107,17 +109,17 @@ struct DeviceStorage::MeshTensorHolder {
 
 DeviceStorage::DeviceStorage() : mesh_tensor_holder_(std::make_shared<MeshTensorHolder>()) {}
 
-DeviceStorage::DeviceStorage(MeshTensor mesh_tensor) :
+DeviceStorage::DeviceStorage(metal::MeshTensor mesh_tensor) :
     mesh_tensor_holder_(std::make_shared<MeshTensorHolder>(std::move(mesh_tensor))),
     coords_(CMAKE_UNIQUE_NAMESPACE::get_all_mesh_coordinates(get_mesh_tensor().device())) {}
 
-DeviceStorage::DeviceStorage(MeshTensor mesh_tensor_, std::vector<distributed::MeshCoordinate> coords) :
+DeviceStorage::DeviceStorage(metal::MeshTensor mesh_tensor_, std::vector<metal::distributed::MeshCoordinate> coords) :
     DeviceStorage(std::make_shared<MeshTensorHolder>(std::move(mesh_tensor_)), std::move(coords), nullptr) {}
 
-DeviceStorage::DeviceStorage(const DeviceStorage& other, std::vector<distributed::MeshCoordinate> coords) :
+DeviceStorage::DeviceStorage(const DeviceStorage& other, std::vector<metal::distributed::MeshCoordinate> coords) :
     DeviceStorage(other.mesh_tensor_holder_, std::move(coords), other.root_mesh_tensor_holder_) {}
 
-DeviceStorage::DeviceStorage(const DeviceStorage& owning_storage, MeshTensor reinterpreted_mesh_tensor) :
+DeviceStorage::DeviceStorage(const DeviceStorage& owning_storage, metal::MeshTensor reinterpreted_mesh_tensor) :
     DeviceStorage(
         std::make_shared<MeshTensorHolder>(std::move(reinterpreted_mesh_tensor)),
         owning_storage.coords_,
@@ -125,7 +127,7 @@ DeviceStorage::DeviceStorage(const DeviceStorage& owning_storage, MeshTensor rei
 
 DeviceStorage::DeviceStorage(
     std::shared_ptr<MeshTensorHolder> mesh_tensor_holder,
-    std::vector<distributed::MeshCoordinate> coords,
+    std::vector<metal::distributed::MeshCoordinate> coords,
     std::shared_ptr<MeshTensorHolder> root_mesh_tensor_holder) :
     mesh_tensor_holder_(std::move(mesh_tensor_holder)),
     coords_(std::move(coords)),
@@ -135,15 +137,15 @@ DeviceStorage::DeviceStorage(
     }
 }
 
-Buffer* DeviceStorage::get_buffer() const { return get_mesh_buffer().get_reference_buffer(); }
+metal::Buffer* DeviceStorage::get_buffer() const { return get_mesh_buffer().get_reference_buffer(); }
 
-const distributed::MeshBuffer& DeviceStorage::get_mesh_buffer() const {
+const metal::distributed::MeshBuffer& DeviceStorage::get_mesh_buffer() const {
     return std::visit(
         ttsl::overloaded{
-            [](const MeshTensorHolder::Allocated& allocated) -> const distributed::MeshBuffer& {
+            [](const MeshTensorHolder::Allocated& allocated) -> const metal::distributed::MeshBuffer& {
                 return allocated.mesh_tensor_.mesh_buffer();
             },
-            [](const auto&) -> const distributed::MeshBuffer& { TT_THROW("Tensor is not allocated"); }},
+            [](const auto&) -> const metal::distributed::MeshBuffer& { TT_THROW("Tensor is not allocated"); }},
         mesh_tensor_holder_->state_);
 }
 
@@ -154,32 +156,35 @@ bool DeviceStorage::is_sole_owner_of_device_memory() const {
     return mesh_tensor_holder_.use_count() == 1 && get_root_mesh_tensor().use_count() == 1;
 }
 
-const MeshTensor& DeviceStorage::get_mesh_tensor() const {
+const metal::MeshTensor& DeviceStorage::get_mesh_tensor() const {
     return std::visit(
         ttsl::overloaded{
-            [](const MeshTensorHolder::Allocated& allocated) -> const MeshTensor& { return allocated.mesh_tensor_; },
-            [](const auto&) -> const MeshTensor& { TT_THROW("Tensor is not allocated"); }},
+            [](const MeshTensorHolder::Allocated& allocated) -> const metal::MeshTensor& {
+                return allocated.mesh_tensor_;
+            },
+            [](const auto&) -> const metal::MeshTensor& { TT_THROW("Tensor is not allocated"); }},
         mesh_tensor_holder_->state_);
 }
 
-MeshTensor& DeviceStorage::get_mesh_tensor() {
+metal::MeshTensor& DeviceStorage::get_mesh_tensor() {
     return std::visit(
         ttsl::overloaded{
-            [](MeshTensorHolder::Allocated& allocated) -> MeshTensor& { return allocated.mesh_tensor_; },
-            [](const auto&) -> MeshTensor& { TT_THROW("Tensor is not allocated"); }},
+            [](MeshTensorHolder::Allocated& allocated) -> metal::MeshTensor& { return allocated.mesh_tensor_; },
+            [](const auto&) -> metal::MeshTensor& { TT_THROW("Tensor is not allocated"); }},
         mesh_tensor_holder_->state_);
 }
 
-std::shared_ptr<distributed::MeshBuffer> DeviceStorage::get_mesh_buffer_leak_ownership() const {
+std::shared_ptr<metal::distributed::MeshBuffer> DeviceStorage::get_mesh_buffer_leak_ownership() const {
     return std::visit(
         ttsl::overloaded{
-            [](const MeshTensorHolder::Allocated& allocated) -> std::shared_ptr<distributed::MeshBuffer> {
+            [](const MeshTensorHolder::Allocated& allocated) -> std::shared_ptr<metal::distributed::MeshBuffer> {
                 return allocated.mesh_tensor_.mesh_buffer_invariant_breaking();
             },
-            [](const MeshTensorHolder::DeallocatedTombStone& tombstone) -> std::shared_ptr<distributed::MeshBuffer> {
-                return tombstone.mesh_buffer_;
-            },
-            [](const auto&) -> std::shared_ptr<distributed::MeshBuffer> { TT_THROW("Tensor is not allocated"); }},
+            [](const MeshTensorHolder::DeallocatedTombStone& tombstone)
+                -> std::shared_ptr<metal::distributed::MeshBuffer> { return tombstone.mesh_buffer_; },
+            [](const auto&) -> std::shared_ptr<metal::distributed::MeshBuffer> {
+                TT_THROW("Tensor is not allocated");
+            }},
         mesh_tensor_holder_->state_);
 }
 
@@ -198,12 +203,12 @@ void DeviceStorage::deallocate() {
 
 bool DeviceStorage::is_allocated() const { return mesh_tensor_holder_->is_allocated(); }
 
-distributed::MeshDevice* DeviceStorage::get_device_bypass_deallocate_check() const {
+metal::distributed::MeshDevice* DeviceStorage::get_device_bypass_deallocate_check() const {
     return std::visit(
         ttsl::overloaded{
             [](const MeshTensorHolder::Allocated& allocated) { return &allocated.mesh_tensor_.device(); },
             [](const MeshTensorHolder::DeallocatedTombStone& tombstone) { return tombstone.mesh_buffer_->device(); },
-            [](const auto&) -> distributed::MeshDevice* { TT_THROW("Tensor is not allocated"); }},
+            [](const auto&) -> metal::distributed::MeshDevice* { TT_THROW("Tensor is not allocated"); }},
         mesh_tensor_holder_->state_);
 }
 
@@ -214,7 +219,7 @@ bool DeviceStorage::is_uniform_storage() const {
     return coords_.size() == get_device_bypass_deallocate_check()->num_devices();
 }
 
-std::span<const distributed::MeshCoordinate> DeviceStorage::get_coords() const {
+std::span<const metal::distributed::MeshCoordinate> DeviceStorage::get_coords() const {
     // Conv breaks if we keep the assert here.
     // TT_FATAL(is_allocated(), "Device memory is not allocated");
     return coords_;
@@ -239,14 +244,14 @@ DeviceStorage DeviceStorage::combine_device_storages(
             }),
         "tensor shards must be allocated on the same mesh buffer.");
 
-    std::set<distributed::MeshCoordinate> seen_coords;
+    std::set<metal::distributed::MeshCoordinate> seen_coords;
     for (const auto& storage : storages) {
         for (const auto& coord : storage.get().get_coords()) {
             auto [_, coord_is_new] = seen_coords.insert(coord);
             TT_FATAL(coord_is_new, "Found a tensor shard at duplicate coordinate {}", coord);
         }
     }
-    std::vector<distributed::MeshCoordinate> vec_coords(seen_coords.begin(), seen_coords.end());
+    std::vector<metal::distributed::MeshCoordinate> vec_coords(seen_coords.begin(), seen_coords.end());
 
     const int tensor_rank = static_cast<int>(model_storage.get_tensor_spec().logical_shape().rank());
     TT_FATAL(
@@ -256,38 +261,38 @@ DeviceStorage DeviceStorage::combine_device_storages(
         tensor_rank,
         tensor_rank);
 
-    TensorTopology topology =
-        TensorTopology::create_sharded_tensor_topology(distributed::MeshShape(vec_coords.size()), shard_dim);
+    metal::TensorTopology topology = metal::TensorTopology::create_sharded_tensor_topology(
+        metal::distributed::MeshShape(vec_coords.size()), shard_dim);
 
     DeviceStorage res(model_storage, std::move(vec_coords));
     res.get_mesh_tensor().update_tensor_topology(topology);
     return res;
 }
 
-const TensorSpec& DeviceStorage::get_tensor_spec() const {
+const metal::TensorSpec& DeviceStorage::get_tensor_spec() const {
     return std::visit(
         ttsl::overloaded{
-            [](const MeshTensorHolder::Allocated& allocated) -> const TensorSpec& {
+            [](const MeshTensorHolder::Allocated& allocated) -> const metal::TensorSpec& {
                 return allocated.mesh_tensor_.tensor_spec();
             },
-            [](const MeshTensorHolder::DeallocatedTombStone& tombstone) -> const TensorSpec& {
+            [](const MeshTensorHolder::DeallocatedTombStone& tombstone) -> const metal::TensorSpec& {
                 return tombstone.tensor_spec_;
             },
-            [](const auto&) -> const TensorSpec& { TT_THROW("Tensor is not allocated"); }},
+            [](const auto&) -> const metal::TensorSpec& { TT_THROW("Tensor is not allocated"); }},
         mesh_tensor_holder_->state_);
 }
 
-const TensorTopology& DeviceStorage::get_tensor_topology() const {
+const metal::TensorTopology& DeviceStorage::get_tensor_topology() const {
     return std::visit(
         ttsl::overloaded{
-            [](const MeshTensorHolder::Allocated& allocated) -> const TensorTopology& {
+            [](const MeshTensorHolder::Allocated& allocated) -> const metal::TensorTopology& {
                 return allocated.mesh_tensor_.tensor_topology();
             },
-            [](const MeshTensorHolder::DeallocatedTombStone& tombstone) -> const TensorTopology& {
+            [](const MeshTensorHolder::DeallocatedTombStone& tombstone) -> const metal::TensorTopology& {
                 return tombstone.tensor_topology_;
             },
-            [](const auto&) -> const TensorTopology& { TT_THROW("Tensor is not allocated"); }},
+            [](const auto&) -> const metal::TensorTopology& { TT_THROW("Tensor is not allocated"); }},
         mesh_tensor_holder_->state_);
 }
 
-}  // namespace tt::tt_metal
+}  // namespace ttnn

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -411,11 +411,11 @@ bool Tensor::is_allocated() const {
     return output;
 }
 
-tt::tt_metal::StorageType Tensor::storage_type() const {
+StorageType Tensor::storage_type() const {
     return std::visit(
         ttsl::overloaded{
-            [](const HostStorage&) { return tt::tt_metal::StorageType::HOST; },
-            [](const DeviceStorage&) { return tt::tt_metal::StorageType::DEVICE; },
+            [](const HostStorage&) { return StorageType::HOST; },
+            [](const DeviceStorage&) { return StorageType::DEVICE; },
         },
         tensor_attributes->get_storage());
 }

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -40,32 +40,36 @@
 #include <utility>
 #include <atomic>
 
-namespace tt::tt_metal {
+namespace ttnn {
 namespace {
 std::atomic<std::uint64_t> tensor_id_counter{0};
 }  // namespace
 
 Tensor::Tensor(
-    HostBuffer buffer,
+    tt::tt_metal::HostBuffer buffer,
     const tt::tt_metal::Shape& shape,
-    DataType dtype,
-    Layout layout,
-    const std::optional<Tile>& tile) :
+    tt::tt_metal::DataType dtype,
+    tt::tt_metal::Layout layout,
+    const std::optional<tt::tt_metal::Tile>& tile) :
     Tensor(std::move(buffer), /* logical_shape */ shape, /* padded_shape */ shape, dtype, layout, tile) {}
 
 Tensor::Tensor(
-    HostBuffer buffer,
+    tt::tt_metal::HostBuffer buffer,
     const tt::tt_metal::Shape& logical_shape,
     const tt::tt_metal::Shape& padded_shape,
-    DataType dtype,
-    Layout layout,
-    const std::optional<Tile>& tile) :
+    tt::tt_metal::DataType dtype,
+    tt::tt_metal::Layout layout,
+    const std::optional<tt::tt_metal::Tile>& tile) :
     Tensor(
         std::move(buffer),
         TensorSpec(
             logical_shape,
-            TensorLayout::fromPaddedShape(
-                dtype, PageConfig(layout, tile), MemoryConfig{}, logical_shape, padded_shape))) {
+            tt::tt_metal::TensorLayout::fromPaddedShape(
+                dtype,
+                tt::tt_metal::PageConfig(layout, tile),
+                tt::tt_metal::MemoryConfig{},
+                logical_shape,
+                padded_shape))) {
     using namespace tt::constants;
     if (tile.has_value() and  //
         (tile->get_tile_shape()[0] != TILE_WIDTH or tile->get_tile_shape()[1] != TILE_HEIGHT)) {
@@ -76,14 +80,14 @@ Tensor::Tensor(
     }
 }
 
-Tensor::Tensor(HostBuffer buffer, TensorSpec tensor_spec) :
-    Tensor(HostTensor(std::move(buffer), std::move(tensor_spec), TensorTopology{})) {}
+Tensor::Tensor(tt::tt_metal::HostBuffer buffer, TensorSpec tensor_spec) :
+    Tensor(tt::tt_metal::HostTensor(std::move(buffer), std::move(tensor_spec), tt::tt_metal::TensorTopology{})) {}
 
-Tensor::Tensor(HostTensor tensor) :
+Tensor::Tensor(tt::tt_metal::HostTensor tensor) :
     tensor_id(Tensor::next_tensor_id()),
     tensor_attributes(std::make_shared<TensorAttributes>(HostStorage(std::move(tensor)))) {}
 
-Tensor::Tensor(MeshTensor tensor) : Tensor::Tensor(DeviceStorage(std::move(tensor))) {}
+Tensor::Tensor(tt::tt_metal::MeshTensor tensor) : Tensor::Tensor(DeviceStorage(std::move(tensor))) {}
 
 Tensor::Tensor(DeviceStorage storage) :
     tensor_id(Tensor::next_tensor_id()), tensor_attributes(std::make_shared<TensorAttributes>(std::move(storage))) {
@@ -131,7 +135,7 @@ void Tensor::deallocate_impl(bool force) {
                (shared_resource.use_count() > 1 && force);
     };
 
-    bool tracking = GraphTracker::instance().is_enabled();
+    bool tracking = tt::tt_metal::GraphTracker::instance().is_enabled();
     if (can_deallocate(tensor_attributes, force)) {
         std::visit(
             ttsl::overloaded{
@@ -143,13 +147,14 @@ void Tensor::deallocate_impl(bool force) {
                     }
 
                     if (tracking) {
-                        GraphTracker::instance().track_function_start(std::string_view("Tensor::deallocate"));
+                        tt::tt_metal::GraphTracker::instance().track_function_start(
+                            std::string_view("Tensor::deallocate"));
                     }
 
                     storage.deallocate();
 
                     if (tracking) {
-                        GraphTracker::instance().track_function_end();
+                        tt::tt_metal::GraphTracker::instance().track_function_end();
                     }
                 }},
             this->tensor_attributes->get_storage());
@@ -166,10 +171,10 @@ template <typename T>
 Tensor Tensor::from_span(
     ttsl::Span<const T> buffer,
     const TensorSpec& spec,
-    distributed::MeshDevice* device,
+    tt::tt_metal::distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     T pad_value) {
-    auto host_tensor = HostTensor::from_span(buffer, spec, pad_value);
+    auto host_tensor = tt::tt_metal::HostTensor::from_span(buffer, spec, pad_value);
     auto res = Tensor(std::move(host_tensor));
     if (device) {
         res = res.to_device(device, spec.memory_config(), cq_id);
@@ -182,8 +187,8 @@ Tensor Tensor::from_borrowed_data(
     ttsl::Span<T> buffer,
     const tt::tt_metal::Shape& shape,
     tt::tt_metal::MemoryPin buffer_pin,
-    const std::optional<Tile>& tile) {
-    auto host_tensor = HostTensor::from_borrowed_data(buffer, shape, std::move(buffer_pin), tile);
+    const std::optional<tt::tt_metal::Tile>& tile) {
+    auto host_tensor = tt::tt_metal::HostTensor::from_borrowed_data(buffer, shape, std::move(buffer_pin), tile);
     return Tensor(std::move(host_tensor));
 }
 
@@ -191,12 +196,12 @@ template <typename T>
 Tensor Tensor::from_vector(
     std::vector<T>&& buffer,
     const TensorSpec& spec,
-    distributed::MeshDevice* device,
+    tt::tt_metal::distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     T pad_value) {
-    auto host_tensor = HostTensor::from_vector(std::move(buffer), spec, pad_value);
+    auto host_tensor = tt::tt_metal::HostTensor::from_vector(std::move(buffer), spec, pad_value);
     auto res = Tensor(std::move(host_tensor));
-    res = to_dtype(res, spec.data_type());
+    res = ttnn::to_dtype(res, spec.data_type());
     if (device) {
         res = res.to_device(device, spec.memory_config(), cq_id);
     }
@@ -214,103 +219,103 @@ std::vector<T> Tensor::to_vector(std::optional<tt::tt_metal::QueueId> cq_id) con
 template Tensor Tensor::from_span<bfloat16>(
     ttsl::Span<const bfloat16> buffer,
     const TensorSpec& spec,
-    distributed::MeshDevice* device,
+    tt::tt_metal::distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     bfloat16 pad_value);
 template Tensor Tensor::from_span<float>(
     ttsl::Span<const float> buffer,
     const TensorSpec& spec,
-    distributed::MeshDevice* device,
+    tt::tt_metal::distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     float pad_value);
 template Tensor Tensor::from_span<int32_t>(
     ttsl::Span<const int32_t> buffer,
     const TensorSpec& spec,
-    distributed::MeshDevice* device,
+    tt::tt_metal::distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     int32_t pad_value);
 template Tensor Tensor::from_span<uint8_t>(
     ttsl::Span<const uint8_t> buffer,
     const TensorSpec& spec,
-    distributed::MeshDevice* device,
+    tt::tt_metal::distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     uint8_t pad_value);
 template Tensor Tensor::from_span<uint16_t>(
     ttsl::Span<const uint16_t> buffer,
     const TensorSpec& spec,
-    distributed::MeshDevice* device,
+    tt::tt_metal::distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     uint16_t pad_value);
 template Tensor Tensor::from_span<uint32_t>(
     ttsl::Span<const uint32_t> buffer,
     const TensorSpec& spec,
-    distributed::MeshDevice* device,
+    tt::tt_metal::distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     uint32_t pad_value);
 template Tensor Tensor::from_borrowed_data<float>(
     ttsl::Span<float> buffer,
     const tt::tt_metal::Shape& shape,
     tt::tt_metal::MemoryPin buffer_pin,
-    const std::optional<Tile>& tile);
+    const std::optional<tt::tt_metal::Tile>& tile);
 template Tensor Tensor::from_borrowed_data<bfloat16>(
     ttsl::Span<bfloat16> buffer,
     const tt::tt_metal::Shape& shape,
     tt::tt_metal::MemoryPin buffer_pin,
-    const std::optional<Tile>& tile);
+    const std::optional<tt::tt_metal::Tile>& tile);
 template Tensor Tensor::from_borrowed_data<int32_t>(
     ttsl::Span<int32_t> buffer,
     const tt::tt_metal::Shape& shape,
     tt::tt_metal::MemoryPin buffer_pin,
-    const std::optional<Tile>& tile);
+    const std::optional<tt::tt_metal::Tile>& tile);
 template Tensor Tensor::from_borrowed_data<uint8_t>(
     ttsl::Span<uint8_t> buffer,
     const tt::tt_metal::Shape& shape,
     tt::tt_metal::MemoryPin buffer_pin,
-    const std::optional<Tile>& tile);
+    const std::optional<tt::tt_metal::Tile>& tile);
 template Tensor Tensor::from_borrowed_data<uint16_t>(
     ttsl::Span<uint16_t> buffer,
     const tt::tt_metal::Shape& shape,
     tt::tt_metal::MemoryPin buffer_pin,
-    const std::optional<Tile>& tile);
+    const std::optional<tt::tt_metal::Tile>& tile);
 template Tensor Tensor::from_borrowed_data<uint32_t>(
     ttsl::Span<uint32_t> buffer,
     const tt::tt_metal::Shape& shape,
     tt::tt_metal::MemoryPin buffer_pin,
-    const std::optional<Tile>& tile);
+    const std::optional<tt::tt_metal::Tile>& tile);
 template Tensor Tensor::from_vector<bfloat16>(
     std::vector<bfloat16>&& buffer,
     const TensorSpec& spec,
-    distributed::MeshDevice* device,
+    tt::tt_metal::distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     bfloat16 pad_value);
 template Tensor Tensor::from_vector<float>(
     std::vector<float>&& buffer,
     const TensorSpec& spec,
-    distributed::MeshDevice* device,
+    tt::tt_metal::distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     float pad_value);
 template Tensor Tensor::from_vector<int32_t>(
     std::vector<int32_t>&& buffer,
     const TensorSpec& spec,
-    distributed::MeshDevice* device,
+    tt::tt_metal::distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     int32_t pad_value);
 template Tensor Tensor::from_vector<uint8_t>(
     std::vector<uint8_t>&& buffer,
     const TensorSpec& spec,
-    distributed::MeshDevice* device,
+    tt::tt_metal::distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     uint8_t pad_value);
 template Tensor Tensor::from_vector<uint16_t>(
     std::vector<uint16_t>&& buffer,
     const TensorSpec& spec,
-    distributed::MeshDevice* device,
+    tt::tt_metal::distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     uint16_t pad_value);
 template Tensor Tensor::from_vector<uint32_t>(
     std::vector<uint32_t>&& buffer,
     const TensorSpec& spec,
-    distributed::MeshDevice* device,
+    tt::tt_metal::distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     uint32_t pad_value);
 
@@ -322,8 +327,8 @@ template std::vector<uint16_t> Tensor::to_vector<uint16_t>(std::optional<tt::tt_
 template std::vector<uint32_t> Tensor::to_vector<uint32_t>(std::optional<tt::tt_metal::QueueId> cq_id) const;
 
 Tensor Tensor::to_device(
-    distributed::MeshDevice* mesh_device,
-    ttsl::optional_reference<const MemoryConfig> mem_config,
+    tt::tt_metal::distributed::MeshDevice* mesh_device,
+    ttsl::optional_reference<const tt::tt_metal::MemoryConfig> mem_config,
     std::optional<tt::tt_metal::QueueId> cq_id) const {
     return tt::tt_metal::to_device(*this, mesh_device, mem_config, cq_id);
 }
@@ -332,18 +337,22 @@ Tensor Tensor::cpu(bool blocking, std::optional<tt::tt_metal::QueueId> cq_id) co
     return tt::tt_metal::cpu(*this, blocking, cq_id);
 }
 
-Tensor Tensor::extract_shard(const CoreCoord& core) const {
+Tensor Tensor::extract_shard(const tt::tt_metal::CoreCoord& core) const {
     ZoneScoped;
     const auto& buffer_page_mapping = *this->buffer()->get_buffer_page_mapping();
     auto core_id = buffer_page_mapping.core_to_core_id.at(core);
     return this->extract_shard(core_id);
 }
 
-Tensor Tensor::extract_shard(const uint32_t& core_id) const { return tensor_impl::extract_shard(*this, core_id); }
+Tensor Tensor::extract_shard(const uint32_t& core_id) const {
+    return tt::tt_metal::tensor_impl::extract_shard(*this, core_id);
+}
 
-Tensor Tensor::to_layout(Layout target_layout) const { return tt::tt_metal::to_layout(*this, target_layout); }
+Tensor Tensor::to_layout(tt::tt_metal::Layout target_layout) const {
+    return tt::tt_metal::to_layout(*this, target_layout);
+}
 
-std::string Tensor::write_to_string() const { return tensor_impl::to_string(*this); }
+std::string Tensor::write_to_string() const { return tt::tt_metal::tensor_impl::to_string(*this); }
 
 Tensor Tensor::pad(
     const tt::tt_metal::Shape& output_padded_shape,
@@ -369,14 +378,14 @@ bool Tensor::is_sharded() const {
 
 uint32_t Tensor::element_size() const {
     switch (this->dtype()) {
-        case DataType::BFLOAT16: return sizeof(bfloat16);
-        case DataType::FLOAT32: return sizeof(float);
-        case DataType::INT32: return sizeof(int32_t);
-        case DataType::UINT32: return sizeof(uint32_t);
-        case DataType::UINT16: return sizeof(uint16_t);
-        case DataType::UINT8: return sizeof(uint8_t);
-        case DataType::BFLOAT8_B:
-        case DataType::BFLOAT4_B: return sizeof(std::byte);
+        case tt::tt_metal::DataType::BFLOAT16: return sizeof(bfloat16);
+        case tt::tt_metal::DataType::FLOAT32: return sizeof(float);
+        case tt::tt_metal::DataType::INT32: return sizeof(int32_t);
+        case tt::tt_metal::DataType::UINT32: return sizeof(uint32_t);
+        case tt::tt_metal::DataType::UINT16: return sizeof(uint16_t);
+        case tt::tt_metal::DataType::UINT8: return sizeof(uint8_t);
+        case tt::tt_metal::DataType::BFLOAT8_B:
+        case tt::tt_metal::DataType::BFLOAT4_B: return sizeof(std::byte);
         default: TT_THROW("Unsupported data type");
     }
 }
@@ -388,7 +397,7 @@ Tensor Tensor::reshape(
     return view(*this, new_logical_shape, new_padded_shape);
 }
 
-void Tensor::update_tensor_topology(const TensorTopology& tensor_topology) {
+void Tensor::update_tensor_topology(const tt::tt_metal::TensorTopology& tensor_topology) {
     tensor_attributes->update_tensor_topology(tensor_topology);
 }
 
@@ -402,11 +411,11 @@ bool Tensor::is_allocated() const {
     return output;
 }
 
-StorageType Tensor::storage_type() const {
+tt::tt_metal::StorageType Tensor::storage_type() const {
     return std::visit(
         ttsl::overloaded{
-            [](const HostStorage&) { return StorageType::HOST; },
-            [](const DeviceStorage&) { return StorageType::DEVICE; },
+            [](const HostStorage&) { return tt::tt_metal::StorageType::HOST; },
+            [](const DeviceStorage&) { return tt::tt_metal::StorageType::DEVICE; },
         },
         tensor_attributes->get_storage());
 }
@@ -426,7 +435,7 @@ bool Tensor::is_scalar() const {
 
 // TODO #32045: Remove this function since IDs are assigned in the constructor.
 Tensor set_tensor_id(const Tensor& tensor) {
-    if (not GraphTracker::instance().is_enabled()) {
+    if (not tt::tt_metal::GraphTracker::instance().is_enabled()) {
         return tensor;
     }
     auto output = tensor;
@@ -442,13 +451,17 @@ const tt::tt_metal::Shape& Tensor::padded_shape() const {
     return this->tensor_attributes->get_tensor_spec().padded_shape();
 }
 
-DataType Tensor::dtype() const { return this->tensor_attributes->get_tensor_spec().tensor_layout().get_data_type(); }
+tt::tt_metal::DataType Tensor::dtype() const {
+    return this->tensor_attributes->get_tensor_spec().tensor_layout().get_data_type();
+}
 
-Layout Tensor::layout() const { return this->tensor_attributes->get_tensor_spec().tensor_layout().get_layout(); }
+tt::tt_metal::Layout Tensor::layout() const {
+    return this->tensor_attributes->get_tensor_spec().tensor_layout().get_layout();
+}
 
 const TensorSpec& Tensor::tensor_spec() const { return this->tensor_attributes->get_tensor_spec(); }
 
-Buffer* Tensor::buffer() const { return device_storage().get_buffer(); }
+tt::tt_metal::Buffer* Tensor::buffer() const { return device_storage().get_buffer(); }
 
 const DeviceStorage& Tensor::device_storage() const& {
     const auto* device_storage = std::get_if<DeviceStorage>(&tensor_attributes->get_storage());
@@ -474,38 +487,44 @@ HostStorage& Tensor::host_storage() & {
     return *host_storage;
 }
 
-const HostTensor& Tensor::host_tensor() const& {
+const tt::tt_metal::HostTensor& Tensor::host_tensor() const& {
     const auto* host_storage = std::get_if<HostStorage>(&tensor_attributes->get_storage());
     TT_FATAL(host_storage != nullptr, "Expected Tensor with HostStorage, got {}", this->storage_type());
     return host_storage->host_tensor();
 }
 
-const MeshTensor& Tensor::mesh_tensor() const& {
+const tt::tt_metal::MeshTensor& Tensor::mesh_tensor() const& {
     const auto* mesh_storage = std::get_if<DeviceStorage>(&tensor_attributes->get_storage());
     TT_FATAL(mesh_storage != nullptr, "Expected Tensor with DeviceStorage, got {}", this->storage_type());
     return mesh_storage->get_mesh_tensor();
 }
 
-distributed::MeshDevice* Tensor::device() const {
+tt::tt_metal::distributed::MeshDevice* Tensor::device() const {
     if (this->mesh_device_.has_value()) {
         return this->mesh_device_.value();
     }
     return nullptr;
 }
 
-const distributed::MeshBuffer& Tensor::mesh_buffer() const { return device_storage().get_mesh_buffer(); }
+const tt::tt_metal::distributed::MeshBuffer& Tensor::mesh_buffer() const { return device_storage().get_mesh_buffer(); }
 
-const MemoryConfig& Tensor::memory_config() const { return tensor_spec().tensor_layout().get_memory_config(); }
+const tt::tt_metal::MemoryConfig& Tensor::memory_config() const {
+    return tensor_spec().tensor_layout().get_memory_config();
+}
 
-const std::optional<ShardSpec>& Tensor::shard_spec() const { return this->memory_config().shard_spec(); }
+const std::optional<tt::tt_metal::ShardSpec>& Tensor::shard_spec() const { return this->memory_config().shard_spec(); }
 
-const std::optional<NdShardSpec>& Tensor::nd_shard_spec() const { return this->memory_config().nd_shard_spec(); }
+const std::optional<tt::tt_metal::NdShardSpec>& Tensor::nd_shard_spec() const {
+    return this->memory_config().nd_shard_spec();
+}
 
-const TensorTopology& Tensor::tensor_topology() const { return this->tensor_attributes->get_tensor_topology(); }
+const tt::tt_metal::TensorTopology& Tensor::tensor_topology() const {
+    return this->tensor_attributes->get_tensor_topology();
+}
 
-std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Tensor& tensor) {
+std::ostream& operator<<(std::ostream& os, const Tensor& tensor) {
     ttsl::reflection::operator<<(os, tensor);
     return os;
 }
 
-}  // namespace tt::tt_metal
+}  // namespace ttnn

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -372,9 +372,7 @@ Tensor Tensor::unpad_from_tile(const tt::tt_metal::Shape& output_tensor_shape) c
     return tt::tt_metal::unpad_from_tile(*this, output_tensor_shape);
 }
 
-bool Tensor::is_sharded() const {
-    return tt::tt_metal::is_device_tensor(*this) ? this->memory_config().is_sharded() : false;
-}
+bool Tensor::is_sharded() const { return is_device_tensor(*this) ? this->memory_config().is_sharded() : false; }
 
 uint32_t Tensor::element_size() const {
     switch (this->dtype()) {

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -344,15 +344,13 @@ Tensor Tensor::extract_shard(const tt::tt_metal::CoreCoord& core) const {
     return this->extract_shard(core_id);
 }
 
-Tensor Tensor::extract_shard(const uint32_t& core_id) const {
-    return tt::tt_metal::tensor_impl::extract_shard(*this, core_id);
-}
+Tensor Tensor::extract_shard(const uint32_t& core_id) const { return tensor_impl::extract_shard(*this, core_id); }
 
 Tensor Tensor::to_layout(tt::tt_metal::Layout target_layout) const {
     return tt::tt_metal::to_layout(*this, target_layout);
 }
 
-std::string Tensor::write_to_string() const { return tt::tt_metal::tensor_impl::to_string(*this); }
+std::string Tensor::write_to_string() const { return tensor_impl::to_string(*this); }
 
 Tensor Tensor::pad(
     const tt::tt_metal::Shape& output_padded_shape,

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -7,20 +7,22 @@
 
 namespace tt::tt_metal {
 
-TensorAttributes::TensorAttributes(HostStorage storage) : storage_(std::move(storage)) {}
+TensorAttributes::TensorAttributes(ttnn::HostStorage storage) : storage_(std::move(storage)) {}
 
-TensorAttributes::TensorAttributes(DeviceStorage storage) : storage_(std::move(storage)) {}
+TensorAttributes::TensorAttributes(ttnn::DeviceStorage storage) : storage_(std::move(storage)) {}
 
-const Storage& TensorAttributes::get_storage() const { return storage_; }
-Storage& TensorAttributes::get_storage() { return storage_; }
+const ttnn::Storage& TensorAttributes::get_storage() const { return storage_; }
+ttnn::Storage& TensorAttributes::get_storage() { return storage_; }
 
 const TensorSpec& TensorAttributes::get_tensor_spec() const {
     return std::visit(
         ttsl::overloaded{
-            [](const HostStorage& host_storage) -> const TensorSpec& {
+            [](const ttnn::HostStorage& host_storage) -> const TensorSpec& {
                 return host_storage.host_tensor().tensor_spec();
             },
-            [](const DeviceStorage& device_storage) -> const TensorSpec& { return device_storage.get_tensor_spec(); },
+            [](const ttnn::DeviceStorage& device_storage) -> const TensorSpec& {
+                return device_storage.get_tensor_spec();
+            },
         },
         storage_);
 }
@@ -28,10 +30,10 @@ const TensorSpec& TensorAttributes::get_tensor_spec() const {
 const TensorTopology& TensorAttributes::get_tensor_topology() const {
     return std::visit(
         ttsl::overloaded{
-            [](const HostStorage& host_storage) -> const TensorTopology& {
+            [](const ttnn::HostStorage& host_storage) -> const TensorTopology& {
                 return host_storage.host_tensor().tensor_topology();
             },
-            [](const DeviceStorage& device_storage) -> const TensorTopology& {
+            [](const ttnn::DeviceStorage& device_storage) -> const TensorTopology& {
                 return device_storage.get_tensor_topology();
             },
         },
@@ -41,8 +43,10 @@ const TensorTopology& TensorAttributes::get_tensor_topology() const {
 void TensorAttributes::update_tensor_topology(const TensorTopology& tensor_topology) {
     std::visit(
         ttsl::overloaded{
-            [&](HostStorage& host_storage) { host_storage.host_tensor().update_tensor_topology(tensor_topology); },
-            [&](DeviceStorage& device_storage) {
+            [&](ttnn::HostStorage& host_storage) {
+                host_storage.host_tensor().update_tensor_topology(tensor_topology);
+            },
+            [&](ttnn::DeviceStorage& device_storage) {
                 device_storage.get_mesh_tensor().update_tensor_topology(tensor_topology);
             },
         },

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -5,7 +5,7 @@
 #include "ttnn/tensor/storage.hpp"
 #include "ttnn/tensor/tensor_attributes.hpp"
 
-namespace tt::tt_metal {
+namespace ttnn {
 
 TensorAttributes::TensorAttributes(ttnn::HostStorage storage) : storage_(std::move(storage)) {}
 
@@ -14,33 +14,33 @@ TensorAttributes::TensorAttributes(ttnn::DeviceStorage storage) : storage_(std::
 const ttnn::Storage& TensorAttributes::get_storage() const { return storage_; }
 ttnn::Storage& TensorAttributes::get_storage() { return storage_; }
 
-const TensorSpec& TensorAttributes::get_tensor_spec() const {
+const tt::tt_metal::TensorSpec& TensorAttributes::get_tensor_spec() const {
     return std::visit(
         ttsl::overloaded{
-            [](const ttnn::HostStorage& host_storage) -> const TensorSpec& {
+            [](const HostStorage& host_storage) -> const tt::tt_metal::TensorSpec& {
                 return host_storage.host_tensor().tensor_spec();
             },
-            [](const ttnn::DeviceStorage& device_storage) -> const TensorSpec& {
+            [](const DeviceStorage& device_storage) -> const tt::tt_metal::TensorSpec& {
                 return device_storage.get_tensor_spec();
             },
         },
         storage_);
 }
 
-const TensorTopology& TensorAttributes::get_tensor_topology() const {
+const tt::tt_metal::TensorTopology& TensorAttributes::get_tensor_topology() const {
     return std::visit(
         ttsl::overloaded{
-            [](const ttnn::HostStorage& host_storage) -> const TensorTopology& {
+            [](const HostStorage& host_storage) -> const tt::tt_metal::TensorTopology& {
                 return host_storage.host_tensor().tensor_topology();
             },
-            [](const ttnn::DeviceStorage& device_storage) -> const TensorTopology& {
+            [](const DeviceStorage& device_storage) -> const tt::tt_metal::TensorTopology& {
                 return device_storage.get_tensor_topology();
             },
         },
         storage_);
 }
 
-void TensorAttributes::update_tensor_topology(const TensorTopology& tensor_topology) {
+void TensorAttributes::update_tensor_topology(const tt::tt_metal::TensorTopology& tensor_topology) {
     std::visit(
         ttsl::overloaded{
             [&](ttnn::HostStorage& host_storage) {
@@ -53,4 +53,4 @@ void TensorAttributes::update_tensor_topology(const TensorTopology& tensor_topol
         storage_);
 }
 
-}  // namespace tt::tt_metal
+}  // namespace ttnn

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -243,7 +243,7 @@ void to_string(
 }  // namespace detail
 
 template <typename T>
-std::string to_string_impl(const Tensor& tensor) {
+std::string to_string_impl(const ttnn::Tensor& tensor) {
     const auto& shape = tensor.logical_shape();
 
     if (!tensor.is_allocated()) {
@@ -255,14 +255,14 @@ std::string to_string_impl(const Tensor& tensor) {
             tensor.layout());
     }
 
-    auto get_row_major_tensor = [&](const Tensor& tensor) -> Tensor {
+    auto get_row_major_tensor = [&](const ttnn::Tensor& tensor) -> ttnn::Tensor {
         if (tensor.layout() == Layout::ROW_MAJOR) {
             return tensor;
         }
         if (tensor.dtype() == DataType::BFLOAT8_B || tensor.dtype() == DataType::BFLOAT4_B) {
-            return to_layout(tt::tt_metal::to_dtype(tensor, DataType::FLOAT32), Layout::ROW_MAJOR);
+            return ttnn::to_layout(tt::tt_metal::to_dtype(tensor, DataType::FLOAT32), Layout::ROW_MAJOR);
         }
-        return to_layout(tensor, Layout::ROW_MAJOR);
+        return ttnn::to_layout(tensor, Layout::ROW_MAJOR);
     };
 
     auto get_host_buffers = [&](const HostStorage& storage) {
@@ -272,7 +272,7 @@ std::string to_string_impl(const Tensor& tensor) {
     };
 
     if (is_cpu_tensor(tensor)) {
-        const Tensor row_major_tensor = get_row_major_tensor(tensor);
+        const ttnn::Tensor row_major_tensor = get_row_major_tensor(tensor);
         const auto strides = row_major_tensor.tensor_spec().compute_strides();
         const std::vector<HostBuffer> buffers = get_host_buffers(row_major_tensor.host_storage());
         std::stringstream ss;
@@ -298,7 +298,7 @@ std::string to_string_impl(const Tensor& tensor) {
     //     return to_string<T>(ttnn::distributed::get_device_tensors(cpu_tensor).at(0));
     // }
 
-    const Tensor row_major_tensor = get_row_major_tensor(cpu_tensor);
+    const ttnn::Tensor row_major_tensor = get_row_major_tensor(cpu_tensor);
     const auto strides = row_major_tensor.tensor_spec().compute_strides();
     const auto coords = storage.get_coords();
     auto coords_it = coords.begin();
@@ -318,16 +318,16 @@ std::string to_string_impl(const Tensor& tensor) {
 }
 
 template <>
-std::string to_string_impl<bfloat8_b>(const Tensor& tensor) {
+std::string to_string_impl<bfloat8_b>(const ttnn::Tensor& tensor) {
     return to_string_impl<float>(tensor);
 }
 
 template <>
-std::string to_string_impl<bfloat4_b>(const Tensor& tensor) {
+std::string to_string_impl<bfloat4_b>(const ttnn::Tensor& tensor) {
     return to_string_impl<float>(tensor);
 }
 
-std::string to_string(const Tensor& tensor) {
+std::string to_string(const ttnn::Tensor& tensor) {
     return dispatch(tensor.dtype(), [&]<typename T>() { return to_string_impl<T>(tensor); });
 }
 
@@ -423,7 +423,7 @@ HostTensor view(
 // ======================================================================================
 
 template <typename T>
-Tensor extract_shard_impl(const Tensor& tensor, const uint32_t& core_id) {
+ttnn::Tensor extract_shard_impl(const ttnn::Tensor& tensor, const uint32_t& core_id) {
     auto* buffer = tensor.buffer();
     auto buffer_shard_shape = buffer->shard_spec().shape();
     tt::tt_metal::Shape shard_shape({1, 1, buffer_shard_shape[0], buffer_shard_shape[1]});
@@ -431,7 +431,7 @@ Tensor extract_shard_impl(const Tensor& tensor, const uint32_t& core_id) {
     ::detail::ReadShard(*buffer, device_data, core_id);
 
     auto output_buffer = std::vector<T>(std::move(device_data));
-    return Tensor(
+    return ttnn::Tensor(
         HostBuffer(std::move(output_buffer)),
         shard_shape,
         tensor.dtype(),
@@ -440,16 +440,16 @@ Tensor extract_shard_impl(const Tensor& tensor, const uint32_t& core_id) {
 }
 
 template <>
-Tensor extract_shard_impl<bfloat8_b>(const Tensor& tensor, const uint32_t& core_id) {
+ttnn::Tensor extract_shard_impl<bfloat8_b>(const ttnn::Tensor& tensor, const uint32_t& core_id) {
     return extract_shard_impl<uint32_t>(tensor, core_id);
 }
 
 template <>
-Tensor extract_shard_impl<bfloat4_b>(const Tensor& tensor, const uint32_t& core_id) {
+ttnn::Tensor extract_shard_impl<bfloat4_b>(const ttnn::Tensor& tensor, const uint32_t& core_id) {
     return extract_shard_impl<uint32_t>(tensor, core_id);
 }
 
-Tensor extract_shard(const Tensor& tensor, const uint32_t& core_id) {
+ttnn::Tensor extract_shard(const ttnn::Tensor& tensor, const uint32_t& core_id) {
     return dispatch(tensor.dtype(), [&]<typename T>() { return extract_shard_impl<T>(tensor, core_id); });
 }
 

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -265,7 +265,7 @@ std::string to_string_impl(const ttnn::Tensor& tensor) {
         return ttnn::to_layout(tensor, Layout::ROW_MAJOR);
     };
 
-    auto get_host_buffers = [&](const HostStorage& storage) {
+    auto get_host_buffers = [&](const ttnn::HostStorage& storage) {
         std::vector<HostBuffer> buffers;
         storage.buffer().apply([&](const HostBuffer& shard) { buffers.push_back(shard); });
         return buffers;

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -39,7 +39,7 @@
 
 using namespace tt::tt_metal;
 
-namespace tt::tt_metal::tensor_impl {
+namespace ttnn::tensor_impl {
 
 PrintOptions TTNN_PRINT_OPTIONS;
 
@@ -318,17 +318,17 @@ std::string to_string_impl(const ttnn::Tensor& tensor) {
 }
 
 template <>
-std::string to_string_impl<bfloat8_b>(const ttnn::Tensor& tensor) {
+std::string to_string_impl<tt::tt_metal::tensor_impl::bfloat8_b>(const ttnn::Tensor& tensor) {
     return to_string_impl<float>(tensor);
 }
 
 template <>
-std::string to_string_impl<bfloat4_b>(const ttnn::Tensor& tensor) {
+std::string to_string_impl<tt::tt_metal::tensor_impl::bfloat4_b>(const ttnn::Tensor& tensor) {
     return to_string_impl<float>(tensor);
 }
 
 std::string to_string(const ttnn::Tensor& tensor) {
-    return dispatch(tensor.dtype(), [&]<typename T>() { return to_string_impl<T>(tensor); });
+    return tt::tt_metal::tensor_impl::dispatch(tensor.dtype(), [&]<typename T>() { return to_string_impl<T>(tensor); });
 }
 
 // ======================================================================================
@@ -440,17 +440,20 @@ ttnn::Tensor extract_shard_impl(const ttnn::Tensor& tensor, const uint32_t& core
 }
 
 template <>
-ttnn::Tensor extract_shard_impl<bfloat8_b>(const ttnn::Tensor& tensor, const uint32_t& core_id) {
+ttnn::Tensor extract_shard_impl<tt::tt_metal::tensor_impl::bfloat8_b>(
+    const ttnn::Tensor& tensor, const uint32_t& core_id) {
     return extract_shard_impl<uint32_t>(tensor, core_id);
 }
 
 template <>
-ttnn::Tensor extract_shard_impl<bfloat4_b>(const ttnn::Tensor& tensor, const uint32_t& core_id) {
+ttnn::Tensor extract_shard_impl<tt::tt_metal::tensor_impl::bfloat4_b>(
+    const ttnn::Tensor& tensor, const uint32_t& core_id) {
     return extract_shard_impl<uint32_t>(tensor, core_id);
 }
 
 ttnn::Tensor extract_shard(const ttnn::Tensor& tensor, const uint32_t& core_id) {
-    return dispatch(tensor.dtype(), [&]<typename T>() { return extract_shard_impl<T>(tensor, core_id); });
+    return tt::tt_metal::tensor_impl::dispatch(
+        tensor.dtype(), [&]<typename T>() { return extract_shard_impl<T>(tensor, core_id); });
 }
 
-}  // namespace tt::tt_metal::tensor_impl
+}  // namespace ttnn::tensor_impl

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -409,7 +409,7 @@ ttnn::Tensor view(const ttnn::Tensor& input_tensor, const Shape& new_logical_sha
 
     ttnn::Tensor output;
     if (is_cpu_tensor(input_tensor)) {
-        output = ttnn::Tensor(tensor_impl::view(input_tensor.host_tensor(), new_logical_shape, new_padded_shape));
+        output = ttnn::Tensor(ttnn::tensor_impl::view(input_tensor.host_tensor(), new_logical_shape, new_padded_shape));
     } else {
         output = view_device(input_tensor, new_logical_shape, new_padded_shape);
     }
@@ -469,6 +469,6 @@ ttnn::Tensor to_dtype(const ttnn::Tensor& input_tensor, DataType dtype) {
     return output_tensor;
 }
 
-std::string to_string(const ttnn::Tensor& tensor) { return tensor_impl::to_string(tensor); }
+std::string to_string(const ttnn::Tensor& tensor) { return ttnn::tensor_impl::to_string(tensor); }
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -95,7 +95,7 @@ ttnn::Tensor to_device(
     ttsl::optional_reference<const MemoryConfig> mem_config,
     std::optional<QueueId> cq_id) {
     GraphTracker::instance().track_function_start("Tensor::to_device", input_tensor, mesh_device, mem_config);
-    if (input_tensor.storage_type() == StorageType::DEVICE) {
+    if (input_tensor.storage_type() == ttnn::StorageType::DEVICE) {
         TT_ASSERT(input_tensor.device() == mesh_device, "Currently do not support moving between devices");
         GraphTracker::instance().track_function_end(input_tensor);
         return input_tensor;
@@ -166,7 +166,7 @@ void copy_to_host(
 }
 
 ttnn::Tensor cpu(const ttnn::Tensor& input_tensor, bool blocking, std::optional<QueueId> cq_id) {
-    if (input_tensor.storage_type() != StorageType::DEVICE) {
+    if (input_tensor.storage_type() != ttnn::StorageType::DEVICE) {
         return input_tensor;
     }
 

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -107,7 +107,7 @@ ttnn::Tensor to_device(
     } else {
         auto [mesh_tensor, coords] =
             non_uniform_data_movement::enqueue_write_tensor(cq, input_tensor.host_tensor(), *mesh_device, mem_config);
-        device_tensor = ttnn::Tensor(DeviceStorage(std::move(mesh_tensor), std::move(coords)));
+        device_tensor = ttnn::Tensor(ttnn::DeviceStorage(std::move(mesh_tensor), std::move(coords)));
     }
     GraphTracker::instance().track_function_end(device_tensor);
     return device_tensor;
@@ -122,7 +122,7 @@ void copy_to_device(
     } else {
         auto coords = non_uniform_data_movement::enqueue_write_tensor(
             cq, host_tensor.host_tensor(), device_tensor.device_storage().get_mesh_tensor());
-        device_tensor.device_storage() = DeviceStorage(device_tensor.device_storage(), std::move(coords));
+        device_tensor.device_storage() = ttnn::DeviceStorage(device_tensor.device_storage(), std::move(coords));
     }
     device_tensor = ttnn::set_tensor_id(device_tensor);
     GraphTracker::instance().track_function_end(device_tensor);
@@ -351,7 +351,7 @@ ttnn::Tensor view_device(
             input_buffer.address());
 
         MeshTensor view_mesh_tensor(std::move(view_mesh_buffer), new_spec, input_tensor.tensor_topology());
-        DeviceStorage view_storage(input_tensor.device_storage(), std::move(view_mesh_tensor));
+        ttnn::DeviceStorage view_storage(input_tensor.device_storage(), std::move(view_mesh_tensor));
         return ttnn::Tensor(std::move(view_storage));
     }
     if (!input_tensor.memory_config().is_sharded()) {
@@ -364,7 +364,7 @@ ttnn::Tensor view_device(
             input_buffer.global_config(), new_device_config, input_buffer.device(), input_buffer.address());
 
         MeshTensor view_mesh_tensor(std::move(view_mesh_buffer), new_spec, input_tensor.tensor_topology());
-        DeviceStorage view_storage(input_tensor.device_storage(), std::move(view_mesh_tensor));
+        ttnn::DeviceStorage view_storage(input_tensor.device_storage(), std::move(view_mesh_tensor));
         return ttnn::Tensor(std::move(view_storage));
     }
 
@@ -398,7 +398,7 @@ ttnn::Tensor view_device(
         input_tensor.device(),
         input_tensor.mesh_buffer().address());
 
-    tt::tt_metal::DeviceStorage view_storage(
+    ttnn::DeviceStorage view_storage(
         input_tensor.device_storage(), MeshTensor(view_mesh_buffer, new_spec, input_tensor.tensor_topology()));
     return ttnn::Tensor(std::move(view_storage));
 }
@@ -444,7 +444,7 @@ ttnn::Tensor unchecked_reinterpret_layout(const ttnn::Tensor& input_tensor, Layo
         input_buffer.address());
 
     MeshTensor reinterpreted(std::move(new_mesh_buffer), new_spec, topology);
-    DeviceStorage reinterpreted_storage(input_tensor.device_storage(), std::move(reinterpreted));
+    ttnn::DeviceStorage reinterpreted_storage(input_tensor.device_storage(), std::move(reinterpreted));
     return ttnn::Tensor(std::move(reinterpreted_storage));
 }
 

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -25,7 +25,7 @@
 
 namespace tt::tt_metal {
 
-Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshDevice* device) {
+ttnn::Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshDevice* device) {
     auto distributed_host_buffer = DistributedHostBuffer::create(device->get_view());
 
     std::vector<distributed::MeshCoordinate> coords;
@@ -40,11 +40,13 @@ Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshD
         DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
 
     // TODO (#25340): Implement correct logic and add test for this
-    return Tensor(HostTensor(std::move(distributed_host_buffer), tensor_spec, TensorTopology{}));
+    return ttnn::Tensor(HostTensor(std::move(distributed_host_buffer), tensor_spec, TensorTopology{}));
 }
 
-Tensor create_device_tensor(
-    const TensorSpec& tensor_spec, distributed::MeshDevice* mesh_device, std::optional<TensorTopology> tensor_topology) {
+ttnn::Tensor create_device_tensor(
+    const TensorSpec& tensor_spec,
+    distributed::MeshDevice* mesh_device,
+    std::optional<TensorTopology> tensor_topology) {
     GraphTracker::instance().track_function_start(
         "tt::tt_metal::create_device_tensor",
         tensor_spec.logical_shape(),
@@ -53,7 +55,7 @@ Tensor create_device_tensor(
         mesh_device,
         tensor_spec.tensor_layout().get_memory_config());
 
-    Tensor output;
+    ttnn::Tensor output;
     auto topology = std::invoke([&]() {
         if (tensor_topology.has_value()) {
             return std::move(*tensor_topology);
@@ -76,8 +78,8 @@ Tensor create_device_tensor(
         return TensorTopology{mesh_shape, placements, std::move(coordinates)};
     });
 
-    output = Tensor(MeshTensor::allocate_on_device(*mesh_device, tensor_spec, topology));
-    output = tt::tt_metal::set_tensor_id(output);
+    output = ttnn::Tensor(MeshTensor::allocate_on_device(*mesh_device, tensor_spec, topology));
+    output = ttnn::set_tensor_id(output);
 
     GraphTracker::instance().track_function_end(output);
 
@@ -87,8 +89,8 @@ Tensor create_device_tensor(
 
 namespace tt::tt_metal {
 
-Tensor to_device(
-    const Tensor& input_tensor,
+ttnn::Tensor to_device(
+    const ttnn::Tensor& input_tensor,
     distributed::MeshDevice* mesh_device,
     ttsl::optional_reference<const MemoryConfig> mem_config,
     std::optional<QueueId> cq_id) {
@@ -99,19 +101,20 @@ Tensor to_device(
         return input_tensor;
     }
     auto& cq = mesh_device->mesh_command_queue(raw_optional(cq_id));
-    Tensor device_tensor;
+    ttnn::Tensor device_tensor;
     if (is_uniform_write(input_tensor.host_tensor(), *mesh_device)) {
-        device_tensor = Tensor(enqueue_write_tensor(cq, input_tensor.host_tensor(), *mesh_device, mem_config));
+        device_tensor = ttnn::Tensor(enqueue_write_tensor(cq, input_tensor.host_tensor(), *mesh_device, mem_config));
     } else {
         auto [mesh_tensor, coords] =
             non_uniform_data_movement::enqueue_write_tensor(cq, input_tensor.host_tensor(), *mesh_device, mem_config);
-        device_tensor = Tensor(DeviceStorage(std::move(mesh_tensor), std::move(coords)));
+        device_tensor = ttnn::Tensor(DeviceStorage(std::move(mesh_tensor), std::move(coords)));
     }
     GraphTracker::instance().track_function_end(device_tensor);
     return device_tensor;
 }
 
-void copy_to_device(const Tensor& host_tensor, Tensor& device_tensor, std::optional<tt::tt_metal::QueueId> cq_id) {
+void copy_to_device(
+    const ttnn::Tensor& host_tensor, ttnn::Tensor& device_tensor, std::optional<tt::tt_metal::QueueId> cq_id) {
     GraphTracker::instance().track_function_start("tt::tt_metal::copy_to_device", host_tensor, device_tensor, cq_id);
     auto& cq = device_tensor.device()->mesh_command_queue(raw_optional(cq_id));
     if (is_uniform_write(host_tensor.host_tensor(), *device_tensor.device())) {
@@ -121,14 +124,14 @@ void copy_to_device(const Tensor& host_tensor, Tensor& device_tensor, std::optio
             cq, host_tensor.host_tensor(), device_tensor.device_storage().get_mesh_tensor());
         device_tensor.device_storage() = DeviceStorage(device_tensor.device_storage(), std::move(coords));
     }
-    device_tensor = tt::tt_metal::set_tensor_id(device_tensor);
+    device_tensor = ttnn::set_tensor_id(device_tensor);
     GraphTracker::instance().track_function_end(device_tensor);
 }
 
 void copy_to_device(
     distributed::MeshCommandQueue& queue,
     const std::byte* src,
-    Tensor& device_tensor,
+    ttnn::Tensor& device_tensor,
     const std::optional<BufferRegion>& region) {
     GraphTracker::instance().track_function_start("tt::tt_metal::copy_to_device", queue, src, device_tensor, region);
     enqueue_write_tensor(queue, src, device_tensor.device_storage().get_mesh_tensor(), region);
@@ -137,7 +140,7 @@ void copy_to_device(
 
 void copy_to_host(
     distributed::MeshCommandQueue& queue,
-    const Tensor& device_tensor,
+    const ttnn::Tensor& device_tensor,
     std::byte* dst,
     const std::optional<BufferRegion>& region,
     bool blocking) {
@@ -147,7 +150,8 @@ void copy_to_host(
     GraphTracker::instance().track_function_end(device_tensor);
 }
 
-void copy_to_host(const Tensor& device_tensor, Tensor& host_tensor, bool blocking, std::optional<QueueId> cq_id) {
+void copy_to_host(
+    const ttnn::Tensor& device_tensor, ttnn::Tensor& host_tensor, bool blocking, std::optional<QueueId> cq_id) {
     GraphTracker::instance().track_function_start(
         "tt::tt_metal::copy_to_host", device_tensor, host_tensor, blocking, cq_id);
     auto& cq = device_tensor.device()->mesh_command_queue(raw_optional(cq_id));
@@ -161,7 +165,7 @@ void copy_to_host(const Tensor& device_tensor, Tensor& host_tensor, bool blockin
     GraphTracker::instance().track_function_end(host_tensor);
 }
 
-Tensor cpu(const Tensor& input_tensor, bool blocking, std::optional<QueueId> cq_id) {
+ttnn::Tensor cpu(const ttnn::Tensor& input_tensor, bool blocking, std::optional<QueueId> cq_id) {
     if (input_tensor.storage_type() != StorageType::DEVICE) {
         return input_tensor;
     }
@@ -169,30 +173,30 @@ Tensor cpu(const Tensor& input_tensor, bool blocking, std::optional<QueueId> cq_
     GraphTracker::instance().track_function_start("Tensor::cpu", input_tensor, blocking);
 
     auto& cq = input_tensor.device()->mesh_command_queue(raw_optional(cq_id));
-    Tensor output;
+    ttnn::Tensor output;
     if (input_tensor.device_storage().is_uniform_storage()) {
-        output = Tensor(enqueue_read_tensor(cq, input_tensor.mesh_tensor(), blocking));
+        output = ttnn::Tensor(enqueue_read_tensor(cq, input_tensor.mesh_tensor(), blocking));
     } else {
         auto coords = input_tensor.device_storage().get_coords();
-        output =
-            Tensor(non_uniform_data_movement::enqueue_read_tensor(cq, input_tensor.mesh_tensor(), coords, blocking));
+        output = ttnn::Tensor(
+            non_uniform_data_movement::enqueue_read_tensor(cq, input_tensor.mesh_tensor(), coords, blocking));
     }
-    output = tt::tt_metal::set_tensor_id(output);
+    output = ttnn::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
 }
 
-Tensor to_layout(const Tensor& input_tensor, Layout target_layout) {
+ttnn::Tensor to_layout(const ttnn::Tensor& input_tensor, Layout target_layout) {
     GraphTracker::instance().track_function_start("Tensor::to_layout", input_tensor, target_layout);
     TT_FATAL(is_cpu_tensor(input_tensor), "Tensor must be on host for to_layout conversion");
-    Tensor output = Tensor(tt::tt_metal::to_layout(input_tensor.host_tensor(), target_layout));
-    output = tt::tt_metal::set_tensor_id(output);
+    ttnn::Tensor output = ttnn::Tensor(tt::tt_metal::to_layout(input_tensor.host_tensor(), target_layout));
+    output = ttnn::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
 }
 
-Tensor pad(
-    const Tensor& input_tensor,
+ttnn::Tensor pad(
+    const ttnn::Tensor& input_tensor,
     const tt::tt_metal::Shape& output_padded_shape,
     const tt::tt_metal::Shape& input_tensor_start,
     float pad_value) {
@@ -209,26 +213,26 @@ Tensor pad(
     }
 
     auto output =
-        Tensor(tt::tt_metal::pad(input_tensor.host_tensor(), output_padded_shape, input_tensor_start, pad_value));
-    output = tt::tt_metal::set_tensor_id(output);
+        ttnn::Tensor(tt::tt_metal::pad(input_tensor.host_tensor(), output_padded_shape, input_tensor_start, pad_value));
+    output = ttnn::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
 }
 
-Tensor unpad(
-    const Tensor& input_tensor,
+ttnn::Tensor unpad(
+    const ttnn::Tensor& input_tensor,
     const tt::tt_metal::Shape& output_tensor_start,
     const tt::tt_metal::Shape& output_tensor_end) {
     GraphTracker::instance().track_function_start(
         "Tensor::unpad", input_tensor, output_tensor_start, output_tensor_end);
     TT_FATAL(is_cpu_tensor(input_tensor), "Tensor must be on host for unpadding");
-    auto output = Tensor(tt::tt_metal::unpad(input_tensor.host_tensor(), output_tensor_start, output_tensor_end));
-    output = tt::tt_metal::set_tensor_id(output);
+    auto output = ttnn::Tensor(tt::tt_metal::unpad(input_tensor.host_tensor(), output_tensor_start, output_tensor_end));
+    output = ttnn::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
 }
 
-Tensor pad_to_tile(const Tensor& input_tensor, float pad_value) {
+ttnn::Tensor pad_to_tile(const ttnn::Tensor& input_tensor, float pad_value) {
     // TODO: Flip to assert when we remove use cases in python and c++
     if (input_tensor.layout() != Layout::ROW_MAJOR) {
         log_warning(
@@ -240,17 +244,17 @@ Tensor pad_to_tile(const Tensor& input_tensor, float pad_value) {
 
     GraphTracker::instance().track_function_start("Tensor::pad_to_tile", input_tensor, pad_value);
     TT_FATAL(is_cpu_tensor(input_tensor), "Tensor must be on host for pad_to_tile conversion");
-    auto output = Tensor(tt::tt_metal::pad_to_tile(input_tensor.host_tensor(), pad_value));
-    output = tt::tt_metal::set_tensor_id(output);
+    auto output = ttnn::Tensor(tt::tt_metal::pad_to_tile(input_tensor.host_tensor(), pad_value));
+    output = ttnn::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
 }
 
-Tensor unpad_from_tile(const Tensor& input_tensor, const tt::tt_metal::Shape& output_tensor_shape) {
+ttnn::Tensor unpad_from_tile(const ttnn::Tensor& input_tensor, const tt::tt_metal::Shape& output_tensor_shape) {
     GraphTracker::instance().track_function_start("Tensor::unpad_from_tile", input_tensor, output_tensor_shape);
     TT_FATAL(is_cpu_tensor(input_tensor), "Tensor must be on host for unpad_from_tile conversion");
-    auto output = Tensor(tt::tt_metal::unpad_from_tile(input_tensor.host_tensor(), output_tensor_shape));
-    output = tt::tt_metal::set_tensor_id(output);
+    auto output = ttnn::Tensor(tt::tt_metal::unpad_from_tile(input_tensor.host_tensor(), output_tensor_shape));
+    output = ttnn::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
 }
@@ -259,7 +263,8 @@ Tensor unpad_from_tile(const Tensor& input_tensor, const tt::tt_metal::Shape& ou
 //                                  .tensor_view()
 // ======================================================================================
 
-Tensor view_device(const Tensor& input_tensor, const Shape& new_logical_shape, const Shape& new_padded_shape) {
+ttnn::Tensor view_device(
+    const ttnn::Tensor& input_tensor, const Shape& new_logical_shape, const Shape& new_padded_shape) {
     // Just edit shape if shape has a 0 dimension
     if (input_tensor.logical_volume() == 0) {
         TT_FATAL(new_logical_shape.volume() == 0, "Tensor volume is 0, but shape's volume is not");
@@ -347,7 +352,7 @@ Tensor view_device(const Tensor& input_tensor, const Shape& new_logical_shape, c
 
         MeshTensor view_mesh_tensor(std::move(view_mesh_buffer), new_spec, input_tensor.tensor_topology());
         DeviceStorage view_storage(input_tensor.device_storage(), std::move(view_mesh_tensor));
-        return Tensor(std::move(view_storage));
+        return ttnn::Tensor(std::move(view_storage));
     }
     if (!input_tensor.memory_config().is_sharded()) {
         const auto& input_buffer = input_tensor.device_storage().get_mesh_buffer();
@@ -360,7 +365,7 @@ Tensor view_device(const Tensor& input_tensor, const Shape& new_logical_shape, c
 
         MeshTensor view_mesh_tensor(std::move(view_mesh_buffer), new_spec, input_tensor.tensor_topology());
         DeviceStorage view_storage(input_tensor.device_storage(), std::move(view_mesh_tensor));
-        return Tensor(std::move(view_storage));
+        return ttnn::Tensor(std::move(view_storage));
     }
 
     tt::tt_metal::ShardSpec new_shard_spec = output_memory_config.shard_spec().value();
@@ -395,28 +400,30 @@ Tensor view_device(const Tensor& input_tensor, const Shape& new_logical_shape, c
 
     tt::tt_metal::DeviceStorage view_storage(
         input_tensor.device_storage(), MeshTensor(view_mesh_buffer, new_spec, input_tensor.tensor_topology()));
-    return Tensor(std::move(view_storage));
+    return ttnn::Tensor(std::move(view_storage));
 }
 
-Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Shape& new_padded_shape) {
+ttnn::Tensor view(const ttnn::Tensor& input_tensor, const Shape& new_logical_shape, const Shape& new_padded_shape) {
     tt::tt_metal::GraphTracker::instance().track_function_start(
         "Tensor::reshape", input_tensor, new_logical_shape, new_padded_shape);
 
-    Tensor output;
+    ttnn::Tensor output;
     if (is_cpu_tensor(input_tensor)) {
-        output = Tensor(tensor_impl::view(input_tensor.host_tensor(), new_logical_shape, new_padded_shape));
+        output = ttnn::Tensor(tensor_impl::view(input_tensor.host_tensor(), new_logical_shape, new_padded_shape));
     } else {
         output = view_device(input_tensor, new_logical_shape, new_padded_shape);
     }
 
-    output = tt::tt_metal::set_tensor_id(output);
+    output = ttnn::set_tensor_id(output);
     tt::tt_metal::GraphTracker::instance().track_function_end(output);
     return output;
 }
 
-Tensor view(const Tensor& input_tensor, const Shape& new_shape) { return view(input_tensor, new_shape, new_shape); }
+ttnn::Tensor view(const ttnn::Tensor& input_tensor, const Shape& new_shape) {
+    return view(input_tensor, new_shape, new_shape);
+}
 
-Tensor unchecked_reinterpret_layout(const Tensor& input_tensor, Layout target_layout) {
+ttnn::Tensor unchecked_reinterpret_layout(const ttnn::Tensor& input_tensor, Layout target_layout) {
     const auto& old_spec = input_tensor.tensor_spec();
     const auto& old_layout = old_spec.tensor_layout();
 
@@ -426,7 +433,7 @@ Tensor unchecked_reinterpret_layout(const Tensor& input_tensor, Layout target_la
     const auto& topology = input_tensor.tensor_topology();
 
     if (is_cpu_tensor(input_tensor)) {
-        return Tensor(HostTensor(input_tensor.host_tensor().buffer(), new_spec, topology));
+        return ttnn::Tensor(HostTensor(input_tensor.host_tensor().buffer(), new_spec, topology));
     }
 
     const auto& input_buffer = input_tensor.device_storage().get_mesh_buffer();
@@ -438,30 +445,30 @@ Tensor unchecked_reinterpret_layout(const Tensor& input_tensor, Layout target_la
 
     MeshTensor reinterpreted(std::move(new_mesh_buffer), new_spec, topology);
     DeviceStorage reinterpreted_storage(input_tensor.device_storage(), std::move(reinterpreted));
-    return Tensor(std::move(reinterpreted_storage));
+    return ttnn::Tensor(std::move(reinterpreted_storage));
 }
 
 // ======================================================================================
 //                                  .tensor_reshape()
 // ======================================================================================
-Tensor reshape(
-    const Tensor& input_tensor,
+ttnn::Tensor reshape(
+    const ttnn::Tensor& input_tensor,
     const tt::tt_metal::Shape& new_logical_shape,
     const tt::tt_metal::Shape& new_padded_shape) {
     return view(input_tensor, new_logical_shape, new_padded_shape);
 }
 
-Tensor reshape(const Tensor& input_tensor, const tt::tt_metal::Shape& new_shape) {
-    return reshape(input_tensor, new_shape, new_shape);
+ttnn::Tensor reshape(const ttnn::Tensor& input_tensor, const tt::tt_metal::Shape& new_shape) {
+    return tt::tt_metal::reshape(input_tensor, new_shape, new_shape);
 }
 
-Tensor to_dtype(const Tensor& input_tensor, DataType dtype) {
+ttnn::Tensor to_dtype(const ttnn::Tensor& input_tensor, DataType dtype) {
     GraphTracker::instance().track_function_start("tt::tt_metal::to_dtype", input_tensor, dtype);
-    auto output_tensor = Tensor(tt::tt_metal::to_dtype(input_tensor.host_tensor(), dtype));
+    auto output_tensor = ttnn::Tensor(tt::tt_metal::to_dtype(input_tensor.host_tensor(), dtype));
     GraphTracker::instance().track_function_end(output_tensor);
     return output_tensor;
 }
 
-std::string to_string(const Tensor& tensor) { return tensor_impl::to_string(tensor); }
+std::string to_string(const ttnn::Tensor& tensor) { return tensor_impl::to_string(tensor); }
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/tensor_utils.cpp
+++ b/ttnn/core/tensor/tensor_utils.cpp
@@ -12,9 +12,9 @@
 
 namespace tt::tt_metal {
 
-bool is_cpu_tensor(const ttnn::Tensor& tensor) { return tensor.storage_type() == StorageType::HOST; }
+bool is_cpu_tensor(const ttnn::Tensor& tensor) { return tensor.storage_type() == ttnn::StorageType::HOST; }
 
-bool is_device_tensor(const ttnn::Tensor& tensor) { return tensor.storage_type() == StorageType::DEVICE; }
+bool is_device_tensor(const ttnn::Tensor& tensor) { return tensor.storage_type() == ttnn::StorageType::DEVICE; }
 
 CBDescriptor cb_descriptor_from_sharded_tensor(
     uint8_t cb_index,
@@ -59,7 +59,9 @@ std::vector<CoreCoord> get_optimal_worker_cores_for_sharded_tensor(const ttnn::T
     that have shards on them in order (based on shard orientation) so that the program and kernels will not be launched
     on cores with no data on them (this can cause failures).
     **/
-    TT_FATAL(tensor.storage_type() == StorageType::DEVICE, "Tensor must be on device to compute optimal worker cores.");
+    TT_FATAL(
+        tensor.storage_type() == ttnn::StorageType::DEVICE,
+        "Tensor must be on device to compute optimal worker cores.");
     TT_FATAL(tensor.is_sharded(), "Tensor must be sharded to compute optimal worker cores.");
     if (!tensor.memory_config().is_dram()) {
         return tensor.buffer()->buffer_distribution_spec().value().cores_with_data();

--- a/ttnn/core/tensor/tensor_utils.cpp
+++ b/ttnn/core/tensor/tensor_utils.cpp
@@ -10,7 +10,13 @@
 
 #include <tracy/Tracy.hpp>
 
-namespace tt::tt_metal {
+namespace ttnn {
+
+using tt::tt_metal::CBDescriptor;
+using tt::tt_metal::CBFormatDescriptor;
+using tt::tt_metal::datatype_to_dataformat_converter;
+using tt::tt_metal::NOC;
+using tt::tt_metal::TileDescriptor;
 
 bool is_cpu_tensor(const ttnn::Tensor& tensor) { return tensor.storage_type() == ttnn::StorageType::HOST; }
 
@@ -78,4 +84,4 @@ std::vector<CoreCoord> get_optimal_worker_cores_for_sharded_tensor(const ttnn::T
     return ordered_worker_cores_with_data;
 }
 
-}  // namespace tt::tt_metal
+}  // namespace ttnn

--- a/ttnn/core/tensor/tensor_utils.cpp
+++ b/ttnn/core/tensor/tensor_utils.cpp
@@ -12,13 +12,13 @@
 
 namespace tt::tt_metal {
 
-bool is_cpu_tensor(const Tensor& tensor) { return tensor.storage_type() == StorageType::HOST; }
+bool is_cpu_tensor(const ttnn::Tensor& tensor) { return tensor.storage_type() == StorageType::HOST; }
 
-bool is_device_tensor(const Tensor& tensor) { return tensor.storage_type() == StorageType::DEVICE; }
+bool is_device_tensor(const ttnn::Tensor& tensor) { return tensor.storage_type() == StorageType::DEVICE; }
 
 CBDescriptor cb_descriptor_from_sharded_tensor(
     uint8_t cb_index,
-    const Tensor& tensor,
+    const ttnn::Tensor& tensor,
     uint32_t address_offset,
     uint32_t total_size,
     const std::optional<CoreRangeSet>& core_ranges) {
@@ -42,7 +42,7 @@ CBDescriptor cb_descriptor_from_sharded_tensor(
         .global_circular_buffer = nullptr};
 }
 
-std::vector<CoreCoord> get_optimal_worker_cores_for_sharded_tensor(const Tensor& tensor, NOC noc) {
+std::vector<CoreCoord> get_optimal_worker_cores_for_sharded_tensor(const ttnn::Tensor& tensor, NOC noc) {
     /**
     This function takes in a sharded device tensor (can be legacy 2D sharded or ND sharded) and returns the optimal
     worker cores to launch programs on for the tensor.

--- a/ttnn/core/tensor/to_string.cpp
+++ b/ttnn/core/tensor/to_string.cpp
@@ -26,7 +26,7 @@ std::string to_string(const Tensor& tensor) {
             tensor.layout());
     }
 
-    if (tt::tt_metal::is_device_tensor(tensor)) {
+    if (is_device_tensor(tensor)) {
         if (tensor.is_allocated()) {
             auto* mesh_device = tensor.device();
 

--- a/ttnn/core/tensor/to_string.cpp
+++ b/ttnn/core/tensor/to_string.cpp
@@ -12,7 +12,7 @@
 
 namespace ttnn {
 
-std::string to_string(const tt::tt_metal::Tensor& tensor) {
+std::string to_string(const Tensor& tensor) {
     tt::tt_metal::GraphTracker::instance().track_function_start("ttnn::to_string", tensor);
 
     const auto& shape = tensor.logical_shape();
@@ -26,7 +26,7 @@ std::string to_string(const tt::tt_metal::Tensor& tensor) {
             tensor.layout());
     }
 
-    if (is_device_tensor(tensor)) {
+    if (tt::tt_metal::is_device_tensor(tensor)) {
         if (tensor.is_allocated()) {
             auto* mesh_device = tensor.device();
 

--- a/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
+++ b/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
@@ -97,7 +97,7 @@ ttnn::Tensor aggregate(const std::vector<ttnn::Tensor>& tensors) {
 
     MeshTensor mesh_tensor(mesh_buffer, reference_spec, topology);
 
-    auto result = ttnn::Tensor(tt::tt_metal::DeviceStorage(std::move(mesh_tensor), std::move(coords)));
+    auto result = ttnn::Tensor(ttnn::DeviceStorage(std::move(mesh_tensor), std::move(coords)));
     return result;
 }
 

--- a/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
+++ b/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
@@ -32,7 +32,7 @@ void synchronize_parent_allocator_with_submeshes(tt::tt_metal::distributed::Mesh
 
 }  // namespace
 
-Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors) {
+ttnn::Tensor aggregate(const std::vector<ttnn::Tensor>& tensors) {
     TT_FATAL(!tensors.empty(), "Cannot aggregate empty tensor vector");
 
     // Validate all tensors are allocated on the unit meshes.
@@ -97,11 +97,11 @@ Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors) {
 
     MeshTensor mesh_tensor(mesh_buffer, reference_spec, topology);
 
-    auto result = Tensor(tt::tt_metal::DeviceStorage(std::move(mesh_tensor), std::move(coords)));
+    auto result = ttnn::Tensor(tt::tt_metal::DeviceStorage(std::move(mesh_tensor), std::move(coords)));
     return result;
 }
 
-std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tensor) {
+std::vector<ttnn::Tensor> disaggregate(const ttnn::Tensor& tensor) {
     using namespace tt::tt_metal;
 
     // Validate the tensor is allocated on mesh device, that is parent mesh of unit meshes.
@@ -129,7 +129,7 @@ std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tenso
     const auto& reference_spec = tensor.tensor_spec();
 
     // For all unit meshes, create individual mesh buffers with the same address.
-    std::vector<Tensor> result;
+    std::vector<ttnn::Tensor> result;
     result.reserve(submeshes.size());
     for (const auto& submesh : submeshes) {
         TT_FATAL(
@@ -138,7 +138,7 @@ std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tenso
         auto mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
             input_mesh_buffer.global_config(), input_mesh_buffer.device_local_config(), submesh.get(), input_address);
 
-        Tensor unit_tensor(tt::tt_metal::MeshTensor(mesh_buffer, reference_spec, TensorTopology{}));
+        ttnn::Tensor unit_tensor(tt::tt_metal::MeshTensor(mesh_buffer, reference_spec, TensorTopology{}));
         TT_FATAL(
             unit_tensor.device_storage().get_coords().size() == 1 &&
                 unit_tensor.device_storage().get_coords()[0] == tt::tt_metal::distributed::MeshCoordinate(0, 0),

--- a/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
+++ b/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
@@ -12,7 +12,7 @@
 #include <tt-metalium/allocator.hpp>
 #include <tt_stl/assert.hpp>
 
-namespace tt::tt_metal::experimental::unit_mesh {
+namespace ttnn::experimental::unit_mesh {
 
 namespace {
 
@@ -95,7 +95,7 @@ ttnn::Tensor aggregate(const std::vector<ttnn::Tensor>& tensors) {
     auto topology = tt::tt_metal::TensorTopology::create_sharded_tensor_topology(
         tt::tt_metal::distributed::MeshShape(parent_mesh->shape().mesh_size()), /*shard_dim=*/0);
 
-    MeshTensor mesh_tensor(mesh_buffer, reference_spec, topology);
+    tt::tt_metal::MeshTensor mesh_tensor(mesh_buffer, reference_spec, topology);
 
     auto result = ttnn::Tensor(ttnn::DeviceStorage(std::move(mesh_tensor), std::move(coords)));
     return result;
@@ -150,4 +150,4 @@ std::vector<ttnn::Tensor> disaggregate(const ttnn::Tensor& tensor) {
     return result;
 }
 
-}  // namespace tt::tt_metal::experimental::unit_mesh
+}  // namespace ttnn::experimental::unit_mesh

--- a/ttnn/core/tensor/xtensor/partition.cpp
+++ b/ttnn/core/tensor/xtensor/partition.cpp
@@ -20,7 +20,7 @@
 #include <xtensor/core/xtensor_forward.hpp>
 #include <xtensor/views/xview.hpp>
 
-namespace tt::tt_metal::experimental::xtensor {
+namespace ttnn::experimental::xtensor {
 namespace {
 
 ttsl::SmallVector<int> normalize_dims(const ttsl::SmallVector<int>& dims, size_t tensor_dims) {
@@ -304,4 +304,4 @@ EXPLICIT_INSTANTIATIONS_FOR_TYPE(uint32_t)
 
 #undef EXPLICIT_INSTANTIATIONS_FOR_TYPE
 
-}  // namespace tt::tt_metal::experimental::xtensor
+}  // namespace ttnn::experimental::xtensor

--- a/ttnn/core/tensor/xtensor/partition.cpp
+++ b/ttnn/core/tensor/xtensor/partition.cpp
@@ -236,7 +236,7 @@ namespace adaptor {
 namespace {
 
 template <typename T>
-Tensor concat_impl(const std::vector<Tensor>& tensors, const tt::tt_metal::TensorLayout& layout, int dim) {
+ttnn::Tensor concat_impl(const std::vector<ttnn::Tensor>& tensors, const tt::tt_metal::TensorLayout& layout, int dim) {
     std::vector<xt::xarray<T>> xtensors;
     xtensors.reserve(tensors.size());
     for (const auto& tensor : tensors) {
@@ -249,7 +249,7 @@ Tensor concat_impl(const std::vector<Tensor>& tensors, const tt::tt_metal::Tenso
 }  // namespace
 }  // namespace adaptor
 
-Tensor concat(const std::vector<Tensor>& tensors, int dim) {
+ttnn::Tensor concat(const std::vector<ttnn::Tensor>& tensors, int dim) {
     TT_FATAL(!tensors.empty(), "Cannot concatenate an empty list of tensors");
     const auto& reference_layout = tensors.front().tensor_spec().tensor_layout();
     switch (reference_layout.get_data_type()) {

--- a/ttnn/cpp/ttnn-nanobind/__init__.cpp
+++ b/ttnn/cpp/ttnn-nanobind/__init__.cpp
@@ -340,15 +340,15 @@ NB_MODULE(_ttnn, mod) {
         []() -> std::uint64_t { return ttnn::CoreIDs::instance().fetch_and_increment_python_operation_id(); },
         "Increment tensor id and return the previously held id");
 
-    mod.def("get_tensor_id", &tt::tt_metal::Tensor::get_tensor_id_counter, "Get the current tensor ID counter value");
+    mod.def("get_tensor_id", &ttnn::Tensor::get_tensor_id_counter, "Get the current tensor ID counter value");
     mod.def(
         "set_tensor_id",
-        &tt::tt_metal::Tensor::set_tensor_id_counter,
+        &ttnn::Tensor::set_tensor_id_counter,
         nb::arg("id"),
         "Set the tensor ID counter to a specific value");
     mod.def(
         "fetch_and_increment_tensor_id",
-        &tt::tt_metal::Tensor::next_tensor_id,
+        &ttnn::Tensor::next_tensor_id,
         "Atomically fetch and increment the tensor ID counter");
 
     mod.def(

--- a/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
+++ b/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
@@ -97,8 +97,7 @@ void py_module_types(nb::module_& mod) {
             "write_tensor",
             [](tt::tt_metal::distributed::H2DSocket& self, Tensor& tensor) {
                 TT_FATAL(
-                    tensor.storage_type() == tt::tt_metal::StorageType::HOST,
-                    "write_tensor: tensor must be on host (HostStorage)");
+                    tensor.storage_type() == StorageType::HOST, "write_tensor: tensor must be on host (HostStorage)");
 
                 auto host_buffer = tt::tt_metal::host_buffer::get_host_buffer(tensor);
                 auto data_span = host_buffer.view_bytes();
@@ -247,8 +246,7 @@ void py_module_types(nb::module_& mod) {
             "read_tensor",
             [](tt::tt_metal::distributed::D2HSocket& self, Tensor& tensor, bool notify_sender) {
                 TT_FATAL(
-                    tensor.storage_type() == tt::tt_metal::StorageType::HOST,
-                    "read_tensor: tensor must be on host (HostStorage)");
+                    tensor.storage_type() == StorageType::HOST, "read_tensor: tensor must be on host (HostStorage)");
 
                 auto host_buffer = tt::tt_metal::host_buffer::get_host_buffer(tensor);
                 auto data_span = host_buffer.view_bytes();

--- a/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
+++ b/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
@@ -99,7 +99,7 @@ void py_module_types(nb::module_& mod) {
                 TT_FATAL(
                     tensor.storage_type() == StorageType::HOST, "write_tensor: tensor must be on host (HostStorage)");
 
-                auto host_buffer = tt::tt_metal::host_buffer::get_host_buffer(tensor);
+                auto host_buffer = host_buffer::get_host_buffer(tensor);
                 auto data_span = host_buffer.view_bytes();
                 uint32_t page_size = self.get_page_size();
                 TT_FATAL(page_size > 0, "write_tensor: page_size must be set before calling write_tensor");
@@ -248,7 +248,7 @@ void py_module_types(nb::module_& mod) {
                 TT_FATAL(
                     tensor.storage_type() == StorageType::HOST, "read_tensor: tensor must be on host (HostStorage)");
 
-                auto host_buffer = tt::tt_metal::host_buffer::get_host_buffer(tensor);
+                auto host_buffer = host_buffer::get_host_buffer(tensor);
                 auto data_span = host_buffer.view_bytes();
                 uint32_t page_size = self.get_page_size();
                 TT_FATAL(page_size > 0, "read_tensor: page_size must be set before calling read_tensor");

--- a/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
+++ b/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
@@ -95,7 +95,7 @@ void py_module_types(nb::module_& mod) {
             )doc")
         .def(
             "write_tensor",
-            [](tt::tt_metal::distributed::H2DSocket& self, tt::tt_metal::Tensor& tensor) {
+            [](tt::tt_metal::distributed::H2DSocket& self, Tensor& tensor) {
                 TT_FATAL(
                     tensor.storage_type() == tt::tt_metal::StorageType::HOST,
                     "write_tensor: tensor must be on host (HostStorage)");
@@ -245,7 +245,7 @@ void py_module_types(nb::module_& mod) {
             )doc")
         .def(
             "read_tensor",
-            [](tt::tt_metal::distributed::D2HSocket& self, tt::tt_metal::Tensor& tensor, bool notify_sender) {
+            [](tt::tt_metal::distributed::D2HSocket& self, Tensor& tensor, bool notify_sender) {
                 TT_FATAL(
                     tensor.storage_type() == tt::tt_metal::StorageType::HOST,
                     "read_tensor: tensor must be on host (HostStorage)");

--- a/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
+++ b/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
@@ -482,7 +482,7 @@ void py_module_types(nb::module_& mod) {
     // Helper function for creating CBDescriptor from sharded tensor
     mod.def(
         "cb_descriptor_from_sharded_tensor",
-        &tt::tt_metal::cb_descriptor_from_sharded_tensor,
+        &cb_descriptor_from_sharded_tensor,
         nb::arg("cb_index"),
         nb::arg("tensor"),
         nb::arg("address_offset") = 0,
@@ -524,7 +524,7 @@ void py_module_types(nb::module_& mod) {
     // Helper function for getting the L1 byte address of a CB descriptor
     mod.def(
         "get_cb_address",
-        &tt::tt_metal::get_cb_address,
+        &get_cb_address,
         nb::arg("descriptor"),
         R"pbdoc(
             Get the L1 byte address of a CB descriptor.

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -206,7 +206,7 @@ RowMajorHostBuffer convert_to_row_major_host_buffer(const Tensor& tt_tensor, con
     auto dispatch_to_concrete = [&tensor_spec, padded_output]<typename T>(HostBuffer host_buffer) {
         if (padded_output) {
             if (tensor_spec.layout() == Layout::TILE) {
-                auto row_major_data = tensor_impl::to_row_major_layout(
+                auto row_major_data = tt::tt_metal::tensor_impl::to_row_major_layout(
                     tensor_spec.physical_shape(), tensor_spec.tile(), host_buffer.view_as<const T>());
                 return RowMajorHostBuffer::create_padded(HostBuffer(std::move(row_major_data)), tensor_spec);
             }
@@ -217,7 +217,7 @@ RowMajorHostBuffer convert_to_row_major_host_buffer(const Tensor& tt_tensor, con
         // because the HostBuffer will be returned directly to the other python frameworks
         // wrapped in an ndarray
 
-        auto logical_data = tensor_impl::decode_tensor_data(host_buffer.view_as<const T>(), tensor_spec);
+        auto logical_data = tt::tt_metal::tensor_impl::decode_tensor_data(host_buffer.view_as<const T>(), tensor_spec);
         return RowMajorHostBuffer::create_logical(HostBuffer(std::move(logical_data)), tensor_spec);
     };
 

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -1657,7 +1657,7 @@ void pytensor_module(nb::module_& mod) {
 
     mod.def(
         "get_optimal_worker_cores_for_sharded_tensor",
-        &tt::tt_metal::get_optimal_worker_cores_for_sharded_tensor,
+        &get_optimal_worker_cores_for_sharded_tensor,
         nb::arg("tensor"),
         nb::arg("noc") = tt::tt_metal::NOC::RISCV_0_default,
         R"doc(

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -233,7 +233,7 @@ RowMajorHostBuffer convert_to_row_major_host_buffer(const Tensor& tt_tensor, con
             case DataType::BFLOAT8_B:
             case DataType::BFLOAT4_B: {
                 const auto& tile = tensor_spec.tile();
-                ttsl::Span<const std::uint32_t> uint32_data = host_buffer::get_as<std::uint32_t>(buffer);
+                ttsl::Span<const std::uint32_t> uint32_data = tt::tt_metal::host_buffer::get_as<std::uint32_t>(buffer);
                 auto float_unpacked_data = tt_dtype == DataType::BFLOAT8_B
                                                ? unpack_bfp8_tiles_into_float_vec(
                                                      uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile)

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.cpp
@@ -489,7 +489,7 @@ void MinimalMatmulFusedOpSignaler::init_all_gather(
     uint32_t input_tensor_Wt,
     tt::tt_fabric::Topology topology,
     bool read_local_slice_from_input,
-    const std::optional<const tt::tt_metal::Tensor>& ag_input) {
+    const std::optional<const Tensor>& ag_input) {
     this->ring_size = ring_size;
     this->start_ring_index = start_ring_index;
     this->input_tensor_Wt = input_tensor_Wt;

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
@@ -249,7 +249,7 @@ struct MinimalMatmulFusedOpSignaler {
     uint32_t input_tensor_Wt = 0;
     tt::tt_fabric::Topology topology = tt::tt_fabric::Topology::Ring;
     bool read_local_slice_from_input = false;
-    std::optional<tt::tt_metal::Tensor> ag_input;
+    std::optional<Tensor> ag_input;
 
     bool initialized_all_gather = false;
     bool initialized_fused_op = false;
@@ -262,7 +262,7 @@ struct MinimalMatmulFusedOpSignaler {
         uint32_t input_tensor_Wt,
         tt::tt_fabric::Topology topology,
         bool read_local_slice_from_input,
-        const std::optional<const tt::tt_metal::Tensor>& ag_input);
+        const std::optional<const Tensor>& ag_input);
 
     void init_fused_op(
         tt::tt_metal::Program& program,

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_command_stream_builders.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_command_stream_builders.cpp
@@ -121,7 +121,7 @@ std::vector<ttnn::ccl::v2::TensorSlice> split_tensor_slice_across_workers_wrappe
 
 // Assumed that the tensor_slice shape is in terms of pages, not elements
 std::vector<ttnn::ccl::v2::TensorSlice> compute_page_aligned_slices(
-    size_t const num_slices, const Tensor& input_tensor, size_t split_dim) {
+    const size_t num_slices, const Tensor& input_tensor, size_t split_dim) {
     TT_FATAL(num_slices > 0, "Number of slices must be greater than 0");
     std::vector<ttnn::ccl::v2::TensorSlice> tensor_slices;
 

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_command_stream_builders.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_command_stream_builders.hpp
@@ -10,19 +10,19 @@
 #include <vector>
 // #include <cstdint>
 
-namespace tt::tt_metal {
+namespace ttnn {
 class Tensor;
-};
+}  // namespace ttnn
 
 namespace ttnn::ccl::cmd::builder {
 
 std::vector<ttnn::ccl::v2::TensorSlice> generate_tensor_slices(
-    size_t num_slices, const tt::tt_metal::Tensor& tensor, size_t split_dim);
+    size_t num_slices, const Tensor& tensor, size_t split_dim);
 
-ttnn::ccl::v2::TensorSlice convert_to_whole_tensor_slice(const tt::tt_metal::Tensor& tensor);
+ttnn::ccl::v2::TensorSlice convert_to_whole_tensor_slice(const Tensor& tensor);
 
 std::vector<ttnn::ccl::v2::TensorSlice> compute_page_aligned_slices(
-    size_t num_slices, const tt::tt_metal::Tensor& input_tensor, size_t split_dim);
+    size_t num_slices, const Tensor& input_tensor, size_t split_dim);
 
 // Pairs of slice size and slice offset
 std::vector<std::pair<size_t, size_t>> compute_evenly_split_sizes(size_t size, size_t num_slices);
@@ -35,6 +35,6 @@ std::vector<ttnn::ccl::v2::TensorSlice> split_tensor_slice_across_workers_wrappe
     ttnn::ccl::v2::TensorSlice const& tensor_slice, size_t num_workers);
 
 std::vector<std::vector<ttnn::ccl::v2::TensorSlice>> generate_worker_tensor_slices(
-    size_t num_slices, const tt::tt_metal::Tensor& tensor, size_t num_workers, size_t split_dim);
+    size_t num_slices, const Tensor& tensor, size_t num_workers, size_t split_dim);
 
 };  // namespace ttnn::ccl::cmd::builder

--- a/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.cpp
@@ -25,8 +25,7 @@ args_list_t emit_runtime_args(WorkerEdmInterfaceArgs const& edm_interface_args) 
 
 args_list_t emit_compile_time(const WorkerEdmInterfaceArgs& /*edm_interface_args*/) { return {}; }
 
-args_list_t legacy_emit_address_generator_runtime_args(
-    const tt::tt_metal::IDevice* const d, const tt::tt_metal::Tensor& t) {
+args_list_t legacy_emit_address_generator_runtime_args(const tt::tt_metal::IDevice* const d, const Tensor& t) {
     args_list_t args;
     switch (t.buffer()->buffer_layout()) {
         case tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED:
@@ -53,8 +52,7 @@ args_list_t legacy_emit_address_generator_runtime_args(
     };
 }
 
-args_list_t emit_address_generator_runtime_args(
-    const tt::tt_metal::IDevice* const /*d*/, const tt::tt_metal::Tensor& t) {
+args_list_t emit_address_generator_runtime_args(const tt::tt_metal::IDevice* const /*d*/, const Tensor& t) {
     args_list_t args;
     switch (t.buffer()->buffer_layout()) {
         case tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED:
@@ -79,7 +77,7 @@ args_list_t emit_address_generator_runtime_args(
     };
 }
 
-args_list_t legacy_emit_address_generator_compile_time_args(const tt::tt_metal::Tensor& t) {
+args_list_t legacy_emit_address_generator_compile_time_args(const Tensor& t) {
     switch (t.buffer()->buffer_layout()) {
         case tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED:
         case tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED:
@@ -98,7 +96,7 @@ args_list_t legacy_emit_address_generator_compile_time_args(const tt::tt_metal::
     TT_ASSERT(false);
 }
 
-args_list_t emit_address_generator_compile_time_args(const tt::tt_metal::Tensor& t) {
+args_list_t emit_address_generator_compile_time_args(const Tensor& t) {
     switch (t.buffer()->buffer_layout()) {
         case tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED:
         case tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED:
@@ -153,7 +151,7 @@ static std::pair<std::vector<uint32_t>, std::vector<uint32_t>> shard_noc_cores_f
     return {logical_to_noc_row_map, logical_to_noc_col_map};
 }
 
-std::vector<uint32_t> ShardedAddrGenArgBuilder::emit_rt_args(IDevice const* d, Tensor const& t) {
+std::vector<uint32_t> ShardedAddrGenArgBuilder::emit_rt_args(const IDevice* d, const Tensor& t) {
     std::vector<uint32_t> args;
     auto const& [row_map, col_map] = shard_noc_cores_from_shard_spec(d, t.shard_spec().value());
     args.push_back(row_map.size());
@@ -168,7 +166,7 @@ std::vector<uint32_t> ShardedAddrGenArgBuilder::emit_rt_args(IDevice const* d, T
     return args;
 }
 
-std::vector<uint32_t> ShardedAddrGenArgBuilder::emit_ct_args(Tensor const& t) {
+std::vector<uint32_t> ShardedAddrGenArgBuilder::emit_ct_args(const Tensor& t) {
     std::vector<uint32_t> args;
     TT_ASSERT(t.is_sharded());
     auto const& [pages_per_shard_y, pages_per_shard_x] = t.buffer()->shard_spec().shape_in_pages();
@@ -203,7 +201,7 @@ std::vector<uint32_t> ShardedAddrGenArgBuilder::emit_ct_args(Tensor const& t) {
     return args;
 }
 
-bool ShardedAddrGenArgBuilder::shard_grid_is_transposed(Tensor const& t) {
+bool ShardedAddrGenArgBuilder::shard_grid_is_transposed(const Tensor& t) {
     TT_FATAL(
         t.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
             t.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED ||

--- a/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp
@@ -10,12 +10,15 @@
 #include <string>
 
 namespace tt::tt_metal {
-class Tensor;
 struct ShardSpec;
 
 class IDevice;
 
 }  // namespace tt::tt_metal
+
+namespace ttnn {
+class Tensor;
+}  // namespace ttnn
 
 namespace ttnn::ccl {
 
@@ -43,19 +46,18 @@ args_list_t emit_compile_time(const Shape4D<T>& /*shape*/) {
     return {};
 }
 
-args_list_t emit_address_generator_runtime_args(const tt::tt_metal::IDevice* d, const tt::tt_metal::Tensor& tensor);
-args_list_t legacy_emit_address_generator_runtime_args(
-    const tt::tt_metal::IDevice* d, const tt::tt_metal::Tensor& tensor);
-args_list_t emit_address_generator_compile_time_args(const tt::tt_metal::Tensor& t);
-args_list_t legacy_emit_address_generator_compile_time_args(const tt::tt_metal::Tensor& tensor);
+args_list_t emit_address_generator_runtime_args(const tt::tt_metal::IDevice* d, const Tensor& tensor);
+args_list_t legacy_emit_address_generator_runtime_args(const tt::tt_metal::IDevice* d, const Tensor& tensor);
+args_list_t emit_address_generator_compile_time_args(const Tensor& t);
+args_list_t legacy_emit_address_generator_compile_time_args(const Tensor& tensor);
 
 std::pair<CoreCoord, CoreCoord> shard_grid_from_shard_spec(const tt::tt_metal::ShardSpec& shard_spec);
 
 struct ShardedAddrGenArgBuilder {
-    static bool shard_grid_is_transposed(tt::tt_metal::Tensor const& t);
-    static std::vector<uint32_t> emit_ct_args(tt::tt_metal::Tensor const& t);
-    static std::vector<uint32_t> emit_rt_args(tt::tt_metal::IDevice const* d, tt::tt_metal::Tensor const& t);
-    static void log_sharded_tensor_kernel_args(tt::tt_metal::Tensor const& t, std::string const& prefix);
+    static bool shard_grid_is_transposed(const Tensor& t);
+    static std::vector<uint32_t> emit_ct_args(const Tensor& t);
+    static std::vector<uint32_t> emit_rt_args(const tt::tt_metal::IDevice* d, const Tensor& t);
+    static void log_sharded_tensor_kernel_args(const Tensor& t, const std::string& prefix);
 };
 
 }  // namespace ttnn::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/common/uops/command_lowering.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/uops/command_lowering.cpp
@@ -86,9 +86,7 @@ void validate_lowered_noc_commands(const ttnn::ccl::cmd::HostCclCommandNocTransf
 }
 
 ttnn::ccl::cmd::CclHostLowLevelWorkerCommand lower_tensor_slice_command_to_noc_commands(
-    const ttnn::ccl::cmd::CclHostLowLevelWorkerCommand& command,
-    const tt::tt_metal::Tensor& tensor,
-    size_t packet_size_bytes) {
+    const ttnn::ccl::cmd::CclHostLowLevelWorkerCommand& command, const Tensor& tensor, size_t packet_size_bytes) {
     using namespace tt::tt_metal::address_generators;
     using namespace tt::tt_metal;
 
@@ -212,7 +210,7 @@ ttnn::ccl::cmd::CclHostLowLevelWorkerCommand lower_tensor_slice_command_to_noc_c
 
 std::vector<ttnn::ccl::cmd::CclHostLowLevelWorkerCommand> tensor_slice_commands_to_noc_commands(
     const std::vector<ttnn::ccl::cmd::CclHostLowLevelWorkerCommand>& command_stream,
-    const tt::tt_metal::Tensor& tensor,
+    const Tensor& tensor,
     size_t packet_size_bytes) {
     std::vector<ttnn::ccl::cmd::CclHostLowLevelWorkerCommand> lowered_command_stream;
     for (const auto& command : command_stream) {

--- a/ttnn/cpp/ttnn/operations/ccl/common/uops/command_lowering.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/uops/command_lowering.hpp
@@ -8,7 +8,7 @@
 
 #include <vector>
 
-namespace tt::tt_metal {
+namespace ttnn {
 class Tensor;
 }
 
@@ -17,6 +17,6 @@ namespace ttnn::ccl {
 struct tensor_command_map;
 std::vector<ttnn::ccl::cmd::CclHostLowLevelWorkerCommand> tensor_slice_commands_to_noc_commands(
     const std::vector<ttnn::ccl::cmd::CclHostLowLevelWorkerCommand>& command_stream,
-    const tt::tt_metal::Tensor& tensor,
+    const Tensor& tensor,
     size_t packet_size_bytes);
 }  // namespace ttnn::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.hpp
@@ -38,9 +38,9 @@ struct MeshPartitionDeviceOperation {
         using OverrideRuntimeArgsCallback = std::function<void(
             const void*,
             tt::tt_metal::Program&,  // ‼  no const, exact type
-            const std::vector<tt::tt_metal::Tensor>&,
-            const std::vector<std::optional<const tt::tt_metal::Tensor>>&,
-            const std::vector<tt::tt_metal::Tensor>&)>;
+            const std::vector<Tensor>&,
+            const std::vector<std::optional<const Tensor>>&,
+            const std::vector<Tensor>&)>;
 
         // -- shared variables --------------------------------------------
         using SliceSharedVariables = std::variant<

--- a/ttnn/cpp/ttnn/operations/ccl/sharding_addrgen_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/sharding_addrgen_helper.cpp
@@ -9,7 +9,9 @@
 
 namespace shard_builder {
 
-uint32_t get_sharding_core_count(const tt::tt_metal::Tensor& t) {
+using namespace tt::tt_metal;
+
+uint32_t get_sharding_core_count(const ttnn::Tensor& t) {
     uint32_t core_count = 0;
     const auto core_ranges = t.buffer()->shard_spec().grid().ranges();
     for (const auto& core_range : core_ranges) {
@@ -23,7 +25,7 @@ uint32_t get_sharding_core_count(const tt::tt_metal::Tensor& t) {
     return core_count;
 }
 
-std::vector<CoreCoord> get_shard_cores(const tt::tt_metal::Tensor& t) {
+std::vector<CoreCoord> get_shard_cores(const ttnn::Tensor& t) {
     std::vector<CoreCoord> coordinates;
     const tt::tt_metal::IDevice* device = t.device();
     struct ShardSpec shard_spec = t.shard_spec().value();
@@ -63,7 +65,7 @@ std::vector<CoreCoord> get_shard_cores(const tt::tt_metal::Tensor& t) {
     return coordinates;
 }
 
-std::vector<uint32_t> generate_run_time_args(const tt::tt_metal::Tensor& t) {
+std::vector<uint32_t> generate_run_time_args(const ttnn::Tensor& t) {
     std::vector<uint32_t> args;
     const tt::tt_metal::IDevice* device = t.device();
     struct ShardSpec shard_spec = t.shard_spec().value();
@@ -121,12 +123,12 @@ std::vector<uint32_t> generate_run_time_args(const tt::tt_metal::Tensor& t) {
     return args;
 }
 
-void extend_sharding_run_time_args(const tt::tt_metal::Tensor& t, std::vector<uint32_t>& args) {
+void extend_sharding_run_time_args(const ttnn::Tensor& t, std::vector<uint32_t>& args) {
     const auto& new_args = generate_run_time_args(t);
     std::copy(std::begin(new_args), std::end(new_args), std::back_inserter(args));
 }
 
-std::vector<uint32_t> generate_compile_time_args(const tt::tt_metal::Tensor& t) {
+std::vector<uint32_t> generate_compile_time_args(const ttnn::Tensor& t) {
     std::vector<uint32_t> args;
     TT_ASSERT(t.is_sharded());
     TT_FATAL(
@@ -168,7 +170,7 @@ std::vector<uint32_t> generate_compile_time_args(const tt::tt_metal::Tensor& t) 
     return args;
 }
 
-void extend_sharding_compile_time_args(const tt::tt_metal::Tensor& t, std::vector<uint32_t>& args) {
+void extend_sharding_compile_time_args(const ttnn::Tensor& t, std::vector<uint32_t>& args) {
     const auto& new_args = generate_compile_time_args(t);
     std::copy(std::begin(new_args), std::end(new_args), std::back_inserter(args));
 }

--- a/ttnn/cpp/ttnn/operations/ccl/sharding_addrgen_helper.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/sharding_addrgen_helper.hpp
@@ -6,14 +6,16 @@
 
 #include "ttnn/operations/ccl/common/types/sharding_common.hpp"
 
+namespace ttnn {
+class Tensor;
+}  // namespace ttnn
+
 namespace shard_builder {
 
-using namespace tt::tt_metal;
-
-void extend_sharding_compile_time_args(const tt::tt_metal::Tensor& t, std::vector<uint32_t>& args);
-void extend_sharding_run_time_args(const tt::tt_metal::Tensor& t, std::vector<uint32_t>& args);
-std::vector<uint32_t> generate_run_time_args(const tt::tt_metal::Tensor& t);
-uint32_t get_sharding_core_count(const tt::tt_metal::Tensor& t);
-std::vector<uint32_t> generate_compile_time_args(const tt::tt_metal::Tensor& t);
-std::vector<CoreCoord> get_shard_cores(const tt::tt_metal::Tensor& t);
+void extend_sharding_compile_time_args(const ttnn::Tensor& t, std::vector<uint32_t>& args);
+void extend_sharding_run_time_args(const ttnn::Tensor& t, std::vector<uint32_t>& args);
+std::vector<uint32_t> generate_run_time_args(const ttnn::Tensor& t);
+uint32_t get_sharding_core_count(const ttnn::Tensor& t);
+std::vector<uint32_t> generate_compile_time_args(const ttnn::Tensor& t);
+std::vector<tt::tt_metal::CoreCoord> get_shard_cores(const ttnn::Tensor& t);
 }  // namespace shard_builder

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -199,7 +199,7 @@ Result conv2d_L1(
         orig_stride);
 
     // Prepare weights and move to device if necessary
-    if (!is_device_tensor(weight_tensor)) {
+    if (!tt::tt_metal::is_device_tensor(weight_tensor)) {
         log_trace(tt::LogOp, "conv2d: Preprocessing weights on host and moving to device.");
         std::tie(weight_tensor_on_device, bias_tensor_on_device) =
             prepare_conv_weights_biases_and_move_to_device(weight_tensor, bias_tensor, params, device);
@@ -221,7 +221,7 @@ Result conv2d_L1(
 
     // Prepare bias tensor if it exists and is not yet on device
     if (bias_tensor_on_device.has_value()) {
-        if (!is_device_tensor(bias_tensor_on_device.value())) {
+        if (!tt::tt_metal::is_device_tensor(bias_tensor_on_device.value())) {
             log_trace(tt::LogOp, "conv2d: Preprocessing bias on host and moving to device.");
 
             bias_tensor_on_device = prepare_conv_bias_internal(
@@ -758,7 +758,7 @@ Result conv2d_DRAM(
         padding_n4,
         mm_conv,
         conv_config);
-    if (!is_device_tensor(input_tensor_on_device)) {
+    if (!tt::tt_metal::is_device_tensor(input_tensor_on_device)) {
         input_tensor_on_device =
             ttnn::operations::core::to_device(input_tensor_on_device, device, ttnn::DRAM_MEMORY_CONFIG);
     }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -125,8 +125,7 @@ Result conv2d_L1(
             input_tensor.layout(),
             input_tensor.dtype(),
             output_dtype,
-            tt::tt_metal::is_device_tensor(input_tensor) ? std::make_optional(input_tensor.memory_config())
-                                                         : std::nullopt,
+            is_device_tensor(input_tensor) ? std::make_optional(input_tensor.memory_config()) : std::nullopt,
             kernel_size,
             stride,
             dilation,
@@ -199,7 +198,7 @@ Result conv2d_L1(
         orig_stride);
 
     // Prepare weights and move to device if necessary
-    if (!tt::tt_metal::is_device_tensor(weight_tensor)) {
+    if (!is_device_tensor(weight_tensor)) {
         log_trace(tt::LogOp, "conv2d: Preprocessing weights on host and moving to device.");
         std::tie(weight_tensor_on_device, bias_tensor_on_device) =
             prepare_conv_weights_biases_and_move_to_device(weight_tensor, bias_tensor, params, device);
@@ -221,7 +220,7 @@ Result conv2d_L1(
 
     // Prepare bias tensor if it exists and is not yet on device
     if (bias_tensor_on_device.has_value()) {
-        if (!tt::tt_metal::is_device_tensor(bias_tensor_on_device.value())) {
+        if (!is_device_tensor(bias_tensor_on_device.value())) {
             log_trace(tt::LogOp, "conv2d: Preprocessing bias on host and moving to device.");
 
             bias_tensor_on_device = prepare_conv_bias_internal(
@@ -246,7 +245,7 @@ Result conv2d_L1(
     }
 
     // call conv op or matmul micro op
-    bool input_is_on_device = tt::tt_metal::is_device_tensor(input_tensor_post_tm);
+    bool input_is_on_device = is_device_tensor(input_tensor_post_tm);
     TT_ASSERT(input_is_on_device);
 
     if (!mm_conv) {
@@ -758,7 +757,7 @@ Result conv2d_DRAM(
         padding_n4,
         mm_conv,
         conv_config);
-    if (!tt::tt_metal::is_device_tensor(input_tensor_on_device)) {
+    if (!is_device_tensor(input_tensor_on_device)) {
         input_tensor_on_device =
             ttnn::operations::core::to_device(input_tensor_on_device, device, ttnn::DRAM_MEMORY_CONFIG);
     }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -811,9 +811,8 @@ std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard_tensor
             if (input_padded_shape[-2] != tensor_height || input_padded_shape[-1] != tensor_width) {
                 input_tensor = ttnn::pad(
                     input_tensor,
-                    tt::tt_metal::Array4D(
-                        {input_shape[0], input_shape[1], input_padded_shape[-2], input_padded_shape[-1]}),
-                    tt::tt_metal::Array4D({0, 0, 0, 0}),
+                    Array4D({input_shape[0], input_shape[1], input_padded_shape[-2], input_padded_shape[-1]}),
+                    Array4D({0, 0, 0, 0}),
                     0);
             }
         }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -626,7 +626,7 @@ std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_shape_an
     uint32_t out_channels,
     bool is_mm_conv) {
     const ttnn::Tensor& input_tensor = input_tensor_;  // tensor to return
-    bool input_tensor_on_device = tt::tt_metal::is_device_tensor(input_tensor_);
+    bool input_tensor_on_device = is_device_tensor(input_tensor_);
     bool needs_shard_or_reshard = false;
     if (conv_config.override_sharding_config && conv_config.reshard_if_not_optimal) {
         TT_ASSERT(
@@ -782,7 +782,7 @@ std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard_tensor
     bool is_mm_conv,
     bool auto_shard) {
     ttnn::Tensor input_tensor = input_tensor_;  // tensor to return
-    bool input_tensor_on_device = tt::tt_metal::is_device_tensor(input_tensor_);
+    bool input_tensor_on_device = is_device_tensor(input_tensor_);
     auto compute_grid_size = device->compute_with_storage_grid_size();
 
     auto [input_padded_shape, input_tensor_sharded_memory_config, needs_shard_or_reshard] =
@@ -1378,7 +1378,7 @@ ttnn::Tensor fold_tensor(
 
     // Move to device if needed
     ttnn::Tensor tensor_on_device = tensor;
-    if (!tt::tt_metal::is_device_tensor(tensor_on_device)) {
+    if (!is_device_tensor(tensor_on_device)) {
         tensor_on_device = ttnn::to_device(tensor_on_device, device, ttnn::DRAM_MEMORY_CONFIG);
     }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -578,7 +578,7 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         conv_reader_indices_tensor, input_parallel_config, block_sharded, a.device(), config_tensors_in_dram);
 
     log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor);
-    const tt::tt_metal::DeviceStorage& conv_reader_indices_storage = conv_reader_indices_tensor.device_storage();
+    const DeviceStorage& conv_reader_indices_storage = conv_reader_indices_tensor.device_storage();
 
     TT_FATAL(
         act_matrix_height_ntiles % per_core_out_matrix_height_ntiles == 0,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.hpp
@@ -17,7 +17,7 @@ struct Conv2dShardedProgramFactory {
         tt::tt_metal::CBHandle cb_partials{};
         bool partials_cb_uses_output = false;
         bool has_bias = false;
-        tt::tt_metal::DeviceStorage conv_reader_indices_storage;
+        DeviceStorage conv_reader_indices_storage;
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -411,7 +411,7 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         conv_reader_indices_tensor, parallel_config, false, a.device(), config_tensors_in_dram);
 
     log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor);
-    const tt::tt_metal::DeviceStorage& conv_reader_indices_storage = conv_reader_indices_tensor.device_storage();
+    const DeviceStorage& conv_reader_indices_storage = conv_reader_indices_tensor.device_storage();
 
     // Pass the actual DRAM/L1-small config buffer page size into get_cb_info so the predicted
     // READER_INDICES CB footprint matches the CB this factory creates. Without this, the in-DRAM

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -184,13 +184,13 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
 
     // Device compatibility checks
     TT_FATAL(
-        a.storage_type() == tt::tt_metal::StorageType::DEVICE && b.storage_type() == tt::tt_metal::StorageType::DEVICE,
+        a.storage_type() == StorageType::DEVICE && b.storage_type() == StorageType::DEVICE,
         "Operands to large matmul need to be on device!");
     TT_FATAL(a.device() == b.device(), "Operands to conv need to be on the same device!");
     TT_FATAL(
         a.buffer() != nullptr && b.buffer() != nullptr, "Operands to conv need to be allocated in buffers on device!");
     if (has_bias) {
-        TT_FATAL(bias.value().storage_type() == tt::tt_metal::StorageType::DEVICE, "Bias should be on device");
+        TT_FATAL(bias.value().storage_type() == StorageType::DEVICE, "Bias should be on device");
         TT_FATAL(bias.value().device() == a.device(), "Bias should be on the same device as act tensor");
     }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp
@@ -18,7 +18,7 @@ struct Conv2dWidthShardedProgramFactory {
         CoreCoord full_core_grid;
         tt::tt_metal::KernelHandle weights_kernel_id{};
         uint32_t total_num_active_cores = 0;
-        tt::tt_metal::DeviceStorage conv_reader_indices_storage;
+        DeviceStorage conv_reader_indices_storage;
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -146,7 +146,7 @@ static tt::tt_metal::HostBuffer create_host_buffer_for_conv_weight(
 
 template <typename T, typename Fn>
 Tensor convert_tensor(const Tensor& input_tensor, const Fn& compute, const TensorSpec& output_spec) {
-    TT_FATAL(tt::tt_metal::is_cpu_tensor(input_tensor), "convert_tensor only supports cpu tensors");
+    TT_FATAL(is_cpu_tensor(input_tensor), "convert_tensor only supports cpu tensors");
     auto transformed_buffer = input_tensor.host_storage().buffer().transform(
         compute, tt::tt_metal::DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
     return Tensor(tt::tt_metal::HostTensor(std::move(transformed_buffer), output_spec, input_tensor.tensor_topology()));
@@ -774,15 +774,15 @@ Tensor convert_conv_weight_tensor_to_grouped_layout(
                 {DataType::BFLOAT4_B, &conv_group_weight_zero_pad_helper<uint32_t>},
             };
 
-    if (tt_metal::is_device_tensor(conv_weight_tensor)) {
+    if (is_device_tensor(conv_weight_tensor)) {
         log_warning(
             tt::LogOp,
             "Prepare weights for Conv2D with groups > 1 expects weights on host, but they are on device. The op will "
             "move them back to host.");
     }
     return convert_tensor_to_tiled_layout_common(
-        tt_metal::is_device_tensor(conv_weight_tensor) ? ttnn::operations::core::from_device(conv_weight_tensor)
-                                                       : conv_weight_tensor,
+        is_device_tensor(conv_weight_tensor) ? ttnn::operations::core::from_device(conv_weight_tensor)
+                                             : conv_weight_tensor,
         output_dtype,
         to_w_tile_layout_map,
         original_conv_weight_tensor_shape,
@@ -881,15 +881,15 @@ Tensor convert_conv_weight_tensor_to_grouped_layout_for_conv_transpose2d(
                 {DataType::BFLOAT4_B, &conv_transpose2d_group_weight_zero_pad_helper<uint32_t>},
             };
 
-    if (tt_metal::is_device_tensor(conv_weight_tensor)) {
+    if (is_device_tensor(conv_weight_tensor)) {
         log_warning(
             tt::LogOp,
             "Prepare weights for ConvTranspose2D with groups > 1 expects weights on host, but they are on device. The "
             "op will move them back to host.");
     }
     return convert_tensor_to_tiled_layout_common(
-        tt_metal::is_device_tensor(conv_weight_tensor) ? ttnn::operations::core::from_device(conv_weight_tensor)
-                                                       : conv_weight_tensor,
+        is_device_tensor(conv_weight_tensor) ? ttnn::operations::core::from_device(conv_weight_tensor)
+                                             : conv_weight_tensor,
         output_dtype,
         to_w_tile_layout_map,
         original_conv_weight_tensor_shape,
@@ -926,15 +926,15 @@ Tensor convert_conv_weight_tensor_to_depthwise_layout(
         };
     output_dtype = ((output_dtype == DataType::BFLOAT8_B) || (output_dtype == DataType::BFLOAT4_B)) ? DataType::FLOAT32
                                                                                                     : output_dtype;
-    if (tt_metal::is_device_tensor(conv_weight_tensor)) {
+    if (is_device_tensor(conv_weight_tensor)) {
         log_warning(
             tt::LogOp,
             "Prepare weights for Depthwise Conv1D expects weights on host, but they are on device. The op will move "
             "them back to host.");
     }
     return convert_tensor_to_tiled_layout_common(
-        tt_metal::is_device_tensor(conv_weight_tensor) ? ttnn::operations::core::from_device(conv_weight_tensor)
-                                                       : conv_weight_tensor,
+        is_device_tensor(conv_weight_tensor) ? ttnn::operations::core::from_device(conv_weight_tensor)
+                                             : conv_weight_tensor,
         output_dtype,
         to_w_tile_layout_map,
         original_conv_weight_tensor_shape,
@@ -1635,7 +1635,7 @@ std::optional<ttnn::Tensor> prepare_conv_bias_internal(
     }
 
     ttnn::Tensor bias_tensor_ = bias_tensor.value();
-    bool is_bias_tensor_is_on_device = tt::tt_metal::is_device_tensor(bias_tensor_);
+    bool is_bias_tensor_is_on_device = is_device_tensor(bias_tensor_);
     if (!is_bias_tensor_is_on_device) {
         TT_FATAL(bias_tensor_.logical_shape()[3] == out_channels, "Bias must have the same length as output channels");
         uint32_t out_channels_padded = tt::round_up(out_channels, constants::TILE_WIDTH);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -130,7 +130,7 @@ static tt::tt_metal::HostBuffer create_host_buffer_for_conv_weight(
             auto temp_tensor =
                 Tensor(std::move(data), output_shape, DataType::FLOAT32, Layout::ROW_MAJOR).to_layout(Layout::TILE);
 
-            auto output_float_data = tt::tt_metal::host_buffer::get_as<const float>(temp_tensor);
+            auto output_float_data = host_buffer::get_as<const float>(temp_tensor);
             auto output_packed_data =
                 output_dtype == DataType::BFLOAT8_B
                     ? pack_as_bfp8_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false)
@@ -140,7 +140,7 @@ static tt::tt_metal::HostBuffer create_host_buffer_for_conv_weight(
             TT_THROW("Unsupported data type");
         }
     }
-    return tt::tt_metal::host_buffer::get_host_buffer(
+    return host_buffer::get_host_buffer(
         Tensor(std::move(data), output_shape, output_dtype, Layout::ROW_MAJOR).to_layout(Layout::TILE));
 }
 
@@ -176,7 +176,7 @@ Tensor create_tensor_from_owned_buffer(
         if (output_dtype == DataType::BFLOAT8_B || output_dtype == DataType::BFLOAT4_B) {
             auto tensor =
                 Tensor(std::move(buf), output_shape, DataType::FLOAT32, Layout::ROW_MAJOR).to_layout(Layout::TILE);
-            auto output_float_data = tt::tt_metal::host_buffer::get_as<const float>(tensor);
+            auto output_float_data = host_buffer::get_as<const float>(tensor);
             auto output_packed_data =
                 output_dtype == DataType::BFLOAT8_B
                     ? pack_as_bfp8_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false)

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -146,7 +146,7 @@ static tt::tt_metal::HostBuffer create_host_buffer_for_conv_weight(
 
 template <typename T, typename Fn>
 Tensor convert_tensor(const Tensor& input_tensor, const Fn& compute, const TensorSpec& output_spec) {
-    TT_FATAL(is_cpu_tensor(input_tensor), "convert_tensor only supports cpu tensors");
+    TT_FATAL(tt::tt_metal::is_cpu_tensor(input_tensor), "convert_tensor only supports cpu tensors");
     auto transformed_buffer = input_tensor.host_storage().buffer().transform(
         compute, tt::tt_metal::DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
     return Tensor(tt::tt_metal::HostTensor(std::move(transformed_buffer), output_spec, input_tensor.tensor_topology()));

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1584,8 +1584,8 @@ static ttnn::Tensor prepare_conv_weights_internal(
         out_channel_padding = out_channels_padded - out_channels;
         ttnn::Shape weights_channels_padded_shape({out_channels_padded, in_channels_padded, window_h, window_w});
 
-        weight_tensor_ = ttnn::pad(
-            weight_tensor_, weights_channels_padded_shape.to_array_4D(), tt::tt_metal::Array4D({0, 0, 0, 0}), 0);
+        weight_tensor_ =
+            ttnn::pad(weight_tensor_, weights_channels_padded_shape.to_array_4D(), Array4D({0, 0, 0, 0}), 0);
 
         if (input_parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
             weight_tensor_ = convert_conv_weight_tensor_to_special_padding_tiled_layout(
@@ -1646,8 +1646,7 @@ std::optional<ttnn::Tensor> prepare_conv_bias_internal(
         validate_host_conv_bias(bias_tensor_);
         ttnn::Shape bias_channels_padded_shape(
             {1, 1, 32, round_up(out_channels_padded, params.weight_block_w_ntiles * 32)});
-        bias_tensor_ =
-            ttnn::pad(bias_tensor_, bias_channels_padded_shape.to_array_4D(), tt::tt_metal::Array4D{0, 0, 0, 0}, 0);
+        bias_tensor_ = ttnn::pad(bias_tensor_, bias_channels_padded_shape.to_array_4D(), Array4D{0, 0, 0, 0}, 0);
         bias_tensor_ = ttnn::to_layout(bias_tensor_, Layout::TILE);
         if (bias_tensor_.dtype() != weight_dtype) {
             bias_tensor_ = ttnn::to_dtype(bias_tensor_, weight_dtype);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -960,7 +960,7 @@ static Tensor to_folded_weight_layout(const Tensor& conv_weight_tensor, std::arr
     ttnn::Shape output_shape = ttnn::Shape(
         {out_channels, in_channels * stride[0] * stride[1], padded_kernel_h / stride[0], padded_kernel_w / stride[1]});
 
-    auto fold_weights = [&]<typename T>(const tt::tt_metal::HostStorage& storage) {
+    auto fold_weights = [&]<typename T>(const HostStorage& storage) {
         auto folded_buffer = storage.buffer().transform(
             [&](const tt::tt_metal::HostBuffer& input_host_buffer) {
                 auto input_buffer = tt::tt_metal::host_buffer::get_as<T>(input_host_buffer);

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -141,8 +141,7 @@ ConvTranspose2dResult conv_transpose2d_L1(
             input_tensor.layout(),
             input_tensor.dtype(),
             output_dtype,
-            tt::tt_metal::is_device_tensor(input_tensor) ? std::make_optional(input_tensor.memory_config())
-                                                         : std::nullopt,
+            ttnn::is_device_tensor(input_tensor) ? std::make_optional(input_tensor.memory_config()) : std::nullopt,
             kernel_size,
             ConvTranspose2dDimensions::CONV2D_STRIDE,
             dilation,
@@ -206,7 +205,7 @@ ConvTranspose2dResult conv_transpose2d_L1(
         get_fp32_dest_acc_en(compute_config),
         conv_config.full_inner_dim);
 
-    bool weight_is_on_device = tt::tt_metal::is_device_tensor(weight_tensor);
+    bool weight_is_on_device = ttnn::is_device_tensor(weight_tensor);
     ttnn::Tensor weight_tensor_on_device = weight_tensor;
     std::optional<ttnn::Tensor> bias_tensor_on_device = bias_tensor;
     if (!weight_is_on_device) {
@@ -987,7 +986,7 @@ Result conv_transpose2d_DRAM(
 
     const bool mm_conv = use_matmul_for_1x1_conv(kernel_size, stride, padding_n4, dilation, groups, conv_config);
     Tensor input_tensor_on_device = input_tensor;
-    if (!tt::tt_metal::is_device_tensor(input_tensor_on_device)) {
+    if (!ttnn::is_device_tensor(input_tensor_on_device)) {
         input_tensor_on_device =
             ttnn::operations::core::to_device(input_tensor_on_device, device, ttnn::DRAM_MEMORY_CONFIG);
     }

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -987,7 +987,7 @@ Result conv_transpose2d_DRAM(
 
     const bool mm_conv = use_matmul_for_1x1_conv(kernel_size, stride, padding_n4, dilation, groups, conv_config);
     Tensor input_tensor_on_device = input_tensor;
-    if (!is_device_tensor(input_tensor_on_device)) {
+    if (!tt::tt_metal::is_device_tensor(input_tensor_on_device)) {
         input_tensor_on_device =
             ttnn::operations::core::to_device(input_tensor_on_device, device, ttnn::DRAM_MEMORY_CONFIG);
     }

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -1097,7 +1097,7 @@ ConvT2dExecutionPath determine_conv_transpose2d_execution_path(
 }
 
 ConvT2dExecutionPath determine_conv_transpose2d_execution_path(
-    const tt::tt_metal::StorageType& storage_type,
+    const StorageType& storage_type,
     const MemoryConfig& memory_config,
     const std::optional<const op_slicing::Op2DSliceConfig>& slice_config) {
     // If slice config explicitly specifies L1_FULL, use L1 path
@@ -1113,7 +1113,7 @@ ConvT2dExecutionPath determine_conv_transpose2d_execution_path(
     }
 
     // If no slice config and input is already on device in L1, use L1 path
-    if (!slice_config.has_value() && storage_type == tt::tt_metal::StorageType::DEVICE && memory_config.is_l1()) {
+    if (!slice_config.has_value() && storage_type == StorageType::DEVICE && memory_config.is_l1()) {
         return ConvT2dExecutionPath::L1;
     }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
@@ -79,7 +79,9 @@ ConvTranspose2dDimensions compute_conv_transpose2d_dimensions(
 
 template <typename T>
 ttnn::Tensor _transform_weights_for_conv_transpose2d(const Tensor& conv_weight_tensor, bool mirror_kernel = true) {
-    TT_FATAL(is_cpu_tensor(conv_weight_tensor), "transform_weights_for_conv_transpose2d only supports host tensors");
+    TT_FATAL(
+        tt::tt_metal::is_cpu_tensor(conv_weight_tensor),
+        "transform_weights_for_conv_transpose2d only supports host tensors");
 
     // in_w_shape = {in_channels, out_channels, kernel_height, kernel_width}
     // out_w_shape = {out_channels, in_channels, kernel_height, kernel_width}

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
@@ -268,8 +268,8 @@ ttnn::Tensor prepare_conv_transpose2d_weights(
     }
 
     // Determine execution path based on configuration and input properties
-    ConvT2dExecutionPath path = determine_conv_transpose2d_execution_path(
-        tt::tt_metal::StorageType::DEVICE, input_memory_config, actual_slice_config);
+    ConvT2dExecutionPath path =
+        determine_conv_transpose2d_execution_path(StorageType::DEVICE, input_memory_config, actual_slice_config);
 
     Tensor mirrored_weight_tensor = transform_weights_for_conv_transpose2d(weight_for_transform, mirror_kernel);
     if (path == ConvT2dExecutionPath::L1) {

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
@@ -79,9 +79,7 @@ ConvTranspose2dDimensions compute_conv_transpose2d_dimensions(
 
 template <typename T>
 ttnn::Tensor _transform_weights_for_conv_transpose2d(const Tensor& conv_weight_tensor, bool mirror_kernel = true) {
-    TT_FATAL(
-        tt::tt_metal::is_cpu_tensor(conv_weight_tensor),
-        "transform_weights_for_conv_transpose2d only supports host tensors");
+    TT_FATAL(is_cpu_tensor(conv_weight_tensor), "transform_weights_for_conv_transpose2d only supports host tensors");
 
     // in_w_shape = {in_channels, out_channels, kernel_height, kernel_width}
     // out_w_shape = {out_channels, in_channels, kernel_height, kernel_width}
@@ -143,7 +141,7 @@ ttnn::Tensor _transform_weights_for_conv_transpose2d(const Tensor& conv_weight_t
 
 Tensor transform_weights_for_conv_transpose2d(const Tensor& conv_weight_tensor, bool mirror_kernel) {
     Tensor to_mirror_tensor;
-    if (tt::tt_metal::is_device_tensor(conv_weight_tensor)) {
+    if (is_device_tensor(conv_weight_tensor)) {
         log_warning(
             tt::LogOp,
             "Prepare Weights for ConvTranspose2D needs weights on host, but they are already on device. The op will "

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.hpp
@@ -56,7 +56,7 @@ enum class ConvT2dExecutionPath {
 // Helper function to determine which conv2d execution path to take based on
 // slice configuration and input tensor properties
 ConvT2dExecutionPath determine_conv_transpose2d_execution_path(
-    const tt::tt_metal::StorageType& storage_type,
+    const StorageType& storage_type,
     const MemoryConfig& memory_config,
     const std::optional<const op_slicing::Op2DSliceConfig>& slice_config);
 

--- a/ttnn/cpp/ttnn/operations/copy/typecast/typecast.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/typecast.cpp
@@ -16,7 +16,7 @@ inline Tensor typecast_impl(
     const std::optional<Tensor>& optional_output_tensor = std::nullopt,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt) {
     // Handle host tensors by delegating to to_dtype
-    if (tt::tt_metal::is_cpu_tensor(input_tensor)) {
+    if (ttnn::is_cpu_tensor(input_tensor)) {
         TT_FATAL(
             !optional_output_tensor.has_value(),
             "Preallocated output tensor is not supported for host tensor typecast. "

--- a/ttnn/cpp/ttnn/operations/copy/typecast/typecast.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/typecast.cpp
@@ -16,7 +16,7 @@ inline Tensor typecast_impl(
     const std::optional<Tensor>& optional_output_tensor = std::nullopt,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt) {
     // Handle host tensors by delegating to to_dtype
-    if (is_cpu_tensor(input_tensor)) {
+    if (tt::tt_metal::is_cpu_tensor(input_tensor)) {
         TT_FATAL(
             !optional_output_tensor.has_value(),
             "Preallocated output tensor is not supported for host tensor typecast. "

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -97,7 +97,7 @@ Tensor to_layout_impl(
         }
     }
 
-    if (tt::tt_metal::is_device_tensor(tensor_arg)) {
+    if (ttnn::is_device_tensor(tensor_arg)) {
         bool use_multicore_untilize = true;
         bool use_multicore_tilize = true;
 

--- a/ttnn/cpp/ttnn/operations/creation/creation.cpp
+++ b/ttnn/cpp/ttnn/operations/creation/creation.cpp
@@ -64,7 +64,7 @@ Tensor full_impl(
     Tensor host_tensor(tt::tt_metal::HostBuffer(std::move(owned_buffer)), shape, data_type, layout);
 
     if (optional_output_tensor.has_value()) {
-        copy_to_device(host_tensor, *optional_output_tensor);
+        tt::tt_metal::copy_to_device(host_tensor, *optional_output_tensor);
         return *optional_output_tensor;
     }
     if (device != nullptr) {
@@ -195,7 +195,7 @@ Tensor full_impl(
         case DataType::BFLOAT8_B: {
             TensorSpec tensor_spec(shape_value, TensorLayout(dtype_value, PageConfig(layout_value), mem_cfg));
             std::vector<float> fill_value_vec(shape_value.volume(), static_cast<float>(fill_value));
-            auto output = tt::tt_metal::Tensor::from_vector(std::move(fill_value_vec), tensor_spec);
+            auto output = Tensor::from_vector(std::move(fill_value_vec), tensor_spec);
             if (device_to_use != nullptr) {
                 output = output.to_device(device_to_use, mem_cfg);
             }
@@ -375,7 +375,7 @@ Tensor empty_like(
     MeshDevice* device_ptr = device.has_value() ? &device->get() : tensor.device();
 
     std::optional<tt::tt_metal::TensorTopology> topology = std::nullopt;
-    if (is_device_tensor(tensor) &&
+    if (tt::tt_metal::is_device_tensor(tensor) &&
         device_ptr->shape().mesh_size() == tensor.tensor_topology().distribution_shape().mesh_size()) {
         topology = tensor.tensor_topology();
     }

--- a/ttnn/cpp/ttnn/operations/creation/creation.cpp
+++ b/ttnn/cpp/ttnn/operations/creation/creation.cpp
@@ -220,7 +220,7 @@ Tensor full_like_impl(
     DataType dtype_value =
         optional_output_tensor.has_value() ? optional_output_tensor.value().dtype() : dtype.value_or(tensor.dtype());
     const bool is_tile_layout = (tensor.layout() == Layout::TILE) && (layout_value == Layout::TILE);
-    if (tt::tt_metal::is_device_tensor(tensor)) {
+    if (is_device_tensor(tensor)) {
         // requires reference tensor to be in TILE for device operation fill - this will be changed later
         if (is_tile_layout &&
             (dtype_value == DataType::BFLOAT8_B || dtype_value == DataType::BFLOAT16 ||
@@ -375,7 +375,7 @@ Tensor empty_like(
     MeshDevice* device_ptr = device.has_value() ? &device->get() : tensor.device();
 
     std::optional<tt::tt_metal::TensorTopology> topology = std::nullopt;
-    if (tt::tt_metal::is_device_tensor(tensor) &&
+    if (is_device_tensor(tensor) &&
         device_ptr->shape().mesh_size() == tensor.tensor_topology().distribution_shape().mesh_size()) {
         topology = tensor.tensor_topology();
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -47,10 +47,8 @@ MassagedConcat build_unsqueeze_concat(int input_rank, const MemoryConfig& output
     return MassagedConcat(MassagedConcatParams{
         .predicate = [input_rank](
                          const std::vector<ttnn::Tensor>& tensors, int /*dim*/, unsigned int /*groups*/) -> bool {
-            bool inputs_are_device_tensors =
-                std::all_of(tensors.begin(), tensors.end(), [](const ttnn::Tensor& tensor) {
-                    return tt::tt_metal::is_device_tensor(tensor);
-                });
+            bool inputs_are_device_tensors = std::all_of(
+                tensors.begin(), tensors.end(), [](const ttnn::Tensor& tensor) { return is_device_tensor(tensor); });
             bool res = input_rank < 4 && inputs_are_device_tensors;  // pad only rejects rank != 4 for device tensors
             concat_db_print(res, "unsqueeze to 4D required");
             return res;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -190,7 +190,7 @@ MassagedConcat build_non_aligned_last_dim_concat(
     auto dim_aligned = [](const std::vector<ttnn::Tensor>& tensors, int dim) -> bool {
         return std::all_of(tensors.begin(), tensors.end(), [&](const ttnn::Tensor& tensor) {
             auto storage_type = tensor.storage_type();
-            if (storage_type == tt::tt_metal::StorageType::DEVICE) {
+            if (storage_type == StorageType::DEVICE) {
                 return tensor.padded_shape()[dim] * tensor.element_size() % tensor.buffer()->alignment() == 0;
             }
             TT_THROW(

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -63,8 +63,8 @@ std::vector<Tensor> fold_with_transpose_(
     log_debug(tt::LogOp, "input: {}", input.logical_shape());
 
     // pad input tensor
-    tt::tt_metal::Array4D padded_shape = {n, padded_c, padded_h32, padded_w32};
-    auto pad_output = ttnn::pad(input, padded_shape, tt::tt_metal::Array4D({0, 0, 0, 0}), 0);
+    Array4D padded_shape = {n, padded_c, padded_h32, padded_w32};
+    auto pad_output = ttnn::pad(input, padded_shape, Array4D({0, 0, 0, 0}), 0);
 
     log_debug(tt::LogOp, "pad_output: {}", pad_output.logical_shape());
 
@@ -104,9 +104,9 @@ std::vector<Tensor> fold_with_transpose_(
         // slice
         n = output_shape.value()[0], w = output_shape.value()[1], h = output_shape.value()[2],
         c = output_shape.value()[3];
-        tt::tt_metal::Array4D slice_output_tensor_start = {0, 0, 0, 0};
-        tt::tt_metal::Array4D slice_output_tensor_end = {n, w, h, c};
-        tt::tt_metal::Array4D step = {1, 1, 1, 1};
+        Array4D slice_output_tensor_start = {0, 0, 0, 0};
+        Array4D slice_output_tensor_end = {n, w, h, c};
+        Array4D step = {1, 1, 1, 1};
         auto slice_output =
             ttnn::slice(transpose_hc_output2, slice_output_tensor_start, slice_output_tensor_end, step, L1_mem_config);
 
@@ -174,7 +174,7 @@ std::vector<Tensor> fold_with_transpose_sharded_(
     auto target_h = padded_h / stride_h;
     auto target_w = padded_w / stride_w;
     auto target_c = padded_c * stride_h * stride_w;
-    tt::tt_metal::Array4D slice_output_shape = {n, target_h, target_w, target_c};
+    Array4D slice_output_shape = {n, target_h, target_w, target_c};
 
     log_debug(tt::LogOp, "padded_c: {}", padded_c);
     log_debug(tt::LogOp, "padded_h: {}", padded_h);
@@ -187,10 +187,10 @@ std::vector<Tensor> fold_with_transpose_sharded_(
     auto shard_spec = input.shard_spec().value();
 
     // pad input tensor
-    tt::tt_metal::Array4D padded_shape = {n, padded_c, padded_h32, w};
+    Array4D padded_shape = {n, padded_c, padded_h32, w};
     auto pad_mem_config = create_sharded_memory_config(ttnn::Shape(padded_shape), grid_size, shard_spec.orientation);
-    auto tt_output_tensor = ttnn::pad(
-        input, padded_shape, tt::tt_metal::Array4D({0, 0, pad_h, 0}), 0, /*use_multicore*/ false, pad_mem_config);
+    auto tt_output_tensor =
+        ttnn::pad(input, padded_shape, Array4D({0, 0, pad_h, 0}), 0, /*use_multicore*/ false, pad_mem_config);
 
     log_debug(tt::LogOp, "pad_output: {}", tt_output_tensor.logical_shape());
 
@@ -200,12 +200,12 @@ std::vector<Tensor> fold_with_transpose_sharded_(
     log_debug(tt::LogOp, "transpose_hw_output: {}", tt_output_tensor.logical_shape());
 
     // pad tensor W dim
-    tt::tt_metal::Array4D padded_shape2 = {n, padded_c, padded_h32, padded_w32};
+    Array4D padded_shape2 = {n, padded_c, padded_h32, padded_w32};
     auto pad_mem_config2 = create_sharded_memory_config(ttnn::Shape(padded_shape2), grid_size, shard_spec.orientation);
     tt_output_tensor = ttnn::pad(
         tt_output_tensor,
         padded_shape2,
-        tt::tt_metal::Array4D({0, 0, pad_w, 0}),
+        Array4D({0, 0, pad_w, 0}),
         0,
         /*use_multicore*/ false,
         pad_mem_config2);
@@ -243,13 +243,13 @@ std::vector<Tensor> fold_with_transpose_sharded_(
 
     std::vector<Tensor> output_tensors;
     // override output shape
-    auto steps = tt::tt_metal::Array4D({1, 1, 1, 1});
+    auto steps = Array4D({1, 1, 1, 1});
     if (output_shape.has_value()) {
         // slice
         n = output_shape.value()[0], h = output_shape.value()[1], w = output_shape.value()[2],
         c = output_shape.value()[3];
-        tt::tt_metal::Array4D slice_output_tensor_start = {0, 0, 0, 0};
-        tt::tt_metal::Array4D slice_output_tensor_end = {n, h, w, c};
+        Array4D slice_output_tensor_start = {0, 0, 0, 0};
+        Array4D slice_output_tensor_end = {n, h, w, c};
         auto slice_mem_config = create_sharded_memory_config(
             ttnn::Shape({n, h, w, c}), grid_size, shard_spec.orientation, override_memory_config);
         tt_output_tensor =
@@ -261,8 +261,8 @@ std::vector<Tensor> fold_with_transpose_sharded_(
     } else {
         // slice
         n = slice_output_shape[0], h = slice_output_shape[1], w = slice_output_shape[2], c = slice_output_shape[3];
-        tt::tt_metal::Array4D slice_output_tensor_start = {0, 0, 0, 0};
-        tt::tt_metal::Array4D slice_output_tensor_end = {n, h, w, c};
+        Array4D slice_output_tensor_start = {0, 0, 0, 0};
+        Array4D slice_output_tensor_end = {n, h, w, c};
         auto slice_mem_config = create_sharded_memory_config(
             ttnn::Shape({n, h, w, c}), grid_size, shard_spec.orientation, override_memory_config);
         tt_output_tensor =
@@ -446,13 +446,12 @@ Tensor fold(
         // Apply channel padding separately if needed
         if (has_c_padding) {
             const auto current_shape = processed_tensor.logical_shape();
-            const tt::tt_metal::Array4D padded_shape = {
+            const Array4D padded_shape = {
                 static_cast<uint32_t>(current_shape[0]),
                 static_cast<uint32_t>(current_shape[1]),
                 static_cast<uint32_t>(current_shape[2]),
                 static_cast<uint32_t>(current_shape[3] + pad_c_front + pad_c_back)};
-            processed_tensor =
-                ::ttnn::pad(processed_tensor, padded_shape, tt::tt_metal::Array4D({0, 0, 0, pad_c_front}), 0);
+            processed_tensor = ::ttnn::pad(processed_tensor, padded_shape, Array4D({0, 0, 0, pad_c_front}), 0);
         }
 
         // If processed tensor is tiled, convert to row-major.

--- a/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp
@@ -132,7 +132,7 @@ ttnn::Tensor narrow(
                 input_tensor.tensor_spec().page_config(),
                 input_tensor.tensor_spec().memory_config()));
 
-        tt::tt_metal::DeviceStorage subtensor_storage(
+        DeviceStorage subtensor_storage(
             storage, tt::tt_metal::MeshTensor(subtensor_mesh, subtensor_spec, input_tensor.tensor_topology()));
         return Tensor(std::move(subtensor_storage));
     }
@@ -291,7 +291,7 @@ ttnn::Tensor narrow(
             tt::tt_metal::TensorLayout(
                 input_tensor.dtype(), input_tensor.tensor_spec().page_config(), narrowed_memory_config));
 
-        tt::tt_metal::DeviceStorage subtensor_storage(
+        DeviceStorage subtensor_storage(
             storage, tt::tt_metal::MeshTensor(subtensor_mesh, subtensor_spec, input_tensor.tensor_topology()));
         return Tensor(std::move(subtensor_storage));
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
@@ -119,7 +119,7 @@ void PadDeviceOperation::validate_on_program_cache_miss(
     auto padded_rank = input_tensor.padded_shape().rank();
     TT_FATAL(logical_rank == padded_rank, "ttnn.pad: logical and padded shapes must have the same rank");
     TT_FATAL(input_tensor.logical_shape().rank() <= 4, "ttnn.pad: input tensor rank currently must be 4 or less");
-    TT_FATAL(input_tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "Operand to pad needs to be on device!");
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operand to pad needs to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operand to pad needs to be allocated in a buffer on device!");
     TT_FATAL(
         input_tensor.layout() == tt::tt_metal::Layout::TILE || input_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
@@ -411,8 +411,8 @@ ttnn::Tensor pad(
 
 ttnn::Tensor pad(
     const ttnn::Tensor& input_tensor,
-    const tt::tt_metal::Array4D& output_padded_shape,
-    const tt::tt_metal::Array4D& input_tensor_start,
+    const Array4D& output_padded_shape,
+    const Array4D& input_tensor_start,
     const float value,
     const bool use_multicore,
     const std::optional<MemoryConfig>& memory_config_arg,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.hpp
@@ -40,8 +40,8 @@ ttnn::Tensor pad(
 // legacy API
 ttnn::Tensor pad(
     const ttnn::Tensor& input_tensor,
-    const tt::tt_metal::Array4D& output_padded_shape,
-    const tt::tt_metal::Array4D& input_tensor_start,
+    const Array4D& output_padded_shape,
+    const Array4D& input_tensor_start,
     float value,
     bool use_multicore = false,
     const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad_nanobind.cpp
@@ -59,8 +59,8 @@ void bind_pad(nb::module_& mod) {
         ttnn::overload_t(
             nb::overload_cast<
                 const ttnn::Tensor&,
-                const tt::tt_metal::Array4D&,
-                const tt::tt_metal::Array4D&,
+                const Array4D&,
+                const Array4D&,
                 float,
                 bool,
                 const std::optional<MemoryConfig>&,

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -166,7 +166,7 @@ ttnn::Tensor permute(
     TT_FATAL(
         input_rank == dims.size(),
         "The number of dimensions in the tensor input does not match the length of the desired ordering");
-    TT_FATAL(tt::tt_metal::is_device_tensor(input_tensor), "Tensor must already be on device");
+    TT_FATAL(is_device_tensor(input_tensor), "Tensor must already be on device");
 
     SmallVector<uint32_t> normalized_dims(dims.size());
     std::transform(dims.begin(), dims.end(), normalized_dims.begin(), [input_tensor](std::int64_t idx) {

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -166,7 +166,7 @@ ttnn::Tensor permute(
     TT_FATAL(
         input_rank == dims.size(),
         "The number of dimensions in the tensor input does not match the length of the desired ordering");
-    TT_FATAL(is_device_tensor(input_tensor), "Tensor must already be on device");
+    TT_FATAL(tt::tt_metal::is_device_tensor(input_tensor), "Tensor must already be on device");
 
     SmallVector<uint32_t> normalized_dims(dims.size());
     std::transform(dims.begin(), dims.end(), normalized_dims.begin(), [input_tensor](std::int64_t idx) {

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
@@ -26,9 +26,7 @@ void RepeatDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     // Validate the input tensor
     const Tensor& input_tensor_a = tensor_args.input;
-    TT_FATAL(
-        input_tensor_a.storage_type() == tt::tt_metal::StorageType::DEVICE,
-        "Operands to reshape need to be on device!");
+    TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to reshape need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.layout() == tt::tt_metal::Layout::ROW_MAJOR, "This function is for RM->RM");
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_device_operation_types.hpp
@@ -15,7 +15,7 @@ struct ReshapeOnDeviceParams {
 };
 
 struct ReshapeOnDeviceInputs {
-    tt::tt_metal::Tensor input_tensor;
+    Tensor input_tensor;
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
@@ -97,7 +97,7 @@ ttsl::hash::hash_t ReshapeDeviceOperation::compute_program_hash(
         input_tensor.padded_shape());
 }
 
-tt::tt_metal::Tensor reshape_on_device(
+Tensor reshape_on_device(
     const Tensor& input_tensor,
     const tt::tt_metal::Shape& logical_output_shape,
     const tt::tt_metal::Shape& padded_output_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.hpp
@@ -16,7 +16,7 @@ struct ReshapeDeviceOperation {
     using operation_attributes_t = ReshapeOnDeviceParams;
     using tensor_args_t = ReshapeOnDeviceInputs;
     using spec_return_value_t = tt::tt_metal::TensorSpec;
-    using tensor_return_value_t = tt::tt_metal::Tensor;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<ttnn::prim::ReshapeTileProgramFactory, ttnn::prim::ReshapeRMProgramFactory>;
 
     static program_factory_t select_program_factory(
@@ -35,7 +35,7 @@ struct ReshapeDeviceOperation {
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };
 
-tt::tt_metal::Tensor reshape_on_device(
+Tensor reshape_on_device(
     const Tensor& input_tensor,
     const tt::tt_metal::Shape& logical_output_shape,
     const tt::tt_metal::Shape& padded_output_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_rm_program_factory.cpp
@@ -118,7 +118,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
 ReshapeRMProgramFactory::cached_program_t ReshapeRMProgramFactory::create(
     const ttnn::prim::ReshapeOnDeviceParams& /*operation_attributes*/,
     const ttnn::prim::ReshapeOnDeviceInputs& tensor_args,
-    tt::tt_metal::Tensor& output_tensor) {
+    Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input_tensor;
     TT_FATAL(
         input_tensor.dtype() == output_tensor.dtype(),
@@ -222,7 +222,7 @@ void ReshapeRMProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const ttnn::prim::ReshapeOnDeviceParams& /*operation_attributes*/,
     const ttnn::prim::ReshapeOnDeviceInputs& tensor_args,
-    tt::tt_metal::Tensor& output_tensor) {
+    Tensor& output_tensor) {
     const auto& src_tensor = tensor_args.input_tensor;
     auto& dst_tensor = output_tensor;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_rm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_rm_program_factory.hpp
@@ -22,13 +22,13 @@ struct ReshapeRMProgramFactory {
     static cached_program_t create(
         const ttnn::prim::ReshapeOnDeviceParams& operation_attributes,
         const ttnn::prim::ReshapeOnDeviceInputs& tensor_args,
-        tt::tt_metal::Tensor& output_tensor);
+        Tensor& output_tensor);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const ttnn::prim::ReshapeOnDeviceParams& operation_attributes,
         const ttnn::prim::ReshapeOnDeviceInputs& tensor_args,
-        tt::tt_metal::Tensor& output_tensor);
+        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_tile_program_factory.cpp
@@ -16,7 +16,7 @@ namespace ttnn::prim {
 ReshapeTileProgramFactory::cached_program_t ReshapeTileProgramFactory::create(
     const ttnn::prim::ReshapeOnDeviceParams& /*operation_attributes*/,
     const ttnn::prim::ReshapeOnDeviceInputs& tensor_args,
-    tt::tt_metal::Tensor& output_tensor) {
+    Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input_tensor;
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
@@ -91,7 +91,7 @@ void ReshapeTileProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const ttnn::prim::ReshapeOnDeviceParams& /*operation_attributes*/,
     const ttnn::prim::ReshapeOnDeviceInputs& tensor_args,
-    tt::tt_metal::Tensor& output_tensor) {
+    Tensor& output_tensor) {
     auto* src_buffer = tensor_args.input_tensor.buffer();
     auto* dst_buffer = output_tensor.buffer();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_tile_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_tile_program_factory.hpp
@@ -21,13 +21,13 @@ struct ReshapeTileProgramFactory {
     static cached_program_t create(
         const ttnn::prim::ReshapeOnDeviceParams& operation_attributes,
         const ttnn::prim::ReshapeOnDeviceInputs& tensor_args,
-        tt::tt_metal::Tensor& output_tensor);
+        Tensor& output_tensor);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const ttnn::prim::ReshapeOnDeviceParams& operation_attributes,
         const ttnn::prim::ReshapeOnDeviceInputs& tensor_args,
-        tt::tt_metal::Tensor& output_tensor);
+        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
@@ -80,7 +80,7 @@ ttnn::Tensor reshape_on_device(
             input_tensor.dtype());
 
         return operations::data_movement::detail::manual_insertion(
-            (tt::tt_metal::Tensor)input_tensor,
+            static_cast<Tensor>(input_tensor),
             logical_output_shape,
             padded_output_shape,
             input_tensor.device(),

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -40,7 +40,7 @@ ReshapeViewDeviceOperation::spec_return_value_t ReshapeViewDeviceOperation::comp
             operation_attributes.padded_output_shape));
 }
 
-tt::tt_metal::Tensor ReshapeViewDeviceOperation::create_output_tensors(
+Tensor ReshapeViewDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
@@ -62,13 +62,13 @@ ttsl::hash::hash_t ReshapeViewDeviceOperation::compute_program_hash(
         program_factory.index());
 }
 
-tt::tt_metal::Tensor reshape_view(
+Tensor reshape_view(
     const Tensor& input,
     const ttnn::Shape& logical_output_shape,
     const ttnn::Shape& padded_output_shape,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     bool recreate_mapping_tensor,
-    const std::optional<CoreRangeSet>& sub_core_grid) {
+    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grid) {
     return ttnn::device_operation::launch<ReshapeViewDeviceOperation>(
         ReshapeViewParams{
             logical_output_shape, padded_output_shape, output_mem_config, recreate_mapping_tensor, sub_core_grid},

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp
@@ -34,12 +34,12 @@ struct ReshapeViewDeviceOperation {
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };
 
-tt::tt_metal::Tensor reshape_view(
+Tensor reshape_view(
     const Tensor& input,
     const ttnn::Shape& logical_output_shape,
     const ttnn::Shape& padded_output_shape,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     bool recreate_mapping_tensor,
-    const std::optional<CoreRangeSet>& sub_core_grid);
+    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grid);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -371,7 +371,7 @@ ttnn::Tensor ttnn::reshape(
     }
     TT_FATAL(logical_shape.volume() != 0, "Tensor volume is not 0, but shape volume is 0");
 
-    if (!is_device_tensor(tensor)) {
+    if (!tt::tt_metal::is_device_tensor(tensor)) {
         // This case has been allowed in the past though it means introducing padding values to the data
         return ttnn::experimental::view(tensor, logical_shape, padded_shape);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -371,7 +371,7 @@ ttnn::Tensor ttnn::reshape(
     }
     TT_FATAL(logical_shape.volume() != 0, "Tensor volume is not 0, but shape volume is 0");
 
-    if (!tt::tt_metal::is_device_tensor(tensor)) {
+    if (!ttnn::is_device_tensor(tensor)) {
         // This case has been allowed in the past though it means introducing padding values to the data
         return ttnn::experimental::view(tensor, logical_shape, padded_shape);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_common.cpp
@@ -12,7 +12,7 @@
 
 namespace ttnn::operations::data_movement::detail {
 
-tt::tt_metal::Shape infer_dims_for_reshape(const tt::tt_metal::Tensor& tensor, ttsl::Span<const int32_t> shape) {
+tt::tt_metal::Shape infer_dims_for_reshape(const Tensor& tensor, ttsl::Span<const int32_t> shape) {
     int64_t old_volume = tensor.logical_volume();
     int64_t new_volume = 1;
     int64_t index_of_negative_1 = -1;

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_common.hpp
@@ -12,7 +12,7 @@
 
 namespace ttnn::operations::data_movement::detail {
 
-tt::tt_metal::Shape infer_dims_for_reshape(const tt::tt_metal::Tensor& tensor, ttsl::Span<const int32_t> shape);
+tt::tt_metal::Shape infer_dims_for_reshape(const Tensor& tensor, ttsl::Span<const int32_t> shape);
 
 }  // namespace ttnn::operations::data_movement::detail
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op_types.hpp
@@ -16,8 +16,8 @@ struct InterleavedToShardedParams {
 };
 
 struct InterleavedToShardedInputs {
-    tt::tt_metal::Tensor input_tensor;
-    std::optional<tt::tt_metal::Tensor> output_tensor;
+    Tensor input_tensor;
+    std::optional<Tensor> output_tensor;
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
@@ -76,9 +76,8 @@ Tensor pre_sort_transform_tensor(
     const auto& padded_logical_shape = padded_tensor.logical_shape();
     const Tensor padded_output_tensor = ttnn::pad(
         padded_tensor,
-        tt::tt_metal::Array4D(
-            {padded_logical_shape[0], padded_logical_shape[1], padded_logical_shape[2], padded_last_dim}),
-        tt::tt_metal::Array4D({0, 0, 0, 0}),
+        Array4D({padded_logical_shape[0], padded_logical_shape[1], padded_logical_shape[2], padded_last_dim}),
+        Array4D({0, 0, 0, 0}),
         descending ? -std::numeric_limits<float>::infinity() : std::numeric_limits<float>::infinity(),
         /*use_multicore=*/true);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
@@ -111,8 +111,8 @@ SplitProgramFactory::cached_program_t SplitProgramFactory::create(
         "Number of output tensors ({}) must equal number of chunks ({})",
         output_tensors.size(),
         num_chunks);
-    tt::tt_metal::Tensor& out0 = output_tensors[0];
-    tt::tt_metal::Tensor& out1 = output_tensors[1];
+    Tensor& out0 = output_tensors[0];
+    Tensor& out1 = output_tensors[1];
 
     tt::tt_metal::Buffer* out0_buffer = out0.buffer();
     TT_FATAL(out0_buffer != nullptr, "Output 0 buffer should be allocated on device!");

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.hpp
@@ -9,6 +9,6 @@
 
 namespace ttnn::prim::detail {
 
-uint32_t get_packed_value(const tt::tt_metal::Tensor& tensor, const tt::tt_metal::PadValue& pad_value);
+uint32_t get_packed_value(const Tensor& tensor, const tt::tt_metal::PadValue& pad_value);
 
 }  // namespace ttnn::prim::detail

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -577,10 +577,10 @@ Tensor outer(const Tensor& input_a, const Tensor& input_b, const std::optional<M
 
     auto* device = ttnn::GetDefaultDevice();
     if (device != nullptr) {
-        if (a_slim.storage_type() != tt::tt_metal::StorageType::DEVICE) {
+        if (a_slim.storage_type() != StorageType::DEVICE) {
             a_slim = a_slim.to_device(device);
         }
-        if (b_slim.storage_type() != tt::tt_metal::StorageType::DEVICE) {
+        if (b_slim.storage_type() != StorageType::DEVICE) {
             b_slim = b_slim.to_device(device);
         }
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -20,7 +20,7 @@ namespace CMAKE_UNIQUE_NAMESPACE {
 using namespace ttnn::operations::binary_ng;
 
 // For rank > 5 dims will be collapsed into a single dim
-uint32_t extract_nD_dims(const Tensor& x, const int out_rank) {
+uint32_t extract_nD_dims(const ttnn::Tensor& x, const int out_rank) {
     const auto& shape = x.logical_shape();
     uint32_t nD_dim = 1;
     if (out_rank >= 6 && shape.rank() >= 6) {
@@ -32,7 +32,7 @@ uint32_t extract_nD_dims(const Tensor& x, const int out_rank) {
     return nD_dim;
 }
 
-std::tuple<uint32_t, uint32_t, uint32_t, uint32_t, uint32_t> get_shape_dims(const Tensor& x) {
+std::tuple<uint32_t, uint32_t, uint32_t, uint32_t, uint32_t> get_shape_dims(const ttnn::Tensor& x) {
     const auto& shape = x.padded_shape();
     const auto& tile = x.tensor_spec().tile();
     return {
@@ -62,7 +62,8 @@ std::tuple<uint32_t, uint32_t> calculate_compute_kernel_args(
     }
 }
 
-TensorMemoryLayout get_memory_layout(const Tensor& a, const std::optional<Tensor>& b, const Tensor& c) {
+TensorMemoryLayout get_memory_layout(
+    const ttnn::Tensor& a, const std::optional<ttnn::Tensor>& b, const ttnn::Tensor& c) {
     if (!b.has_value()) {
         return TensorMemoryLayout::INTERLEAVED;
     }
@@ -121,7 +122,7 @@ std::optional<AllShardSpecs> get_shard_specs(
 
 bool should_use_row_major_path(
     const BinaryNgDeviceOperation::operation_attributes_t& operation_attributes,
-    const std::optional<Tensor>& b,
+    const std::optional<ttnn::Tensor>& b,
     const bool has_sharding) {
     if (operation_attributes.input_layout_a != Layout::ROW_MAJOR ||
         operation_attributes.output_layout != Layout::ROW_MAJOR || has_sharding) {
@@ -159,7 +160,7 @@ class ShardShapeGenerator {
 public:
     ShardShapeGenerator() = default;
 
-    ShardShapeGenerator(const ShardSpec& shard_spec, const Tensor& tensor) :
+    ShardShapeGenerator(const ShardSpec& shard_spec, const ttnn::Tensor& tensor) :
         // core ranges are sorted, so the last one is indeed the last core
         end_core(shard_spec.grid.ranges().rbegin()->end_coord),
         row_major(shard_spec.orientation == ShardOrientation::ROW_MAJOR),

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -146,8 +146,7 @@ Tensor UnaryDeviceOperation::create_output_tensors(
 tt::stl::hash::hash_t UnaryDeviceOperation::compute_program_hash(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
-    TT_FATAL(
-        tt::tt_metal::is_device_tensor(input_tensor), "Unary: Unexpected tensor type {}", input_tensor.storage_type());
+    TT_FATAL(is_device_tensor(input_tensor), "Unary: Unexpected tensor type {}", input_tensor.storage_type());
 
     const auto output_spec = compute_output_specs(attributes, tensor_args);
     const auto shard_specs = get_shard_specs(input_tensor.tensor_spec(), output_spec);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -1795,12 +1795,7 @@ std::vector<Tensor> prod_bw(
             tensor_2 = ttnn::untilize(tensor_2, tensor_1.memory_config());
             if (pad_needed) {
                 tensor_2 = ttnn::pad(
-                    tensor_2,
-                    padded_shape.to_array_4D(),
-                    tt::tt_metal::Array4D({0, 0, 0, 0}),
-                    0.0f,
-                    false,
-                    tensor_1.memory_config());
+                    tensor_2, padded_shape.to_array_4D(), Array4D({0, 0, 0, 0}), 0.0f, false, tensor_1.memory_config());
             }
         }
         // If tensor_1 is TILE, tensor_2 is already correct (both TILE, shapes match by assumption)
@@ -1844,12 +1839,7 @@ std::vector<Tensor> prod_bw(
         tensor_2 = ttnn::untilize(tensor_2, tensor_1.memory_config());
         if (pad_needed) {
             tensor_2 = ttnn::pad(
-                tensor_2,
-                padded_shape.to_array_4D(),
-                tt::tt_metal::Array4D({0, 0, 0, 0}),
-                0.0f,
-                false,
-                tensor_1.memory_config());
+                tensor_2, padded_shape.to_array_4D(), Array4D({0, 0, 0, 0}), 0.0f, false, tensor_1.memory_config());
         }
     }
     // If tensor_1 is TILE, tensor_2 is already correct (both TILE, shapes match by assumption)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.cpp
@@ -32,8 +32,8 @@ enum class CORE_TYPE : uint32_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 }
 static ttnn::prim::matmul_mcast_1d_common_override_variables_t
 process_agmm_fusion_program_and_create_override_variables(
     tt_metal::Program& program,
-    const tt::tt_metal::Tensor& /*a*/,
-    const std::vector<tt::tt_metal::Tensor>& b_tensors,
+    const Tensor& /*a*/,
+    const std::vector<Tensor>& b_tensors,
     tt_metal::IDevice* device,
     tt::tt_metal::MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
@@ -659,9 +659,9 @@ void override_agmm_fusion_program_parameters(
     const ttnn::prim::matmul_mcast_1d_common_override_variables_t& override_variables,
     const ttnn::prim::MatmulParams& operation,
     tt_metal::Program& program,
-    const std::vector<tt::tt_metal::Tensor>& input_tensors,
-    const std::vector<std::optional<const tt::tt_metal::Tensor>>& /*optional_input_tensors*/,
-    const std::vector<tt::tt_metal::Tensor>& output_tensors) {
+    const std::vector<Tensor>& input_tensors,
+    const std::vector<std::optional<const Tensor>>& /*optional_input_tensors*/,
+    const std::vector<Tensor>& output_tensors) {
     const auto& global_cb = operation.global_cb;
 
     auto* src_buffer_a = input_tensors[0].buffer();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.hpp
@@ -32,7 +32,7 @@ void override_agmm_fusion_program_parameters(
     const ttnn::prim::matmul_mcast_1d_common_override_variables_t& override_variables,
     const ttnn::prim::MatmulParams& operation,
     tt::tt_metal::Program& program,
-    const std::vector<tt::tt_metal::Tensor>& input_tensors,
-    const std::vector<std::optional<const tt::tt_metal::Tensor>>& optional_input_tensors,
-    const std::vector<tt::tt_metal::Tensor>& output_tensors);
+    const std::vector<Tensor>& input_tensors,
+    const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+    const std::vector<Tensor>& output_tensors);
 }  // namespace ttnn::operations::llama_matmul

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -1850,7 +1850,7 @@ void RingReduceScatterMeshWorkloadFactory::override_runtime_arguments(
     for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
         auto& shared_vars = cached_workload.shared_variables.at(coordinate_range);
 
-        ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(
+        ttnn::experimental::prim::ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(
             program,
             shared_vars.reader_kernel_id,
             shared_vars.writer_kernel_id,
@@ -1950,7 +1950,7 @@ void LineReduceScatterMeshWorkloadFactory::override_runtime_arguments(
             operation_attributes.topology == ttnn::ccl::Topology::Linear,
             "LineReduceScatterMeshWorkloadFactory expects Linear topology");
 
-        line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
+        ttnn::experimental::prim::line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
             program,
             shared_vars.reader_kernel_id,
             shared_vars.writer_kernel_id,

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.cpp
@@ -124,15 +124,15 @@ Tensor convert_conv_weight_tensor_to_grouped_layout(
                 {DataType::BFLOAT4_B, &conv_group_weight_zero_pad_helper<uint32_t>},
             };
 
-    if (tt::tt_metal::is_device_tensor(conv_weight_tensor)) {
+    if (is_device_tensor(conv_weight_tensor)) {
         log_warning(
             tt::LogOp,
             "Prepare weights for Conv3D with groups > 1 expects weights on host, but they are on device. The op will "
             "move them back to host.");
     }
     return convert_tensor_to_tiled_layout_common(
-        tt::tt_metal::is_device_tensor(conv_weight_tensor) ? ttnn::operations::core::from_device(conv_weight_tensor)
-                                                           : conv_weight_tensor,
+        is_device_tensor(conv_weight_tensor) ? ttnn::operations::core::from_device(conv_weight_tensor)
+                                             : conv_weight_tensor,
         output_dtype,
         to_w_tile_layout_map,
         original_conv_weight_tensor_shape,

--- a/ttnn/cpp/ttnn/operations/experimental/core_subset_write/copy_to_device_filtered.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/core_subset_write/copy_to_device_filtered.cpp
@@ -17,8 +17,8 @@
 namespace ttnn::experimental::core_subset_write {
 
 void copy_to_device_filtered(
-    const tt::tt_metal::Tensor& host_tensor,
-    tt::tt_metal::Tensor& device_tensor,
+    const Tensor& host_tensor,
+    Tensor& device_tensor,
     const tt::tt_metal::CoreRangeSet& logical_core_filter,
     std::optional<tt::tt_metal::QueueId> cq_id) {
     tt::tt_metal::GraphTracker::instance().track_function_start(
@@ -29,7 +29,7 @@ void copy_to_device_filtered(
         "copy_to_device_filtered does not support non-uniform host->device writes.");
     tt::tt_metal::experimental::core_subset_write::enqueue_write_tensor(
         cq, host_tensor.host_tensor(), device_tensor.device_storage().get_mesh_tensor(), logical_core_filter);
-    device_tensor = tt::tt_metal::set_tensor_id(device_tensor);
+    device_tensor = ttnn::set_tensor_id(device_tensor);
     tt::tt_metal::GraphTracker::instance().track_function_end(device_tensor);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/core_subset_write/copy_to_device_filtered.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/core_subset_write/copy_to_device_filtered.hpp
@@ -9,14 +9,17 @@
 
 namespace tt::tt_metal {
 class CoreRangeSet;
-class Tensor;
 }
+
+namespace ttnn {
+class Tensor;
+}  // namespace ttnn
 
 namespace ttnn::experimental::core_subset_write {
 
 void copy_to_device_filtered(
-    const tt::tt_metal::Tensor& host_tensor,
-    tt::tt_metal::Tensor& device_tensor,
+    const Tensor& host_tensor,
+    Tensor& device_tensor,
     const tt::tt_metal::CoreRangeSet& logical_core_filter,
     std::optional<tt::tt_metal::QueueId> cq_id = std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/extract_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/extract_device_operation.cpp
@@ -22,7 +22,7 @@ bool is_dram_interleaved(const ttnn::Tensor& tensor) {
 }
 
 void validate_index_tensor(const ttnn::Tensor& tensor, const std::string& name) {
-    TT_FATAL(tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "{} must be on device", name);
+    TT_FATAL(tensor.storage_type() == StorageType::DEVICE, "{} must be on device", name);
     TT_FATAL(tensor.buffer() != nullptr, "{} must have a buffer", name);
     TT_FATAL(tensor.dtype() == tt::tt_metal::DataType::UINT32, "{} must be UINT32, got {}", name, tensor.dtype());
     TT_FATAL(
@@ -64,7 +64,7 @@ void ExtractDeviceOperation::validate_on_program_cache_miss(
     const auto& global_expert_idx_table = tensor_args.global_expert_idx_table;
 
     // Global tensor validation: 2D, BFLOAT8_B, TILE layout, DRAM interleaved, on device.
-    TT_FATAL(global_tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "global_tensor must be on device");
+    TT_FATAL(global_tensor.storage_type() == StorageType::DEVICE, "global_tensor must be on device");
     TT_FATAL(global_tensor.buffer() != nullptr, "global_tensor must have a buffer");
     TT_FATAL(
         global_tensor.dtype() == tt::tt_metal::DataType::BFLOAT8_B,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/insert_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/insert_device_operation.cpp
@@ -22,7 +22,7 @@ bool is_dram_interleaved(const ttnn::Tensor& tensor) {
 }
 
 void validate_index_tensor(const ttnn::Tensor& tensor, const std::string& name) {
-    TT_FATAL(tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "{} must be on device", name);
+    TT_FATAL(tensor.storage_type() == StorageType::DEVICE, "{} must be on device", name);
     TT_FATAL(tensor.buffer() != nullptr, "{} must have a buffer", name);
     TT_FATAL(tensor.dtype() == tt::tt_metal::DataType::UINT32, "{} must be UINT32, got {}", name, tensor.dtype());
     TT_FATAL(
@@ -37,7 +37,7 @@ void validate_index_tensor(const ttnn::Tensor& tensor, const std::string& name) 
 }
 
 void validate_data_tensor(const ttnn::Tensor& tensor, const std::string& name) {
-    TT_FATAL(tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "{} must be on device", name);
+    TT_FATAL(tensor.storage_type() == StorageType::DEVICE, "{} must be on device", name);
     TT_FATAL(tensor.buffer() != nullptr, "{} must have a buffer", name);
     TT_FATAL(tensor.dtype() == tt::tt_metal::DataType::BFLOAT8_B, "{} must be BFLOAT8_B, got {}", name, tensor.dtype());
     TT_FATAL(tensor.layout() == tt::tt_metal::Layout::TILE, "{} must be TILE layout, got {}", name, tensor.layout());

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/moe_grouped_topk_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/moe_grouped_topk_device_operation.cpp
@@ -13,8 +13,8 @@ void MoeGroupedTopkDeviceOperation::validate_on_program_cache_miss(
     const auto& scores = tensor_args.scores;
     const auto& bias = tensor_args.bias;
 
-    TT_FATAL(scores.storage_type() == tt::tt_metal::StorageType::DEVICE, "Scores tensor must be on device");
-    TT_FATAL(bias.storage_type() == tt::tt_metal::StorageType::DEVICE, "Bias tensor must be on device");
+    TT_FATAL(scores.storage_type() == StorageType::DEVICE, "Scores tensor must be on device");
+    TT_FATAL(bias.storage_type() == StorageType::DEVICE, "Bias tensor must be on device");
     TT_FATAL(scores.buffer() != nullptr, "Scores tensor must be allocated");
     TT_FATAL(bias.buffer() != nullptr, "Bias tensor must be allocated");
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
@@ -29,9 +29,7 @@ void FastReduceNCDeviceOperation::validate_on_program_cache_miss(
     // validate input dim
     const auto input_rank = input.logical_shape().rank();
     TT_FATAL(
-        (args.dim >= 0 && args.dim <= tt::tt_metal::MAX_NUM_DIMENSIONS - 2),
-        "dim must be between 0 and {}.",
-        tt::tt_metal::MAX_NUM_DIMENSIONS - 2);
+        (args.dim >= 0 && args.dim <= MAX_NUM_DIMENSIONS - 2), "dim must be between 0 and {}.", MAX_NUM_DIMENSIONS - 2);
     TT_FATAL((args.dim < input_rank), "dim must be smaller than input tensor rank {}.", input_rank);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
@@ -18,7 +18,7 @@ void ConcatenateHeadsDeviceOperation::validate_on_program_cache_miss(
     // TODO: See issue #1744
     TT_FATAL(batch_size >= 7 && batch_size <= 9, "Input batch size must be between 7 to 9 for bert large TM ops!");
 
-    TT_FATAL(input_tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "Operands to TM need to be on device!");
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
     TT_FATAL(
         input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16 ||

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.cpp
@@ -11,7 +11,7 @@ void NLPConcatHeadsDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args;
 
-    TT_FATAL(input_tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "Operands to TM need to be on device!");
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
     TT_FATAL(
         input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32 ||

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation.cpp
@@ -11,7 +11,7 @@ void NLPConcatHeadsBoltzDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
 
-    TT_FATAL(input_tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "Operands to TM need to be on device!");
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
     TT_FATAL(
         input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32 ||

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
@@ -25,7 +25,7 @@ void NLPConcatHeadsDecodeDeviceOperation::validate_on_program_cache_miss(
     const auto& input_shape = input_tensor.padded_shape();
 
     // input tensor and shape
-    TT_FATAL(input_tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "Operands to TM need to be on device!");
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
     TT_FATAL(
         input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32 ||

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
@@ -75,9 +75,9 @@ NlpCreateHeadsDeviceOperation::Interleaved::cached_program_t NlpCreateHeadsDevic
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Tensor& q = std::get<0>(output);
-    tt_metal::Tensor& k = std::get<1>(output);
-    tt_metal::Tensor& v = std::get<2>(output);
+    Tensor& q = std::get<0>(output);
+    Tensor& k = std::get<1>(output);
+    Tensor& v = std::get<2>(output);
 
     tt_metal::Buffer* q_buffer = q.buffer();
     TT_ASSERT(q_buffer != nullptr, "Output q buffer should be allocated on device!");

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_program_factory.cpp
@@ -76,9 +76,9 @@ NlpCreateHeadsBoltzDeviceOperation::Interleaved::create(
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Tensor& q = std::get<0>(output);
-    tt_metal::Tensor& k = std::get<1>(output);
-    tt_metal::Tensor& v = std::get<2>(output);
+    Tensor& q = std::get<0>(output);
+    Tensor& k = std::get<1>(output);
+    Tensor& v = std::get<2>(output);
 
     tt_metal::Buffer* q_buffer = q.buffer();
     TT_ASSERT(q_buffer != nullptr, "Output q buffer should be allocated on device!");

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_program_factory.cpp
@@ -53,9 +53,9 @@ NlpCreateQkvHeadsFalcon7BProgramFactory::cached_program_t NlpCreateQkvHeadsFalco
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Tensor& q = tensor_return_value.q;
-    tt_metal::Tensor& k = tensor_return_value.k;
-    tt_metal::Tensor& v = tensor_return_value.v;
+    Tensor& q = tensor_return_value.q;
+    Tensor& k = tensor_return_value.k;
+    Tensor& v = tensor_return_value.v;
 
     tt_metal::Buffer* q_buffer = q.buffer();
     TT_ASSERT(q_buffer != nullptr, "Output q buffer should be allocated on device!");

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/device/nlp_create_qkv_heads_segformer_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/device/nlp_create_qkv_heads_segformer_program_factory.cpp
@@ -56,9 +56,9 @@ NlpCreateQkvHeadsSegformerProgramFactory::cached_program_t NlpCreateQkvHeadsSegf
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Tensor& q = std::get<0>(output);
-    tt_metal::Tensor& k = std::get<1>(output);
-    tt_metal::Tensor& v = std::get<2>(output);
+    Tensor& q = std::get<0>(output);
+    Tensor& k = std::get<1>(output);
+    Tensor& v = std::get<2>(output);
 
     tt_metal::Buffer* q_buffer = q.buffer();
     TT_ASSERT(q_buffer != nullptr, "Output q buffer should be allocated on device!");

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/device/nlp_create_qkv_heads_vit_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/device/nlp_create_qkv_heads_vit_program_factory.cpp
@@ -59,9 +59,9 @@ NlpCreateQkvHeadsVitProgramFactory::cached_program_t NlpCreateQkvHeadsVitProgram
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
     TT_ASSERT((output.size() == 3), "Output vector must be size 3 for split fused qkv!");
-    tt_metal::Tensor& q = output[0];
-    tt_metal::Tensor& k = output[1];
-    tt_metal::Tensor& v = output[2];
+    Tensor& q = output[0];
+    Tensor& k = output[1];
+    Tensor& v = output[2];
 
     tt_metal::Buffer* q_buffer = q.buffer();
     TT_ASSERT(q_buffer != nullptr, "Output q buffer should be allocated on device!");

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.cpp
@@ -12,8 +12,7 @@ void NlpKVCacheLoadSliceDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     using namespace tt::constants;
     const auto& input_tensor_a = tensor_args.input;
-    TT_FATAL(
-        input_tensor_a.storage_type() == tt::tt_metal::StorageType::DEVICE, "Operands to unpad need to be on device!");
+    TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to unpad need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to unpad need to be allocated in buffers on device!");
     TT_FATAL(
         input_tensor_a.layout() == tt::tt_metal::Layout::TILE,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation.cpp
@@ -27,11 +27,11 @@ void RotaryEmbeddingHfDeviceOperation::validate_on_program_cache_miss(
     const auto& sin = tensor_args.sin_cache;
 
     auto* ref_device = input_tensor.device();
-    TT_FATAL(input_tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "Input must be on device!");
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Input must be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Input must be allocated in buffer on device!");
-    TT_FATAL(cos.storage_type() == tt::tt_metal::StorageType::DEVICE, "Cos must be on device!");
+    TT_FATAL(cos.storage_type() == StorageType::DEVICE, "Cos must be on device!");
     TT_FATAL(cos.buffer() != nullptr, "Cos must be allocated in buffer on device!");
-    TT_FATAL(sin.storage_type() == tt::tt_metal::StorageType::DEVICE, "Sin must be on device!");
+    TT_FATAL(sin.storage_type() == StorageType::DEVICE, "Sin must be on device!");
     TT_FATAL(sin.buffer() != nullptr, "Sin must be allocated in buffer on device!");
     TT_FATAL(input_tensor.device() == ref_device, "All tensors must be on same device!");
     TT_FATAL(cos.device() == ref_device, "All tensors must be on same device!");

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation.cpp
@@ -120,7 +120,7 @@ tt::tt_metal::TensorSpec RotaryEmbeddingHfDeviceOperation::compute_output_specs(
             input_tensor.dtype(), tt::tt_metal::PageConfig(input_tensor.layout()), args.output_mem_config));
 }
 
-tt::tt_metal::Tensor RotaryEmbeddingHfDeviceOperation::create_output_tensors(
+Tensor RotaryEmbeddingHfDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     return tt::tt_metal::create_device_tensor(
         compute_output_specs(args, tensor_args), tensor_args.input_tensor.device());
@@ -144,10 +144,10 @@ tt::stl::hash::hash_t RotaryEmbeddingHfDeviceOperation::compute_program_hash(
 
 namespace ttnn::prim {
 
-tt::tt_metal::Tensor rotary_embedding_hf(
-    const tt::tt_metal::Tensor& input,
-    const tt::tt_metal::Tensor& cos,
-    const tt::tt_metal::Tensor& sin,
+Tensor rotary_embedding_hf(
+    const Tensor& input,
+    const Tensor& cos,
+    const Tensor& sin,
     bool is_decode_mode,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     ttnn::DeviceComputeKernelConfig compute_kernel_config) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation.hpp
@@ -15,7 +15,7 @@ struct RotaryEmbeddingHfDeviceOperation {
     using operation_attributes_t = RotaryEmbeddingHfParams;
     using tensor_args_t = RotaryEmbeddingHfInputs;
     using spec_return_value_t = tt::tt_metal::TensorSpec;
-    using tensor_return_value_t = tt::tt_metal::Tensor;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<RotaryEmbeddingHfMultiCore, RotaryEmbeddingHfMultiCoreSharded>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation_types.hpp
@@ -17,9 +17,9 @@ struct RotaryEmbeddingHfParams {
 };
 
 struct RotaryEmbeddingHfInputs {
-    tt::tt_metal::Tensor input_tensor;
-    tt::tt_metal::Tensor cos_cache;
-    tt::tt_metal::Tensor sin_cache;
+    Tensor input_tensor;
+    Tensor cos_cache;
+    Tensor sin_cache;
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/rotary_embedding_hf.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/rotary_embedding_hf.cpp
@@ -8,10 +8,10 @@
 
 namespace ttnn::prim {
 
-tt::tt_metal::Tensor rotary_embedding_hf(
-    const tt::tt_metal::Tensor& input,
-    const tt::tt_metal::Tensor& cos,
-    const tt::tt_metal::Tensor& sin,
+Tensor rotary_embedding_hf(
+    const Tensor& input,
+    const Tensor& cos,
+    const Tensor& sin,
     bool is_decode_mode,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     ttnn::DeviceComputeKernelConfig compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.cpp
@@ -235,11 +235,11 @@ ttsl::hash::hash_t RotaryEmbeddingLlamaDeviceOperation::compute_program_hash(
 
 namespace ttnn::prim {
 
-tt::tt_metal::Tensor rotary_embedding_llama(
-    const tt::tt_metal::Tensor& input_tensor,
-    const tt::tt_metal::Tensor& cos_cache,
-    const tt::tt_metal::Tensor& sin_cache,
-    const tt::tt_metal::Tensor& trans_mat,
+Tensor rotary_embedding_llama(
+    const Tensor& input_tensor,
+    const Tensor& cos_cache,
+    const Tensor& sin_cache,
+    const Tensor& trans_mat,
     bool is_decode_mode,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.hpp
@@ -16,7 +16,7 @@ struct RotaryEmbeddingLlamaDeviceOperation {
     using operation_attributes_t = RotaryEmbeddingLlamaParams;
     using tensor_args_t = RotaryEmbeddingLlamaInputs;
     using spec_return_value_t = std::vector<tt::tt_metal::TensorSpec>;
-    using tensor_return_value_t = tt::tt_metal::Tensor;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<
         RotaryEmbeddingLlamaMultiCore,
         RotaryEmbeddingLlamaMultiCoreSharded,
@@ -32,11 +32,11 @@ struct RotaryEmbeddingLlamaDeviceOperation {
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {
-tt::tt_metal::Tensor rotary_embedding_llama(
-    const tt::tt_metal::Tensor& input_tensor,
-    const tt::tt_metal::Tensor& cos_cache,
-    const tt::tt_metal::Tensor& sin_cache,
-    const tt::tt_metal::Tensor& trans_mat,
+Tensor rotary_embedding_llama(
+    const Tensor& input_tensor,
+    const Tensor& cos_cache,
+    const Tensor& sin_cache,
+    const Tensor& trans_mat,
     bool is_decode_mode,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation_types.hpp
@@ -16,10 +16,10 @@ struct RotaryEmbeddingLlamaParams {
 };
 
 struct RotaryEmbeddingLlamaInputs {
-    tt::tt_metal::Tensor input_tensor;
-    tt::tt_metal::Tensor cos_cache;
-    tt::tt_metal::Tensor sin_cache;
-    tt::tt_metal::Tensor trans_mat;
+    Tensor input_tensor;
+    Tensor cos_cache;
+    Tensor sin_cache;
+    Tensor trans_mat;
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_prefill_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_prefill_sharded_program_factory.cpp
@@ -12,7 +12,7 @@ namespace ttnn::experimental::prim {
 RotaryEmbeddingLlamaMultiCorePrefillSharded::cached_program_t RotaryEmbeddingLlamaMultiCorePrefillSharded::create(
     const RotaryEmbeddingLlamaParams& operation_attributes,
     const RotaryEmbeddingLlamaInputs& tensor_args,
-    tt::tt_metal::Tensor& output) {
+    Tensor& output) {
     using namespace tt::constants;
     using namespace tt::tt_metal;
     using namespace tt;
@@ -410,7 +410,7 @@ void RotaryEmbeddingLlamaMultiCorePrefillSharded::override_runtime_arguments(
     cached_program_t& cached_program,
     const RotaryEmbeddingLlamaParams& /*operation_attributes*/,
     const RotaryEmbeddingLlamaInputs& tensor_args,
-    tt::tt_metal::Tensor& output) {
+    Tensor& output) {
     using namespace tt::constants;
     using namespace tt::tt_metal;
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_prefill_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_prefill_sharded_program_factory.hpp
@@ -31,13 +31,13 @@ struct RotaryEmbeddingLlamaMultiCorePrefillSharded {
     static cached_program_t create(
         const RotaryEmbeddingLlamaParams& operation_attributes,
         const RotaryEmbeddingLlamaInputs& tensor_args,
-        tt::tt_metal::Tensor& output);
+        Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const RotaryEmbeddingLlamaParams& operation_attributes,
         const RotaryEmbeddingLlamaInputs& tensor_args,
-        tt::tt_metal::Tensor& output);
+        Tensor& output);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_program_factory.cpp
@@ -12,7 +12,7 @@ namespace ttnn::experimental::prim {
 RotaryEmbeddingLlamaMultiCore::cached_program_t RotaryEmbeddingLlamaMultiCore::create(
     const RotaryEmbeddingLlamaParams& operation_attributes,
     const RotaryEmbeddingLlamaInputs& tensor_args,
-    tt::tt_metal::Tensor& output) {
+    Tensor& output) {
     using namespace tt::constants;
     using namespace tt::tt_metal;
     using namespace tt;
@@ -299,7 +299,7 @@ void RotaryEmbeddingLlamaMultiCore::override_runtime_arguments(
     cached_program_t& cached_program,
     const RotaryEmbeddingLlamaParams& /*operation_attributes*/,
     const RotaryEmbeddingLlamaInputs& tensor_args,
-    tt::tt_metal::Tensor& output) {
+    Tensor& output) {
     using namespace tt::constants;
     using namespace tt::tt_metal;
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_program_factory.hpp
@@ -29,13 +29,13 @@ struct RotaryEmbeddingLlamaMultiCore {
     static cached_program_t create(
         const RotaryEmbeddingLlamaParams& operation_attributes,
         const RotaryEmbeddingLlamaInputs& tensor_args,
-        tt::tt_metal::Tensor& output);
+        Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const RotaryEmbeddingLlamaParams& operation_attributes,
         const RotaryEmbeddingLlamaInputs& tensor_args,
-        tt::tt_metal::Tensor& output);
+        Tensor& output);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_sharded_program_factory.cpp
@@ -12,7 +12,7 @@ namespace ttnn::experimental::prim {
 RotaryEmbeddingLlamaMultiCoreSharded::cached_program_t RotaryEmbeddingLlamaMultiCoreSharded::create(
     const RotaryEmbeddingLlamaParams& operation_attributes,
     const RotaryEmbeddingLlamaInputs& tensor_args,
-    tt::tt_metal::Tensor& output) {
+    Tensor& output) {
     using namespace tt::constants;
     using namespace tt;
     using namespace tt::tt_metal;
@@ -172,7 +172,7 @@ void RotaryEmbeddingLlamaMultiCoreSharded::override_runtime_arguments(
     cached_program_t& cached_program,
     const RotaryEmbeddingLlamaParams& /*operation_attributes*/,
     const RotaryEmbeddingLlamaInputs& tensor_args,
-    tt::tt_metal::Tensor& output) {
+    Tensor& output) {
     using namespace tt::constants;
     using namespace tt::tt_metal;
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_sharded_program_factory.hpp
@@ -29,13 +29,13 @@ struct RotaryEmbeddingLlamaMultiCoreSharded {
     static cached_program_t create(
         const RotaryEmbeddingLlamaParams& operation_attributes,
         const RotaryEmbeddingLlamaInputs& tensor_args,
-        tt::tt_metal::Tensor& output);
+        Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const RotaryEmbeddingLlamaParams& operation_attributes,
         const RotaryEmbeddingLlamaInputs& tensor_args,
-        tt::tt_metal::Tensor& output);
+        Tensor& output);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation.cpp
@@ -24,7 +24,7 @@ void SplitFusedQKVAndSplitHeadsDeviceOperation::validate_on_program_cache_miss(
     const auto batch_size = input_tensor.padded_shape()[0];
 
     // TODO: See issue #1744
-    TT_FATAL(input_tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "Operands to TM need to be on device!");
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
     TT_FATAL(
         input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16 ||

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_program_factory.cpp
@@ -61,9 +61,9 @@ SplitFusedQKVAndSplitHeadsProgramFactory::cached_program_t SplitFusedQKVAndSplit
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
     TT_ASSERT((output.size() == 3), "Output vector must be size 3 for split fused qkv!");
-    tt_metal::Tensor& q = output[0];
-    tt_metal::Tensor& k = output[1];
-    tt_metal::Tensor& v = output[2];
+    Tensor& q = output[0];
+    Tensor& k = output[1];
+    Tensor& v = output[2];
 
     tt_metal::Buffer* q_buffer = q.buffer();
     TT_ASSERT(q_buffer != nullptr, "Output q buffer should be allocated on device!");

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_nd_sharded.cpp
@@ -29,7 +29,7 @@ ProgramDescriptor FullNDShardedProgramFactory::create_descriptor(
     uint32_t num_shards = distribution_spec.num_shards();
     uint32_t num_compute_cores = distribution_spec.cores_with_data().size();
 
-    std::vector<CoreCoord> ordered_cores_with_data = tt::tt_metal::get_optimal_worker_cores_for_sharded_tensor(output);
+    std::vector<CoreCoord> ordered_cores_with_data = get_optimal_worker_cores_for_sharded_tensor(output);
     const auto& compute_core_range = CoreRangeSet(ttsl::Span<const CoreCoord>(ordered_cores_with_data));
     const auto& aligned_page_size = output.buffer()->aligned_page_size();
     const auto& page_size = output.buffer()->page_size();

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_nd_sharded.cpp
@@ -29,7 +29,7 @@ ProgramDescriptor FullNDShardedProgramFactory::create_descriptor(
     uint32_t num_shards = distribution_spec.num_shards();
     uint32_t num_compute_cores = distribution_spec.cores_with_data().size();
 
-    std::vector<CoreCoord> ordered_cores_with_data = get_optimal_worker_cores_for_sharded_tensor(output);
+    std::vector<CoreCoord> ordered_cores_with_data = tt::tt_metal::get_optimal_worker_cores_for_sharded_tensor(output);
     const auto& compute_core_range = CoreRangeSet(ttsl::Span<const CoreCoord>(ordered_cores_with_data));
     const auto& aligned_page_size = output.buffer()->aligned_page_size();
     const auto& page_size = output.buffer()->page_size();

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_sharded.cpp
@@ -28,7 +28,7 @@ ProgramDescriptor FullShardedProgramFactory::create_descriptor(
 
     uint32_t tensor_width_in_pages = output.buffer()->shard_spec().tensor2d_shape_in_pages[1];
 
-    std::vector<CoreCoord> runtime_cores = tt::tt_metal::get_optimal_worker_cores_for_sharded_tensor(output);
+    std::vector<CoreCoord> runtime_cores = get_optimal_worker_cores_for_sharded_tensor(output);
     const auto& compute_core_range = CoreRangeSet(ttsl::Span<const CoreCoord>(runtime_cores));
 
     const auto& aligned_page_size = output.buffer()->aligned_page_size();

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_sharded.cpp
@@ -28,7 +28,7 @@ ProgramDescriptor FullShardedProgramFactory::create_descriptor(
 
     uint32_t tensor_width_in_pages = output.buffer()->shard_spec().tensor2d_shape_in_pages[1];
 
-    std::vector<CoreCoord> runtime_cores = get_optimal_worker_cores_for_sharded_tensor(output);
+    std::vector<CoreCoord> runtime_cores = tt::tt_metal::get_optimal_worker_cores_for_sharded_tensor(output);
     const auto& compute_core_range = CoreRangeSet(ttsl::Span<const CoreCoord>(runtime_cores));
 
     const auto& aligned_page_size = output.buffer()->aligned_page_size();

--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -238,7 +238,7 @@ static Tensor fill_first_val_into_tensor(
     auto physical_volume = input_tensor.physical_volume();
     auto output_buffer = std::vector<T>(physical_volume);
     auto input_cpu_tensor = input_tensor.cpu();
-    ttsl::Span<const T> host_buffer = tt::tt_metal::host_buffer::get_as<T>(input_cpu_tensor);
+    ttsl::Span<const T> host_buffer = host_buffer::get_as<T>(input_cpu_tensor);
     const ttnn::Shape input_tensor_strides = input_tensor.strides();
     for (uint32_t i = 0; i < physical_volume; i++) {
         output_buffer[i] = host_buffer[0];
@@ -269,7 +269,7 @@ static Tensor prod_result_computation_WH_B0(
     const MemoryConfig& output_mem_config = MemoryConfig{}) {
     auto output_buffer = std::vector<T>(tt::constants::TILE_HW);
     auto input_cpu_tensor = input_tensor.cpu();
-    ttsl::Span<const T> input_buffer = tt::tt_metal::host_buffer::get_as<T>(input_cpu_tensor);
+    ttsl::Span<const T> input_buffer = host_buffer::get_as<T>(input_cpu_tensor);
     const ttnn::Shape input_tensor_strides = input_tensor.strides();
     T result = static_cast<T>(1.0f);
 
@@ -392,7 +392,7 @@ static Tensor manual_insertion(
         "Required shape volume must match old shape volume");
     auto input_cpu_tensor = input_tensor.cpu();
     auto output = Tensor(
-                      tt::tt_metal::host_buffer::get_host_buffer(input_cpu_tensor),
+                      host_buffer::get_host_buffer(input_cpu_tensor),
                       TensorSpec(
                           logical_shape,
                           TensorLayout::fromPaddedShape(
@@ -511,8 +511,8 @@ static bool allclose(const Tensor& tensor_a, const Tensor& tensor_b, Args... arg
         return false;
     }
 
-    ttsl::Span<const DataType> tensor_a_buffer = tt::tt_metal::host_buffer::get_as<DataType>(tensor_a);
-    ttsl::Span<const DataType> tensor_b_buffer = tt::tt_metal::host_buffer::get_as<DataType>(tensor_b);
+    ttsl::Span<const DataType> tensor_a_buffer = host_buffer::get_as<DataType>(tensor_a);
+    ttsl::Span<const DataType> tensor_b_buffer = host_buffer::get_as<DataType>(tensor_b);
 
     for (int index = 0; index < tensor_a_buffer.size(); index++) {
         using ::ttnn::detail::nearly_equal;

--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -24,7 +24,6 @@ using tt::tt_metal::Layout;
 using tt::tt_metal::MemoryConfig;
 using tt::tt_metal::PageConfig;
 using tt::tt_metal::StorageType;
-using tt::tt_metal::Tensor;
 using tt::tt_metal::TensorLayout;
 using tt::tt_metal::TensorMemoryLayout;
 using tt::tt_metal::distributed::MeshDevice;

--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -23,7 +23,6 @@ using tt::tt_metal::DataType;
 using tt::tt_metal::Layout;
 using tt::tt_metal::MemoryConfig;
 using tt::tt_metal::PageConfig;
-using tt::tt_metal::StorageType;
 using tt::tt_metal::TensorLayout;
 using tt::tt_metal::TensorMemoryLayout;
 using tt::tt_metal::distributed::MeshDevice;

--- a/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_multi_core_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_multi_core_factory.cpp
@@ -18,8 +18,8 @@ IndexFillOperation::MultiCore::cached_program_t IndexFillOperation::MultiCore::c
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
     ////////////////////////////////////////////////////////////////////////////
-    const tt::tt_metal::Tensor& index = tensor_args.index;
-    const tt::tt_metal::Tensor& input = tensor_args.input;
+    const Tensor& index = tensor_args.index;
+    const Tensor& input = tensor_args.input;
     uint32_t dim = operation_attributes.dim;
 
     const auto input_shape = input.padded_shape();

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -73,7 +73,7 @@ uint32_t get_preferred_noc(
 
 MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_program_and_create_override_variables(
     tt_metal::Program& program,
-    const tt::tt_metal::Tensor& a,
+    const Tensor& a,
     tt_metal::IDevice* device,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
@@ -1076,7 +1076,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
 
 MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_program_and_create_override_variables(
     tt_metal::Program& program,
-    const tt::tt_metal::Tensor& a,
+    const Tensor& a,
     tt_metal::IDevice* device,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
@@ -1925,8 +1925,8 @@ enum class CORE_TYPE : uint32_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 }
 
 MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0_program_and_create_override_variables(
     tt_metal::Program& program,
-    const tt::tt_metal::Tensor& a,
-    const std::vector<tt::tt_metal::Tensor>& b_tensors,
+    const Tensor& a,
+    const std::vector<Tensor>& b_tensors,
     tt_metal::IDevice* device,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
@@ -2878,7 +2878,7 @@ void override_program_parameters(
 }
 
 static ProgramDescriptor create_program_mcast_in0_descriptor(
-    const tt::tt_metal::Tensor& a,
+    const Tensor& a,
     tt_metal::IDevice* device,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
@@ -3893,7 +3893,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
 }
 
 static ProgramDescriptor create_program_mcast_in1_descriptor(
-    const tt::tt_metal::Tensor& a,
+    const Tensor& a,
     tt_metal::IDevice* device,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -19,7 +19,6 @@ using tt::tt_metal::ComputeConfigDescriptor;
 using tt::tt_metal::KernelDescriptor;
 using tt::tt_metal::ProgramDescriptor;
 using tt::tt_metal::ReaderConfigDescriptor;
-using tt::tt_metal::Tensor;
 using tt::tt_metal::WriterConfigDescriptor;
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -73,7 +73,7 @@ uint32_t estimate_interm_tile_size(
     return result;
 }
 
-uint32_t get_max_l1_space(const tt::tt_metal::Tensor& input_tensor_a) {
+uint32_t get_max_l1_space(const Tensor& input_tensor_a) {
     auto* device = input_tensor_a.device();
     auto lowest_address = device->lowest_occupied_compute_l1_address();
     uint32_t max_l1_space = lowest_address.has_value() ? lowest_address.value() : device->l1_size_per_core();

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
@@ -47,7 +47,7 @@ uint32_t estimate_interm_tile_size(
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     tt::tt_metal::DataType output_dtype);
 
-uint32_t get_max_l1_space(const tt::tt_metal::Tensor& input_tensor_a);
+uint32_t get_max_l1_space(const Tensor& input_tensor_a);
 
 bool is_input_batched(const ttnn::Shape& shape);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.cpp
@@ -112,8 +112,7 @@ Tensor moreh_clip_grad_norm(
         init_device_compute_kernel_config(inputs.at(0).device()->arch(), compute_kernel_config, tt::tt_metal::MathFidelity::HiFi4));
 
     if (error_if_nonfinite) {
-        const auto fp32_total_norm =
-            cast_vec<float>(tt::tt_metal::host_buffer::get_as<bfloat16>(output_total_norm.cpu())).at(0);
+        const auto fp32_total_norm = cast_vec<float>(host_buffer::get_as<bfloat16>(output_total_norm.cpu())).at(0);
         TT_FATAL(
             std::isfinite(fp32_total_norm),
             "The total norm of order {} for gradients from `parameters` is non-finite, so it cannot be "

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
@@ -341,10 +341,7 @@ void validate_input_with_dim(const Tensor& input, const int64_t& dim) {
     const auto& input_shape = input.padded_shape();
     const auto input_rank = input_shape.rank();
     log_debug(LogOp, "{}:{} input_rank {}", __func__, __LINE__, input_rank);
-    TT_FATAL(
-        (dim >= 0 && dim <= tt::tt_metal::MAX_NUM_DIMENSIONS),
-        "dim must be between 0 and {}.",
-        tt::tt_metal::MAX_NUM_DIMENSIONS);
+    TT_FATAL((dim >= 0 && dim <= MAX_NUM_DIMENSIONS), "dim must be between 0 and {}.", MAX_NUM_DIMENSIONS);
     TT_FATAL((dim < input_rank), "dim must be smaller than input tensor rank {}.", input_rank);
 }
 
@@ -379,10 +376,10 @@ void validate_output_with_keepdim(const Tensor& input, const Tensor& output, con
                 output_rank);
         }
 
-        ttnn::SmallVector<uint32_t> input_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-        ttnn::SmallVector<uint32_t> output_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-        ttnn::SmallVector<uint32_t> input_dim_wo_padding(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-        ttnn::SmallVector<uint32_t> output_dim_wo_padding(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+        ttnn::SmallVector<uint32_t> input_dim(MAX_NUM_DIMENSIONS, 1);
+        ttnn::SmallVector<uint32_t> output_dim(MAX_NUM_DIMENSIONS, 1);
+        ttnn::SmallVector<uint32_t> input_dim_wo_padding(MAX_NUM_DIMENSIONS, 1);
+        ttnn::SmallVector<uint32_t> output_dim_wo_padding(MAX_NUM_DIMENSIONS, 1);
         expand_to_max_dim(input_dim, input_shape);
         expand_to_max_dim(output_dim, output_shape);
         expand_to_max_dim(input_dim_wo_padding, input_shape_wo_padding);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/moreh_linear_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/moreh_linear_backward.cpp
@@ -32,7 +32,7 @@ void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::Shape& shape) 
     }
 
     log_debug(tt::LogOp, "rank {}", rank);
-    for (auto i = 0; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
+    for (auto i = 0; i < MAX_NUM_DIMENSIONS; ++i) {
         log_debug(tt::LogOp, "dim[{}] = {}", i, dim[i]);
     }
 }
@@ -62,8 +62,8 @@ inline void moreh_linear_backward_validate(
 }
 
 ttnn::SmallVector<int64_t> find_reduce_dim(const ttnn::Shape& a_shape, const ttnn::Shape& b_shape) {
-    ttnn::SmallVector<uint32_t> a_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-    ttnn::SmallVector<uint32_t> b_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttnn::SmallVector<uint32_t> a_dim(MAX_NUM_DIMENSIONS, 1);
+    ttnn::SmallVector<uint32_t> b_dim(MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(a_dim, a_shape);
     get_tensor_dim(b_dim, b_shape);
     int32_t rank = std::max(a_shape.rank(), b_shape.rank());
@@ -85,11 +85,11 @@ bool is_same_batch_dim(const Tensor& tensor_a, const Tensor& tensor_b) {
     // check batch dims
     const auto& a_shape = tensor_a.padded_shape();
     const auto& b_shape = tensor_b.padded_shape();
-    ttnn::SmallVector<uint32_t> a_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-    ttnn::SmallVector<uint32_t> b_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttnn::SmallVector<uint32_t> a_dim(MAX_NUM_DIMENSIONS, 1);
+    ttnn::SmallVector<uint32_t> b_dim(MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(a_dim, a_shape);
     get_tensor_dim(b_dim, b_shape);
-    for (auto i = 2; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
+    for (auto i = 2; i < MAX_NUM_DIMENSIONS; ++i) {
         if (a_dim[i] != b_dim[i]) {
             log_debug(tt::LogOp, "{}:{} {} a_dim {} - b_dim {}", __func__, __LINE__, i, a_dim[i], b_dim[i]);
             return false;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.cpp
@@ -41,11 +41,11 @@ void MorehMatmulOperation::validate_inputs(
     TT_FATAL(input_k == other_k, "k must be the same. input_k {}, other_k {}", input_k, other_k);
 
     // check batch dims
-    ttnn::SmallVector<uint32_t> input_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-    ttnn::SmallVector<uint32_t> other_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttnn::SmallVector<uint32_t> input_dim(MAX_NUM_DIMENSIONS, 1);
+    ttnn::SmallVector<uint32_t> other_dim(MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(input_dim, input_shape);
     get_tensor_dim(other_dim, other_shape);
-    for (auto i = 2; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
+    for (auto i = 2; i < MAX_NUM_DIMENSIONS; ++i) {
         if (input_dim[i] != other_dim[i]) {
             TT_FATAL(
                 input_dim[i] == 1 || other_dim[i] == 1,
@@ -64,10 +64,10 @@ void MorehMatmulOperation::validate_inputs(
         TT_FATAL(input_m == output_m, "m must be the same. input_m {}, output_m {}", input_m, output_m);
         TT_FATAL(other_n == output_n, "n must be the same. other_n {}, output_n {}", other_n, output_n);
 
-        ttnn::SmallVector<uint32_t> output_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+        ttnn::SmallVector<uint32_t> output_dim(MAX_NUM_DIMENSIONS, 1);
         get_tensor_dim(output_dim, output_shape);
 
-        for (auto i = 2; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
+        for (auto i = 2; i < MAX_NUM_DIMENSIONS; ++i) {
             TT_FATAL(
                 std::max(input_dim[i], other_dim[i]) == output_dim[i],
                 "{}th max(input_dim[i], other_dim[i]) {} must be the same as output_dim[i] {}",
@@ -120,8 +120,8 @@ MorehMatmulOperation::spec_return_value_t MorehMatmulOperation::compute_output_s
     auto h_wo_padding = (transpose_input) ? (input_shape_wo_padding[-1]) : (input_shape_wo_padding[-2]);
     auto w_wo_padding = (transpose_other) ? (other_shape_wo_padding[-2]) : (other_shape_wo_padding[-1]);
 
-    ttnn::SmallVector<uint32_t> input_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-    ttnn::SmallVector<uint32_t> other_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttnn::SmallVector<uint32_t> input_dim(MAX_NUM_DIMENSIONS, 1);
+    ttnn::SmallVector<uint32_t> other_dim(MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(input_dim, input_shape);
     get_tensor_dim(other_dim, other_shape);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
@@ -26,14 +26,14 @@ void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::Shape& shape) 
     }
 
     log_debug(tt::LogOp, "rank {}", rank);
-    for (auto i = 0; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
+    for (auto i = 0; i < MAX_NUM_DIMENSIONS; ++i) {
         log_debug(tt::LogOp, "dim[{}] = {}", i, dim[i]);
     }
 }
 
 ttnn::SmallVector<int64_t> find_reduce_dim(const ttnn::Shape& a_shape, const ttnn::Shape& b_shape) {
-    ttnn::SmallVector<uint32_t> a_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-    ttnn::SmallVector<uint32_t> b_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttnn::SmallVector<uint32_t> a_dim(MAX_NUM_DIMENSIONS, 1);
+    ttnn::SmallVector<uint32_t> b_dim(MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(a_dim, a_shape);
     get_tensor_dim(b_dim, b_shape);
     int32_t rank = std::max(a_shape.rank(), b_shape.rank());
@@ -55,11 +55,11 @@ bool is_same_batch_dim(const Tensor& tensor_a, const Tensor& tensor_b) {
     // check batch dims
     const auto& a_shape = tensor_a.padded_shape();
     const auto& b_shape = tensor_b.padded_shape();
-    ttnn::SmallVector<uint32_t> a_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-    ttnn::SmallVector<uint32_t> b_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttnn::SmallVector<uint32_t> a_dim(MAX_NUM_DIMENSIONS, 1);
+    ttnn::SmallVector<uint32_t> b_dim(MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(a_dim, a_shape);
     get_tensor_dim(b_dim, b_shape);
-    for (auto i = 2; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
+    for (auto i = 2; i < MAX_NUM_DIMENSIONS; ++i) {
         if (a_dim[i] != b_dim[i]) {
             log_debug(tt::LogOp, "{}:{} {} a_dim {} - b_dim {}", __func__, __LINE__, i, a_dim[i], b_dim[i]);
             return false;
@@ -71,11 +71,11 @@ bool is_same_batch_dim(const Tensor& tensor_a, const Tensor& tensor_b) {
 
 void get_tensor_stride(ttnn::SmallVector<uint32_t>& stride, ttnn::SmallVector<uint32_t>& dim) {
     stride[0] = 1;
-    for (auto i = 1; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
+    for (auto i = 1; i < MAX_NUM_DIMENSIONS; ++i) {
         stride[i] = stride[i - 1] * dim[i - 1];
     }
 
-    for (auto i = 0; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
+    for (auto i = 0; i < MAX_NUM_DIMENSIONS; ++i) {
         log_debug(tt::LogOp, "stride[{}] = {}", i, stride[i]);
     }
 }
@@ -87,7 +87,7 @@ void get_not_bcast(
     ttnn::SmallVector<uint32_t>& other_dim) {
     // first 2-dims are M,K and K,N
     // TODO: refaactoring
-    for (auto i = 2; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
+    for (auto i = 2; i < MAX_NUM_DIMENSIONS; ++i) {
         if (input_dim[i] == other_dim[i]) {
             input_not_bcast[i] = 1;
             other_not_bcast[i] = 1;
@@ -102,7 +102,7 @@ void get_not_bcast(
         }
     }
 
-    for (auto i = 0; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
+    for (auto i = 0; i < MAX_NUM_DIMENSIONS; ++i) {
         log_debug(tt::LogOp, "not bcast [{}] input {} other {}", i, input_not_bcast[i], other_not_bcast[i]);
     }
 }
@@ -140,37 +140,37 @@ MorehMatmulOperation::MultiCoreProgramFactory::cached_program_t MorehMatmulOpera
     const auto& input_shape = input.padded_shape();
     const auto& input_shape_wo_padding = input.logical_shape();
     log_debug(tt::LogOp, "input dim");
-    ttnn::SmallVector<uint32_t> input_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttnn::SmallVector<uint32_t> input_dim(MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(input_dim, input_shape);
 
     log_debug(tt::LogOp, "input stride");
-    ttnn::SmallVector<uint32_t> input_stride(tt::tt_metal::MAX_NUM_DIMENSIONS);
+    ttnn::SmallVector<uint32_t> input_stride(MAX_NUM_DIMENSIONS);
     get_tensor_stride(input_stride, input_dim);
 
     // other tensor
     const auto& other_shape = other.padded_shape();
     const auto& other_shape_wo_padding = other.logical_shape();
     log_debug(tt::LogOp, "other dim");
-    ttnn::SmallVector<uint32_t> other_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttnn::SmallVector<uint32_t> other_dim(MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(other_dim, other_shape);
 
     log_debug(tt::LogOp, "other stride");
-    ttnn::SmallVector<uint32_t> other_stride(tt::tt_metal::MAX_NUM_DIMENSIONS);
+    ttnn::SmallVector<uint32_t> other_stride(MAX_NUM_DIMENSIONS);
     get_tensor_stride(other_stride, other_dim);
 
     log_debug(tt::LogOp, "not bcast");
-    ttnn::SmallVector<uint32_t> input_not_bcast(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-    ttnn::SmallVector<uint32_t> other_not_bcast(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttnn::SmallVector<uint32_t> input_not_bcast(MAX_NUM_DIMENSIONS, 1);
+    ttnn::SmallVector<uint32_t> other_not_bcast(MAX_NUM_DIMENSIONS, 1);
     get_not_bcast(input_not_bcast, input_dim, other_not_bcast, other_dim);
 
     // output tensor
     const auto& output_shape = output.padded_shape();
     log_debug(tt::LogOp, "output dim");
-    ttnn::SmallVector<uint32_t> output_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    ttnn::SmallVector<uint32_t> output_dim(MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(output_dim, output_shape);
 
     log_debug(tt::LogOp, "output stride");
-    ttnn::SmallVector<uint32_t> output_stride(tt::tt_metal::MAX_NUM_DIMENSIONS);
+    ttnn::SmallVector<uint32_t> output_stride(MAX_NUM_DIMENSIONS);
     get_tensor_stride(output_stride, output_dim);
 
     // matrix shape

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
@@ -31,7 +31,10 @@ void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::Shape& shape) 
 }
 
 ttnn::Shape get_output_grad_shape(
-    const Tensor& output_grad, const Tensor& input_grad, const ttnn::SmallVector<int64_t>& dims, const bool& keepdim) {
+    const ttnn::Tensor& output_grad,
+    const ttnn::Tensor& input_grad,
+    const ttnn::SmallVector<int64_t>& dims,
+    const bool& keepdim) {
     if (keepdim) {
         return output_grad.logical_shape();
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.cpp
@@ -23,10 +23,7 @@ std::tuple<uint32_t, float, bool> get_floored_p_and_decimal_and_p_is_negative(fl
 
 inline void validate_input_tensor_with_dim(const Tensor& input, int64_t dim) {
     const auto input_rank = input.logical_shape().rank();
-    TT_FATAL(
-        (dim >= 0 && dim <= tt::tt_metal::MAX_NUM_DIMENSIONS),
-        "dim must be between 0 and {}.",
-        tt::tt_metal::MAX_NUM_DIMENSIONS);
+    TT_FATAL((dim >= 0 && dim <= MAX_NUM_DIMENSIONS), "dim must be between 0 and {}.", MAX_NUM_DIMENSIONS);
     TT_FATAL((dim < input_rank), "dim must be smaller than input tensor rank {}.", input_rank);
 }
 
@@ -49,10 +46,10 @@ inline void validate_output_tensor_with_keepdim(const Tensor& input, const Tenso
         adjusted_input_shape[dim] = (is_tile_dim) ? tt::constants::TILE_HEIGHT : 1;
         adjusted_input_shape_wo_padding[dim] = 1;
 
-        ttnn::SmallVector<uint32_t> input_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-        ttnn::SmallVector<uint32_t> output_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-        ttnn::SmallVector<uint32_t> input_dim_wo_padding(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-        ttnn::SmallVector<uint32_t> output_dim_wo_padding(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+        ttnn::SmallVector<uint32_t> input_dim(MAX_NUM_DIMENSIONS, 1);
+        ttnn::SmallVector<uint32_t> output_dim(MAX_NUM_DIMENSIONS, 1);
+        ttnn::SmallVector<uint32_t> input_dim_wo_padding(MAX_NUM_DIMENSIONS, 1);
+        ttnn::SmallVector<uint32_t> output_dim_wo_padding(MAX_NUM_DIMENSIONS, 1);
 
         expand_to_max_dim(input_dim, adjusted_input_shape);
         expand_to_max_dim(output_dim, output_shape);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -16,7 +16,7 @@ namespace CMAKE_UNIQUE_NAMESPACE {
 
 using namespace ttnn::operations::normalization;
 
-std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> extract_shape_dims(const tt::tt_metal::Tensor& x) {
+std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> extract_shape_dims(const ttnn::Tensor& x) {
     const auto& shape = x.padded_shape();
     const auto& tile = x.tensor_spec().tile();
     return {shape[-4], shape[-3], shape[-2] / tile.get_height(), shape[-1] / tile.get_width()};

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.hpp
@@ -7,15 +7,15 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include <optional>
 
-namespace tt::tt_metal {
+namespace ttnn {
 class Tensor;
-};
+}
 
 namespace ttnn::operations::normalization::batch_norm::utils {
 
 // resolve an optional compute kernel config or compute
 // a default based on input tensor's data type
 DeviceComputeKernelConfig resolve_compute_kernel_config(
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config, const tt::tt_metal::Tensor& input);
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config, const Tensor& input);
 
 }  // namespace ttnn::operations::normalization::batch_norm::utils

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -16,7 +16,7 @@ namespace CMAKE_UNIQUE_NAMESPACE {
 
 using namespace ttnn::operations::normalization;
 
-std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> extract_shape_dims(const tt::tt_metal::Tensor& x) {
+std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> extract_shape_dims(const ttnn::Tensor& x) {
     const auto& shape = x.padded_shape();
     const auto& tile = x.tensor_spec().tile();
     return {shape[-4], shape[-3], shape[-2] / tile.get_height(), shape[-1] / tile.get_width()};

--- a/ttnn/cpp/ttnn/operations/normalization/shard_spec_validation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/shard_spec_validation.hpp
@@ -30,8 +30,6 @@ namespace ttnn::operations::normalization::detail {
 // known to support shard widths that are not a multiple of the tile width
 // (currently: groupnorm).
 void validate_sharded_input(
-    const tt::tt_metal::Tensor& tensor,
-    const CoreCoord& program_grid_size,
-    bool require_shard_width_tile_aligned = true);
+    const Tensor& tensor, const CoreCoord& program_grid_size, bool require_shard_width_tile_aligned = true);
 
 }  // namespace ttnn::operations::normalization::detail

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -291,7 +291,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     bool config_tensor_in_dram) {
     distributed::MeshDevice* device = input.device();
 
-    const tt::tt_metal::DeviceStorage& reader_indices_storage = reader_indices.device_storage();
+    const DeviceStorage& reader_indices_storage = reader_indices.device_storage();
     const bool is_block_sharded = input.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
     const bool is_width_sharded = input.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
 
@@ -627,7 +627,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
      * Reader Kernel: input rows -> input cb
      */
     tt::tt_metal::CBHandle config_cb;
-    tt::tt_metal::DeviceStorage scalar_config_storage;
+    DeviceStorage scalar_config_storage;
     uint32_t config_cb_id = INVALID_CB_ID;
     Tensor config_tensor;
     if (!one_scalar_per_core) {

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
@@ -67,8 +67,8 @@ struct Pool2D {
             tt::tt_metal::CBHandle intra_kernel_down_left_wrap_inc_cb{};
             tt::tt_metal::CBHandle compute_tmp_idx_cb{};
             uint32_t ncores{};
-            tt::tt_metal::DeviceStorage reader_indices_storage;
-            tt::tt_metal::DeviceStorage scalar_config_storage;
+            DeviceStorage reader_indices_storage;
+            DeviceStorage scalar_config_storage;
         };
 
         using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.cpp
@@ -10,8 +10,8 @@
 namespace tt::tt_metal {
 
 template <PoolType pool>
-Tensor pool_2d(
-    const Tensor& input, const MemoryConfig& memory_config, const std::optional<DataType>& /*output_dtype*/) {
+ttnn::Tensor pool_2d(
+    const ttnn::Tensor& input, const MemoryConfig& memory_config, const std::optional<DataType>& /*output_dtype*/) {
     TT_FATAL(input.storage_type() == StorageType::DEVICE, "Input tensor needs to be on device");
     const auto& input_shape = input.padded_shape();
     switch (pool) {
@@ -24,8 +24,8 @@ Tensor pool_2d(
     }
 }
 
-Tensor global_avg_pool2d(
-    const Tensor& input, const MemoryConfig& memory_config, const std::optional<DataType>& output_dtype) {
+ttnn::Tensor global_avg_pool2d(
+    const ttnn::Tensor& input, const MemoryConfig& memory_config, const std::optional<DataType>& output_dtype) {
     TT_FATAL(input.storage_type() == StorageType::DEVICE, "Input tensor needs to be on device");
 
     // Handle different tensor ranks: 2D [H,W], 3D [H,W,C], or 4D [N,H,W,C]
@@ -33,7 +33,7 @@ Tensor global_avg_pool2d(
     auto logical_shape = input.logical_shape();
     uint32_t rank = in_shape.rank();
 
-    Tensor input_4d = input;
+    ttnn::Tensor input_4d = input;
 
     // Reshape to 4D if needed
     if (rank == 3) {

--- a/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.cpp
@@ -12,7 +12,7 @@ namespace tt::tt_metal {
 template <PoolType pool>
 ttnn::Tensor pool_2d(
     const ttnn::Tensor& input, const MemoryConfig& memory_config, const std::optional<DataType>& /*output_dtype*/) {
-    TT_FATAL(input.storage_type() == StorageType::DEVICE, "Input tensor needs to be on device");
+    TT_FATAL(input.storage_type() == ttnn::StorageType::DEVICE, "Input tensor needs to be on device");
     const auto& input_shape = input.padded_shape();
     switch (pool) {
         case PoolType::AVG: {
@@ -26,7 +26,7 @@ ttnn::Tensor pool_2d(
 
 ttnn::Tensor global_avg_pool2d(
     const ttnn::Tensor& input, const MemoryConfig& memory_config, const std::optional<DataType>& output_dtype) {
-    TT_FATAL(input.storage_type() == StorageType::DEVICE, "Input tensor needs to be on device");
+    TT_FATAL(input.storage_type() == ttnn::StorageType::DEVICE, "Input tensor needs to be on device");
 
     // Handle different tensor ranks: 2D [H,W], 3D [H,W,C], or 4D [N,H,W,C]
     auto in_shape = input.padded_shape();

--- a/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.hpp
@@ -12,8 +12,8 @@ namespace tt::tt_metal {
 
 enum class PoolType { AVG };
 
-Tensor global_avg_pool2d(
-    const Tensor& input,
+ttnn::Tensor global_avg_pool2d(
+    const ttnn::Tensor& input,
     const MemoryConfig& memory_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
     const std::optional<DataType>& output_dtype = std::nullopt);
 
@@ -28,8 +28,8 @@ namespace operations::pool {
 
 Tensor global_avg_pool2d(
     const Tensor& input,
-    const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
-    const std::optional<DataType>& output_dtype = std::nullopt);
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config_arg = std::nullopt,
+    const std::optional<tt::tt_metal::DataType>& output_dtype = std::nullopt);
 
 }  // namespace operations::pool
 

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_prepare_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_prepare_grid.cpp
@@ -30,7 +30,7 @@ tt::tt_metal::HostBuffer create_host_buffer_for_grid_preprocessing(
     const std::string& mode,
     bool align_corners,
     const std::vector<uint32_t>& tensor_input_shape) {
-    auto input_buffer = tt::tt_metal::host_buffer::get_as<InputType>(input_tensor);
+    auto input_buffer = host_buffer::get_as<InputType>(input_tensor);
     std::vector<OutputType> output_buffer(output_shape.volume());
 
     // Extract dimensions

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation.cpp
@@ -47,7 +47,7 @@ UpsampleOperation::program_factory_t UpsampleOperation::select_program_factory(
 
 void UpsampleOperation::validate_on_program_cache_miss(const operation_attributes_t& args, const Tensor& input) {
     // Basic tensor validation
-    TT_FATAL(input.storage_type() == tt::tt_metal::StorageType::DEVICE, "Input tensor must be on device");
+    TT_FATAL(input.storage_type() == StorageType::DEVICE, "Input tensor must be on device");
     TT_FATAL(input.buffer() != nullptr, "Input tensor must have allocated buffer");
 
     // Scale factor validation

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_sharded.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_sharded.hpp
@@ -14,7 +14,7 @@ struct UpsampleMultiCoreShardedProgramFactory {
         tt::tt_metal::CBHandle cb_src0{};
         tt::tt_metal::CBHandle out_cb{};
         tt::tt_metal::CBHandle config_cb{};
-        tt::tt_metal::DeviceStorage config_storage;
+        DeviceStorage config_storage;
         tt::tt_metal::Buffer* config_buffer = nullptr;
     };
 

--- a/ttnn/cpp/ttnn/operations/pool/upsample/upsample.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/upsample.cpp
@@ -50,7 +50,7 @@ static std::pair<Tensor, sliding_window::SlidingWindowConfig> apply_bilinear_hal
     const tt::tt_metal::Shape new_shape({1, 1, input_shape[0] * input_shape[1] * input_shape[2], input_shape[3]});
     ttnn::Tensor input_tensor_reshaped = ttnn::reshape(input_tensor, new_shape);
 
-    tt::tt_metal::Tensor haloed_tensor = ttnn::halo(
+    Tensor haloed_tensor = ttnn::halo(
         input_tensor_reshaped,
         sliding_window_config,
         compute_kernel_config,
@@ -134,9 +134,9 @@ ttnn::Tensor upsample(
         // Apply halo preprocessing (requires integer scales)
         int scale_h_int = static_cast<int>(scale_h);
         int scale_w_int = static_cast<int>(scale_w);
-        std::pair<tt::tt_metal::Tensor, sliding_window::SlidingWindowConfig> halo_result =
+        std::pair<Tensor, sliding_window::SlidingWindowConfig> halo_result =
             apply_bilinear_halo_preprocessing(input_for_halo, scale_h_int, scale_w_int, config);
-        tt::tt_metal::Tensor haloed_tensor = halo_result.first;
+        Tensor haloed_tensor = halo_result.first;
         sliding_window::SlidingWindowConfig sliding_window_config = halo_result.second;
 
         // Pass the HALOED tensor to upsample for bilinear mode

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
@@ -73,7 +73,7 @@ Tensor postprocess_output_tensor(
 }
 
 void validate_output_tensor(const Tensor& input_tensor, const Tensor& output_tensor) {
-    TT_FATAL(tt::tt_metal::is_device_tensor(output_tensor), "Preallocated output tensor must be on device");
+    TT_FATAL(is_device_tensor(output_tensor), "Preallocated output tensor must be on device");
     TT_FATAL(
         input_tensor.logical_shape() == output_tensor.logical_shape(),
         "Shape mismatch: input tensor shape {} does not match output tensor shape {}.",

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
@@ -73,7 +73,7 @@ Tensor postprocess_output_tensor(
 }
 
 void validate_output_tensor(const Tensor& input_tensor, const Tensor& output_tensor) {
-    TT_FATAL(is_device_tensor(output_tensor), "Preallocated output tensor must be on device");
+    TT_FATAL(tt::tt_metal::is_device_tensor(output_tensor), "Preallocated output tensor must be on device");
     TT_FATAL(
         input_tensor.logical_shape() == output_tensor.logical_shape(),
         "Shape mismatch: input tensor shape {} does not match output tensor shape {}.",

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.cpp
@@ -57,9 +57,9 @@ Tensor argmax(
     std::optional<Tensor> optional_output_tensor) {
     auto output_memory_config = memory_config.value_or(input_tensor.memory_config());
 
-    TT_FATAL(tt::tt_metal::is_device_tensor(input_tensor), "Input tensor must be on device");
+    TT_FATAL(is_device_tensor(input_tensor), "Input tensor must be on device");
     TT_FATAL(
-        !optional_output_tensor.has_value() || tt::tt_metal::is_device_tensor(optional_output_tensor.value()),
+        !optional_output_tensor.has_value() || is_device_tensor(optional_output_tensor.value()),
         "Preallocated output tensor must be on device");
 
     if (input_tensor.logical_volume() == 0) [[unlikely]] {

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.cpp
@@ -42,7 +42,7 @@ static Tensor zero_volume_argmax(
     // here because the tensor is 0-volume (i.e., it has no elements).
     auto host_buffer = tt::tt_metal::tensor_impl::allocate_host_buffer(tensor_spec);
     Tensor host_tensor(std::move(host_buffer), output_shape, tensor_spec.data_type(), tensor_spec.layout());
-    copy_to_device(host_tensor, preallocated_tensor);
+    tt::tt_metal::copy_to_device(host_tensor, preallocated_tensor);
 
     return preallocated_tensor;
 }
@@ -57,9 +57,9 @@ Tensor argmax(
     std::optional<Tensor> optional_output_tensor) {
     auto output_memory_config = memory_config.value_or(input_tensor.memory_config());
 
-    TT_FATAL(is_device_tensor(input_tensor), "Input tensor must be on device");
+    TT_FATAL(tt::tt_metal::is_device_tensor(input_tensor), "Input tensor must be on device");
     TT_FATAL(
-        !optional_output_tensor.has_value() || is_device_tensor(optional_output_tensor.value()),
+        !optional_output_tensor.has_value() || tt::tt_metal::is_device_tensor(optional_output_tensor.value()),
         "Preallocated output tensor must be on device");
 
     if (input_tensor.logical_volume() == 0) [[unlikely]] {
@@ -97,7 +97,7 @@ Tensor argmax(
             preallocated_spec.physical_shape().height() * preallocated_spec.physical_shape().width(), 0);
         Tensor host_indices(
             tt::tt_metal::HostBuffer(std::move(result_vec)), input_shape, DataType::UINT32, preallocated_spec.layout());
-        copy_to_device(host_indices, preallocated_tensor);
+        tt::tt_metal::copy_to_device(host_indices, preallocated_tensor);
 
         return preallocated_tensor;
     }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp
@@ -12,7 +12,7 @@
 
 namespace ttnn::prim {
 tt::tt_metal::ReduceOpParallelizationStrategy get_parallelization_strategy(
-    const tt::tt_metal::Tensor& input_tensor, tt::tt_metal::ReduceOpDim reduce_dim) {
+    const Tensor& input_tensor, tt::tt_metal::ReduceOpDim reduce_dim) {
     uint32_t num_tiles = input_tensor.physical_volume() / input_tensor.tensor_spec().tile().get_tile_hw();
     if (reduce_dim == tt::tt_metal::ReduceOpDim::H) {
         return tt::tt_metal::ReduceOpParallelizationStrategy::MULTI_CORE_H;
@@ -133,7 +133,7 @@ void validate_reduce_sharded_buffer_types(
 }
 
 bool h_reduce_negate_fits_in_l1(
-    const tt::tt_metal::Tensor& input_tensor, const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids) {
+    const Tensor& input_tensor, const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids) {
     using namespace tt::tt_metal;
 
     const auto& shape = input_tensor.padded_shape();

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
@@ -22,7 +22,7 @@ enum class ReduceOpParallelizationStrategy { MULTI_CORE_H, MULTI_CORE_W, MULTI_C
 namespace ttnn::prim {
 
 tt::tt_metal::ReduceOpParallelizationStrategy get_parallelization_strategy(
-    const tt::tt_metal::Tensor& input_tensors, tt::tt_metal::ReduceOpDim reduce_dim);
+    const Tensor& input_tensors, tt::tt_metal::ReduceOpDim reduce_dim);
 
 // Returns true if the fused-negate H reduce path's CBs fit in available L1.
 // The reduce_h_neg compute kernel pushes ntiles tiles per inner-loop iteration;
@@ -31,7 +31,7 @@ tt::tt_metal::ReduceOpParallelizationStrategy get_parallelization_strategy(
 // tiles.  For wide reductions this can exceed L1, in which case callers must
 // fall back to external negation around a non-fused (regular) reduce.
 bool h_reduce_negate_fits_in_l1(
-    const tt::tt_metal::Tensor& input_tensor, const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids);
+    const Tensor& input_tensor, const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids);
 
 // Builds a tilized TensorSpec for a reduction-style op output, given the
 // already shape-adjusted output shape and the dimension that was reduced.

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -49,8 +49,7 @@ Tensor reduce_min(
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt) {
     Tensor input = input_tensor;
-    if (input.layout() == tt::tt_metal::Layout::ROW_MAJOR &&
-        input.storage_type() == tt::tt_metal::StorageType::DEVICE) {
+    if (input.layout() == tt::tt_metal::Layout::ROW_MAJOR && input.storage_type() == StorageType::DEVICE) {
         // Changing layout to TILE with +inf padding
         auto pad_shape = ttnn::operations::data_movement::pad_to_tile_shape(input.padded_shape());
         input = ttnn::tilize_with_val_padding(
@@ -92,7 +91,7 @@ Tensor reduce(
     auto is_multicore_hw = parallelization_strategy == tt::tt_metal::ReduceOpParallelizationStrategy::MULTI_CORE_HW;
     float pad_value = reduce_math == tt::tt_metal::ReduceOpMath::MAX ? -std::numeric_limits<float>::infinity() : 0;
 
-    TT_FATAL(input_tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "Expected input tensor to be on device");
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Expected input tensor to be on device");
     TT_FATAL(
         input_tensor.device() != nullptr,
         "input_tensor.device() == nullptr, No device found, move input_tensor to device");

--- a/ttnn/cpp/ttnn/operations/reduction/moe/moe.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/moe.cpp
@@ -37,7 +37,7 @@ Tensor moe(
         }
 
         const Tensor& preallocated_tensor = output_tensor.value();
-        TT_FATAL(tt::tt_metal::is_device_tensor(preallocated_tensor), "Preallocated output tensor must be on device");
+        TT_FATAL(is_device_tensor(preallocated_tensor), "Preallocated output tensor must be on device");
 
         TT_FATAL(
             preallocated_tensor.logical_shape() == desired_output_shape,

--- a/ttnn/cpp/ttnn/operations/reduction/moe/moe.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/moe.cpp
@@ -37,7 +37,7 @@ Tensor moe(
         }
 
         const Tensor& preallocated_tensor = output_tensor.value();
-        TT_FATAL(is_device_tensor(preallocated_tensor), "Preallocated output tensor must be on device");
+        TT_FATAL(tt::tt_metal::is_device_tensor(preallocated_tensor), "Preallocated output tensor must be on device");
 
         TT_FATAL(
             preallocated_tensor.logical_shape() == desired_output_shape,

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.cpp
@@ -11,7 +11,7 @@ void ProdAllDeviceOperation::validate_on_program_cache_miss(
     const auto& input = tensor_args.input;
 
     TT_FATAL(
-        input.storage_type() == tt::tt_metal::StorageType::DEVICE,
+        input.storage_type() == StorageType::DEVICE,
         "Operands need to be on device! Got storage type: {}",
         input.storage_type());
     TT_FATAL(input.buffer() != nullptr, "Operands need to be allocated in buffers on device!");

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
@@ -22,7 +22,7 @@ ttnn::Shape compute_output_shape(const ttnn::Shape& input_shape, int64_t dim) {
 ttnn::Tensor create_output_tensor(
     const ttnn::Tensor& input_tensor, const ttnn::Shape& output_shape, const MemoryConfig& mem_config) {
     TT_FATAL(
-        input_tensor.storage_type() == tt_metal::StorageType::DEVICE,
+        input_tensor.storage_type() == ttnn::StorageType::DEVICE,
         "Input tensor must be stored on device. Storage type: {}",
         input_tensor.storage_type());
     return create_device_tensor(

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
@@ -19,8 +19,8 @@ ttnn::Shape compute_output_shape(const ttnn::Shape& input_shape, int64_t dim) {
     return output_shape;
 }
 
-Tensor create_output_tensor(
-    const Tensor& input_tensor, const ttnn::Shape& output_shape, const MemoryConfig& mem_config) {
+ttnn::Tensor create_output_tensor(
+    const ttnn::Tensor& input_tensor, const ttnn::Shape& output_shape, const MemoryConfig& mem_config) {
     TT_FATAL(
         input_tensor.storage_type() == tt_metal::StorageType::DEVICE,
         "Input tensor must be stored on device. Storage type: {}",
@@ -33,13 +33,13 @@ Tensor create_output_tensor(
 }
 
 // output as arg
-Tensor prod_(const Tensor& input, const Tensor& output, const int64_t& dim) {
+ttnn::Tensor prod_(const ttnn::Tensor& input, const ttnn::Tensor& output, const int64_t& dim) {
     ttnn::prim::prod_nc(input, output, dim);
     return output;
 }
 
 // output creation inside
-Tensor prod_(const Tensor& input, const int64_t& dim, const MemoryConfig& mem_config) {
+ttnn::Tensor prod_(const ttnn::Tensor& input, const int64_t& dim, const MemoryConfig& mem_config) {
     const auto& input_shape = input.padded_shape();
     auto output_shape = compute_output_shape(input_shape, dim);
     auto output = create_output_tensor(input, output_shape, mem_config);
@@ -50,9 +50,9 @@ Tensor prod_(const Tensor& input, const int64_t& dim, const MemoryConfig& mem_co
 
 }  // namespace
 
-Tensor prod_nc(
-    const Tensor& input,
-    const Tensor& output,
+ttnn::Tensor prod_nc(
+    const ttnn::Tensor& input,
+    const ttnn::Tensor& output,
     ttnn::SmallVector<int64_t>& dims,
     const MemoryConfig& output_mem_config) {
     TT_FATAL(!dims.empty(), "prod_nc dims should not be empty");

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.hpp
@@ -14,9 +14,9 @@ namespace tt::operations::primary {
 
 using namespace tt_metal;
 
-Tensor prod_nc(
-    const Tensor& input,
-    const Tensor& output,
+ttnn::Tensor prod_nc(
+    const ttnn::Tensor& input,
+    const ttnn::Tensor& output,
     ttnn::SmallVector<int64_t>& dims,
     const MemoryConfig& output_mem_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -8,8 +8,8 @@
 
 namespace tt::operations::primary {
 
-tt::tt_metal::Tensor prod_all(const tt::tt_metal::Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config) {
-    tt::tt_metal::Tensor result = ttnn::prim::prod_all(input, output_mem_config);
+ttnn::Tensor prod_all(const ttnn::Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config) {
+    ttnn::Tensor result = ttnn::prim::prod_all(input, output_mem_config);
     return ttnn::prod_result_computation_WH_B0<bfloat16>(
         result, result.dtype(), result.layout(), result.device(), output_mem_config);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.hpp
@@ -8,8 +8,8 @@
 
 namespace tt::operations::primary {
 
-tt::tt_metal::Tensor prod_all(
-    const tt::tt_metal::Tensor& input,
+ttnn::Tensor prod_all(
+    const ttnn::Tensor& input,
     const tt::tt_metal::MemoryConfig& mem_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 }  // namespace tt::operations::primary

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -198,7 +198,7 @@ std::vector<Tensor> topk(
     // Store original shape for final output validation
     const ttnn::Shape& original_lshape = input_tensor.logical_shape();
 
-    TT_FATAL(is_device_tensor(input_tensor), "Input tensor must be on device");
+    TT_FATAL(tt::tt_metal::is_device_tensor(input_tensor), "Input tensor must be on device");
 
     // Analyze input tensor properties to determine required transformations
     std::size_t rank_st = input_tensor.logical_shape().rank();
@@ -231,8 +231,11 @@ std::vector<Tensor> topk(
     if (preallocated_output_tensors.has_value()) {
         const Tensor& preallocated_values = std::get<0>(preallocated_output_tensors.value());
         const Tensor& preallocated_indices = std::get<1>(preallocated_output_tensors.value());
-        TT_FATAL(is_device_tensor(preallocated_values), "Preallocated output values tensor must be on device");
-        TT_FATAL(is_device_tensor(preallocated_indices), "Preallocated output indices tensor must be on device");
+        TT_FATAL(
+            tt::tt_metal::is_device_tensor(preallocated_values), "Preallocated output values tensor must be on device");
+        TT_FATAL(
+            tt::tt_metal::is_device_tensor(preallocated_indices),
+            "Preallocated output indices tensor must be on device");
 
         TT_FATAL(
             preallocated_values.logical_shape() == desired_final_shape,
@@ -282,7 +285,7 @@ std::vector<Tensor> topk(
             std::vector<uint16_t>(indices_spec.physical_shape().height() * indices_spec.physical_shape().width(), 0);
         Tensor host_indices(
             tt::tt_metal::HostBuffer(std::move(indices_vec)), desired_final_shape, DataType::UINT16, indices.layout());
-        copy_to_device(host_indices, indices);
+        tt::tt_metal::copy_to_device(host_indices, indices);
 
         return {values, indices};
     }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -198,7 +198,7 @@ std::vector<Tensor> topk(
     // Store original shape for final output validation
     const ttnn::Shape& original_lshape = input_tensor.logical_shape();
 
-    TT_FATAL(tt::tt_metal::is_device_tensor(input_tensor), "Input tensor must be on device");
+    TT_FATAL(is_device_tensor(input_tensor), "Input tensor must be on device");
 
     // Analyze input tensor properties to determine required transformations
     std::size_t rank_st = input_tensor.logical_shape().rank();
@@ -231,11 +231,8 @@ std::vector<Tensor> topk(
     if (preallocated_output_tensors.has_value()) {
         const Tensor& preallocated_values = std::get<0>(preallocated_output_tensors.value());
         const Tensor& preallocated_indices = std::get<1>(preallocated_output_tensors.value());
-        TT_FATAL(
-            tt::tt_metal::is_device_tensor(preallocated_values), "Preallocated output values tensor must be on device");
-        TT_FATAL(
-            tt::tt_metal::is_device_tensor(preallocated_indices),
-            "Preallocated output indices tensor must be on device");
+        TT_FATAL(is_device_tensor(preallocated_values), "Preallocated output values tensor must be on device");
+        TT_FATAL(is_device_tensor(preallocated_indices), "Preallocated output indices tensor must be on device");
 
         TT_FATAL(
             preallocated_values.logical_shape() == desired_final_shape,

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.hpp
@@ -17,10 +17,10 @@ struct UntilizeWithHaloProgramFactory {
         tt::tt_metal::CBHandle padding_config_cb1{};
         tt::tt_metal::CBHandle gather_config_cb0{};
         tt::tt_metal::CBHandle gather_config_cb1{};
-        tt::tt_metal::DeviceStorage padding_config_storage0;
-        tt::tt_metal::DeviceStorage padding_config_storage1;
-        tt::tt_metal::DeviceStorage gather_config_storage0;
-        tt::tt_metal::DeviceStorage gather_config_storage1;
+        DeviceStorage padding_config_storage0;
+        DeviceStorage padding_config_storage1;
+        DeviceStorage gather_config_storage0;
+        DeviceStorage gather_config_storage1;
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.cpp
@@ -72,7 +72,7 @@ std::tuple<Tensor, Tensor, Tensor> split_query_key_value_and_split_heads(
         static_cast<int>(input_tensor.layout()));
 
     TT_FATAL(
-        input_tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+        input_tensor.storage_type() == StorageType::DEVICE,
         "Invalid storage type: input tensor must be on a device, but found {}.",
         static_cast<int>(input_tensor.storage_type()));
 


### PR DESCRIPTION
### PR Category
Cleanup

### Summary

Part of #43663 .

This PR moves most of the `ttnn` Tensor infrastructure from the `tt::tt_metal` namespace to the `ttnn` namespace, and updates all use sites accordingly. The following headers have been migrated:

- `tensor.hpp` — `Tensor`
- `storage.hpp` — `HostStorage`, `DeviceStorage`, `Storage`
- `types.hpp` — `StorageType`, `Array1D`–`Array8D`, `PyDType`
- `tensor_utils.hpp` — `is_cpu_tensor`, `is_device_tensor`, `get_cb_address`, `get_optimal_worker_cores_for_sharded_tensor`
- `tensor_attributes.hpp` — `TensorAttributes`
- `serialization.hpp` — `dump_tensor_flatbuffer`, `load_tensor_flatbuffer`
- `overlapped_tensor.hpp` — `OverlappedTensorView`, `dump_overlapped_tensors`
- `host_buffer/functions.hpp` — `host_buffer::get_host_buffer`, `host_buffer::get_as<T>`
- `unit_mesh_utils.hpp` — `experimental::unit_mesh::aggregate`, `experimental::unit_mesh::disaggregate`
- `tensor_impl.hpp` — `tensor_impl::view`, `tensor_impl::to_string`, `tensor_impl::extract_shard`, `TensorPrintProfile`, `SciMode`
- xtensor utils — `experimental::xtensor::concat`, `chunk`, `to_xtensor`, `from_xtensor`, `XtensorAdapter`

`tensor_apis.hpp` is intentionally excluded — its free functions (e.g. `to_layout`, `pad`, `unpad`) have name collisions with existing `ttnn::` symbols and require a more careful migration. Left for a follow-up.

A compatibility bridge of type aliases and inline function directions are put in with a deprecation message and suggested removal time line (1-2 month).

### Notes for reviewers

This is a pure refactoring PR — no semantic changes are introduced.

The "real" changes are all residing in `ttnn/api/ttnn/tensor`, all diffs in other paths are simply use-site updates.

While this is one of the cleanup steps of the Metal Tensor Project, this is **not**:
1. The tensor lowering project. The tensor lowering project is currently in the cleanup stage; we no longer migrate `ttnn::Tensor` to `tt_metal` wholesale, but instead made `ttnn::Tensor` a wrapper around new Metal Tensors (`tt_metal::HostTensor` and `tt_metal::MeshTensor`).
2. Replacing usage of current `ttnn::Tensor` with metal tensor. That migration is out of scope for this PR and is tracked by https://github.com/tenstorrent/tt-metal/issues/43669 .

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/tensor-namespace)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/tensor-namespace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/tensor-namespace)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/tensor-namespace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/tensor-namespace)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/tensor-namespace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/tensor-namespace)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/tensor-namespace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/tensor-namespace)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/tensor-namespace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/tensor-namespace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/tensor-namespace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/tensor-namespace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/tensor-namespace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/tensor-namespace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/tensor-namespace)
