### PR TITLE
[Test]Use assert_equal for data movement ops for next set of ops

### DIFF
--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -769,6 +769,11 @@ def comp_equal(golden, calculated):
     if golden.dtype != calculated.dtype:
         calculated = calculated.type(golden.dtype)
 
+    # If either tensor is zero-volume, broadcasting can still yield an empty delta and
+    # crash torch.max(); defer entirely to torch.equal (False on shape mismatch).
+    if golden.numel() == 0 or calculated.numel() == 0:
+        return torch.equal(golden, calculated), f"{golden} != {calculated}"
+
     atol_delta = torch.max(torch.abs(golden - calculated)).item()
     rtol_delta = torch.max(torch.abs(golden - calculated) / torch.abs(calculated)).item()
     return (

--- a/tests/ttnn/unit_tests/base_functionality/test_chunk.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_chunk.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 import ttnn
 import math
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_equal
 
 
 @pytest.mark.parametrize(
@@ -46,4 +46,4 @@ def test_chunking(device, shape, num_chunks, dim):
     ttnn_chunks = ttnn.chunk(ttnn_tensor, num_chunks, dim)
 
     ttnn_chunks_torch = [ttnn.to_torch(chunk) for chunk in ttnn_chunks]
-    assert_with_pcc(torch.cat(torch_chunks, dim=-1), torch.cat(ttnn_chunks_torch, dim=-1))
+    assert_equal(torch.cat(torch_chunks, dim=-1), torch.cat(ttnn_chunks_torch, dim=-1))

--- a/tests/ttnn/unit_tests/base_functionality/test_copy.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_copy.py
@@ -32,7 +32,6 @@ def test_copy(shape, layout, dtype, device):
 
     ttnn.copy(input, input_b)
     assert input_b.shape == input.shape
-    assert_with_pcc(ttnn.to_torch(input), ttnn.to_torch(input_b), 1)
     assert_equal(ttnn.to_torch(input), ttnn.to_torch(input_b))
 
 
@@ -87,7 +86,6 @@ def test_copy_block_sharded(device, layout, shape, shard_scheme, dtype):
     ttnn.copy(input_tensor, output_tensor)
     input_tensor = ttnn.to_torch(input_tensor)
     outout_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(input_tensor, outout_tensor, 1)
     assert_equal(input_tensor, outout_tensor)
 
 
@@ -146,7 +144,6 @@ def test_copy_width_sharded(device, layout, shape, shard_scheme, dtype):
     ttnn.copy(input_tensor, output_tensor)
     input_tensor = ttnn.to_torch(input_tensor)
     outout_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(input_tensor, outout_tensor, 1)
     assert_equal(input_tensor, outout_tensor)
 
 
@@ -206,7 +203,6 @@ def test_copy_height_sharded(device, layout, shape, shard_scheme, dtype):
     ttnn.copy(input_tensor, output_tensor)
     input_tensor = ttnn.to_torch(input_tensor)
     outout_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(input_tensor, outout_tensor, 1)
     assert_equal(input_tensor, outout_tensor)
 
 

--- a/tests/ttnn/unit_tests/base_functionality/test_getitem.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_getitem.py
@@ -46,7 +46,6 @@ def test_getitem(device, batch_sizes, height, width, input_layout, on_device):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_equal(torch_output_tensor, output_tensor)
-    assert torch.allclose(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("height", [32, 64])
@@ -75,7 +74,6 @@ def test_getitem_2d(device, height, width, input_layout, on_device):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_equal(torch_output_tensor, output_tensor)
-    assert torch.allclose(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("batch_sizes", [(), (1, 1)])
@@ -107,4 +105,3 @@ def test_getitem_non_tile_boundary(device, batch_sizes, height, width, input_lay
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_equal(torch_output_tensor, output_tensor)
-    assert torch.allclose(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/base_functionality/test_getitem.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_getitem.py
@@ -8,7 +8,7 @@ import torch
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_equal
 
 pytestmark = pytest.mark.use_module_device
 
@@ -45,7 +45,7 @@ def test_getitem(device, batch_sizes, height, width, input_layout, on_device):
 
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    assert_equal(torch_output_tensor, output_tensor)
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
@@ -74,7 +74,7 @@ def test_getitem_2d(device, height, width, input_layout, on_device):
 
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    assert_equal(torch_output_tensor, output_tensor)
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
@@ -106,5 +106,5 @@ def test_getitem_non_tile_boundary(device, batch_sizes, height, width, input_lay
 
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    assert_equal(torch_output_tensor, output_tensor)
     assert torch.allclose(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/base_functionality/test_tilize_pad_cb.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_tilize_pad_cb.py
@@ -9,7 +9,7 @@ import torch
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc_without_tensor_printout
+from tests.ttnn.utils_for_testing import check_with_pcc_without_tensor_printout
 
 
 @pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32])

--- a/tests/ttnn/unit_tests/base_functionality/test_tilize_untilize_2D.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_tilize_untilize_2D.py
@@ -11,7 +11,7 @@ import torch
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc_without_tensor_printout
+from tests.ttnn.utils_for_testing import check_with_pcc_without_tensor_printout
 
 
 def random_torch_tensor(dtype, shape):

--- a/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
@@ -97,7 +97,6 @@ def test_to_layout_2D(device, height, width, on_device, from_layout, to_layout, 
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_equal(torch_input_tensor, output_tensor)
-    assert torch.allclose(torch_input_tensor, output_tensor)
 
 
 @pytest.mark.parametrize(
@@ -130,7 +129,6 @@ def test_to_layout_wide_tensor(device, shape, on_device, from_layout, to_layout)
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_equal(torch_input_tensor, output_tensor)
-    assert torch.allclose(torch_input_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("in_dtype", [ttnn.bfloat8_b, ttnn.bfloat16, ttnn.float32])
@@ -258,7 +256,7 @@ def test_to_from_01d(device, shape):
     ttnn_input = ttnn.to_layout(ttnn_input, ttnn.ROW_MAJOR_LAYOUT)
     ttnn_input = ttnn.to_torch(ttnn_input)
 
-    assert_equal(ttnn_input, torch_input)
+    assert_equal(torch_input, ttnn_input)
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
@@ -1001,7 +999,6 @@ def _run_to_layout_nd_sharded(device, tensor_shape, input_mem_config, target_lay
     output_torch = ttnn.to_torch(output_tensor)
     assert tuple(output_torch.shape) == tuple(tensor_shape)
     assert_equal(torch_input, output_torch)
-    assert torch.allclose(torch_input, output_torch)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
@@ -10,7 +10,7 @@ import torch
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc_without_tensor_printout
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal, check_with_pcc_without_tensor_printout
 from models.common.utility_functions import torch_random
 
 
@@ -33,7 +33,7 @@ def test_wan22_failure_t3k(mesh_device):
             output_tensor, dtype=torch.bfloat16, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0)
         )
         expanded_input_tensor = torch_input_tensor.expand(8, 6240, 384)
-        assert_with_pcc(expanded_input_tensor, torch_output_tensor)
+        assert_equal(expanded_input_tensor, torch_output_tensor)
 
 
 def test_wan22_failure():
@@ -47,7 +47,7 @@ def test_wan22_failure():
         )
         output_tensor = ttnn.to_layout(input_tensor, ttnn.TILE_LAYOUT)
         torch_output_tensor = ttnn.to_torch(output_tensor, dtype=torch.bfloat16)
-        assert_with_pcc(torch_input_tensor, torch_output_tensor)
+        assert_equal(torch_input_tensor, torch_output_tensor)
 
 
 @pytest.mark.parametrize("height", [32, 30])
@@ -96,7 +96,7 @@ def test_to_layout_2D(device, height, width, on_device, from_layout, to_layout, 
 
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_input_tensor, output_tensor)
+    assert_equal(torch_input_tensor, output_tensor)
     assert torch.allclose(torch_input_tensor, output_tensor)
 
 
@@ -129,7 +129,7 @@ def test_to_layout_wide_tensor(device, shape, on_device, from_layout, to_layout)
 
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_input_tensor, output_tensor)
+    assert_equal(torch_input_tensor, output_tensor)
     assert torch.allclose(torch_input_tensor, output_tensor)
 
 
@@ -193,7 +193,7 @@ def test_to_layout_subcore(device, h, w, input_layout, output_layout, sub_core_g
         input_tensor = ttnn.from_torch(torch_input_tensor, device=device, dtype=ttnn.bfloat16, layout=input_layout)
         new_layout_tensor = ttnn.to_layout(input_tensor, layout=output_layout, sub_core_grids=sub_core_grids)
         torch_brought_back = ttnn.to_torch(new_layout_tensor)
-        assert_with_pcc(torch_input_tensor, torch_brought_back)
+        assert_equal(torch_input_tensor, torch_brought_back)
 
 
 @pytest.mark.parametrize("shape", [[3, 50, 1, 3, 768], [3, 1370, 1, 32, 1280]])
@@ -205,7 +205,7 @@ def test_to_layout_5D(shape, input_layout, output_layout, device):
     input_tensor = ttnn.from_torch(input_a, device=device, layout=input_layout, dtype=ttnn.bfloat16)
     output_tensor = ttnn.to_layout(input_tensor, output_layout)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(input_a, output_tensor)
+    assert_equal(input_a, output_tensor)
 
 
 @pytest.mark.parametrize("shape", [[4, 7, 58, 1, 37, 256], [1, 3, 64, 1, 32, 1280]])
@@ -217,7 +217,7 @@ def test_to_layout_6D(shape, input_layout, output_layout, device):
     input_tensor = ttnn.from_torch(input_a, device=device, layout=input_layout, dtype=ttnn.bfloat16)
     output_tensor = ttnn.to_layout(input_tensor, output_layout)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(input_a, output_tensor)
+    assert_equal(input_a, output_tensor)
 
 
 @pytest.mark.parametrize(
@@ -231,7 +231,7 @@ def test_to_layout_nd_hangs(shape, input_layout, output_layout, device):
     input_tensor = ttnn.from_torch(input_a, device=device, layout=input_layout, dtype=ttnn.bfloat16)
     output_tensor = ttnn.to_layout(input_tensor, output_layout)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(input_a, output_tensor)
+    assert_equal(input_a, output_tensor)
 
 
 @pytest.mark.parametrize("shape", [[1, 768], [3, 230], [32, 768], [32, 143]])
@@ -243,7 +243,7 @@ def test_to_layout_for_2D(shape, input_layout, output_layout, device):
     input_tensor = ttnn.from_torch(input_a, device=device, layout=input_layout, dtype=ttnn.bfloat16)
     output_tensor = ttnn.to_layout(input_tensor, output_layout)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(input_a, output_tensor)
+    assert_equal(input_a, output_tensor)
 
 
 @pytest.mark.parametrize("shape", [1, 5, 14, 97, 0, ()])
@@ -258,7 +258,7 @@ def test_to_from_01d(device, shape):
     ttnn_input = ttnn.to_layout(ttnn_input, ttnn.ROW_MAJOR_LAYOUT)
     ttnn_input = ttnn.to_torch(ttnn_input)
 
-    assert_with_pcc(ttnn_input, torch_input)
+    assert_equal(ttnn_input, torch_input)
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
@@ -296,7 +296,7 @@ def test_int_untilize(device, batch_size, sentence_size):
     output_tt = ttnn.to_layout(ttnn_input, ttnn.ROW_MAJOR_LAYOUT)
     output_torch = ttnn.to_torch(output_tt)
 
-    assert_with_pcc(torch_input_tensor, output_torch)
+    assert_equal(torch_input_tensor, output_torch)
 
 
 @pytest.mark.parametrize("shape", [[143], [64], [380]])
@@ -309,7 +309,7 @@ def test_to_layout_for_1D(shape, dtype, input_layout, output_layout, device):
     input_tensor = ttnn.from_torch(input_a, device=device, layout=input_layout)
     output_tensor = ttnn.to_layout(input_tensor, output_layout)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(input_a, output_tensor)
+    assert_equal(input_a, output_tensor)
 
 
 @pytest.mark.parametrize("shape", [[30], [64], [2040]])
@@ -320,7 +320,7 @@ def test_tilize_with_padding_for_1D(shape, dtype, device):
     input_tensor = ttnn.from_torch(input_a, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.tilize_with_zero_padding(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(input_a, output_tensor)
+    assert_equal(input_a, output_tensor)
 
 
 @pytest.mark.parametrize("shape", [[32, 32], [32, 128], [512, 512]])
@@ -334,7 +334,7 @@ def test_tilize_for_2D(shape, dtype, device):
     input_tensor = ttnn.from_torch(input_a, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.tilize(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(input_a, output_tensor)
+    assert_equal(input_a, output_tensor)
 
 
 @pytest.mark.parametrize("shape", [[10, 10], [100, 100], [1000, 1000]])
@@ -348,7 +348,7 @@ def test_tilize_with_zero_padding_for_2D(shape, dtype, device):
     input_tensor = ttnn.from_torch(input_a, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.tilize_with_zero_padding(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(input_a, output_tensor)
+    assert_equal(input_a, output_tensor)
 
 
 @pytest.mark.parametrize("shape", [[10, 10], [50, 50], [300, 300]])
@@ -362,7 +362,7 @@ def test_tilize_with_val_padding_for_2D(shape, dtype, device):
     input_tensor = ttnn.from_torch(input_a, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.tilize_with_val_padding(input_tensor, [512, 512], 70)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(input_a, output_tensor)
+    assert_equal(input_a, output_tensor)
 
 
 @pytest.mark.parametrize("shape", [[1, 9, 91, 7, 9]])
@@ -377,7 +377,7 @@ def test_to_layout_page_error(shape, device):
 
     torch_output = torch_tensor
     assert torch_output.shape == output_tensor.shape
-    assert_with_pcc(torch_output, output_tensor, 0.9999)
+    assert_equal(torch_output, output_tensor)
 
 
 @pytest.mark.parametrize("shape", [[64, 7680]])
@@ -391,7 +391,7 @@ def test_untilize_w1(shape, input_layout, output_layout, device):
     output_tensor = ttnn.untilize_with_unpadding(input_tensor, [36, 7667])
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(input_a[:37, :7668], output_tensor)
+    assert_equal(input_a[:37, :7668], output_tensor)
 
 
 @pytest.mark.parametrize("shape", [[2, 32, 6144]])
@@ -405,7 +405,7 @@ def test_untilize_w2(shape, input_layout, output_layout, device):
     output_tensor = ttnn.untilize_with_unpadding(input_tensor, [1, 30, 6140])
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(input_a[:, :31, :6141], output_tensor)
+    assert_equal(input_a[:, :31, :6141], output_tensor)
 
 
 @pytest.mark.parametrize("shape", [[1, 1, 32, 1536]])
@@ -419,7 +419,7 @@ def test_untilize_w3(shape, input_layout, output_layout, device):
     output_tensor = ttnn.untilize_with_unpadding(input_tensor, [0, 0, 31, 1535])
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(input_a[:, :, :32, :1536], output_tensor)
+    assert_equal(input_a[:, :, :32, :1536], output_tensor)
 
 
 @pytest.mark.parametrize("shape", [[1, 1, 32, 10912]])
@@ -433,7 +433,7 @@ def test_untilize_w4(shape, input_layout, output_layout, device):
     output_tensor = ttnn.untilize_with_unpadding(input_tensor, [0, 0, 0, 10911])
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(input_a[:, :, :1, :10912], output_tensor)
+    assert_equal(input_a[:, :, :1, :10912], output_tensor)
 
 
 def test_interleaved_to_sharded_block_shareded_unaligned_width(device):
@@ -470,7 +470,7 @@ def test_to_layout_wh1(shape, input_layout, output_layout, device):
     output_tensor = ttnn.to_layout(input_tensor, output_layout)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(input_a, output_tensor)
+    assert_equal(input_a, output_tensor)
 
 
 @pytest.mark.parametrize("shape", [[32, 128 * 1024]])
@@ -511,7 +511,7 @@ def test_to_layout_low_perf(shape, device, sub_core_grids, dtype):
     output_tensor = ttnn.tilize(input_tensor, sub_core_grids=sub_core_grids, use_low_perf=True)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(input_a, output_tensor)
+    assert_equal(input_a, output_tensor)
 
 
 @pytest.mark.parametrize("shape", [[11432, 11021]])
@@ -525,7 +525,7 @@ def test_to_layout_wh2(shape, input_layout, output_layout, device):
     output_tensor = ttnn.to_layout(input_tensor, output_layout)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(input_a, output_tensor)
+    assert_equal(input_a, output_tensor)
 
 
 @pytest.mark.parametrize("shape", [[32, 128], [2, 4, 96, 256], [1, 160, 64], [64, 512], [10, 1024, 2048]])
@@ -537,7 +537,7 @@ def test_untilize_with_unpad_int32(shape, dtype, device):
     input_tensor = ttnn.from_torch(input_a, device=device, layout=ttnn.TILE_LAYOUT, dtype=dtype)
     output_tensor = ttnn.untilize_with_unpadding(input_tensor, end_shape)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(input_a, output_tensor)
+    assert_equal(input_a, output_tensor)
 
 
 @pytest.mark.parametrize("shape", [[3072, 1024], [2, 2048, 512]])
@@ -548,7 +548,7 @@ def test_untilize_int32_t(shape, dtype, device):
     input_tensor = ttnn.from_torch(input_a, device=device, layout=ttnn.TILE_LAYOUT, dtype=dtype)
     output_tensor = ttnn.untilize(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(input_a, output_tensor)
+    assert_equal(input_a, output_tensor)
 
 
 def run_unary_with_aprox_mode_fruit_test(
@@ -1000,7 +1000,7 @@ def _run_to_layout_nd_sharded(device, tensor_shape, input_mem_config, target_lay
 
     output_torch = ttnn.to_torch(output_tensor)
     assert tuple(output_torch.shape) == tuple(tensor_shape)
-    assert_with_pcc(torch_input, output_torch, 0.9999)
+    assert_equal(torch_input, output_torch)
     assert torch.allclose(torch_input, output_torch)
 
 

--- a/tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py
@@ -29,7 +29,6 @@ def test_to_memory_config(shape, layout, dtype, device):
 
     ttnn.to_memory_config(input, input_b.memory_config(), output_tensor=input_b)
     assert input_b.shape == input.shape
-    assert_with_pcc(ttnn.to_torch(input), ttnn.to_torch(input_b), 1)
     assert_equal(ttnn.to_torch(input), ttnn.to_torch(input_b))
 
 
@@ -84,7 +83,6 @@ def test_to_memory_config_block_sharded(device, layout, shape, shard_scheme, dty
     ttnn.to_memory_config(input_tensor, output_mem_config, output_tensor=output_tensor)
     input_tensor = ttnn.to_torch(input_tensor)
     outout_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(input_tensor, outout_tensor, 1)
     assert_equal(input_tensor, outout_tensor)
 
 
@@ -143,7 +141,6 @@ def test_to_memory_config_width_sharded(device, layout, shape, shard_scheme, dty
     ttnn.to_memory_config(input_tensor, output_mem_config, output_tensor=output_tensor)
     input_tensor = ttnn.to_torch(input_tensor)
     outout_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(input_tensor, outout_tensor, 1)
     assert_equal(input_tensor, outout_tensor)
 
 
@@ -203,7 +200,6 @@ def test_to_memory_config_height_sharded(device, layout, shape, shard_scheme, dt
     ttnn.to_memory_config(input_tensor, output_mem_config, output_tensor=output_tensor)
     input_tensor = ttnn.to_torch(input_tensor)
     outout_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(input_tensor, outout_tensor, 1)
     assert_equal(input_tensor, outout_tensor)
 
 

--- a/tests/ttnn/unit_tests/operations/data_movement/test_core.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_core.py
@@ -9,7 +9,7 @@ import torch
 import ttnn
 
 from models.common.utility_functions import get_debug_tensor
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_equal
 from enum import Enum
 
 
@@ -316,7 +316,7 @@ def test_reshard(
 
     output = ttnn.to_torch(interleaved_output_tensor)
 
-    assert_with_pcc(torch_input_tensor, output, 1.0)
+    assert_equal(torch_input_tensor, output)
 
 
 class DirectReadWriteType(Enum):
@@ -401,7 +401,7 @@ def test_shard_with_corerangeset(
     else:
         output = ttnn.to_torch(sharded_input_tensor)
 
-    assert_with_pcc(torch_input_tensor, output, 1.0)
+    assert_equal(torch_input_tensor, output)
 
 
 @pytest.mark.parametrize(
@@ -613,7 +613,7 @@ def test_mnist_max_pool_s2i(
     output_pytorch = torch.permute(output_pytorch, (0, 3, 1, 2))  ## N, C, H, W
 
     pcc_thresh = 1.0
-    assert_with_pcc(output_pytorch, golden_pytorch, pcc_thresh)
+    assert_equal(output_pytorch, golden_pytorch)
 
 
 @pytest.mark.parametrize(
@@ -661,7 +661,7 @@ def test_reshard_conv(device, shape, orientation, core_grid_1, core_grid_2):
     ttnn_tensor_2_interleaved_to_sharded = ttnn.to_memory_config(ttnn_tensor_1_dram, memory_config_2)
     out_tensor_2_interleaved_to_sharded = ttnn.to_torch(ttnn_tensor_2_interleaved_to_sharded)
 
-    passing, pcc_msg = assert_with_pcc(out_tensor_1, out_tensor_2_interleaved_to_sharded, pcc=1.0)
+    passing, pcc_msg = assert_equal(out_tensor_1, out_tensor_2_interleaved_to_sharded)
 
     ttnn_tensor_2_resharded = ttnn.reshard(ttnn_tensor_1, memory_config_2)
     out_tensor_2_resharded = ttnn.to_torch(ttnn_tensor_2_resharded)
@@ -670,4 +670,4 @@ def test_reshard_conv(device, shape, orientation, core_grid_1, core_grid_2):
         print("Output Tensor 2 Resharded:", out_tensor_2_resharded)
         torch.set_printoptions(profile="default")
 
-    passing, pcc_msg = assert_with_pcc(out_tensor_1, out_tensor_2_resharded, pcc=1.0)
+    passing, pcc_msg = assert_equal(out_tensor_1, out_tensor_2_resharded)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_core.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_core.py
@@ -612,7 +612,6 @@ def test_mnist_max_pool_s2i(
 
     output_pytorch = torch.permute(output_pytorch, (0, 3, 1, 2))  ## N, C, H, W
 
-    pcc_thresh = 1.0
     assert_equal(output_pytorch, golden_pytorch)
 
 
@@ -661,7 +660,7 @@ def test_reshard_conv(device, shape, orientation, core_grid_1, core_grid_2):
     ttnn_tensor_2_interleaved_to_sharded = ttnn.to_memory_config(ttnn_tensor_1_dram, memory_config_2)
     out_tensor_2_interleaved_to_sharded = ttnn.to_torch(ttnn_tensor_2_interleaved_to_sharded)
 
-    passing, pcc_msg = assert_equal(out_tensor_1, out_tensor_2_interleaved_to_sharded)
+    assert_equal(out_tensor_1, out_tensor_2_interleaved_to_sharded)
 
     ttnn_tensor_2_resharded = ttnn.reshard(ttnn_tensor_1, memory_config_2)
     out_tensor_2_resharded = ttnn.to_torch(ttnn_tensor_2_resharded)
@@ -670,4 +669,4 @@ def test_reshard_conv(device, shape, orientation, core_grid_1, core_grid_2):
         print("Output Tensor 2 Resharded:", out_tensor_2_resharded)
         torch.set_printoptions(profile="default")
 
-    passing, pcc_msg = assert_equal(out_tensor_1, out_tensor_2_resharded)
+    assert_equal(out_tensor_1, out_tensor_2_resharded)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_creation.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn as nn
 import ttnn
 
-from tests.ttnn.utils_for_testing import divup, assert_equal
+from tests.ttnn.utils_for_testing import assert_equal
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/data_movement/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_creation.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn as nn
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc, divup, assert_equal
+from tests.ttnn.utils_for_testing import divup, assert_equal
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/data_movement/test_interleaved_to_sharded.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_interleaved_to_sharded.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
 
 
 @pytest.mark.parametrize(
@@ -266,7 +266,7 @@ def test_interleaved_to_sharded_nd_with_equivalent_2d(
     ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)
     ttnn_output_tensor = ttnn.interleaved_to_sharded(ttnn_input_tensor, output_mem_config)
 
-    assert_with_pcc(torch_input_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+    assert_equal(torch_input_tensor, ttnn.to_torch(ttnn_output_tensor))
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/data_movement/test_non_zero_indices.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_non_zero_indices.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
+from tests.ttnn.utils_for_testing import assert_equal
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/data_movement/test_repeat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_repeat.py
@@ -10,7 +10,7 @@ import torch
 import ttnn
 
 from models.common.utility_functions import comp_pcc
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
 
 layouts = [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT]
 
@@ -114,7 +114,7 @@ def test_pc_repeat(device, layout, shape, repeat_shape):
             output.shape == torch_results[i].shape
         ), f"Output shape {output.shape} does not match torch shape {torch_results[i].shape}"
 
-        assert_with_pcc(torch_results[i], output, 0.9999)
+        assert_equal(torch_results[i], output)
         if i == 0:
             base_count = device.cache_entries_counter.total
         else:

--- a/tests/ttnn/unit_tests/operations/data_movement/test_repeat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_repeat.py
@@ -9,7 +9,6 @@ import pytest
 import torch
 import ttnn
 
-from models.common.utility_functions import comp_pcc
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
 
 layouts = [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT]


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/43695

### PR Category
Test Only

### Summary

- Replace assert_with_pcc with assert_equal for data movement and base functionality tests where bit-exact output is expected.
- Fix comp_equal crash on empty tensors by guarding torch.max call :  torch.max() without a dim argument raises RuntimeError when called on a zero-element tensor. Add an early return in comp_equal for numel()==0 so assert_equal correctly handles empty tensor comparisons.

### Pipeline Checklist

- [x] Sanity tests - PASSED
- [x] (Runtime) Sanity Tests - PASSED
- [x] BHPC - PASSED as in main
- [x] Nightly L2 - PASSED as in main

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/pcc_dm_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/pcc_dm_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/pcc_dm_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/pcc_dm_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/pcc_dm_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchani/pcc_dm_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/pcc_dm_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/pcc_dm_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/pcc_dm_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/pcc_dm_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/pcc_dm_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/pcc_dm_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/pcc_dm_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/pcc_dm_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/pcc_dm_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/pcc_dm_2)