### PR TITLE
fix(rms_allgather): post-reduce data-format-reconfig for #43527

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -839,6 +839,7 @@ jobs:
         timeout-minutes: ${{ inputs.timeout }}
         run: pytest tests/ttnn/nightly/unit_tests/operations/data_movement -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
       - name: ttnn nightly data_movement/ccl tests group 1
+        if: ${{ !cancelled() }}
         run: pytest --timeout 300 tests/ttnn/unit_tests/operations/data_movement tests/ttnn/unit_tests/operations/ccl tests/ttnn/unit_tests/operations/point_to_point -xv --splits 3 --group 1 -m "not disable_fast_runtime_mode"
       - name: ttnn nightly data_movement/ccl tests group 2
         if: ${{ !cancelled() }}

--- a/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/rms_test.py
+++ b/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/rms_test.py
@@ -840,6 +840,7 @@ def run_rms_fuse_impl_deepseek(
     epsilon=1e-05,
     atol_threshold=None,
     rtol_threshold=None,
+    compute_kernel_config=None,
 ):
     ccl_sub_device_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(4, 7))})
     worker_sub_device = ttnn.SubDevice(
@@ -895,13 +896,20 @@ def run_rms_fuse_impl_deepseek(
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
         use_height_and_width_as_shard_shape=True,
     )
+    # cb_stats CB uses cb_data_format = Float32 when fp32_dest_acc_en=True
+    stats_dtype = (
+        ttnn.float32
+        if compute_kernel_config is not None and getattr(compute_kernel_config, "fp32_dest_acc_en", False)
+        else ttnn.bfloat16
+    )
+    stats_torch_dtype = torch.float32 if stats_dtype == ttnn.float32 else torch.bfloat16
     ag_shape = [1, 1, 32, num_devices]
-    stats_tensor = torch.ones(ag_shape, dtype=torch.bfloat16)
+    stats_tensor = torch.ones(ag_shape, dtype=stats_torch_dtype)
     tt_stats = ttnn.from_torch(
         stats_tensor,
         device=mesh_device,
         layout=ttnn.TILE_LAYOUT,
-        dtype=ttnn.bfloat16,
+        dtype=stats_dtype,
         memory_config=ag_memory_config,
         mesh_mapper=ttnn.ShardTensor2dMesh(
             mesh_device, dims=(3, None), mesh_shape=list(ttnn.MeshShape(num_devices, 1))
@@ -978,12 +986,7 @@ def run_rms_fuse_impl_deepseek(
             )
         )
     for i in range(num_iters):
-        tt_out = ttnn.fused_rms_minimal(
-            input_tensor[i],
-            layer_norm_config,
-            0,
-            mesh_device,
-            ccl_semaphore_handles[i],
+        kwargs = dict(
             topology=all_gather_topology,
             memory_config=output_memory_config,
             epsilon=epsilon,
@@ -992,6 +995,16 @@ def run_rms_fuse_impl_deepseek(
             residual_input_tensor=residual_tensor[i],
             stats=tt_stats,
             use_noc1_only=use_noc1_only,
+        )
+        if compute_kernel_config is not None:
+            kwargs["compute_kernel_config"] = compute_kernel_config
+        tt_out = ttnn.fused_rms_minimal(
+            input_tensor[i],
+            layer_norm_config,
+            0,
+            mesh_device,
+            ccl_semaphore_handles[i],
+            **kwargs,
         )
         tt_out_array.append(tt_out)
     for i in range(num_iters):

--- a/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
@@ -1014,6 +1014,7 @@ def test_rms_fuse(
         ),
     ],
 )
+@pytest.mark.parametrize("fp32_dest_acc_en", [False, True])
 @pytest.mark.parametrize("num_links", [1])
 @pytest.mark.parametrize("num_iters", [5])
 @pytest.mark.parametrize("fused_add", [True, False])
@@ -1037,6 +1038,7 @@ def test_rms_fuse_n300(
     function_level_defaults,
     input_shard_grid,
     output_shard_grid,
+    fp32_dest_acc_en,
     fused_add,
     use_noc1_only,
     input_dtype,
@@ -1048,6 +1050,18 @@ def test_rms_fuse_n300(
         pytest.skip("Not N300 - this test targets 2-chip Wormhole")
     atol_threshold = 1.0 if fused_add else 0.6
     rtol_threshold = 20.0 if fused_add else 0.1
+    # Match the op's default compute_kernel_config (init_device_compute_kernel_config in
+    # rms_allgather_device_operation.cpp) and only flip fp32_dest_acc_en.
+    compute_kernel_config = (
+        ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=True,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
+        if fp32_dest_acc_en
+        else None
+    )
     run_rms_fuse_impl_deepseek(
         mesh_device,
         num_devices,
@@ -1065,6 +1079,7 @@ def test_rms_fuse_n300(
         residual_dtype=residual_dtype,
         atol_threshold=atol_threshold,
         rtol_threshold=rtol_threshold,
+        compute_kernel_config=compute_kernel_config,
     )
 
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/compute/rms_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/compute/rms_compute.cpp
@@ -194,7 +194,7 @@ void kernel_main() {
                 PoolType::AVG,
                 ReduceDim::REDUCE_ROW,
                 compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop,
-                compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
+                compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
                 cb_stats,
                 post_cb_scaler_global,
                 cb_var,


### PR DESCRIPTION
### Summary
Fixes #43527. `DistributedRMSNorm` produced PCC ~0.87 (alternating zero / ~300x rows in the output) on N300 with `fp32_dest_acc_en=True`. Single-line kernel fix; adds an `fp32_dest_acc_en` parametrize to `test_rms_fuse_n300` so the regression is gated.

### Root cause
In `rms_compute.cpp`, the post all-gather reduce was called with `ReduceDataFormatReconfigMode::NONE`. Between this reduce and the preceding cross-core matmul reduce, `binary_op_init_common(cb_stats, post_cb_scaler_global, cb_var)` runs and reconfigures srca / srcb / pack for **eltwise binary**, invalidating the matmul state.

With `NONE`, the helper still calls `reduce_with_matmul_init` but does **not** call `reconfig_data_format(scaler_cb, input_cb)`. The matmul therefore reads operands with stale unpacker formats and writes garbage to `cb_var`.

The bug only manifests with `fp32_dest_acc_en=True` because that is when `cb_var` / `cb_stats` become `Float32` while the scaler stays `Float16_b` — the missing reconfig produces mismatched-width unpacker reads. With `fp32_dest_acc_en=False` all CBs are `Float16_b` and the stale state happens to be wrong-but-compatible, so the kernel accidentally works.

Originally introduced in `7fb82fd003d` (#41637, reduce helpers PR) — the first-stage reduce was correctly set to `INPUT`, only the second-stage was set to `NONE`.

### Fix
One-line change in `rms_compute.cpp` — `NONE` → `INPUT` for the second-stage reduce, matching the first-stage reduce. The helper then issues the missing `reconfig_data_format` and the matmul reads with correct unpacker formats.

### Test
Adds `fp32_dest_acc_en=[False, True]` parametrize to `test_rms_fuse_n300` (cross-products with `fused_add` for 4 cases on the existing 2048-elt × 32-core shard config).

- Without fix: `fp32_dest_acc_en=True` cases fail with PCC ≈ 0.87
- With fix: all 4 cases pass (PCC ≥ 0.999).

`compute_kernel_config` in the test mirrors the op's default and only flips `fp32_dest_acc_en`. `run_rms_fuse_impl_deepseek` gains a `compute_kernel_config` arg and the stats buffer dtype is now matched to `cb_data_format` so `fp32_dest_acc_en=True` does not trip the CB-config size assert.

### Why a cherry-pick of `c74e9307867`
The L2 nightly workflow was set to skip the data_movement/ccl group when prior runs failed, which would have masked this regression. Cherry-picking `c74e9307867` ("Run L2 nightly data_movement/ccl group 1 even on prior failure") onto this branch ensures the new test parametrize actually executes on the nightly runner.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sjovic/issue-43527-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sjovic/issue-43527-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sjovic/issue-43527-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sjovic/issue-43527-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sjovic/issue-43527-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sjovic/issue-43527-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sjovic/issue-43527-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sjovic/issue-43527-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sjovic/issue-43527-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sjovic/issue-43527-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sjovic/issue-43527-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sjovic/issue-43527-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sjovic/issue-43527-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sjovic/issue-43527-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sjovic/issue-43527-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sjovic/issue-43527-fix)