### PR TITLE
[Bugfix] Fix missing constant initializations in uint32-> bf16 LLK

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
@@ -7,7 +7,7 @@ import torch
 import ttnn
 
 from tests.ttnn.python_api_testing.sweep_tests.ttnn_pytorch_ops import eltwise_typecast
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, assert_equal
 
 mem_configs = [
     ttnn.DRAM_MEMORY_CONFIG,
@@ -126,7 +126,11 @@ class TestTypecast:
 
         torch_golden = eltwise_typecast(torch_input, tt_input_dtype=tt_input_dtype, tt_output_dtype=tt_output_dtype)
         pcc = 0.98 if tt_input_dtype == ttnn.bfloat4_b or tt_output_dtype == ttnn.bfloat4_b else 0.99
-        assert_with_pcc(torch_golden, torch_output, pcc=pcc)
+
+        if tt_output_dtype == ttnn.float32 or tt_output_dtype == ttnn.bfloat16:
+            assert_with_ulp(torch_golden, torch_output, ulp_threshold=1)
+        else:
+            assert_with_pcc(torch_golden, torch_output, pcc=pcc)
 
 
 @pytest.mark.parametrize("tt_output_dtype", [ttnn.uint8, ttnn.uint16, ttnn.uint32, ttnn.int32])

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
@@ -7,7 +7,7 @@ import torch
 import ttnn
 
 from tests.ttnn.python_api_testing.sweep_tests.ttnn_pytorch_ops import eltwise_typecast
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, assert_equal
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
 
 mem_configs = [
     ttnn.DRAM_MEMORY_CONFIG,
@@ -128,7 +128,7 @@ class TestTypecast:
         pcc = 0.98 if tt_input_dtype == ttnn.bfloat4_b or tt_output_dtype == ttnn.bfloat4_b else 0.99
 
         if tt_output_dtype == ttnn.float32 or tt_output_dtype == ttnn.bfloat16:
-            assert_with_ulp(torch_golden, torch_output, ulp_threshold=1)
+            assert_equal(torch_golden, torch_output)
         else:
             assert_with_pcc(torch_golden, torch_output, pcc=pcc)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
@@ -125,11 +125,11 @@ class TestTypecast:
         torch_output = ttnn.to_torch(tt_output)
 
         torch_golden = eltwise_typecast(torch_input, tt_input_dtype=tt_input_dtype, tt_output_dtype=tt_output_dtype)
-        pcc = 0.98 if tt_input_dtype == ttnn.bfloat4_b or tt_output_dtype == ttnn.bfloat4_b else 0.99
 
         if tt_output_dtype == ttnn.float32 or tt_output_dtype == ttnn.bfloat16:
             assert_equal(torch_golden, torch_output)
         else:
+            pcc = 0.98 if tt_input_dtype == ttnn.bfloat4_b or tt_output_dtype == ttnn.bfloat4_b else 0.99
             assert_with_pcc(torch_golden, torch_output, pcc=pcc)
 
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -670,6 +670,9 @@ template <bool APPROXIMATION_MODE>
 inline void _init_typecast_uint32_to_fp32_()
 {
 #ifndef DISABLE_SFPLOADMACRO
+    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
+    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
+    // preloaded with -31 -- the shift amount used to extract that bit.
     sfpi::vConstIntPrgm0 = -31;
 
     constexpr int a = p_sfpu::LREG2;
@@ -727,6 +730,9 @@ inline void _init_typecast_int32_to_fp32_()
 #ifndef DISABLE_SFPLOADMACRO
     constexpr int t = p_sfpu::LREG4;
 
+    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
+    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
+    // preloaded with -31 -- the shift amount used to extract that bit.
     sfpi::vConstIntPrgm0 = -31;
 
     // InstructionTemplate[0]
@@ -762,6 +768,9 @@ inline void _init_typecast_int32_to_fp16b_()
 #ifndef DISABLE_SFPLOADMACRO
     constexpr int t = p_sfpu::LREG4;
 
+    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
+    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
+    // preloaded with -31 -- the shift amount used to extract that bit.
     sfpi::vConstIntPrgm0 = -31;
 
     // InstructionTemplate[0]
@@ -857,6 +866,9 @@ template <bool APPROXIMATION_MODE>
 inline void _init_typecast_uint32_to_fp16b_()
 {
 #ifndef DISABLE_SFPLOADMACRO
+    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
+    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
+    // preloaded with -31 -- the shift amount used to extract that bit.
     sfpi::vConstIntPrgm0 = -31;
 
     // InstructionTemplate[0]

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -857,6 +857,8 @@ template <bool APPROXIMATION_MODE>
 inline void _init_typecast_uint32_to_fp16b_()
 {
 #ifndef DISABLE_SFPLOADMACRO
+    sfpi::vConstIntPrgm0 = -31;
+
     // InstructionTemplate[0]
     TTI_SFPCAST(0, 12, 0);
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -878,6 +878,8 @@ template <bool APPROXIMATION_MODE>
 inline void _init_typecast_uint32_to_fp16b_()
 {
 #ifndef DISABLE_SFPLOADMACRO
+    sfpi::vConstIntPrgm0 = -31;
+
     // InstructionTemplate[0]
     TTI_SFPCAST(0, 12, 0);
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -691,6 +691,9 @@ template <bool APPROXIMATION_MODE>
 inline void _init_typecast_uint32_to_fp32_()
 {
 #ifndef DISABLE_SFPLOADMACRO
+    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
+    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
+    // preloaded with -31 -- the shift amount used to extract that bit.
     sfpi::vConstIntPrgm0 = -31;
 
     constexpr int a = p_sfpu::LREG2;
@@ -748,6 +751,9 @@ inline void _init_typecast_int32_to_fp32_()
 #ifndef DISABLE_SFPLOADMACRO
     constexpr int t = p_sfpu::LREG4;
 
+    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
+    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
+    // preloaded with -31 -- the shift amount used to extract that bit.
     sfpi::vConstIntPrgm0 = -31;
 
     // InstructionTemplate[0]
@@ -783,6 +789,9 @@ inline void _init_typecast_int32_to_fp16b_()
 #ifndef DISABLE_SFPLOADMACRO
     constexpr int t = p_sfpu::LREG4;
 
+    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
+    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
+    // preloaded with -31 -- the shift amount used to extract that bit.
     sfpi::vConstIntPrgm0 = -31;
 
     // InstructionTemplate[0]
@@ -878,6 +887,9 @@ template <bool APPROXIMATION_MODE>
 inline void _init_typecast_uint32_to_fp16b_()
 {
 #ifndef DISABLE_SFPLOADMACRO
+    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
+    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
+    // preloaded with -31 -- the shift amount used to extract that bit.
     sfpi::vConstIntPrgm0 = -31;
 
     // InstructionTemplate[0]


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

LREG12/vConstPrgm0 is not initialized in typecast LLK inits for uint32 -> bfloat16 conversions. This led to bad outputs:



This PR fixes this by initializing these constants for -31:

Failing tests (before):

- https://github.com/tenstorrent/tt-metal/actions/runs/25372423329/job/74400180526

With fix:

- WH: https://github.com/tenstorrent/tt-metal/actions/runs/25350161817
- BH: https://github.com/tenstorrent/tt-metal/actions/runs/25350146459

Also updated typecast test to use `assert_with_ulp` with float/bfloat16 inputs. 

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Note: I tried to adjust other accuracy measurements in `test_eltwise_typecast.py` but this led to other failures. That's why I am leaving PCC check for non-float32/bfloat16 inputs. 


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmaurice/fix-uint32-bfloat16-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmaurice/fix-uint32-bfloat16-bug) (failed on lgamma ~ unrelated failure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmaurice/fix-uint32-bfloat16-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmaurice/fix-uint32-bfloat16-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmaurice/fix-uint32-bfloat16-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmaurice/fix-uint32-bfloat16-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmaurice/fix-uint32-bfloat16-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmaurice/fix-uint32-bfloat16-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmaurice/fix-uint32-bfloat16-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmaurice/fix-uint32-bfloat16-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmaurice/fix-uint32-bfloat16-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmaurice/fix-uint32-bfloat16-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmaurice/fix-uint32-bfloat16-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmaurice/fix-uint32-bfloat16-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmaurice/fix-uint32-bfloat16-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmaurice/fix-uint32-bfloat16-bug)