### PR TITLE
Removed the fatal to support batched input

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -1310,3 +1310,58 @@ def test_linear_fused_non_broadcast_bias_width_sharded_in0_in1(device, m, k, n):
         frobenius_threshold=0.001 * k,
         pcc_threshold=0.993,
     )
+
+
+@pytest.mark.parametrize(
+    "a_shape, b_shape, bias_shape",
+    [
+        ((1, 3, 128, 32), (1, 3, 32, 64), (1, 1, 1, 64)),
+        ((1, 3, 128, 32), (1, 3, 32, 32), (1, 1, 1, 32)),
+        ((1, 3, 128, 32), (1, 3, 32, 64), (1, 1, 1, 64)),
+        ((1, 3, 32, 32), (1, 3, 32, 64), (1, 1, 32, 64)),
+        ((1, 3, 32, 32), (1, 3, 32, 64), (1, 3, 32, 64)),
+        ((1, 2, 16, 64), (1, 2, 64, 64), (1, 2, 16, 64)),
+    ],
+)
+def test_linear_with_batched(a_shape, b_shape, bias_shape):
+    device = ttnn.open_device(device_id=0)
+
+    try:
+        torch.manual_seed(0)
+
+        # Create inputs
+        tensor_a_torch = torch.randn(a_shape)
+        tensor_b_torch = torch.randn(b_shape)
+        bias_torch = torch.randn(bias_shape)
+
+        # PyTorch reference
+        result_torch = torch.matmul(tensor_a_torch, tensor_b_torch) + bias_torch
+
+        # TTNN tensors
+        tensor_a_ttnn = ttnn.from_torch(tensor_a_torch, device=device)
+        tensor_b_ttnn = ttnn.from_torch(tensor_b_torch, device=device)
+        bias_ttnn = ttnn.from_torch(bias_torch, device=device)
+
+        # Convert to TILE layout
+        tensor_a_ttnn = ttnn.to_layout(tensor_a_ttnn, ttnn.Layout.TILE)
+        tensor_b_ttnn = ttnn.to_layout(tensor_b_ttnn, ttnn.Layout.TILE)
+        bias_ttnn = ttnn.to_layout(bias_ttnn, ttnn.Layout.TILE)
+
+        # Run TTNN
+        result_ttnn = ttnn.linear(
+            tensor_a_ttnn,
+            tensor_b_ttnn,
+            bias=bias_ttnn,
+        )
+
+        result_ttnn_torch = ttnn.to_torch(result_ttnn)
+        assert_numeric_metrics(
+            result_torch,
+            result_ttnn_torch,
+            atol=0.1,
+            rtol=0.1,
+            frobenius_threshold=0.002,
+            pcc_threshold=0.99,
+        )
+    finally:
+        ttnn.close_device(device)

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -110,9 +110,13 @@ static bool get_post_process_bias(
         if (detail::is_input_batched(input_tensor_b_adjusted.logical_shape())) {
             return true;
         }
+        const auto& bias_tensor = bias.value();
+        // Fused matmul+bias does not support batched bias; apply bias via add().
+        if (detail::is_input_batched(bias_tensor.logical_shape())) {
+            return true;
+        }
         // Check if bias shape is compatible with kernel fusion
         // Bias fusion requires bias_shape_aligned[-2] == tile_height
-        const auto& bias_tensor = bias.value();
         const auto& bias_padded_shape = bias_tensor.padded_shape();
         const auto& tile_shape = input_tensor_a_adjusted.tensor_spec().tile().get_tile_shape();
         uint32_t tile_height = transpose_a ? tile_shape[1] : tile_shape[0];

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -106,6 +106,10 @@ static bool get_post_process_bias(
     // MatmulMultiCoreProgramConfig doesn't support bias fusion, so we need to apply it as a post-process
     bool post_process_bias = false;
     if (bias.has_value()) {
+        // Fused matmul+bias does not support batched weights; apply bias via add().
+        if (detail::is_input_batched(input_tensor_b_adjusted.logical_shape())) {
+            return true;
+        }
         // Check if bias shape is compatible with kernel fusion
         // Bias fusion requires bias_shape_aligned[-2] == tile_height
         const auto& bias_tensor = bias.value();
@@ -361,8 +365,7 @@ Tensor linear(
     if (core_grid.has_value()) {
         user_core_coord = CoreCoord(core_grid->x, core_grid->y);
     }
-    bool b_is_batched = detail::is_input_batched(input_tensor_b.logical_shape());
-    TT_FATAL(!(b_is_batched && bias.has_value()), "Batched input not supported when bias exists (linear operation).");
+    bool user_run_batched = detail::is_input_batched(input_tensor_b.logical_shape());
 
     auto matmul_params = ttnn::prim::MatmulParams{
         program_config,
@@ -373,7 +376,7 @@ Tensor linear(
         /*untilize_out=*/false,
         user_core_coord,
         get_fused_activation(activation),
-        /*user_run_batched=*/false,
+        user_run_batched,
         transpose_a,
         transpose_b,
         output_tile,


### PR DESCRIPTION

### Ticket: #31634
### Problem description
The ttnn program crashes when ttnn.linear op has a b tensor batched and bias 

### What's changed
Removed the fatal and called matmul with user_run_batched.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/linear_bias_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/linear_bias_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/linear_bias_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/linear_bias_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/linear_bias_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/linear_bias_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/linear_bias_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/linear_bias_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/linear_bias_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/linear_bias_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/linear_bias_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/linear_bias_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/linear_bias_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/linear_bias_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/linear_bias_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/linear_bias_fix)