### PR TITLE
Frequent models CI segformer fix

### DIFF
--- a/models/demos/vision/segmentation/segformer/tests/pcc/test_segformer_for_image_classification.py
+++ b/models/demos/vision/segmentation/segformer/tests/pcc/test_segformer_for_image_classification.py
@@ -44,7 +44,7 @@ def create_custom_mesh_preprocessor(mesh_mapper=None, device=None):
                 mesh_mapper=mesh_mapper,
             )
             parameters["classifier"]["bias"] = ttnn.from_torch(
-                model.classifier.bias.reshape(1, 1, 1, model.classifier.bias.shape[-1]),
+                model.classifier.bias.reshape(1, model.classifier.bias.shape[-1]),
                 dtype=ttnn.bfloat16,
                 layout=ttnn.TILE_LAYOUT,
                 device=device,


### PR DESCRIPTION
## Summary
- Nightly `test_segformer_image_classificaton` failing with shape mismatch `[1, 1000]` vs `[1, 1, 1, 1000]`.
- Root cause: PR #42430 (re-applied in d964b8e778c) modified matmul reshape logic — output rank now follows bias rank. Test's `custom_preprocessor` reshaped classifier bias to rank-4 `(1,1,1,N)`, forcing rank-4 logits despite rank-2 activation.
- Bisect:
  - `d964b8e778c` (re-apply #42430): FAIL — same `[1,1,1,1000]` shape mismatch.
  - `b5fada0b5e9` (parent): PASS in 31s.
- Fix: reshape classifier bias to rank-2 `(1, N)` matching the rank-2 activation feeding `ttnn.linear`.

## Context: 
Failing run https://github.com/tenstorrent/tt-metal/actions/runs/25348957442/job/74378448313

## CI 
- [x] (Single-card) [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/25371413432) 