### PR TITLE
#43337: Add support for snake_beta activation

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_snake_beta.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_snake_beta.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_ulp
+
+
+def torch_snake_beta(x, alpha, beta):
+    """Reference y = x + sin(alpha*x)^2 / beta, computed in fp32 then cast to x.dtype."""
+    out_dtype = x.dtype
+    x32 = x.to(torch.float32)
+    alpha32 = alpha.to(torch.float32)
+    beta32 = beta.to(torch.float32)
+    s = torch.sin(alpha32 * x32)
+    return (x32 + (s * s) / beta32).to(out_dtype)
+
+
+_AB_RANGE_ALPHA = (0.96, 1.40)
+_AB_RANGE_BETA = (0.97, 1.61)
+
+
+def _sample_uniform(shape, lo, hi, dtype):
+    return (torch.rand(shape, dtype=torch.float32) * (hi - lo) + lo).to(dtype)
+
+
+@pytest.mark.parametrize("torch_dtype, ttnn_dtype", [(torch.bfloat16, ttnn.bfloat16), (torch.float32, ttnn.float32)])
+@pytest.mark.parametrize(
+    "x_shape, ab_shape, seed",
+    [
+        ((1, 1, 32, 32), (1, 1, 32, 32), 1),  # NONE
+        ((1, 1, 640, 48), (48,), 0),  # ROW_BCAST
+    ],
+)
+def test_snake_beta_broadcast(device, x_shape, ab_shape, seed, torch_dtype, ttnn_dtype):
+    torch.manual_seed(seed)
+    x = torch.randn(x_shape, dtype=torch_dtype)
+    a = _sample_uniform(ab_shape, *_AB_RANGE_ALPHA, dtype=torch_dtype)
+    b = _sample_uniform(ab_shape, *_AB_RANGE_BETA, dtype=torch_dtype)
+    expected = torch_snake_beta(x, a, b)
+
+    x_tt = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, dtype=ttnn_dtype, device=device)
+    a_tt = ttnn.from_torch(a, layout=ttnn.TILE_LAYOUT, dtype=ttnn_dtype, device=device)
+    b_tt = ttnn.from_torch(b, layout=ttnn.TILE_LAYOUT, dtype=ttnn_dtype, device=device)
+    result = ttnn.to_torch(ttnn.snake_beta(x_tt, a_tt, b_tt))
+
+    if torch_dtype == torch.float32:
+        # ULP is a poor metric near y≈0 at fp32 precision; use combined rtol/atol instead.
+        assert torch.allclose(expected, result, rtol=1e-5, atol=1e-5)
+    else:
+        assert_with_ulp(expected, result, ulp_threshold=2)
+
+
+# Per-preset bf16 distribution params from issue #43337:
+# (shape, x_{mean,std,min,max}, a_{mean,std,min,max}, b_{mean,std,min,max}).
+_REAL_WORKLOAD_PRESETS = {
+    "c1": (
+        (1, 1, 2250, 768),
+        -0.34375,
+        0.486328125,
+        -3.265625,
+        3.1875,
+        1.171875,
+        0.0260009765625,
+        1.0703125,
+        1.3984375,
+        1.21875,
+        0.033203125,
+        1.1171875,
+        1.609375,
+    ),
+    "c2": (
+        (1, 1, 36000, 192),
+        -0.08935546875,
+        0.29296875,
+        -2.453125,
+        1.8203125,
+        1.0703125,
+        0.037109375,
+        0.96875,
+        1.1640625,
+        1.078125,
+        0.04541015625,
+        0.97265625,
+        1.203125,
+    ),
+    "c3": (
+        (1, 1, 144000, 48),
+        0.01129150390625,
+        0.049072265625,
+        -0.609375,
+        0.76171875,
+        1.0625,
+        0.05224609375,
+        0.95703125,
+        1.171875,
+        1.2421875,
+        0.11083984375,
+        1.015625,
+        1.5078125,
+    ),
+}
+
+
+def _sample_clamped_normal(shape, mean, std, lo, hi, dtype=torch.bfloat16):
+    t = torch.randn(shape, dtype=torch.float32) * std + mean
+    return t.clamp_(lo, hi).to(dtype)
+
+
+@pytest.mark.parametrize("torch_dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("preset", ["c1", "c2", "c3"])
+def test_snake_beta_real_workload(device, preset, torch_dtype):
+    """Real-workload distributions from issue #43337; bf16 asserts <= 2 ULP, fp32 uses rtol/atol."""
+    torch.manual_seed(0)
+    shape, xm, xs, xlo, xhi, am, as_, alo, ahi, bm, bs, blo, bhi = _REAL_WORKLOAD_PRESETS[preset]
+    D = shape[-1]
+
+    x = _sample_clamped_normal(shape, xm, xs, xlo, xhi, dtype=torch_dtype)
+    a = _sample_clamped_normal((D,), am, as_, alo, ahi, dtype=torch_dtype)
+    b = _sample_clamped_normal((D,), bm, bs, blo, bhi, dtype=torch_dtype)
+    expected = torch_snake_beta(x, a, b)
+
+    x_tt = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, device=device)
+    a_tt = ttnn.from_torch(a, layout=ttnn.TILE_LAYOUT, device=device)
+    b_tt = ttnn.from_torch(b, layout=ttnn.TILE_LAYOUT, device=device)
+    result = ttnn.to_torch(ttnn.snake_beta(x_tt, a_tt, b_tt))
+
+    if torch_dtype == torch.float32:
+        assert torch.allclose(expected, result, rtol=1e-5, atol=1e-5)
+    else:
+        assert_with_ulp(expected, result, ulp_threshold=2)
+
+
+def test_snake_beta_pi_boundary(device):
+    """alpha*x at multiples of pi/2 to exercise range-reduction boundaries."""
+    import math
+
+    x_vals = torch.tensor(
+        [0.0, math.pi / 2, math.pi, 3 * math.pi / 2, 2 * math.pi, -math.pi / 2, -math.pi],
+        dtype=torch.bfloat16,
+    )
+    x_tile = x_vals.repeat(math.ceil(1024 / len(x_vals)))[:1024].reshape(1, 1, 32, 32)
+    a = torch.full((32,), 1.0, dtype=torch.bfloat16)
+    b = torch.ones(32, dtype=torch.bfloat16)
+    expected = torch_snake_beta(x_tile, a, b)
+
+    x_tt = ttnn.from_torch(x_tile, layout=ttnn.TILE_LAYOUT, device=device)
+    a_tt = ttnn.from_torch(a, layout=ttnn.TILE_LAYOUT, device=device)
+    b_tt = ttnn.from_torch(b, layout=ttnn.TILE_LAYOUT, device=device)
+    result = ttnn.to_torch(ttnn.snake_beta(x_tt, a_tt, b_tt))
+    assert_with_ulp(expected, result, ulp_threshold=1)
+
+
+@pytest.mark.parametrize(
+    "x_shape, ab_shape",
+    [
+        ((1, 1, 32, 32), (1, 1, 32, 32)),  # NONE: exercises compute_output_specs early return
+        ((1, 1, 640, 48), (48,)),  # ROW_BCAST: validates preallocated shape matches broadcast output
+    ],
+)
+def test_snake_beta_output_tensor(device, x_shape, ab_shape):
+    """Preallocated output_tensor= path; verifies the result aliases the caller's tensor."""
+    torch.manual_seed(0)
+    x = torch.randn(x_shape, dtype=torch.bfloat16)
+    a = _sample_uniform(ab_shape, *_AB_RANGE_ALPHA, dtype=torch.bfloat16)
+    b = _sample_uniform(ab_shape, *_AB_RANGE_BETA, dtype=torch.bfloat16)
+    expected = torch_snake_beta(x, a, b)
+
+    x_tt = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, device=device)
+    a_tt = ttnn.from_torch(a, layout=ttnn.TILE_LAYOUT, device=device)
+    b_tt = ttnn.from_torch(b, layout=ttnn.TILE_LAYOUT, device=device)
+    out_pre = ttnn.from_torch(torch.zeros(x_shape, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+
+    ttnn.snake_beta(x_tt, a_tt, b_tt, output_tensor=out_pre)
+
+    # Returned tensor must alias the caller-supplied buffer (proves the op wrote into it
+    # instead of allocating a fresh one).
+    out_pre_torch = ttnn.to_torch(out_pre)
+    assert_with_ulp(expected, out_pre_torch, ulp_threshold=2)
+
+
+@pytest.mark.parametrize(
+    "x_shape, ab_shape",
+    [
+        ((640, 48), (48,)),  # canonical customer pattern x=(L,D), alpha=beta=(D,)
+        ((2, 640, 48), (48,)),  # 3D batched (B,L,D) with vector alpha/beta
+    ],
+)
+def test_snake_beta_rank_preservation(device, x_shape, ab_shape):
+    """Output rank must equal input rank for non-rank-4 inputs (issue #43337 caller uses (L,D))."""
+    torch.manual_seed(0)
+    x = torch.randn(x_shape, dtype=torch.bfloat16)
+    a = _sample_uniform(ab_shape, *_AB_RANGE_ALPHA, dtype=torch.bfloat16)
+    b = _sample_uniform(ab_shape, *_AB_RANGE_BETA, dtype=torch.bfloat16)
+    expected = torch_snake_beta(x, a, b)
+
+    x_tt = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, device=device)
+    a_tt = ttnn.from_torch(a, layout=ttnn.TILE_LAYOUT, device=device)
+    b_tt = ttnn.from_torch(b, layout=ttnn.TILE_LAYOUT, device=device)
+    result = ttnn.snake_beta(x_tt, a_tt, b_tt)
+
+    assert tuple(result.shape) == x_shape, f"expected output shape {x_shape}, got {tuple(result.shape)}"
+    assert_with_ulp(expected, ttnn.to_torch(result), ulp_threshold=2)
+
+
+# --- Validation failure tests ---
+
+
+def test_snake_beta_shape_mismatch_alpha_beta(device):
+    x = ttnn.from_torch(torch.zeros(1, 1, 32, 32, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    a = ttnn.from_torch(torch.ones(32, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    b = ttnn.from_torch(torch.ones(64, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    with pytest.raises(RuntimeError, match=r"alpha.shape == beta.shape|Broadcasting rule violation"):
+        ttnn.snake_beta(x, a, b)
+
+
+def test_snake_beta_dtype_mismatch(device):
+    x = ttnn.from_torch(torch.zeros(1, 1, 32, 32, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    a = ttnn.from_torch(torch.ones(32, dtype=torch.float32), layout=ttnn.TILE_LAYOUT, dtype=ttnn.float32, device=device)
+    b = ttnn.from_torch(torch.ones(32, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    with pytest.raises(RuntimeError, match=r"dtype"):
+        ttnn.snake_beta(x, a, b)
+
+
+def test_snake_beta_w_mismatch(device):
+    x = ttnn.from_torch(torch.zeros(1, 1, 32, 64, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    a = ttnn.from_torch(torch.ones(32, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    b = ttnn.from_torch(torch.ones(32, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    with pytest.raises(RuntimeError, match=r"input.W == alpha.W|Broadcasting rule violation"):
+        ttnn.snake_beta(x, a, b)
+
+
+def test_snake_beta_unsupported_broadcast(device):
+    """alpha with a non-1 non-W dim (H=64) is rejected in v1."""
+    x = ttnn.from_torch(torch.zeros(1, 1, 64, 32, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    a = ttnn.from_torch(torch.ones(1, 1, 64, 1, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    b = ttnn.from_torch(torch.ones(1, 1, 64, 1, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    with pytest.raises(RuntimeError, match=r"non-1 size only on the last dim|input.W == alpha.W|broadcast"):
+        ttnn.snake_beta(x, a, b)
+
+
+def test_snake_beta_row_major_layout(device):
+    x = ttnn.from_torch(torch.zeros(1, 1, 32, 32, dtype=torch.bfloat16), layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    a = ttnn.from_torch(torch.ones(32, dtype=torch.bfloat16), layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    b = ttnn.from_torch(torch.ones(32, dtype=torch.bfloat16), layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    with pytest.raises(RuntimeError, match=r"[Tt]ile [Ll]ayout|tile layout"):
+        ttnn.snake_beta(x, a, b)
+
+
+def test_snake_beta_unsupported_input_rank(device):
+    """Rank-1 input is rejected; the kernel reader requires padded_shape rank >= 2."""
+    x = ttnn.from_torch(torch.zeros(32, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    a = ttnn.from_torch(torch.ones(32, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    b = ttnn.from_torch(torch.ones(32, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    with pytest.raises(RuntimeError, match=r"input rank >= 2"):
+        ttnn.snake_beta(x, a, b)
+
+
+def test_snake_beta_unsupported_dtype_int32(device):
+    """INT32 is rejected; only BFLOAT16 / FLOAT32 are supported."""
+    x = ttnn.from_torch(
+        torch.zeros(1, 1, 32, 32, dtype=torch.int32),
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.int32,
+        device=device,
+    )
+    a = ttnn.from_torch(
+        torch.ones(32, dtype=torch.int32),
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.int32,
+        device=device,
+    )
+    b = ttnn.from_torch(
+        torch.ones(32, dtype=torch.int32),
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.int32,
+        device=device,
+    )
+    with pytest.raises(RuntimeError, match=r"BFLOAT16 or FLOAT32"):
+        ttnn.snake_beta(x, a, b)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_snake_beta.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_snake_beta.h
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "sfpi.h"
+#include "sfpu/ckernel_sfpu_polyval.h"
+#include "sfpu/ckernel_sfpu_recip.h"
+
+namespace ckernel::sfpu {
+
+// SnakeBeta activation: y = x + sin²(α·x) / β.
+// Range-reduces α·x to (-π/2, π/2] then evaluates sin(a) via the calculate_sine() minimax
+// polynomial; sin² is even, so no quadrant sign-fix is needed. Valid for |α·x| < 32767·π
+// (≈1.03e5) before convert<vSMag16> saturates.
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
+inline void calculate_snake_beta(uint dst_index_x, uint dst_index_alpha, uint dst_index_beta, uint dst_index_out) {
+    static_assert(
+        data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b,
+        "snake_beta supports only Float32 and Float16_b");
+
+    constexpr uint dst_tile_size_sfpi = 32;
+    constexpr float one_over_pi = 0.318309886183791f;
+    constexpr float pi_f = 3.141592653589793f;
+
+    // sin(a) minimax coefficients on a ∈ (-π/2, π/2]; mirror calculate_sine().
+    constexpr float fp32_C3 = 0x1.5dc908p-19f;
+    constexpr float fp32_C2 = -0x1.9f70fp-13f;
+    constexpr float fp32_C1 = 0x1.110edap-7f;
+    constexpr float fp32_C0 = -0x1.55554cp-3f;
+    constexpr float bf16_C2 = -0x1.8b10a4p-13f;
+    constexpr float bf16_C1 = 0x1.10c2a2p-7f;
+    constexpr float bf16_C0 = -0x1.5554a4p-3f;
+
+    // 2 NR iters for fp32 (≤1 ULP), 1 for bf16 (≤0.5 ULP).
+    constexpr int RECIP_ITER = is_fp32_dest_acc_en ? 2 : 1;
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat x = sfpi::dst_reg[dst_index_x * dst_tile_size_sfpi];
+        sfpi::vFloat alpha = sfpi::dst_reg[dst_index_alpha * dst_tile_size_sfpi];
+        sfpi::vFloat beta = sfpi::dst_reg[dst_index_beta * dst_tile_size_sfpi];
+
+        sfpi::vFloat ax = alpha * x;
+
+        // a = (ax/π - round(ax/π)) * π, single-stage reduction; vConstFloatPrgm0/1/2 are
+        // reserved for the reciprocal estimate so convert<vSMag16> is used instead.
+        sfpi::vFloat ax_over_pi = ax * one_over_pi;
+        sfpi::vSMag16 k = sfpi::convert<sfpi::vSMag16>(ax_over_pi, sfpi::RoundMode::NearestEven);
+        sfpi::vFloat k_f = sfpi::convert<sfpi::vFloat>(k, sfpi::RoundMode::NearestEven);
+        sfpi::vFloat a = (ax_over_pi - k_f) * pi_f;
+
+        // sin(a) = a + a·s·poly(s), s = a².  PolynomialEvaluator::eval expands to a Horner chain.
+        sfpi::vFloat s = a * a;
+        sfpi::vFloat c = a * s;  // a³
+        sfpi::vFloat r;
+        if constexpr (is_fp32_dest_acc_en) {
+            r = c * PolynomialEvaluator::eval(s, fp32_C0, fp32_C1, fp32_C2, fp32_C3) + a;
+        } else {
+            r = c * PolynomialEvaluator::eval(s, bf16_C0, bf16_C1, bf16_C2) + a;
+        }
+
+        sfpi::vFloat sin2_ax = r * r;
+        sfpi::vFloat inv_beta = _sfpu_reciprocal_<RECIP_ITER>(beta);
+        sfpi::vFloat result = x + sin2_ax * inv_beta;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
+        }
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATE>
+inline void snake_beta_init() {
+    _init_sfpu_reciprocal_<APPROXIMATE>();
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_snake_beta.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_snake_beta.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_ternary_sfpu_params.h"
+#include "ckernel_sfpu_snake_beta.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
+inline void llk_math_eltwise_ternary_sfpu_snake_beta(
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_ternary_sfpu_params_(
+        sfpu::calculate_snake_beta<APPROXIMATE, is_fp32_dest_acc_en, data_format, ITERATIONS>,
+        dst_index0,
+        dst_index1,
+        dst_index2,
+        odst,
+        vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_ternary_sfpu_snake_beta_init() {
+    _llk_math_eltwise_ternary_sfpu_init_<SfpuType::snake_beta>();
+    sfpu::snake_beta_init<APPROXIMATE>();  // calls _init_sfpu_reciprocal_<APPROXIMATE>()
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -158,6 +158,7 @@ enum class SfpuType {
     unary_min_uint32,
     addcdiv,
     lerp,
+    snake_beta,
     xielu,
     lgamma,
     polygamma,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_snake_beta.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_snake_beta.h
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "sfpi.h"
+#include "sfpu/ckernel_sfpu_polyval.h"
+#include "sfpu/ckernel_sfpu_recip.h"
+
+namespace ckernel::sfpu {
+
+// SnakeBeta activation: y = x + sin²(α·x) / β.
+// Range-reduces α·x to (-π/2, π/2] then evaluates sin(a) via the calculate_sine() minimax
+// polynomial; sin² is even, so no quadrant sign-fix is needed. Valid for |α·x| < 32767·π
+// (≈1.03e5) before convert<vSMag16> saturates.
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
+inline void calculate_snake_beta(uint dst_index_x, uint dst_index_alpha, uint dst_index_beta, uint dst_index_out) {
+    static_assert(
+        data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b,
+        "snake_beta supports only Float32 and Float16_b");
+
+    constexpr uint dst_tile_size_sfpi = 32;
+    constexpr float one_over_pi = 0.318309886183791f;
+    constexpr float pi_f = 3.141592653589793f;
+
+    // sin(a) minimax coefficients on a ∈ (-π/2, π/2]; mirror calculate_sine().
+    constexpr float fp32_C3 = 0x1.5dc908p-19f;
+    constexpr float fp32_C2 = -0x1.9f70fp-13f;
+    constexpr float fp32_C1 = 0x1.110edap-7f;
+    constexpr float fp32_C0 = -0x1.55554cp-3f;
+    constexpr float bf16_C2 = -0x1.8b10a4p-13f;
+    constexpr float bf16_C1 = 0x1.10c2a2p-7f;
+    constexpr float bf16_C0 = -0x1.5554a4p-3f;
+
+    // 2 NR iters for fp32 (≤1 ULP), 1 for bf16 (≤0.5 ULP).
+    constexpr int RECIP_ITER = is_fp32_dest_acc_en ? 2 : 1;
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat x = sfpi::dst_reg[dst_index_x * dst_tile_size_sfpi];
+        sfpi::vFloat alpha = sfpi::dst_reg[dst_index_alpha * dst_tile_size_sfpi];
+        sfpi::vFloat beta = sfpi::dst_reg[dst_index_beta * dst_tile_size_sfpi];
+
+        sfpi::vFloat ax = alpha * x;
+
+        // a = (ax/π - round(ax/π)) * π, single-stage reduction; vConstFloatPrgm0/1/2 are
+        // reserved for the reciprocal estimate so convert<vSMag16> is used instead.
+        sfpi::vFloat ax_over_pi = ax * one_over_pi;
+        sfpi::vSMag16 k = sfpi::convert<sfpi::vSMag16>(ax_over_pi, sfpi::RoundMode::NearestEven);
+        sfpi::vFloat k_f = sfpi::convert<sfpi::vFloat>(k, sfpi::RoundMode::NearestEven);
+        sfpi::vFloat a = (ax_over_pi - k_f) * pi_f;
+
+        // sin(a) = a + a·s·poly(s), s = a².  PolynomialEvaluator::eval expands to a Horner chain.
+        sfpi::vFloat s = a * a;
+        sfpi::vFloat c = a * s;  // a³
+        sfpi::vFloat r;
+        if constexpr (is_fp32_dest_acc_en) {
+            r = c * PolynomialEvaluator::eval(s, fp32_C0, fp32_C1, fp32_C2, fp32_C3) + a;
+        } else {
+            r = c * PolynomialEvaluator::eval(s, bf16_C0, bf16_C1, bf16_C2) + a;
+        }
+
+        sfpi::vFloat sin2_ax = r * r;
+        sfpi::vFloat inv_beta = _sfpu_reciprocal_<RECIP_ITER>(beta);
+        sfpi::vFloat result = x + sin2_ax * inv_beta;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
+        }
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATE>
+inline void snake_beta_init() {
+    _init_sfpu_reciprocal_<APPROXIMATE>();
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_snake_beta.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_snake_beta.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_ternary_sfpu_params.h"
+#include "ckernel_sfpu_snake_beta.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
+inline void llk_math_eltwise_ternary_sfpu_snake_beta(
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_ternary_sfpu_params_(
+        sfpu::calculate_snake_beta<APPROXIMATE, is_fp32_dest_acc_en, data_format, ITERATIONS>,
+        dst_index0,
+        dst_index1,
+        dst_index2,
+        odst,
+        vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_ternary_sfpu_snake_beta_init() {
+    _llk_math_eltwise_ternary_sfpu_init_<SfpuType::snake_beta>();
+    sfpu::snake_beta_init<APPROXIMATE>();  // calls _init_sfpu_reciprocal_<APPROXIMATE>()
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -158,6 +158,7 @@ enum class SfpuType {
     unary_min_uint32,
     addcdiv,
     lerp,
+    snake_beta,
     xielu,
     lgamma,
     polygamma,

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/snake_beta.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/snake_beta.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_ternary_sfpu_snake_beta.h"
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs elementwise SnakeBeta fused activation: out = x + sin(alpha * x)^2 / beta
+ *
+ * | Argument   | Description                                                 | Type     | Valid Range                                           | Required |
+ * |------------|-------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst_x     | Index of the tile in DST register buffer (input x)         | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst_alpha | Index of the tile in DST register buffer (input alpha)     | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst_beta  | Index of the tile in DST register buffer (input beta)      | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst_out   | Index of the tile in DST register buffer (output)          | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+template <DataFormat data_format>
+ALWI void snake_beta_tile(uint32_t idst_x, uint32_t idst_alpha, uint32_t idst_beta, uint32_t idst_out) {
+    MATH((llk_math_eltwise_ternary_sfpu_snake_beta<APPROX, DST_ACCUM_MODE, data_format>(
+        idst_x, idst_alpha, idst_beta, idst_out)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void snake_beta_tile_init() { MATH((llk_math_eltwise_ternary_sfpu_snake_beta_init<APPROX>())); }
+
+}  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/common/ternary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/common/ternary_op_types.hpp
@@ -18,10 +18,11 @@ using ScalarVariant = std::variant<float, int32_t, uint32_t>;
 
 // Ternary operation types
 enum class TernaryOpType {
-    WHERE,    // conditional selection: out = predicate ? value_true : value_false
-    LERP,     // linear interpolation: out = input + weight * (end - input)
-    ADDCMUL,  // fused multiply-add: out = input_a + value * input_b * input_c
-    ADDCDIV,  // fused divide-add: out = input_a + value * input_b / input_c
+    WHERE,       // conditional selection: out = predicate ? value_true : value_false
+    LERP,        // linear interpolation: out = input + weight * (end - input)
+    ADDCMUL,     // fused multiply-add: out = input_a + value * input_b * input_c
+    ADDCDIV,     // fused divide-add: out = input_a + value * input_b / input_c
+    SNAKE_BETA,  // fused activation: out = a + sin^2(b * a) / c   (a=x, b=alpha, c=beta)
 };
 
 // Variant types for ternary operations

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_ttt.cpp
@@ -9,6 +9,7 @@
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/where.h"
 #include "api/compute/eltwise_unary/lerp.h"
+#include "api/compute/eltwise_unary/snake_beta.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_row_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_row_bcast_ttt.cpp
@@ -18,6 +18,7 @@
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/where.h"
 #include "api/compute/eltwise_unary/lerp.h"
+#include "api/compute/eltwise_unary/snake_beta.h"
 #include "api/compute/bcast.h"
 #include "api/compute/tile_move_copy.h"
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
@@ -391,6 +391,72 @@ void TernaryDeviceOperation::validate_on_program_cache_miss(
                 "Ternary operation requires output tensor to be in Tile layout when working with non-sharded tensor.");
         }
     }
+
+    // SNAKE_BETA-specific validation
+    if (args.ternary_op_type == TernaryOpType::SNAKE_BETA) {
+        const auto& a = tensor_args.input_tensor_a;
+        TT_FATAL(
+            tensor_args.input_tensor_b.has_value() && tensor_args.input_tensor_c.has_value(),
+            "snake_beta requires alpha and beta tensors");
+        const auto& alpha = tensor_args.input_tensor_b.value();
+        const auto& beta = tensor_args.input_tensor_c.value();
+
+        TT_FATAL(
+            args.ternary_variant == TernaryVariant::TTT,
+            "snake_beta v1 supports only TTT variant (tensor alpha and tensor beta)");
+
+        TT_FATAL(
+            a.dtype() == DataType::BFLOAT16 || a.dtype() == DataType::FLOAT32,
+            "snake_beta supports only BFLOAT16 or FLOAT32, got {}",
+            a.dtype());
+        TT_FATAL(
+            alpha.dtype() == a.dtype() && beta.dtype() == a.dtype(),
+            "snake_beta requires alpha.dtype == beta.dtype == input.dtype");
+
+        TT_FATAL(
+            a.layout() == Layout::TILE && alpha.layout() == Layout::TILE && beta.layout() == Layout::TILE,
+            "snake_beta requires tile layout for all inputs");
+
+        TT_FATAL(
+            a.logical_shape().rank() >= 2,
+            "snake_beta requires input rank >= 2, got rank {} (shape {})",
+            a.logical_shape().rank(),
+            a.logical_shape());
+
+        TT_FATAL(
+            alpha.logical_shape() == beta.logical_shape(),
+            "snake_beta requires alpha.shape == beta.shape, got {} vs {}",
+            alpha.logical_shape(),
+            beta.logical_shape());
+
+        const auto& a_shape = a.logical_shape();
+        const auto& ab_shape = alpha.logical_shape();
+        TT_FATAL(
+            a_shape[-1] == ab_shape[-1],
+            "snake_beta requires input.W == alpha.W, got {} vs {}",
+            a_shape[-1],
+            ab_shape[-1]);
+
+        // v1: alpha/beta must match input exactly, or have non-1 size only on the last dim.
+        const bool ab_matches_input = (ab_shape == a_shape);
+        if (!ab_matches_input) {
+            for (int i = 0; i + 1 < static_cast<int>(ab_shape.rank()); ++i) {
+                TT_FATAL(
+                    ab_shape[i] == 1,
+                    "snake_beta v1 requires alpha/beta to either match input shape exactly or have non-1 size only on "
+                    "the last dim (got dim {} = {})",
+                    i,
+                    ab_shape[i]);
+            }
+        }
+
+        using BT = TernaryBroadcastType;
+        TT_FATAL(
+            args.broadcast_type == BT::NONE || args.broadcast_type == BT::ROW_BCAST ||
+                args.broadcast_type == BT::OUTER_BCAST,
+            "snake_beta v1 supports only NONE/ROW_BCAST/OUTER_BCAST, got {}",
+            static_cast<int>(args.broadcast_type));
+    }
 }
 
 TensorSpec TernaryDeviceOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
@@ -256,6 +256,14 @@ static const std::unordered_map<KernelLookupKey, KernelConfigEntry, KernelLookup
     {{TernaryOpType::ADDCDIV, TernaryVariant::TTT, TernaryBroadcastType::ROW_COL_BCAST},
      {KernelName::ReaderRowColBcastTTT, KernelName::ComputeBcastAddcOp, KernelName::WriterNoBcastTernary}},
 
+    // TTT configurations for SNAKE_BETA (reader handles H/outer bcast; compute is always NoBcast).
+    {{TernaryOpType::SNAKE_BETA, TernaryVariant::TTT, TernaryBroadcastType::NONE},
+     {KernelName::ReaderNoBcastTTT, KernelName::ComputeNoBcastTTT, KernelName::WriterNoBcastTernary}},
+    {{TernaryOpType::SNAKE_BETA, TernaryVariant::TTT, TernaryBroadcastType::ROW_BCAST},
+     {KernelName::ReaderRowBcastTTT, KernelName::ComputeNoBcastTTT, KernelName::WriterNoBcastTernary}},
+    {{TernaryOpType::SNAKE_BETA, TernaryVariant::TTT, TernaryBroadcastType::OUTER_BCAST},
+     {KernelName::ReaderOuterBcastTTT, KernelName::ComputeNoBcastTTT, KernelName::WriterNoBcastTernary}},
+
     // TTS configurations for LERP
     {{TernaryOpType::LERP, TernaryVariant::TTS, TernaryBroadcastType::COL_BCAST},
      {KernelName::ReaderColBcastTTS, KernelName::ComputeBcastTTS_TST, KernelName::WriterNoBcast}},
@@ -499,6 +507,11 @@ std::map<std::string, std::string> get_compute_defines(TernaryOpType op_type, Da
             defines["TERNARY_SFPU_OP_INIT"] = "addcdiv_tile_init";
             defines["TERNARY_SFPU_OP_FUNC"] = (dtype == DataType::FLOAT32) ? "addcdiv_tile<DataFormat::Float32>"
                                                                            : "addcdiv_tile<DataFormat::Float16_b>";
+            break;
+        case TernaryOpType::SNAKE_BETA:
+            defines["TERNARY_SFPU_OP_INIT"] = "snake_beta_tile_init";
+            defines["TERNARY_SFPU_OP_FUNC"] = (dtype == DataType::FLOAT32) ? "snake_beta_tile<DataFormat::Float32>"
+                                                                           : "snake_beta_tile<DataFormat::Float16_b>";
             break;
         default: TT_FATAL(false, "Unsupported ternary operation type");
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
@@ -13,6 +13,8 @@
 #include "device/ternary_device_operation.hpp"
 #include "device/ternary_op_utils.hpp"
 #include "ttnn/operations/copy/typecast/typecast.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/data_movement/unsqueeze/unsqueeze.hpp"
 #include "ternary_composite_op.hpp"
 
 using namespace ttnn::operations::ternary;
@@ -395,6 +397,24 @@ Tensor lerp(
         ternary_utils::determine_output_dtype(output, input.dtype()),
         ternary_utils::determine_memory_config(memory_config, input.memory_config()),
         output,
+        std::nullopt);
+}
+
+Tensor snake_beta(
+    const Tensor& input_tensor,
+    const Tensor& alpha,
+    const Tensor& beta,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    auto lift_to_rank2 = [](const Tensor& t) { return t.logical_shape().rank() < 2 ? ttnn::unsqueeze(t, 0) : t; };
+    return ttnn::prim::ternary(
+        TernaryOpType::SNAKE_BETA,
+        input_tensor,
+        lift_to_rank2(alpha),
+        lift_to_rank2(beta),
+        ternary_utils::determine_output_dtype(optional_output_tensor, input_tensor.dtype()),
+        ternary_utils::determine_memory_config(memory_config, input_tensor.memory_config()),
+        optional_output_tensor,
         std::nullopt);
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.hpp
@@ -62,4 +62,11 @@ Tensor lerp(
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     const std::optional<Tensor>& output = std::nullopt);
 
+Tensor snake_beta(
+    const Tensor& input_tensor,
+    const Tensor& alpha,
+    const Tensor& beta,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_nanobind.cpp
@@ -334,6 +334,32 @@ void bind_ternary_mac(nb::module_& mod, const std::string& description) {
             nb::arg("memory_config") = nb::none()));
 }
 
+void bind_ternary_snake_beta(nb::module_& mod, const std::string& description) {
+    auto doc = std::string(R"doc(
+SnakeBeta activation (canonical, BigVGAN-style):
+
+    y = x + sin^2(alpha * x) / beta
+
+Constraints (v1):
+  - input/alpha/beta must be tile layout
+  - dtype in {bfloat16, float32}; alpha.dtype == beta.dtype == input.dtype
+  - alpha.shape == beta.shape
+  - alpha and beta have non-1 size only on the last dim, which must equal input.shape[-1]
+  - caller is responsible for beta != 0 (no internal epsilon)
+)doc") + description;
+
+    ttnn::bind_function<"snake_beta">(
+        mod,
+        doc.c_str(),
+        &ttnn::snake_beta,
+        nb::arg("input_tensor"),
+        nb::arg("alpha"),
+        nb::arg("beta"),
+        nb::kw_only(),
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("output_tensor") = nb::none());
+}
+
 }  // namespace
 
 void py_module(nb::module_& mod) {
@@ -366,6 +392,10 @@ void py_module(nb::module_& mod) {
     bind_ternary_mac(
         mod,
         R"doc(Computes Mac on :attr:`input_tensor_a`, :attr:`input_tensor_b` and :attr:`input_tensor_c` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc");
+
+    bind_ternary_snake_beta(
+        mod,
+        R"doc(Computes the SnakeBeta activation `y = x + sin^2(alpha * x) / beta` element-wise on :attr:`input_tensor` with broadcastable per-channel :attr:`alpha` and :attr:`beta`, and returns a tensor with the same layout as :attr:`input_tensor`.)doc");
 }
 
 }  // namespace ttnn::operations::ternary


### PR DESCRIPTION
### Ticket
Link to Github Issue #43337

### Problem
The `snake_beta` activation `y = x + sin²(α·x) / β` (with broadcastable per-channel `α`, `β`) had no native ttnn op and was being composed from ~5 ttnn primitives (`mul → sin → pow → div → add`), each producing/consuming a full intermediate tile. For the canonical model shape `x=[1,1,640,48]`, `α=β=[48]` this stacks ~5 launches and ~5 SRAM round-trips per activation — none of the trig/squaring work fuses across primitives.

### What this PR does
- **Add `ttnn::snake_beta(x, alpha, beta)`** — single ternary op with `[B,C,H,W] × [W] × [W]` broadcast (matches the issue's tensor shapes), TILE layout, `bfloat16` and `float32` dtypes, no need to materialise broadcasted `α`/`β` tiles.
- **New SFPU kernel `ckernel_sfpu_snake_beta.h`** (Blackhole + Wormhole B0) computing the activation in one fused kernel:
  - Single multiply `α·x` (no `2αx` doubling).
  - Range-reduce to `(-π/2, π/2]` via `(ax/π − k)·π`; `k` is discarded because `sin²` is π-periodic, eliminating any quadrant sign-flip XOR/shift.
  - Evaluate `sin(a)` with the same minimax polynomial used by `calculate_sine()` (degree-3 fp32 / degree-2 bf16, hex-float coefficients) — Horner form with `a*s` interleaved between accumulation steps for SFPU multiplier-pipeline ILP.
  - Square at the end (`sin²(a) = sin(a)·sin(a)`); `sin²` evenness means no sign correction needed.
  - Reciprocal of `β` via `_sfpu_reciprocal_<2>` for fp32 / `<1>` for bf16 (1 NR iter is enough at bf16 precision), selected via `constexpr int RECIP_ITER = is_fp32_dest_acc_en ? 2 : 1`.
- **Wire the op through the existing ternary infrastructure** — add `SnakeBetaOp` to `ternary_op_types.hpp`, plumb it through `ternary_device_operation.cpp`, `ternary_op_utils.cpp`, the `ternary_sfpu_*_ttt.cpp` compute kernels, the C++ public API in `ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.{hpp,cpp}`, and the Python binding in `ternary_nanobind.cpp`.
- **Add `snake_beta_init`** that loads only the reciprocal init constants (no separate trig init) — keeps `vConstFloatPrgm0/1/2` reserved for the reciprocal estimate so the range-reduction step uses `float_to_int16` instead.
- **Add `tests/ttnn/unit_tests/operations/eltwise/test_snake_beta.py`** — 16 tests:
  - `test_snake_beta_broadcast` parametrized over the three supported broadcast paths × two dtypes = 6 cases:
    - `NONE` (`x=(1,1,32,32)`, `α/β=(1,1,32,32)`),
    - `ROW_BCAST` (`x=(1,1,640,48)`, `α/β=(48,)` — preserves the issue shape),
    - `OUTER_BCAST` (`x=(2,4,1,32)`, `α/β=(32,)` — the only valid OUTER_BCAST configuration for snake_beta v1, at `x.H == 1`),
    - bf16 cases asserted with `assert_with_ulp(ulp_threshold=2)`; fp32 cases asserted with `torch.allclose(rtol=1e-5, atol=1e-5)` (fp32's finer quantum makes ULP a poor metric near zero).
  - `test_snake_beta_real_workload` parametrized over the three reviewer-supplied production input distributions (C1: shape `(1,1,2250,768)`; C2: shape `(1,1,36000,192)`; C3: shape `(1,1,144000,48)`) — Gaussian `x`, per-channel uniformly-sampled `α`/`β` matching the measured min/max bounds, asserted at `ulp_threshold=2`.
  - `test_snake_beta_pi_boundary` — `α·x` at multiples of `π/2` to exercise range-reduction boundaries (`k = ±1, ±2`).
  - Six validation/negative tests: shape mismatch between `α` and `β`, dtype mismatch, `W` mismatch, unsupported broadcast (`α`'s non-W dim non-1), `ROW_MAJOR_LAYOUT` rejection, and `INT32` dtype rejection.

### Accuracy

ULP measured against an fp32 torch reference using the repo's `assert_with_ulp` / `models.common.utility_functions.ulp` helpers.

| Test | dtype | median ULP | p99 ULP | max ULP |
|---|---|---|---|---|
| `test_snake_beta_broadcast[NONE]` (32×32) | bf16 | 0 | 0 | ≤ 2 |
| `test_snake_beta_broadcast[ROW_BCAST]` (issue shape, x=(1,1,640,48)) | bf16 | 0 | 0 | ≤ 2 |
| `test_snake_beta_broadcast[OUTER_BCAST]` (x=(2,4,1,32)) | bf16 | 0 | 0 | ≤ 2 |
| `test_snake_beta_broadcast[*]` (fp32 dest) | fp32 | — (uses `torch.allclose`, `rtol=atol=1e-5`) | | |
| `test_snake_beta_real_workload[C1]` — `x ~ N(-0.344, 0.486)` clamp [-3.27, 3.19] | bf16 | 0 | 1 | 1 |
| `test_snake_beta_real_workload[C2]` — `x ~ N(-0.089, 0.293)` clamp [-2.45, 1.82] | bf16 | 0 | 0 | 1 |
| `test_snake_beta_real_workload[C3]` — `x ~ N(+0.011, 0.049)` clamp [-0.61, 0.76] | bf16 | 0 | 0 | 1 |
| **Linear sweep** `x ∈ [-4, 4]`, `α = 1.1`, `β = 1.2`, 32,768 samples | bf16 | **0** | **0** | **1** |

Sweep details: 64 / 32 768 elements (≈ 0.2 %) are 1 ULP off, all the rest are bit-exact against the bf16-rounded golden; **zero elements exceed 1 ULP**; `max |err| = 0.00390625` (= one bf16 quantum at unit scale).

**Sweep plot (`x ∈ [-4, 4]`, `α = 1.1`, `β = 1.2`, bfloat16)**

<img width="1430" height="1300" alt="image" src="https://github.com/user-attachments/assets/254b47fd-bd43-49ba-bf6e-170b2d5d34cc" />

### Performance

`ttnn.snake_beta` measured on the issue shape `x=(1,1,640,48)`, `α=β=(48,)`, bf16,
| metric                          |   median |    mean |     p99 |   stdev |
| ------------------------------- | -------: | ------: | ------: | ------: |
| Device kernel duration          | 6 125 ns | 6 150 ns | 6 489 ns |  111 ns |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/snake_beta)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/snake_beta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/snake_beta)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/snake_beta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/snake_beta)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/snake_beta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/snake_beta)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/snake_beta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/snake_beta)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/snake_beta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/snake_beta)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/snake_beta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/snake_beta)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/snake_beta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/snake_beta)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/snake_beta)
