### PR TITLE
[LLK] Split dst_index into dst_index_in/dst_index_out for SFPU unary ops

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/bitwise_or_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/bitwise_or_tile.rst
@@ -2,4 +2,4 @@ bitwise_or_tile
 ===============
 
 .. doxygenfunction:: bitwise_or_tile_init
-.. doxygenfunction:: bitwise_or_tile
+.. doxygenfunction:: bitwise_or_tile(uint32_t idst, uint32_t param0)

--- a/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_add.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_add.rst
@@ -207,6 +207,8 @@ This layered structure keeps high-level logic separate from hardware-specific de
     There are 3 internal APIs to invoke custom SFPI functions, depending on the number of input tiles. Please view the header file for the most up-to-date information.
 
     *  ``_llk_math_eltwise_unary_sfpu_params_``: For functions with one input tile (e.g., ``sin``, ``exp``).
+       The second and third positional arguments are ``dst_index_in`` and ``dst_index_out``; pass the same value
+       for standard in-place unary ops.
     *  ``_llk_math_eltwise_binary_sfpu_params_``: For functions with two input tiles (e.g., ``add``, ``sub``, ``mul``, ``div``).
     *  ``_llk_math_eltwise_ternary_sfpu_params_``: For functions with three input tiles (e.g., ``where``).
 

--- a/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_smoothstep.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_smoothstep.rst
@@ -197,7 +197,8 @@ The ``my_smoothstep_tiles`` function uses the layered abstraction pattern shown 
     inline void my_smoothstep_tile(uint32_t idx_dst0, float edge0, float edge1, float inv_delta) {
         MATH(_llk_math_eltwise_unary_sfpu_params_(
             smoothstep_tile_face,
-            idx_dst0,
+            idx_dst0,  // dst_index_in: tile to read from
+            idx_dst0,  // dst_index_out: tile to write to (same for standard unary ops)
             VectorMode::RC, // Apply on all 4 faces of the tile
             edge0,
             edge1,

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
@@ -14,17 +14,18 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void deepseek_moe_gate_sum_top2() {
+inline void deepseek_moe_gate_sum_top2(uint32_t /*dst_index_in*/, uint32_t /*dst_index_out*/) {
     _deepseek_moe_gate_sum_top2<APPROXIMATION_MODE, is_fp32_dest_acc_en>();
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void deepseek_moe_gate_sort_top4_groups() {
+inline void deepseek_moe_gate_sort_top4_groups(uint32_t /*dst_index_in*/, uint32_t /*dst_index_out*/) {
     _deepseek_moe_gate_sort_top4_groups<APPROXIMATION_MODE, is_fp32_dest_acc_en>();
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void deepseek_moe_gate_top8(uint32_t eps, uint32_t scale) {
+inline void deepseek_moe_gate_top8(
+    uint32_t /*dst_index_in*/, uint32_t /*dst_index_out*/, uint32_t eps, uint32_t scale) {
     _deepseek_moe_gate_top8<APPROXIMATION_MODE, is_fp32_dest_acc_en>(eps, scale);
 }
 

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_deepseek_top32_rm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_deepseek_top32_rm.h
@@ -21,14 +21,21 @@ template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_deepseek_top32_rm_local_sort(
     uint dst_index, int idir, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::_bitonic_top32_phases_steps_<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode, idir);
+        [](std::uint32_t, std::uint32_t, int idir) {
+            ckernel::sfpu::_bitonic_top32_phases_steps_<APPROXIMATE, is_fp32_dest_acc_en>(idir);
+        },
+        dst_index,
+        vector_mode,
+        idir);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool idir = false>
 inline void llk_math_deepseek_top32_rm_merge(
     uint dst_index, bool across_tiles, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::_bitonic_top32_merge_<APPROXIMATE, is_fp32_dest_acc_en, idir>,
+        [](std::uint32_t, std::uint32_t, bool across_tiles) {
+            ckernel::sfpu::_bitonic_top32_merge_<APPROXIMATE, is_fp32_dest_acc_en, idir>(across_tiles);
+        },
         dst_index,
         vector_mode,
         across_tiles);
@@ -38,7 +45,9 @@ template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_deepseek_top32_rm_rebuild(
     uint dst_index, bool idir, bool skip_second, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::_bitonic_top32_rebuild_<APPROXIMATE, is_fp32_dest_acc_en>,
+        [](std::uint32_t, std::uint32_t, bool idir, bool skip_second) {
+            ckernel::sfpu::_bitonic_top32_rebuild_<APPROXIMATE, is_fp32_dest_acc_en>(idir, skip_second);
+        },
         dst_index,
         vector_mode,
         idir,
@@ -49,7 +58,10 @@ template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool top_min>
 inline void llk_math_deepseek_top32_of_1024_rm_pre_sorted_prep(
     uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::_bitonic_top32_of_1024_rm_pre_sorted_prep_<APPROXIMATE, is_fp32_dest_acc_en, top_min>,
+        [](std::uint32_t, std::uint32_t, std::uint32_t dst_idx) {
+            ckernel::sfpu::_bitonic_top32_of_1024_rm_pre_sorted_prep_<APPROXIMATE, is_fp32_dest_acc_en, top_min>(
+                dst_idx);
+        },
         dst_index,
         vector_mode,
         dst_index);
@@ -59,7 +71,9 @@ template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_deepseek_top32_of_1024_rm_pre_sorted_combine(
     uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::_bitonic_top32_of_1024_rm_pre_sorted_combine_<APPROXIMATE, is_fp32_dest_acc_en>,
+        [](std::uint32_t, std::uint32_t, std::uint32_t dst_idx) {
+            ckernel::sfpu::_bitonic_top32_of_1024_rm_pre_sorted_combine_<APPROXIMATE, is_fp32_dest_acc_en>(dst_idx);
+        },
         dst_index,
         vector_mode,
         dst_index);
@@ -69,7 +83,9 @@ template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_deepseek_top32_of_1024_rm_pre_sorted_final(
     uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::_bitonic_top32_of_1024_rm_pre_sorted_final_<APPROXIMATE, is_fp32_dest_acc_en>,
+        [](std::uint32_t, std::uint32_t, std::uint32_t dst_idx) {
+            ckernel::sfpu::_bitonic_top32_of_1024_rm_pre_sorted_final_<APPROXIMATE, is_fp32_dest_acc_en>(dst_idx);
+        },
         dst_index,
         vector_mode,
         dst_index);

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
@@ -14,17 +14,18 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void deepseek_moe_gate_sum_top2() {
+inline void deepseek_moe_gate_sum_top2(uint32_t /*dst_index_in*/, uint32_t /*dst_index_out*/) {
     _deepseek_moe_gate_sum_top2<APPROXIMATION_MODE, is_fp32_dest_acc_en>();
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void deepseek_moe_gate_sort_top4_groups() {
+inline void deepseek_moe_gate_sort_top4_groups(uint32_t /*dst_index_in*/, uint32_t /*dst_index_out*/) {
     _deepseek_moe_gate_sort_top4_groups<APPROXIMATION_MODE, is_fp32_dest_acc_en>();
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void deepseek_moe_gate_top8(uint32_t eps, uint32_t scale) {
+inline void deepseek_moe_gate_top8(
+    uint32_t /*dst_index_in*/, uint32_t /*dst_index_out*/, uint32_t eps, uint32_t scale) {
     _deepseek_moe_gate_top8<APPROXIMATION_MODE, is_fp32_dest_acc_en>(eps, scale);
 }
 

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h
@@ -371,7 +371,7 @@ void compute_sdpa_recip(uint32_t cb_q, uint32_t sum_dst_offset, uint32_t recip_d
  * fused_max_sub_exp_add_tile
  */
 template <bool SDPA_EXP_APPROX_MODE, bool final_norm = false>
-void calculate_fused_max_sub_exp_add_tile(int scale_bf16) {
+void calculate_fused_max_sub_exp_add_tile(uint32_t /*dst_index_in*/, uint32_t /*dst_index_out*/, int scale_bf16) {
     // Non-Approx mode for exp initializes recip for final normalization
     static_assert(!(final_norm && SDPA_EXP_APPROX_MODE), "Approx mode must be disabled when final_norm is true");
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
@@ -13,22 +13,22 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_abs() {
+inline void calculate_abs(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
-        dst_reg[0] = sfpi::abs(v);
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::abs(v);
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_abs_int32() {
+inline void calculate_abs_int32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         TT_SFPLOAD(1, 12, ADDR_MOD_7, 0);
         TTI_SFPABS(0, 1, 0, 0);
-        TTI_SFPSTORE(0, 12, ADDR_MOD_7, 0);
+        TT_SFPSTORE(0, 12, ADDR_MOD_7, (dst_index_out - dst_index_in) * TILE_R_DIM);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add1.h
@@ -13,10 +13,10 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_add1() {
+inline void calculate_add1(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat val = dst_reg[0];
-        dst_reg[0] = 1.0f + val;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = 1.0f + val;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h
@@ -13,11 +13,12 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
-inline void calculate_alt_complex_rotate90() {
+inline void calculate_alt_complex_rotate90(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    const int out_off = (dst_index_out - dst_index_in) * TILE_R_DIM;
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat val = dst_reg[0];
-        dst_reg[0] = -vFloat(dst_reg[1]);
-        dst_reg[1] = val;
+        dst_reg[out_off] = -dst_reg[1];
+        dst_reg[out_off + 1] = val;
         dst_reg += 2;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binop_with_unary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binop_with_unary.h
@@ -23,7 +23,7 @@ enum {
 };  // BINOP_MODE
 
 template <bool APPROXIMATION_MODE, int BINOP_MODE, int ITERATIONS = 8>
-void calculate_binop_with_scalar(uint32_t param) {
+void calculate_binop_with_scalar(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t param) {
     const sfpi::vFloat parameter = Converter::as_float(param);
 
     for (int d = 0; d < ITERATIONS; d++) {
@@ -43,39 +43,39 @@ void calculate_binop_with_scalar(uint32_t param) {
             result = parameter - val;
         }
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_add(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, ADD, ITERATIONS>(param);
+void calculate_add(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, ADD, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_sub(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, SUB, ITERATIONS>(param);
+void calculate_sub(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, SUB, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_mul(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, MUL, ITERATIONS>(param);
+void calculate_mul(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, MUL, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_div(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, DIV, ITERATIONS>(param);
+void calculate_div(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, DIV, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_rsub(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, RSUB, ITERATIONS>(param);
+void calculate_rsub(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, RSUB, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-void calculate_add_int32(uint32_t scalar) {
+void calculate_add_int32(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t scalar) {
     int int_scalar = scalar;
 
     // Load value scalar to lreg2
@@ -84,13 +84,13 @@ void calculate_add_int32(uint32_t scalar) {
         TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_7, 0);
         TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);  // Using mov to preserve the scalar value after each iteration
         TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 4);
-        TTI_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_7, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_7, (dst_index_out - dst_index_in) * TILE_R_DIM);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-void calculate_sub_int32(uint32_t scalar) {
+void calculate_sub_int32(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t scalar) {
     int int_scalar = scalar;
 
     // Load value scalar to lreg2
@@ -102,7 +102,7 @@ void calculate_sub_int32(uint32_t scalar) {
         TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
         // Used 6 as imod to convert operand B to 2's complement for sub operation
         TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
-        TTI_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_7, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_7, (dst_index_out - dst_index_in) * TILE_R_DIM);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_and.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_and.h
@@ -13,12 +13,12 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_and(const uint value) {
+inline void calculate_bitwise_and(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint value) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];
         vInt res = input & value;
-        dst_reg[0] = res;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = res;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
@@ -14,12 +14,12 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_not() {
+inline void calculate_bitwise_not(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::LREG4, ADDR_MOD_7, 0);
         TTI_SFPNOT(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::LREG4, ADDR_MOD_7, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, p_sfpu::LREG4, ADDR_MOD_7, (dst_index_out - dst_index_in) * TILE_R_DIM);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
@@ -9,7 +9,7 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_or(const uint value) {
+inline void calculate_bitwise_or(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint value) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];
@@ -19,7 +19,7 @@ inline void calculate_bitwise_or(const uint value) {
             res = 0 - res;
             res = copysgn(res, scalar_value);
         }
-        v_endif dst_reg[0] = res;
+        v_endif dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = res;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_xor(const uint value) {
+inline void calculate_bitwise_xor(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint value) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];
@@ -24,7 +24,7 @@ inline void calculate_bitwise_xor(const uint value) {
             res = 0 - res;
             res = copysgn(res, v);
         }
-        v_endif dst_reg[0] = res;
+        v_endif dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = res;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -13,12 +13,12 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void cast_fp32_to_fp16a() {
+inline void cast_fp32_to_fp16a(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat x = sfpi::dst_reg[0];
-        sfpi::dst_reg[0].mode<sfpi::SFPSTORE_MOD0_FMT_FP16A>() =
-            sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
+        TTI_SFPLOAD(0, 0, 3, 0);
+        TTI_SFP_STOCH_RND(0, 0, 0, 0, 0, 8);
+        TT_SFPSTORE(0, 1, 3, (dst_index_out - dst_index_in) * TILE_R_DIM);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
@@ -14,7 +14,7 @@ namespace ckernel::sfpu {
 // Moroz et al. <https://doi.org/10.3390/en14041058>
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_cube_root() {
+inline void calculate_cube_root(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     sfpi::vFloat negative_third_256 = -0x1.555556p-10f;
 
     // Magic constant 0x548c2b4b / 256 + 2^23

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
@@ -9,8 +9,8 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_celu(uint32_t param0, uint32_t param1) {
-    _calculate_celu_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(param0, param1);
+inline void calculate_celu(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t param0, uint32_t param1) {
+    _calculate_celu_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(dst_index_in, dst_index_out, param0, param1);
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
@@ -14,24 +14,26 @@ enum { Max = true, Min = false };  // Clamp Mode
 
 // out = min(max(x, min_val), max_val)
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_clamp(uint min_val, uint max_val) {
+inline void calculate_clamp(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint min_val, uint max_val) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         load_value_param_float(min_val);
-        calculate_unary_max_min_float_body<Max>();
+        calculate_unary_max_min_float_body<Max>(dst_index_in, dst_index_out);
         load_value_param_float(max_val);
-        calculate_unary_max_min_float_body<Min>();
+        calculate_unary_max_min_float_body<Min>(
+            dst_index_in, dst_index_out, (dst_index_out - dst_index_in) * TILE_R_DIM);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_clamp_int32(uint min_val, uint max_val) {
+inline void calculate_clamp_int32(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint min_val, uint max_val) {
     for (int d = 0; d < ITERATIONS; d++) {
         load_value_param_int(min_val);
-        calculate_unary_max_min_int32_body<Max>(min_val);
+        calculate_unary_max_min_int32_body<Max>(dst_index_in, dst_index_out, min_val);
         load_value_param_int(max_val);
-        calculate_unary_max_min_int32_body<Min>(max_val);
+        calculate_unary_max_min_int32_body<Min>(
+            dst_index_in, dst_index_out, max_val, (dst_index_out - dst_index_in) * TILE_R_DIM);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -95,7 +95,7 @@ inline void calculate_comp() {
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void calculate_comp_int() {
+inline void calculate_comp_int(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         vInt v = dst_reg[0];
         vInt zero = 0;
@@ -142,13 +142,13 @@ inline void calculate_comp_int() {
             v_endif;
         }
 
-        dst_reg[0] = v;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void calculate_comp_uint16() {
+inline void calculate_comp_uint16(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     static_assert((COMP_MODE == SfpuType::equal_zero) or (COMP_MODE == SfpuType::not_equal_zero));
     constexpr int check = ((COMP_MODE == SfpuType::equal_zero) ? SFPSETCC_MOD1_LREG_EQ0 : SFPSETCC_MOD1_LREG_NE0);
     for (int d = 0; d < ITERATIONS; d++) {
@@ -163,26 +163,26 @@ inline void calculate_comp_uint16() {
         // end_if
         TTI_SFPENCC(0, 0, 0, 0);
         // store result
-        TTI_SFPSTORE(p_sfpu::LREG1, LO16, ADDR_MOD_7, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, LO16, ADDR_MOD_7, (dst_index_out - dst_index_in) * TILE_R_DIM);
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_eqz_uint32() {
+inline void calculate_eqz_uint32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     int scalar = -5;  // used for shift operation
     _sfpu_load_imm32_(p_sfpu::LREG2, scalar);
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_7, 0);
         TTI_SFPLZ(0, 0, 1, 4);    // result in lreg1 is leading zero count
         TTI_SFPSHFT(0, 2, 1, 0);  // 32 >> 5 = 1 else 0
-        TTI_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_7, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_7, (dst_index_out - dst_index_in) * TILE_R_DIM);
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_nez_uint32() {
+inline void calculate_nez_uint32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_7, 0);
         // initially put 0 into output
@@ -194,13 +194,13 @@ inline void calculate_nez_uint32() {
         // end_if
         TTI_SFPENCC(0, 0, 0, 0);
         // store result
-        TTI_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_7, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_7, (dst_index_out - dst_index_in) * TILE_R_DIM);
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void calculate_comp_unary_int(int scalar) {
+inline void calculate_comp_unary_int(std::uint32_t dst_index_in, std::uint32_t dst_index_out, int scalar) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         vInt v = dst_reg[0];
@@ -216,7 +216,7 @@ inline void calculate_comp_unary_int(int scalar) {
             v_if(v == scalar) { val = 1; }
             v_endif;
         }
-        dst_reg[0] = val;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -15,7 +15,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void calculate_comp() {
+inline void calculate_comp(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     constexpr uint V = p_sfpu::LREG0;
     constexpr uint ABS_V = p_sfpu::LREG2;
     constexpr uint INF = p_sfpu::LREG5;
@@ -27,6 +27,8 @@ inline void calculate_comp() {
         TTI_SFPLOADI(INF, sfpi::SFPLOADI_MOD0_FLOATB, BFLOAT16_INF);
     }
 
+    const std::uint32_t store_offset = (dst_index_out - dst_index_in) * TILE_R_DIM;
+
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(V, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
@@ -34,61 +36,61 @@ inline void calculate_comp() {
 
         // eqz: default 0, set 1 where |v| == 0 (handles ±0; NaN has |v|!=0 → stays 0)
         if constexpr (COMP_MODE == SfpuType::equal_zero) {
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, store_offset);
             TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
-            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, store_offset);
             TTI_SFPENCC(0, 0, 0, 0);
         }
 
         // nez: default 1, set 0 where |v| == 0 (handles ±0; NaN has |v|!=0 → stays 1)
         if constexpr (COMP_MODE == SfpuType::not_equal_zero) {
-            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, store_offset);
             TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, store_offset);
             TTI_SFPENCC(0, 0, 0, 0);
         }
 
         // ltz: default 0; chain: (v < 0) AND (|v| != 0) AND (|v| <= inf) → 1
         if constexpr (COMP_MODE == SfpuType::less_than_zero) {
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, store_offset);
             TTI_SFPSETCC(0, V, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
             TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
             TTI_SFPIADD(0, INF, ABS_V, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_GTE0);
-            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, store_offset);
             TTI_SFPENCC(0, 0, 0, 0);
         }
 
         // gtz: default 0; chain: (v >= 0) AND (|v| != 0) AND (|v| <= inf) → 1
         if constexpr (COMP_MODE == SfpuType::greater_than_zero) {
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, store_offset);
             TTI_SFPSETCC(0, V, 0, sfpi::SFPSETCC_MOD1_LREG_GTE0);
             TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
             TTI_SFPIADD(0, INF, ABS_V, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_GTE0);
-            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, store_offset);
             TTI_SFPENCC(0, 0, 0, 0);
         }
 
         // gez: default 1; chain1: (v<0) AND (|v|!=0) → 0 (negatives excl. -0); chain2: |v|>inf → 0 (NaN)
         if constexpr (COMP_MODE == SfpuType::greater_than_equal_zero) {
-            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, store_offset);
             TTI_SFPSETCC(0, V, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
             TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, store_offset);
             TTI_SFPENCC(0, 0, 0, 0);
             TTI_SFPIADD(0, INF, ABS_V, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_LT0);
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, store_offset);
             TTI_SFPENCC(0, 0, 0, 0);
         }
 
         // lez: default 1; chain1: (v>=0) AND (|v|!=0) → 0 (positives excl. +0); chain2: |v|>inf → 0 (NaN)
         if constexpr (COMP_MODE == SfpuType::less_than_equal_zero) {
-            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, store_offset);
             TTI_SFPSETCC(0, V, 0, sfpi::SFPSETCC_MOD1_LREG_GTE0);
             TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, store_offset);
             TTI_SFPENCC(0, 0, 0, 0);
             TTI_SFPIADD(0, INF, ABS_V, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_LT0);
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, store_offset);
             TTI_SFPENCC(0, 0, 0, 0);
         }
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
@@ -14,8 +14,9 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE /*unused*/, int ITERATIONS = 8 /*unused*/>
-inline void calculate_cumsum(bool first) {
-    _calculate_cumsum_<false, 1>(first);  // There is only non APPROXIMATE implementation and one iteration
+inline void calculate_cumsum(std::uint32_t dst_index_in, std::uint32_t dst_index_out, bool first) {
+    _calculate_cumsum_<false, 1>(
+        dst_index_in, dst_index_out, first);  // There is only non APPROXIMATE implementation and one iteration
 }
 
 template <bool APPROXIMATION_MODE /*unused*/>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
@@ -57,13 +57,13 @@ constexpr std::array<float, 53> DIGAMMA_LUT = {
 #endif
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_digamma() {
+inline void calculate_digamma(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
         sfpi::vFloat result =
             piecewise_rational_eval<DIGAMMA_NUM_DEGREE, DIGAMMA_DEN_DEGREE, DIGAMMA_NUM_SEGMENTS, DIGAMMA_LUT_SIZE>(
                 DIGAMMA_LUT, x);
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
@@ -12,8 +12,8 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_dropout(uint probability, uint scale) {
-    _calculate_dropout_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, probability, scale);
+inline void calculate_dropout(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint probability, uint scale) {
+    _calculate_dropout_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out, ITERATIONS, probability, scale);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
@@ -9,8 +9,8 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_elu(uint slope) {
-    _calculate_elu_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(slope);
+inline void calculate_elu(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint slope) {
+    _calculate_elu_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(dst_index_in, dst_index_out, slope);
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erf.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erf.h
@@ -52,7 +52,7 @@ constexpr std::array<float, ERF_LUT_SIZE> ERF_LUT = {
 #endif
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_erf() {
+inline void calculate_erf(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
         // Clamp |x| to 10.0 before evaluation (erf is odd, rational is exact at boundary)
@@ -74,7 +74,7 @@ inline void calculate_erf() {
         sfpi::vFloat pos_one = sfpi::vConst1;
         sfpi::vec_min_max(neg_one, result);
         sfpi::vec_min_max(result, pos_one);
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfc.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfc.h
@@ -60,7 +60,7 @@ constexpr std::array<float, ERFC_LUT_SIZE> ERFC_LUT = {{// Breakpoints
                                              -2.1375391632e-02f}};
 
 template <int ITERATIONS = 8>
-inline void calculate_erfc() {
+inline void calculate_erfc(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
         // Clamp |x| to 5.0 before evaluation (avoids extrapolation, saves one branch)
@@ -73,7 +73,7 @@ inline void calculate_erfc() {
         // erfc(-x) = 2 - erfc(x)
         v_if(x < 0.0f) { r = 2.0f - r; }
         v_endif;
-        sfpi::dst_reg[0] = r;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = r;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -45,13 +45,13 @@ sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat x) {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void calculate_erfinv() {
+inline void calculate_erfinv(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     constexpr int ITERATIONS = 8;
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];
         sfpi::vFloat result = calculate_erfinv_body<false>(in);
         in = sfpi::dst_reg[0];  // reload due to register pressure
-        sfpi::dst_reg[0] = sfpi::copysgn(result, in);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::copysgn(result, in);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -18,9 +18,12 @@ template <
     bool SCALE_EN = false,
     int ITERATIONS = 8,
     bool CLAMP_NEGATIVE = true>
-void calculate_exponential(const uint exp_base_scale_factor = p_sfpu::kCONST_1_FP16B) {
+void calculate_exponential(
+    std::uint32_t dst_index_in,
+    std::uint32_t dst_index_out,
+    const uint exp_base_scale_factor = p_sfpu::kCONST_1_FP16B) {
     _calculate_exponential_<APPROXIMATION_MODE, SCALE_EN, ITERATIONS, CLAMP_NEGATIVE, is_fp32_dest_acc_en>(
-        exp_base_scale_factor);
+        dst_index_in, dst_index_out, exp_base_scale_factor);
 }
 
 template <bool APPROXIMATION_MODE, uint32_t scale = 0x3F800000, bool CLAMP_NEGATIVE = true>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -9,8 +9,8 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_exp2() {
-    _calculate_exp2_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>();
+inline void calculate_exp2(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_exp2_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -114,19 +114,19 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_improved_<true>(sfpi::vFloat val) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_expm1() {
+inline void calculate_expm1(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     if constexpr (APPROXIMATION_MODE) {
         // Use original approximation mode
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat v = sfpi::dst_reg[0];
-            sfpi::dst_reg[0] = _sfpu_expm1_<is_fp32_dest_acc_en>(v);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _sfpu_expm1_<is_fp32_dest_acc_en>(v);
             sfpi::dst_reg++;
         }
     } else {
         // Use improved version based on destination precision
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat v = sfpi::dst_reg[0];
-            sfpi::dst_reg[0] = _sfpu_expm1_improved_<is_fp32_dest_acc_en>(v);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _sfpu_expm1_improved_<is_fp32_dest_acc_en>(v);
             sfpi::dst_reg++;
         }
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
@@ -22,7 +22,8 @@ inline void init_fmod(const uint value, const uint recip) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_fmod(const uint value, const uint recip) {
+inline void calculate_fmod(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint value, const uint recip) {
     // SFPU microcode
     vFloat s = vConstFloatPrgm0;
     vFloat recip_val = vConstFloatPrgm1;
@@ -65,7 +66,7 @@ inline void calculate_fmod(const uint value, const uint recip) {
         }
         v_if(sfpi::abs(v) - s == 0.0f) { v = 0.0f; }
         v_endif;
-        dst_reg[0] = v;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -275,9 +275,9 @@ void gelu_derivative_init() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_gelu() {
+inline void calculate_gelu(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     if constexpr (APPROXIMATION_MODE) {
-        _calculate_gelu_<APPROXIMATION_MODE, ITERATIONS>();
+        _calculate_gelu_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
     } else {
 #pragma GCC unroll 0
         for (int d = 0; d < ITERATIONS; d++) {
@@ -286,15 +286,15 @@ inline void calculate_gelu() {
             if constexpr (!is_fp32_dest_acc_en) {
                 result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
             }
-            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
             sfpi::dst_reg++;
         }
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_gelu_derivative() {
-    _calculate_gelu_derivative_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_gelu_derivative(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_gelu_derivative_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 // =============================================================================
@@ -392,7 +392,7 @@ sfpi_inline sfpi::vFloat calculate_gelu_derivative_simple(sfpi::vFloat x) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
-inline void calculate_gelu_derivative_polynomial() {
+inline void calculate_gelu_derivative_polynomial(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat val = sfpi::dst_reg[0];
@@ -400,7 +400,7 @@ inline void calculate_gelu_derivative_polynomial() {
         if constexpr (!is_fp32_dest_acc_en) {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardmish.h
@@ -25,7 +25,7 @@ namespace sfpu {
 // Clamping to [0, 1] gives exact boundary values (0 or 1),
 // so the final multiply produces exact 0 or exact x at transitions.
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void hardmish() {
+inline void hardmish(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
         sfpi::vFloat scale = x * 0.5f + 1.0f;
@@ -35,7 +35,7 @@ inline void hardmish() {
         sfpi::vec_min_max(low_bound, scale);   // scale = max(scale, 0.0)
         sfpi::vec_min_max(scale, high_bound);  // scale = min(scale, 1.0)
 
-        sfpi::dst_reg[0] = x * scale;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = x * scale;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardshrink.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardshrink.h
@@ -10,7 +10,7 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_hardshrink(uint32_t param0) {
+inline void calculate_hardshrink(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t param0) {
     // Hardshrink(x, λ) = x if |x| > λ, else 0
     // Single comparison using abs: setsgn(v, 0) clears sign bit
     // param0 contains lambda as FP32 bits. For BF16 inputs, the host pre-rounds
@@ -23,7 +23,7 @@ inline void calculate_hardshrink(uint32_t param0) {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vFloat abs_v = sfpi::setsgn(v, 0);
-        v_if(abs_v <= lambda) { sfpi::dst_reg[0] = sfpi::vConst0; }
+        v_if(abs_v <= lambda) { sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::vConst0; }
         v_endif;
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
@@ -12,7 +12,7 @@ namespace ckernel::sfpu {
 // Hardtanh(x) = max_val if x > max_val, min_val if x < min_val, else x
 // Equivalent to: clamp(x, min_val, max_val) = min(max(x, min_val), max_val)
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_hardtanh(uint param0, uint param1) {
+inline void calculate_hardtanh(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint param0, uint param1) {
     // Load both params outside the loop for better performance
     // param0 = min_val -> LREG2, param1 = max_val -> LREG3
     TT_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_LOWER, param0 & 0xFFFF);
@@ -25,13 +25,21 @@ inline void calculate_hardtanh(uint param0, uint param1) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
         TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1 /* smaller value to LREG0 */);
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);  // store max
+        TT_SFPSTORE(
+            p_sfpu::LREG1,
+            InstrModLoadStore::DEFAULT,
+            ADDR_MOD_7,
+            (dst_index_out - dst_index_in) * TILE_R_DIM);  // store max
 
-        // x = min(x, max_val) using LREG3
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+        // x = min(x, max_val) using LREG3 — load from output offset where max result was stored
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, (dst_index_out - dst_index_in) * TILE_R_DIM);
         TTI_SFPMOV(0, p_sfpu::LREG3, p_sfpu::LREG1, 0);
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1 /* smaller value to LREG0 */);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);  // store min
+        TT_SFPSTORE(
+            p_sfpu::LREG0,
+            InstrModLoadStore::DEFAULT,
+            ADDR_MOD_7,
+            (dst_index_out - dst_index_in) * TILE_R_DIM);  // store min
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_heaviside.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_heaviside.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_heaviside(uint value) {
+inline void calculate_heaviside(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     // SFPU microcode
     vFloat s = Converter::as_float(value);
 
@@ -27,7 +27,7 @@ inline void calculate_heaviside(uint value) {
         v_else { v = s; }
         v_endif;
 
-        dst_reg[0] = v;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
 
         dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -23,7 +23,7 @@ namespace sfpu {
           t4) *                                                                                                   \
      t4)
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_i0() {
+inline void calculate_i0(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 0
 
     for (int d = 0; d < ITERATIONS; d++) {
@@ -45,7 +45,7 @@ inline void calculate_i0() {
                             0.25f,
                             x);
 
-        dst_reg[0] = result;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
@@ -82,9 +82,10 @@ inline sfpi::vFloat calculate_i1_asymptotic_(const sfpi::vFloat abs_x, const sfp
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_i1() {
+inline void calculate_i1(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     constexpr float I1_MAX_INPUT = 88.5f;
     constexpr float I1_THRESHOLD = 10.0f;
+    const int out_off = (dst_index_out - dst_index_in) * TILE_R_DIM;
 
 #pragma GCC unroll 1
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_identity.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_identity.h
@@ -17,21 +17,21 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_identity() {
+inline void calculate_identity(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
-        dst_reg[0] = v;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_identity_uint() {
+inline void calculate_identity_uint(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vUInt v = dst_reg[0];
-        dst_reg[0] = v;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_int_sum.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_int_sum.h
@@ -15,7 +15,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE>
-inline void calculate_sum_int_col() {
+inline void calculate_sum_int_col(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (size_t i = 0; i < 2; ++i) {
         vInt a = dst_reg[i];
 
@@ -34,7 +34,7 @@ inline void calculate_sum_int_col() {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void calculate_sum_int_row() {
+inline void calculate_sum_int_row(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (size_t i = 0; i < 8; i += 2) {
         vInt a = dst_reg[i];
 
@@ -52,15 +52,15 @@ template <bool APPROXIMATION_MODE>
 inline void sum_int_init() {}
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void add_int(const uint dst_offset) {
+inline void add_int(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint dst_offset) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         vInt a = dst_reg[0];
-        vInt b = dst_reg[32];
+        vInt b = dst_reg[0 + 32];
 
         vInt r = a + b;
 
-        dst_reg[0] = r;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = r;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_left_shift.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_left_shift.h
@@ -13,12 +13,12 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_left_shift(const uint shift_amt) {
+inline void calculate_left_shift(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint shift_amt) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(0,12,ADDR_MOD_7,0);
+        TTI_SFPLOAD(0, 12, ADDR_MOD_7, 0);
         TT_SFPSHFT(shift_amt,0,0,1);
-        TTI_SFPSTORE(0,12,ADDR_MOD_7,0);
+        TT_SFPSTORE(0, 12, ADDR_MOD_7, (dst_index_out - dst_index_in) * TILE_R_DIM);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
@@ -15,7 +15,7 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_lgamma_stirling() {
+inline void calculate_lgamma_stirling(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     constexpr float LOG_SQRT_2PI = 0.9189385332046727f;
 
     // Minimal coefficients for 0-3 ULP
@@ -48,7 +48,7 @@ inline void calculate_lgamma_stirling() {
             res = sfpi::convert<sfpi::vFloat16b>(res, sfpi::RoundMode::NearestEven);
         }
 
-        sfpi::dst_reg[0] = res;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = res;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -117,7 +117,7 @@ template <
     bool HAS_BASE_SCALING,
     bool is_fp32_dest_acc_en,
     int ITERATIONS = 8>
-inline void calculate_log(uint log_base_scale_factor) {
+inline void calculate_log(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint log_base_scale_factor) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat result = calculate_log_body<FAST_APPROX, HAS_BASE_SCALING, is_fp32_dest_acc_en>(
@@ -125,7 +125,7 @@ inline void calculate_log(uint log_base_scale_factor) {
         if constexpr (!is_fp32_dest_acc_en) {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -134,14 +134,14 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
  * @tparam ITERATIONS Number of iterations for given face
  */
 template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_log1p() {
+inline void calculate_log1p(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat result = calculate_log1p_fp32<is_fp32_dest_acc_en>(sfpi::dst_reg[0]);
         if constexpr (!is_fp32_dest_acc_en) {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not.h
@@ -11,14 +11,13 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, InstrModLoadStore INSTRUCTION_MODE, int ITERATIONS>
-inline void calculate_logical_not() {
+inline void calculate_logical_not(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     static_assert(
         INSTRUCTION_MODE == InstrModLoadStore::DEFAULT || INSTRUCTION_MODE == InstrModLoadStore::LO16 ||
             INSTRUCTION_MODE == InstrModLoadStore::INT32,
         "INSTRUCTION_MODE must be one of: DEFAULT, LO16, INT32.");
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        constexpr int tile_size = 64;
         // load in conditional uint16 value
         TTI_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, 0);
         // initially put 0 into output
@@ -38,7 +37,7 @@ inline void calculate_logical_not() {
         // INSTR_MOD1: 0 => condition code enable reg is not modified.
         TTI_SFPENCC(0, 0, 0, 0);
         // store result
-        TTI_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, (dst_index_out - dst_index_in) * TILE_R_DIM);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
@@ -15,38 +15,42 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_mask() {
+inline void calculate_mask(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     const bool exponent_size_8 = true;
     const int mask_val_idx = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat mask = dst_reg[mask_val_idx];
-        v_if(_sfpu_is_fp16_zero_(mask, exponent_size_8)) { dst_reg[0] = vConst0; }
+        v_if(_sfpu_is_fp16_zero_(mask, exponent_size_8)) {
+            dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = vConst0;
+        }
         v_endif;
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_int_mask() {
+inline void calculate_int_mask(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     const int mask_idx = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         vInt mask = dst_reg[mask_idx];
-        v_if(mask == 0) { dst_reg[0] = vConst0; }
+        v_if(mask == 0) { dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = vConst0; }
         v_endif;
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_mask_posinf() {
+inline void calculate_mask_posinf(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     const bool exponent_size_8 = true;
     const int mask_val_idx = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat mask = dst_reg[mask_val_idx];
-        v_if(_sfpu_is_fp16_zero_(mask, exponent_size_8)) { dst_reg[0] = std::numeric_limits<float>::infinity(); }
+        v_if(_sfpu_is_fp16_zero_(mask, exponent_size_8)) {
+            dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = std::numeric_limits<float>::infinity();
+        }
         v_endif;
         dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
@@ -36,7 +36,8 @@ namespace ckernel::sfpu {
  *   scale_packed: precomputed (-1)^(n+1) * n! (as float bits)
  */
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_polygamma(uint32_t n_packed, uint32_t scale_packed) {
+inline void calculate_polygamma(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t n_packed, uint32_t scale_packed) {
     constexpr int NUM_TERMS = 11;  // Exact terms (k=0..10)
 
     // Unpack parameters using Converter (union-based type punning supported by SFPU compiler)
@@ -123,7 +124,7 @@ inline void calculate_polygamma(uint32_t n_packed, uint32_t scale_packed) {
         if constexpr (!is_fp32_dest_acc_en) {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_prelu(const uint value) {
+inline void calculate_prelu(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint value) {
     // SFPU microcode
     vFloat init = Converter::as_float(value);
 
@@ -23,7 +23,7 @@ inline void calculate_prelu(const uint value) {
         vFloat a = dst_reg[0];
         v_if(a < 0.0f) { a = a * init; }
         v_endif;
-        dst_reg[0] = a;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = a;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h
@@ -16,7 +16,7 @@ inline void rand_init(uint32_t seed) {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void rand(uint32_t from, uint32_t scale) {
+inline void rand(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t from, uint32_t scale) {
     // Load scale param to lreg1
     TT_SFPLOADI(p_sfpu::LREG1, 10, scale & 0xFFFF);
     TT_SFPLOADI(p_sfpu::LREG1, 8, scale >> 16);
@@ -44,7 +44,7 @@ inline void rand(uint32_t from, uint32_t scale) {
         // lreg0 = lreg0 * scale + from
         TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0);
 
-        TTI_SFPSTORE(p_sfpu::LREG0, FP32, ADDR_MOD_7, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, FP32, ADDR_MOD_7, (dst_index_out - dst_index_in) * TILE_R_DIM);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, RoundingMode rounding_mode, int ITERATIONS>
-inline void calculate_rdiv(const uint value) {
+inline void calculate_rdiv(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint value) {
     sfpi::vFloat val = Converter::as_float(value);
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
@@ -36,7 +36,7 @@ inline void calculate_rdiv(const uint value) {
         } else if constexpr (rounding_mode == RoundingMode::Floor) {
             result = _floor_body_(result);
         }
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -24,8 +24,9 @@ sfpi_inline void sfpu_reciprocal_init() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8, bool legacy_compat = false>
-inline void calculate_reciprocal() {
-    _calculate_reciprocal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en, legacy_compat>(ITERATIONS);
+inline void calculate_reciprocal(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_reciprocal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en, legacy_compat>(
+        dst_index_in, dst_index_out, ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool legacy_compat = false>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -12,8 +12,9 @@
 namespace ckernel::sfpu {
 
 template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
-inline void calculate_reduce(uint32_t ct_dim, uint32_t rt_dim) {
-    _calculate_reduce_<pool_type, reduce_dim, format>(ct_dim, rt_dim);
+inline void calculate_reduce(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t ct_dim, uint32_t rt_dim) {
+    _calculate_reduce_<pool_type, reduce_dim, format>(dst_index_in, dst_index_out, ct_dim, rt_dim);
 }
 
 template <PoolType pool_type, DataFormat format>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
@@ -15,19 +15,19 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE>
-inline void relu_min(uint uint_threshold) {
+inline void relu_min(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint uint_threshold) {
     vFloat threshold = Converter::as_float(uint_threshold);
     for (int d = 0; d < 8; d++) {
         vFloat a = dst_reg[0];
         v_if(a < threshold) { a = threshold; }
         v_endif;
-        dst_reg[0] = a;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = a;
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE>
-inline void relu_max(uint uint_threshold) {
+inline void relu_max(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint uint_threshold) {
     vFloat threshold = Converter::as_float(uint_threshold);
     for (int d = 0; d < 8; d++) {
         vFloat a = dst_reg[0];
@@ -35,14 +35,14 @@ inline void relu_max(uint uint_threshold) {
         v_endif;
         v_if(a < 0.0f) { a = 0.0f; }
         v_endif;
-        dst_reg[0] = a;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = a;
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_lrelu(uint slope) {
-    _calculate_lrelu_<APPROXIMATION_MODE>(ITERATIONS, slope);
+inline void calculate_lrelu(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint slope) {
+    _calculate_lrelu_<APPROXIMATION_MODE>(dst_index_in, dst_index_out, ITERATIONS, slope);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -22,7 +22,8 @@ inline void init_remainder(const uint value, const uint recip) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_remainder(const uint value, const uint recip) {
+inline void calculate_remainder(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint value, const uint recip) {
     // SFPU microcode
     vFloat s = vConstFloatPrgm0;
     vFloat recip_val = vConstFloatPrgm1;
@@ -70,7 +71,7 @@ inline void calculate_remainder(const uint value, const uint recip) {
         }
         v_if(sfpi::abs(v) - s == 0.0f) { v = 0.0f; }
         v_endif;
-        dst_reg[0] = v;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
@@ -12,8 +12,8 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE>
-inline void calculate_reshuffle_rows(uint idx_addr) {
-    _calculate_reshuffle_rows_(idx_addr);
+inline void calculate_reshuffle_rows(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint idx_addr) {
+    _calculate_reshuffle_rows_(dst_index_in, dst_index_out, idx_addr);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_right_shift.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_right_shift.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_right_shift(const uint shift_amt) {
+inline void calculate_right_shift(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint shift_amt) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];
@@ -26,7 +26,7 @@ inline void calculate_right_shift(const uint shift_amt) {
         v_if(input < 0) { res = ~res; }
         v_endif;
 
-        dst_reg[0] = res;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = res;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rpow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rpow.h
@@ -11,11 +11,12 @@
 namespace ckernel::sfpu {
 // ttnn.rpow(exponent, scalar_base) = pow(scalar_base, exponent)
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
-inline void calculate_rpow(const uint32_t base_val) {
+inline void calculate_rpow(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint32_t base_val) {
     sfpi::vFloat base_val_v = Converter::as_float(base_val);
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::dst_reg[0] = _sfpu_binary_power_<is_fp32_dest_acc_en>(base_val_v, sfpi::dst_reg[0]);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] =
+            _sfpu_binary_power_<is_fp32_dest_acc_en>(base_val_v, sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
@@ -14,8 +14,9 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>
-inline void calculate_rsqrt() {
-    _calculate_rsqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX, legacy_compat>(ITERATIONS);
+inline void calculate_rsqrt(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_rsqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX, legacy_compat>(
+        dst_index_in, dst_index_out, ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE, bool legacy_compat>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
@@ -18,7 +18,6 @@ inline void calculate_rsub_int(const uint dst_index_in0, const uint dst_index_in
         is_valid_instruction_mode(INSTRUCTION_MODE), "INSTRUCTION_MODE must be one of: INT32_2S_COMP, INT32, LO16.");
     constexpr int sfpload_instr_mod = static_cast<std::underlying_type_t<InstrModLoadStore>>(INSTRUCTION_MODE);
 
-    // size of each tile in Dest is 64 rows
     constexpr uint dst_tile_size = 64;
 
 #pragma GCC unroll 8
@@ -43,7 +42,7 @@ inline void calculate_rsub_int(const uint dst_index_in0, const uint dst_index_in
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-void calculate_rsub_scalar_int32(uint32_t scalar) {
+void calculate_rsub_scalar_int32(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t scalar) {
     int int_scalar = scalar;
     // Load scalar value param to lreg2
     _sfpu_load_imm32_(p_sfpu::LREG1, int_scalar);
@@ -53,7 +52,7 @@ void calculate_rsub_scalar_int32(uint32_t scalar) {
         // specified in lreg_dest. The condition code register is not modified (2).
         TTI_SFPIADD(
             0, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_NONE);
-        TTI_SFPSTORE(p_sfpu::LREG0, INT32, ADDR_MOD_7, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, INT32, ADDR_MOD_7, (dst_index_out - dst_index_in) * TILE_R_DIM);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_selu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_selu.h
@@ -9,8 +9,8 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_selu(uint32_t scale, uint32_t alpha) {
-    _calculate_selu_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(scale, alpha);
+inline void calculate_selu(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t scale, uint32_t alpha) {
+    _calculate_selu_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(dst_index_in, dst_index_out, scale, alpha);
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -40,7 +40,7 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_sigmoid() {
+inline void calculate_sigmoid(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     if constexpr (!APPROXIMATION_MODE) {
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
@@ -50,11 +50,11 @@ inline void calculate_sigmoid() {
                 result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
             }
 
-            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
             sfpi::dst_reg++;
         }
     } else {
-        calculate_sigmoid_appx<ITERATIONS>();
+        calculate_sigmoid_appx<ITERATIONS>(dst_index_in, dst_index_out);
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid_appx.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <int ITERATIONS = 8>
-inline void calculate_sigmoid_appx() {
+inline void calculate_sigmoid_appx(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     vUInt l0 = l_reg[LRegs::LReg0];
     vUInt l1 = l_reg[LRegs::LReg1];
     vUInt l2 = l_reg[LRegs::LReg2];
@@ -22,7 +22,7 @@ inline void calculate_sigmoid_appx() {
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat val = dst_reg[0];
 
-        dst_reg[0] = lut(val, l0, l1, l2) + 0.5f;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = lut(val, l0, l1, l2) + 0.5f;
 
         dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h
@@ -14,8 +14,8 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_sign(const uint exponent_size_8) {
-    _calculate_sign_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, exponent_size_8);
+inline void calculate_sign(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint exponent_size_8) {
+    _calculate_sign_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out, ITERATIONS, exponent_size_8);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_signbit.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_signbit.h
@@ -12,7 +12,7 @@ using namespace sfpi;
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_signbit() {
+inline void calculate_signbit(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
     //
     // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
@@ -24,29 +24,30 @@ inline void calculate_signbit() {
     //    | ...  | [a] L16 = cast_fp32(a) |     |            |          |
     //    | ...  |                        |     |            | [a] L16  |
 
-    constexpr int offset = 0;
+    const int in_offset = 0;
+    const int out_offset = (dst_index_out - dst_index_in) * TILE_R_DIM;
 
 #ifndef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         int a = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
-        TT_SFPLOADMACRO((0 << 2) | (a & 3), InstrModLoadStore::DEFAULT, ADDR_MOD_6, offset | (a >> 2));
+        TT_SFPLOADMACRO((0 << 2) | (a & 3), InstrModLoadStore::DEFAULT, ADDR_MOD_6, in_offset | (a >> 2));
     }
     TTI_SFPNOP;
     TTI_SFPNOP;
     TTI_SFPNOP;
 #else
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, offset);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, in_offset);
         TTI_SFPSHFT(-31 & 0xfff, p_sfpu::LREG0, p_sfpu::LREG0, 1);  // SFPSHFT_MOD1_ARG_IMM
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, offset);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, out_offset);
     }
 #endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_signbit_int32() {
+inline void calculate_signbit_int32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
     //
     // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
@@ -57,21 +58,22 @@ inline void calculate_signbit_int32() {
     //    | ...  |        |     | [a] L16 = a >> 31 |          |
     //    | ...  |        |     |                   | [a] L16  |
 
-    constexpr int offset = 0;
+    const int in_offset = 0;
+    const int out_offset = (dst_index_out - dst_index_in) * TILE_R_DIM;
 
 #ifndef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr int a = p_sfpu::LREG0;
-        TTI_SFPLOADMACRO((0 << 2) | (a & 3), InstrModLoadStore::INT32, ADDR_MOD_6, offset | (a >> 2));
+        TTI_SFPLOADMACRO((0 << 2) | (a & 3), InstrModLoadStore::INT32, ADDR_MOD_6, in_offset | (a >> 2));
     }
     TTI_SFPNOP;
     TTI_SFPNOP;
 #else
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, offset);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, in_offset);
         TTI_SFPSHFT(-31 & 0xfff, p_sfpu::LREG0, p_sfpu::LREG0, 1);  // SFPSHFT_MOD1_ARG_IMM
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_6, offset);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_6, out_offset);
     }
 #endif
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -10,7 +10,7 @@
 namespace ckernel::sfpu {
 
 template <bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_silu() {
+inline void calculate_silu(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
@@ -23,7 +23,7 @@ inline void calculate_silu() {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -80,7 +80,12 @@ sfpi_inline sfpi::vFloat softplus_exp_negative(sfpi::vFloat x) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void calculate_softplus_body(const float beta, const float beta_reciprocal, const float threshold) {
+inline void calculate_softplus_body(
+    std::uint32_t dst_index_in,
+    std::uint32_t dst_index_out,
+    const float beta,
+    const float beta_reciprocal,
+    const float threshold) {
     sfpi::vFloat val = sfpi::dst_reg[0];
     sfpi::vFloat t = beta * val;
 
@@ -128,18 +133,20 @@ inline void calculate_softplus_body(const float beta, const float beta_reciproca
         if constexpr (!is_fp32_dest_acc_en) {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
     }
     v_endif;
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_softplus(uint param0, uint param1, uint param2) {
+inline void calculate_softplus(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint param0, uint param1, uint param2) {
     const float beta = Converter::as_float(param0);
     const float beta_reciprocal = Converter::as_float(param1);
     const float threshold = Converter::as_float(param2);
     for (int d = 0; d < ITERATIONS; d++) {
-        calculate_softplus_body<APPROXIMATION_MODE, is_fp32_dest_acc_en>(beta, beta_reciprocal, threshold);
+        calculate_softplus_body<APPROXIMATION_MODE, is_fp32_dest_acc_en>(
+            dst_index_in, dst_index_out, beta, beta_reciprocal, threshold);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
@@ -10,15 +10,15 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_softshrink(uint32_t param0) {
+inline void calculate_softshrink(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t param0) {
     // Softshrink(x) = x - λ if x > λ, x + λ if x < -λ, else 0
     // SFPU microcode
     sfpi::vFloat lambda = Converter::as_float(param0);
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::vConst0;
-        v_if(v > lambda) { sfpi::dst_reg[0] = v - lambda; }
-        v_elseif(v < (-lambda)) { sfpi::dst_reg[0] = v + lambda; }
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::vConst0;
+        v_if(v > lambda) { sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v - lambda; }
+        v_elseif(v < (-lambda)) { sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v + lambda; }
         v_endif;
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
@@ -10,13 +10,13 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_softsign() {
+inline void calculate_softsign(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vFloat tmp = sfpi::abs(v) + sfpi::vConst1;
         tmp = sfpu_reciprocal<APPROXIMATION_MODE>(tmp);
-        sfpi::dst_reg[0] = v * tmp;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v * tmp;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -14,8 +14,9 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool fp32_dest_acc_en, bool FAST_APPROX>
-inline void calculate_sqrt() {
-    _calculate_sqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX>(ITERATIONS);
+inline void calculate_sqrt(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_sqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX>(
+        dst_index_in, dst_index_out, ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -11,8 +11,8 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_square() {
-    _calculate_square_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_square(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_square_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -118,7 +118,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_tanh() {
+inline void calculate_tanh(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     if constexpr (APPROXIMATION_MODE) {
         // SFPU microcode
         sfpi::vUInt l0 = l_reg[sfpi::LRegs::LReg0];
@@ -129,7 +129,7 @@ inline void calculate_tanh() {
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];
             val = sfpi::lut(val, l0, l1, l2);
-            sfpi::dst_reg[0] = val;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
 
             sfpi::dst_reg++;
         }
@@ -152,7 +152,7 @@ inline void calculate_tanh() {
                 result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
             }
 
-            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
             sfpi::dst_reg++;
         }
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
@@ -19,7 +19,7 @@ namespace sfpu {
 // WARNING: This has catastrophic cancellation for |x| > ~3.4 (Max ULP = 15,140).
 // Kept for backward compatibility. Use calculate_tanh_derivative_sech2 instead.
 template <bool APPROXIMATION_MODE, int WITH_PRECOMPUTED_TANH = 0, int ITERATIONS = 8>
-inline void calculate_tanh_derivative() {
+inline void calculate_tanh_derivative(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     vUInt l0 = l_reg[LRegs::LReg0];
     vUInt l1 = l_reg[LRegs::LReg1];
     vUInt l2 = l_reg[LRegs::LReg2];
@@ -33,7 +33,7 @@ inline void calculate_tanh_derivative() {
         }
 
         val = val * (-val) + vConst1;
-        dst_reg[0] = val;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
 
         dst_reg++;
     }
@@ -170,7 +170,7 @@ constexpr float CORE_REGION_LIMIT = 3.0f;   // Polynomial ↔ exp boundary
 constexpr float TAIL_REGION_LIMIT = 45.0f;  // Exp ↔ zero saturation boundary
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_tanh_derivative_sech2() {
+inline void calculate_tanh_derivative_sech2(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat val = sfpi::dst_reg[0];
         sfpi::vFloat result = sfpi::vConst0;
@@ -210,7 +210,7 @@ inline void calculate_tanh_derivative_sech2() {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tiled_prod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tiled_prod.h
@@ -13,18 +13,18 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_tiled_prod() {
+inline void calculate_tiled_prod(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     vFloat result = 1.0f;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
         result *= v;
-        dst_reg[0] = result;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         dst_reg++;
     }
     vFloat v = dst_reg[0];
     result *= v;
-    dst_reg[0] = result;
+    dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
     dst_reg++;
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
@@ -15,18 +15,32 @@ namespace sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
 inline void calculate_bitonic_topk_phases_steps(
-    uint idir, uint i_end_phase, uint i_start_phase, uint i_end_step, uint i_start_step) {
+    [[maybe_unused]] std::uint32_t dst_index_in,
+    [[maybe_unused]] std::uint32_t dst_index_out,
+    uint idir,
+    uint i_end_phase,
+    uint i_start_phase,
+    uint i_end_step,
+    uint i_start_step) {
     _bitonic_topk_phases_steps<APPROXIMATION_MODE, is_fp32_dest_acc_en, STABLE_SORT>(
         idir, i_end_phase, i_start_phase, i_end_step, i_start_step);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool idir = false, bool STABLE_SORT = false>
-inline void calculate_bitonic_topk_merge(uint m_iter, uint k) {
+inline void calculate_bitonic_topk_merge(
+    [[maybe_unused]] std::uint32_t dst_index_in, [[maybe_unused]] std::uint32_t dst_index_out, uint m_iter, uint k) {
     _bitonic_topk_merge<APPROXIMATION_MODE, is_fp32_dest_acc_en, idir, STABLE_SORT>(m_iter, k);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
-inline void calculate_bitonic_topk_rebuild(uint idir, uint m_iter, uint k, uint logk, uint skip_second) {
+inline void calculate_bitonic_topk_rebuild(
+    [[maybe_unused]] std::uint32_t dst_index_in,
+    [[maybe_unused]] std::uint32_t dst_index_out,
+    uint idir,
+    uint m_iter,
+    uint k,
+    uint logk,
+    uint skip_second) {
     _bitonic_topk_rebuild<APPROXIMATION_MODE, is_fp32_dest_acc_en, STABLE_SORT>(idir, m_iter, k, logk, skip_second);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -92,7 +92,7 @@ sfpi_inline sfpi::vFloat sfpu_tan<false>(sfpi::vFloat a, sfpi::vInt i) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_tangent() {
+inline void calculate_tangent(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // Constants for four-stage Cody-Waite reduction with -PI/2 = P0 + P1 + P2 + P3
     const float P0 = -0x1.92p+0f;       // representable as bf16
     const float P1 = -0x1.fbp-12f;      // representable as fp16
@@ -137,7 +137,7 @@ inline void calculate_tangent() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_sine() {
+inline void calculate_sine(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // 1. Reduce argument using a four-stage Cody-Waite reduction to the interval [-PI/2, PI/2].
     // 2. Use odd symmetry (sin(-x) = -sin(x)) via quadrant/sign tracking.
     // 3. Evaluate sin(a) = a + a^3 (C0 + a^2 (C1 + a^2 (C2 + a^2 C3))) on [0, PI/2].
@@ -209,7 +209,7 @@ inline void calculate_sine() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_cosine() {
+inline void calculate_cosine(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // 1. Build an odd quadrant index j for PI/2-based reduction.
     // 2. Reduce to a in [-PI/2, PI/2] and fold sign from the quadrant parity.
     // 3. Evaluate sin(a) polynomial and use identity cos(x) = sin(x + PI/2).
@@ -349,7 +349,7 @@ sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_atan() {
+inline void calculate_atan(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];
         sfpi::vFloat result = sfpu_atan<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in);
@@ -358,7 +358,7 @@ inline void calculate_atan() {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
 
         sfpi::dst_reg++;
     }
@@ -418,7 +418,7 @@ sfpi_inline sfpi::vFloat sfpu_asin_range_reduced(sfpi::vFloat val) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool IS_ACOS, int ITERATIONS = 8>
-inline void calculate_asin_acos_impl() {
+inline void calculate_asin_acos_impl(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
@@ -437,43 +437,43 @@ inline void calculate_asin_acos_impl() {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_asin() {
-    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, false, ITERATIONS>();
+inline void calculate_asin(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, false, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_acos() {
-    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, true, ITERATIONS>();
+inline void calculate_acos(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, true, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 // cosh = (exp(x) + exp(-x)) / 2
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_cosh() {
+inline void calculate_cosh(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vFloat result =
             (_sfpu_exp_21f_bf16_<is_fp32_dest_acc_en>(v) + _sfpu_exp_21f_bf16_<is_fp32_dest_acc_en>(-v)) * 0.5f;
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }
 
 // sinh = (exp(x) - exp(-x)) / 2
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_sinh() {
+inline void calculate_sinh(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vFloat result =
             (_sfpu_exp_21f_bf16_<is_fp32_dest_acc_en>(v) - _sfpu_exp_21f_bf16_<is_fp32_dest_acc_en>(-v)) * 0.5f;
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -16,11 +16,11 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_uint16() {
-    _calculate_typecast_fp32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_fp32_to_uint16(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_fp32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_uint8() {
+inline void calculate_typecast_fp32_to_uint8(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; ++d) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
@@ -47,12 +47,12 @@ inline void calculate_typecast_fp32_to_uint8() {
         TTI_SFPIADD(256, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
         // result &= 0xFF
         TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG1, 0);
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_6, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_6, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool u16 = false>
-inline void calculate_typecast_uint_to_uint8() {
+inline void calculate_typecast_uint_to_uint8(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; ++d) {
         if constexpr (u16) {
@@ -62,68 +62,68 @@ inline void calculate_typecast_uint_to_uint8() {
         }
         TTI_SFPIADD(256, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
         TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_6, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_6, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint16_to_fp16b() {
-    _calculate_typecast_uint16_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint16_to_fp16b(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_uint16_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_int32_to_fp16b() {
-    _calculate_typecast_int32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_int32_to_fp16b(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_int32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_int32() {
-    _calculate_typecast_fp32_to_int32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_fp32_to_int32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_fp32_to_int32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_fp16b() {
-    _calculate_typecast_fp32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_fp32_to_fp16b(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_fp32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint16_to_fp32() {
-    _calculate_typecast_uint16_to_fp32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint16_to_fp32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_uint16_to_fp32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_int32_to_fp32() {
-    _calculate_typecast_int32_to_fp32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_int32_to_fp32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_int32_to_fp32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_uint32() {
-    _calculate_typecast_fp32_to_uint32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_fp32_to_uint32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_fp32_to_uint32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint32_to_fp16b() {
-    _calculate_typecast_uint32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint32_to_fp16b(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_uint32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint32_to_fp32() {
-    _calculate_typecast_uint32_to_fp32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint32_to_fp32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_uint32_to_fp32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint16_to_uint32() {
-    _calculate_typecast_uint16_to_uint32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint16_to_uint32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_uint16_to_uint32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint32_to_uint16() {
-    _calculate_typecast_uint32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint32_to_uint16(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_uint32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_int32_to_uint16() {
-    _calculate_typecast_int32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_int32_to_uint16(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_int32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_ne(uint value) {
+inline void calculate_unary_ne(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -24,14 +24,14 @@ inline void calculate_unary_ne(uint value) {
         v_else { v = 1.0f; }
         v_endif;
 
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
 
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_eq(uint value) {
+inline void calculate_unary_eq(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -42,14 +42,14 @@ inline void calculate_unary_eq(uint value) {
         v_else { v = 0.0f; }
         v_endif;
 
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
 
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_gt(uint value) {
+inline void calculate_unary_gt(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -60,14 +60,14 @@ inline void calculate_unary_gt(uint value) {
         v_else { v = 0.0f; }
         v_endif;
 
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
 
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_lt(uint value) {
+inline void calculate_unary_lt(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -78,14 +78,14 @@ inline void calculate_unary_lt(uint value) {
         v_else { v = 0.0f; }
         v_endif;
 
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
 
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_ge(uint value) {
+inline void calculate_unary_ge(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -96,14 +96,14 @@ inline void calculate_unary_ge(uint value) {
         v_else { v = 1.0f; }
         v_endif;
 
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
 
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_le(uint value) {
+inline void calculate_unary_le(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -114,7 +114,7 @@ inline void calculate_unary_le(uint value) {
         v_else { v = 1.0f; }
         v_endif;
 
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -13,9 +13,15 @@ namespace ckernel::sfpu {
 sfpi_inline void load_value_param_float(uint value) { sfpi::vConstIntPrgm0 = value; }
 
 template <bool IS_MAX_OP>
-sfpi_inline void calculate_unary_max_min_float_body() {
+sfpi_inline void calculate_unary_max_min_float_body(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, int load_offset = 0) {
+    int store_offset = (dst_index_out - dst_index_in) * TILE_R_DIM;
     sfpi::l_reg[sfpi::LRegs::LReg0].in_use();
-    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+    if (load_offset != 0) {
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, load_offset);
+    } else {
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+    }
 
     if constexpr (IS_MAX_OP) {
         // L0 = max(L0, constant); this will only write to L0 since L12 is a constant register.
@@ -24,11 +30,15 @@ sfpi_inline void calculate_unary_max_min_float_body() {
         // L0 = min(L0, constant); this will only write to L0 since L12 is a constant register.
         TTI_SFPSWAP(0, p_sfpu::LREG12, p_sfpu::LREG0, sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);
     }
-    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+    if (store_offset != 0) {
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, store_offset);
+    } else {
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+    }
 }
 
 template <bool IS_MAX_OP = true, bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_unary_max_min(uint value) {
+inline void calculate_unary_max_min(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
     //
     // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
@@ -44,7 +54,7 @@ inline void calculate_unary_max_min(uint value) {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        calculate_unary_max_min_float_body<IS_MAX_OP>();
+        calculate_unary_max_min_float_body<IS_MAX_OP>(dst_index_in, dst_index_out);
         sfpi::dst_reg++;
     }
 #else
@@ -70,9 +80,15 @@ sfpi_inline void load_value_param_int(uint value) {
 }
 
 template <bool IS_MAX_OP, bool IS_UNSIGNED = false>
-sfpi_inline void calculate_unary_max_min_int32_body(uint value) {
+sfpi_inline void calculate_unary_max_min_int32_body(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value, int load_offset = 0) {
+    int store_offset = (dst_index_out - dst_index_in) * TILE_R_DIM;
     sfpi::l_reg[sfpi::LRegs::LReg0].in_use();
-    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+    if (load_offset != 0) {
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, load_offset);
+    } else {
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+    }
 
     if (IS_UNSIGNED ^ ((int)value >= 0)) {
         // if msb(value) == 0, we can safely use SFPSWAP even though it expects sign-magnitude integers
@@ -91,17 +107,21 @@ sfpi_inline void calculate_unary_max_min_int32_body(uint value) {
             IS_MAX_OP ^ IS_UNSIGNED ? sfpi::SFPSWAP_MOD1_VEC_MIN_MAX : 9);  // mod1=9 means set VD=max and VC=min
         TTI_SFPNOT(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
     }
-    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+    if (store_offset != 0) {
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, store_offset);
+    } else {
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+    }
 }
 
 template <bool IS_MAX_OP = true, bool IS_UNSIGNED = false, bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_unary_max_min_int32(uint value) {
+inline void calculate_unary_max_min_int32(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     load_value_param_int<IS_UNSIGNED>(value);
 
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        calculate_unary_max_min_int32_body<IS_MAX_OP, IS_UNSIGNED>(value);
+        calculate_unary_max_min_int32_body<IS_MAX_OP, IS_UNSIGNED>(dst_index_in, dst_index_out, value);
         sfpi::dst_reg++;
     }
 #else

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -265,7 +265,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
 }
 
 template <int ITERATIONS>
-inline void _sfpu_unary_power_bf16_(const uint32_t exponent) {
+inline void _sfpu_unary_power_bf16_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint32_t exponent) {
     // Convert exponent to float
     const float pow_scalar = Converter::as_float(exponent);
     const sfpi::vFloat pow = pow_scalar;
@@ -274,21 +274,21 @@ inline void _sfpu_unary_power_bf16_(const uint32_t exponent) {
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat base = sfpi::dst_reg[0];
-            sfpi::dst_reg[0] = _sfpu_unary_power_21f_<true>(base, pow);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _sfpu_unary_power_21f_<true>(base, pow);
             sfpi::dst_reg++;
         }
     } else {
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat base = sfpi::dst_reg[0];
-            sfpi::dst_reg[0] = _sfpu_unary_power_21f_<false>(base, pow);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _sfpu_unary_power_21f_<false>(base, pow);
             sfpi::dst_reg++;
         }
     }
 }
 
 template <int ITERATIONS>
-inline void _sfpu_unary_power_fp32_(const uint32_t exponent) {
+inline void _sfpu_unary_power_fp32_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint32_t exponent) {
     // Convert exponent to float
     const float pow_scalar = Converter::as_float(exponent);
     const sfpi::vFloat pow = pow_scalar;
@@ -297,14 +297,16 @@ inline void _sfpu_unary_power_fp32_(const uint32_t exponent) {
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat base = sfpi::dst_reg[0];
-            sfpi::dst_reg[0] = _sfpu_unary_power_61f_updated_<true>(base, pow);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] =
+                _sfpu_unary_power_61f_updated_<true>(base, pow);
             sfpi::dst_reg++;
         }
     } else {
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat base = sfpi::dst_reg[0];
-            sfpi::dst_reg[0] = _sfpu_unary_power_61f_updated_<false>(base, pow);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] =
+                _sfpu_unary_power_61f_updated_<false>(base, pow);
             sfpi::dst_reg++;
         }
     }
@@ -316,11 +318,11 @@ inline void _sfpu_unary_power_fp32_(const uint32_t exponent) {
  * @param exponent The exponent as IEEE 754 float bits (reinterpreted as uint32_t)
  */
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_unary_power(const uint32_t exponent) {
+inline void calculate_unary_power(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint32_t exponent) {
     if constexpr (is_fp32_dest_acc_en) {
-        _sfpu_unary_power_fp32_<ITERATIONS>(exponent);
+        _sfpu_unary_power_fp32_<ITERATIONS>(dst_index_in, dst_index_out, exponent);
     } else {
-        _sfpu_unary_power_bf16_<ITERATIONS>(exponent);
+        _sfpu_unary_power_bf16_<ITERATIONS>(dst_index_in, dst_index_out, exponent);
     }
 }
 
@@ -330,13 +332,14 @@ inline void calculate_unary_power(const uint32_t exponent) {
  * @param exponent Non-negative integer exponent value
  */
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_power_iterative(const uint32_t exponent) {
+inline void calculate_unary_power_iterative(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint32_t exponent) {
     // iterative approach for positive integer exponents
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];
         if (exponent == 0) {
-            sfpi::dst_reg[0] = 1.0f;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = 1.0f;
         } else {
             sfpi::vFloat result = in;
             uint32_t exp = exponent - 1;
@@ -348,7 +351,7 @@ inline void calculate_unary_power_iterative(const uint32_t exponent) {
                 in *= in;
                 exp >>= 1;
             }
-            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         }
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
@@ -90,12 +90,17 @@ sfpi_inline sfpi::vFloat _sfpu_neg_exp_f32_(sfpi::vFloat val) {
 
 // mul_a * mul_b + addend (MAD)
 template <bool is_fp32_dest_acc_en>
-sfpi_inline void _xielu_mad_(sfpi::vFloat mul_a, sfpi::vFloat mul_b, sfpi::vFloat addend) {
+sfpi_inline void _xielu_mad_(
+    std::uint32_t dst_index_in,
+    std::uint32_t dst_index_out,
+    sfpi::vFloat mul_a,
+    sfpi::vFloat mul_b,
+    sfpi::vFloat addend) {
     sfpi::vFloat result = mul_a * mul_b + addend;
     if constexpr (!is_fp32_dest_acc_en) {
         result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
     }
-    sfpi::dst_reg[0] = result;
+    sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
 }
 
 /*
@@ -116,18 +121,19 @@ sfpi_inline void _xielu_mad_(sfpi::vFloat mul_a, sfpi::vFloat mul_b, sfpi::vFloa
  *        --> alpha_n * (expm1(minimum(x, eps)) - x) + beta * x
  */
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_xielu(const uint32_t param0, const uint32_t param1) {
+inline void calculate_xielu(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint32_t param0, const uint32_t param1) {
     sfpi::vFloat alpha_p = Converter::as_float(param0);
     sfpi::vFloat alpha_n = Converter::as_float(param1);
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
         sfpi::vFloat beta_mul_x = 0.5f * x;
         v_if(x > 0.0f) {  // positive
-            _xielu_mad_<is_fp32_dest_acc_en>(alpha_p * x, x, beta_mul_x);
+            _xielu_mad_<is_fp32_dest_acc_en>(dst_index_in, dst_index_out, alpha_p * x, x, beta_mul_x);
         }
         v_elseif(x >= sfpi::vConstFloatPrgm1) {  // very small negative
             sfpi::vFloat exp_term = sfpi::vConstFloatPrgm2 - x;
-            _xielu_mad_<is_fp32_dest_acc_en>(alpha_n, exp_term, beta_mul_x);
+            _xielu_mad_<is_fp32_dest_acc_en>(dst_index_in, dst_index_out, alpha_n, exp_term, beta_mul_x);
         }
         v_elseif(x > -0.5f) {  // moderate negative region
             // For small x >- 0.5: use Taylor series to avoid cancellation
@@ -145,11 +151,11 @@ inline void calculate_xielu(const uint32_t param0, const uint32_t param1) {
                                         8.333188481628894805908203125e-3f,
                                         1.400390756316483020782470703125e-3f,
                                         1.99588379473425447940826416015625e-4f);
-            _xielu_mad_<is_fp32_dest_acc_en>(alpha_n, exp_term, beta_mul_x);
+            _xielu_mad_<is_fp32_dest_acc_en>(dst_index_in, dst_index_out, alpha_n, exp_term, beta_mul_x);
         }
         v_else {  // large negative
             sfpi::vFloat exp_term = _sfpu_neg_exp_f32_(x) - sfpi::vConst1 - x;
-            _xielu_mad_<is_fp32_dest_acc_en>(alpha_n, exp_term, beta_mul_x);
+            _xielu_mad_<is_fp32_dest_acc_en>(dst_index_in, dst_index_out, alpha_n, exp_term, beta_mul_x);
         }
         v_endif;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
@@ -10,9 +10,7 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_abs_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::abs>();
-}
+inline void llk_math_eltwise_unary_sfpu_abs_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::abs>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs(uint dst_index, int vector_mode = (int)VectorMode::RC) {
@@ -20,8 +18,22 @@ inline void llk_math_eltwise_unary_sfpu_abs(uint dst_index, int vector_mode = (i
 }
 
 template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_abs(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_abs<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
+}
+
+template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_abs_int32<APPROXIMATE>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_abs_int32(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_abs_int32<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
@@ -23,8 +23,20 @@ inline void llk_math_eltwise_unary_sfpu_hardsigmoid_init() {
 template <bool APPROXIMATE, ckernel::ActivationType ACTIVATION, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardsigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
-        static_cast<void (*)()>(ckernel::sfpu::_calculate_activation_<APPROXIMATE, ACTIVATION, ITERATIONS>),
+        static_cast<void (*)(std::uint32_t, std::uint32_t)>(
+            ckernel::sfpu::_calculate_activation_<APPROXIMATE, ACTIVATION, ITERATIONS>),
         dst_index,
+        vector_mode);
+}
+
+template <bool APPROXIMATE, ckernel::ActivationType ACTIVATION, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_hardsigmoid(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        static_cast<void (*)(std::uint32_t, std::uint32_t)>(
+            ckernel::sfpu::_calculate_activation_<APPROXIMATE, ACTIVATION, ITERATIONS>),
+        dst_index_in,
+        dst_index_out,
         vector_mode);
 }
 
@@ -40,17 +52,23 @@ inline void llk_math_eltwise_unary_sfpu_softsign(uint dst_index, int vector_mode
         ckernel::sfpu::calculate_softsign<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
 
-// celu
-inline void llk_math_eltwise_unary_sfpu_celu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::celu>();
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_softsign(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_softsign<APPROXIMATE, ITERATIONS>, dst_index_in, dst_index_out, vector_mode);
 }
+
+// celu
+inline void llk_math_eltwise_unary_sfpu_celu_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::celu>(); }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_celu(
     uint dst_index, uint32_t alpha, uint32_t alpha_recip, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
-        [](uint32_t alpha, uint32_t alpha_recip) {
-            ckernel::sfpu::calculate_celu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>(alpha, alpha_recip);
+        [](std::uint32_t dst_index_in, std::uint32_t dst_index_out, std::uint32_t alpha, std::uint32_t alpha_recip) {
+            ckernel::sfpu::calculate_celu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>(
+                dst_index_in, dst_index_out, alpha, alpha_recip);
         },
         dst_index,
         vector_mode,
@@ -58,10 +76,27 @@ inline void llk_math_eltwise_unary_sfpu_celu(
         alpha_recip);
 }
 
-// softshrink
-inline void llk_math_eltwise_unary_sfpu_softshrink_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::softshrink>();
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_celu(
+    uint dst_index_in,
+    uint dst_index_out,
+    uint32_t alpha,
+    uint32_t alpha_recip,
+    int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        [](std::uint32_t dst_index_in, std::uint32_t dst_index_out, std::uint32_t alpha, std::uint32_t alpha_recip) {
+            ckernel::sfpu::calculate_celu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>(
+                dst_index_in, dst_index_out, alpha, alpha_recip);
+        },
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        alpha,
+        alpha_recip);
 }
+
+// softshrink
+inline void llk_math_eltwise_unary_sfpu_softshrink_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::softshrink>(); }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_softshrink(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
@@ -69,15 +104,27 @@ inline void llk_math_eltwise_unary_sfpu_softshrink(uint dst_index, uint param0, 
         ckernel::sfpu::calculate_softshrink<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
 }
 
-// hardshrink
-inline void llk_math_eltwise_unary_sfpu_hardshrink_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::hardshrink>();
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_softshrink(
+    uint dst_index_in, uint dst_index_out, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_softshrink<APPROXIMATE, ITERATIONS>, dst_index_in, dst_index_out, vector_mode, param0);
 }
+
+// hardshrink
+inline void llk_math_eltwise_unary_sfpu_hardshrink_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::hardshrink>(); }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardshrink(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_hardshrink<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_hardshrink(
+    uint dst_index_in, uint dst_index_out, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_hardshrink<APPROXIMATE, ITERATIONS>, dst_index_in, dst_index_out, vector_mode, param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
@@ -10,13 +10,18 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_add1_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::add1>();
-}
+inline void llk_math_eltwise_unary_sfpu_add1_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::add1>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_add1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_add1<APPROXIMATE>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_add1(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_add1<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
@@ -20,4 +20,11 @@ inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90(uint dst_index, int
         ckernel::sfpu::calculate_alt_complex_rotate90<APPROXIMATE>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_alt_complex_rotate90<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
@@ -17,6 +17,17 @@ inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(
         sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>, dst_index, vector_mode, scalar);
 }
 
+template <bool APPROXIMATE, int binop_mode>
+inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(
+    uint dst_index_in, uint dst_index_out, uint32_t scalar, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        scalar);
+}
+
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>();
 }
@@ -29,10 +40,24 @@ inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_add_int32(
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_add_int32(
+    uint dst_index_in, uint dst_index_out, uint32_t scalar, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::calculate_add_int32<APPROXIMATE, ITERATIONS>, dst_index_in, dst_index_out, vector_mode, scalar);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_sub_int32(
     uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_sub_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_sub_int32(
+    uint dst_index_in, uint dst_index_out, uint32_t scalar, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::calculate_sub_int32<APPROXIMATE, ITERATIONS>, dst_index_in, dst_index_out, vector_mode, scalar);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
@@ -20,4 +20,11 @@ inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a(uint dst_index, int v
         ckernel::sfpu::calculate_cast_fp32_to_fp16a<APPROXIMATE>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_cast_fp32_to_fp16a<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
@@ -21,4 +21,11 @@ inline void llk_math_eltwise_unary_sfpu_cbrt(uint dst_index, int vector_mode = (
         sfpu::calculate_cube_root<APPROXIMATE, fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE, bool fp32_dest_acc_en, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_cbrt(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::calculate_cube_root<APPROXIMATE, fp32_dest_acc_en, ITERATIONS>, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
@@ -10,9 +10,7 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_clamp_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::clamp>();
-}
+inline void llk_math_eltwise_unary_sfpu_clamp_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::clamp>(); }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp(
@@ -22,10 +20,34 @@ inline void llk_math_eltwise_unary_sfpu_clamp(
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_clamp(
+    uint dst_index_in, uint dst_index_out, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_clamp<APPROXIMATE, ITERATIONS>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        min_val,
+        max_val);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp_int32(
     uint dst_index, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_clamp_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, min_val, max_val);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_clamp_int32(
+    uint dst_index_in, uint dst_index_out, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_clamp_int32<APPROXIMATE, ITERATIONS>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        min_val,
+        max_val);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
@@ -19,9 +19,21 @@ inline void llk_math_eltwise_unary_sfpu_cumsum_init() {
 template <bool APPROXIMATE /*unused*/>
 inline void llk_math_eltwise_unary_sfpu_cumsum(
     uint dst_index, bool first, int vector_mode = (int)VectorMode::RC_custom /*unused*/) {
-    _llk_math_eltwise_unary_sfpu_params_(
+    _llk_math_eltwise_unary_sfpu_params_split_(
         ckernel::sfpu::calculate_cumsum<false>,  // There is only non APPROXIMATE implementation
         dst_index,
+        dst_index,
+        VectorMode::RC_custom,  // Can only work in RC_custom mode
+        first);
+}
+
+template <bool APPROXIMATE /*unused*/>
+inline void llk_math_eltwise_unary_sfpu_cumsum(
+    uint dst_index_in, uint dst_index_out, bool first, int vector_mode = (int)VectorMode::RC_custom /*unused*/) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_cumsum<false>,  // There is only non APPROXIMATE implementation
+        dst_index_in,
+        dst_index_out,
         VectorMode::RC_custom,  // Can only work in RC_custom mode
         first);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
@@ -21,4 +21,11 @@ inline void llk_math_eltwise_unary_sfpu_exp2(uint dst_index, int vector_mode = (
         ckernel::sfpu::calculate_exp2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_exp2(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_exp2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
@@ -21,4 +21,11 @@ inline void llk_math_eltwise_unary_sfpu_expm1(uint dst_index, int vector_mode = 
         ckernel::sfpu::calculate_expm1<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+inline void llk_math_eltwise_unary_sfpu_expm1(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_expm1<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
@@ -10,13 +10,18 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_hardmish_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::hardmish>();
-}
+inline void llk_math_eltwise_unary_sfpu_hardmish_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::hardmish>(); }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardmish(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::hardmish<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_hardmish(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::hardmish<APPROXIMATE, ITERATIONS>, dst_index_in, dst_index_out, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
@@ -10,15 +10,25 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_hardtanh_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::hardtanh>();
-}
+inline void llk_math_eltwise_unary_sfpu_hardtanh_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::hardtanh>(); }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardtanh(
     uint dst_index, uint param0, uint param1, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_hardtanh<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0, param1);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_hardtanh(
+    uint dst_index_in, uint dst_index_out, uint param0, uint param1, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_hardtanh<APPROXIMATE, ITERATIONS>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        param0,
+        param1);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
@@ -10,14 +10,19 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_heaviside_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::heaviside>();
-}
+inline void llk_math_eltwise_unary_sfpu_heaviside_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::heaviside>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_heaviside(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_heaviside<APPROXIMATE>, dst_index, vector_mode, param0);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_heaviside(
+    uint dst_index_in, uint dst_index_out, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_heaviside<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode, param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
@@ -22,6 +22,17 @@ inline void llk_math_eltwise_unary_sfpu_log(uint dst_index, int vector_mode = (i
 }
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
+inline void llk_math_eltwise_unary_sfpu_log(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, false, is_fp32_dest_acc_en>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        0);
+}
+
+template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log_with_base_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::log_with_base>(
         sfpu::log_init<APPROXIMATE, FAST_APPROX, is_fp32_dest_acc_en>);
@@ -33,6 +44,17 @@ inline void llk_math_eltwise_unary_sfpu_log_with_base(
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, true, is_fp32_dest_acc_en>,
         dst_index,
+        vector_mode,
+        base_scale);
+}
+
+template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
+inline void llk_math_eltwise_unary_sfpu_log_with_base(
+    uint dst_index_in, uint dst_index_out, uint base_scale, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, true, is_fp32_dest_acc_en>,
+        dst_index_in,
+        dst_index_out,
         vector_mode,
         base_scale);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -39,6 +39,26 @@ inline __attribute__((always_inline)) void _sfpu_check_and_call_(
         std::forward<Callable>(sfpu_func), dst_index, vector_mode, std::forward<Args>(args)...);
 }
 
+// Split-dest overload: separate read/write tile indices for SFPU ops that
+// take a source tile and write to a different destination tile. Asserts
+// both indices against the per-mode destination capacity, then dispatches
+// to _llk_math_eltwise_unary_sfpu_params_split_.
+template <DstSync DST_SYNC, bool DST_ACCUM, typename Callable, typename... Args>
+inline __attribute__((always_inline)) void _sfpu_check_and_call_(
+    Callable&& sfpu_func, std::uint32_t dst_index_in, std::uint32_t dst_index_out, int vector_mode, Args&&... args) {
+    LLK_ASSERT(
+        (dst_index_in < get_dest_max_tiles<DST_SYNC, DST_ACCUM, DstTileShape::Tile32x32>()),
+        "dst_index_in exceeds max dest tiles");
+    LLK_ASSERT(
+        (dst_index_out < get_dest_max_tiles<DST_SYNC, DST_ACCUM, DstTileShape::Tile32x32>()),
+        "dst_index_out exceeds max dest tiles");
+    LLK_ASSERT(
+        (dst_index_out >= dst_index_in),
+        "dst_index_out must be >= dst_index_in (unsigned store offset would underflow)");
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        std::forward<Callable>(sfpu_func), dst_index_in, dst_index_out, vector_mode, std::forward<Args>(args)...);
+}
+
 }  // namespace ckernel
 
 /*
@@ -136,6 +156,36 @@ inline __attribute__((always_inline)) void _sfpu_check_and_call_(
         static_cast<_SFPU_EXPAND SIGNATURE>(::ckernel::sfpu::FN<_SFPU_EXPAND TEMPLATES>),        \
         DST_IDX,                                                                                 \
         VECTOR_MODE,                                                                             \
+        ##__VA_ARGS__)
+
+/*
+ * Split-dest variants of SFPU_CALL{,_MODE,_CAST}
+ *
+ * Same shape as their non-_SPLIT counterparts, but accept distinct
+ * (DST_IDX_IN, DST_IDX_OUT) and route through the split overload of
+ * ckernel::_sfpu_check_and_call_, which forwards into
+ * _llk_math_eltwise_unary_sfpu_params_split_. Use these when the
+ * underlying calculate function reads from one dest tile and writes to a
+ * different one.
+ */
+#define SFPU_CALL_SPLIT(DST_SYNC, DST_ACCUM, FN, TEMPLATES, DST_IDX_IN, DST_IDX_OUT, VECTOR_MODE, ...) \
+    ::ckernel::_sfpu_check_and_call_<DST_SYNC, DST_ACCUM>(                                             \
+        ::ckernel::sfpu::FN<_SFPU_EXPAND TEMPLATES>, DST_IDX_IN, DST_IDX_OUT, VECTOR_MODE, ##__VA_ARGS__)
+
+#define SFPU_CALL_MODE_SPLIT(DST_SYNC, DST_ACCUM, FN, TEMPLATES, MODE, DST_IDX_IN, DST_IDX_OUT, ...) \
+    ::ckernel::_sfpu_check_and_call_<DST_SYNC, DST_ACCUM>(                                           \
+        ::ckernel::sfpu::FN<_SFPU_EXPAND TEMPLATES>,                                                 \
+        DST_IDX_IN,                                                                                  \
+        DST_IDX_OUT,                                                                                 \
+        (int)::ckernel::VectorMode::MODE,                                                            \
+        ##__VA_ARGS__)
+
+#define SFPU_CALL_CAST_SPLIT(DST_SYNC, DST_ACCUM, FN, TEMPLATES, SIGNATURE, DST_IDX_IN, DST_IDX_OUT, VECTOR_MODE, ...) \
+    ::ckernel::_sfpu_check_and_call_<DST_SYNC, DST_ACCUM>(                                                             \
+        static_cast<_SFPU_EXPAND SIGNATURE>(::ckernel::sfpu::FN<_SFPU_EXPAND TEMPLATES>),                              \
+        DST_IDX_IN,                                                                                                    \
+        DST_IDX_OUT,                                                                                                   \
+        VECTOR_MODE,                                                                                                   \
         ##__VA_ARGS__)
 
 /*

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
@@ -10,13 +10,18 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_mask_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::mask>();
-}
+inline void llk_math_eltwise_unary_sfpu_mask_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::mask>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_mask_posinf(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_mask_posinf<APPROXIMATE>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_mask_posinf(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_mask_posinf<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -26,6 +31,18 @@ inline void llk_math_eltwise_unary_sfpu_mask(
         _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_mask<APPROXIMATE>, dst_index, vector_mode);
     } else if (data_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_int_mask<APPROXIMATE>, dst_index, vector_mode);
+    }
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_mask(
+    uint dst_index_in, uint dst_index_out, DataFormat data_format, int vector_mode = (int)VectorMode::RC) {
+    if (data_format == DataFormat::Float16_b || data_format == DataFormat::Float16) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_mask<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
+    } else if (data_format == DataFormat::Int32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_int_mask<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
@@ -21,6 +21,13 @@ inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, i
         ckernel::sfpu::calculate_unary_max_min<true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_max(
+    uint dst_index_in, uint dst_index_out, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_max_min<true, APPROXIMATE>, dst_index_in, dst_index_out, vector_mode, param0);
+}
+
 inline void llk_math_eltwise_unary_sfpu_unary_max_int32_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max_int32>(sfpu::unary_max_min_int32_init<true, false>);
 }
@@ -30,6 +37,17 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_int32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<true, false, APPROXIMATE>, dst_index, vector_mode, param0);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_max_int32(
+    uint dst_index_in, uint dst_index_out, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_max_min_int32<true, false, APPROXIMATE>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        param0);
 }
 
 inline void llk_math_eltwise_unary_sfpu_unary_max_uint32_init() {
@@ -43,6 +61,17 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_uint32(
         ckernel::sfpu::calculate_unary_max_min_int32<true, true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_max_uint32(
+    uint dst_index_in, uint dst_index_out, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_max_min_int32<true, true, APPROXIMATE>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        param0);
+}
+
 // Unary minimum
 inline void llk_math_eltwise_unary_sfpu_unary_min_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min>(sfpu::unary_max_min_init<false>);
@@ -52,6 +81,13 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min<false, APPROXIMATE>, dst_index, vector_mode, param0);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_min(
+    uint dst_index_in, uint dst_index_out, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_max_min<false, APPROXIMATE>, dst_index_in, dst_index_out, vector_mode, param0);
 }
 
 inline void llk_math_eltwise_unary_sfpu_unary_min_int32_init() {
@@ -65,6 +101,17 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_int32(
         ckernel::sfpu::calculate_unary_max_min_int32<false, false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_min_int32(
+    uint dst_index_in, uint dst_index_out, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_max_min_int32<false, false, APPROXIMATE>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        param0);
+}
+
 inline void llk_math_eltwise_unary_sfpu_unary_min_uint32_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min_uint32>(sfpu::unary_max_min_int32_init<false, true>);
 }
@@ -74,6 +121,17 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_uint32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<false, true, APPROXIMATE>, dst_index, vector_mode, param0);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_min_uint32(
+    uint dst_index_in, uint dst_index_out, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_max_min_int32<false, true, APPROXIMATE>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
@@ -21,15 +21,35 @@ inline void llk_math_eltwise_unary_sfpu_power(
         ckernel::sfpu::calculate_unary_power<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode, exponent);
 }
 
-inline void llk_math_eltwise_unary_sfpu_power_iterative_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::power>();
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+inline void llk_math_eltwise_unary_sfpu_power(
+    uint dst_index_in, uint dst_index_out, uint32_t exponent, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_power<APPROXIMATE, is_fp32_dest_acc_en, 8>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        exponent);
 }
+
+inline void llk_math_eltwise_unary_sfpu_power_iterative_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::power>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_power_iterative(
     uint dst_index, uint32_t exponent = 0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_power_iterative<APPROXIMATE, 8>, dst_index, vector_mode, exponent);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_power_iterative(
+    uint dst_index_in, uint dst_index_out, uint32_t exponent, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_power_iterative<APPROXIMATE, 8>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        exponent);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
@@ -25,4 +25,15 @@ inline void llk_math_eltwise_unary_sfpu_rdiv(
         value);
 }
 
+template <bool APPROXIMATE, bool fp32_dest_acc_en, RoundingMode rounding_mode, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_rdiv(
+    uint32_t dst_index_in, uint32_t dst_index_out, uint32_t value, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_rdiv<APPROXIMATE, fp32_dest_acc_en, rounding_mode, ITERATIONS>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        value);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
@@ -16,10 +16,21 @@ inline void llk_math_eltwise_unary_sfpu_reduce_init() {
 }
 
 template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
-inline void llk_math_eltwise_unary_sfpu_reduce(
-    uint32_t dst_index, uint32_t ct_dim, uint32_t rt_dim, VectorMode vector_mode) {
+inline void llk_math_eltwise_unary_sfpu_reduce(uint32_t dst_index, uint32_t ct_dim, uint32_t rt_dim, int vector_mode) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_reduce<pool_type, reduce_dim, format>, dst_index, vector_mode, ct_dim, rt_dim);
+}
+
+template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
+inline void llk_math_eltwise_unary_sfpu_reduce(
+    uint32_t dst_index_in, uint32_t dst_index_out, uint32_t ct_dim, uint32_t rt_dim, int vector_mode) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::calculate_reduce<pool_type, reduce_dim, format>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        ct_dim,
+        rt_dim);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
@@ -49,4 +49,11 @@ inline void llk_math_eltwise_unary_sfpu_reshuffle_rows(
     _llk_math_eltwise_unary_sfpu_params_(sfpu::calculate_reshuffle_rows<APPROXIMATE>, dst_index, vector_mode, idx_addr);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_reshuffle_rows(
+    uint dst_index_in, uint dst_index_out, uint32_t idx_addr, int vector_mode = (int)VectorMode::RC_custom) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::calculate_reshuffle_rows<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode, idx_addr);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
@@ -21,4 +21,11 @@ inline void llk_math_eltwise_unary_sfpu_rpow(uint dst_index, uint32_t base_val, 
         sfpu::calculate_rpow<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode, base_val);
 }
 
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
+inline void llk_math_eltwise_unary_sfpu_rpow(
+    uint dst_index_in, uint dst_index_out, uint32_t base_val, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::calculate_rpow<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index_in, dst_index_out, vector_mode, base_val);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
@@ -23,4 +23,14 @@ inline void llk_math_eltwise_unary_sfpu_rsqrt(uint dst_index, int vector_mode = 
         vector_mode);
 }
 
+template <bool APPROXIMATE, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>
+inline void llk_math_eltwise_unary_sfpu_rsqrt(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_rsqrt<APPROXIMATE, 8, fp32_dest_acc_en, FAST_APPROX, legacy_compat>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
@@ -10,14 +10,19 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_rsub_int32_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unused>();
-}
+inline void llk_math_eltwise_unary_sfpu_rsub_int32_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(); }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_rsub_int32(uint dst_index, uint scalar, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_rsub_scalar_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_rsub_int32(
+    uint dst_index_in, uint dst_index_out, uint scalar, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::calculate_rsub_scalar_int32<APPROXIMATE, ITERATIONS>, dst_index_in, dst_index_out, vector_mode, scalar);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
@@ -22,4 +22,16 @@ inline void llk_math_eltwise_unary_sfpu_selu(
         alpha);
 }
 
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_selu(
+    uint dst_index_in, uint dst_index_out, uint scale, uint alpha, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_selu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        scale,
+        alpha);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
@@ -21,4 +21,14 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid(uint dst_index, int vector_mode 
         sfpu::calculate_sigmoid<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_sigmoid(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::calculate_sigmoid<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
@@ -19,4 +19,11 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_appx(uint dst_index, int vector_
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_sigmoid_appx, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_sigmoid_appx(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_sigmoid_appx, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
@@ -10,15 +10,20 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_sign_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::sign>();
-}
+inline void llk_math_eltwise_unary_sfpu_sign_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::sign>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sign(
     uint dst_index, int vector_mode = (int)VectorMode::RC, uint exponent_size_8 = 1) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_sign<APPROXIMATE>, dst_index, vector_mode, exponent_size_8);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_sign(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC, uint exponent_size_8 = 1) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_sign<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode, exponent_size_8);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
@@ -20,6 +20,13 @@ inline void llk_math_eltwise_unary_sfpu_signbit(uint dst_index, int vector_mode 
         ckernel::sfpu::calculate_signbit<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_signbit(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_signbit<APPROXIMATE, ITERATIONS>, dst_index_in, dst_index_out, vector_mode);
+}
+
 inline void llk_math_eltwise_unary_sfpu_signbit_int32_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::signbit>(ckernel::sfpu::signbit_int32_init);
 }
@@ -28,6 +35,13 @@ template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_signbit_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_signbit_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_signbit_int32(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_signbit_int32<APPROXIMATE, ITERATIONS>, dst_index_in, dst_index_out, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -21,4 +21,11 @@ inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (
         ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_silu(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, ITERATIONS>, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
@@ -10,13 +10,18 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_square_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::square>();
-}
+inline void llk_math_eltwise_unary_sfpu_square_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::square>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_square(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_square<APPROXIMATE>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_square(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_square<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
@@ -21,4 +21,11 @@ inline void llk_math_eltwise_unary_sfpu_tanh(uint dst_index, int vector_mode = (
         ckernel::sfpu::calculate_tanh<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+inline void llk_math_eltwise_unary_sfpu_tanh(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_tanh<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
@@ -20,4 +20,11 @@ inline void llk_math_eltwise_unary_sfpu_tanh_derivative(uint dst_index, int vect
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_tanh_derivative<APPROXIMATE>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_tanh_derivative(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_tanh_derivative<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
@@ -10,16 +10,28 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_threshold_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::threshold>();
-}
+inline void llk_math_eltwise_unary_sfpu_threshold_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::threshold>(); }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_threshold(
     uint dst_index, uint32_t param0, uint32_t param1, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
-        static_cast<void (*)(uint32_t, uint32_t)>(ckernel::sfpu::_calculate_threshold_<APPROXIMATE, ITERATIONS>),
+        static_cast<void (*)(uint32_t, uint32_t, uint32_t, uint32_t)>(
+            ckernel::sfpu::_calculate_threshold_<APPROXIMATE, ITERATIONS, uint32_t>),
         dst_index,
+        vector_mode,
+        param0,
+        param1);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_threshold(
+    uint dst_index_in, uint dst_index_out, uint32_t param0, uint32_t param1, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        static_cast<void (*)(uint32_t, uint32_t, uint32_t, uint32_t)>(
+            ckernel::sfpu::_calculate_threshold_<APPROXIMATE, ITERATIONS, uint32_t>),
+        dst_index_in,
+        dst_index_out,
         vector_mode,
         param0,
         param1);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
@@ -10,13 +10,18 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_tiled_prod_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::tiled_prod>();
-}
+inline void llk_math_eltwise_unary_sfpu_tiled_prod_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::tiled_prod>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tiled_prod(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_tiled_prod<APPROXIMATE>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_tiled_prod(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_tiled_prod<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
@@ -35,12 +35,46 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
         i_start_step);
 }
 
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
+inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
+    uint dst_index_in,
+    uint dst_index_out,
+    int idir,
+    int i_end_phase,
+    int i_start_phase,
+    int i_end_step,
+    int i_start_step,
+    int vector_mode = (int)VectorMode::RC_custom) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        idir,
+        i_end_phase,
+        i_start_phase,
+        i_end_step,
+        i_start_step);
+}
+
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool idir = false, bool STABLE_SORT = false>
 inline void llk_math_eltwise_unary_sfpu_topk_merge(
     uint dst_index, int m_iter, int k, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_bitonic_topk_merge<APPROXIMATE, is_fp32_dest_acc_en, idir, STABLE_SORT>,
         dst_index,
+        vector_mode,
+        m_iter,
+        k);
+}
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool idir = false, bool STABLE_SORT = false>
+inline void llk_math_eltwise_unary_sfpu_topk_merge(
+    uint dst_index_in, uint dst_index_out, int m_iter, int k, int vector_mode = (int)VectorMode::RC_custom) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_bitonic_topk_merge<APPROXIMATE, is_fp32_dest_acc_en, idir, STABLE_SORT>,
+        dst_index_in,
+        dst_index_out,
         vector_mode,
         m_iter,
         k);
@@ -58,6 +92,28 @@ inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
         dst_index,
+        vector_mode,
+        idir,
+        m_iter,
+        k,
+        logk,
+        skip_second);
+}
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
+inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
+    uint dst_index_in,
+    uint dst_index_out,
+    bool idir,
+    int m_iter,
+    int k,
+    int logk,
+    int skip_second,
+    int vector_mode = (int)VectorMode::RC_custom) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
+        dst_index_in,
+        dst_index_out,
         vector_mode,
         idir,
         m_iter,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
@@ -156,6 +156,189 @@ inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode
 }
 
 template <bool APPROXIMATE, uint32_t IN_DTYPE, uint32_t OUT_DTYPE>
+inline void llk_math_eltwise_unary_sfpu_typecast(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    constexpr DataFormat in_format = static_cast<DataFormat>(IN_DTYPE);
+    constexpr DataFormat out_format = static_cast<DataFormat>(OUT_DTYPE);
+
+    if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::UInt16) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float16_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Float16_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Int32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Float32) {
+        // no SFPU kernel needed, handled by packer
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Float16_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_fp16b<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::UInt16) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint16_to_fp32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Int32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Float32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_int32_to_fp32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::UInt16) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Bfp8_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Int32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Bfp8_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::UInt32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Float16_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::UInt32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Float32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint32_to_fp32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::UInt32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Bfp8_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::UInt32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Int32) {
+        // Calls same kernel as UInt32 case
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::UInt16) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint32_to_uint16<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::UInt16) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_int32_to_uint16<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Float16_b) {
+        // no SFPU kernel needed, handled by unpacker
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Bfp8_b) {
+        // no SFPU kernel needed, handled by packer
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Float32) {
+        // no SFPU kernel needed, handled by unpacker/packer
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Bfp8_b) {
+        // no SFPU kernel needed, handled by packer
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::UInt16) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Bfp4_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Int32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Bfp4_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::UInt32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Bfp4_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Float16_b) {
+        // no SFPU kernel needed, handled by unpacker
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Bfp4_b) {
+        // no SFPU kernel needed, handled by packer
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Bfp8_b) {
+        // no SFPU kernel needed, handled by unpacker
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Bfp4_b) {
+        // no SFPU kernel needed, handled by packer
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Float32) {
+        // no SFPU kernel needed, handled by unpacker/packer
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Bfp4_b) {
+        // no SFPU kernel needed, handled by packer
+    } else if constexpr (
+        (in_format == DataFormat::Float32 || in_format == DataFormat::Float16_b || in_format == DataFormat::Bfp8_b ||
+         in_format == DataFormat::Bfp4_b) &&
+        out_format == DataFormat::UInt8) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_uint8<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (
+        (in_format == DataFormat::Int32 || in_format == DataFormat::UInt32 || in_format == DataFormat::UInt16) &&
+        out_format == DataFormat::UInt8) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint_to_uint8<APPROXIMATE, 8, (in_format == DataFormat::UInt16)>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt8 && out_format == DataFormat::Float32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint32_to_fp32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (
+        in_format == DataFormat::UInt8 &&
+        (out_format == DataFormat::Float16_b || out_format == DataFormat::Bfp8_b || out_format == DataFormat::Bfp4_b)) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (
+        in_format == DataFormat::UInt8 && (out_format == DataFormat::Int32 || out_format == DataFormat::UInt32)) {
+        // No SFPU kernel needed.
+    } else if constexpr (in_format == DataFormat::UInt8 && out_format == DataFormat::UInt16) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint32_to_uint16<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    }
+}
+
+template <bool APPROXIMATE, uint32_t IN_DTYPE, uint32_t OUT_DTYPE>
 inline void llk_math_eltwise_unary_sfpu_typecast_init() {
     constexpr DataFormat in_format = static_cast<DataFormat>(IN_DTYPE);
     constexpr DataFormat out_format = static_cast<DataFormat>(OUT_DTYPE);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -35,7 +35,8 @@ template <DstSync DST_SYNC, bool DST_ACCUM, typename Callable, typename... Args>
 inline __attribute__((always_inline)) void _sfpu_check_and_call_(
     Callable&& sfpu_func, std::uint32_t dst_index, [[maybe_unused]] int vector_mode, Args&&... args) {
     LLK_ASSERT(vector_mode == (int)VectorMode::RC, "Quasar currently only supports vector mode RC");
-    _llk_math_eltwise_unary_sfpu_params_(std::forward<Callable>(sfpu_func), dst_index, std::forward<Args>(args)...);
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        std::forward<Callable>(sfpu_func), dst_index, dst_index, std::forward<Args>(args)...);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
@@ -13,22 +13,22 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_abs() {
+inline void calculate_abs(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
-        dst_reg[0] = sfpi::abs(v);
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::abs(v);
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_abs_int32() {
+inline void calculate_abs_int32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         TT_SFPLOAD(1, 4, 3, 0);
         TTI_SFPABS(0, 1, 0, 0);
-        TTI_SFPSTORE(0, 4, 3, 0);
+        TT_SFPSTORE(0, 4, 3, (dst_index_out - dst_index_in) * TILE_R_DIM);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_add1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_add1.h
@@ -13,10 +13,10 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_add1() {
+inline void calculate_add1(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat val = dst_reg[0];
-        dst_reg[0] = 1.0f + val;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = 1.0f + val;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h
@@ -13,11 +13,12 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
-inline void calculate_alt_complex_rotate90() {
+inline void calculate_alt_complex_rotate90(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    const int out_off = (dst_index_out - dst_index_in) * TILE_R_DIM;
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat val = dst_reg[0];
-        dst_reg[0] = -vFloat(dst_reg[1]);
-        dst_reg[1] = val;
+        dst_reg[out_off] = -dst_reg[1];
+        dst_reg[out_off + 1] = val;
         dst_reg += 2;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binop_with_unary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binop_with_unary.h
@@ -24,7 +24,7 @@ enum {
 };  // BINOP_MODE
 
 template <bool APPROXIMATION_MODE, int BINOP_MODE, int ITERATIONS = 8>
-void calculate_binop_with_scalar(uint32_t param) {
+void calculate_binop_with_scalar(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t param) {
     const sfpi::vFloat parameter = Converter::as_float(param);
 
     for (int d = 0; d < ITERATIONS; d++) {
@@ -44,39 +44,39 @@ void calculate_binop_with_scalar(uint32_t param) {
             result = parameter - val;
         }
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_add(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, ADD, ITERATIONS>(param);
+void calculate_add(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, ADD, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_sub(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, SUB, ITERATIONS>(param);
+void calculate_sub(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, SUB, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_mul(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, MUL, ITERATIONS>(param);
+void calculate_mul(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, MUL, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_div(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, DIV, ITERATIONS>(param);
+void calculate_div(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, DIV, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_rsub(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, RSUB, ITERATIONS>(param);
+void calculate_rsub(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, RSUB, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-void calculate_add_int32(uint32_t scalar) {
+void calculate_add_int32(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t scalar) {
     int int_scalar = scalar;
     // Load value param to lreg2
     _sfpu_load_imm32_(p_sfpu::LREG2, int_scalar);
@@ -84,13 +84,13 @@ void calculate_add_int32(uint32_t scalar) {
         TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_3, 0);
         TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);  // Using mov to preserve the scalar value after each iteration
         TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 4);
-        TTI_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_3, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_3, (dst_index_out - dst_index_in) * TILE_R_DIM);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-void calculate_sub_int32(uint32_t scalar) {
+void calculate_sub_int32(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t scalar) {
     int int_scalar = scalar;
     // Load value scalar to lreg2
     _sfpu_load_imm32_(p_sfpu::LREG2, int_scalar);
@@ -101,7 +101,7 @@ void calculate_sub_int32(uint32_t scalar) {
         TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
         // Used 6 as imod to convert operand B to 2's complement for sub operation
         TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
-        TTI_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_3, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_3, (dst_index_out - dst_index_in) * TILE_R_DIM);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_and.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_and.h
@@ -13,12 +13,12 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_and(const uint value) {
+inline void calculate_bitwise_and(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint value) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];
         vInt res = input & value;
-        dst_reg[0] = res;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = res;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
@@ -14,12 +14,12 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_not() {
+inline void calculate_bitwise_not(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::LREG4, ADDR_MOD_3, 0);
         TTI_SFPNOT(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::LREG4, ADDR_MOD_3, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, p_sfpu::LREG4, ADDR_MOD_3, (dst_index_out - dst_index_in) * TILE_R_DIM);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
@@ -9,7 +9,7 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_or(const uint value) {
+inline void calculate_bitwise_or(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint value) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];
@@ -19,7 +19,7 @@ inline void calculate_bitwise_or(const uint value) {
             res = 0 - res;
             res = copysgn(res, scalar_value);
         }
-        v_endif dst_reg[0] = res;
+        v_endif dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = res;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_xor(const uint value) {
+inline void calculate_bitwise_xor(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint value) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];
@@ -24,7 +24,7 @@ inline void calculate_bitwise_xor(const uint value) {
             res = 0 - res;
             res = copysgn(res, v);
         }
-        v_endif dst_reg[0] = res;
+        v_endif dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = res;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -13,13 +13,13 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void cast_fp32_to_fp16a() {
+inline void cast_fp32_to_fp16a(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat x = sfpi::dst_reg[0];
-        sfpi::dst_reg[0].mode<sfpi::SFPSTORE_MOD0_FMT_FP16A>() =
-            sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
-        sfpi::dst_reg++;
+        TTI_SFPLOAD(0, 0, 3, 0);
+        TTI_SFP_STOCH_RND(0, 0, 0, 0, 0, 8);
+        TT_SFPSTORE(0, 1, 3, (dst_index_out - dst_index_in) * TILE_R_DIM);
+        dst_reg++;
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
@@ -14,7 +14,7 @@ namespace ckernel::sfpu {
 // Moroz et al. <https://doi.org/10.3390/en14041058>
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_cube_root() {
+inline void calculate_cube_root(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     sfpi::vFloat negative_third_256 = -0x1.555556p-10f;
 
     // Magic constant 0x548c2b4b / 256 + 2^23

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
@@ -9,8 +9,8 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_celu(uint32_t param0, uint32_t param1) {
-    _calculate_celu_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(param0, param1);
+inline void calculate_celu(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t param0, uint32_t param1) {
+    _calculate_celu_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(dst_index_in, dst_index_out, param0, param1);
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
@@ -13,25 +13,27 @@ enum { Max = true, Min = false };  // Clamp Mode
 
 // out = min(max(x, min_val), max_val)
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_clamp(uint min_val, uint max_val) {
+inline void calculate_clamp(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint min_val, uint max_val) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         load_value_param_float(min_val);
-        calculate_unary_max_min_float_body<Max>();
+        calculate_unary_max_min_float_body<Max>(dst_index_in, dst_index_out);
         load_value_param_float(max_val);
-        calculate_unary_max_min_float_body<Min>();
+        calculate_unary_max_min_float_body<Min>(
+            dst_index_in, dst_index_out, (dst_index_out - dst_index_in) * TILE_R_DIM);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_clamp_int32(uint min_val, uint max_val) {
+inline void calculate_clamp_int32(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint min_val, uint max_val) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         load_value_param_int(min_val);
-        calculate_unary_max_min_int32_body<Max>(min_val);
+        calculate_unary_max_min_int32_body<Max>(dst_index_in, dst_index_out, min_val);
         load_value_param_int(max_val);
-        calculate_unary_max_min_int32_body<Min>(max_val);
+        calculate_unary_max_min_int32_body<Min>(
+            dst_index_in, dst_index_out, max_val, (dst_index_out - dst_index_in) * TILE_R_DIM);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -116,7 +116,7 @@ inline void calculate_comp() {
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void calculate_comp_int() {
+inline void calculate_comp_int(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         vInt v = dst_reg[0];
         vInt zero = 0;
@@ -163,13 +163,13 @@ inline void calculate_comp_int() {
             v_endif;
         }
 
-        dst_reg[0] = v;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void calculate_comp_uint16() {
+inline void calculate_comp_uint16(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     static_assert((COMP_MODE == SfpuType::equal_zero) or (COMP_MODE == SfpuType::not_equal_zero));
     constexpr int check = ((COMP_MODE == SfpuType::equal_zero) ? SFPSETCC_MOD1_LREG_EQ0 : SFPSETCC_MOD1_LREG_NE0);
     for (int d = 0; d < ITERATIONS; d++) {
@@ -184,26 +184,26 @@ inline void calculate_comp_uint16() {
         // end_if
         TTI_SFPENCC(0, 0, 0, 0);
         // store result
-        TTI_SFPSTORE(p_sfpu::LREG1, LO16, ADDR_MOD_3, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, LO16, ADDR_MOD_3, (dst_index_out - dst_index_in) * TILE_R_DIM);
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_eqz_uint32() {
+inline void calculate_eqz_uint32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     int scalar = -5;  // used for shift operation
     _sfpu_load_imm32_(p_sfpu::LREG2, scalar);
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_3, 0);
         TTI_SFPLZ(0, 0, 1, 4);    // result in lreg1 is leading zero count
         TTI_SFPSHFT(0, 2, 1, 0);  // 32 >> 5 = 1 else 0
-        TTI_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_3, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_3, (dst_index_out - dst_index_in) * TILE_R_DIM);
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_nez_uint32() {
+inline void calculate_nez_uint32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_3, 0);
         // initially put 0 into output
@@ -215,13 +215,13 @@ inline void calculate_nez_uint32() {
         // end_if
         TTI_SFPENCC(0, 0, 0, 0);
         // store result
-        TTI_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_3, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_3, (dst_index_out - dst_index_in) * TILE_R_DIM);
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void calculate_comp_unary_int(int scalar) {
+inline void calculate_comp_unary_int(std::uint32_t dst_index_in, std::uint32_t dst_index_out, int scalar) {
     // Convert both operands to two's complement format
     //
     // LOGIC:
@@ -250,7 +250,7 @@ inline void calculate_comp_unary_int(int scalar) {
             v_endif;
         }
 
-        dst_reg[0] = val;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -36,7 +36,7 @@ sfpi_inline vInt sfpu_sign_mag_to_twos_comp(vInt value) {
 #endif  // SFPU_SIGN_MAG_TO_TWOS_COMP_DEFINED
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void calculate_comp() {
+inline void calculate_comp(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     constexpr uint V = p_sfpu::LREG0;
     constexpr uint ABS_V = p_sfpu::LREG2;
     constexpr uint INF = p_sfpu::LREG5;
@@ -48,6 +48,8 @@ inline void calculate_comp() {
         TTI_SFPLOADI(INF, sfpi::SFPLOADI_MOD0_FLOATB, BFLOAT16_INF);
     }
 
+    const std::uint32_t store_offset = (dst_index_out - dst_index_in) * TILE_R_DIM;
+
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(V, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
@@ -55,61 +57,61 @@ inline void calculate_comp() {
 
         // eqz: default 0, set 1 where |v| == 0 (handles ±0; NaN has |v|!=0 → stays 0)
         if constexpr (COMP_MODE == SfpuType::equal_zero) {
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, store_offset);
             TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
-            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_2, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_2, store_offset);
             TTI_SFPENCC(0, 0, 0, 0);
         }
 
         // nez: default 1, set 0 where |v| == 0 (handles ±0; NaN has |v|!=0 → stays 1)
         if constexpr (COMP_MODE == SfpuType::not_equal_zero) {
-            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, store_offset);
             TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, store_offset);
             TTI_SFPENCC(0, 0, 0, 0);
         }
 
         // ltz: default 0; chain: (v < 0) AND (|v| != 0) AND (|v| <= inf) → 1; NaN: |NaN| > inf → rejected
         if constexpr (COMP_MODE == SfpuType::less_than_zero) {
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, store_offset);
             TTI_SFPSETCC(0, V, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
             TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
             TTI_SFPIADD(0, INF, ABS_V, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_GTE0);
-            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_2, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_2, store_offset);
             TTI_SFPENCC(0, 0, 0, 0);
         }
 
         // gtz: default 0; chain: (v >= 0) AND (|v| != 0) AND (|v| <= inf) → 1; NaN: |NaN| > inf → rejected
         if constexpr (COMP_MODE == SfpuType::greater_than_zero) {
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, store_offset);
             TTI_SFPSETCC(0, V, 0, sfpi::SFPSETCC_MOD1_LREG_GTE0);
             TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
             TTI_SFPIADD(0, INF, ABS_V, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_GTE0);
-            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_2, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_2, store_offset);
             TTI_SFPENCC(0, 0, 0, 0);
         }
 
         // gez: default 1; chain1: (v<0) AND (|v|!=0) → 0 (negatives excl. -0); chain2: |v|>inf → 0 (NaN)
         if constexpr (COMP_MODE == SfpuType::greater_than_equal_zero) {
-            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, store_offset);
             TTI_SFPSETCC(0, V, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
             TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, store_offset);
             TTI_SFPENCC(0, 0, 0, 0);
             TTI_SFPIADD(0, INF, ABS_V, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_LT0);
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, store_offset);
             TTI_SFPENCC(0, 0, 0, 0);
         }
 
         // lez: default 1; chain1: (v>=0) AND (|v|!=0) → 0 (positives excl. +0); chain2: |v|>inf → 0 (NaN)
         if constexpr (COMP_MODE == SfpuType::less_than_equal_zero) {
-            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, store_offset);
             TTI_SFPSETCC(0, V, 0, sfpi::SFPSETCC_MOD1_LREG_GTE0);
             TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, store_offset);
             TTI_SFPENCC(0, 0, 0, 0);
             TTI_SFPIADD(0, INF, ABS_V, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_LT0);
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, 0);
+            TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, store_offset);
             TTI_SFPENCC(0, 0, 0, 0);
         }
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
@@ -14,8 +14,9 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE /*unused*/, int ITERATIONS = 8 /*unused*/>
-inline void calculate_cumsum(bool first) {
-    _calculate_cumsum_<false, 1>(first);  // There is only non APPROXIMATE implementation and one iteration
+inline void calculate_cumsum(std::uint32_t dst_index_in, std::uint32_t dst_index_out, bool first) {
+    _calculate_cumsum_<false, 1>(
+        dst_index_in, dst_index_out, first);  // There is only non APPROXIMATE implementation and one iteration
 }
 
 template <bool APPROXIMATION_MODE /*unused*/>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
@@ -57,13 +57,13 @@ constexpr std::array<float, 53> DIGAMMA_LUT = {
 #endif
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_digamma() {
+inline void calculate_digamma(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
         sfpi::vFloat result =
             piecewise_rational_eval<DIGAMMA_NUM_DEGREE, DIGAMMA_DEN_DEGREE, DIGAMMA_NUM_SEGMENTS, DIGAMMA_LUT_SIZE>(
                 DIGAMMA_LUT, x);
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
@@ -14,8 +14,8 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_dropout(uint probability, uint scale) {
-    _calculate_dropout_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, probability, scale);
+inline void calculate_dropout(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint probability, uint scale) {
+    _calculate_dropout_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out, ITERATIONS, probability, scale);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
@@ -9,8 +9,8 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_elu(uint slope) {
-    _calculate_elu_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(slope);
+inline void calculate_elu(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint slope) {
+    _calculate_elu_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(dst_index_in, dst_index_out, slope);
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erf.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erf.h
@@ -61,7 +61,7 @@ constexpr std::array<float, ERF_LUT_SIZE> ERF_LUT = {
 #endif
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_erf() {
+inline void calculate_erf(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
         // Clamp |x| to 10.0 before evaluation (erf is odd, rational is exact at boundary)
@@ -83,7 +83,7 @@ inline void calculate_erf() {
         sfpi::vFloat pos_one = sfpi::vConst1;
         sfpi::vec_min_max(neg_one, result);
         sfpi::vec_min_max(result, pos_one);
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfc.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfc.h
@@ -60,7 +60,7 @@ constexpr std::array<float, ERFC_LUT_SIZE> ERFC_LUT = {{// Breakpoints
                                              -2.1375391632e-02f}};
 
 template <int ITERATIONS = 8>
-inline void calculate_erfc() {
+inline void calculate_erfc(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
         // Clamp |x| to 5.0 before evaluation (avoids extrapolation, saves one branch)
@@ -73,7 +73,7 @@ inline void calculate_erfc() {
         // erfc(-x) = 2 - erfc(x)
         v_if(x < 0.0f) { r = 2.0f - r; }
         v_endif;
-        sfpi::dst_reg[0] = r;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = r;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -45,13 +45,13 @@ sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat x) {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void calculate_erfinv() {
+inline void calculate_erfinv(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     constexpr int ITERATIONS = 8;
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];
         sfpi::vFloat result = calculate_erfinv_body<false>(in);
         in = sfpi::dst_reg[0];  // reload due to register pressure
-        sfpi::dst_reg[0] = sfpi::copysgn(result, in);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::copysgn(result, in);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -17,9 +17,12 @@ template <
     bool SCALE_EN = false,
     int ITERATIONS = 8,
     bool CLAMP_NEGATIVE = true>
-void calculate_exponential(const uint exp_base_scale_factor = p_sfpu::kCONST_1_FP16B) {
+void calculate_exponential(
+    std::uint32_t dst_index_in,
+    std::uint32_t dst_index_out,
+    const uint exp_base_scale_factor = p_sfpu::kCONST_1_FP16B) {
     _calculate_exponential_<APPROXIMATION_MODE, SCALE_EN, ITERATIONS, CLAMP_NEGATIVE, is_fp32_dest_acc_en>(
-        exp_base_scale_factor);
+        dst_index_in, dst_index_out, exp_base_scale_factor);
 }
 
 template <bool APPROXIMATION_MODE, uint32_t scale = 0x3F800000, bool CLAMP_NEGATIVE = true>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -9,8 +9,8 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_exp2() {
-    _calculate_exp2_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>();
+inline void calculate_exp2(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_exp2_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -114,19 +114,19 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_improved_<true>(sfpi::vFloat val) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_expm1() {
+inline void calculate_expm1(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     if constexpr (APPROXIMATION_MODE) {
         // Use original approximation mode
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat v = sfpi::dst_reg[0];
-            sfpi::dst_reg[0] = _sfpu_expm1_<is_fp32_dest_acc_en>(v);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _sfpu_expm1_<is_fp32_dest_acc_en>(v);
             sfpi::dst_reg++;
         }
     } else {
         // Use improved version based on destination precision
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat v = sfpi::dst_reg[0];
-            sfpi::dst_reg[0] = _sfpu_expm1_improved_<is_fp32_dest_acc_en>(v);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _sfpu_expm1_improved_<is_fp32_dest_acc_en>(v);
             sfpi::dst_reg++;
         }
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
@@ -22,7 +22,8 @@ inline void init_fmod(const uint value, const uint recip) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_fmod(const uint value, const uint recip) {
+inline void calculate_fmod(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint value, const uint recip) {
     // SFPU microcode
     vFloat s = vConstFloatPrgm0;
     vFloat recip_val = vConstFloatPrgm1;
@@ -65,7 +66,7 @@ inline void calculate_fmod(const uint value, const uint recip) {
         }
         v_if(sfpi::abs(v) - s == 0.0f) { v = 0.0f; }
         v_endif;
-        dst_reg[0] = v;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -275,9 +275,9 @@ void gelu_derivative_init() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_gelu() {
+inline void calculate_gelu(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     if constexpr (APPROXIMATION_MODE) {
-        _calculate_gelu_<APPROXIMATION_MODE, ITERATIONS>();
+        _calculate_gelu_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
     } else {
 #pragma GCC unroll 0
         for (int d = 0; d < ITERATIONS; d++) {
@@ -286,15 +286,15 @@ inline void calculate_gelu() {
             if constexpr (!is_fp32_dest_acc_en) {
                 result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
             }
-            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
             sfpi::dst_reg++;
         }
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_gelu_derivative() {
-    _calculate_gelu_derivative_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_gelu_derivative(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_gelu_derivative_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 // =============================================================================
@@ -392,7 +392,7 @@ sfpi_inline sfpi::vFloat calculate_gelu_derivative_simple(sfpi::vFloat x) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
-inline void calculate_gelu_derivative_polynomial() {
+inline void calculate_gelu_derivative_polynomial(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat val = sfpi::dst_reg[0];
@@ -400,7 +400,7 @@ inline void calculate_gelu_derivative_polynomial() {
         if constexpr (!is_fp32_dest_acc_en) {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardmish.h
@@ -25,7 +25,7 @@ namespace sfpu {
 // Clamping to [0, 1] gives exact boundary values (0 or 1),
 // so the final multiply produces exact 0 or exact x at transitions.
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void hardmish() {
+inline void hardmish(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
         sfpi::vFloat scale = x * 0.5f + 1.0f;
@@ -35,7 +35,7 @@ inline void hardmish() {
         sfpi::vec_min_max(low_bound, scale);   // scale = max(scale, 0.0)
         sfpi::vec_min_max(scale, high_bound);  // scale = min(scale, 1.0)
 
-        sfpi::dst_reg[0] = x * scale;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = x * scale;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardshrink.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardshrink.h
@@ -10,7 +10,7 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_hardshrink(uint32_t param0) {
+inline void calculate_hardshrink(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t param0) {
     // Hardshrink(x, λ) = x if |x| > λ, else 0
     // Single comparison using abs: setsgn(v, 0) clears sign bit
     // param0 contains lambda as FP32 bits. For BF16 inputs, the host pre-rounds
@@ -23,7 +23,7 @@ inline void calculate_hardshrink(uint32_t param0) {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vFloat abs_v = sfpi::setsgn(v, 0);
-        v_if(abs_v <= lambda) { sfpi::dst_reg[0] = sfpi::vConst0; }
+        v_if(abs_v <= lambda) { sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::vConst0; }
         v_endif;
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
@@ -12,7 +12,7 @@ namespace ckernel::sfpu {
 // Hardtanh(x) = max_val if x > max_val, min_val if x < min_val, else x
 // Equivalent to: clamp(x, min_val, max_val) = min(max(x, min_val), max_val)
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_hardtanh(uint param0, uint param1) {
+inline void calculate_hardtanh(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint param0, uint param1) {
     // Load both params outside the loop for better performance
     // param0 = min_val -> LREG2, param1 = max_val -> LREG3
     TT_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_LOWER, param0 & 0xFFFF);
@@ -25,13 +25,21 @@ inline void calculate_hardtanh(uint param0, uint param1) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
         TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1 /* smaller value to LREG0 */);
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);  // store max
+        TT_SFPSTORE(
+            p_sfpu::LREG1,
+            InstrModLoadStore::DEFAULT,
+            ADDR_MOD_3,
+            (dst_index_out - dst_index_in) * TILE_R_DIM);  // store max
 
-        // x = min(x, max_val) using LREG3
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+        // x = min(x, max_val) using LREG3 — load from output offset where max result was stored
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, (dst_index_out - dst_index_in) * TILE_R_DIM);
         TTI_SFPMOV(0, p_sfpu::LREG3, p_sfpu::LREG1, 0);
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1 /* smaller value to LREG0 */);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);  // store min
+        TT_SFPSTORE(
+            p_sfpu::LREG0,
+            InstrModLoadStore::DEFAULT,
+            ADDR_MOD_3,
+            (dst_index_out - dst_index_in) * TILE_R_DIM);  // store min
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_heaviside.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_heaviside.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_heaviside(uint value) {
+inline void calculate_heaviside(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     // SFPU microcode
     vFloat s = Converter::as_float(value);
 
@@ -27,7 +27,7 @@ inline void calculate_heaviside(uint value) {
         v_else { v = s; }
         v_endif;
 
-        dst_reg[0] = v;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
 
         dst_reg++;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -23,7 +23,7 @@ namespace sfpu {
           t4) *                                                                                                   \
      t4)
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_i0() {
+inline void calculate_i0(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 0
 
     for (int d = 0; d < ITERATIONS; d++) {
@@ -45,7 +45,7 @@ inline void calculate_i0() {
                             0.25f,
                             x);
 
-        dst_reg[0] = result;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
@@ -82,9 +82,10 @@ inline sfpi::vFloat calculate_i1_asymptotic_(const sfpi::vFloat abs_x, const sfp
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_i1() {
+inline void calculate_i1(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     constexpr float I1_MAX_INPUT = 88.5f;
     constexpr float I1_THRESHOLD = 10.0f;
+    const int out_off = (dst_index_out - dst_index_in) * TILE_R_DIM;
 
 #pragma GCC unroll 1
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_identity.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_identity.h
@@ -17,21 +17,21 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_identity() {
+inline void calculate_identity(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
-        dst_reg[0] = v;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_identity_uint() {
+inline void calculate_identity_uint(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vUInt v = dst_reg[0];
-        dst_reg[0] = v;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_int_sum.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_int_sum.h
@@ -42,7 +42,7 @@ sfpi_inline vInt sfpu_twos_comp_to_sign_mag(vInt value) {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void calculate_sum_int_col() {
+inline void calculate_sum_int_col(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (unsigned i = 0; i < 2; ++i) {
         vInt a = dst_reg[i];
         a = sfpu_twos_comp_to_sign_mag(a);
@@ -65,7 +65,7 @@ inline void calculate_sum_int_col() {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void calculate_sum_int_row() {
+inline void calculate_sum_int_row(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (unsigned i = 0; i < 8; i += 2) {
         vInt a = dst_reg[i];
         a = sfpu_twos_comp_to_sign_mag(a);
@@ -86,7 +86,7 @@ template <bool APPROXIMATION_MODE>
 inline void sum_int_init() {}
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void add_int(const uint dst_offset) {
+inline void add_int(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint dst_offset) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         vInt a = dst_reg[0];
@@ -97,7 +97,7 @@ inline void add_int(const uint dst_offset) {
         vInt r = a + b;
         r = sfpu_sign_mag_to_twos_comp(r);
 
-        dst_reg[0] = r;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = r;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_left_shift.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_left_shift.h
@@ -13,12 +13,12 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_left_shift(const uint shift_amt) {
+inline void calculate_left_shift(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint shift_amt) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(0,4,3,0);
+        TTI_SFPLOAD(0, 4, 3, 0);
         TT_SFPSHFT(shift_amt,0,0,1);
-        TTI_SFPSTORE(0,4,3,0);
+        TT_SFPSTORE(0, 4, 3, (dst_index_out - dst_index_in) * TILE_R_DIM);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
@@ -15,7 +15,7 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_lgamma_stirling() {
+inline void calculate_lgamma_stirling(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     constexpr float LOG_SQRT_2PI = 0.9189385332046727f;
 
     // Minimal coefficients for 0-3 ULP
@@ -47,7 +47,7 @@ inline void calculate_lgamma_stirling() {
         if constexpr (!is_fp32_dest_acc_en) {
             res = sfpi::convert<sfpi::vFloat16b>(res, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = res;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = res;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -117,7 +117,7 @@ template <
     bool HAS_BASE_SCALING,
     bool is_fp32_dest_acc_en,
     int ITERATIONS = 8>
-inline void calculate_log(uint log_base_scale_factor) {
+inline void calculate_log(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint log_base_scale_factor) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat result = calculate_log_body<FAST_APPROX, HAS_BASE_SCALING, is_fp32_dest_acc_en>(
@@ -125,7 +125,7 @@ inline void calculate_log(uint log_base_scale_factor) {
         if constexpr (!is_fp32_dest_acc_en) {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -134,14 +134,14 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
  * @tparam ITERATIONS Number of iterations for given face
  */
 template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_log1p() {
+inline void calculate_log1p(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat result = calculate_log1p_fp32<is_fp32_dest_acc_en>(sfpi::dst_reg[0]);
         if constexpr (!is_fp32_dest_acc_en) {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not.h
@@ -11,14 +11,13 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, InstrModLoadStore INSTRUCTION_MODE, int ITERATIONS>
-inline void calculate_logical_not() {
+inline void calculate_logical_not(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     static_assert(
         INSTRUCTION_MODE == InstrModLoadStore::DEFAULT || INSTRUCTION_MODE == InstrModLoadStore::LO16 ||
             INSTRUCTION_MODE == InstrModLoadStore::INT32,
         "INSTRUCTION_MODE must be one of: DEFAULT, LO16, INT32.");
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        constexpr int tile_size = 64;
         // load in conditional uint16 value
         TTI_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, 0);
         // initially put 0 into output
@@ -38,7 +37,7 @@ inline void calculate_logical_not() {
         // INSTR_MOD1: 0 => condition code enable reg is not modified.
         TTI_SFPENCC(0, 0, 0, 0);
         // store result
-        TTI_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, (dst_index_out - dst_index_in) * TILE_R_DIM);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
@@ -15,38 +15,48 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_mask() {
+inline void calculate_mask(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     const bool exponent_size_8 = true;
     const int mask_val_idx = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat mask = dst_reg[mask_val_idx];
-        v_if(_sfpu_is_fp16_zero_(mask, exponent_size_8)) { dst_reg[0] = vConst0; }
+        vFloat val = dst_reg[0];
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
+        v_if(_sfpu_is_fp16_zero_(mask, exponent_size_8)) {
+            dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = vConst0;
+        }
         v_endif;
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_int_mask() {
+inline void calculate_int_mask(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     const int mask_idx = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         vInt mask = dst_reg[mask_idx];
-        v_if(mask == 0) { dst_reg[0] = vConst0; }
+        vFloat val = dst_reg[0];
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
+        v_if(mask == 0) { dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = vConst0; }
         v_endif;
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_mask_posinf() {
+inline void calculate_mask_posinf(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     const bool exponent_size_8 = true;
     const int mask_val_idx = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat mask = dst_reg[mask_val_idx];
-        v_if(_sfpu_is_fp16_zero_(mask, exponent_size_8)) { dst_reg[0] = std::numeric_limits<float>::infinity(); }
+        vFloat val = dst_reg[0];
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
+        v_if(_sfpu_is_fp16_zero_(mask, exponent_size_8)) {
+            dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = std::numeric_limits<float>::infinity();
+        }
         v_endif;
         dst_reg++;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
@@ -36,7 +36,8 @@ namespace ckernel::sfpu {
  *   scale_packed: precomputed (-1)^(n+1) * n! (as float bits)
  */
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_polygamma(uint32_t n_packed, uint32_t scale_packed) {
+inline void calculate_polygamma(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t n_packed, uint32_t scale_packed) {
     constexpr int NUM_TERMS = 11;  // Exact terms (k=0..10)
 
     // Unpack parameters using Converter (union-based type punning supported by SFPU compiler)
@@ -123,7 +124,7 @@ inline void calculate_polygamma(uint32_t n_packed, uint32_t scale_packed) {
         if constexpr (!is_fp32_dest_acc_en) {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_prelu(uint value) {
+inline void calculate_prelu(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     // SFPU microcode
     vFloat init = Converter::as_float(value);
 
@@ -23,7 +23,7 @@ inline void calculate_prelu(uint value) {
         vFloat a = dst_reg[0];
         v_if(a < 0.0f) { a = a * init; }
         v_endif;
-        dst_reg[0] = a;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = a;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h
@@ -16,7 +16,7 @@ inline void rand_init(uint32_t seed) {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void rand(uint32_t from, uint32_t scale) {
+inline void rand(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t from, uint32_t scale) {
     // Load scale param to lreg1
     TT_SFPLOADI(p_sfpu::LREG1, 10, scale & 0xFFFF);
     TT_SFPLOADI(p_sfpu::LREG1, 8, scale >> 16);
@@ -46,7 +46,7 @@ inline void rand(uint32_t from, uint32_t scale) {
         TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG0, 0);
         TTI_SFPNOP;
 
-        TTI_SFPSTORE(0, 3, 3, 0);
+        TT_SFPSTORE(0, 3, 3, (dst_index_out - dst_index_in) * TILE_R_DIM);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, RoundingMode rounding_mode, int ITERATIONS>
-inline void calculate_rdiv(const uint value) {
+inline void calculate_rdiv(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint value) {
     sfpi::vFloat val = Converter::as_float(value);
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
@@ -36,7 +36,7 @@ inline void calculate_rdiv(const uint value) {
         } else if constexpr (rounding_mode == RoundingMode::Floor) {
             result = _floor_body_(result);
         }
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -25,8 +25,9 @@ sfpi_inline void sfpu_reciprocal_init() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8, bool legacy_compat = false>
-inline void calculate_reciprocal() {
-    _calculate_reciprocal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en, legacy_compat>(ITERATIONS);
+inline void calculate_reciprocal(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_reciprocal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en, legacy_compat>(
+        dst_index_in, dst_index_out, ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool legacy_compat = false>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -12,8 +12,9 @@
 namespace ckernel::sfpu {
 
 template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
-inline void calculate_reduce(uint32_t ct_dim, uint32_t rt_dim) {
-    _calculate_reduce_<pool_type, reduce_dim, format>(ct_dim, rt_dim);
+inline void calculate_reduce(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t ct_dim, uint32_t rt_dim) {
+    _calculate_reduce_<pool_type, reduce_dim, format>(dst_index_in, dst_index_out, ct_dim, rt_dim);
 }
 
 template <PoolType pool_type, DataFormat format>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
@@ -15,19 +15,19 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE>
-inline void relu_min(uint uint_threshold) {
+inline void relu_min(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint uint_threshold) {
     vFloat threshold = Converter::as_float(uint_threshold);
     for (int d = 0; d < 8; d++) {
         vFloat a = dst_reg[0];
         v_if(a < threshold) { a = threshold; }
         v_endif;
-        dst_reg[0] = a;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = a;
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE>
-inline void relu_max(uint uint_threshold) {
+inline void relu_max(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint uint_threshold) {
     vFloat threshold = Converter::as_float(uint_threshold);
     for (int d = 0; d < 8; d++) {
         vFloat a = dst_reg[0];
@@ -35,14 +35,14 @@ inline void relu_max(uint uint_threshold) {
         v_endif;
         v_if(a < 0.0f) { a = 0.0f; }
         v_endif;
-        dst_reg[0] = a;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = a;
         dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_lrelu(const uint slope) {
-    _calculate_lrelu_<APPROXIMATION_MODE>(ITERATIONS, slope);
+inline void calculate_lrelu(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint slope) {
+    _calculate_lrelu_<APPROXIMATION_MODE>(dst_index_in, dst_index_out, ITERATIONS, slope);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -22,7 +22,8 @@ inline void init_remainder(const uint value, const uint recip) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_remainder(const uint value, const uint recip) {
+inline void calculate_remainder(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint value, const uint recip) {
     // SFPU microcode
     vFloat s = vConstFloatPrgm0;
     vFloat recip_val = vConstFloatPrgm1;
@@ -70,7 +71,7 @@ inline void calculate_remainder(const uint value, const uint recip) {
         }
         v_if(sfpi::abs(v) - s == 0.0f) { v = 0.0f; }
         v_endif;
-        dst_reg[0] = v;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
@@ -12,8 +12,8 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE>
-inline void calculate_reshuffle_rows(uint idx_addr) {
-    _calculate_reshuffle_rows_(idx_addr);
+inline void calculate_reshuffle_rows(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint idx_addr) {
+    _calculate_reshuffle_rows_(dst_index_in, dst_index_out, idx_addr);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_right_shift.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_right_shift.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_right_shift(const uint shift_amt) {
+inline void calculate_right_shift(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint shift_amt) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];
@@ -26,7 +26,7 @@ inline void calculate_right_shift(const uint shift_amt) {
         v_if(input < 0) { res = copysgn(res + 1, input); }
         v_endif;
 
-        dst_reg[0] = res;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = res;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rpow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rpow.h
@@ -11,11 +11,12 @@
 namespace ckernel::sfpu {
 // ttnn.rpow(exponent, scalar_base) = pow(scalar_base, exponent)
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
-inline void calculate_rpow(const uint32_t base_val) {
+inline void calculate_rpow(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint32_t base_val) {
     sfpi::vFloat base_val_v = Converter::as_float(base_val);
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::dst_reg[0] = _sfpu_binary_power_<is_fp32_dest_acc_en>(base_val_v, sfpi::dst_reg[0]);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] =
+            _sfpu_binary_power_<is_fp32_dest_acc_en>(base_val_v, sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
@@ -14,8 +14,9 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>
-inline void calculate_rsqrt() {
-    _calculate_rsqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX, legacy_compat>(ITERATIONS);
+inline void calculate_rsqrt(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_rsqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX, legacy_compat>(
+        dst_index_in, dst_index_out, ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE, bool legacy_compat>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
@@ -16,7 +16,6 @@ inline void calculate_rsub_int(const uint dst_index_in0, const uint dst_index_in
     static_assert(
         is_valid_instruction_mode(INSTRUCTION_MODE), "INSTRUCTION_MODE must be one of: INT32_2S_COMP, INT32, LO16.");
     constexpr int sfpload_instr_mod = static_cast<std::underlying_type_t<InstrModLoadStore>>(INSTRUCTION_MODE);
-    // size of each tile in Dest is 64 rows
     constexpr uint dst_tile_size = 64;
 
 #pragma GCC unroll 8
@@ -41,7 +40,7 @@ inline void calculate_rsub_int(const uint dst_index_in0, const uint dst_index_in
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-void calculate_rsub_scalar_int32(uint32_t scalar) {
+void calculate_rsub_scalar_int32(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t scalar) {
     int int_scalar = scalar;
     // Load scalar value param to lreg2
     _sfpu_load_imm32_(p_sfpu::LREG1, int_scalar);
@@ -51,7 +50,7 @@ void calculate_rsub_scalar_int32(uint32_t scalar) {
         // specified in lreg_dest. The condition code register is not modified (2).
         TTI_SFPIADD(
             0, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_NONE);
-        TTI_SFPSTORE(p_sfpu::LREG0, INT32, ADDR_MOD_3, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, INT32, ADDR_MOD_3, (dst_index_out - dst_index_in) * TILE_R_DIM);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_selu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_selu.h
@@ -9,8 +9,8 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_selu(uint32_t scale, uint32_t alpha) {
-    _calculate_selu_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(scale, alpha);
+inline void calculate_selu(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t scale, uint32_t alpha) {
+    _calculate_selu_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(dst_index_in, dst_index_out, scale, alpha);
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -40,7 +40,7 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_sigmoid() {
+inline void calculate_sigmoid(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     if constexpr (!APPROXIMATION_MODE) {
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
@@ -52,11 +52,11 @@ inline void calculate_sigmoid() {
                 result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
             }
 
-            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
             sfpi::dst_reg++;
         }
     } else {
-        calculate_sigmoid_appx<ITERATIONS>();
+        calculate_sigmoid_appx<ITERATIONS>(dst_index_in, dst_index_out);
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid_appx.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <int ITERATIONS = 8>
-inline void calculate_sigmoid_appx() {
+inline void calculate_sigmoid_appx(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     vUInt l0 = l_reg[LRegs::LReg0];
     vUInt l1 = l_reg[LRegs::LReg1];
     vUInt l2 = l_reg[LRegs::LReg2];
@@ -22,7 +22,7 @@ inline void calculate_sigmoid_appx() {
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat val = dst_reg[0];
 
-        dst_reg[0] = lut(val, l0, l1, l2) + 0.5f;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = lut(val, l0, l1, l2) + 0.5f;
 
         dst_reg++;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h
@@ -14,8 +14,8 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_sign(const uint exponent_size_8) {
-    _calculate_sign_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, exponent_size_8);
+inline void calculate_sign(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint exponent_size_8) {
+    _calculate_sign_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out, ITERATIONS, exponent_size_8);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_signbit.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_signbit.h
@@ -12,7 +12,7 @@ using namespace sfpi;
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_signbit() {
+inline void calculate_signbit(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
     //
     // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
@@ -24,29 +24,30 @@ inline void calculate_signbit() {
     //    | ...  | [a] L16 = cast_fp32(a) |     |            |          |
     //    | ...  |                        |     |            | [a] L16  |
 
-    constexpr int offset = 0;
+    const int in_offset = 0;
+    const int out_offset = (dst_index_out - dst_index_in) * TILE_R_DIM;
 
 #ifndef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         int a = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
-        TT_SFPLOADMACRO((0 << 2) | (a & 3), InstrModLoadStore::DEFAULT, ADDR_MOD_2, offset | (a >> 2));
+        TT_SFPLOADMACRO((0 << 2) | (a & 3), InstrModLoadStore::DEFAULT, ADDR_MOD_2, in_offset | (a >> 2));
     }
     TTI_SFPNOP;
     TTI_SFPNOP;
     TTI_SFPNOP;
 #else
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, offset);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, in_offset);
         TTI_SFPSHFT(-31 & 0xfff, p_sfpu::LREG0, p_sfpu::LREG0, 1);  // SFPSHFT_MOD1_ARG_IMM
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, offset);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, out_offset);
     }
 #endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_signbit_int32() {
+inline void calculate_signbit_int32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
     //
     // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
@@ -57,21 +58,22 @@ inline void calculate_signbit_int32() {
     //    | ...  |        |     | [a] L16 = a >> 31 |          |
     //    | ...  |        |     |                   | [a] L16  |
 
-    constexpr int offset = 0;
+    const int in_offset = 0;
+    const int out_offset = (dst_index_out - dst_index_in) * TILE_R_DIM;
 
 #ifndef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr int a = p_sfpu::LREG0;
-        TTI_SFPLOADMACRO((0 << 2) | (a & 3), InstrModLoadStore::INT32, ADDR_MOD_2, offset | (a >> 2));
+        TTI_SFPLOADMACRO((0 << 2) | (a & 3), InstrModLoadStore::INT32, ADDR_MOD_2, in_offset | (a >> 2));
     }
     TTI_SFPNOP;
     TTI_SFPNOP;
 #else
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, offset);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, in_offset);
         TTI_SFPSHFT(-31 & 0xfff, p_sfpu::LREG0, p_sfpu::LREG0, 1);  // SFPSHFT_MOD1_ARG_IMM
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_2, offset);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_2, out_offset);
     }
 #endif
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -10,7 +10,7 @@
 namespace ckernel::sfpu {
 
 template <bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_silu() {
+inline void calculate_silu(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
@@ -23,7 +23,7 @@ inline void calculate_silu() {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -80,7 +80,12 @@ sfpi_inline sfpi::vFloat softplus_exp_negative(sfpi::vFloat x) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void calculate_softplus_body(const float beta, const float beta_reciprocal, const float threshold) {
+inline void calculate_softplus_body(
+    std::uint32_t dst_index_in,
+    std::uint32_t dst_index_out,
+    const float beta,
+    const float beta_reciprocal,
+    const float threshold) {
     sfpi::vFloat val = sfpi::dst_reg[0];
     sfpi::vFloat t = beta * val;
 
@@ -128,18 +133,20 @@ inline void calculate_softplus_body(const float beta, const float beta_reciproca
         if constexpr (!is_fp32_dest_acc_en) {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
     }
     v_endif;
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_softplus(uint param0, uint param1, uint param2) {
+inline void calculate_softplus(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint param0, uint param1, uint param2) {
     const float beta = Converter::as_float(param0);
     const float beta_reciprocal = Converter::as_float(param1);
     const float threshold = Converter::as_float(param2);
     for (int d = 0; d < ITERATIONS; d++) {
-        calculate_softplus_body<APPROXIMATION_MODE, is_fp32_dest_acc_en>(beta, beta_reciprocal, threshold);
+        calculate_softplus_body<APPROXIMATION_MODE, is_fp32_dest_acc_en>(
+            dst_index_in, dst_index_out, beta, beta_reciprocal, threshold);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
@@ -10,15 +10,15 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_softshrink(uint32_t param0) {
+inline void calculate_softshrink(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint32_t param0) {
     // Softshrink(x) = x - λ if x > λ, x + λ if x < -λ, else 0
     // SFPU microcode
     sfpi::vFloat lambda = Converter::as_float(param0);
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::vConst0;
-        v_if(v > lambda) { sfpi::dst_reg[0] = v - lambda; }
-        v_elseif(v < (-lambda)) { sfpi::dst_reg[0] = v + lambda; }
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::vConst0;
+        v_if(v > lambda) { sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v - lambda; }
+        v_elseif(v < (-lambda)) { sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v + lambda; }
         v_endif;
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
@@ -10,13 +10,13 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_softsign() {
+inline void calculate_softsign(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vFloat tmp = sfpi::abs(v) + sfpi::vConst1;
         tmp = sfpu_reciprocal<APPROXIMATION_MODE>(tmp);
-        sfpi::dst_reg[0] = v * tmp;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v * tmp;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -14,8 +14,9 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool fp32_dest_acc_en, bool FAST_APPROX>
-inline void calculate_sqrt() {
-    _calculate_sqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX>(ITERATIONS);
+inline void calculate_sqrt(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_sqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX>(
+        dst_index_in, dst_index_out, ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -11,8 +11,8 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_square() {
-    _calculate_square_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_square(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_square_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -116,7 +116,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_tanh() {
+inline void calculate_tanh(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     if constexpr (APPROXIMATION_MODE) {
         // SFPU microcode
         sfpi::vUInt l0 = l_reg[sfpi::LRegs::LReg0];
@@ -127,7 +127,7 @@ inline void calculate_tanh() {
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];
             val = sfpi::lut(val, l0, l1, l2);
-            sfpi::dst_reg[0] = val;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
 
             sfpi::dst_reg++;
         }
@@ -150,7 +150,7 @@ inline void calculate_tanh() {
                 result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
             }
 
-            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
             sfpi::dst_reg++;
         }
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
@@ -19,7 +19,7 @@ namespace sfpu {
 // WARNING: This has catastrophic cancellation for |x| > ~3.4 (Max ULP = 15,140).
 // Kept for backward compatibility. Use calculate_tanh_derivative_sech2 instead.
 template <bool APPROXIMATION_MODE, int WITH_PRECOMPUTED_TANH = 0, int ITERATIONS = 8>
-inline void calculate_tanh_derivative() {
+inline void calculate_tanh_derivative(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     vUInt l0 = l_reg[LRegs::LReg0];
     vUInt l1 = l_reg[LRegs::LReg1];
     vUInt l2 = l_reg[LRegs::LReg2];
@@ -33,7 +33,7 @@ inline void calculate_tanh_derivative() {
         }
 
         val = val * (-val) + vConst1;
-        dst_reg[0] = val;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
 
         dst_reg++;
     }
@@ -170,7 +170,7 @@ constexpr float CORE_REGION_LIMIT = 3.0f;   // Polynomial ↔ exp boundary
 constexpr float TAIL_REGION_LIMIT = 45.0f;  // Exp ↔ zero saturation boundary
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_tanh_derivative_sech2() {
+inline void calculate_tanh_derivative_sech2(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat val = sfpi::dst_reg[0];
         sfpi::vFloat result = sfpi::vConst0;
@@ -210,7 +210,7 @@ inline void calculate_tanh_derivative_sech2() {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tiled_prod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tiled_prod.h
@@ -13,18 +13,18 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_tiled_prod() {
+inline void calculate_tiled_prod(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     vFloat result = 1.0f;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
         result *= v;
-        dst_reg[0] = result;
+        dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         dst_reg++;
     }
     vFloat v = dst_reg[0];
     result *= v;
-    dst_reg[0] = result;
+    dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
     dst_reg++;
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
@@ -15,18 +15,32 @@ namespace sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
 inline void calculate_bitonic_topk_phases_steps(
-    uint idir, uint i_end_phase, uint i_start_phase, uint i_end_step, uint i_start_step) {
+    [[maybe_unused]] std::uint32_t dst_index_in,
+    [[maybe_unused]] std::uint32_t dst_index_out,
+    uint idir,
+    uint i_end_phase,
+    uint i_start_phase,
+    uint i_end_step,
+    uint i_start_step) {
     _bitonic_topk_phases_steps<APPROXIMATION_MODE, is_fp32_dest_acc_en, STABLE_SORT>(
         idir, i_end_phase, i_start_phase, i_end_step, i_start_step);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool idir = false, bool STABLE_SORT = false>
-inline void calculate_bitonic_topk_merge(uint m_iter, uint k) {
+inline void calculate_bitonic_topk_merge(
+    [[maybe_unused]] std::uint32_t dst_index_in, [[maybe_unused]] std::uint32_t dst_index_out, uint m_iter, uint k) {
     _bitonic_topk_merge<APPROXIMATION_MODE, is_fp32_dest_acc_en, idir, STABLE_SORT>(m_iter, k);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
-inline void calculate_bitonic_topk_rebuild(uint idir, uint m_iter, uint k, uint logk, uint skip_second) {
+inline void calculate_bitonic_topk_rebuild(
+    [[maybe_unused]] std::uint32_t dst_index_in,
+    [[maybe_unused]] std::uint32_t dst_index_out,
+    uint idir,
+    uint m_iter,
+    uint k,
+    uint logk,
+    uint skip_second) {
     _bitonic_topk_rebuild<APPROXIMATION_MODE, is_fp32_dest_acc_en, STABLE_SORT>(idir, m_iter, k, logk, skip_second);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -112,7 +112,7 @@ sfpi_inline sfpi::vFloat sfpu_tan<false>(sfpi::vFloat a, sfpi::vInt i) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_tangent() {
+inline void calculate_tangent(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // Constants for four-stage Cody-Waite reduction with -PI/2 = P0 + P1 + P2 + P3
     const float P0 = -0x1.92p+0f;   // representable as bf16
     const float P1 = -0x1.fbp-12f;  // representable as fp16
@@ -157,7 +157,7 @@ inline void calculate_tangent() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_sine() {
+inline void calculate_sine(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // 1. Reduce argument using a four-stage Cody-Waite reduction to the interval [-PI/2, PI/2].
     // 2. Use odd symmetry (sin(-x) = -sin(x)) via quadrant/sign tracking.
     // 3. Evaluate sin(a) = a + a^3 (C0 + a^2 (C1 + a^2 (C2 + a^2 C3))) on [0, PI/2].
@@ -229,7 +229,7 @@ inline void calculate_sine() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_cosine() {
+inline void calculate_cosine(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // 1. Build an odd quadrant index j for PI/2-based reduction.
     // 2. Reduce to a in [-PI/2, PI/2] and fold sign from the quadrant parity.
     // 3. Evaluate sin(a) polynomial and use identity cos(x) = sin(x + PI/2).
@@ -370,7 +370,7 @@ sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_atan() {
+inline void calculate_atan(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];
         sfpi::vFloat result = sfpu_atan<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in);
@@ -379,7 +379,7 @@ inline void calculate_atan() {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
 
         sfpi::dst_reg++;
     }
@@ -439,7 +439,7 @@ sfpi_inline sfpi::vFloat sfpu_asin_range_reduced(sfpi::vFloat val) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool IS_ACOS, int ITERATIONS = 8>
-inline void calculate_asin_acos_impl() {
+inline void calculate_asin_acos_impl(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
@@ -458,43 +458,43 @@ inline void calculate_asin_acos_impl() {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_asin() {
-    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, false, ITERATIONS>();
+inline void calculate_asin(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, false, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_acos() {
-    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, true, ITERATIONS>();
+inline void calculate_acos(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, true, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 // cosh = (exp(x) + exp(-x)) / 2
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_cosh() {
+inline void calculate_cosh(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vFloat result =
             (_sfpu_exp_21f_bf16_<is_fp32_dest_acc_en>(v) + _sfpu_exp_21f_bf16_<is_fp32_dest_acc_en>(-v)) * 0.5f;
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }
 
 // sinh = (exp(x) - exp(-x)) / 2
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_sinh() {
+inline void calculate_sinh(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vFloat result =
             (_sfpu_exp_21f_bf16_<is_fp32_dest_acc_en>(v) - _sfpu_exp_21f_bf16_<is_fp32_dest_acc_en>(-v)) * 0.5f;
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -16,12 +16,12 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_uint16() {
-    _calculate_typecast_fp32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_fp32_to_uint16(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_fp32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_uint8() {
+inline void calculate_typecast_fp32_to_uint8(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; ++d) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
@@ -48,12 +48,12 @@ inline void calculate_typecast_fp32_to_uint8() {
         TTI_SFPIADD(256, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
         // result &= 0xFF
         TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG1, 0);
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_2, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_2, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool u16 = false>
-inline void calculate_typecast_uint_to_uint8() {
+inline void calculate_typecast_uint_to_uint8(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; ++d) {
         if constexpr (u16) {
@@ -63,68 +63,68 @@ inline void calculate_typecast_uint_to_uint8() {
         }
         TTI_SFPIADD(256, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
         TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_2, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_2, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint16_to_fp16b() {
-    _calculate_typecast_uint16_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint16_to_fp16b(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_uint16_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_int32_to_fp16b() {
-    _calculate_typecast_int32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_int32_to_fp16b(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_int32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_int32() {
-    _calculate_typecast_fp32_to_int32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_fp32_to_int32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_fp32_to_int32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_fp16b() {
-    _calculate_typecast_fp32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_fp32_to_fp16b(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_fp32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint16_to_fp32() {
-    _calculate_typecast_uint16_to_fp32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint16_to_fp32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_uint16_to_fp32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_int32_to_fp32() {
-    _calculate_typecast_int32_to_fp32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_int32_to_fp32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_int32_to_fp32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_uint32() {
-    _calculate_typecast_fp32_to_uint32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_fp32_to_uint32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_fp32_to_uint32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint32_to_fp16b() {
-    _calculate_typecast_uint32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint32_to_fp16b(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_uint32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint32_to_fp32() {
-    _calculate_typecast_uint32_to_fp32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint32_to_fp32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_uint32_to_fp32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint16_to_uint32() {
-    _calculate_typecast_uint16_to_uint32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint16_to_uint32(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_uint16_to_uint32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint32_to_uint16() {
-    _calculate_typecast_uint32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint32_to_uint16(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_uint32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_int32_to_uint16() {
-    _calculate_typecast_int32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_int32_to_uint16(std::uint32_t dst_index_in, std::uint32_t dst_index_out) {
+    _calculate_typecast_int32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_ne(uint value) {
+inline void calculate_unary_ne(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -24,14 +24,14 @@ inline void calculate_unary_ne(uint value) {
         v_else { v = 1.0f; }
         v_endif;
 
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
 
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_eq(uint value) {
+inline void calculate_unary_eq(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -42,14 +42,14 @@ inline void calculate_unary_eq(uint value) {
         v_else { v = 0.0f; }
         v_endif;
 
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
 
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_gt(uint value) {
+inline void calculate_unary_gt(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -60,14 +60,14 @@ inline void calculate_unary_gt(uint value) {
         v_else { v = 0.0f; }
         v_endif;
 
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
 
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_lt(uint value) {
+inline void calculate_unary_lt(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -78,14 +78,14 @@ inline void calculate_unary_lt(uint value) {
         v_else { v = 0.0f; }
         v_endif;
 
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
 
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_ge(uint value) {
+inline void calculate_unary_ge(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -96,14 +96,14 @@ inline void calculate_unary_ge(uint value) {
         v_else { v = 1.0f; }
         v_endif;
 
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
 
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_le(uint value) {
+inline void calculate_unary_le(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -114,7 +114,7 @@ inline void calculate_unary_le(uint value) {
         v_else { v = 1.0f; }
         v_endif;
 
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -13,9 +13,15 @@ namespace ckernel::sfpu {
 sfpi_inline void load_value_param_float(uint value) { sfpi::vConstIntPrgm0 = value; }
 
 template <bool IS_MAX_OP>
-sfpi_inline void calculate_unary_max_min_float_body() {
+sfpi_inline void calculate_unary_max_min_float_body(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, int load_offset = 0) {
+    int store_offset = (dst_index_out - dst_index_in) * TILE_R_DIM;
     sfpi::l_reg[sfpi::LRegs::LReg0].in_use();
-    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+    if (load_offset != 0) {
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, load_offset);
+    } else {
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+    }
 
     if constexpr (IS_MAX_OP) {
         // L0 = max(L0, constant); this will only write to L0 since L12 is a constant register.
@@ -24,11 +30,15 @@ sfpi_inline void calculate_unary_max_min_float_body() {
         // L0 = min(L0, constant); this will only write to L0 since L12 is a constant register.
         TTI_SFPSWAP(0, p_sfpu::LREG12, p_sfpu::LREG0, sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);
     }
-    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+    if (store_offset != 0) {
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, store_offset);
+    } else {
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+    }
 }
 
 template <bool IS_MAX_OP = true, bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_unary_max_min(uint value) {
+inline void calculate_unary_max_min(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
     //
     // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
@@ -44,7 +54,7 @@ inline void calculate_unary_max_min(uint value) {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        calculate_unary_max_min_float_body<IS_MAX_OP>();
+        calculate_unary_max_min_float_body<IS_MAX_OP>(dst_index_in, dst_index_out);
         sfpi::dst_reg++;
     }
 #else
@@ -70,9 +80,15 @@ sfpi_inline void load_value_param_int(uint value) {
 }
 
 template <bool IS_MAX_OP, bool IS_UNSIGNED = false>
-sfpi_inline void calculate_unary_max_min_int32_body(uint value) {
+sfpi_inline void calculate_unary_max_min_int32_body(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value, int load_offset = 0) {
+    int store_offset = (dst_index_out - dst_index_in) * TILE_R_DIM;
     sfpi::l_reg[sfpi::LRegs::LReg0].in_use();
-    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+    if (load_offset != 0) {
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, load_offset);
+    } else {
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+    }
 
     if (IS_UNSIGNED ^ ((int)value >= 0)) {
         // if msb(value) == 0, we can safely use SFPSWAP even though it expects sign-magnitude integers
@@ -91,17 +107,21 @@ sfpi_inline void calculate_unary_max_min_int32_body(uint value) {
             IS_MAX_OP ^ IS_UNSIGNED ? sfpi::SFPSWAP_MOD1_VEC_MIN_MAX : 9);  // mod1=9 means set VD=max and VC=min
         TTI_SFPNOT(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
     }
-    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+    if (store_offset != 0) {
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, store_offset);
+    } else {
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+    }
 }
 
 template <bool IS_MAX_OP = true, bool IS_UNSIGNED = false, bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_unary_max_min_int32(uint value) {
+inline void calculate_unary_max_min_int32(std::uint32_t dst_index_in, std::uint32_t dst_index_out, uint value) {
     load_value_param_int<IS_UNSIGNED>(value);
 
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        calculate_unary_max_min_int32_body<IS_MAX_OP, IS_UNSIGNED>(value);
+        calculate_unary_max_min_int32_body<IS_MAX_OP, IS_UNSIGNED>(dst_index_in, dst_index_out, value);
         sfpi::dst_reg++;
     }
 #else

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -267,7 +267,7 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
 }
 
 template <int ITERATIONS>
-inline void _sfpu_unary_power_bf16_(const uint32_t exponent) {
+inline void _sfpu_unary_power_bf16_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint32_t exponent) {
     // Convert exponent to float
     const float pow_scalar = Converter::as_float(exponent);
     const sfpi::vFloat pow = pow_scalar;
@@ -276,21 +276,21 @@ inline void _sfpu_unary_power_bf16_(const uint32_t exponent) {
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat base = sfpi::dst_reg[0];
-            sfpi::dst_reg[0] = _sfpu_unary_power_21f_<true>(base, pow);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _sfpu_unary_power_21f_<true>(base, pow);
             sfpi::dst_reg++;
         }
     } else {
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat base = sfpi::dst_reg[0];
-            sfpi::dst_reg[0] = _sfpu_unary_power_21f_<false>(base, pow);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _sfpu_unary_power_21f_<false>(base, pow);
             sfpi::dst_reg++;
         }
     }
 }
 
 template <int ITERATIONS>
-inline void _sfpu_unary_power_fp32_(const uint32_t exponent) {
+inline void _sfpu_unary_power_fp32_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint32_t exponent) {
     // Convert exponent to float
     const float pow_scalar = Converter::as_float(exponent);
     const sfpi::vFloat pow = pow_scalar;
@@ -299,14 +299,16 @@ inline void _sfpu_unary_power_fp32_(const uint32_t exponent) {
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat base = sfpi::dst_reg[0];
-            sfpi::dst_reg[0] = _sfpu_unary_power_61f_updated_<true>(base, pow);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] =
+                _sfpu_unary_power_61f_updated_<true>(base, pow);
             sfpi::dst_reg++;
         }
     } else {
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat base = sfpi::dst_reg[0];
-            sfpi::dst_reg[0] = _sfpu_unary_power_61f_updated_<false>(base, pow);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] =
+                _sfpu_unary_power_61f_updated_<false>(base, pow);
             sfpi::dst_reg++;
         }
     }
@@ -318,11 +320,11 @@ inline void _sfpu_unary_power_fp32_(const uint32_t exponent) {
  * @param exponent The exponent as IEEE 754 float bits (reinterpreted as uint32_t)
  */
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_unary_power(const uint32_t exponent) {
+inline void calculate_unary_power(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint32_t exponent) {
     if constexpr (is_fp32_dest_acc_en) {
-        _sfpu_unary_power_fp32_<ITERATIONS>(exponent);
+        _sfpu_unary_power_fp32_<ITERATIONS>(dst_index_in, dst_index_out, exponent);
     } else {
-        _sfpu_unary_power_bf16_<ITERATIONS>(exponent);
+        _sfpu_unary_power_bf16_<ITERATIONS>(dst_index_in, dst_index_out, exponent);
     }
 }
 
@@ -332,13 +334,14 @@ inline void calculate_unary_power(const uint32_t exponent) {
  * @param exponent Non-negative integer exponent value
  */
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_power_iterative(const uint32_t exponent) {
+inline void calculate_unary_power_iterative(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint32_t exponent) {
     // iterative approach for positive integer exponents
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];
         if (exponent == 0) {
-            sfpi::dst_reg[0] = 1.0f;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = 1.0f;
         } else {
             sfpi::vFloat result = in;
             uint32_t exp = exponent - 1;
@@ -350,7 +353,7 @@ inline void calculate_unary_power_iterative(const uint32_t exponent) {
                 in *= in;
                 exp >>= 1;
             }
-            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         }
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
@@ -87,12 +87,17 @@ sfpi_inline sfpi::vFloat _sfpu_neg_exp_f32_(sfpi::vFloat val) {
 
 // mul_a * mul_b + addend (MAD)
 template <bool is_fp32_dest_acc_en>
-sfpi_inline void _xielu_mad_(sfpi::vFloat mul_a, sfpi::vFloat mul_b, sfpi::vFloat addend) {
+sfpi_inline void _xielu_mad_(
+    std::uint32_t dst_index_in,
+    std::uint32_t dst_index_out,
+    sfpi::vFloat mul_a,
+    sfpi::vFloat mul_b,
+    sfpi::vFloat addend) {
     sfpi::vFloat result = mul_a * mul_b + addend;
     if constexpr (!is_fp32_dest_acc_en) {
         result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
     }
-    sfpi::dst_reg[0] = result;
+    sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
 }
 
 /*
@@ -113,18 +118,19 @@ sfpi_inline void _xielu_mad_(sfpi::vFloat mul_a, sfpi::vFloat mul_b, sfpi::vFloa
  *        --> alpha_n * (expm1(minimum(x, eps)) - x) + beta * x
  */
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_xielu(const uint32_t param0, const uint32_t param1) {
+inline void calculate_xielu(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, const uint32_t param0, const uint32_t param1) {
     sfpi::vFloat alpha_p = Converter::as_float(param0);
     sfpi::vFloat alpha_n = Converter::as_float(param1);
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
         sfpi::vFloat beta_mul_x = 0.5f * x;
         v_if(x > 0.0f) {  // positive
-            _xielu_mad_<is_fp32_dest_acc_en>(alpha_p * x, x, beta_mul_x);
+            _xielu_mad_<is_fp32_dest_acc_en>(dst_index_in, dst_index_out, alpha_p * x, x, beta_mul_x);
         }
         v_elseif(x >= sfpi::vConstFloatPrgm1) {  // very small negative
             sfpi::vFloat exp_term = sfpi::vConstFloatPrgm2 - x;
-            _xielu_mad_<is_fp32_dest_acc_en>(alpha_n, exp_term, beta_mul_x);
+            _xielu_mad_<is_fp32_dest_acc_en>(dst_index_in, dst_index_out, alpha_n, exp_term, beta_mul_x);
         }
         v_elseif(x > -0.5f) {  // moderate negative region
             // For small x >- 0.5: use Taylor series to avoid cancellation
@@ -142,11 +148,11 @@ inline void calculate_xielu(const uint32_t param0, const uint32_t param1) {
                                         8.333188481628894805908203125e-3f,
                                         1.400390756316483020782470703125e-3f,
                                         1.99588379473425447940826416015625e-4f);
-            _xielu_mad_<is_fp32_dest_acc_en>(alpha_n, exp_term, beta_mul_x);
+            _xielu_mad_<is_fp32_dest_acc_en>(dst_index_in, dst_index_out, alpha_n, exp_term, beta_mul_x);
         }
         v_else {  // large negative
             sfpi::vFloat exp_term = _sfpu_neg_exp_f32_(x) - sfpi::vConst1 - x;
-            _xielu_mad_<is_fp32_dest_acc_en>(alpha_n, exp_term, beta_mul_x);
+            _xielu_mad_<is_fp32_dest_acc_en>(dst_index_in, dst_index_out, alpha_n, exp_term, beta_mul_x);
         }
         v_endif;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
@@ -10,9 +10,7 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_abs_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::abs>();
-}
+inline void llk_math_eltwise_unary_sfpu_abs_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::abs>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs(uint dst_index, int vector_mode = (int)VectorMode::RC) {
@@ -20,8 +18,22 @@ inline void llk_math_eltwise_unary_sfpu_abs(uint dst_index, int vector_mode = (i
 }
 
 template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_abs(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_abs<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
+}
+
+template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_abs_int32<APPROXIMATE>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_abs_int32(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_abs_int32<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
@@ -22,8 +22,20 @@ inline void llk_math_eltwise_unary_sfpu_hardsigmoid_init() {
 template <bool APPROXIMATE, ckernel::ActivationType ACTIVATION, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardsigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
-        static_cast<void (*)()>(ckernel::sfpu::_calculate_activation_<APPROXIMATE, ACTIVATION, ITERATIONS>),
+        static_cast<void (*)(std::uint32_t, std::uint32_t)>(
+            ckernel::sfpu::_calculate_activation_<APPROXIMATE, ACTIVATION, ITERATIONS>),
         dst_index,
+        vector_mode);
+}
+
+template <bool APPROXIMATE, ckernel::ActivationType ACTIVATION, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_hardsigmoid(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        static_cast<void (*)(std::uint32_t, std::uint32_t)>(
+            ckernel::sfpu::_calculate_activation_<APPROXIMATE, ACTIVATION, ITERATIONS>),
+        dst_index_in,
+        dst_index_out,
         vector_mode);
 }
 
@@ -39,17 +51,23 @@ inline void llk_math_eltwise_unary_sfpu_softsign(uint dst_index, int vector_mode
         ckernel::sfpu::calculate_softsign<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
 
-// celu
-inline void llk_math_eltwise_unary_sfpu_celu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::celu>();
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_softsign(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_softsign<APPROXIMATE, ITERATIONS>, dst_index_in, dst_index_out, vector_mode);
 }
+
+// celu
+inline void llk_math_eltwise_unary_sfpu_celu_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::celu>(); }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_celu(
     uint dst_index, uint32_t alpha, uint32_t alpha_recip, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
-        [](uint32_t alpha, uint32_t alpha_recip) {
-            ckernel::sfpu::calculate_celu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>(alpha, alpha_recip);
+        [](std::uint32_t dst_index_in, std::uint32_t dst_index_out, std::uint32_t alpha, std::uint32_t alpha_recip) {
+            ckernel::sfpu::calculate_celu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>(
+                dst_index_in, dst_index_out, alpha, alpha_recip);
         },
         dst_index,
         vector_mode,
@@ -57,10 +75,27 @@ inline void llk_math_eltwise_unary_sfpu_celu(
         alpha_recip);
 }
 
-// softshrink
-inline void llk_math_eltwise_unary_sfpu_softshrink_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::softshrink>();
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_celu(
+    uint dst_index_in,
+    uint dst_index_out,
+    uint32_t alpha,
+    uint32_t alpha_recip,
+    int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        [](std::uint32_t dst_index_in, std::uint32_t dst_index_out, std::uint32_t alpha, std::uint32_t alpha_recip) {
+            ckernel::sfpu::calculate_celu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>(
+                dst_index_in, dst_index_out, alpha, alpha_recip);
+        },
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        alpha,
+        alpha_recip);
 }
+
+// softshrink
+inline void llk_math_eltwise_unary_sfpu_softshrink_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::softshrink>(); }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_softshrink(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
@@ -68,15 +103,27 @@ inline void llk_math_eltwise_unary_sfpu_softshrink(uint dst_index, uint param0, 
         ckernel::sfpu::calculate_softshrink<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
 }
 
-// hardshrink
-inline void llk_math_eltwise_unary_sfpu_hardshrink_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::hardshrink>();
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_softshrink(
+    uint dst_index_in, uint dst_index_out, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_softshrink<APPROXIMATE, ITERATIONS>, dst_index_in, dst_index_out, vector_mode, param0);
 }
+
+// hardshrink
+inline void llk_math_eltwise_unary_sfpu_hardshrink_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::hardshrink>(); }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardshrink(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_hardshrink<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_hardshrink(
+    uint dst_index_in, uint dst_index_out, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_hardshrink<APPROXIMATE, ITERATIONS>, dst_index_in, dst_index_out, vector_mode, param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
@@ -10,13 +10,18 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_add1_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::add1>();
-}
+inline void llk_math_eltwise_unary_sfpu_add1_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::add1>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_add1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_add1<APPROXIMATE>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_add1(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_add1<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
@@ -20,4 +20,11 @@ inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90(uint dst_index, int
         ckernel::sfpu::calculate_alt_complex_rotate90<APPROXIMATE>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_alt_complex_rotate90<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
@@ -17,6 +17,17 @@ inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(
         sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>, dst_index, vector_mode, scalar);
 }
 
+template <bool APPROXIMATE, int binop_mode>
+inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(
+    uint dst_index_in, uint dst_index_out, uint32_t scalar, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        scalar);
+}
+
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>();
 }
@@ -29,10 +40,24 @@ inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_add_int32(
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_add_int32(
+    uint dst_index_in, uint dst_index_out, uint32_t scalar, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::calculate_add_int32<APPROXIMATE, ITERATIONS>, dst_index_in, dst_index_out, vector_mode, scalar);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_sub_int32(
     uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_sub_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_sub_int32(
+    uint dst_index_in, uint dst_index_out, uint32_t scalar, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::calculate_sub_int32<APPROXIMATE, ITERATIONS>, dst_index_in, dst_index_out, vector_mode, scalar);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
@@ -20,4 +20,11 @@ inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a(uint dst_index, int v
         ckernel::sfpu::calculate_cast_fp32_to_fp16a<APPROXIMATE>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_cast_fp32_to_fp16a<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
@@ -21,4 +21,11 @@ inline void llk_math_eltwise_unary_sfpu_cbrt(uint dst_index, int vector_mode = (
         sfpu::calculate_cube_root<APPROXIMATE, fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE, bool fp32_dest_acc_en, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_cbrt(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::calculate_cube_root<APPROXIMATE, fp32_dest_acc_en, ITERATIONS>, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
@@ -10,9 +10,7 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_clamp_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::clamp>();
-}
+inline void llk_math_eltwise_unary_sfpu_clamp_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::clamp>(); }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp(
@@ -22,10 +20,34 @@ inline void llk_math_eltwise_unary_sfpu_clamp(
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_clamp(
+    uint dst_index_in, uint dst_index_out, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_clamp<APPROXIMATE, ITERATIONS>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        min_val,
+        max_val);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp_int32(
     uint dst_index, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_clamp_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, min_val, max_val);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_clamp_int32(
+    uint dst_index_in, uint dst_index_out, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_clamp_int32<APPROXIMATE, ITERATIONS>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        min_val,
+        max_val);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
@@ -19,9 +19,21 @@ inline void llk_math_eltwise_unary_sfpu_cumsum_init() {
 template <bool APPROXIMATE /*unused*/>
 inline void llk_math_eltwise_unary_sfpu_cumsum(
     uint dst_index, bool first, int vector_mode = (int)VectorMode::RC_custom /*unused*/) {
-    _llk_math_eltwise_unary_sfpu_params_(
+    _llk_math_eltwise_unary_sfpu_params_split_(
         ckernel::sfpu::calculate_cumsum<false>,  // There is only non APPROXIMATE implementation
         dst_index,
+        dst_index,
+        VectorMode::RC_custom,  // Can only work in RC_custom mode
+        first);
+}
+
+template <bool APPROXIMATE /*unused*/>
+inline void llk_math_eltwise_unary_sfpu_cumsum(
+    uint dst_index_in, uint dst_index_out, bool first, int vector_mode = (int)VectorMode::RC_custom /*unused*/) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_cumsum<false>,  // There is only non APPROXIMATE implementation
+        dst_index_in,
+        dst_index_out,
         VectorMode::RC_custom,  // Can only work in RC_custom mode
         first);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
@@ -21,4 +21,11 @@ inline void llk_math_eltwise_unary_sfpu_exp2(uint dst_index, int vector_mode = (
         ckernel::sfpu::calculate_exp2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_exp2(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_exp2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
@@ -21,4 +21,11 @@ inline void llk_math_eltwise_unary_sfpu_expm1(uint dst_index, int vector_mode = 
         ckernel::sfpu::calculate_expm1<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+inline void llk_math_eltwise_unary_sfpu_expm1(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_expm1<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
@@ -10,13 +10,18 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_hardmish_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::hardmish>();
-}
+inline void llk_math_eltwise_unary_sfpu_hardmish_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::hardmish>(); }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardmish(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(sfpu::hardmish<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_hardmish(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::hardmish<APPROXIMATE, ITERATIONS>, dst_index_in, dst_index_out, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
@@ -10,15 +10,25 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_hardtanh_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::hardtanh>();
-}
+inline void llk_math_eltwise_unary_sfpu_hardtanh_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::hardtanh>(); }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardtanh(
     uint dst_index, uint param0, uint param1, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_hardtanh<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0, param1);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_hardtanh(
+    uint dst_index_in, uint dst_index_out, uint param0, uint param1, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_hardtanh<APPROXIMATE, ITERATIONS>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        param0,
+        param1);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
@@ -10,14 +10,19 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_heaviside_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::heaviside>();
-}
+inline void llk_math_eltwise_unary_sfpu_heaviside_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::heaviside>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_heaviside(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_heaviside<APPROXIMATE>, dst_index, vector_mode, param0);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_heaviside(
+    uint dst_index_in, uint dst_index_out, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_heaviside<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode, param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
@@ -22,6 +22,17 @@ inline void llk_math_eltwise_unary_sfpu_log(uint dst_index, int vector_mode = (i
 }
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
+inline void llk_math_eltwise_unary_sfpu_log(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, false, is_fp32_dest_acc_en>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        0);
+}
+
+template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log_with_base_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::log_with_base>(
         sfpu::log_init<APPROXIMATE, FAST_APPROX, is_fp32_dest_acc_en>);
@@ -33,6 +44,17 @@ inline void llk_math_eltwise_unary_sfpu_log_with_base(
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, true, is_fp32_dest_acc_en>,
         dst_index,
+        vector_mode,
+        base_scale);
+}
+
+template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
+inline void llk_math_eltwise_unary_sfpu_log_with_base(
+    uint dst_index_in, uint dst_index_out, uint base_scale, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, true, is_fp32_dest_acc_en>,
+        dst_index_in,
+        dst_index_out,
         vector_mode,
         base_scale);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -39,6 +39,26 @@ inline __attribute__((always_inline)) void _sfpu_check_and_call_(
         std::forward<Callable>(sfpu_func), dst_index, vector_mode, std::forward<Args>(args)...);
 }
 
+// Split-dest overload: separate read/write tile indices for SFPU ops that
+// take a source tile and write to a different destination tile. Asserts
+// both indices against the per-mode destination capacity, then dispatches
+// to _llk_math_eltwise_unary_sfpu_params_split_.
+template <DstSync DST_SYNC, bool DST_ACCUM, typename Callable, typename... Args>
+inline __attribute__((always_inline)) void _sfpu_check_and_call_(
+    Callable&& sfpu_func, std::uint32_t dst_index_in, std::uint32_t dst_index_out, int vector_mode, Args&&... args) {
+    LLK_ASSERT(
+        (dst_index_in < get_dest_max_tiles<DST_SYNC, DST_ACCUM, DstTileShape::Tile32x32>()),
+        "dst_index_in exceeds max dest tiles");
+    LLK_ASSERT(
+        (dst_index_out < get_dest_max_tiles<DST_SYNC, DST_ACCUM, DstTileShape::Tile32x32>()),
+        "dst_index_out exceeds max dest tiles");
+    LLK_ASSERT(
+        (dst_index_out >= dst_index_in),
+        "dst_index_out must be >= dst_index_in (unsigned store offset would underflow)");
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        std::forward<Callable>(sfpu_func), dst_index_in, dst_index_out, vector_mode, std::forward<Args>(args)...);
+}
+
 }  // namespace ckernel
 
 /*
@@ -136,6 +156,36 @@ inline __attribute__((always_inline)) void _sfpu_check_and_call_(
         static_cast<_SFPU_EXPAND SIGNATURE>(::ckernel::sfpu::FN<_SFPU_EXPAND TEMPLATES>),        \
         DST_IDX,                                                                                 \
         VECTOR_MODE,                                                                             \
+        ##__VA_ARGS__)
+
+/*
+ * Split-dest variants of SFPU_CALL{,_MODE,_CAST}
+ *
+ * Same shape as their non-_SPLIT counterparts, but accept distinct
+ * (DST_IDX_IN, DST_IDX_OUT) and route through the split overload of
+ * ckernel::_sfpu_check_and_call_, which forwards into
+ * _llk_math_eltwise_unary_sfpu_params_split_. Use these when the
+ * underlying calculate function reads from one dest tile and writes to a
+ * different one.
+ */
+#define SFPU_CALL_SPLIT(DST_SYNC, DST_ACCUM, FN, TEMPLATES, DST_IDX_IN, DST_IDX_OUT, VECTOR_MODE, ...) \
+    ::ckernel::_sfpu_check_and_call_<DST_SYNC, DST_ACCUM>(                                             \
+        ::ckernel::sfpu::FN<_SFPU_EXPAND TEMPLATES>, DST_IDX_IN, DST_IDX_OUT, VECTOR_MODE, ##__VA_ARGS__)
+
+#define SFPU_CALL_MODE_SPLIT(DST_SYNC, DST_ACCUM, FN, TEMPLATES, MODE, DST_IDX_IN, DST_IDX_OUT, ...) \
+    ::ckernel::_sfpu_check_and_call_<DST_SYNC, DST_ACCUM>(                                           \
+        ::ckernel::sfpu::FN<_SFPU_EXPAND TEMPLATES>,                                                 \
+        DST_IDX_IN,                                                                                  \
+        DST_IDX_OUT,                                                                                 \
+        (int)::ckernel::VectorMode::MODE,                                                            \
+        ##__VA_ARGS__)
+
+#define SFPU_CALL_CAST_SPLIT(DST_SYNC, DST_ACCUM, FN, TEMPLATES, SIGNATURE, DST_IDX_IN, DST_IDX_OUT, VECTOR_MODE, ...) \
+    ::ckernel::_sfpu_check_and_call_<DST_SYNC, DST_ACCUM>(                                                             \
+        static_cast<_SFPU_EXPAND SIGNATURE>(::ckernel::sfpu::FN<_SFPU_EXPAND TEMPLATES>),                              \
+        DST_IDX_IN,                                                                                                    \
+        DST_IDX_OUT,                                                                                                   \
+        VECTOR_MODE,                                                                                                   \
         ##__VA_ARGS__)
 
 /*

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
@@ -10,13 +10,18 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_mask_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::mask>();
-}
+inline void llk_math_eltwise_unary_sfpu_mask_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::mask>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_mask_posinf(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_mask_posinf<APPROXIMATE>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_mask_posinf(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_mask_posinf<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -26,6 +31,18 @@ inline void llk_math_eltwise_unary_sfpu_mask(
         _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_mask<APPROXIMATE>, dst_index, vector_mode);
     } else if (data_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_int_mask<APPROXIMATE>, dst_index, vector_mode);
+    }
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_mask(
+    uint dst_index_in, uint dst_index_out, DataFormat data_format, int vector_mode = (int)VectorMode::RC) {
+    if (data_format == DataFormat::Float16_b || data_format == DataFormat::Float16) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_mask<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
+    } else if (data_format == DataFormat::Int32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_int_mask<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
@@ -21,6 +21,13 @@ inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, i
         ckernel::sfpu::calculate_unary_max_min<true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_max(
+    uint dst_index_in, uint dst_index_out, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_max_min<true, APPROXIMATE>, dst_index_in, dst_index_out, vector_mode, param0);
+}
+
 inline void llk_math_eltwise_unary_sfpu_unary_max_int32_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max_int32>(sfpu::unary_max_min_int32_init<true, false>);
 }
@@ -30,6 +37,17 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_int32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<true, false, APPROXIMATE>, dst_index, vector_mode, param0);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_max_int32(
+    uint dst_index_in, uint dst_index_out, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_max_min_int32<true, false, APPROXIMATE>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        param0);
 }
 
 inline void llk_math_eltwise_unary_sfpu_unary_max_uint32_init() {
@@ -43,6 +61,17 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_uint32(
         ckernel::sfpu::calculate_unary_max_min_int32<true, true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_max_uint32(
+    uint dst_index_in, uint dst_index_out, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_max_min_int32<true, true, APPROXIMATE>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        param0);
+}
+
 // Unary minimum
 inline void llk_math_eltwise_unary_sfpu_unary_min_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min>(sfpu::unary_max_min_init<false>);
@@ -52,6 +81,13 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min<false, APPROXIMATE>, dst_index, vector_mode, param0);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_min(
+    uint dst_index_in, uint dst_index_out, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_max_min<false, APPROXIMATE>, dst_index_in, dst_index_out, vector_mode, param0);
 }
 
 inline void llk_math_eltwise_unary_sfpu_unary_min_int32_init() {
@@ -65,6 +101,17 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_int32(
         ckernel::sfpu::calculate_unary_max_min_int32<false, false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_min_int32(
+    uint dst_index_in, uint dst_index_out, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_max_min_int32<false, false, APPROXIMATE>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        param0);
+}
+
 inline void llk_math_eltwise_unary_sfpu_unary_min_uint32_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min_uint32>(sfpu::unary_max_min_int32_init<false, true>);
 }
@@ -74,6 +121,17 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_uint32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_max_min_int32<false, true, APPROXIMATE>, dst_index, vector_mode, param0);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_min_uint32(
+    uint dst_index_in, uint dst_index_out, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_max_min_int32<false, true, APPROXIMATE>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
@@ -21,14 +21,34 @@ inline void llk_math_eltwise_unary_sfpu_power(
         ckernel::sfpu::calculate_unary_power<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode, exponent);
 }
 
-inline void llk_math_eltwise_unary_sfpu_power_iterative_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::power>();
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+inline void llk_math_eltwise_unary_sfpu_power(
+    uint dst_index_in, uint dst_index_out, uint32_t exponent, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_power<APPROXIMATE, is_fp32_dest_acc_en, 8>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        exponent);
 }
+
+inline void llk_math_eltwise_unary_sfpu_power_iterative_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::power>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_power_iterative(
     uint dst_index, uint32_t exponent = 0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_unary_power_iterative<APPROXIMATE, 8>, dst_index, vector_mode, exponent);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_power_iterative(
+    uint dst_index_in, uint dst_index_out, uint32_t exponent, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_power_iterative<APPROXIMATE, 8>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        exponent);
 }
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
@@ -25,4 +25,15 @@ inline void llk_math_eltwise_unary_sfpu_rdiv(
         value);
 }
 
+template <bool APPROXIMATE, bool fp32_dest_acc_en, RoundingMode rounding_mode, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_rdiv(
+    uint32_t dst_index_in, uint32_t dst_index_out, uint32_t value, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_rdiv<APPROXIMATE, fp32_dest_acc_en, rounding_mode, ITERATIONS>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        value);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
@@ -16,10 +16,21 @@ inline void llk_math_eltwise_unary_sfpu_reduce_init() {
 }
 
 template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
-inline void llk_math_eltwise_unary_sfpu_reduce(
-    uint32_t dst_index, uint32_t ct_dim, uint32_t rt_dim, VectorMode vector_mode) {
+inline void llk_math_eltwise_unary_sfpu_reduce(uint32_t dst_index, uint32_t ct_dim, uint32_t rt_dim, int vector_mode) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_reduce<pool_type, reduce_dim, format>, dst_index, vector_mode, ct_dim, rt_dim);
+}
+
+template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
+inline void llk_math_eltwise_unary_sfpu_reduce(
+    uint32_t dst_index_in, uint32_t dst_index_out, uint32_t ct_dim, uint32_t rt_dim, int vector_mode) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::calculate_reduce<pool_type, reduce_dim, format>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        ct_dim,
+        rt_dim);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
@@ -49,4 +49,11 @@ inline void llk_math_eltwise_unary_sfpu_reshuffle_rows(
     _llk_math_eltwise_unary_sfpu_params_(sfpu::calculate_reshuffle_rows<APPROXIMATE>, dst_index, vector_mode, idx_addr);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_reshuffle_rows(
+    uint dst_index_in, uint dst_index_out, uint32_t idx_addr, int vector_mode = (int)VectorMode::RC_custom) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::calculate_reshuffle_rows<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode, idx_addr);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
@@ -21,4 +21,11 @@ inline void llk_math_eltwise_unary_sfpu_rpow(uint dst_index, uint32_t base_val, 
         sfpu::calculate_rpow<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode, base_val);
 }
 
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
+inline void llk_math_eltwise_unary_sfpu_rpow(
+    uint dst_index_in, uint dst_index_out, uint32_t base_val, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::calculate_rpow<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index_in, dst_index_out, vector_mode, base_val);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
@@ -23,4 +23,14 @@ inline void llk_math_eltwise_unary_sfpu_rsqrt(uint dst_index, int vector_mode = 
         vector_mode);
 }
 
+template <bool APPROXIMATE, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>
+inline void llk_math_eltwise_unary_sfpu_rsqrt(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_rsqrt<APPROXIMATE, 8, fp32_dest_acc_en, FAST_APPROX, legacy_compat>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
@@ -10,14 +10,19 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_rsub_int32_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unused>();
-}
+inline void llk_math_eltwise_unary_sfpu_rsub_int32_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(); }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_rsub_int32(uint dst_index, uint scalar, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         sfpu::calculate_rsub_scalar_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_rsub_int32(
+    uint dst_index_in, uint dst_index_out, uint scalar, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::calculate_rsub_scalar_int32<APPROXIMATE, ITERATIONS>, dst_index_in, dst_index_out, vector_mode, scalar);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
@@ -22,4 +22,16 @@ inline void llk_math_eltwise_unary_sfpu_selu(
         alpha);
 }
 
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_selu(
+    uint dst_index_in, uint dst_index_out, uint scale, uint alpha, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_selu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        scale,
+        alpha);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
@@ -21,4 +21,11 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid(uint dst_index, int vector_mode 
         sfpu::calculate_sigmoid<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+inline void llk_math_eltwise_unary_sfpu_sigmoid(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        sfpu::calculate_sigmoid<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
@@ -19,4 +19,11 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_appx(uint dst_index, int vector_
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_sigmoid_appx, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_sigmoid_appx(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_sigmoid_appx, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
@@ -10,15 +10,20 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_sign_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::sign>();
-}
+inline void llk_math_eltwise_unary_sfpu_sign_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::sign>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sign(
     uint dst_index, int vector_mode = (int)VectorMode::RC, uint exponent_size_8 = 1) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_sign<APPROXIMATE>, dst_index, vector_mode, exponent_size_8);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_sign(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC, uint exponent_size_8 = 1) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_sign<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode, exponent_size_8);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
@@ -20,6 +20,13 @@ inline void llk_math_eltwise_unary_sfpu_signbit(uint dst_index, int vector_mode 
         ckernel::sfpu::calculate_signbit<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_signbit(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_signbit<APPROXIMATE, ITERATIONS>, dst_index_in, dst_index_out, vector_mode);
+}
+
 inline void llk_math_eltwise_unary_sfpu_signbit_int32_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::signbit>(ckernel::sfpu::signbit_int32_init);
 }
@@ -28,6 +35,13 @@ template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_signbit_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_signbit_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_signbit_int32(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_signbit_int32<APPROXIMATE, ITERATIONS>, dst_index_in, dst_index_out, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -20,4 +20,11 @@ inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+inline void llk_math_eltwise_unary_sfpu_silu(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, 8>, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
@@ -10,13 +10,18 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_square_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::square>();
-}
+inline void llk_math_eltwise_unary_sfpu_square_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::square>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_square(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_square<APPROXIMATE>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_square(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_square<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
@@ -21,4 +21,11 @@ inline void llk_math_eltwise_unary_sfpu_tanh(uint dst_index, int vector_mode = (
         ckernel::sfpu::calculate_tanh<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+inline void llk_math_eltwise_unary_sfpu_tanh(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_tanh<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
@@ -20,4 +20,11 @@ inline void llk_math_eltwise_unary_sfpu_tanh_derivative(uint dst_index, int vect
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_tanh_derivative<APPROXIMATE>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_tanh_derivative(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_tanh_derivative<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
@@ -10,16 +10,28 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_threshold_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::threshold>();
-}
+inline void llk_math_eltwise_unary_sfpu_threshold_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::threshold>(); }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_threshold(
     uint dst_index, uint32_t param0, uint32_t param1, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(
-        static_cast<void (*)(uint32_t, uint32_t)>(ckernel::sfpu::_calculate_threshold_<APPROXIMATE, ITERATIONS>),
+        static_cast<void (*)(uint32_t, uint32_t, uint32_t, uint32_t)>(
+            ckernel::sfpu::_calculate_threshold_<APPROXIMATE, ITERATIONS, uint32_t>),
         dst_index,
+        vector_mode,
+        param0,
+        param1);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_threshold(
+    uint dst_index_in, uint dst_index_out, uint32_t param0, uint32_t param1, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        static_cast<void (*)(uint32_t, uint32_t, uint32_t, uint32_t)>(
+            ckernel::sfpu::_calculate_threshold_<APPROXIMATE, ITERATIONS, uint32_t>),
+        dst_index_in,
+        dst_index_out,
         vector_mode,
         param0,
         param1);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
@@ -10,13 +10,18 @@
 
 namespace ckernel {
 
-inline void llk_math_eltwise_unary_sfpu_tiled_prod_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::tiled_prod>();
-}
+inline void llk_math_eltwise_unary_sfpu_tiled_prod_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::tiled_prod>(); }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tiled_prod(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_tiled_prod<APPROXIMATE>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_tiled_prod(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_tiled_prod<APPROXIMATE>, dst_index_in, dst_index_out, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
@@ -35,12 +35,46 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
         i_start_step);
 }
 
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
+inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
+    uint dst_index_in,
+    uint dst_index_out,
+    int idir,
+    int i_end_phase,
+    int i_start_phase,
+    int i_end_step,
+    int i_start_step,
+    int vector_mode = (int)VectorMode::RC_custom) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
+        dst_index_in,
+        dst_index_out,
+        vector_mode,
+        idir,
+        i_end_phase,
+        i_start_phase,
+        i_end_step,
+        i_start_step);
+}
+
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool idir = false, bool STABLE_SORT = false>
 inline void llk_math_eltwise_unary_sfpu_topk_merge(
     uint dst_index, int m_iter, int k, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_bitonic_topk_merge<APPROXIMATE, is_fp32_dest_acc_en, idir, STABLE_SORT>,
         dst_index,
+        vector_mode,
+        m_iter,
+        k);
+}
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool idir = false, bool STABLE_SORT = false>
+inline void llk_math_eltwise_unary_sfpu_topk_merge(
+    uint dst_index_in, uint dst_index_out, int m_iter, int k, int vector_mode = (int)VectorMode::RC_custom) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_bitonic_topk_merge<APPROXIMATE, is_fp32_dest_acc_en, idir, STABLE_SORT>,
+        dst_index_in,
+        dst_index_out,
         vector_mode,
         m_iter,
         k);
@@ -58,6 +92,28 @@ inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
         dst_index,
+        vector_mode,
+        idir,
+        m_iter,
+        k,
+        logk,
+        skip_second);
+}
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
+inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
+    uint dst_index_in,
+    uint dst_index_out,
+    bool idir,
+    int m_iter,
+    int k,
+    int logk,
+    int skip_second,
+    int vector_mode = (int)VectorMode::RC_custom) {
+    _llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
+        dst_index_in,
+        dst_index_out,
         vector_mode,
         idir,
         m_iter,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
@@ -156,6 +156,189 @@ inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode
 }
 
 template <bool APPROXIMATE, uint32_t IN_DTYPE, uint32_t OUT_DTYPE>
+inline void llk_math_eltwise_unary_sfpu_typecast(
+    uint dst_index_in, uint dst_index_out, int vector_mode = (int)VectorMode::RC) {
+    constexpr DataFormat in_format = static_cast<DataFormat>(IN_DTYPE);
+    constexpr DataFormat out_format = static_cast<DataFormat>(OUT_DTYPE);
+
+    if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::UInt16) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float16_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Float16_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Int32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Float32) {
+        // no SFPU kernel needed, handled by packer
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Float16_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_fp16b<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::UInt16) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint16_to_fp32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Int32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Float32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_int32_to_fp32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::UInt16) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Bfp8_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Int32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Bfp8_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::UInt32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Float16_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::UInt32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Float32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint32_to_fp32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::UInt32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Bfp8_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::UInt32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Int32) {
+        // Calls same kernel as UInt32 case
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::UInt16) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint32_to_uint16<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::UInt16) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_int32_to_uint16<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Float16_b) {
+        // no SFPU kernel needed, handled by unpacker
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Bfp8_b) {
+        // no SFPU kernel needed, handled by packer
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Float32) {
+        // no SFPU kernel needed, handled by unpacker/packer
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Bfp8_b) {
+        // no SFPU kernel needed, handled by packer
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::UInt16) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Bfp4_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Int32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Bfp4_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::UInt32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Bfp4_b) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Float16_b) {
+        // no SFPU kernel needed, handled by unpacker
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Bfp4_b) {
+        // no SFPU kernel needed, handled by packer
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Bfp8_b) {
+        // no SFPU kernel needed, handled by unpacker
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Bfp4_b) {
+        // no SFPU kernel needed, handled by packer
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Float32) {
+        // no SFPU kernel needed, handled by unpacker/packer
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Bfp4_b) {
+        // no SFPU kernel needed, handled by packer
+    } else if constexpr (
+        (in_format == DataFormat::Float32 || in_format == DataFormat::Float16_b || in_format == DataFormat::Bfp8_b ||
+         in_format == DataFormat::Bfp4_b) &&
+        out_format == DataFormat::UInt8) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_fp32_to_uint8<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (
+        (in_format == DataFormat::Int32 || in_format == DataFormat::UInt32 || in_format == DataFormat::UInt16) &&
+        out_format == DataFormat::UInt8) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint_to_uint8<APPROXIMATE, 8, (in_format == DataFormat::UInt16)>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (in_format == DataFormat::UInt8 && out_format == DataFormat::Float32) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint32_to_fp32<APPROXIMATE, 8>, dst_index_in, dst_index_out, vector_mode);
+    } else if constexpr (
+        in_format == DataFormat::UInt8 &&
+        (out_format == DataFormat::Float16_b || out_format == DataFormat::Bfp8_b || out_format == DataFormat::Bfp4_b)) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    } else if constexpr (
+        in_format == DataFormat::UInt8 && (out_format == DataFormat::Int32 || out_format == DataFormat::UInt32)) {
+        // No SFPU kernel needed.
+    } else if constexpr (in_format == DataFormat::UInt8 && out_format == DataFormat::UInt16) {
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            ckernel::sfpu::calculate_typecast_uint32_to_uint16<APPROXIMATE, 8>,
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    }
+}
+
+template <bool APPROXIMATE, uint32_t IN_DTYPE, uint32_t OUT_DTYPE>
 inline void llk_math_eltwise_unary_sfpu_typecast_init() {
     constexpr DataFormat in_format = static_cast<DataFormat>(IN_DTYPE);
     constexpr DataFormat out_format = static_cast<DataFormat>(OUT_DTYPE);

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -93,6 +93,11 @@ ALWI void sigmoid_tile(uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_sigmoid<fast_and_approx, DST_ACCUM_MODE>(idst, vec_mode)));
 }
 
+template <int vec_mode = VectorMode::RC, bool fast_and_approx = false>
+ALWI void sigmoid_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_sigmoid<fast_and_approx, DST_ACCUM_MODE>(idst_in, idst_out, vec_mode)));
+}
+
 // clang-format off
 /**
  * Performs SILU (same as Swish) operation on each element of a tile
@@ -109,6 +114,10 @@ ALWI void sigmoid_tile(uint32_t idst) {
  */
 // clang-format on
 ALWI void silu_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_silu<APPROX, DST_ACCUM_MODE>(idst))); }
+
+ALWI void silu_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_silu<APPROX, DST_ACCUM_MODE>(idst_in, idst_out)));
+}
 
 ALWI void silu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_silu_init<APPROX>())); }
 
@@ -154,6 +163,11 @@ ALWI void log_tile(uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_log<APPROX, fast_and_approx, DST_ACCUM_MODE>(idst)));
 }
 
+template <bool fast_and_approx = false>
+ALWI void log_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_log<APPROX, fast_and_approx, DST_ACCUM_MODE>(idst_in, idst_out)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -181,6 +195,12 @@ ALWI void log_with_base_tile_init() {
 template <bool fast_and_approx = false>
 ALWI void log_with_base_tile(uint32_t idst, uint32_t base_scale) {
     MATH((llk_math_eltwise_unary_sfpu_log_with_base<APPROX, fast_and_approx, DST_ACCUM_MODE>(idst, base_scale)));
+}
+
+template <bool fast_and_approx = false>
+ALWI void log_with_base_tile(uint32_t idst_in, uint32_t idst_out, uint32_t base_scale) {
+    MATH((llk_math_eltwise_unary_sfpu_log_with_base<APPROX, fast_and_approx, DST_ACCUM_MODE>(
+        idst_in, idst_out, base_scale)));
 }
 
 // TODO: Move to trigonometry.h
@@ -224,6 +244,11 @@ ALWI void tanh_tile(uint32_t idst) {
 }
 
 template <bool fast_and_approx = false>
+ALWI void tanh_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_tanh<fast_and_approx, DST_ACCUM_MODE>(idst_in, idst_out)));
+}
+
+template <bool fast_and_approx = false>
 ALWI void tanh_tile_pack(uint32_t idst) {
     PACK((llk_math_eltwise_unary_sfpu_tanh<fast_and_approx, DST_ACCUM_MODE>(idst)));
 }
@@ -249,6 +274,10 @@ ALWI void signbit_tile_init() { MATH((llk_math_eltwise_unary_sfpu_signbit_init()
 // clang-format on
 ALWI void signbit_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_signbit<APPROX>(idst))); }
 
+ALWI void signbit_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_signbit<APPROX>(idst_in, idst_out)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -270,6 +299,10 @@ ALWI void signbit_tile_int32_init() { MATH((llk_math_eltwise_unary_sfpu_signbit_
 // clang-format on
 ALWI void signbit_tile_int32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_signbit_int32<APPROX>(idst))); }
 
+ALWI void signbit_tile_int32(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_signbit_int32<APPROX>(idst_in, idst_out)));
+}
+
 // clang-format off
 /**
  * Performs element-wise computation of absolute value on each element of a tile
@@ -285,6 +318,10 @@ ALWI void signbit_tile_int32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_
  */
 // clang-format on
 ALWI void abs_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_abs<APPROX>(idst))); }
+
+ALWI void abs_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_abs<APPROX>(idst_in, idst_out)));
+}
 
 /**
  * Please refer to documentation for any_init.
@@ -309,6 +346,10 @@ ALWI void abs_tile_init() { MATH((llk_math_eltwise_unary_sfpu_abs_init())); }
 // clang-format on
 ALWI void abs_tile_int32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_abs_int32<APPROX>(idst))); }
 
+ALWI void abs_tile_int32(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_abs_int32<APPROX>(idst_in, idst_out)));
+}
+
 // clang-format off
 /**
  * Will store in the output of the compute core the signum of the tile.
@@ -324,6 +365,10 @@ ALWI void abs_tile_int32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_abs_
  */
 // clang-format on
 ALWI void sign_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_sign<APPROX>(idst))); }
+
+ALWI void sign_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_sign<APPROX>(idst_in, idst_out)));
+}
 
 /**
  * Please refer to documentation for any_init.
@@ -346,6 +391,10 @@ ALWI void sign_tile_init() { MATH((llk_math_eltwise_unary_sfpu_sign_init())); }
 // clang-format on
 ALWI void square_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_square<APPROX>(idst))); }
 
+ALWI void square_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_square<APPROX>(idst_in, idst_out)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -366,6 +415,10 @@ ALWI void square_tile_init() { MATH((llk_math_eltwise_unary_sfpu_square_init()))
  */
 // clang-format on
 ALWI void tiled_prod_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_tiled_prod<APPROX>(idst))); }
+
+ALWI void tiled_prod_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_tiled_prod<APPROX>(idst_in, idst_out)));
+}
 
 /**
  * Please refer to documentation for any_init.
@@ -390,6 +443,10 @@ ALWI void tiled_prod_tile_init() { MATH((llk_math_eltwise_unary_sfpu_tiled_prod_
 // clang-format on
 ALWI void power_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_power<APPROX, DST_ACCUM_MODE>(idst, param0)));
+}
+
+ALWI void power_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_power<APPROX, DST_ACCUM_MODE>(idst_in, idst_out, param0)));
 }
 
 /**
@@ -419,6 +476,10 @@ ALWI void power_iterative_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_power_iterative<APPROX>(idst, param0)));
 }
 
+ALWI void power_iterative_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_power_iterative<APPROX>(idst_in, idst_out, param0)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -440,6 +501,10 @@ ALWI void power_iterative_tile_init() { MATH((llk_math_eltwise_unary_sfpu_power_
  */
 // clang-format on
 ALWI void exp2_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_exp2<true, DST_ACCUM_MODE>(idst))); }
+
+ALWI void exp2_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_exp2<true, DST_ACCUM_MODE>(idst_in, idst_out)));
+}
 
 /**
  * Please refer to documentation for any_init.
@@ -466,6 +531,10 @@ ALWI void heaviside_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_heaviside<APPROX>(idst, param0)));
 }
 
+ALWI void heaviside_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_heaviside<APPROX>(idst_in, idst_out, param0)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -489,6 +558,11 @@ ALWI void heaviside_tile_init() { MATH((llk_math_eltwise_unary_sfpu_heaviside_in
 template <bool approx = false>
 ALWI void expm1_tile(uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_expm1<approx, DST_ACCUM_MODE>(idst)));
+}
+
+template <bool approx = false>
+ALWI void expm1_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_expm1<approx, DST_ACCUM_MODE>(idst_in, idst_out)));
 }
 
 /**
@@ -826,6 +900,10 @@ ALWI void unary_max_int32_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_unary_max_int32<APPROX>(idst, param0)));
 }
 
+ALWI void unary_max_int32_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_unary_max_int32<APPROX>(idst_in, idst_out, param0)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -849,6 +927,10 @@ ALWI void unary_max_int32_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_
 // clang-format on
 ALWI void unary_max_uint32_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_unary_max_uint32<APPROX>(idst, param0)));
+}
+
+ALWI void unary_max_uint32_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_unary_max_uint32<APPROX>(idst_in, idst_out, param0)));
 }
 
 /**
@@ -876,6 +958,10 @@ ALWI void unary_max_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_unary_max<APPROX>(idst, param0)));
 }
 
+ALWI void unary_max_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_unary_max<APPROX>(idst_in, idst_out, param0)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -898,6 +984,10 @@ ALWI void unary_max_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_max_in
 // clang-format on
 ALWI void alt_complex_rotate90_tile(uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_alt_complex_rotate90<APPROX>(idst)));
+}
+
+ALWI void alt_complex_rotate90_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_alt_complex_rotate90<APPROX>(idst_in, idst_out)));
 }
 
 /**
@@ -925,6 +1015,10 @@ ALWI void unary_min_int32_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_unary_min_int32<APPROX>(idst, param0)));
 }
 
+ALWI void unary_min_int32_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_unary_min_int32<APPROX>(idst_in, idst_out, param0)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -950,6 +1044,10 @@ ALWI void unary_min_uint32_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_unary_min_uint32<APPROX>(idst, param0)));
 }
 
+ALWI void unary_min_uint32_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_unary_min_uint32<APPROX>(idst_in, idst_out, param0)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -973,6 +1071,10 @@ ALWI void unary_min_uint32_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary
 // clang-format on
 ALWI void unary_min_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_unary_min<APPROX>(idst, param0)));
+}
+
+ALWI void unary_min_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_unary_min<APPROX>(idst_in, idst_out, param0)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/activations.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/activations.h
@@ -32,6 +32,10 @@ ALWI void hardsigmoid_tile_pack(uint32_t idst) {
     PACK((llk_math_eltwise_unary_sfpu_hardsigmoid<APPROX, ckernel::ActivationType::Hardsigmoid>(idst)));
 }
 
+ALWI void hardsigmoid_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_hardsigmoid<APPROX, ckernel::ActivationType::Hardsigmoid>(idst_in, idst_out)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -53,6 +57,10 @@ ALWI void hardsigmoid_tile_init_pack() { PACK((llk_math_eltwise_unary_sfpu_hards
 */
 // clang-format on
 ALWI void softsign_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_softsign<APPROX>(idst))); }
+
+ALWI void softsign_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_softsign<APPROX>(idst_in, idst_out)));
+}
 
 /**
  * Please refer to documentation for any_init.
@@ -78,6 +86,10 @@ ALWI void celu_tile(uint32_t idst, uint32_t alpha, uint32_t alpha_recip) {
     MATH((llk_math_eltwise_unary_sfpu_celu<APPROX, DST_ACCUM_MODE>(idst, alpha, alpha_recip)));
 }
 
+ALWI void celu_tile(uint32_t idst_in, uint32_t idst_out, uint32_t alpha, uint32_t alpha_recip) {
+    MATH((llk_math_eltwise_unary_sfpu_celu<APPROX, DST_ACCUM_MODE>(idst_in, idst_out, alpha, alpha_recip)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -99,6 +111,10 @@ ALWI void celu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_celu_init())); }
  // clang-format on
  ALWI void softshrink_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_softshrink<APPROX>(idst, param0)));
+}
+
+ALWI void softshrink_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_softshrink<APPROX>(idst_in, idst_out, param0)));
 }
 
 /**
@@ -125,6 +141,10 @@ ALWI void softshrink_tile_init() { MATH((llk_math_eltwise_unary_sfpu_softshrink_
 // clang-format on
 ALWI void hardshrink_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_hardshrink<APPROX>(idst, param0)));
+}
+
+ALWI void hardshrink_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_hardshrink<APPROX>(idst_in, idst_out, param0)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/binop_with_scalar.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/binop_with_scalar.h
@@ -29,20 +29,40 @@ ALWI void add_unary_tile(uint32_t idst, uint32_t param1) {
     MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, ADD_UNARY>(idst, param1)));
 }
 
+ALWI void add_unary_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, ADD_UNARY>(idst_in, idst_out, param1)));
+}
+
 ALWI void sub_unary_tile(uint32_t idst, uint32_t param1) {
     MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, SUB_UNARY>(idst, param1)));
+}
+
+ALWI void sub_unary_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, SUB_UNARY>(idst_in, idst_out, param1)));
 }
 
 ALWI void mul_unary_tile(uint32_t idst, uint32_t param1) {
     MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, MUL_UNARY>(idst, param1)));
 }
 
+ALWI void mul_unary_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, MUL_UNARY>(idst_in, idst_out, param1)));
+}
+
 ALWI void div_unary_tile(uint32_t idst, uint32_t param1) {
     MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, DIV_UNARY>(idst, param1)));
 }
 
+ALWI void div_unary_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, DIV_UNARY>(idst_in, idst_out, param1)));
+}
+
 ALWI void rsub_unary_tile(uint32_t idst, uint32_t param1) {
     MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, RSUB_UNARY>(idst, param1)));
+}
+
+ALWI void rsub_unary_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, RSUB_UNARY>(idst_in, idst_out, param1)));
 }
 
 // clang-format off
@@ -64,6 +84,10 @@ ALWI void add_unary_tile_int32(uint32_t idst, uint32_t param1) {
     MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar_add_int32<APPROX, 8>(idst, param1)));
 }
 
+ALWI void add_unary_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar_add_int32<APPROX, 8>(idst_in, idst_out, param1)));
+}
+
 // clang-format off
 /**
 * Performs element-wise sub operation with int32 scalar. The DST
@@ -81,6 +105,10 @@ ALWI void add_unary_tile_int32(uint32_t idst, uint32_t param1) {
 
 ALWI void sub_unary_tile_int32(uint32_t idst, uint32_t param1) {
     MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar_sub_int32<APPROX, 8>(idst, param1)));
+}
+
+ALWI void sub_unary_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar_sub_int32<APPROX, 8>(idst_in, idst_out, param1)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/bitwise_and.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/bitwise_and.h
@@ -31,6 +31,11 @@ ALWI void bitwise_and_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_FN(calculate_bitwise_and, RC, APPROX, idst, param0));
 }
 
+ALWI void bitwise_and_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_bitwise_and<APPROX>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/bitwise_and.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/bitwise_and.h
@@ -32,8 +32,8 @@ ALWI void bitwise_and_tile(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void bitwise_and_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_bitwise_and<APPROX>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_bitwise_and, (APPROX), RC, idst_in, idst_out, param0)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/bitwise_not.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/bitwise_not.h
@@ -30,6 +30,11 @@ ALWI void bitwise_not_tile(uint32_t idst) {
     MATH(SFPU_UNARY_NO_PARAM_KERNEL_FN(calculate_bitwise_not, RC, APPROX, idst));
 }
 
+ALWI void bitwise_not_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_bitwise_not<APPROX>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/bitwise_not.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/bitwise_not.h
@@ -31,8 +31,7 @@ ALWI void bitwise_not_tile(uint32_t idst) {
 }
 
 ALWI void bitwise_not_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_bitwise_not<APPROX>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_bitwise_not, (APPROX), RC, idst_in, idst_out)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/bitwise_or.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/bitwise_or.h
@@ -31,6 +31,11 @@ ALWI void bitwise_or_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_FN(calculate_bitwise_or, RC, APPROX, idst, param0));
 }
 
+ALWI void bitwise_or_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_bitwise_or<APPROX>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/bitwise_or.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/bitwise_or.h
@@ -32,8 +32,8 @@ ALWI void bitwise_or_tile(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void bitwise_or_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_bitwise_or<APPROX>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_bitwise_or, (APPROX), RC, idst_in, idst_out, param0)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/bitwise_xor.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/bitwise_xor.h
@@ -31,6 +31,11 @@ ALWI void bitwise_xor_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_FN(calculate_bitwise_xor, RC, APPROX, idst, param0));
 }
 
+ALWI void bitwise_xor_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_bitwise_xor<APPROX>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/bitwise_xor.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/bitwise_xor.h
@@ -32,8 +32,8 @@ ALWI void bitwise_xor_tile(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void bitwise_xor_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_bitwise_xor<APPROX>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_bitwise_xor, (APPROX), RC, idst_in, idst_out, param0)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/cbrt.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/cbrt.h
@@ -25,6 +25,10 @@ namespace ckernel {
 // clang-format on
 ALWI void cbrt_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_cbrt<APPROX, DST_ACCUM_MODE>(idst))); }
 
+ALWI void cbrt_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_cbrt<APPROX, DST_ACCUM_MODE>(idst_in, idst_out)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/clamp.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/clamp.h
@@ -30,6 +30,10 @@ ALWI void clamp_tile(uint32_t idst, uint32_t param0, uint32_t param1) {
     MATH((llk_math_eltwise_unary_sfpu_clamp<APPROX>(idst, param0, param1)));
 }
 
+ALWI void clamp_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_clamp<APPROX>(idst_in, idst_out, param0, param1)));
+}
+
 // clang-format off
 /**
  * Performs element-wise clamp operation for int32. The DST
@@ -47,6 +51,10 @@ ALWI void clamp_tile(uint32_t idst, uint32_t param0, uint32_t param1) {
 // clang-format on
 ALWI void clamp_tile_int32(uint32_t idst, uint32_t param0, uint32_t param1) {
     MATH((llk_math_eltwise_unary_sfpu_clamp_int32<APPROX>(idst, param0, param1)));
+}
+
+ALWI void clamp_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param0, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_clamp_int32<APPROX>(idst_in, idst_out, param0, param1)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/comp.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/comp.h
@@ -386,11 +386,7 @@ ALWI void gtz_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(greater_than_zero, RC,
 
 ALWI void gtz_tile(uint32_t idst_in, uint32_t idst_out) {
     MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp<APPROX, SfpuType::greater_than_zero>,
-        idst_in,
-        idst_out,
-        (int)VectorMode::RC,
-        8)));
+        ckernel::sfpu::calculate_comp<APPROX, SfpuType::greater_than_zero>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 // clang-format off
@@ -442,7 +438,7 @@ ALWI void nez_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(not_equal_zero, RC, AP
 
 ALWI void nez_tile(uint32_t idst_in, uint32_t idst_out) {
     MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp<APPROX, SfpuType::not_equal_zero>, idst_in, idst_out, (int)VectorMode::RC, 8)));
+        ckernel::sfpu::calculate_comp<APPROX, SfpuType::not_equal_zero>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 // clang-format off
@@ -494,8 +490,7 @@ ALWI void gez_tile(uint32_t idst_in, uint32_t idst_out) {
         ckernel::sfpu::calculate_comp<APPROX, SfpuType::greater_than_equal_zero>,
         idst_in,
         idst_out,
-        (int)VectorMode::RC,
-        8)));
+        (int)VectorMode::RC)));
 }
 
 // clang-format off
@@ -547,7 +542,7 @@ ALWI void ltz_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(less_than_zero, RC, AP
 
 ALWI void ltz_tile(uint32_t idst_in, uint32_t idst_out) {
     MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp<APPROX, SfpuType::less_than_zero>, idst_in, idst_out, (int)VectorMode::RC, 8)));
+        ckernel::sfpu::calculate_comp<APPROX, SfpuType::less_than_zero>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 // clang-format off
@@ -596,7 +591,7 @@ ALWI void eqz_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(equal_zero, RC, APPROX
 
 ALWI void eqz_tile(uint32_t idst_in, uint32_t idst_out) {
     MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp<APPROX, SfpuType::equal_zero>, idst_in, idst_out, (int)VectorMode::RC, 8)));
+        ckernel::sfpu::calculate_comp<APPROX, SfpuType::equal_zero>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 // clang-format off
@@ -695,8 +690,7 @@ ALWI void lez_tile(uint32_t idst_in, uint32_t idst_out) {
         ckernel::sfpu::calculate_comp<APPROX, SfpuType::less_than_equal_zero>,
         idst_in,
         idst_out,
-        (int)VectorMode::RC,
-        8)));
+        (int)VectorMode::RC)));
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/comp.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/comp.h
@@ -35,8 +35,8 @@ ALWI void unary_ne_tile(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void unary_ne_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_unary_ne<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_unary_ne, (APPROX, 8), RC, idst_in, idst_out, param0)));
 }
 
 /**
@@ -65,11 +65,14 @@ ALWI void unary_ne_tile_int32(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void unary_ne_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp_unary_int<APPROX, SfpuType::unary_ne, 8>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_comp_unary_int,
+        (APPROX, SfpuType::unary_ne, 8),
+        RC,
         idst_in,
         idst_out,
-        (int)VectorMode::RC,
         param0)));
 }
 
@@ -94,8 +97,8 @@ ALWI void unary_eq_tile(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void unary_eq_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_unary_eq<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_unary_eq, (APPROX, 8), RC, idst_in, idst_out, param0)));
 }
 
 /**
@@ -124,11 +127,14 @@ ALWI void unary_eq_tile_int32(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void unary_eq_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp_unary_int<APPROX, SfpuType::unary_eq, 8>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_comp_unary_int,
+        (APPROX, SfpuType::unary_eq, 8),
+        RC,
         idst_in,
         idst_out,
-        (int)VectorMode::RC,
         param0)));
 }
 
@@ -153,8 +159,8 @@ ALWI void unary_gt_tile(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void unary_gt_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_unary_gt<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_unary_gt, (APPROX, 8), RC, idst_in, idst_out, param0)));
 }
 
 /**
@@ -183,11 +189,14 @@ ALWI void unary_gt_tile_int32(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void unary_gt_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_comp_unary_int_<APPROX, SfpuType::unary_gt, 8>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        _calculate_comp_unary_int_,
+        (APPROX, SfpuType::unary_gt, 8),
+        RC,
         idst_in,
         idst_out,
-        (int)VectorMode::RC,
         param0)));
 }
 
@@ -212,8 +221,8 @@ ALWI void unary_ge_tile(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void unary_ge_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_unary_ge<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_unary_ge, (APPROX, 8), RC, idst_in, idst_out, param0)));
 }
 
 /**
@@ -242,11 +251,14 @@ ALWI void unary_ge_tile_int32(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void unary_ge_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_comp_unary_int_<APPROX, SfpuType::unary_ge, 8>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        _calculate_comp_unary_int_,
+        (APPROX, SfpuType::unary_ge, 8),
+        RC,
         idst_in,
         idst_out,
-        (int)VectorMode::RC,
         param0)));
 }
 
@@ -271,8 +283,8 @@ ALWI void unary_lt_tile(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void unary_lt_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_unary_lt<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_unary_lt, (APPROX, 8), RC, idst_in, idst_out, param0)));
 }
 
 // unary lt : if x < value --> 1, else 0
@@ -296,11 +308,14 @@ ALWI void unary_lt_tile_int32(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void unary_lt_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_comp_unary_int_<APPROX, SfpuType::unary_lt, 8>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        _calculate_comp_unary_int_,
+        (APPROX, SfpuType::unary_lt, 8),
+        RC,
         idst_in,
         idst_out,
-        (int)VectorMode::RC,
         param0)));
 }
 
@@ -330,8 +345,8 @@ ALWI void unary_le_tile(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void unary_le_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_unary_le<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_unary_le, (APPROX, 8), RC, idst_in, idst_out, param0)));
 }
 
 // unary le : if x <= value --> 1, else 0
@@ -355,11 +370,14 @@ ALWI void unary_le_tile_int32(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void unary_le_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_comp_unary_int_<APPROX, SfpuType::unary_le, 8>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        _calculate_comp_unary_int_,
+        (APPROX, SfpuType::unary_le, 8),
+        RC,
         idst_in,
         idst_out,
-        (int)VectorMode::RC,
         param0)));
 }
 
@@ -385,8 +403,8 @@ ALWI void unary_le_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(unary_le, APPROX));
 ALWI void gtz_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(greater_than_zero, RC, APPROX, idst)); }
 
 ALWI void gtz_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp<APPROX, SfpuType::greater_than_zero>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp, (APPROX, SfpuType::greater_than_zero), RC, idst_in, idst_out)));
 }
 
 // clang-format off
@@ -408,11 +426,14 @@ ALWI void gtz_tile_int32(uint32_t idst) {
 }
 
 ALWI void gtz_tile_int32(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp_int<APPROX, SfpuType::greater_than_zero>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_comp_int,
+        (APPROX, SfpuType::greater_than_zero),
+        RC,
         idst_in,
-        idst_out,
-        (int)VectorMode::RC)));
+        idst_out)));
 }
 
 /**
@@ -437,8 +458,8 @@ ALWI void gtz_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(greater_than_zero, APPRO
 ALWI void nez_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(not_equal_zero, RC, APPROX, idst)); }
 
 ALWI void nez_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp<APPROX, SfpuType::not_equal_zero>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp, (APPROX, SfpuType::not_equal_zero), RC, idst_in, idst_out)));
 }
 
 // clang-format off
@@ -460,8 +481,8 @@ ALWI void nez_tile_int32(uint32_t idst) {
 }
 
 ALWI void nez_tile_int32(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp_int<APPROX, SfpuType::not_equal_zero>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp_int, (APPROX, SfpuType::not_equal_zero), RC, idst_in, idst_out)));
 }
 
 /**
@@ -486,11 +507,14 @@ ALWI void nez_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(not_equal_zero, APPROX))
 ALWI void gez_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(greater_than_equal_zero, RC, APPROX, idst)); }
 
 ALWI void gez_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp<APPROX, SfpuType::greater_than_equal_zero>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_comp,
+        (APPROX, SfpuType::greater_than_equal_zero),
+        RC,
         idst_in,
-        idst_out,
-        (int)VectorMode::RC)));
+        idst_out)));
 }
 
 // clang-format off
@@ -512,11 +536,14 @@ ALWI void gez_tile_int32(uint32_t idst) {
 }
 
 ALWI void gez_tile_int32(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp_int<APPROX, SfpuType::greater_than_equal_zero>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_comp_int,
+        (APPROX, SfpuType::greater_than_equal_zero),
+        RC,
         idst_in,
-        idst_out,
-        (int)VectorMode::RC)));
+        idst_out)));
 }
 
 /**
@@ -541,8 +568,8 @@ ALWI void gez_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(greater_than_equal_zero,
 ALWI void ltz_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(less_than_zero, RC, APPROX, idst)); }
 
 ALWI void ltz_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp<APPROX, SfpuType::less_than_zero>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp, (APPROX, SfpuType::less_than_zero), RC, idst_in, idst_out)));
 }
 
 // clang-format off
@@ -564,8 +591,8 @@ ALWI void ltz_tile_int32(uint32_t idst) {
 }
 
 ALWI void ltz_tile_int32(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp_int<APPROX, SfpuType::less_than_zero>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp_int, (APPROX, SfpuType::less_than_zero), RC, idst_in, idst_out)));
 }
 
 /**
@@ -590,8 +617,8 @@ ALWI void ltz_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(less_than_zero, APPROX))
 ALWI void eqz_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(equal_zero, RC, APPROX, idst)); }
 
 ALWI void eqz_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp<APPROX, SfpuType::equal_zero>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp, (APPROX, SfpuType::equal_zero), RC, idst_in, idst_out)));
 }
 
 // clang-format off
@@ -613,8 +640,8 @@ ALWI void eqz_tile_int32(uint32_t idst) {
 }
 
 ALWI void eqz_tile_int32(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp_int<APPROX, SfpuType::equal_zero>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp_int, (APPROX, SfpuType::equal_zero), RC, idst_in, idst_out)));
 }
 
 // clang-format off
@@ -636,8 +663,8 @@ ALWI void eqz_tile_uint16(uint32_t idst) {
 }
 
 ALWI void eqz_tile_uint16(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp_uint16<APPROX, SfpuType::equal_zero>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_comp_uint16, (APPROX, SfpuType::equal_zero), RC, idst_in, idst_out)));
 }
 
 // clang-format off
@@ -660,8 +687,8 @@ ALWI void eqz_tile_uint32(uint32_t idst) {
 }
 
 ALWI void eqz_tile_uint32(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_eqz_uint32<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((
+        SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_eqz_uint32, (APPROX, 8), RC, idst_in, idst_out)));
 }
 
 /**
@@ -686,11 +713,14 @@ ALWI void eqz_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(equal_zero, APPROX)); }
 ALWI void lez_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(less_than_equal_zero, RC, APPROX, idst)); }
 
 ALWI void lez_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp<APPROX, SfpuType::less_than_equal_zero>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_comp,
+        (APPROX, SfpuType::less_than_equal_zero),
+        RC,
         idst_in,
-        idst_out,
-        (int)VectorMode::RC)));
+        idst_out)));
 }
 
 // clang-format off
@@ -712,11 +742,14 @@ ALWI void lez_tile_int32(uint32_t idst) {
 }
 
 ALWI void lez_tile_int32(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp_int<APPROX, SfpuType::less_than_equal_zero>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_comp_int,
+        (APPROX, SfpuType::less_than_equal_zero),
+        RC,
         idst_in,
-        idst_out,
-        (int)VectorMode::RC)));
+        idst_out)));
 }
 
 // clang-format off
@@ -738,11 +771,14 @@ ALWI void nez_tile_uint16(uint32_t idst) {
 }
 
 ALWI void nez_tile_uint16(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_comp_uint16<APPROX, SfpuType::not_equal_zero>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_comp_uint16,
+        (APPROX, SfpuType::not_equal_zero),
+        RC,
         idst_in,
-        idst_out,
-        (int)VectorMode::RC)));
+        idst_out)));
 }
 
 // clang-format off
@@ -764,8 +800,8 @@ ALWI void nez_tile_uint32(uint32_t idst) {
 }
 
 ALWI void nez_tile_uint32(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_nez_uint32<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((
+        SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_nez_uint32, (APPROX, 8), RC, idst_in, idst_out)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/comp.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/comp.h
@@ -34,6 +34,11 @@ ALWI void unary_ne_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_unary_ne, RC, APPROX, 8, idst, param0));
 }
 
+ALWI void unary_ne_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_ne<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -59,6 +64,15 @@ ALWI void unary_ne_tile_int32(uint32_t idst, uint32_t param0) {
     MATH(SFPU_COMP_INT32_KERNEL(unary_ne, RC, APPROX, 8, idst, param0));
 }
 
+ALWI void unary_ne_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_comp_unary_int<APPROX, SfpuType::unary_ne, 8>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC,
+        param0)));
+}
+
 // unary eq : if x == value --> 1.0, else 0.0
 // clang-format off
 /**
@@ -77,6 +91,11 @@ ALWI void unary_ne_tile_int32(uint32_t idst, uint32_t param0) {
 // clang-format on
 ALWI void unary_eq_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_unary_eq, RC, APPROX, 8, idst, param0));
+}
+
+ALWI void unary_eq_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_eq<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, param0)));
 }
 
 /**
@@ -104,6 +123,15 @@ ALWI void unary_eq_tile_int32(uint32_t idst, uint32_t param0) {
     MATH(SFPU_COMP_INT32_KERNEL(unary_eq, RC, APPROX, 8, idst, param0));
 }
 
+ALWI void unary_eq_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_comp_unary_int<APPROX, SfpuType::unary_eq, 8>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC,
+        param0)));
+}
+
 // unary gt : if x > value --> 1.0, else 0.0
 // clang-format off
 /**
@@ -122,6 +150,11 @@ ALWI void unary_eq_tile_int32(uint32_t idst, uint32_t param0) {
 // clang-format on
 ALWI void unary_gt_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_unary_gt, RC, APPROX, 8, idst, param0));
+}
+
+ALWI void unary_gt_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_gt<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, param0)));
 }
 
 /**
@@ -149,6 +182,15 @@ ALWI void unary_gt_tile_int32(uint32_t idst, uint32_t param0) {
     MATH(SFPU_COMP_INT32_KERNEL_UNDERSCORE(unary_gt, RC, APPROX, 8, idst, param0));
 }
 
+ALWI void unary_gt_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_comp_unary_int_<APPROX, SfpuType::unary_gt, 8>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC,
+        param0)));
+}
+
 // unary ge : if x >= value --> 1.0, else 0.0
 // clang-format off
 /**
@@ -167,6 +209,11 @@ ALWI void unary_gt_tile_int32(uint32_t idst, uint32_t param0) {
 // clang-format on
 ALWI void unary_ge_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_unary_ge, RC, APPROX, 8, idst, param0));
+}
+
+ALWI void unary_ge_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_ge<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, param0)));
 }
 
 /**
@@ -194,6 +241,15 @@ ALWI void unary_ge_tile_int32(uint32_t idst, uint32_t param0) {
     MATH(SFPU_COMP_INT32_KERNEL_UNDERSCORE(unary_ge, RC, APPROX, 8, idst, param0));
 }
 
+ALWI void unary_ge_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_comp_unary_int_<APPROX, SfpuType::unary_ge, 8>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC,
+        param0)));
+}
+
 // unary lt : if x < value --> 1.0, else 0.0
 // clang-format off
 /**
@@ -214,6 +270,11 @@ ALWI void unary_lt_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_unary_lt, RC, APPROX, 8, idst, param0));
 }
 
+ALWI void unary_lt_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_lt<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+}
+
 // unary lt : if x < value --> 1, else 0
 // clang-format off
 /**
@@ -232,6 +293,15 @@ ALWI void unary_lt_tile(uint32_t idst, uint32_t param0) {
 // clang-format on
 ALWI void unary_lt_tile_int32(uint32_t idst, uint32_t param0) {
     MATH(SFPU_COMP_INT32_KERNEL_UNDERSCORE(unary_lt, RC, APPROX, 8, idst, param0));
+}
+
+ALWI void unary_lt_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_comp_unary_int_<APPROX, SfpuType::unary_lt, 8>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC,
+        param0)));
 }
 
 /**
@@ -259,6 +329,11 @@ ALWI void unary_le_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_unary_le, RC, APPROX, 8, idst, param0));
 }
 
+ALWI void unary_le_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_unary_le<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+}
+
 // unary le : if x <= value --> 1, else 0
 // clang-format off
 /**
@@ -277,6 +352,15 @@ ALWI void unary_le_tile(uint32_t idst, uint32_t param0) {
 // clang-format on
 ALWI void unary_le_tile_int32(uint32_t idst, uint32_t param0) {
     MATH(SFPU_COMP_INT32_KERNEL_UNDERSCORE(unary_le, RC, APPROX, 8, idst, param0));
+}
+
+ALWI void unary_le_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_comp_unary_int_<APPROX, SfpuType::unary_le, 8>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC,
+        param0)));
 }
 
 /**
@@ -300,6 +384,15 @@ ALWI void unary_le_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(unary_le, APPROX));
 // clang-format on
 ALWI void gtz_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(greater_than_zero, RC, APPROX, idst)); }
 
+ALWI void gtz_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_comp<APPROX, SfpuType::greater_than_zero>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC,
+        8)));
+}
+
 // clang-format off
 /**
  * Will store in the output of the compute core True if each element is greater than zero.
@@ -316,6 +409,14 @@ ALWI void gtz_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(greater_than_zero, RC,
 // clang-format on
 ALWI void gtz_tile_int32(uint32_t idst) {
     MATH(SFPU_ZERO_KERNEL_TYPE(calculate_comp_int, greater_than_zero, RC, APPROX, idst));
+}
+
+ALWI void gtz_tile_int32(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_comp_int<APPROX, SfpuType::greater_than_zero>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC)));
 }
 
 /**
@@ -339,6 +440,11 @@ ALWI void gtz_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(greater_than_zero, APPRO
 // clang-format on
 ALWI void nez_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(not_equal_zero, RC, APPROX, idst)); }
 
+ALWI void nez_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_comp<APPROX, SfpuType::not_equal_zero>, idst_in, idst_out, (int)VectorMode::RC, 8)));
+}
+
 // clang-format off
 /**
  * Will store in the output of the compute core True if each element is not equal to zero.
@@ -355,6 +461,11 @@ ALWI void nez_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(not_equal_zero, RC, AP
 // clang-format on
 ALWI void nez_tile_int32(uint32_t idst) {
     MATH(SFPU_ZERO_KERNEL_TYPE(calculate_comp_int, not_equal_zero, RC, APPROX, idst));
+}
+
+ALWI void nez_tile_int32(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_comp_int<APPROX, SfpuType::not_equal_zero>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 /**
@@ -378,6 +489,15 @@ ALWI void nez_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(not_equal_zero, APPROX))
 // clang-format on
 ALWI void gez_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(greater_than_equal_zero, RC, APPROX, idst)); }
 
+ALWI void gez_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_comp<APPROX, SfpuType::greater_than_equal_zero>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC,
+        8)));
+}
+
 // clang-format off
 /**
  * Will store in the output of the compute core True if each element is greater than or equal to zero.
@@ -394,6 +514,14 @@ ALWI void gez_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(greater_than_equal_zer
 // clang-format on
 ALWI void gez_tile_int32(uint32_t idst) {
     MATH(SFPU_ZERO_KERNEL_TYPE(calculate_comp_int, greater_than_equal_zero, RC, APPROX, idst));
+}
+
+ALWI void gez_tile_int32(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_comp_int<APPROX, SfpuType::greater_than_equal_zero>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC)));
 }
 
 /**
@@ -417,6 +545,11 @@ ALWI void gez_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(greater_than_equal_zero,
 // clang-format on
 ALWI void ltz_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(less_than_zero, RC, APPROX, idst)); }
 
+ALWI void ltz_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_comp<APPROX, SfpuType::less_than_zero>, idst_in, idst_out, (int)VectorMode::RC, 8)));
+}
+
 // clang-format off
 /**
  * Will store in the output of the compute core True if each element of a tile is less than zero.
@@ -433,6 +566,11 @@ ALWI void ltz_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(less_than_zero, RC, AP
 // clang-format on
 ALWI void ltz_tile_int32(uint32_t idst) {
     MATH(SFPU_ZERO_KERNEL_TYPE(calculate_comp_int, less_than_zero, RC, APPROX, idst));
+}
+
+ALWI void ltz_tile_int32(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_comp_int<APPROX, SfpuType::less_than_zero>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 /**
@@ -456,6 +594,11 @@ ALWI void ltz_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(less_than_zero, APPROX))
 // clang-format on
 ALWI void eqz_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(equal_zero, RC, APPROX, idst)); }
 
+ALWI void eqz_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_comp<APPROX, SfpuType::equal_zero>, idst_in, idst_out, (int)VectorMode::RC, 8)));
+}
+
 // clang-format off
 /**
  * Will store in the output of the compute core True if each element of a tile is equal to zero.
@@ -472,6 +615,11 @@ ALWI void eqz_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(equal_zero, RC, APPROX
 // clang-format on
 ALWI void eqz_tile_int32(uint32_t idst) {
     MATH(SFPU_ZERO_KERNEL_TYPE(calculate_comp_int, equal_zero, RC, APPROX, idst));
+}
+
+ALWI void eqz_tile_int32(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_comp_int<APPROX, SfpuType::equal_zero>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 // clang-format off
@@ -492,6 +640,11 @@ ALWI void eqz_tile_uint16(uint32_t idst) {
     MATH(SFPU_ZERO_KERNEL_TYPE(calculate_comp_uint16, equal_zero, RC, APPROX, idst));
 }
 
+ALWI void eqz_tile_uint16(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_comp_uint16<APPROX, SfpuType::equal_zero>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 // clang-format off
 
 /**
@@ -509,6 +662,11 @@ ALWI void eqz_tile_uint16(uint32_t idst) {
 // clang-format on
 ALWI void eqz_tile_uint32(uint32_t idst) {
     MATH((SFPU_TWO_PARAM_KERNEL(calculate_eqz_uint32, APPROX, 8, idst, (int)VectorMode::RC)));
+}
+
+ALWI void eqz_tile_uint32(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_eqz_uint32<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 /**
@@ -532,6 +690,15 @@ ALWI void eqz_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(equal_zero, APPROX)); }
 // clang-format on
 ALWI void lez_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(less_than_equal_zero, RC, APPROX, idst)); }
 
+ALWI void lez_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_comp<APPROX, SfpuType::less_than_equal_zero>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC,
+        8)));
+}
+
 // clang-format off
 /**
  * Will store in the output of the compute core True if each element is less than or equal to zero.
@@ -548,6 +715,14 @@ ALWI void lez_tile(uint32_t idst) { MATH(SFPU_ZERO_KERNEL(less_than_equal_zero, 
 // clang-format on
 ALWI void lez_tile_int32(uint32_t idst) {
     MATH(SFPU_ZERO_KERNEL_TYPE(calculate_comp_int, less_than_equal_zero, RC, APPROX, idst));
+}
+
+ALWI void lez_tile_int32(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_comp_int<APPROX, SfpuType::less_than_equal_zero>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC)));
 }
 
 // clang-format off
@@ -568,6 +743,14 @@ ALWI void nez_tile_uint16(uint32_t idst) {
     MATH(SFPU_ZERO_KERNEL_TYPE(calculate_comp_uint16, not_equal_zero, RC, APPROX, idst));
 }
 
+ALWI void nez_tile_uint16(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_comp_uint16<APPROX, SfpuType::not_equal_zero>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC)));
+}
+
 // clang-format off
 /**
  * Will store in the output of the compute core True if each element is not equal to zero.
@@ -584,6 +767,11 @@ ALWI void nez_tile_uint16(uint32_t idst) {
 // clang-format on
 ALWI void nez_tile_uint32(uint32_t idst) {
     MATH((SFPU_TWO_PARAM_KERNEL(calculate_nez_uint32, APPROX, 8, idst, (int)VectorMode::RC)));
+}
+
+ALWI void nez_tile_uint32(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_nez_uint32<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/digamma.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/digamma.h
@@ -14,6 +14,11 @@ namespace ckernel {
 
 ALWI void digamma_tile(uint32_t idst) { MATH(SFPU_UNARY_NO_PARAM_KERNEL_FN(calculate_digamma, RC, APPROX, idst)); }
 
+ALWI void digamma_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_digamma<APPROX>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 ALWI void digamma_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(unused, sfpu::digamma_init, APPROX)); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/digamma.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/digamma.h
@@ -15,8 +15,7 @@ namespace ckernel {
 ALWI void digamma_tile(uint32_t idst) { MATH(SFPU_UNARY_NO_PARAM_KERNEL_FN(calculate_digamma, RC, APPROX, idst)); }
 
 ALWI void digamma_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_digamma<APPROX>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_digamma, (APPROX), RC, idst_in, idst_out)));
 }
 
 ALWI void digamma_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(unused, sfpu::digamma_init, APPROX)); }

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/dropout.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/dropout.h
@@ -32,6 +32,11 @@ ALWI void dropout_tile(uint32_t idst, uint32_t probability, uint32_t scale_facto
     MATH(SFPU_UNARY_PARAMS_KERNEL_EXTRA_ARGS(calculate_dropout, RC, APPROX, idst, probability, scale_factor));
 }
 
+ALWI void dropout_tile(uint32_t idst_in, uint32_t idst_out, uint32_t probability, uint32_t scale_factor) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_dropout<APPROX>, idst_in, idst_out, (int)VectorMode::RC, probability, scale_factor)));
+}
+
 /**
  * This init should be called once in kernel
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/dropout.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/dropout.h
@@ -33,8 +33,8 @@ ALWI void dropout_tile(uint32_t idst, uint32_t probability, uint32_t scale_facto
 }
 
 ALWI void dropout_tile(uint32_t idst_in, uint32_t idst_out, uint32_t probability, uint32_t scale_factor) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_dropout<APPROX>, idst_in, idst_out, (int)VectorMode::RC, probability, scale_factor)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_dropout, (APPROX), RC, idst_in, idst_out, probability, scale_factor)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/elu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/elu.h
@@ -35,8 +35,8 @@ ALWI void elu_tile(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void elu_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_elu<APPROX, DST_ACCUM_MODE>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_elu, (APPROX, DST_ACCUM_MODE), RC, idst_in, idst_out, param0)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/elu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/elu.h
@@ -30,7 +30,15 @@ namespace ckernel {
  * | slope          | slope used in elu calculation                                              | uint32_t | Greater than 0                                        | True     |
  */
 // clang-format on
-ALWI void elu_tile(uint32_t idst, uint32_t param0) { MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_elu, RC, APPROX, DST_ACCUM_MODE, idst, param0)); }
+ALWI void elu_tile(uint32_t idst, uint32_t param0) {
+    MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(calculate_elu, RC, APPROX, DST_ACCUM_MODE, idst, param0));
+}
+
+ALWI void elu_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_elu<APPROX, DST_ACCUM_MODE>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/erf_erfc.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/erf_erfc.h
@@ -43,6 +43,12 @@ ALWI void erf_tile(uint32_t idst) {
     MATH(SFPU_UNARY_NO_PARAM_KERNEL_FN(calculate_erf, RC, fast_and_approx, idst));
 }
 
+template <bool fast_and_approx = true>
+ALWI void erf_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_erf<fast_and_approx>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 /************** ERFC *****************/
 
 /**
@@ -66,6 +72,10 @@ ALWI void erfc_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(erfc, sfpu::erfc_init, t
 // clang-format on
 ALWI void erfc_tile(uint32_t idst) {
     MATH(_llk_math_eltwise_unary_sfpu_params_(sfpu::calculate_erfc<>, idst, (int)VectorMode::RC));
+}
+
+ALWI void erfc_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(sfpu::calculate_erfc<>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 #endif

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/erf_erfc.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/erf_erfc.h
@@ -45,8 +45,8 @@ ALWI void erf_tile(uint32_t idst) {
 
 template <bool fast_and_approx = true>
 ALWI void erf_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_erf<fast_and_approx>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH(
+        (SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_erf, (fast_and_approx), RC, idst_in, idst_out)));
 }
 
 /************** ERFC *****************/
@@ -75,7 +75,7 @@ ALWI void erfc_tile(uint32_t idst) {
 }
 
 ALWI void erfc_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(sfpu::calculate_erfc<>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_erfc, (), RC, idst_in, idst_out)));
 }
 
 #endif

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/erfinv.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/erfinv.h
@@ -27,6 +27,11 @@ namespace ckernel {
 // clang-format on
 ALWI void erfinv_tile(uint32_t idst) { MATH(SFPU_UNARY_NO_PARAM_KERNEL_FN(calculate_erfinv, RC, APPROX, idst)); }
 
+ALWI void erfinv_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_erfinv<APPROX>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/erfinv.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/erfinv.h
@@ -28,8 +28,7 @@ namespace ckernel {
 ALWI void erfinv_tile(uint32_t idst) { MATH(SFPU_UNARY_NO_PARAM_KERNEL_FN(calculate_erfinv, RC, APPROX, idst)); }
 
 ALWI void erfinv_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_erfinv<APPROX>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_erfinv, (APPROX), RC, idst_in, idst_out)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/exp.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/exp.h
@@ -82,6 +82,25 @@ ALWI void exp_tile(uint32_t idst, int vector_mode = (int)VectorMode::RC, uint16_
 
 #ifndef ARCH_QUASAR
 
+template <
+    bool approx = false,
+    bool scale_en = false,
+    InputClamping input_clamping = InputClamping::ClampToNegative,
+    int iterations = 8>
+ALWI void exp_tile(uint32_t idst_in, uint32_t idst_out, int vector_mode, uint16_t scale = p_sfpu::kCONST_1_FP16B) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_exponential<
+            approx,
+            DST_ACCUM_MODE,
+            scale_en,
+            iterations,
+            (input_clamping == InputClamping::ClampToNegative)>,
+        idst_in,
+        idst_out,
+        vector_mode,
+        scale)));
+}
+
 /**
  * Pack-thread variant of exp_tile_init. Runs the init on the pack thread
  * to enable FPU/SFPU overlap with math-thread matmul operations.

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/exp.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/exp.h
@@ -88,13 +88,11 @@ template <
     InputClamping input_clamping = InputClamping::ClampToNegative,
     int iterations = 8>
 ALWI void exp_tile(uint32_t idst_in, uint32_t idst_out, int vector_mode, uint16_t scale = p_sfpu::kCONST_1_FP16B) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_exponential<
-            approx,
-            DST_ACCUM_MODE,
-            scale_en,
-            iterations,
-            (input_clamping == InputClamping::ClampToNegative)>,
+    MATH((SFPU_CALL_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_exponential,
+        (approx, DST_ACCUM_MODE, scale_en, iterations, (input_clamping == InputClamping::ClampToNegative)),
         idst_in,
         idst_out,
         vector_mode,

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/fill.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/fill.h
@@ -30,6 +30,11 @@ ALWI void fill_tile(uint32_t idst, float param0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(_calculate_fill_, RC, APPROX, 8, idst, param0));
 }
 
+ALWI void fill_tile(uint32_t idst_in, uint32_t idst_out, float param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_fill_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+}
+
 // clang-format off
 /**
  * Performs element-wise fill operation. The value to be filled in the tile is provided as const param0. The DST
@@ -51,6 +56,18 @@ ALWI void fill_tile_int(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_DATA_FORMAT_EXTRA_PARAM(_calculate_fill_int_, RC, APPROX, DATA_FORMAT, 8, idst, param0));
 }
 
+template <DataFormat DATA_FORMAT>
+ALWI void fill_tile_int(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    static_assert(
+        DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16,
+        "Unsupported data format. Supported: Int32, UInt32, UInt16");
+    constexpr InstrModLoadStore _INSTRUCTION_MODE =
+        (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_fill_int_<APPROX, _INSTRUCTION_MODE, 8>,
+        idst_in, idst_out, (int)VectorMode::RC, param0)));
+}
+
 // clang-format off
 /**
  * Performs element-wise fill operation. The value to be filled in the tile is provided as const param0, which is
@@ -68,6 +85,12 @@ ALWI void fill_tile_int(uint32_t idst, uint32_t param0) {
 ALWI void fill_tile_bitcast(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(_calculate_fill_bitcast_, RC, APPROX, 8, idst, param0));
 }
+
+ALWI void fill_tile_bitcast(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_fill_bitcast_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/fill.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/fill.h
@@ -31,8 +31,8 @@ ALWI void fill_tile(uint32_t idst, float param0) {
 }
 
 ALWI void fill_tile(uint32_t idst_in, uint32_t idst_out, float param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_fill_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_fill_, (APPROX, 8), RC, idst_in, idst_out, param0)));
 }
 
 // clang-format off
@@ -63,9 +63,8 @@ ALWI void fill_tile_int(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
         "Unsupported data format. Supported: Int32, UInt32, UInt16");
     constexpr InstrModLoadStore _INSTRUCTION_MODE =
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_fill_int_<APPROX, _INSTRUCTION_MODE, 8>,
-        idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_fill_int_, (APPROX, _INSTRUCTION_MODE, 8), RC, idst_in, idst_out, param0)));
 }
 
 // clang-format off
@@ -87,8 +86,8 @@ ALWI void fill_tile_bitcast(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void fill_tile_bitcast(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_fill_bitcast_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_fill_bitcast_, (APPROX, 8), RC, idst_in, idst_out, param0)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/fmod.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/fmod.h
@@ -33,8 +33,8 @@ ALWI void fmod_tile(uint32_t idst, uint32_t param0, uint32_t param1) {
 }
 
 ALWI void fmod_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0, uint32_t param1) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_fmod<APPROX>, idst_in, idst_out, (int)VectorMode::RC, param0, param1)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_fmod, (APPROX), RC, idst_in, idst_out, param0, param1)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/fmod.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/fmod.h
@@ -32,6 +32,11 @@ ALWI void fmod_tile(uint32_t idst, uint32_t param0, uint32_t param1) {
     MATH(SFPU_UNARY_TWO_PARAM_KERNEL_FN(calculate_fmod, RC, APPROX, idst, param0, param1));
 }
 
+ALWI void fmod_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0, uint32_t param1) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_fmod<APPROX>, idst_in, idst_out, (int)VectorMode::RC, param0, param1)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/gelu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/gelu.h
@@ -54,8 +54,8 @@ ALWI void gelu_tile_pack(uint32_t idst) {
 
 template <bool fast_and_approx = true>
 ALWI void gelu_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_gelu<fast_and_approx, DST_ACCUM_MODE>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_gelu, (fast_and_approx, DST_ACCUM_MODE), RC, idst_in, idst_out)));
 }
 
 /**
@@ -93,8 +93,14 @@ ALWI void gelu_derivative_tile(uint32_t idst) {
 
 template <bool fast_and_approx = false>
 ALWI void gelu_derivative_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_gelu_derivative_polynomial<fast_and_approx>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_gelu_derivative_polynomial,
+        (fast_and_approx),
+        RC,
+        idst_in,
+        idst_out)));
 }
 
 #endif

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/gelu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/gelu.h
@@ -52,6 +52,12 @@ ALWI void gelu_tile_pack(uint32_t idst) {
     PACK(SFPU_TWO_PARAM_KERNEL(calculate_gelu, fast_and_approx, DST_ACCUM_MODE, idst, (int)VectorMode::RC));
 }
 
+template <bool fast_and_approx = true>
+ALWI void gelu_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_gelu<fast_and_approx, DST_ACCUM_MODE>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -83,6 +89,12 @@ ALWI void gelu_derivative_tile_init() {
 template <bool fast_and_approx = false>
 ALWI void gelu_derivative_tile(uint32_t idst) {
     MATH(SFPU_UNARY_NO_PARAM_KERNEL_FN(calculate_gelu_derivative_polynomial, RC, fast_and_approx, idst));
+}
+
+template <bool fast_and_approx = false>
+ALWI void gelu_derivative_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_gelu_derivative_polynomial<fast_and_approx>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 #endif

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/hardmish.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/hardmish.h
@@ -35,6 +35,10 @@ namespace ckernel {
 // clang-format on
 ALWI void hardmish_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_hardmish<APPROX>(idst))); }
 
+ALWI void hardmish_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_hardmish<APPROX>(idst_in, idst_out)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/hardtanh.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/hardtanh.h
@@ -35,6 +35,10 @@ ALWI void hardtanh_tile_pack(uint32_t idst, uint32_t param0, uint32_t param1) {
     PACK((llk_math_eltwise_unary_sfpu_hardtanh<APPROX>(idst, param0, param1)));
 }
 
+ALWI void hardtanh_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_hardtanh<APPROX>(idst_in, idst_out, param0, param1)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/i0.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/i0.h
@@ -26,6 +26,11 @@ namespace ckernel {
 // clang-format on
 ALWI void i0_tile(uint32_t idst) { MATH(SFPU_UNARY_NO_PARAM_KERNEL_FN(calculate_i0, RC, APPROX, idst)); }
 
+ALWI void i0_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_i0<APPROX>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/i0.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/i0.h
@@ -27,8 +27,7 @@ namespace ckernel {
 ALWI void i0_tile(uint32_t idst) { MATH(SFPU_UNARY_NO_PARAM_KERNEL_FN(calculate_i0, RC, APPROX, idst)); }
 
 ALWI void i0_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_i0<APPROX>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_i0, (APPROX), RC, idst_in, idst_out)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/i1.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/i1.h
@@ -28,8 +28,7 @@ namespace ckernel {
 ALWI void i1_tile(uint32_t idst) { MATH(SFPU_UNARY_NO_PARAM_KERNEL_FN(calculate_i1, RC, APPROX, idst)); }
 
 ALWI void i1_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_i1<APPROX>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_i1, (APPROX), RC, idst_in, idst_out)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/i1.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/i1.h
@@ -27,6 +27,11 @@ namespace ckernel {
 // clang-format on
 ALWI void i1_tile(uint32_t idst) { MATH(SFPU_UNARY_NO_PARAM_KERNEL_FN(calculate_i1, RC, APPROX, idst)); }
 
+ALWI void i1_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_i1<APPROX>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/identity.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/identity.h
@@ -28,8 +28,7 @@ ALWI void identity_tile(uint32_t idst) {
 }
 
 ALWI void identity_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_identity<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_identity, (APPROX, 8), RC, idst_in, idst_out)));
 }
 
 /**
@@ -54,8 +53,8 @@ ALWI void identity_tile_uint32(uint32_t idst) {
 }
 
 ALWI void identity_tile_uint32(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_identity_uint<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_identity_uint, (APPROX, 8), RC, idst_in, idst_out)));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/identity.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/identity.h
@@ -27,6 +27,11 @@ ALWI void identity_tile(uint32_t idst) {
     MATH(SFPU_TWO_PARAM_KERNEL(calculate_identity, APPROX, 8, idst, (int)VectorMode::RC));
 }
 
+ALWI void identity_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_identity<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -46,6 +51,11 @@ ALWI void identity_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(unused, APPROX)); }
 // clang-format on
 ALWI void identity_tile_uint32(uint32_t idst) {
     MATH(SFPU_TWO_PARAM_KERNEL(calculate_identity_uint, APPROX, 8, idst, (int)VectorMode::RC));
+}
+
+ALWI void identity_tile_uint32(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_identity_uint<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/isinf_isnan.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/isinf_isnan.h
@@ -30,11 +30,14 @@ ALWI void isinf_tile(uint32_t idst) {
 }
 
 ALWI void isinf_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_sfpu_isinf_isnan_<SfpuType::isinf, APPROX, 8>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        _calculate_sfpu_isinf_isnan_,
+        (SfpuType::isinf, APPROX, 8),
+        RC,
         idst_in,
-        idst_out,
-        (int)VectorMode::RC)));
+        idst_out)));
 }
 
 /**
@@ -62,11 +65,14 @@ ALWI void isposinf_tile(uint32_t idst) {
 }
 
 ALWI void isposinf_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_sfpu_isinf_isnan_<SfpuType::isposinf, APPROX, 8>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        _calculate_sfpu_isinf_isnan_,
+        (SfpuType::isposinf, APPROX, 8),
+        RC,
         idst_in,
-        idst_out,
-        (int)VectorMode::RC)));
+        idst_out)));
 }
 
 /**
@@ -94,11 +100,14 @@ ALWI void isneginf_tile(uint32_t idst) {
 }
 
 ALWI void isneginf_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_sfpu_isinf_isnan_<SfpuType::isneginf, APPROX, 8>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        _calculate_sfpu_isinf_isnan_,
+        (SfpuType::isneginf, APPROX, 8),
+        RC,
         idst_in,
-        idst_out,
-        (int)VectorMode::RC)));
+        idst_out)));
 }
 
 /**
@@ -125,11 +134,14 @@ ALWI void isnan_tile(uint32_t idst) {
 }
 
 ALWI void isnan_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_sfpu_isinf_isnan_<SfpuType::isnan, APPROX, 8>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        _calculate_sfpu_isinf_isnan_,
+        (SfpuType::isnan, APPROX, 8),
+        RC,
         idst_in,
-        idst_out,
-        (int)VectorMode::RC)));
+        idst_out)));
 }
 
 /**
@@ -157,11 +169,14 @@ ALWI void isfinite_tile(uint32_t idst) {
 }
 
 ALWI void isfinite_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_sfpu_isinf_isnan_<SfpuType::isfinite, APPROX, 8>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        _calculate_sfpu_isinf_isnan_,
+        (SfpuType::isfinite, APPROX, 8),
+        RC,
         idst_in,
-        idst_out,
-        (int)VectorMode::RC)));
+        idst_out)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/isinf_isnan.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/isinf_isnan.h
@@ -29,6 +29,14 @@ ALWI void isinf_tile(uint32_t idst) {
     MATH(SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE_AND_ITERATIONS(_calculate_sfpu_isinf_isnan_, isinf, RC, APPROX, idst, 8));
 }
 
+ALWI void isinf_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_sfpu_isinf_isnan_<SfpuType::isinf, APPROX, 8>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -49,7 +57,16 @@ ALWI void isinf_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(isinf, APPROX)); }
  */
 // clang-format on
 ALWI void isposinf_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE_AND_ITERATIONS(_calculate_sfpu_isinf_isnan_, isposinf, RC, APPROX, idst, 8));
+    MATH(SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE_AND_ITERATIONS(
+        _calculate_sfpu_isinf_isnan_, isposinf, RC, APPROX, idst, 8));
+}
+
+ALWI void isposinf_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_sfpu_isinf_isnan_<SfpuType::isposinf, APPROX, 8>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC)));
 }
 
 /**
@@ -72,7 +89,16 @@ ALWI void isposinf_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(isposinf, APPROX));
  */
 // clang-format on
 ALWI void isneginf_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE_AND_ITERATIONS(_calculate_sfpu_isinf_isnan_, isneginf, RC, APPROX, idst, 8));
+    MATH(SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE_AND_ITERATIONS(
+        _calculate_sfpu_isinf_isnan_, isneginf, RC, APPROX, idst, 8));
+}
+
+ALWI void isneginf_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_sfpu_isinf_isnan_<SfpuType::isneginf, APPROX, 8>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC)));
 }
 
 /**
@@ -98,6 +124,14 @@ ALWI void isnan_tile(uint32_t idst) {
     MATH(SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE_AND_ITERATIONS(_calculate_sfpu_isinf_isnan_, isnan, RC, APPROX, idst, 8));
 }
 
+ALWI void isnan_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_sfpu_isinf_isnan_<SfpuType::isnan, APPROX, 8>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -118,7 +152,16 @@ ALWI void isnan_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(isnan, APPROX)); }
  */
 // clang-format on
 ALWI void isfinite_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE_AND_ITERATIONS(_calculate_sfpu_isinf_isnan_, isfinite, RC, APPROX, idst, 8));
+    MATH(SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE_AND_ITERATIONS(
+        _calculate_sfpu_isinf_isnan_, isfinite, RC, APPROX, idst, 8));
+}
+
+ALWI void isfinite_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_sfpu_isinf_isnan_<SfpuType::isfinite, APPROX, 8>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/left_shift.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/left_shift.h
@@ -32,8 +32,8 @@ ALWI void left_shift_tile(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void left_shift_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_left_shift<APPROX>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_left_shift, (APPROX), RC, idst_in, idst_out, param0)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/left_shift.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/left_shift.h
@@ -31,6 +31,11 @@ ALWI void left_shift_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_FN(calculate_left_shift, RC, APPROX, idst, param0));
 }
 
+ALWI void left_shift_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_left_shift<APPROX>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/lgamma.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/lgamma.h
@@ -30,6 +30,10 @@ ALWI void lgamma_stirling_tile(uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_lgamma_stirling<APPROX, DST_ACCUM_MODE>(idst)));
 }
 
+ALWI void lgamma_stirling_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_lgamma_stirling<APPROX, DST_ACCUM_MODE>(idst_in, idst_out)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/log1p.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/log1p.h
@@ -40,4 +40,13 @@ ALWI void log1p_tile(uint32_t idst) {
     MATH(SFPU_UNARY_NO_PARAM_KERNEL_LOG1P_FN(calculate_log1p, RC, APPROX, fast_and_approx, DST_ACCUM_MODE, idst));
 }
 
+template <bool fast_and_approx = false>
+ALWI void log1p_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_log1p<APPROX, fast_and_approx, DST_ACCUM_MODE>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC)));
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/log1p.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/log1p.h
@@ -42,11 +42,14 @@ ALWI void log1p_tile(uint32_t idst) {
 
 template <bool fast_and_approx = false>
 ALWI void log1p_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_log1p<APPROX, fast_and_approx, DST_ACCUM_MODE>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_log1p,
+        (APPROX, fast_and_approx, DST_ACCUM_MODE),
+        RC,
         idst_in,
-        idst_out,
-        (int)VectorMode::RC)));
+        idst_out)));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/logical_not.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/logical_not.h
@@ -48,8 +48,8 @@ ALWI void logical_not_tile(uint32_t idst_in, uint32_t idst_out) {
         : (DATA_FORMAT == DataFormat::UInt16)                                     ? InstrModLoadStore::LO16
         : (DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32) ? InstrModLoadStore::INT32
                                                                                   : InstrModLoadStore::DEFAULT;
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_logical_not<APPROX, INSTRUCTION_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_logical_not, (APPROX, INSTRUCTION_MODE, 8), RC, idst_in, idst_out)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/logical_not.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/logical_not.h
@@ -33,6 +33,25 @@ ALWI void logical_not_tile(uint32_t idst) {
     MATH(SFPU_UNARY_KERNEL_THREE_TEMPLATE_ARGS_FN(calculate_logical_not, APPROX, DATA_FORMAT, 8, idst, RC));
 }
 
+template <DataFormat DATA_FORMAT>
+ALWI void logical_not_tile(uint32_t idst_in, uint32_t idst_out) {
+    static_assert(
+        DATA_FORMAT == DataFormat::Float32 || DATA_FORMAT == DataFormat::Float16_b ||
+            DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 ||
+            DATA_FORMAT == DataFormat::UInt16 || DATA_FORMAT == DataFormat::Bfp8_b || DATA_FORMAT == DataFormat::Bfp4_b,
+        "Unsupported data format. Supported data formats are: Float32, Float16_b, Int32, UInt32, UInt16, Bfp8_b, "
+        "Bfp4_b.");
+    constexpr InstrModLoadStore INSTRUCTION_MODE =
+        (DATA_FORMAT == DataFormat::Float32 || DATA_FORMAT == DataFormat::Float16_b ||
+         DATA_FORMAT == DataFormat::Bfp8_b || DATA_FORMAT == DataFormat::Bfp4_b)
+            ? InstrModLoadStore::DEFAULT
+        : (DATA_FORMAT == DataFormat::UInt16)                                     ? InstrModLoadStore::LO16
+        : (DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32) ? InstrModLoadStore::INT32
+                                                                                  : InstrModLoadStore::DEFAULT;
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_logical_not<APPROX, INSTRUCTION_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/negative.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/negative.h
@@ -37,8 +37,8 @@ ALWI void negative_tile(uint32_t idst) {
 }
 
 ALWI void negative_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_negative_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((
+        SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_negative_, (APPROX, 8), RC, idst_in, idst_out)));
 }
 
 ALWI void negative_tile_int32(uint32_t idst) {
@@ -46,8 +46,8 @@ ALWI void negative_tile_int32(uint32_t idst) {
 }
 
 ALWI void negative_tile_int32(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_negative_int_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_negative_int_, (APPROX, 8), RC, idst_in, idst_out)));
 }
 
 #endif

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/negative.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/negative.h
@@ -36,8 +36,18 @@ ALWI void negative_tile(uint32_t idst) {
     MATH(SFPU_TWO_PARAM_KERNEL(_calculate_negative_, APPROX, 8, idst, (int)VectorMode::RC));
 }
 
+ALWI void negative_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_negative_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 ALWI void negative_tile_int32(uint32_t idst) {
     MATH(SFPU_TWO_PARAM_KERNEL(_calculate_negative_int_, APPROX, 8, idst, (int)VectorMode::RC));
+}
+
+ALWI void negative_tile_int32(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_negative_int_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 #endif

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/polygamma.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/polygamma.h
@@ -40,6 +40,10 @@ ALWI void polygamma_tile(uint32_t idst, uint32_t n_packed, uint32_t scale_packed
     MATH((llk_math_eltwise_unary_sfpu_polygamma<APPROX, DST_ACCUM_MODE>(idst, n_packed, scale_packed)));
 }
 
+ALWI void polygamma_tile(uint32_t idst_in, uint32_t idst_out, uint32_t n_packed, uint32_t scale_packed) {
+    MATH((llk_math_eltwise_unary_sfpu_polygamma<APPROX, DST_ACCUM_MODE>(idst_in, idst_out, n_packed, scale_packed)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/prelu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/prelu.h
@@ -29,6 +29,11 @@ ALWI void prelu_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_FN(calculate_prelu, RC, APPROX, idst, param0));
 }
 
+ALWI void prelu_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_prelu<APPROX>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/prelu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/prelu.h
@@ -30,8 +30,8 @@ ALWI void prelu_tile(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void prelu_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_prelu<APPROX>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((
+        SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_prelu, (APPROX), RC, idst_in, idst_out, param0)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/rand.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/rand.h
@@ -32,6 +32,11 @@ ALWI void rand_tile(uint32_t idst, uint32_t from, uint32_t scale) {
     MATH(SFPU_UNARY_PARAMS_KERNEL_EXTRA_ARGS(rand, RC, APPROX, idst, from, scale));
 }
 
+ALWI void rand_tile(uint32_t idst_in, uint32_t idst_out, uint32_t from, uint32_t scale) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::rand<APPROX>, idst_in, idst_out, (int)VectorMode::RC, from, scale)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/rand.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/rand.h
@@ -33,8 +33,7 @@ ALWI void rand_tile(uint32_t idst, uint32_t from, uint32_t scale) {
 }
 
 ALWI void rand_tile(uint32_t idst_in, uint32_t idst_out, uint32_t from, uint32_t scale) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::rand<APPROX>, idst_in, idst_out, (int)VectorMode::RC, from, scale)));
+    MATH((SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, rand, (APPROX), RC, idst_in, idst_out, from, scale)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/rdiv.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/rdiv.h
@@ -36,4 +36,10 @@ ALWI void rdiv_tile(uint32_t dst_index, uint32_t value, int vector_mode = (int)V
     MATH((llk_math_eltwise_unary_sfpu_rdiv<APPROX, DST_ACCUM_MODE, rounding_mode>(dst_index, value, vector_mode)));
 }
 
+template <RoundingMode rounding_mode = RoundingMode::None>
+ALWI void rdiv_tile(uint32_t idst_in, uint32_t idst_out, uint32_t value, int vector_mode = (int)VectorMode::RC) {
+    MATH((llk_math_eltwise_unary_sfpu_rdiv<APPROX, DST_ACCUM_MODE, rounding_mode>(
+        idst_in, idst_out, value, vector_mode)));
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/recip.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/recip.h
@@ -18,7 +18,9 @@ namespace ckernel {
  * Please refer to documentation for any_init.
  */
 template <bool legacy_compat = true>
-ALWI void recip_tile_init() { MATH(SFPU_THREE_TEMPLATE_PARAM_INIT(reciprocal, sfpu::recip_init, APPROX, DST_ACCUM_MODE, legacy_compat)); }
+ALWI void recip_tile_init() {
+    MATH(SFPU_THREE_TEMPLATE_PARAM_INIT(reciprocal, sfpu::recip_init, APPROX, DST_ACCUM_MODE, legacy_compat));
+}
 // clang-format off
 /**
  * Performs element-wise computation of the reciprocal on each element of a tile
@@ -40,5 +42,15 @@ ALWI void recip_tile(uint32_t idst, int vector_mode = (int)VectorMode::RC) {
     MATH(SFPU_FOUR_PARAM_KERNEL_FP32_FIRST_FN(
         calculate_reciprocal, APPROX, DST_ACCUM_MODE, 8, legacy_compat, idst, vector_mode));
 }
+
+template <bool legacy_compat = true>
+ALWI void recip_tile(uint32_t idst_in, uint32_t idst_out, int vector_mode) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_reciprocal<APPROX, DST_ACCUM_MODE, 8, legacy_compat>,
+        idst_in,
+        idst_out,
+        vector_mode)));
+}
+
 #endif
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/recip.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/recip.h
@@ -45,8 +45,11 @@ ALWI void recip_tile(uint32_t idst, int vector_mode = (int)VectorMode::RC) {
 
 template <bool legacy_compat = true>
 ALWI void recip_tile(uint32_t idst_in, uint32_t idst_out, int vector_mode) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_reciprocal<APPROX, DST_ACCUM_MODE, 8, legacy_compat>,
+    MATH((SFPU_CALL_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_reciprocal,
+        (APPROX, DST_ACCUM_MODE, 8, legacy_compat),
         idst_in,
         idst_out,
         vector_mode)));

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/relu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/relu.h
@@ -31,8 +31,8 @@ ALWI void relu_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(relu_min, APPROX)); }
 ALWI void relu_tile(uint32_t idst) { MATH(SFPU_UNARY_ONE_PARAM_KERNEL_FN_FLOAT(_relu_min_, RC, APPROX, idst, 0)); }
 
 ALWI void relu_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_relu_min_<sfpi::vFloat, APPROX, 8, uint32_t>, idst_in, idst_out, (int)VectorMode::RC, 0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, _relu_min_, (sfpi::vFloat, APPROX, 8, uint32_t), RC, idst_in, idst_out, 0)));
 }
 
 #ifndef ARCH_QUASAR
@@ -61,8 +61,15 @@ ALWI void relu_max_tile_pack(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void relu_max_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_relu_max_<sfpi::vFloat, APPROX, 8, uint32_t>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        _relu_max_,
+        (sfpi::vFloat, APPROX, 8, uint32_t),
+        RC,
+        idst_in,
+        idst_out,
+        param0)));
 }
 
 ALWI void relu_max_tile_int32(uint32_t idst, uint32_t param0) {
@@ -70,8 +77,8 @@ ALWI void relu_max_tile_int32(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void relu_max_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_relu_max_<sfpi::vInt, APPROX, 8, uint32_t>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, _relu_max_, (sfpi::vInt, APPROX, 8, uint32_t), RC, idst_in, idst_out, param0)));
 }
 
 ALWI void relu_max_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(relu_max, APPROX)); }
@@ -98,8 +105,15 @@ ALWI void relu_min_tile(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void relu_min_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_relu_min_<sfpi::vFloat, APPROX, 8, uint32_t>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        _relu_min_,
+        (sfpi::vFloat, APPROX, 8, uint32_t),
+        RC,
+        idst_in,
+        idst_out,
+        param0)));
 }
 
 ALWI void relu_min_tile_int32(uint32_t idst, uint32_t param0) {
@@ -107,8 +121,8 @@ ALWI void relu_min_tile_int32(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void relu_min_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_relu_min_<sfpi::vInt, APPROX, 8, uint32_t>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, _relu_min_, (sfpi::vInt, APPROX, 8, uint32_t), RC, idst_in, idst_out, param0)));
 }
 
 ALWI void relu_min_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(relu_min, APPROX)); }
@@ -116,8 +130,8 @@ ALWI void relu_min_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(relu_min, APPROX));
 ALWI void relu_tile_int32(uint32_t idst) { MATH(SFPU_UNARY_ONE_PARAM_KERNEL_FN_INT(_relu_min_, RC, APPROX, idst, 0)); }
 
 ALWI void relu_tile_int32(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_relu_min_<sfpi::vInt, APPROX, 8, uint32_t>, idst_in, idst_out, (int)VectorMode::RC, 0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, _relu_min_, (sfpi::vInt, APPROX, 8, uint32_t), RC, idst_in, idst_out, 0)));
 }
 
 // clang-format off
@@ -141,8 +155,8 @@ ALWI void leaky_relu_tile(uint32_t idst, uint32_t slope = 0) {
 }
 
 ALWI void leaky_relu_tile(uint32_t idst_in, uint32_t idst_out, uint32_t slope) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_lrelu<APPROX>, idst_in, idst_out, (int)VectorMode::RC, slope)));
+    MATH(
+        (SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_lrelu, (APPROX), RC, idst_in, idst_out, slope)));
 }
 
 ALWI void leaky_relu_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(lrelu, APPROX)); }

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/relu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/relu.h
@@ -29,6 +29,12 @@ ALWI void relu_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(relu_min, APPROX)); }
  */
 // clang-format on
 ALWI void relu_tile(uint32_t idst) { MATH(SFPU_UNARY_ONE_PARAM_KERNEL_FN_FLOAT(_relu_min_, RC, APPROX, idst, 0)); }
+
+ALWI void relu_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_relu_min_<sfpi::vFloat, APPROX, 8, uint32_t>, idst_in, idst_out, (int)VectorMode::RC, 0)));
+}
+
 #ifndef ARCH_QUASAR
 // clang-format off
 /**
@@ -54,8 +60,18 @@ ALWI void relu_max_tile_pack(uint32_t idst, uint32_t param0) {
     PACK(SFPU_UNARY_ONE_PARAM_KERNEL_FN_FLOAT(_relu_max_, RC, APPROX, idst, param0));
 }
 
+ALWI void relu_max_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_relu_max_<sfpi::vFloat, APPROX, 8, uint32_t>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+}
+
 ALWI void relu_max_tile_int32(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_FN_INT(_relu_max_, RC, APPROX, idst, param0));
+}
+
+ALWI void relu_max_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_relu_max_<sfpi::vInt, APPROX, 8, uint32_t>, idst_in, idst_out, (int)VectorMode::RC, param0)));
 }
 
 ALWI void relu_max_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(relu_max, APPROX)); }
@@ -81,13 +97,28 @@ ALWI void relu_min_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_FN_FLOAT(_relu_min_, RC, APPROX, idst, param0));
 }
 
+ALWI void relu_min_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_relu_min_<sfpi::vFloat, APPROX, 8, uint32_t>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+}
+
 ALWI void relu_min_tile_int32(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_FN_INT(_relu_min_, RC, APPROX, idst, param0));
+}
+
+ALWI void relu_min_tile_int32(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_relu_min_<sfpi::vInt, APPROX, 8, uint32_t>, idst_in, idst_out, (int)VectorMode::RC, param0)));
 }
 
 ALWI void relu_min_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(relu_min, APPROX)); }
 
 ALWI void relu_tile_int32(uint32_t idst) { MATH(SFPU_UNARY_ONE_PARAM_KERNEL_FN_INT(_relu_min_, RC, APPROX, idst, 0)); }
+
+ALWI void relu_tile_int32(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_relu_min_<sfpi::vInt, APPROX, 8, uint32_t>, idst_in, idst_out, (int)VectorMode::RC, 0)));
+}
 
 // clang-format off
 /**
@@ -107,6 +138,11 @@ ALWI void relu_tile_int32(uint32_t idst) { MATH(SFPU_UNARY_ONE_PARAM_KERNEL_FN_I
 // clang-format on
 ALWI void leaky_relu_tile(uint32_t idst, uint32_t slope = 0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_FN(calculate_lrelu, RC, APPROX, idst, slope));
+}
+
+ALWI void leaky_relu_tile(uint32_t idst_in, uint32_t idst_out, uint32_t slope) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_lrelu<APPROX>, idst_in, idst_out, (int)VectorMode::RC, slope)));
 }
 
 ALWI void leaky_relu_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(lrelu, APPROX)); }

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/remainder.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/remainder.h
@@ -32,6 +32,11 @@ ALWI void remainder_tile(uint32_t idst, uint32_t param0, uint32_t param1) {
     MATH(SFPU_UNARY_TWO_PARAM_KERNEL_FN(calculate_remainder, RC, APPROX, idst, param0, param1));
 }
 
+ALWI void remainder_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0, uint32_t param1) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_remainder<APPROX>, idst_in, idst_out, (int)VectorMode::RC, param0, param1)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/remainder.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/remainder.h
@@ -33,8 +33,8 @@ ALWI void remainder_tile(uint32_t idst, uint32_t param0, uint32_t param1) {
 }
 
 ALWI void remainder_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0, uint32_t param1) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_remainder<APPROX>, idst_in, idst_out, (int)VectorMode::RC, param0, param1)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_remainder, (APPROX), RC, idst_in, idst_out, param0, param1)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/reverseops.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/reverseops.h
@@ -37,6 +37,10 @@ namespace ckernel {
 // clang-format on
 ALWI void rsub_tile(uint32_t idst, uint32_t param0) { MATH((llk_math_eltwise_unary_sfpu_rsub<APPROX>(idst, param0))); }
 
+ALWI void rsub_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_rsub<APPROX>(idst_in, idst_out, param0)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/right_shift.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/right_shift.h
@@ -31,6 +31,11 @@ ALWI void right_shift_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_FN(calculate_right_shift, RC, APPROX, idst, param0));
 }
 
+ALWI void right_shift_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_right_shift<APPROX>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/right_shift.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/right_shift.h
@@ -32,8 +32,8 @@ ALWI void right_shift_tile(uint32_t idst, uint32_t param0) {
 }
 
 ALWI void right_shift_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_right_shift<APPROX>, idst_in, idst_out, (int)VectorMode::RC, param0)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_right_shift, (APPROX), RC, idst_in, idst_out, param0)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/rounding.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/rounding.h
@@ -36,8 +36,7 @@ ALWI void ceil_tile(uint32_t idst) {
 }
 
 ALWI void ceil_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_ceil_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_ceil_, (APPROX, 8), RC, idst_in, idst_out)));
 }
 
 // clang-format off
@@ -59,8 +58,7 @@ ALWI void floor_tile(uint32_t idst) {
 }
 
 ALWI void floor_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_floor_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_floor_, (APPROX, 8), RC, idst_in, idst_out)));
 }
 
 // clang-format off
@@ -82,8 +80,7 @@ ALWI void trunc_tile(uint32_t idst) {
 }
 
 ALWI void trunc_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_trunc_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_trunc_, (APPROX, 8), RC, idst_in, idst_out)));
 }
 
 // clang-format off
@@ -106,8 +103,8 @@ ALWI void round_tile(uint32_t idst, int32_t decimals) {
 }
 
 ALWI void round_tile(uint32_t idst_in, uint32_t idst_out, int32_t decimals) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_round_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, decimals)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_round_, (APPROX, 8), RC, idst_in, idst_out, decimals)));
 }
 
 // clang-format off
@@ -133,8 +130,8 @@ ALWI void stochastic_round_tile(uint32_t idst) {
 }
 
 ALWI void stochastic_round_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_stochastic_round_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_stochastic_round_, (APPROX, 8), RC, idst_in, idst_out)));
 }
 
 // clang-format off
@@ -156,8 +153,7 @@ ALWI void frac_tile(uint32_t idst) {
 }
 
 ALWI void frac_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_frac_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_frac_, (APPROX, 8), RC, idst_in, idst_out)));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/rounding.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/rounding.h
@@ -35,6 +35,11 @@ ALWI void ceil_tile(uint32_t idst) {
     MATH(SFPU_TWO_PARAM_KERNEL(_calculate_ceil_, APPROX, 8, idst, (int)VectorMode::RC));
 }
 
+ALWI void ceil_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_ceil_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 // clang-format off
 /**
  * Performs element-wise floor computation on input x , where x is each element of a tile
@@ -51,6 +56,11 @@ ALWI void ceil_tile(uint32_t idst) {
 // clang-format on
 ALWI void floor_tile(uint32_t idst) {
     MATH(SFPU_TWO_PARAM_KERNEL(_calculate_floor_, APPROX, 8, idst, (int)VectorMode::RC));
+}
+
+ALWI void floor_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_floor_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 // clang-format off
@@ -71,6 +81,11 @@ ALWI void trunc_tile(uint32_t idst) {
     MATH(SFPU_TWO_PARAM_KERNEL(_calculate_trunc_, APPROX, 8, idst, (int)VectorMode::RC));
 }
 
+ALWI void trunc_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_trunc_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 // clang-format off
 /**
  * Performs element-wise computation of the round operation on each element of a tile
@@ -88,6 +103,11 @@ ALWI void trunc_tile(uint32_t idst) {
 // clang-format on
 ALWI void round_tile(uint32_t idst, int32_t decimals) {
     MATH(SFPU_TWO_PARAM_KERNEL_ONE_RUNTIME(_calculate_round_, APPROX, 8, idst, (int)VectorMode::RC, decimals));
+}
+
+ALWI void round_tile(uint32_t idst_in, uint32_t idst_out, int32_t decimals) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_round_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, decimals)));
 }
 
 // clang-format off
@@ -112,6 +132,11 @@ ALWI void stochastic_round_tile(uint32_t idst) {
     MATH(SFPU_TWO_PARAM_KERNEL(_calculate_stochastic_round_, APPROX, 8, idst, (int)VectorMode::RC));
 }
 
+ALWI void stochastic_round_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_stochastic_round_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 // clang-format off
 /**
  * Performs element-wise frac computation on input x , where x is each element of a tile
@@ -128,6 +153,11 @@ ALWI void stochastic_round_tile(uint32_t idst) {
 // clang-format on
 ALWI void frac_tile(uint32_t idst) {
     MATH(SFPU_TWO_PARAM_KERNEL(_calculate_frac_, APPROX, 8, idst, (int)VectorMode::RC));
+}
+
+ALWI void frac_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_frac_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/rpow.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/rpow.h
@@ -33,4 +33,8 @@ ALWI void rpow_tile(uint32_t idst, uint32_t base_val, int vector_mode = (int)Vec
     MATH((llk_math_eltwise_unary_sfpu_rpow<APPROX, DST_ACCUM_MODE>(idst, base_val, vector_mode)));
 }
 
+ALWI void rpow_tile(uint32_t idst_in, uint32_t idst_out, uint32_t base_val, int vector_mode = (int)VectorMode::RC) {
+    MATH((llk_math_eltwise_unary_sfpu_rpow<APPROX, DST_ACCUM_MODE>(idst_in, idst_out, base_val, vector_mode)));
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/rsqrt.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/rsqrt.h
@@ -38,4 +38,9 @@ ALWI void rsqrt_tile(uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_rsqrt<APPROX, DST_ACCUM_MODE, FAST_APPROX, legacy_compat>(idst)));
 }
 
+template <bool legacy_compat = false, bool FAST_APPROX = false>
+ALWI void rsqrt_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_rsqrt<APPROX, DST_ACCUM_MODE, FAST_APPROX, legacy_compat>(idst_in, idst_out)));
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/rsub.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/rsub.h
@@ -33,6 +33,10 @@ ALWI void rsub_tile(uint32_t idst, uint32_t scalar) {
     MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, RSUB_UNARY>(idst, scalar)));
 }
 
+ALWI void rsub_tile(uint32_t idst_in, uint32_t idst_out, uint32_t scalar) {
+    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, RSUB_UNARY>(idst_in, idst_out, scalar)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -55,6 +59,10 @@ ALWI void rsub_tile_init() { MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar
 // clang-format on
 ALWI void rsub_unary_int32_tile(uint32_t idst, uint32_t scalar) {
     MATH((llk_math_eltwise_unary_sfpu_rsub_int32<APPROX>(idst, scalar)));
+}
+
+ALWI void rsub_unary_int32_tile(uint32_t idst_in, uint32_t idst_out, uint32_t scalar) {
+    MATH((llk_math_eltwise_unary_sfpu_rsub_int32<APPROX>(idst_in, idst_out, scalar)));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/selu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/selu.h
@@ -35,6 +35,10 @@ ALWI void selu_tile_pack(uint32_t idst, uint32_t param0, uint32_t param1) {
     PACK((llk_math_eltwise_unary_sfpu_selu<APPROX, DST_ACCUM_MODE>(idst, param0, param1)));
 }
 
+ALWI void selu_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_selu<APPROX, DST_ACCUM_MODE>(idst_in, idst_out, param0, param1)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/sfpu_int_sum.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/sfpu_int_sum.h
@@ -19,8 +19,7 @@ ALWI void sfpu_sum_int_col(uint32_t idst) {
 }
 
 ALWI void sfpu_sum_int_col(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_sum_int_col<APPROX>, idst_in, idst_out, (int)VectorMode::R)));
+    MATH((SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_sum_int_col, (APPROX), R, idst_in, idst_out)));
 }
 
 ALWI void sfpu_sum_int_row(uint32_t idst) {
@@ -28,8 +27,7 @@ ALWI void sfpu_sum_int_row(uint32_t idst) {
 }
 
 ALWI void sfpu_sum_int_row(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_sum_int_row<APPROX>, idst_in, idst_out, (int)VectorMode::C)));
+    MATH((SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_sum_int_row, (APPROX), C, idst_in, idst_out)));
 }
 
 ALWI void sfpu_add_int(uint32_t idst, uint32_t dst_offset = 2, int32_t iterations = 8) {
@@ -37,8 +35,8 @@ ALWI void sfpu_add_int(uint32_t idst, uint32_t dst_offset = 2, int32_t iteration
 }
 
 ALWI void sfpu_add_int(uint32_t idst_in, uint32_t idst_out, uint32_t dst_offset, int32_t iterations = 8) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::add_int<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, dst_offset)));
+    MATH(
+        (SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, add_int, (APPROX, 8), RC, idst_in, idst_out, dst_offset)));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/sfpu_int_sum.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/sfpu_int_sum.h
@@ -18,12 +18,27 @@ ALWI void sfpu_sum_int_col(uint32_t idst) {
     MATH(SFPU_ONE_PARAM_KERNEL(calculate_sum_int_col, APPROX, idst, (int)VectorMode::R));
 }
 
+ALWI void sfpu_sum_int_col(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_sum_int_col<APPROX>, idst_in, idst_out, (int)VectorMode::R)));
+}
+
 ALWI void sfpu_sum_int_row(uint32_t idst) {
     MATH(SFPU_ONE_PARAM_KERNEL(calculate_sum_int_row, APPROX, idst, (int)VectorMode::C));
 }
 
+ALWI void sfpu_sum_int_row(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_sum_int_row<APPROX>, idst_in, idst_out, (int)VectorMode::C)));
+}
+
 ALWI void sfpu_add_int(uint32_t idst, uint32_t dst_offset = 2, int32_t iterations = 8) {
     MATH(SFPU_TWO_PARAM_KERNEL_ONE_RUNTIME(add_int, APPROX, 8, idst, (int)VectorMode::RC, dst_offset));
+}
+
+ALWI void sfpu_add_int(uint32_t idst_in, uint32_t idst_out, uint32_t dst_offset, int32_t iterations = 8) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::add_int<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC, dst_offset)));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/softplus.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/softplus.h
@@ -41,11 +41,14 @@ ALWI void softplus_tile_pack(uint32_t idst, uint32_t beta, uint32_t beta_recipro
 
 ALWI void softplus_tile(
     uint32_t idst_in, uint32_t idst_out, uint32_t beta, uint32_t beta_reciprocal, uint32_t threshold) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_softplus<APPROX, DST_ACCUM_MODE>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_softplus,
+        (APPROX, DST_ACCUM_MODE),
+        RC,
         idst_in,
         idst_out,
-        (int)VectorMode::RC,
         beta,
         beta_reciprocal,
         threshold)));

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/softplus.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/softplus.h
@@ -39,6 +39,18 @@ ALWI void softplus_tile_pack(uint32_t idst, uint32_t beta, uint32_t beta_recipro
         calculate_softplus, RC, APPROX, DST_ACCUM_MODE, idst, beta, beta_reciprocal, threshold));
 }
 
+ALWI void softplus_tile(
+    uint32_t idst_in, uint32_t idst_out, uint32_t beta, uint32_t beta_reciprocal, uint32_t threshold) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_softplus<APPROX, DST_ACCUM_MODE>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC,
+        beta,
+        beta_reciprocal,
+        threshold)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/sqrt.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/sqrt.h
@@ -40,11 +40,14 @@ ALWI void sqrt_tile(uint32_t idst) {
 
 template <bool FAST_APPROX = false>
 ALWI void sqrt_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_sqrt<APPROX, 8, DST_ACCUM_MODE, FAST_APPROX>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_sqrt,
+        (APPROX, 8, DST_ACCUM_MODE, FAST_APPROX),
+        RC,
         idst_in,
-        idst_out,
-        (int)VectorMode::RC)));
+        idst_out)));
 }
 
 #endif

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/sqrt.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/sqrt.h
@@ -38,6 +38,15 @@ ALWI void sqrt_tile(uint32_t idst) {
     MATH(SFPU_FOUR_PARAM_KERNEL_ITER_FIRST_FN(calculate_sqrt, APPROX, 8, DST_ACCUM_MODE, FAST_APPROX, idst, RC));
 }
 
+template <bool FAST_APPROX = false>
+ALWI void sqrt_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_sqrt<APPROX, 8, DST_ACCUM_MODE, FAST_APPROX>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC)));
+}
+
 #endif
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/tanh_derivative.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/tanh_derivative.h
@@ -44,4 +44,13 @@ ALWI void tanh_derivative_tile(uint32_t idst) {
         calculate_tanh_derivative_sech2, fast_and_approx, DST_ACCUM_MODE, idst, (int)VectorMode::RC));
 }
 
+template <bool fast_and_approx = false>
+ALWI void tanh_derivative_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_tanh_derivative_sech2<fast_and_approx, DST_ACCUM_MODE>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC)));
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/tanh_derivative.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/tanh_derivative.h
@@ -46,11 +46,14 @@ ALWI void tanh_derivative_tile(uint32_t idst) {
 
 template <bool fast_and_approx = false>
 ALWI void tanh_derivative_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_tanh_derivative_sech2<fast_and_approx, DST_ACCUM_MODE>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_tanh_derivative_sech2,
+        (fast_and_approx, DST_ACCUM_MODE),
+        RC,
         idst_in,
-        idst_out,
-        (int)VectorMode::RC)));
+        idst_out)));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/threshold.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/threshold.h
@@ -30,6 +30,10 @@ ALWI void threshold_tile(uint32_t idst, uint32_t param0, uint32_t param1) {
     MATH((llk_math_eltwise_unary_sfpu_threshold<APPROX>(idst, param0, param1)));
 }
 
+ALWI void threshold_tile(uint32_t idst_in, uint32_t idst_out, uint32_t param0, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_threshold<APPROX>(idst_in, idst_out, param0, param1)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
@@ -35,6 +35,11 @@ ALWI void sin_tile(uint32_t idst) {
     MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_sine, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
 }
 
+ALWI void sin_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_sine<APPROX, DST_ACCUM_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -56,6 +61,11 @@ ALWI void cos_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(cosine, ckernel::sfpu::co
 // clang-format on
 ALWI void cos_tile(uint32_t idst) {
     MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_cosine, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+}
+
+ALWI void cos_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_cosine<APPROX, DST_ACCUM_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 /**
@@ -81,6 +91,11 @@ ALWI void acosh_tile(uint32_t idst) {
     MATH(SFPU_TWO_PARAM_KERNEL(_calculate_acosh_, APPROX, 8, idst, (int)VectorMode::RC));
 }
 
+ALWI void acosh_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_acosh_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -102,6 +117,11 @@ ALWI void tan_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(tan, ckernel::sfpu::tange
 // clang-format on
 ALWI void tan_tile(uint32_t idst) {
     MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_tangent, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+}
+
+ALWI void tan_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_tangent<APPROX, DST_ACCUM_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 /**
@@ -127,6 +147,11 @@ ALWI void asinh_tile(uint32_t idst) {
     MATH(SFPU_TWO_PARAM_KERNEL(_calculate_asinh_, APPROX, 8, idst, (int)VectorMode::RC));
 }
 
+ALWI void asinh_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_asinh_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -147,8 +172,12 @@ ALWI void atanh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(atanh, ckernel::sfpu::_
  */
 // clang-format on
 ALWI void atanh_tile(uint32_t idst) {
-    MATH(
-        SFPU_THREE_PARAM_KERNEL_FP32_FIRST(_calculate_atanh_, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(_calculate_atanh_, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+}
+
+ALWI void atanh_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::_calculate_atanh_<APPROX, DST_ACCUM_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 // clang-format off
@@ -167,6 +196,11 @@ ALWI void atanh_tile(uint32_t idst) {
 // clang-format on
 ALWI void asin_tile(uint32_t idst) {
     MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_asin, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+}
+
+ALWI void asin_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_asin<APPROX, DST_ACCUM_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 /**
@@ -192,6 +226,11 @@ ALWI void atan_tile(uint32_t idst) {
     MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_atan, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
 }
 
+ALWI void atan_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_atan<APPROX, DST_ACCUM_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -215,14 +254,19 @@ ALWI void acos_tile(uint32_t idst) {
     MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_acos, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
 }
 
+ALWI void acos_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_acos<APPROX, DST_ACCUM_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
 ALWI void acos_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(acos, true)); }
 
 /**
-* Please refer to documentation for any_init.
-*/
+ * Please refer to documentation for any_init.
+ */
 ALWI void cosh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(cosh, ckernel::sfpu::init_hyperbolic_trig, APPROX)); }
 
 // clang-format off
@@ -240,8 +284,12 @@ ALWI void cosh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(cosh, ckernel::sfpu::ini
  */
 // clang-format on
 ALWI void cosh_tile(uint32_t idst) {
-    MATH(
-        SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_cosh, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_cosh, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+}
+
+ALWI void cosh_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_cosh<APPROX, DST_ACCUM_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 /**
@@ -264,8 +312,12 @@ ALWI void sinh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(sinh, ckernel::sfpu::ini
  */
 // clang-format on
 ALWI void sinh_tile(uint32_t idst) {
-    MATH(
-        SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_sinh, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_sinh, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+}
+
+ALWI void sinh_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_sinh<APPROX, DST_ACCUM_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
@@ -36,8 +36,8 @@ ALWI void sin_tile(uint32_t idst) {
 }
 
 ALWI void sin_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_sine<APPROX, DST_ACCUM_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_sine, (APPROX, DST_ACCUM_MODE, 8), RC, idst_in, idst_out)));
 }
 
 /**
@@ -64,8 +64,8 @@ ALWI void cos_tile(uint32_t idst) {
 }
 
 ALWI void cos_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_cosine<APPROX, DST_ACCUM_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_cosine, (APPROX, DST_ACCUM_MODE, 8), RC, idst_in, idst_out)));
 }
 
 /**
@@ -92,8 +92,7 @@ ALWI void acosh_tile(uint32_t idst) {
 }
 
 ALWI void acosh_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_acosh_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_acosh_, (APPROX, 8), RC, idst_in, idst_out)));
 }
 
 /**
@@ -120,8 +119,8 @@ ALWI void tan_tile(uint32_t idst) {
 }
 
 ALWI void tan_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_tangent<APPROX, DST_ACCUM_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_tangent, (APPROX, DST_ACCUM_MODE, 8), RC, idst_in, idst_out)));
 }
 
 /**
@@ -148,8 +147,7 @@ ALWI void asinh_tile(uint32_t idst) {
 }
 
 ALWI void asinh_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_asinh_<APPROX, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_asinh_, (APPROX, 8), RC, idst_in, idst_out)));
 }
 
 /**
@@ -176,8 +174,8 @@ ALWI void atanh_tile(uint32_t idst) {
 }
 
 ALWI void atanh_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::_calculate_atanh_<APPROX, DST_ACCUM_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_atanh_, (APPROX, DST_ACCUM_MODE, 8), RC, idst_in, idst_out)));
 }
 
 // clang-format off
@@ -199,8 +197,8 @@ ALWI void asin_tile(uint32_t idst) {
 }
 
 ALWI void asin_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_asin<APPROX, DST_ACCUM_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_asin, (APPROX, DST_ACCUM_MODE, 8), RC, idst_in, idst_out)));
 }
 
 /**
@@ -227,8 +225,8 @@ ALWI void atan_tile(uint32_t idst) {
 }
 
 ALWI void atan_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_atan<APPROX, DST_ACCUM_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_atan, (APPROX, DST_ACCUM_MODE, 8), RC, idst_in, idst_out)));
 }
 
 /**
@@ -255,8 +253,8 @@ ALWI void acos_tile(uint32_t idst) {
 }
 
 ALWI void acos_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_acos<APPROX, DST_ACCUM_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_acos, (APPROX, DST_ACCUM_MODE, 8), RC, idst_in, idst_out)));
 }
 
 /**
@@ -288,8 +286,8 @@ ALWI void cosh_tile(uint32_t idst) {
 }
 
 ALWI void cosh_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_cosh<APPROX, DST_ACCUM_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_cosh, (APPROX, DST_ACCUM_MODE, 8), RC, idst_in, idst_out)));
 }
 
 /**
@@ -316,8 +314,8 @@ ALWI void sinh_tile(uint32_t idst) {
 }
 
 ALWI void sinh_tile(uint32_t idst_in, uint32_t idst_out) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_sinh<APPROX, DST_ACCUM_MODE, 8>, idst_in, idst_out, (int)VectorMode::RC)));
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_sinh, (APPROX, DST_ACCUM_MODE, 8), RC, idst_in, idst_out)));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/typecast.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/typecast.h
@@ -57,6 +57,11 @@ ALWI void typecast_tile(uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_typecast<APPROX, IN_DTYPE, OUT_DTYPE>(idst)));
 }
 
+template <uint32_t IN_DTYPE, uint32_t OUT_DTYPE>
+ALWI void typecast_tile(uint32_t idst_in, uint32_t idst_out) {
+    MATH((llk_math_eltwise_unary_sfpu_typecast<APPROX, IN_DTYPE, OUT_DTYPE>(idst_in, idst_out)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/xielu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/xielu.h
@@ -34,11 +34,14 @@ ALWI void xielu_tile(uint32_t idst, uint32_t alpha_p, uint32_t alpha_n) {
 }
 
 ALWI void xielu_tile(uint32_t idst_in, uint32_t idst_out, uint32_t alpha_p, uint32_t alpha_n) {
-    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
-        ckernel::sfpu::calculate_xielu<APPROX, DST_ACCUM_MODE>,
+    MATH((SFPU_CALL_MODE_SPLIT(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_xielu,
+        (APPROX, DST_ACCUM_MODE),
+        RC,
         idst_in,
         idst_out,
-        (int)VectorMode::RC,
         alpha_p,
         alpha_n)));
 }

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/xielu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/xielu.h
@@ -33,6 +33,16 @@ ALWI void xielu_tile(uint32_t idst, uint32_t alpha_p, uint32_t alpha_n) {
         calculate_xielu, RC, APPROX, DST_ACCUM_MODE, idst, alpha_p, alpha_n));
 }
 
+ALWI void xielu_tile(uint32_t idst_in, uint32_t idst_out, uint32_t alpha_p, uint32_t alpha_n) {
+    MATH((_llk_math_eltwise_unary_sfpu_params_split_(
+        ckernel::sfpu::calculate_xielu<APPROX, DST_ACCUM_MODE>,
+        idst_in,
+        idst_out,
+        (int)VectorMode::RC,
+        alpha_p,
+        alpha_n)));
+}
+
 ALWI void xielu_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(xielu, sfpu::xielu_init, APPROX)); }
 
 }  // namespace ckernel

--- a/tt_metal/programming_examples/custom_sfpi_smoothstep/kernels/compute/tiles_smoothstep.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_smoothstep/kernels/compute/tiles_smoothstep.cpp
@@ -27,16 +27,18 @@
  *
  * This function only processes ONE FACE of a tile. The wrapper will call it for each face.
  */
-inline void smoothstep_tile_face(float edge0, float edge1, float inv_delta) {
+inline void smoothstep_tile_face(
+    uint32_t dst_index_in, uint32_t dst_index_out, float edge0, float edge1, float inv_delta) {
     constexpr size_t vectors_per_face = 8;
+    constexpr uint32_t SFP_DST_TILE_ROWS = 32;
     for (size_t i = 0; i < vectors_per_face; i++) {
-        vFloat x = dst_reg[i];
+        vFloat x = dst_reg[dst_index_in * SFP_DST_TILE_ROWS + i];
         vFloat t = (x - edge0) * inv_delta;
         v_if(t < sfpi::vConst0) { t = sfpi::vConst0; }
         v_elseif(t > sfpi::vConst1) { t = sfpi::vConst1; }
         v_endif;
         vFloat result = t * t * (3.0f - 2.0f * t);
-        dst_reg[i] = result;
+        dst_reg[dst_index_out * SFP_DST_TILE_ROWS + i] = result;
     }
 }
 #endif

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -280,13 +280,15 @@ void call_unary_sfpu_operation(
     }
     else if constexpr (OPERATION == SfpuType::hardsigmoid)
     {
-        // Zero-arg _calculate_activation_ vs param overload — cast so Callable deduces.
+        // Two-arg _calculate_activation_ (dst_index_in, dst_index_out) vs param overload —
+        // cast so Callable deduces. The single-idx params path passes (dst_index, dst_index)
+        // for both slots.
         SFPU_CALL_CAST(
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             _calculate_activation_,
             (APPROX_MODE, ckernel::ActivationType::Hardsigmoid, ITERATIONS),
-            (void (*)()),
+            (void (*)(std::uint32_t, std::uint32_t)),
             dst_index,
             vector_mode);
     }
@@ -413,6 +415,316 @@ void call_unary_sfpu_operation(
     else
     {
         LLK_ASSERT(false, "Unsupported operation");
+    }
+}
+
+/**
+ * Split-dest variant of call_unary_sfpu_operation: reads from dst_index_in,
+ * writes to dst_index_out. Delegates to SFPU_CALL_SPLIT / SFPU_CALL_MODE_SPLIT
+ * / SFPU_CALL_CAST_SPLIT from llk_math_eltwise_unary_sfpu_macros.h, which
+ * funnel through the split overload of ckernel::_sfpu_check_and_call_.
+ *
+ * For ops whose underlying calculate function does not accept separate in/out
+ * indices (TopK family — they reduce in place across DST), this falls back to
+ * the legacy single-idx path using dst_index_in.
+ */
+template <
+    DstSync DST_SYNC_MODE,
+    bool DST_ACCUM_MODE,
+    SfpuType OPERATION,
+    bool APPROX_MODE,
+    bool is_fp32_dest_acc_en,
+    int ITERATIONS,
+    bool FAST_MODE      = false,
+    bool STABLE_SORT    = false,
+    bool CLAMP_NEGATIVE = false>
+void call_unary_sfpu_operation_split(
+    std::uint32_t dst_index_in,
+    std::uint32_t dst_index_out,
+    std::uint32_t math_format = 0,
+    float fill_const_value    = 5.0f,
+    int vector_mode           = static_cast<int>(VectorMode::None))
+{
+    if constexpr (OPERATION == SfpuType::abs)
+    {
+        SFPU_CALL_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_abs_, (APPROX_MODE, ITERATIONS), dst_index_in, dst_index_out, vector_mode, ITERATIONS);
+    }
+    else if constexpr (OPERATION == SfpuType::acosh)
+    {
+        SFPU_CALL_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_acosh_, (APPROX_MODE, ITERATIONS), dst_index_in, dst_index_out, vector_mode);
+    }
+    else if constexpr (OPERATION == SfpuType::asinh)
+    {
+        SFPU_CALL_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_asinh_, (APPROX_MODE, ITERATIONS), dst_index_in, dst_index_out, vector_mode);
+    }
+    else if constexpr (OPERATION == SfpuType::atanh)
+    {
+        SFPU_CALL_SPLIT(
+            DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_atanh_, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index_in, dst_index_out, vector_mode);
+    }
+    else if constexpr (OPERATION == SfpuType::celu)
+    {
+        SFPU_CALL_SPLIT(
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            _calculate_celu_,
+            (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS),
+            dst_index_in,
+            dst_index_out,
+            vector_mode,
+            0x3f800000u /* alpha = 1.0f */,
+            0x3f800000u /* 1/alpha = 1.0f */);
+    }
+    else if constexpr (OPERATION == SfpuType::cosine)
+    {
+        SFPU_CALL_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_cosine_, (APPROX_MODE, ITERATIONS), dst_index_in, dst_index_out, vector_mode, ITERATIONS);
+    }
+    else if constexpr (OPERATION == SfpuType::elu)
+    {
+        SFPU_CALL_SPLIT(
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            _calculate_elu_,
+            (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS),
+            dst_index_in,
+            dst_index_out,
+            vector_mode,
+            0x3f800000u /* alpha = 1.0f */);
+    }
+    else if constexpr (OPERATION == SfpuType::exp2)
+    {
+        SFPU_CALL_SPLIT(
+            DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_exp2_, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index_in, dst_index_out, vector_mode);
+    }
+    else if constexpr (OPERATION == SfpuType::exponential && APPROX_MODE && CLAMP_NEGATIVE)
+    {
+        SFPU_CALL_MODE_SPLIT(
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            _calculate_exponential_,
+            (APPROX_MODE, false /* scale_en */, 8, CLAMP_NEGATIVE),
+            RC,
+            dst_index_in,
+            dst_index_out,
+            p_sfpu::kCONST_1_FP16B /* exp_base_scale_factor */);
+    }
+    else if constexpr (OPERATION == SfpuType::exponential)
+    {
+        SFPU_CALL_SPLIT(
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            _calculate_exponential_,
+            (APPROX_MODE, false /* scale_en */, ITERATIONS, CLAMP_NEGATIVE),
+            dst_index_in,
+            dst_index_out,
+            vector_mode,
+            p_sfpu::kCONST_1_FP16B /* exp_base_scale_factor */);
+    }
+    else if constexpr (OPERATION == SfpuType::fill)
+    {
+        if (math_format == ckernel::to_underlying(DataFormat::Int32))
+        {
+            SFPU_CALL_SPLIT(
+                DST_SYNC_MODE,
+                DST_ACCUM_MODE,
+                _calculate_fill_int_,
+                (APPROX_MODE, ckernel::InstrModLoadStore::INT32, ITERATIONS),
+                dst_index_in,
+                dst_index_out,
+                vector_mode,
+                static_cast<std::uint32_t>(fill_const_value));
+        }
+        else if (math_format == ckernel::to_underlying(DataFormat::UInt16))
+        {
+            SFPU_CALL_SPLIT(
+                DST_SYNC_MODE,
+                DST_ACCUM_MODE,
+                _calculate_fill_int_,
+                (APPROX_MODE, ckernel::InstrModLoadStore::LO16, ITERATIONS),
+                dst_index_in,
+                dst_index_out,
+                vector_mode,
+                static_cast<std::uint32_t>(fill_const_value));
+        }
+        else if (math_format == ckernel::to_underlying(DataFormat::UInt32))
+        {
+            SFPU_CALL_SPLIT(
+                DST_SYNC_MODE,
+                DST_ACCUM_MODE,
+                _calculate_fill_int_,
+                (APPROX_MODE, ckernel::InstrModLoadStore::INT32, ITERATIONS),
+                dst_index_in,
+                dst_index_out,
+                vector_mode,
+                static_cast<std::uint32_t>(fill_const_value));
+        }
+        else
+        {
+            SFPU_CALL_SPLIT(
+                DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_fill_, (APPROX_MODE, ITERATIONS), dst_index_in, dst_index_out, vector_mode, fill_const_value);
+        }
+    }
+    else if constexpr (OPERATION == SfpuType::gelu)
+    {
+        SFPU_CALL_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_gelu_, (APPROX_MODE, ITERATIONS), dst_index_in, dst_index_out, vector_mode);
+    }
+    else if constexpr (OPERATION == SfpuType::hardsigmoid)
+    {
+        SFPU_CALL_CAST_SPLIT(
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            _calculate_activation_,
+            (APPROX_MODE, ckernel::ActivationType::Hardsigmoid, ITERATIONS),
+            (void (*)(std::uint32_t, std::uint32_t)),
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    }
+    else if constexpr (OPERATION == SfpuType::log)
+    {
+        SFPU_CALL_SPLIT(
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            _calculate_log_,
+            (APPROX_MODE, false, ITERATIONS),
+            dst_index_in,
+            dst_index_out,
+            vector_mode,
+            ITERATIONS,
+            0u /* log_base_scale_factor */);
+    }
+    else if constexpr (OPERATION == SfpuType::log1p)
+    {
+        SFPU_CALL_SPLIT(
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            calculate_log1p,
+            (APPROX_MODE, FAST_MODE, is_fp32_dest_acc_en, ITERATIONS),
+            dst_index_in,
+            dst_index_out,
+            vector_mode);
+    }
+    else if constexpr (OPERATION == SfpuType::negative)
+    {
+        if (math_format == ckernel::to_underlying(DataFormat::Int32))
+        {
+            SFPU_CALL_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_negative_int_, (APPROX_MODE, ITERATIONS), dst_index_in, dst_index_out, vector_mode);
+        }
+        else
+        {
+            SFPU_CALL_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_negative_, (APPROX_MODE, ITERATIONS), dst_index_in, dst_index_out, vector_mode);
+        }
+    }
+    else if constexpr (OPERATION == SfpuType::reciprocal)
+    {
+        SFPU_CALL_SPLIT(
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            _calculate_reciprocal_,
+            (APPROX_MODE, ITERATIONS, is_fp32_dest_acc_en),
+            dst_index_in,
+            dst_index_out,
+            vector_mode,
+            ITERATIONS);
+    }
+    else if constexpr (OPERATION == SfpuType::rsqrt)
+    {
+        SFPU_CALL_SPLIT(
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            _calculate_rsqrt_,
+            (APPROX_MODE, ITERATIONS, is_fp32_dest_acc_en, FAST_MODE),
+            dst_index_in,
+            dst_index_out,
+            vector_mode,
+            ITERATIONS);
+    }
+    else if constexpr (OPERATION == SfpuType::silu)
+    {
+        SFPU_CALL_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_silu_, (APPROX_MODE, ITERATIONS), dst_index_in, dst_index_out, vector_mode);
+    }
+    else if constexpr (OPERATION == SfpuType::sine)
+    {
+        SFPU_CALL_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_sine_, (APPROX_MODE, ITERATIONS), dst_index_in, dst_index_out, vector_mode, ITERATIONS);
+    }
+    else if constexpr (OPERATION == SfpuType::sqrt)
+    {
+        SFPU_CALL_SPLIT(
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            _calculate_sqrt_,
+            (APPROX_MODE, ITERATIONS, is_fp32_dest_acc_en, FAST_MODE),
+            dst_index_in,
+            dst_index_out,
+            vector_mode,
+            ITERATIONS);
+    }
+    else if constexpr (OPERATION == SfpuType::square)
+    {
+        SFPU_CALL_SPLIT(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_square_, (APPROX_MODE, ITERATIONS), dst_index_in, dst_index_out, vector_mode);
+    }
+    else if constexpr (OPERATION == SfpuType::tanh)
+    {
+        SFPU_CALL_SPLIT(
+            DST_SYNC_MODE, DST_ACCUM_MODE, calculate_tanh, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index_in, dst_index_out, vector_mode);
+    }
+    else if constexpr (OPERATION == SfpuType::threshold)
+    {
+        SFPU_CALL_SPLIT(
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            _calculate_threshold_,
+            (APPROX_MODE, ITERATIONS, float),
+            dst_index_in,
+            dst_index_out,
+            vector_mode,
+            5.0f /* threshold_value */,
+            10.0f /* replacement_value */);
+    }
+    else if constexpr (OPERATION == SfpuType::topk_local_sort || OPERATION == SfpuType::topk_merge || OPERATION == SfpuType::topk_rebuild)
+    {
+        // TopK reduces in place across DST; there is no semantically meaningful
+        // (in, out) split, so we exercise the existing single-idx legacy path
+        // anchored at dst_index_in. dst_index_out is ignored for these ops.
+        (void)dst_index_out;
+        call_unary_sfpu_operation<
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            OPERATION,
+            APPROX_MODE,
+            is_fp32_dest_acc_en,
+            ITERATIONS,
+            FAST_MODE,
+            STABLE_SORT,
+            CLAMP_NEGATIVE>(dst_index_in, math_format, fill_const_value, vector_mode);
+    }
+    else if constexpr (OPERATION == SfpuType::relu_max)
+    {
+        SFPU_CALL_SPLIT(
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            _relu_max_,
+            (sfpi::vFloat, APPROX_MODE, ITERATIONS, float),
+            dst_index_in,
+            dst_index_out,
+            vector_mode,
+            5.0f /* threshold */);
+    }
+    else if constexpr (OPERATION == SfpuType::relu_min)
+    {
+        SFPU_CALL_SPLIT(
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            _relu_min_,
+            (sfpi::vFloat, APPROX_MODE, ITERATIONS, float),
+            dst_index_in,
+            dst_index_out,
+            vector_mode,
+            5.0f /* threshold */);
+    }
+    else
+    {
+        LLK_ASSERT(false, "Unsupported operation for split-dest path");
     }
 }
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -489,6 +489,22 @@ class SFPU_TILE_INDICES(RuntimeParameter):
 
 
 @dataclass
+class DST_INDEX_IN(TemplateParameter):
+    dst_index_in: int = 0
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr int DST_INDEX_IN = {self.dst_index_in};"
+
+
+@dataclass
+class DST_INDEX_OUT(TemplateParameter):
+    dst_index_out: int = 0
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr int DST_INDEX_OUT = {self.dst_index_out};"
+
+
+@dataclass
 class L1_ACC(RuntimeParameter):
     l1_acc: L1Accumulation = L1Accumulation.No
 

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu_separate_tiles.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu_separate_tiles.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from helpers.format_config import DataFormat, InputOutputFormat
+from helpers.golden_generators import (
+    UnarySFPUGolden,
+    get_golden_generator,
+)
+from helpers.llk_params import (
+    ApproximationMode,
+    DestAccumulation,
+    FastMode,
+    MathOperation,
+    format_dict,
+)
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    APPROX_MODE,
+    CLAMP_NEGATIVE,
+    DST_INDEX_IN,
+    DST_INDEX_OUT,
+    FAST_MODE,
+    MATH_OP,
+    NUM_BLOCKS,
+    NUM_TILES_IN_BLOCK,
+    TILE_COUNT,
+    generate_input_dim,
+)
+from helpers.utils import passed_test
+
+# Representative ops covering different write patterns:
+# - SFPI dst_reg writes: abs, square, gelu, silu
+# - TT_SFPSTORE writes (metal layer): handled via abs, square
+SEPARATE_TILE_OPS = [
+    MathOperation.Abs,
+    MathOperation.Square,
+    MathOperation.Gelu,
+    MathOperation.Silu,
+    MathOperation.Neg,
+]
+
+# Tile index pairs: (dst_index_in, dst_index_out)
+# With SyncHalf and dest_acc=No, max tiles = 8 (indices 0-7)
+# NOTE: dst_out must be >= dst_in because the offset (out - in) * 32 is computed
+# as unsigned and used as a store immediate. Negative offsets underflow and are
+# rejected by the compiler (out of sfpstore immediate range).
+TILE_INDEX_PAIRS = [
+    (0, 0),  # baseline: in-place (should match existing tests)
+    (0, 1),  # write to next tile slot
+    (0, 2),  # larger offset
+    (1, 2),  # both non-zero, offset=1
+]
+
+
+@pytest.mark.parametrize("mathop", SEPARATE_TILE_OPS)
+@pytest.mark.parametrize("dst_in,dst_out", TILE_INDEX_PAIRS)
+def test_sfpu_separate_tiles(
+    mathop: MathOperation,
+    dst_in: int,
+    dst_out: int,
+):
+    torch.manual_seed(0)
+    torch.set_printoptions(precision=10)
+
+    input_dimensions = [32, 32]  # single tile
+    formats = InputOutputFormat(DataFormat.Float16_b, DataFormat.Float16_b)
+    dest_acc = DestAccumulation.No
+    approx_mode = ApproximationMode.No
+
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+    )
+
+    generate_golden = get_golden_generator(UnarySFPUGolden)
+    golden_tensor = generate_golden(
+        mathop,
+        src_A,
+        formats.output_format,
+        dest_acc,
+        formats.input_format,
+        input_dimensions,
+    )
+
+    num_blocks = tile_cnt_A
+    num_tiles_in_block = 1  # process one tile per block for separate-tiles test
+
+    configuration = TestConfig(
+        "sources/eltwise_unary_sfpu_separate_tiles_test.cpp",
+        formats,
+        templates=[
+            generate_input_dim(input_dimensions, input_dimensions),
+            APPROX_MODE(approx_mode),
+            FAST_MODE(FastMode.No),
+            CLAMP_NEGATIVE(True),
+            MATH_OP(mathop=mathop),
+            DST_INDEX_IN(dst_in),
+            DST_INDEX_OUT(dst_out),
+        ],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_BLOCKS(num_blocks),
+            NUM_TILES_IN_BLOCK(num_tiles_in_block),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_B,
+            tile_count_res=tile_cnt_A,
+        ),
+        dest_acc=dest_acc,
+        unpack_to_dest=False,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    torch_format = format_dict[formats.output_format]
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+
+    assert passed_test(
+        golden_tensor, res_tensor, formats.output_format
+    ), f"Separate-tiles test failed for {mathop} with dst_in={dst_in}, dst_out={dst_out}"
+
+
+# Test that exp in accurate mode (non-SFPLOADMACRO) works with separate tiles
+@pytest.mark.parametrize("dst_in,dst_out", [(0, 1), (1, 2)])
+def test_sfpu_separate_tiles_exp_accurate(dst_in: int, dst_out: int):
+    torch.manual_seed(0)
+    input_dimensions = [32, 32]
+    formats = InputOutputFormat(DataFormat.Float16_b, DataFormat.Float16_b)
+    dest_acc = DestAccumulation.No
+
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+    )
+
+    generate_golden = get_golden_generator(UnarySFPUGolden)
+    golden_tensor = generate_golden(
+        MathOperation.Exp,
+        src_A,
+        formats.output_format,
+        dest_acc,
+        formats.input_format,
+        input_dimensions,
+    )
+
+    num_blocks = tile_cnt_A
+    num_tiles_in_block = 1
+
+    configuration = TestConfig(
+        "sources/eltwise_unary_sfpu_separate_tiles_test.cpp",
+        formats,
+        templates=[
+            generate_input_dim(input_dimensions, input_dimensions),
+            APPROX_MODE(ApproximationMode.No),  # accurate mode = no SFPLOADMACRO
+            FAST_MODE(FastMode.No),
+            CLAMP_NEGATIVE(True),
+            MATH_OP(mathop=MathOperation.Exp),
+            DST_INDEX_IN(dst_in),
+            DST_INDEX_OUT(dst_out),
+        ],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_BLOCKS(num_blocks),
+            NUM_TILES_IN_BLOCK(num_tiles_in_block),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_B,
+            tile_count_res=tile_cnt_A,
+        ),
+        dest_acc=dest_acc,
+        unpack_to_dest=False,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(golden_tensor)
+
+    torch_format = format_dict[formats.output_format]
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+
+    assert passed_test(
+        golden_tensor, res_tensor, formats.output_format
+    ), f"Exp accurate separate-tiles test failed with dst_in={dst_in}, dst_out={dst_out}"

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_separate_tiles_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_separate_tiles_test.cpp
@@ -118,9 +118,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, false /* untilize */, false /* tilize */>(
-        formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);
-    _llk_pack_init_wrapper_<false /* untilize */, false /* zero_output */>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, TILE_NUM_FACES);
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, TILE_NUM_FACES);
     _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en>();
 
     for (int block = 0; block < params.NUM_BLOCKS; block++)
@@ -128,7 +127,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_packer_wait_for_math_done_();
 
         // Pack from DST_INDEX_OUT — the SFPU wrote its result here
-        _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, /* untilize */ false>(DST_INDEX_OUT, L1_ADDRESS(params.buffer_Res[block]));
+        _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, PackMode::Default>(DST_INDEX_OUT, L1_ADDRESS(params.buffer_Res[block]));
 
         _llk_pack_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
     }

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_separate_tiles_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_separate_tiles_test.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <type_traits>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "llk_defs.h"
+#include "params.h"
+
+// Globals
+std::uint32_t unp_cfg_context              = 0;
+std::uint32_t pack_sync_tile_dst_ptr       = 0;
+std::uint32_t math_sync_tile_dst_index     = 0;
+static constexpr ckernel::DstSync DST_SYNC = ckernel::DstSync::SyncHalf;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_unpack_A.h"
+#include "llk_unpack_common.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, TILE_NUM_FACES, TILE_NUM_FACES);
+
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+        0, 0, FACE_R_DIM, TILE_NUM_FACES, formats.unpack_A_src, formats.unpack_A_dst);
+
+    for (int i = 0; i < params.NUM_BLOCKS; ++i)
+    {
+        _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+            L1_ADDRESS(params.buffer_A[i]), formats.unpack_A_src, formats.unpack_A_dst);
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "ckernel_sfpu.h"
+#include "llk_lib_math_wrappers.h"
+#include "llk_math_eltwise_unary_sfpu.h"
+#include "sfpu_operations.h"
+
+using namespace ckernel;
+using namespace ckernel::sfpu;
+
+const int iterations = 32;
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    // copy srca to dest — use the cross-arch wrapper (same as eltwise_unary_sfpu_test.cpp)
+    _llk_math_eltwise_unary_datacopy_init_wrapper_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false /* is_int_fpu_en */, PackMode::Default>(
+        TILE_NUM_FACES, formats.math);
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
+    _llk_math_pack_sync_init_<DST_SYNC, is_fp32_dest_acc_en>();
+
+    test_utils::call_unary_sfpu_operation_init<
+        SFPU_UNARY_OPERATION,
+        APPROX_MODE,
+        is_fp32_dest_acc_en,
+        iterations,
+        FAST_MODE,
+        false /* STABLE_SORT */,
+        CLAMP_NEGATIVE>();
+
+    LLK_ASSERT((DST_INDEX_IN < get_dest_max_tiles<DST_SYNC, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "DST_INDEX_IN exceeds max dest tiles");
+    LLK_ASSERT((DST_INDEX_OUT < get_dest_max_tiles<DST_SYNC, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "DST_INDEX_OUT exceeds max dest tiles");
+
+    for (int block = 0; block < params.NUM_BLOCKS; block++)
+    {
+        _llk_math_wait_for_dest_available_<DST_SYNC>();
+
+        // Data-copy input tile into DEST at position DST_INDEX_IN
+        _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DST_SYNC, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+            DST_INDEX_IN, formats.math, formats.math);
+
+        // Run SFPU: read from DST_INDEX_IN, write to DST_INDEX_OUT. The split
+        // helper routes through ckernel::_sfpu_check_and_call_<DST_SYNC, DST_ACCUM>
+        // (dst-bound LLK_ASSERT) and then _llk_math_eltwise_unary_sfpu_params_split_,
+        // which calls the op's calculate function with
+        // (dst_index_in, dst_index_out, args...).
+        test_utils::call_unary_sfpu_operation_split<
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            SFPU_UNARY_OPERATION,
+            APPROX_MODE,
+            is_fp32_dest_acc_en,
+            iterations,
+            FAST_MODE,
+            false /* STABLE_SORT */,
+            CLAMP_NEGATIVE>(DST_INDEX_IN, DST_INDEX_OUT, formats.math);
+
+        _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_lib_pack_wrappers.h"
+#include "llk_pack_common.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, false /* untilize */, false /* tilize */>(
+        formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);
+    _llk_pack_init_wrapper_<false /* untilize */, false /* zero_output */>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, TILE_NUM_FACES);
+    _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en>();
+
+    for (int block = 0; block < params.NUM_BLOCKS; block++)
+    {
+        _llk_packer_wait_for_math_done_();
+
+        // Pack from DST_INDEX_OUT — the SFPU wrote its result here
+        _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, /* untilize */ false>(DST_INDEX_OUT, L1_ADDRESS(params.buffer_Res[block]));
+
+        _llk_pack_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+    }
+}
+
+#endif

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_abs_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_abs_quasar_test.cpp
@@ -160,7 +160,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // UNPACK-to-Dest), so it is offset by params.DST_INDEX.
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
-        _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_calculate_abs_, params.DST_INDEX + i, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_split_(ckernel::sfpu::_calculate_abs_, params.DST_INDEX + i, params.DST_INDEX + i, num_sfpu_iterations);
     }
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_nonlinear_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_nonlinear_quasar_test.cpp
@@ -103,9 +103,9 @@ struct sfpu_op_dispatcher;
 template <>
 struct sfpu_op_dispatcher<SfpuType::exponential>
 {
-    static void call(int tile_idx, int num_sfpu_iterations)
+    static void call(std::uint32_t tile_idx, int num_sfpu_iterations)
     {
-        _llk_math_eltwise_unary_sfpu_params_(_calculate_exp_<true>, tile_idx, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_split_(_calculate_exp_<true>, tile_idx, tile_idx, num_sfpu_iterations);
     }
 };
 
@@ -117,68 +117,75 @@ struct sfpu_op_dispatcher<SfpuType::gelu>
         _init_gelu_();
     }
 
-    static void call(int tile_idx, int num_sfpu_iterations)
+    static void call(std::uint32_t tile_idx, int num_sfpu_iterations)
     {
-        _llk_math_eltwise_unary_sfpu_params_(_calculate_gelu_, tile_idx, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_split_(_calculate_gelu_, tile_idx, tile_idx, num_sfpu_iterations);
     }
 };
 
 template <>
 struct sfpu_op_dispatcher<SfpuType::relu>
 {
-    static void call(int tile_idx, int num_sfpu_iterations)
+    static void call(std::uint32_t tile_idx, int num_sfpu_iterations)
     {
-        _llk_math_eltwise_unary_sfpu_params_(_calculate_relu_, tile_idx, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_split_(_calculate_relu_, tile_idx, tile_idx, num_sfpu_iterations);
     }
 };
 
 template <>
 struct sfpu_op_dispatcher<SfpuType::reciprocal>
 {
-    static void call(int tile_idx, int num_sfpu_iterations)
+    static void call(std::uint32_t tile_idx, int num_sfpu_iterations)
     {
-        _llk_math_eltwise_unary_sfpu_params_(_calculate_reciprocal_<true>, tile_idx, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_split_(_calculate_reciprocal_<true>, tile_idx, tile_idx, num_sfpu_iterations);
     }
 };
 
 template <>
 struct sfpu_op_dispatcher<SfpuType::sqrt>
 {
-    static void call(int tile_idx, int num_sfpu_iterations)
+    static void call(std::uint32_t tile_idx, int num_sfpu_iterations)
     {
-        _llk_math_eltwise_unary_sfpu_params_(_calculate_sqrt_<true>, tile_idx, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_split_(_calculate_sqrt_<true>, tile_idx, tile_idx, num_sfpu_iterations);
     }
 };
 
 template <>
 struct sfpu_op_dispatcher<SfpuType::tanh>
 {
-    static void call(int tile_idx, int num_sfpu_iterations)
+    static void call(std::uint32_t tile_idx, int num_sfpu_iterations)
     {
-        _llk_math_eltwise_unary_sfpu_params_(_calculate_tanh_<true>, tile_idx, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_split_(_calculate_tanh_<true>, tile_idx, tile_idx, num_sfpu_iterations);
     }
 };
 
 template <>
 struct sfpu_op_dispatcher<SfpuType::sigmoid>
 {
-    static void call(int tile_idx, int num_sfpu_iterations)
+    static void call(std::uint32_t tile_idx, int num_sfpu_iterations)
     {
-        _llk_math_eltwise_unary_sfpu_params_(_calculate_sigmoid_, tile_idx, num_sfpu_iterations);
+        // Wrap in lambda to disambiguate from the legacy 1-arg overload of _calculate_sigmoid_.
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            [](std::uint32_t in, std::uint32_t out, const int iterations) { _calculate_sigmoid_(in, out, iterations); },
+            tile_idx,
+            tile_idx,
+            num_sfpu_iterations);
     }
 };
 
 template <>
 struct sfpu_op_dispatcher<SfpuType::silu>
 {
-    static void call(int tile_idx, int num_sfpu_iterations)
+    static void call(std::uint32_t tile_idx, int num_sfpu_iterations)
     {
-        _llk_math_eltwise_unary_sfpu_params_(_calculate_silu_, tile_idx, num_sfpu_iterations);
+        // Wrap in lambda to disambiguate from the legacy 1-arg overload of _calculate_silu_.
+        _llk_math_eltwise_unary_sfpu_params_split_(
+            [](std::uint32_t in, std::uint32_t out, const int iterations) { _calculate_silu_(in, out, iterations); }, tile_idx, tile_idx, num_sfpu_iterations);
     }
 };
 
 // Convert constexpr SFPU_UNARY_OPERATION to template parameter using tag dispatch
-inline void call_sfpu_operation_quasar(int tile_idx, int num_sfpu_iterations)
+inline void call_sfpu_operation_quasar(std::uint32_t tile_idx, int num_sfpu_iterations)
 {
     // The compiler should optimize this to a direct call based on SFPU_UNARY_OPERATION
     constexpr SfpuType op = SFPU_UNARY_OPERATION;
@@ -267,7 +274,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Apply SFPU operation to all tiles using compile-time dispatch
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
-        call_sfpu_operation_quasar(static_cast<int>(params.DST_INDEX + i), static_cast<int>(num_sfpu_iterations));
+        call_sfpu_operation_quasar(static_cast<std::uint32_t>(params.DST_INDEX + i), static_cast<int>(num_sfpu_iterations));
     }
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_rsqrt_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_rsqrt_quasar_test.cpp
@@ -128,7 +128,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Apply SFPU rsqrt to all tiles
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
-        _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_calculate_rsqrt_, params.DST_INDEX + i, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_split_(ckernel::sfpu::_calculate_rsqrt_, params.DST_INDEX + i, params.DST_INDEX + i, num_sfpu_iterations);
     }
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_quasar_test.cpp
@@ -127,7 +127,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Apply SFPU square to all tiles
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
-        _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_calculate_square_, params.DST_INDEX + i, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_split_(ckernel::sfpu::_calculate_square_, params.DST_INDEX + i, params.DST_INDEX + i, num_sfpu_iterations);
     }
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
@@ -142,7 +142,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
-        _llk_math_eltwise_unary_sfpu_params_(_calculate_square_, params.DST_INDEX + i, num_sfpu_iterations);
+        _llk_math_eltwise_unary_sfpu_params_split_(_calculate_square_, params.DST_INDEX + i, params.DST_INDEX + i, num_sfpu_iterations);
     }
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_test.cpp
@@ -92,7 +92,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     (tile < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
                     "Block tile index exceeds maximum destination tiles");
                 _llk_math_eltwise_sfpu_start_(tile);
-                ckernel::sfpu::_calculate_reduce_<POOL_TYPE, REDUCE_DIM, static_cast<DataFormat>(formats.math)>();
+                ckernel::sfpu::_calculate_reduce_<POOL_TYPE, REDUCE_DIM, static_cast<DataFormat>(formats.math)>(tile, tile);
             }
 
             _llk_math_eltwise_sfpu_done_();
@@ -114,7 +114,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
 
         _llk_math_eltwise_sfpu_start_(0);
-        ckernel::sfpu::_calculate_reduce_<POOL_TYPE, REDUCE_DIM, static_cast<DataFormat>(formats.math)>(BLOCK_CT_DIM, BLOCK_RT_DIM);
+        ckernel::sfpu::_calculate_reduce_<POOL_TYPE, REDUCE_DIM, static_cast<DataFormat>(formats.math)>(0, 0, BLOCK_CT_DIM, BLOCK_RT_DIM);
 
 #ifdef ADD_TOP_ROW
         _llk_math_eltwise_binary_sfpu_init_<SfpuType::add_top_row>();

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_abs.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_abs.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sfpi.h"
 
 namespace ckernel
@@ -12,13 +14,13 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_abs_(const int iterations)
+inline void _calculate_abs_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat v   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::abs(v);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::abs(v);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_abs.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_abs.h
@@ -19,8 +19,8 @@ inline void _calculate_abs_(std::uint32_t dst_index_in, std::uint32_t dst_index_
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat v   = sfpi::dst_reg[0];
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::abs(v);
+        sfpi::vFloat v                                             = sfpi::dst_reg[0];
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::abs(v);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_activations.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_activations.h
@@ -70,27 +70,27 @@ inline void apply_activation(sfpi::vFloat& v)
 }
 
 template <bool APPROXIMATION_MODE, ActivationType ACTIVATION_TYPE, int ITERATIONS = 8>
-inline void _calculate_activation_(std::uint32_t param0, std::uint32_t param1)
+inline void _calculate_activation_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, std::uint32_t param0, std::uint32_t param1)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat v = sfpi::dst_reg[0];
         apply_activation<APPROXIMATION_MODE, ACTIVATION_TYPE>(v, param0, param1);
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, ActivationType ACTIVATION_TYPE, int ITERATIONS>
-inline void _calculate_activation_()
+inline void _calculate_activation_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat v = sfpi::dst_reg[0];
         apply_activation<APPROXIMATION_MODE, ACTIVATION_TYPE>(v);
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_activations.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_activations.h
@@ -77,7 +77,7 @@ inline void _calculate_activation_(std::uint32_t dst_index_in, std::uint32_t dst
     {
         sfpi::vFloat v = sfpi::dst_reg[0];
         apply_activation<APPROXIMATION_MODE, ACTIVATION_TYPE>(v, param0, param1);
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         sfpi::dst_reg++;
     }
 }
@@ -90,7 +90,7 @@ inline void _calculate_activation_(std::uint32_t dst_index_in, std::uint32_t dst
     {
         sfpi::vFloat v = sfpi::dst_reg[0];
         apply_activation<APPROXIMATION_MODE, ACTIVATION_TYPE>(v);
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -23,7 +23,7 @@ inline void _cast_fp32_to_fp16a_(std::uint32_t dst_index_in, std::uint32_t dst_i
     {
         TTI_SFPLOAD(0, 0, ADDR_MOD_7, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, 0, 0, 8);
-        TT_SFPSTORE(0, 1, ADDR_MOD_7, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(0, 1, ADDR_MOD_7, (dst_index_out - dst_index_in) * TILE_R_DIM);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_addrmod.h"
 #include "ckernel_ops.h"
 #include "sfpi.h"
@@ -14,13 +16,14 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _cast_fp32_to_fp16a_(const int iterations)
+inline void _cast_fp32_to_fp16a_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat x   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0].mode<sfpi::SFPSTORE_MOD0_FMT_FP16A>() = sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
+        TTI_SFPLOAD(0, 0, ADDR_MOD_7, 0);
+        TTI_SFP_STOCH_RND(0, 0, 0, 0, 0, 8);
+        TT_SFPSTORE(0, 1, ADDR_MOD_7, (dst_index_out - dst_index_in) * 32);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_celu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_celu.h
@@ -15,7 +15,7 @@ namespace ckernel::sfpu
 // celu(x) = x for x>=0, alpha*(exp(x/alpha)-1) for x<0
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void _calculate_celu_(std::uint32_t param0, std::uint32_t param1)
+inline void _calculate_celu_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, std::uint32_t param0, std::uint32_t param1)
 {
     sfpi::vFloat alpha       = Converter::as_float(param0);
     sfpi::vFloat alpha_recip = Converter::as_float(param1);
@@ -37,7 +37,7 @@ inline void _calculate_celu_(std::uint32_t param0, std::uint32_t param1)
         {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_celu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_celu.h
@@ -37,7 +37,7 @@ inline void _calculate_celu_(std::uint32_t dst_index_in, std::uint32_t dst_index
         {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -14,7 +14,8 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_clamp_(const int iterations, std::uint32_t param0, std::uint32_t param1, std::uint32_t param2)
+inline void _calculate_clamp_(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations, std::uint32_t param0, std::uint32_t param1, std::uint32_t param2)
 {
     // All params are in FP16 format
     // param0 = min
@@ -41,7 +42,7 @@ inline void _calculate_clamp_(const int iterations, std::uint32_t param0, std::u
         }
         v_endif;
 
-        sfpi::dst_reg[0] = val + offset;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val + offset;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -42,7 +42,7 @@ inline void _calculate_clamp_(
         }
         v_endif;
 
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val + offset;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val + offset;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_comp.h
@@ -31,7 +31,7 @@ sfpi_inline void _calculate_comp_init_flag_(bool check, sfpi::vFloat& flag1, sfp
 }
 
 template <bool APPROXIMATION_MODE, bool invert_output, bool check_zero, bool second_check, bool is_less_than_equal_zero, int ITERATIONS>
-inline void _calculate_comp_(const int iterations, std::uint32_t exponent_size_8)
+inline void _calculate_comp_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations, std::uint32_t exponent_size_8)
 {
     // output_0 and output_1 hold the outputs use use when a zero or negative check is true/false.
     // False = 0.0 = kCONST_0 (5/8-bit exponent format)
@@ -100,7 +100,7 @@ inline void _calculate_comp_(const int iterations, std::uint32_t exponent_size_8
             result = flag1;
         }
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
 
         sfpi::dst_reg++;
     }
@@ -194,13 +194,13 @@ inline void apply_zero_comp<SfpuType::less_than_equal_zero>(sfpi::vFloat& v, std
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void _calculate_zero_comp_(std::uint32_t exponent_size_8)
+inline void _calculate_zero_comp_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, std::uint32_t exponent_size_8)
 {
     for (int d = ZERO; d < ITERATIONS; d++)
     {
         sfpi::vFloat v = sfpi::dst_reg[0];
         apply_zero_comp<COMP_MODE>(v, exponent_size_8);
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
         sfpi::dst_reg++;
     }
 }
@@ -293,13 +293,13 @@ inline void apply_zero_comp_int<SfpuType::greater_than_equal_zero>(sfpi::vInt& v
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void _calculate_zero_comp_int_()
+inline void _calculate_zero_comp_int_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     for (int d = ZERO; d < ITERATIONS; d++)
     {
         sfpi::vInt v = sfpi::dst_reg[0];
         apply_zero_comp_int<COMP_MODE>(v);
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
         sfpi::dst_reg++;
     }
 }
@@ -414,7 +414,7 @@ inline void apply_unary_int_comp<SfpuType::unary_le>(sfpi::vInt& v, int scalar, 
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void _calculate_comp_unary_int_(int scalar)
+inline void _calculate_comp_unary_int_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, int scalar)
 {
 #pragma GCC unroll 8
     for (int d = ZERO; d < ITERATIONS; d++)
@@ -424,7 +424,7 @@ inline void _calculate_comp_unary_int_(int scalar)
 
         apply_unary_int_comp<COMP_MODE>(v, scalar, val);
 
-        sfpi::dst_reg[0] = val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
         sfpi::dst_reg++;
     }
 }
@@ -523,7 +523,7 @@ inline void apply_unary_float_comp<SfpuType::unary_le>(sfpi::vFloat v, sfpi::vFl
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void _calculate_comp_unary_(std::uint32_t value)
+inline void _calculate_comp_unary_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, std::uint32_t value)
 {
     const sfpi::vFloat s = value;
 
@@ -535,7 +535,7 @@ inline void _calculate_comp_unary_(std::uint32_t value)
 
         apply_unary_float_comp<COMP_MODE>(v, s, val);
 
-        sfpi::dst_reg[0] = val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_comp.h
@@ -100,7 +100,7 @@ inline void _calculate_comp_(std::uint32_t dst_index_in, std::uint32_t dst_index
             result = flag1;
         }
 
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
 
         sfpi::dst_reg++;
     }
@@ -200,7 +200,7 @@ inline void _calculate_zero_comp_(std::uint32_t dst_index_in, std::uint32_t dst_
     {
         sfpi::vFloat v = sfpi::dst_reg[0];
         apply_zero_comp<COMP_MODE>(v, exponent_size_8);
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         sfpi::dst_reg++;
     }
 }
@@ -299,7 +299,7 @@ inline void _calculate_zero_comp_int_(std::uint32_t dst_index_in, std::uint32_t 
     {
         sfpi::vInt v = sfpi::dst_reg[0];
         apply_zero_comp_int<COMP_MODE>(v);
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         sfpi::dst_reg++;
     }
 }
@@ -424,7 +424,7 @@ inline void _calculate_comp_unary_int_(std::uint32_t dst_index_in, std::uint32_t
 
         apply_unary_int_comp<COMP_MODE>(v, scalar, val);
 
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
         sfpi::dst_reg++;
     }
 }
@@ -535,7 +535,7 @@ inline void _calculate_comp_unary_(std::uint32_t dst_index_in, std::uint32_t dst
 
         apply_unary_float_comp<COMP_MODE>(v, s, val);
 
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cumsum.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_addrmod.h"
 #include "ckernel_ops.h"
 #include "sfpi.h"
@@ -14,7 +16,7 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE /*unused*/, int ITERATIONS /*unused*/>
-inline void _calculate_cumsum_(const bool first)
+inline void _calculate_cumsum_(std::uint32_t /*dst_index_in*/, std::uint32_t /*dst_index_out*/, const bool first)
 {
     if (first)
     {

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
@@ -17,7 +17,7 @@ namespace sfpu
 // probability should be between 0 - INT_MAX (signed)
 // scale should be binary representation of a float32
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_dropout_(const int iterations, std::uint32_t probability, std::uint32_t scale)
+inline void _calculate_dropout_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations, std::uint32_t probability, std::uint32_t scale)
 {
     // SFPU microcode
 
@@ -30,9 +30,9 @@ inline void _calculate_dropout_(const int iterations, std::uint32_t probability,
     {
         ////////////////////////
         // Scale samples
-        // dst_reg[0] = dst_reg[0] * sFloat16b(scale);
+        // dst_reg[(dst_index_out - dst_index_in) * 32] = dst_reg[0] * sFloat16b(scale);
         ///////////////////////
-        TTI_SFPLOAD(p_sfpu::LREG0, 0, 3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, 0, 3, 0);
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
 
         ////////////////////////
@@ -47,12 +47,12 @@ inline void _calculate_dropout_(const int iterations, std::uint32_t probability,
         ////////////////////////
         // Drop samples
         // v_if (rand < probability)
-        //   dst_reg[0] = vConst0;
+        //   dst_reg[(dst_index_out - dst_index_in) * 32] = vConst0;
         ///////////////////////
         TTI_SFPIADD(0, p_sfpu::LREG2, p_sfpu::LREG3, 10);
         TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
         TTI_SFPENCC(0, 0, 0, 0);
-        TTI_SFPSTORE(0, 0, 3, 0);
+        TT_SFPSTORE(0, 0, 3, (dst_index_out - dst_index_in) * 32);
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
@@ -30,7 +30,7 @@ inline void _calculate_dropout_(std::uint32_t dst_index_in, std::uint32_t dst_in
     {
         ////////////////////////
         // Scale samples
-        // dst_reg[(dst_index_out - dst_index_in) * 32] = dst_reg[0] * sFloat16b(scale);
+        // dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = dst_reg[0] * sFloat16b(scale);
         ///////////////////////
         TT_SFPLOAD(p_sfpu::LREG0, 0, 3, 0);
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
@@ -47,12 +47,12 @@ inline void _calculate_dropout_(std::uint32_t dst_index_in, std::uint32_t dst_in
         ////////////////////////
         // Drop samples
         // v_if (rand < probability)
-        //   dst_reg[(dst_index_out - dst_index_in) * 32] = vConst0;
+        //   dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = vConst0;
         ///////////////////////
         TTI_SFPIADD(0, p_sfpu::LREG2, p_sfpu::LREG3, 10);
         TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
         TTI_SFPENCC(0, 0, 0, 0);
-        TT_SFPSTORE(0, 0, 3, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(0, 0, 3, (dst_index_out - dst_index_in) * TILE_R_DIM);
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_elu.h
@@ -13,7 +13,7 @@ namespace ckernel::sfpu
 {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void _calculate_elu_(std::uint32_t slope)
+inline void _calculate_elu_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, std::uint32_t slope)
 {
     sfpi::vFloat alpha = Converter::as_float(slope);
 // unroll 2: with expm1_cw_clamped inlined the loop body is large enough that
@@ -34,7 +34,7 @@ inline void _calculate_elu_(std::uint32_t slope)
         {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_elu.h
@@ -34,7 +34,7 @@ inline void _calculate_elu_(std::uint32_t dst_index_in, std::uint32_t dst_index_
         {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -60,8 +60,9 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_bf16_unsafe_(sfpi::vFloat val)
 
     sfpi::vInt z = _float_to_int32_for_exp_21f_(xlog2);
 
-    sfpi::vInt exponential_part = sfpi::exexp(sfpi::reinterpret<sfpi::vFloat>(z), sfpi::ExponentMode::NoDebias); // Extract exponent ( = 2**(integer part of val/ln2))
-    sfpi::vInt fractional_part  = sfpi::exman(sfpi::reinterpret<sfpi::vFloat>(z));                         // Extract mantissa ( = leftover part, in [0; 1])
+    sfpi::vInt exponential_part =
+        sfpi::exexp(sfpi::reinterpret<sfpi::vFloat>(z), sfpi::ExponentMode::NoDebias); // Extract exponent ( = 2**(integer part of val/ln2))
+    sfpi::vInt fractional_part = sfpi::exman(sfpi::reinterpret<sfpi::vFloat>(z));      // Extract mantissa ( = leftover part, in [0; 1])
 
     sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, sfpi::RoundMode::NearestEven);
 
@@ -129,7 +130,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_bf16_(sfpi::vFloat val)
     sfpi::vInt z = _float_to_int32_for_exp_21f_(xlog2);
 
     sfpi::vInt exponential_part = exexp(sfpi::reinterpret<sfpi::vFloat>(z), sfpi::ExponentMode::NoDebias); // Extract exponent ( = 2**(integer part of val/ln2))
-    sfpi::vInt fractional_part  = sfpi::exman(sfpi::reinterpret<sfpi::vFloat>(z));                   // Extract mantissa ( = leftover part, in [0; 1])
+    sfpi::vInt fractional_part  = sfpi::exman(sfpi::reinterpret<sfpi::vFloat>(z));                         // Extract mantissa ( = leftover part, in [0; 1])
 
     sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, sfpi::RoundMode::NearestEven);
 
@@ -420,7 +421,7 @@ void _calculate_exponential_(std::uint32_t dst_index_in, std::uint32_t dst_index
             TTI_SFPMAD(p_sfpu::LREG12, p_sfpu::LREG0, p_sfpu::LREG13, p_sfpu::LREG0, 0);
             TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
             TTI_SFPSHFT(15, p_sfpu::LREG0, p_sfpu::LREG0, 1);
-            TT_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, (dst_index_out - dst_index_in) * 32);
+            TT_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, (dst_index_out - dst_index_in) * TILE_R_DIM);
             sfpi::dst_reg++;
         }
 #else
@@ -530,7 +531,7 @@ void _calculate_exponential_(std::uint32_t dst_index_in, std::uint32_t dst_index
             TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT16);
             TTI_SFPSHFT2(p_sfpu::LREG0, p_sfpu::LREG14, p_sfpu::LREG1, 5); // lreg[1] = lreg[0] << 15
             TTI_SFPSETSGN(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);             // lreg[0] preserves sign, copies e/m from lreg[1]
-            TT_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, (dst_index_out - dst_index_in) * 32);
+            TT_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, (dst_index_out - dst_index_in) * TILE_R_DIM);
             sfpi::dst_reg++;
         }
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -13,6 +13,7 @@
 #include "ckernel_sfpu_polyval.h"
 // clang-format on
 #include "ckernel_sfpu_recip.h"
+#include "cmath_common.h"
 #include "lltt.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
@@ -398,7 +399,7 @@ sfpi_inline sfpi::vFloat _ckernel_sfpu_exp_accurate_(sfpi::vFloat val, const std
 }
 
 template <bool APPROXIMATION_MODE, bool SCALE_EN, int ITERATIONS, bool CLAMP_NEGATIVE = true, bool is_fp32_dest_acc_en = false>
-void _calculate_exponential_(const std::uint16_t exp_base_scale_factor /* 1.0f in BF16 */)
+void _calculate_exponential_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const std::uint16_t exp_base_scale_factor /* 1.0f in BF16 */)
 {
     if constexpr (!APPROXIMATION_MODE)
     {
@@ -414,15 +415,16 @@ void _calculate_exponential_(const std::uint16_t exp_base_scale_factor /* 1.0f i
 #ifdef DISABLE_SFPLOADMACRO
         for (int d = 0; d < ITERATIONS; d++)
         {
-            TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
+            TT_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
             TTI_SFPSWAP(0, p_sfpu::LREG14, p_sfpu::LREG0, 9);
             TTI_SFPMAD(p_sfpu::LREG12, p_sfpu::LREG0, p_sfpu::LREG13, p_sfpu::LREG0, 0);
             TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
             TTI_SFPSHFT(15, p_sfpu::LREG0, p_sfpu::LREG0, 1);
-            TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
+            TT_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, (dst_index_out - dst_index_in) * 32);
             sfpi::dst_reg++;
         }
 #else
+        LLK_ASSERT(dst_index_out == dst_index_in, "exp SFPLOADMACRO path requires dst_index_out == dst_index_in");
         // Code below is hand-unrolled for 8 iterations
         // so it doesn't respect ITERATIONS. TODO: tt-llk#1486
         // static_assert(ITERATIONS == 8);
@@ -523,18 +525,19 @@ void _calculate_exponential_(const std::uint16_t exp_base_scale_factor /* 1.0f i
     {
         for (int d = 0; d < ITERATIONS; d++)
         {
-            TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
+            TT_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
             TTI_SFPMAD(p_sfpu::LREG12, p_sfpu::LREG0, p_sfpu::LREG13, p_sfpu::LREG0, 0);
             TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT16);
             TTI_SFPSHFT2(p_sfpu::LREG0, p_sfpu::LREG14, p_sfpu::LREG1, 5); // lreg[1] = lreg[0] << 15
             TTI_SFPSETSGN(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);             // lreg[0] preserves sign, copies e/m from lreg[1]
-            TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
+            TT_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, (dst_index_out - dst_index_in) * 32);
             sfpi::dst_reg++;
         }
     }
 #else
     else if constexpr (APPROXIMATION_MODE && ITERATIONS == 8)
     {
+        LLK_ASSERT(dst_index_out == dst_index_in, "exp replay-buffer path requires dst_index_out == dst_index_in");
         // =======================================================================
         // 8-element version using replay buffer.
         // Total: ~20 cycles for 8 elements = 2.5 cycles/element
@@ -565,6 +568,7 @@ void _calculate_exponential_(const std::uint16_t exp_base_scale_factor /* 1.0f i
     }
     else if constexpr (APPROXIMATION_MODE && ITERATIONS == 32)
     {
+        LLK_ASSERT(dst_index_out == dst_index_in, "exp replay-buffer path requires dst_index_out == dst_index_in");
         // =======================================================================
         // 32-element version using replay buffer.
         // Total: ~68 cycles for 32 elements = 2.125 cycles/element

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp2.h
@@ -33,7 +33,7 @@ inline void _calculate_exp2_(std::uint32_t dst_index_in, std::uint32_t dst_index
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp2.h
@@ -13,7 +13,7 @@ namespace ckernel::sfpu
 {
 
 template <bool APPROXIMATION_MODE /*unused*/, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void _calculate_exp2_()
+inline void _calculate_exp2_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
@@ -33,7 +33,7 @@ inline void _calculate_exp2_()
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_fill.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_fill.h
@@ -14,20 +14,20 @@ namespace ckernel::sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_fill_(const float value)
+inline void _calculate_fill_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const float value)
 {
     // SFPU microcode
     sfpi::vFloat fill_val = value;
 
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[0] = fill_val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = fill_val;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, InstrModLoadStore INSTRUCTION_MODE, int ITERATIONS>
-inline void _calculate_fill_int_(const std::uint32_t value)
+inline void _calculate_fill_int_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const std::uint32_t value)
 {
     // SFPU microcode
     if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32)
@@ -44,20 +44,20 @@ inline void _calculate_fill_int_(const std::uint32_t value)
     }
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, (dst_index_out - dst_index_in) * 32);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_fill_bitcast_(const std::uint32_t value_bit_mask)
+inline void _calculate_fill_bitcast_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const std::uint32_t value_bit_mask)
 {
     // SFPU microcode
     sfpi::vFloat fill_val = Converter::as_float(value_bit_mask);
 
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[0] = fill_val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = fill_val;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_fill.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_fill.h
@@ -21,7 +21,7 @@ inline void _calculate_fill_(std::uint32_t dst_index_in, std::uint32_t dst_index
 
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = fill_val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = fill_val;
         sfpi::dst_reg++;
     }
 }
@@ -44,7 +44,7 @@ inline void _calculate_fill_int_(std::uint32_t dst_index_in, std::uint32_t dst_i
     }
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TT_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, (dst_index_out - dst_index_in) * TILE_R_DIM);
         sfpi::dst_reg++;
     }
 }
@@ -57,7 +57,7 @@ inline void _calculate_fill_bitcast_(std::uint32_t dst_index_in, std::uint32_t d
 
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = fill_val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = fill_val;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -37,7 +37,7 @@ inline sfpi::vFloat _calculate_gelu_core_(sfpi::vFloat in)
 }
 
 template <int ITERATIONS>
-inline void _calculate_gelu_appx_()
+inline void _calculate_gelu_appx_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
     sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
@@ -56,7 +56,7 @@ inline void _calculate_gelu_appx_()
         // result = lut(result, l0, l1, l2);
         // result = half_in * result + half_in;
 
-        // sfpi::dst_reg[0] = result;
+        // sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
 
         sfpi::vFloat in      = sfpi::dst_reg[0];
         sfpi::vFloat half    = sfpi::vConstFloatPrgm0;
@@ -64,7 +64,7 @@ inline void _calculate_gelu_appx_()
         sfpi::vFloat result  = lut2_sign(in, l0, l1, l2, l4, l5, l6);
         result               = half_in + result;
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
 
         sfpi::dst_reg++;
 
@@ -85,34 +85,34 @@ inline void _calculate_gelu_appx_()
 }
 
 template <int ITERATIONS>
-inline void _calculate_gelu_accurate_()
+inline void _calculate_gelu_accurate_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     constexpr bool scaled = true;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat in     = sfpi::dst_reg[0];
-        sfpi::vFloat result = _calculate_cdf_appx_(in, scaled);
-        sfpi::dst_reg[0]    = result;
+        sfpi::vFloat in                                    = sfpi::dst_reg[0];
+        sfpi::vFloat result                                = _calculate_cdf_appx_(in, scaled);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_gelu_()
+inline void _calculate_gelu_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     if constexpr (APPROXIMATION_MODE)
     {
-        _calculate_gelu_appx_<ITERATIONS>();
+        _calculate_gelu_appx_<ITERATIONS>(dst_index_in, dst_index_out);
     }
     else
     {
-        _calculate_gelu_accurate_<ITERATIONS>();
+        _calculate_gelu_accurate_<ITERATIONS>(dst_index_in, dst_index_out);
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_gelu_derivative_()
+inline void _calculate_gelu_derivative_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     if constexpr (APPROXIMATION_MODE)
     {
@@ -136,7 +136,7 @@ inline void _calculate_gelu_derivative_()
                 val = val + 1.0f;
             }
             v_endif;
-            sfpi::dst_reg[0] = val;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
             sfpi::dst_reg++;
         }
 
@@ -171,7 +171,7 @@ inline void _calculate_gelu_derivative_()
 
             result = lut(result, l0, l1, imm2);
 
-            sfpi::dst_reg[0] = partial + result + 0.5f;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = partial + result + 0.5f;
             sfpi::dst_reg++;
         }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -56,7 +56,7 @@ inline void _calculate_gelu_appx_(std::uint32_t dst_index_in, std::uint32_t dst_
         // result = lut(result, l0, l1, l2);
         // result = half_in * result + half_in;
 
-        // sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        // sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
 
         sfpi::vFloat in      = sfpi::dst_reg[0];
         sfpi::vFloat half    = sfpi::vConstFloatPrgm0;
@@ -64,7 +64,7 @@ inline void _calculate_gelu_appx_(std::uint32_t dst_index_in, std::uint32_t dst_
         sfpi::vFloat result  = lut2_sign(in, l0, l1, l2, l4, l5, l6);
         result               = half_in + result;
 
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
 
         sfpi::dst_reg++;
 
@@ -91,9 +91,9 @@ inline void _calculate_gelu_accurate_(std::uint32_t dst_index_in, std::uint32_t 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat in                                    = sfpi::dst_reg[0];
-        sfpi::vFloat result                                = _calculate_cdf_appx_(in, scaled);
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        sfpi::vFloat in                                            = sfpi::dst_reg[0];
+        sfpi::vFloat result                                        = _calculate_cdf_appx_(in, scaled);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }
@@ -136,7 +136,7 @@ inline void _calculate_gelu_derivative_(std::uint32_t dst_index_in, std::uint32_
                 val = val + 1.0f;
             }
             v_endif;
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
             sfpi::dst_reg++;
         }
 
@@ -171,7 +171,7 @@ inline void _calculate_gelu_derivative_(std::uint32_t dst_index_in, std::uint32_
 
             result = lut(result, l0, l1, imm2);
 
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = partial + result + 0.5f;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = partial + result + 0.5f;
             sfpi::dst_reg++;
         }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -14,7 +14,8 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_hardtanh_(const int iterations, std::uint32_t param0, std::uint32_t param1, std::uint32_t param2)
+inline void _calculate_hardtanh_(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations, std::uint32_t param0, std::uint32_t param1, std::uint32_t param2)
 {
     // All params are in FP16_B format
     // param0 = -(neg_threshold)
@@ -46,7 +47,7 @@ inline void _calculate_hardtanh_(const int iterations, std::uint32_t param0, std
 
         val += p2; // 12 bits
 
-        sfpi::dst_reg[0] = val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -47,7 +47,7 @@ inline void _calculate_hardtanh_(
 
         val += p2; // 12 bits
 
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "sfpi.h"
@@ -118,7 +120,7 @@ inline sfpi::vFloat _calculate_isfinite_(const sfpi::vFloat& v)
 }
 
 template <SfpuType operation, bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_sfpu_isinf_isnan_()
+inline void _calculate_sfpu_isinf_isnan_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
@@ -127,23 +129,23 @@ inline void _calculate_sfpu_isinf_isnan_()
 
         if constexpr (operation == SfpuType::isinf)
         {
-            sfpi::dst_reg[0] = _calculate_isinf_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isinf_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isposinf)
         {
-            sfpi::dst_reg[0] = _calculate_isposinf_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isposinf_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isneginf)
         {
-            sfpi::dst_reg[0] = _calculate_isneginf_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isneginf_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isnan)
         {
-            sfpi::dst_reg[0] = _calculate_isnan_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isnan_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isfinite)
         {
-            sfpi::dst_reg[0] = _calculate_isfinite_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isfinite_<APPROXIMATION_MODE>(in);
         }
 
         sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
@@ -129,23 +129,23 @@ inline void _calculate_sfpu_isinf_isnan_(std::uint32_t dst_index_in, std::uint32
 
         if constexpr (operation == SfpuType::isinf)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isinf_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _calculate_isinf_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isposinf)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isposinf_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _calculate_isposinf_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isneginf)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isneginf_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _calculate_isneginf_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isnan)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isnan_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _calculate_isnan_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isfinite)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isfinite_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _calculate_isfinite_<APPROXIMATION_MODE>(in);
         }
 
         sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
@@ -14,7 +14,7 @@ namespace sfpu
 {
 
 template <bool HAS_BASE_SCALING>
-sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor, const std::uint32_t dst_idx = 0)
+sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
     // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
     constexpr std::uint32_t dst_tile_size_sfpi = 32;
@@ -22,7 +22,7 @@ sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor,
     ////////////////////////////
     // Load From dest + "normalize to calculation range"
     ////////////////////////////
-    sfpi::vFloat in = sfpi::dst_reg[dst_idx * dst_tile_size_sfpi];
+    sfpi::vFloat in = sfpi::dst_reg[0];
     sfpi::vFloat x  = setexp(in, 127); // set exp to exp bias (put in range of 1-2)
 
     // XXXXXX ask Namal? if we can derive the coefficients below to higher precision
@@ -71,7 +71,7 @@ sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor,
     }
     v_endif;
 
-    sfpi::dst_reg[dst_idx * dst_tile_size_sfpi] = result;
+    sfpi::dst_reg[(dst_index_out - dst_index_in) * dst_tile_size_sfpi] = result;
 }
 
 sfpi_inline sfpi::vFloat _calculate_log_body_no_init_(sfpi::vFloat base)
@@ -106,12 +106,12 @@ sfpi_inline sfpi::vFloat _calculate_log_body_no_init_(sfpi::vFloat base)
 }
 
 template <bool APPROXIMATION_MODE, bool HAS_BASE_SCALING, int ITERATIONS>
-inline void _calculate_log_(const int iterations, std::uint32_t log_base_scale_factor)
+inline void _calculate_log_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations, std::uint32_t log_base_scale_factor)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_log_body_<HAS_BASE_SCALING>(log_base_scale_factor);
+        _calculate_log_body_<HAS_BASE_SCALING>(log_base_scale_factor, dst_index_in, dst_index_out);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_negative.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_negative.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sfpi.h"
 
 namespace ckernel
@@ -12,25 +14,25 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_negative_()
+inline void _calculate_negative_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat val = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = -val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = -val;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_negative_int_()
+inline void _calculate_negative_int_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vInt val   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = -val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = -val;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_negative.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_negative.h
@@ -19,8 +19,8 @@ inline void _calculate_negative_(std::uint32_t dst_index_in, std::uint32_t dst_i
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat val = sfpi::dst_reg[0];
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = -val;
+        sfpi::vFloat val                                           = sfpi::dst_reg[0];
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = -val;
         sfpi::dst_reg++;
     }
 }
@@ -31,8 +31,8 @@ inline void _calculate_negative_int_(std::uint32_t dst_index_in, std::uint32_t d
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vInt val   = sfpi::dst_reg[0];
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = -val;
+        sfpi::vInt val                                             = sfpi::dst_reg[0];
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = -val;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 
 #include "ckernel_sfpu_rsqrt_compat.h"
+#include "cmath_common.h"
 #include "lltt.h"
 #include "sfpi.h"
 
@@ -58,7 +59,7 @@ sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat x)
 }
 
 // Approximate reciprocal, with throughput of 1c/32.
-inline void _calculate_reciprocal_fast_7b_(const int iterations)
+inline void _calculate_reciprocal_fast_7b_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
@@ -66,9 +67,10 @@ inline void _calculate_reciprocal_fast_7b_(const int iterations)
     {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
         TTI_SFPARECIP(0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPARECIP_MOD1_RECIP);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
     }
 #else
+    LLK_ASSERT(dst_index_out == dst_index_in, "recip fast-7b SFPLOADMACRO path requires dst_index_out == dst_index_in");
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
@@ -80,7 +82,7 @@ inline void _calculate_reciprocal_fast_7b_(const int iterations)
 }
 
 // BF16 reciprocal, with throughput of 3c/32.
-inline void _calculate_reciprocal_fast_8b_3c_(const int iterations)
+inline void _calculate_reciprocal_fast_8b_3c_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
 #ifdef DISABLE_SFPLOADMACRO
     TTI_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_USHORT, 0x8000);
@@ -95,9 +97,10 @@ inline void _calculate_reciprocal_fast_8b_3c_(const int iterations)
         TTI_SFPMAD(p_sfpu::LREG1, p_sfpu::LREG0, p_sfpu::LCONST_neg1, p_sfpu::LREG1, 0);
         TTI_SFPSHFT((-16) & 0xFFF, p_sfpu::LREG1, p_sfpu::LREG1, 5);
         TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_CC_NONE);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
     }
 #else
+    LLK_ASSERT(dst_index_out == dst_index_in, "recip fast-8b SFPLOADMACRO path requires dst_index_out == dst_index_in");
     // We use SFPMAD_MOD1_INDIRECT_VD to schedule SFPMAD and write to L[L7],
     // with L7=x throughout.
     //
@@ -188,7 +191,7 @@ inline void _calculate_reciprocal_fast_8b_3c_(const int iterations)
 }
 
 // FP32 reciprocal, with throughput of 5c/32.
-inline void _calculate_reciprocal_fast_24b_5c_(const int iterations)
+inline void _calculate_reciprocal_fast_24b_5c_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
@@ -201,9 +204,10 @@ inline void _calculate_reciprocal_fast_24b_5c_(const int iterations)
         TTI_SFPMAD(p_sfpu::LREG3, p_sfpu::LREG2, p_sfpu::LREG2, p_sfpu::LREG3, 0);
         TTI_SFPSWAP(0, p_sfpu::LCONST_1, p_sfpu::LREG3, sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);
         TTI_SFPMAD(p_sfpu::LREG3, p_sfpu::LREG1, p_sfpu::LREG1, p_sfpu::LREG0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
     }
 #else
+    LLK_ASSERT(dst_index_out == dst_index_in, "recip fast-24b SFPLOADMACRO path requires dst_index_out == dst_index_in");
     // Pseudocode:
     //
     // y = arecip(x)
@@ -255,32 +259,32 @@ inline void _calculate_reciprocal_fast_24b_5c_(const int iterations)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
-inline void _calculate_reciprocal_internal_(const int iterations)
+inline void _calculate_reciprocal_internal_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
     if constexpr (APPROXIMATION_MODE)
     {
-        _calculate_reciprocal_fast_7b_(iterations);
+        _calculate_reciprocal_fast_7b_(dst_index_in, dst_index_out, iterations);
     }
     else if constexpr (is_fp32_dest_acc_en)
     {
-        _calculate_reciprocal_fast_24b_5c_(iterations);
+        _calculate_reciprocal_fast_24b_5c_(dst_index_in, dst_index_out, iterations);
     }
     else
     {
-        _calculate_reciprocal_fast_8b_3c_(iterations);
+        _calculate_reciprocal_fast_8b_3c_(dst_index_in, dst_index_out, iterations);
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en, bool legacy_compat = false>
-inline void _calculate_reciprocal_(const int iterations)
+inline void _calculate_reciprocal_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
     if constexpr (legacy_compat)
     {
-        _calculate_reciprocal_compat_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en>(iterations);
+        _calculate_reciprocal_compat_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en>(dst_index_in, dst_index_out, iterations);
     }
     else
     {
-        _calculate_reciprocal_internal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en>(iterations);
+        _calculate_reciprocal_internal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en>(dst_index_in, dst_index_out, iterations);
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -67,7 +67,7 @@ inline void _calculate_reciprocal_fast_7b_(std::uint32_t dst_index_in, std::uint
     {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
         TTI_SFPARECIP(0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPARECIP_MOD1_RECIP);
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     LLK_ASSERT(dst_index_out == dst_index_in, "recip fast-7b SFPLOADMACRO path requires dst_index_out == dst_index_in");
@@ -97,7 +97,7 @@ inline void _calculate_reciprocal_fast_8b_3c_(std::uint32_t dst_index_in, std::u
         TTI_SFPMAD(p_sfpu::LREG1, p_sfpu::LREG0, p_sfpu::LCONST_neg1, p_sfpu::LREG1, 0);
         TTI_SFPSHFT((-16) & 0xFFF, p_sfpu::LREG1, p_sfpu::LREG1, 5);
         TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_CC_NONE);
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     LLK_ASSERT(dst_index_out == dst_index_in, "recip fast-8b SFPLOADMACRO path requires dst_index_out == dst_index_in");
@@ -204,7 +204,7 @@ inline void _calculate_reciprocal_fast_24b_5c_(std::uint32_t dst_index_in, std::
         TTI_SFPMAD(p_sfpu::LREG3, p_sfpu::LREG2, p_sfpu::LREG2, p_sfpu::LREG3, 0);
         TTI_SFPSWAP(0, p_sfpu::LCONST_1, p_sfpu::LREG3, sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);
         TTI_SFPMAD(p_sfpu::LREG3, p_sfpu::LREG1, p_sfpu::LREG1, p_sfpu::LREG0, 0);
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     LLK_ASSERT(dst_index_out == dst_index_in, "recip fast-24b SFPLOADMACRO path requires dst_index_out == dst_index_in");

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_reduce.h
@@ -1128,7 +1128,8 @@ inline void _init_reduce_(std::uint32_t block_ct_dim = 1)
  * @param block_rt_dim Block dimension (used for MAX/MIN reduction to specify block height, or SUM/MAX row reduction; default is 1 for single tile)
  */
 template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
-inline void _calculate_reduce_(std::uint32_t block_ct_dim = 1, std::uint32_t block_rt_dim = 1)
+inline void _calculate_reduce_(
+    [[maybe_unused]] std::uint32_t dst_index_in, [[maybe_unused]] std::uint32_t dst_index_out, std::uint32_t block_ct_dim = 1, std::uint32_t block_rt_dim = 1)
 {
     static_assert(
         reduce_dim == REDUCE_COL || (pool_type == PoolType::SUM && reduce_dim == REDUCE_ROW) || (pool_type == PoolType::MAX && reduce_dim == REDUCE_ROW),

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -18,18 +18,18 @@ template <typename T>
 constexpr bool is_supported_relu_type_v = std::is_same_v<T, float> || std::is_same_v<T, std::uint32_t>;
 
 template <bool APPROXIMATION_MODE>
-inline void _calculate_lrelu_(const int iterations, std::uint32_t slope)
+inline void _calculate_lrelu_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations, std::uint32_t slope)
 {
     TT_SFPLOADI(p_sfpu::LREG2, 10, slope & 0xFFFF);
     TT_SFPLOADI(p_sfpu::LREG2, 8, slope >> 16);
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);        // load from dest into lreg[0]
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);         // load from dest into lreg[0]
         TTI_SFPSETCC(0, p_sfpu::LREG0, 0, 0);                                         // condition - if value in LREG0 is negative //will set cc result reg
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG2, p_sfpu::LCONST_0, p_sfpu::LREG0, 0); // Multiply LREG0 * LREG2 (x * slope)
         TTI_SFPENCC(0, 0, 0, 0);                                                      // clear cc result reg
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);       // store from lreg0 into dest register
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, (dst_index_out - dst_index_in) * 32); // store from lreg0 into dest register
         sfpi::dst_reg++;
     }
 }
@@ -51,7 +51,7 @@ sfpi_inline sfpi::vFloat _relu_max_body_(sfpi::vFloat val, sfpi::vFloat threshol
 }
 
 template <typename VecType, bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _relu_max_impl_(const int iterations, VecType threshold)
+inline void _relu_max_impl_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations, VecType threshold)
 {
     for (int d = 0; d < iterations; d++)
     {
@@ -66,14 +66,14 @@ inline void _relu_max_impl_(const int iterations, VecType threshold)
             result = 0;
         }
         v_endif;
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
         sfpi::dst_reg++;
     }
 }
 
 // Wrappers
 template <typename VectorType, bool APPROXIMATION_MODE, int ITERATIONS, typename T>
-inline void _relu_max_(T threshold)
+inline void _relu_max_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, T threshold)
 {
     static_assert(std::is_same_v<VectorType, sfpi::vFloat> || std::is_same_v<VectorType, sfpi::vInt>, "VectorType must be sfpi::vFloat or sfpi::vInt");
 
@@ -98,18 +98,18 @@ inline void _relu_max_(T threshold)
         static_assert(std::is_same_v<T, float> || std::is_same_v<T, std::uint32_t>, "Threshold type must be float or uint32_t");
     }
 
-    _relu_max_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold);
+    _relu_max_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out, ITERATIONS, v_threshold);
 }
 
 template <typename VecType, bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _relu_min_impl_(const int iterations, VecType threshold)
+inline void _relu_min_impl_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations, VecType threshold)
 {
     for (int d = 0; d < iterations; d++)
     {
         VecType a = sfpi::dst_reg[0];
         v_if (a < threshold)
         {
-            sfpi::dst_reg[0] = threshold;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = threshold;
         }
         v_endif;
         sfpi::dst_reg++;
@@ -118,7 +118,7 @@ inline void _relu_min_impl_(const int iterations, VecType threshold)
 
 // Wrappers
 template <typename VectorType, bool APPROXIMATION_MODE, int ITERATIONS, typename T>
-inline void _relu_min_(T threshold)
+inline void _relu_min_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, T threshold)
 {
     static_assert(std::is_same_v<VectorType, sfpi::vFloat> || std::is_same_v<VectorType, sfpi::vInt>, "VectorType must be sfpi::vFloat or sfpi::vInt");
 
@@ -143,7 +143,7 @@ inline void _relu_min_(T threshold)
         static_assert(std::is_same_v<T, float> || std::is_same_v<T, std::uint32_t>, "Threshold type must be float or uint32_t");
     }
 
-    _relu_min_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold);
+    _relu_min_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out, ITERATIONS, v_threshold);
 }
 
 } // namespace sfpu

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -29,7 +29,7 @@ inline void _calculate_lrelu_(std::uint32_t dst_index_in, std::uint32_t dst_inde
         TTI_SFPSETCC(0, p_sfpu::LREG0, 0, 0);                                         // condition - if value in LREG0 is negative //will set cc result reg
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG2, p_sfpu::LCONST_0, p_sfpu::LREG0, 0); // Multiply LREG0 * LREG2 (x * slope)
         TTI_SFPENCC(0, 0, 0, 0);                                                      // clear cc result reg
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, (dst_index_out - dst_index_in) * 32); // store from lreg0 into dest register
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, (dst_index_out - dst_index_in) * TILE_R_DIM); // store from lreg0 into dest register
         sfpi::dst_reg++;
     }
 }
@@ -66,7 +66,7 @@ inline void _relu_max_impl_(std::uint32_t dst_index_in, std::uint32_t dst_index_
             result = 0;
         }
         v_endif;
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }
@@ -109,7 +109,7 @@ inline void _relu_min_impl_(std::uint32_t dst_index_in, std::uint32_t dst_index_
         VecType a = sfpi::dst_reg[0];
         v_if (a < threshold)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = threshold;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = threshold;
         }
         v_endif;
         sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_reshuffle_rows.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_reshuffle_rows.h
@@ -37,7 +37,7 @@ namespace sfpu
  *
  * @param idx_addr L1 address of the mask tile containing destination row mappings (uint8_t[32])
  */
-inline void _calculate_reshuffle_rows_(const std::uint32_t idx_addr)
+inline void _calculate_reshuffle_rows_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const std::uint32_t idx_addr)
 {
     constexpr std::uint32_t output_tile_offset = 64;
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -87,7 +87,7 @@ sfpi_inline void _calculate_floor_(std::uint32_t dst_index_in, std::uint32_t dst
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _floor_body_(sfpi::dst_reg[0]);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _floor_body_(sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }
@@ -97,7 +97,7 @@ sfpi_inline void _calculate_ceil_(std::uint32_t dst_index_in, std::uint32_t dst_
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _ceil_body_(sfpi::dst_reg[0]);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _ceil_body_(sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }
@@ -107,7 +107,7 @@ sfpi_inline void _calculate_trunc_(std::uint32_t dst_index_in, std::uint32_t dst
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _trunc_body_(sfpi::dst_reg[0]);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _trunc_body_(sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }
@@ -117,8 +117,8 @@ sfpi_inline void _calculate_frac_(std::uint32_t dst_index_in, std::uint32_t dst_
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat x   = sfpi::dst_reg[0];
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = x - _trunc_body_(x);
+        sfpi::vFloat x                                             = sfpi::dst_reg[0];
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = x - _trunc_body_(x);
         sfpi::dst_reg++;
     }
 }
@@ -166,9 +166,9 @@ void _calculate_round_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, 
 
     for (int d = 0; d < ITERATIONS; ++d)
     {
-        sfpi::vFloat v                                     = sfpi::dst_reg[0];
-        sfpi::vFloat result                                = inverse * _round_even_(v * coeff);
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        sfpi::vFloat v                                             = sfpi::dst_reg[0];
+        sfpi::vFloat result                                        = inverse * _round_even_(v * coeff);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }
@@ -180,8 +180,8 @@ sfpi_inline void _calculate_stochastic_round_(std::uint32_t dst_index_in, std::u
 #pragma GCC unroll ITERATIONS
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat x   = sfpi::dst_reg[0];
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::Stochastic);
+        sfpi::vFloat x                                             = sfpi::dst_reg[0];
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::Stochastic);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <climits>
+#include <cstdint>
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
@@ -82,42 +83,42 @@ inline constexpr std::array<float, 84> PRECOMPUTED_POW10_TABLE = {
 };
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-sfpi_inline void _calculate_floor_()
+sfpi_inline void _calculate_floor_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[0] = _floor_body_(sfpi::dst_reg[0]);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _floor_body_(sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-sfpi_inline void _calculate_ceil_()
+sfpi_inline void _calculate_ceil_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[0] = _ceil_body_(sfpi::dst_reg[0]);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _ceil_body_(sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-sfpi_inline void _calculate_trunc_()
+sfpi_inline void _calculate_trunc_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[0] = _trunc_body_(sfpi::dst_reg[0]);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _trunc_body_(sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-sfpi_inline void _calculate_frac_()
+sfpi_inline void _calculate_frac_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat x   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = x - _trunc_body_(x);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = x - _trunc_body_(x);
         sfpi::dst_reg++;
     }
 }
@@ -143,7 +144,7 @@ sfpi_inline sfpi::vFloat _round_even_(sfpi::vFloat v)
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-void _calculate_round_(const int decimals)
+void _calculate_round_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int decimals)
 {
     const auto exp10i = [](int n)
     {
@@ -165,22 +166,22 @@ void _calculate_round_(const int decimals)
 
     for (int d = 0; d < ITERATIONS; ++d)
     {
-        sfpi::vFloat v      = sfpi::dst_reg[0];
-        sfpi::vFloat result = inverse * _round_even_(v * coeff);
-        sfpi::dst_reg[0]    = result;
+        sfpi::vFloat v                                     = sfpi::dst_reg[0];
+        sfpi::vFloat result                                = inverse * _round_even_(v * coeff);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
         sfpi::dst_reg++;
     }
 }
 
 // Performs stochastic rounding of values in DST from fp32 to fp16b format.
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-sfpi_inline void _calculate_stochastic_round_()
+sfpi_inline void _calculate_stochastic_round_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #pragma GCC unroll ITERATIONS
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat x   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::Stochastic);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::Stochastic);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_sfpu_rsqrt_compat.h"
 #include "ckernel_sfpu_sqrt.h"
 #include "sfpi.h"
@@ -14,15 +16,15 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat = false>
-inline void _calculate_rsqrt_(int iterations)
+inline void _calculate_rsqrt_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, int iterations)
 {
     if constexpr (legacy_compat)
     {
-        return _calculate_rsqrt_compat_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en>(iterations);
+        return _calculate_rsqrt_compat_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en>(dst_index_in, dst_index_out, iterations);
     }
     else
     {
-        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, true, FAST_APPROX>(iterations);
+        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, true, FAST_APPROX>(dst_index_in, dst_index_out, iterations);
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sfpi.h"
 
 namespace ckernel
@@ -97,14 +99,14 @@ sfpi_inline sfpi::vFloat _reciprocal_compat_(const sfpi::vFloat in)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en>
-inline void _calculate_rsqrt_compat_(const int iterations)
+inline void _calculate_rsqrt_compat_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::dst_reg[0] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
-        sfpi::vFloat in  = sfpi::dst_reg[0];
-        sfpi::vFloat out = _reciprocal_compat_<APPROXIMATION_MODE ? 2 : 3>(in);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
+        sfpi::vFloat in                                    = sfpi::dst_reg[(dst_index_out - dst_index_in) * 32];
+        sfpi::vFloat out                                   = _reciprocal_compat_<APPROXIMATION_MODE ? 2 : 3>(in);
         v_if (in < 0.0)
         {
             out = -out;
@@ -120,18 +122,18 @@ inline void _calculate_rsqrt_compat_(const int iterations)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en>
-inline void _calculate_sqrt_compat_(const int iterations)
+inline void _calculate_sqrt_compat_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::dst_reg[0] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en>
-inline void _calculate_reciprocal_compat_(const int iterations)
+inline void _calculate_reciprocal_compat_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
@@ -104,9 +104,9 @@ inline void _calculate_rsqrt_compat_(std::uint32_t dst_index_in, std::uint32_t d
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
-        sfpi::vFloat in                                    = sfpi::dst_reg[(dst_index_out - dst_index_in) * 32];
-        sfpi::vFloat out                                   = _reciprocal_compat_<APPROXIMATION_MODE ? 2 : 3>(in);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
+        sfpi::vFloat in                                            = sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM];
+        sfpi::vFloat out                                           = _reciprocal_compat_<APPROXIMATION_MODE ? 2 : 3>(in);
         v_if (in < 0.0)
         {
             out = -out;
@@ -127,7 +127,7 @@ inline void _calculate_sqrt_compat_(std::uint32_t dst_index_in, std::uint32_t ds
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_selu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_selu.h
@@ -38,7 +38,7 @@ inline void _calculate_selu_(std::uint32_t dst_index_in, std::uint32_t dst_index
         {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_selu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_selu.h
@@ -16,7 +16,7 @@ namespace ckernel::sfpu
 // scale ≈ 1.0507, alpha ≈ 1.6733, scale*alpha ≈ 1.7581
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void _calculate_selu_(std::uint32_t scale, std::uint32_t alpha)
+inline void _calculate_selu_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, std::uint32_t scale, std::uint32_t alpha)
 {
     const sfpi::vFloat scale_val   = Converter::as_float(scale);
     const sfpi::vFloat scale_alpha = Converter::as_float(scale) * Converter::as_float(alpha);
@@ -38,7 +38,7 @@ inline void _calculate_selu_(std::uint32_t scale, std::uint32_t alpha)
         {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_sfpu_load_config.h"
 #include "sfpi.h"
 
@@ -13,7 +15,7 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_sigmoid_(const int iterations)
+inline void _calculate_sigmoid_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
     constexpr int lut_mode = 0; // SFPLUTFP32_MOD0_FP16_6ENTRY_TABLE1
     sfpi::vUInt l0         = sfpi::l_reg[sfpi::LRegs::LReg0];
@@ -28,7 +30,7 @@ inline void _calculate_sigmoid_(const int iterations)
     {
         sfpi::vFloat val = sfpi::dst_reg[0];
 
-        sfpi::dst_reg[0] = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode) + 0.5f;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode) + 0.5f;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -30,7 +30,7 @@ inline void _calculate_sigmoid_(std::uint32_t dst_index_in, std::uint32_t dst_in
     {
         sfpi::vFloat val = sfpi::dst_reg[0];
 
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode) + 0.5f;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode) + 0.5f;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sign.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sign.h
@@ -15,7 +15,7 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_sign_(const int iterations, std::uint32_t exponent_size_8)
+inline void _calculate_sign_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations, std::uint32_t exponent_size_8)
 {
 // All params are in FP16 format
 // uint format = 1;
@@ -23,10 +23,10 @@ inline void _calculate_sign_(const int iterations, std::uint32_t exponent_size_8
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat v   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::vConst1;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::vConst1;
         v_if (v < 0.0F)
         {
-            sfpi::dst_reg[0] = sfpi::vConstNeg1;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::vConstNeg1;
         }
         v_endif;
 
@@ -34,7 +34,7 @@ inline void _calculate_sign_(const int iterations, std::uint32_t exponent_size_8
         // param0 != 0 is Float16 format and exp bias needs to be removed for zero check.
         v_if (_sfpu_is_fp16_zero_(v, exponent_size_8))
         {
-            sfpi::dst_reg[0] = sfpi::vConst0;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::vConst0;
         }
         v_endif;
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sign.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sign.h
@@ -22,11 +22,11 @@ inline void _calculate_sign_(std::uint32_t dst_index_in, std::uint32_t dst_index
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat v   = sfpi::dst_reg[0];
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::vConst1;
+        sfpi::vFloat v                                             = sfpi::dst_reg[0];
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::vConst1;
         v_if (v < 0.0F)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::vConstNeg1;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::vConstNeg1;
         }
         v_endif;
 
@@ -34,7 +34,7 @@ inline void _calculate_sign_(std::uint32_t dst_index_in, std::uint32_t dst_index
         // param0 != 0 is Float16 format and exp bias needs to be removed for zero check.
         v_if (_sfpu_is_fp16_zero_(v, exponent_size_8))
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::vConst0;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::vConst0;
         }
         v_endif;
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_silu.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_sfpu_polyval.h"
 #include "sfpi.h"
 
@@ -26,7 +28,7 @@ inline sfpi::vFloat _sigmoid_piecewise_linear_positive_(sfpi::vFloat val)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_silu_()
+inline void _calculate_silu_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
@@ -39,7 +41,7 @@ inline void _calculate_silu_()
             result = 1.0f - result;
         }
         v_endif;
-        sfpi::dst_reg[0] = val * result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val * result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_silu.h
@@ -41,7 +41,7 @@ inline void _calculate_silu_(std::uint32_t dst_index_in, std::uint32_t dst_index
             result = 1.0f - result;
         }
         v_endif;
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val * result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val * result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_sfpu_rsqrt_compat.h"
 #include "sfpi.h"
 
@@ -114,7 +116,7 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool RECIPROCAL, bool FAST_APPROX>
-inline void _calculate_sqrt_internal_(const int iterations)
+inline void _calculate_sqrt_internal_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
@@ -130,15 +132,15 @@ inline void _calculate_sqrt_internal_(const int iterations)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat = false>
-inline void _calculate_sqrt_(int iterations)
+inline void _calculate_sqrt_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, int iterations)
 {
     if constexpr (legacy_compat)
     {
-        return _calculate_sqrt_compat_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en>(iterations);
+        return _calculate_sqrt_compat_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en>(dst_index_in, dst_index_out, iterations);
     }
     else
     {
-        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, false, FAST_APPROX>(iterations);
+        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, false, FAST_APPROX>(dst_index_in, dst_index_out, iterations);
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -126,7 +126,7 @@ inline void _calculate_sqrt_internal_(std::uint32_t dst_index_in, std::uint32_t 
         {
             tmp = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = tmp;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = tmp;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_square.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sfpi.h"
 
 namespace ckernel
@@ -12,17 +14,17 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_square_()
+inline void _calculate_square_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
+    // SFPI-style: addressing via sfpi::dst_reg[] keeps the read row and the write
+    // row in sync as we advance, which is required when dst_index_in != dst_index_out.
+    // Earlier TT_SFP*-based implementations only kept addressing correct for the
+    // in == out case (offset 0); see ckernel_sfpu_abs.h for the same pattern.
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        // Load input from destination into LREG0
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
-        // Multiply LREG0 * LREG0, store result in LREG0
-        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
-        // Store result back to destination
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+        sfpi::vFloat v                                     = sfpi::dst_reg[0];
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v * v;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_square.h
@@ -23,8 +23,8 @@ inline void _calculate_square_(std::uint32_t dst_index_in, std::uint32_t dst_ind
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat v                                     = sfpi::dst_reg[0];
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v * v;
+        sfpi::vFloat v                                             = sfpi::dst_reg[0];
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v * v;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh.h
@@ -15,7 +15,7 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_tanh_(const int iterations)
+inline void _calculate_tanh_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
     // SFPU microcode
     sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
@@ -25,9 +25,9 @@ inline void _calculate_tanh_(const int iterations)
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat val = sfpi::dst_reg[0];
-        val              = lut(val, l0, l1, l2);
-        sfpi::dst_reg[0] = val;
+        sfpi::vFloat val                                   = sfpi::dst_reg[0];
+        val                                                = lut(val, l0, l1, l2);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh.h
@@ -25,9 +25,9 @@ inline void _calculate_tanh_(std::uint32_t dst_index_in, std::uint32_t dst_index
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat val                                   = sfpi::dst_reg[0];
-        val                                                = lut(val, l0, l1, l2);
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
+        sfpi::vFloat val                                           = sfpi::dst_reg[0];
+        val                                                        = lut(val, l0, l1, l2);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sfpi.h"
 
 namespace ckernel
@@ -12,7 +14,7 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int WITH_PRECOMPUTED_TANH, int ITERATIONS>
-inline void _calculate_tanh_derivative_(const int iterations)
+inline void _calculate_tanh_derivative_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
     sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
     sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
@@ -28,8 +30,8 @@ inline void _calculate_tanh_derivative_(const int iterations)
             val = lut(val, l0, l1, l2);
         }
 
-        val              = val * (-val) + sfpi::vConst1;
-        sfpi::dst_reg[0] = val;
+        val                                                = val * (-val) + sfpi::vConst1;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
@@ -30,8 +30,8 @@ inline void _calculate_tanh_derivative_(std::uint32_t dst_index_in, std::uint32_
             val = lut(val, l0, l1, l2);
         }
 
-        val                                                = val * (-val) + sfpi::vConst1;
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
+        val                                                        = val * (-val) + sfpi::vConst1;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_threshold.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_threshold.h
@@ -18,7 +18,7 @@ template <typename T>
 constexpr bool is_supported_threshold_type_v = std::is_same_v<T, float> || std::is_same_v<T, std::uint32_t>;
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, typename T>
-inline void _calculate_threshold_(T threshold, T value)
+inline void _calculate_threshold_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, T threshold, T value)
 {
     static_assert(is_supported_threshold_type_v<T>, "Type T must be either float or uint32_t");
 
@@ -41,7 +41,7 @@ inline void _calculate_threshold_(T threshold, T value)
 
         v_if (in <= v_threshold)
         {
-            sfpi::dst_reg[0] = v_value;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v_value;
         }
         v_endif;
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_threshold.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_threshold.h
@@ -41,7 +41,7 @@ inline void _calculate_threshold_(std::uint32_t dst_index_in, std::uint32_t dst_
 
         v_if (in <= v_threshold)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v_value;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v_value;
         }
         v_endif;
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <limits>
 
 #include "ckernel_sfpu_log.h"
@@ -80,7 +81,7 @@ sfpi_inline sfpi::vFloat _sfpu_cosine_maclaurin_series_(sfpi::vFloat val)
 // Legacy implementation
 // Candidate for removal in future versions. See https://github.com/tenstorrent/tt-llk/issues/225 for more details.
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_sine_(const int iterations)
+inline void _calculate_sine_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
@@ -99,7 +100,7 @@ inline void _calculate_sine_(const int iterations)
             v *= -1;
         }
         v_endif;
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
         sfpi::dst_reg++;
     }
 }
@@ -107,7 +108,7 @@ inline void _calculate_sine_(const int iterations)
 // Legacy implementation, replaced by newer void _calculate_sine_() which produces more accurate results
 // Candidate for removal in future versions. See https://github.com/tenstorrent/tt-llk/issues/225 for more details.
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_cosine_(const int iterations)
+inline void _calculate_cosine_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
@@ -126,7 +127,7 @@ inline void _calculate_cosine_(const int iterations)
             v *= -1;
         }
         v_endif;
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
         sfpi::dst_reg++;
     }
 }
@@ -134,7 +135,7 @@ inline void _calculate_cosine_(const int iterations)
 // https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions#Definitions_in_terms_of_logarithms
 // acosh(x) = log(x + sqrt(x^2 - 1))
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_acosh_()
+inline void _calculate_acosh_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
@@ -142,19 +143,19 @@ inline void _calculate_acosh_()
         sfpi::vFloat inp = sfpi::dst_reg[0];
         v_if (inp < sfpi::vConst1)
         {
-            sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN();
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = std::numeric_limits<float>::quiet_NaN();
         }
         v_elseif (inp == sfpi::vConst1)
         {
-            sfpi::dst_reg[0] = sfpi::vConst0;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::vConst0;
         }
         v_else
         {
-            sfpi::vFloat tmp = inp * inp;
-            tmp              = tmp - sfpi::vConst1;
-            tmp              = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-            tmp              = tmp + inp;
-            sfpi::dst_reg[0] = _calculate_log_body_no_init_(tmp);
+            sfpi::vFloat tmp                                   = inp * inp;
+            tmp                                                = tmp - sfpi::vConst1;
+            tmp                                                = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
+            tmp                                                = tmp + inp;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_log_body_no_init_(tmp);
         }
         v_endif;
         sfpi::dst_reg++;
@@ -163,7 +164,7 @@ inline void _calculate_acosh_()
 
 // asinh(x) = log(x + sqrt(x^2 + 1))
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_asinh_()
+inline void _calculate_asinh_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
@@ -178,14 +179,14 @@ inline void _calculate_asinh_()
             res = -res;
         }
         v_endif;
-        sfpi::dst_reg[0] = res;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = res;
         sfpi::dst_reg++;
     }
 }
 
 // atanh[x] = 0.5 * ln((1 + x) / (1 - x))
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void _calculate_atanh_()
+inline void _calculate_atanh_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
@@ -216,12 +217,12 @@ inline void _calculate_atanh_()
             {
                 den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::NearestEven);
             }
-            num              = num * den;
-            den              = _calculate_log_body_no_init_(num);
-            res              = 0.5f * den;
+            num = num * den;
+            den = _calculate_log_body_no_init_(num);
+            res = 0.5f * den;
         }
         v_endif;
-        sfpi::dst_reg[0] = res;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = res;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -100,7 +100,7 @@ inline void _calculate_sine_(std::uint32_t dst_index_in, std::uint32_t dst_index
             v *= -1;
         }
         v_endif;
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         sfpi::dst_reg++;
     }
 }
@@ -127,7 +127,7 @@ inline void _calculate_cosine_(std::uint32_t dst_index_in, std::uint32_t dst_ind
             v *= -1;
         }
         v_endif;
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         sfpi::dst_reg++;
     }
 }
@@ -143,19 +143,19 @@ inline void _calculate_acosh_(std::uint32_t dst_index_in, std::uint32_t dst_inde
         sfpi::vFloat inp = sfpi::dst_reg[0];
         v_if (inp < sfpi::vConst1)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = std::numeric_limits<float>::quiet_NaN();
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = std::numeric_limits<float>::quiet_NaN();
         }
         v_elseif (inp == sfpi::vConst1)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::vConst0;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::vConst0;
         }
         v_else
         {
-            sfpi::vFloat tmp                                   = inp * inp;
-            tmp                                                = tmp - sfpi::vConst1;
-            tmp                                                = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-            tmp                                                = tmp + inp;
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_log_body_no_init_(tmp);
+            sfpi::vFloat tmp                                           = inp * inp;
+            tmp                                                        = tmp - sfpi::vConst1;
+            tmp                                                        = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
+            tmp                                                        = tmp + inp;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _calculate_log_body_no_init_(tmp);
         }
         v_endif;
         sfpi::dst_reg++;
@@ -179,7 +179,7 @@ inline void _calculate_asinh_(std::uint32_t dst_index_in, std::uint32_t dst_inde
             res = -res;
         }
         v_endif;
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = res;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = res;
         sfpi::dst_reg++;
     }
 }
@@ -222,7 +222,7 @@ inline void _calculate_atanh_(std::uint32_t dst_index_in, std::uint32_t dst_inde
             res = 0.5f * den;
         }
         v_endif;
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = res;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = res;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -18,16 +18,16 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_fp32_to_uint16_()
+inline void _calculate_typecast_fp32_to_uint16_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
         TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_6, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
@@ -56,16 +56,16 @@ inline void _calculate_typecast_fp32_to_uint16_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_uint16_to_fp16b_()
+inline void _calculate_typecast_uint16_to_fp16b_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
@@ -92,13 +92,13 @@ inline void _calculate_typecast_uint16_to_fp16b_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_int32_to_fp16b_()
+inline void _calculate_typecast_int32_to_fp16b_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
         TTI_SFPABS(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);                  // lreg[1] = iabs(lreg[0])
         TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, 0);                    // lreg[2] = cast(lreg[1])
         TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG0, 0);               // lreg[0] = sign(lreg[0]) | exp_man(lreg[2])
@@ -106,7 +106,7 @@ inline void _calculate_typecast_int32_to_fp16b_()
         TTI_SFPADDI(0xcf00, p_sfpu::LREG0, 0);                           // lreg[0] += -2**31
         TTI_SFPENCC(0, 0, 0, 0);                                         // restore cc
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 4 cycles per input row.
@@ -154,12 +154,12 @@ inline void _calculate_typecast_int32_to_fp16b_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_fp32_to_int32_()
+inline void _calculate_typecast_fp32_to_int32_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
         // result = 0
         TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, 0);
 
@@ -184,17 +184,17 @@ inline void _calculate_typecast_fp32_to_int32_()
         // LaneEnabled = true
         TTI_SFPENCC(0, 0, 0, 0);
 
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_6, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_fp32_to_uint32_()
+inline void _calculate_typecast_fp32_to_uint32_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
         // result = 0
         TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, 0);
 
@@ -214,23 +214,23 @@ inline void _calculate_typecast_fp32_to_uint32_()
         // LaneEnabled = true
         TTI_SFPENCC(0, 0, 0, 0);
 
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_6, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_fp32_to_fp16b_()
+inline void _calculate_typecast_fp32_to_fp16b_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
         TTI_SFPSHFT((-16) & 0xFFF, p_sfpu::LREG1, p_sfpu::LREG0, 5);               // lreg[0] = lreg[1] >> 16
         TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG0, 0);                           // lreg[0] &= 1
         TTI_SFPIADD(0, p_sfpu::LREG13, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_CC_NONE); // lreg[1] += 0x7FFF
         TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_CC_NONE);  // lreg[1] += lreg[0]
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_6, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
@@ -268,15 +268,15 @@ inline void _calculate_typecast_fp32_to_fp16b_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_uint16_to_fp32_()
+inline void _calculate_typecast_uint16_to_fp32_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_6, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
@@ -302,20 +302,20 @@ inline void _calculate_typecast_uint16_to_fp32_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_int32_to_fp32_()
+inline void _calculate_typecast_int32_to_fp32_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
         TTI_SFPABS(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);                  // lreg[1] = iabs(lreg[0])
         TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, 0);                    // lreg[2] = cast(lreg[1])
         TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG0, 0);               // lreg[0] = sign(lreg[0]) | exp_man(lreg[2])
         TTI_SFPSETCC(0, p_sfpu::LREG1, 0, sfpi::SFPSETCC_MOD1_LREG_LT0); // cc = lreg[1] < 0
         TTI_SFPADDI(0xcf00, p_sfpu::LREG0, 0);                           // lreg[0] += -2**31
         TTI_SFPENCC(0, 0, 0, 0);                                         // restore cc
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 4 cycles per input row.
@@ -361,20 +361,20 @@ inline void _calculate_typecast_int32_to_fp32_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_uint32_to_fp16b_()
+inline void _calculate_typecast_uint32_to_fp16b_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
         TTI_SFPSETSGN(0, p_sfpu::LREG0, p_sfpu::LREG1, 1);
         TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0);
         TTI_SFPSETCC(0, p_sfpu::LREG0, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
         TTI_SFPADDI(0x4f00, p_sfpu::LREG1, 0); // 2^31
         TTI_SFPENCC(0, 0, 0, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
@@ -418,19 +418,19 @@ inline void _calculate_typecast_uint32_to_fp16b_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_uint32_to_fp32_()
+inline void _calculate_typecast_uint32_to_fp32_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
         TTI_SFPSETSGN(0, p_sfpu::LREG0, p_sfpu::LREG1, 1);
         TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, 0);
         TTI_SFPSETCC(0, p_sfpu::LREG0, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
         TTI_SFPADDI(0x4f00, p_sfpu::LREG2, 0); // 2^31
         TTI_SFPENCC(0, 0, 0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::FP32, ADDR_MOD_6, 0);
+        TT_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::FP32, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
@@ -475,14 +475,14 @@ inline void _calculate_typecast_uint32_to_fp32_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_uint16_to_uint32_()
+inline void _calculate_typecast_uint16_to_uint32_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_6, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
@@ -504,18 +504,18 @@ inline void _calculate_typecast_uint16_to_uint32_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_uint32_to_uint16_()
+inline void _calculate_typecast_uint32_to_uint16_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
         TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_CC_NONE | sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST);
         TTI_SFPSHFT((-16) & 0xFFF, 0, p_sfpu::LREG0, 1);
-        TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
         TTI_SFPOR(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_6, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
@@ -544,17 +544,17 @@ inline void _calculate_typecast_uint32_to_uint16_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_int32_to_uint16_()
+inline void _calculate_typecast_int32_to_uint16_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_6, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -27,7 +27,7 @@ inline void _calculate_typecast_fp32_to_uint16_(std::uint32_t dst_index_in, std:
         TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
         TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_6, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
@@ -65,7 +65,7 @@ inline void _calculate_typecast_uint16_to_fp16b_(std::uint32_t dst_index_in, std
         TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
@@ -106,7 +106,7 @@ inline void _calculate_typecast_int32_to_fp16b_(std::uint32_t dst_index_in, std:
         TTI_SFPADDI(0xcf00, p_sfpu::LREG0, 0);                           // lreg[0] += -2**31
         TTI_SFPENCC(0, 0, 0, 0);                                         // restore cc
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 4 cycles per input row.
@@ -184,7 +184,7 @@ inline void _calculate_typecast_fp32_to_int32_(std::uint32_t dst_index_in, std::
         // LaneEnabled = true
         TTI_SFPENCC(0, 0, 0, 0);
 
-        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_6, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 }
 
@@ -214,7 +214,7 @@ inline void _calculate_typecast_fp32_to_uint32_(std::uint32_t dst_index_in, std:
         // LaneEnabled = true
         TTI_SFPENCC(0, 0, 0, 0);
 
-        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_6, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 }
 
@@ -230,7 +230,7 @@ inline void _calculate_typecast_fp32_to_fp16b_(std::uint32_t dst_index_in, std::
         TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG0, 0);                           // lreg[0] &= 1
         TTI_SFPIADD(0, p_sfpu::LREG13, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_CC_NONE); // lreg[1] += 0x7FFF
         TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_CC_NONE);  // lreg[1] += lreg[0]
-        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_6, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
@@ -276,7 +276,7 @@ inline void _calculate_typecast_uint16_to_fp32_(std::uint32_t dst_index_in, std:
     {
         TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_6, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
@@ -315,7 +315,7 @@ inline void _calculate_typecast_int32_to_fp32_(std::uint32_t dst_index_in, std::
         TTI_SFPSETCC(0, p_sfpu::LREG1, 0, sfpi::SFPSETCC_MOD1_LREG_LT0); // cc = lreg[1] < 0
         TTI_SFPADDI(0xcf00, p_sfpu::LREG0, 0);                           // lreg[0] += -2**31
         TTI_SFPENCC(0, 0, 0, 0);                                         // restore cc
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 4 cycles per input row.
@@ -374,7 +374,7 @@ inline void _calculate_typecast_uint32_to_fp16b_(std::uint32_t dst_index_in, std
         TTI_SFPADDI(0x4f00, p_sfpu::LREG1, 0); // 2^31
         TTI_SFPENCC(0, 0, 0, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
@@ -430,7 +430,7 @@ inline void _calculate_typecast_uint32_to_fp32_(std::uint32_t dst_index_in, std:
         TTI_SFPSETCC(0, p_sfpu::LREG0, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
         TTI_SFPADDI(0x4f00, p_sfpu::LREG2, 0); // 2^31
         TTI_SFPENCC(0, 0, 0, 0);
-        TT_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::FP32, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::FP32, ADDR_MOD_6, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
@@ -482,7 +482,7 @@ inline void _calculate_typecast_uint16_to_uint32_(std::uint32_t dst_index_in, st
     for (int d = 0; d < ITERATIONS; d++)
     {
         TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_6, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
@@ -515,7 +515,7 @@ inline void _calculate_typecast_uint32_to_uint16_(std::uint32_t dst_index_in, st
         TTI_SFPSHFT((-16) & 0xFFF, 0, p_sfpu::LREG0, 1);
         TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
         TTI_SFPOR(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
-        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_6, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
@@ -554,7 +554,7 @@ inline void _calculate_typecast_int32_to_uint16_(std::uint32_t dst_index_in, std
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_6, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_6, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu_params.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu_params.h
@@ -4,18 +4,72 @@
 
 #pragma once
 #include <cstdint>
+#include <type_traits>
 #include <utility>
 
 #include "llk_math_eltwise_sfpu_common.h"
 #include "llk_math_eltwise_unary_sfpu.h"
 
+// Dispatch the SFPU callable with or without leading dst indices, depending on
+// which signature it accepts. Some calculate functions take (dst_in, dst_out,
+// args...) — these are the split-aware ones added on top of the legacy
+// (args...) ones (e.g. TopK helpers). This helper selects the right shape at
+// compile time so the single-idx `_params_` template can drive both kinds of
+// callable while keeping in == out for the legacy single-dst contract.
+template <typename Callable, typename... Args>
+inline void _llk_math_eltwise_unary_sfpu_dispatch_(Callable&& sfpu_func, std::uint32_t dst_index, Args&&... args)
+{
+    if constexpr (std::is_invocable_v<Callable&, std::uint32_t, std::uint32_t, Args&...>)
+    {
+        std::forward<Callable>(sfpu_func)(dst_index, dst_index, std::forward<Args>(args)...);
+    }
+    else
+    {
+        std::forward<Callable>(sfpu_func)(std::forward<Args>(args)...);
+    }
+}
+
+// Single-index variant. The dispatch helper above lets a callable that
+// accepts (dst_in, dst_out, Args&...) work here by repeating dst_index for
+// both positions (in == out), so legacy single-dst paths and macro callers
+// can drive split-aware SFPU calculate functions without changing shape.
 template <typename Callable, typename... Args>
 inline void _llk_math_eltwise_unary_sfpu_params_(
     Callable&& sfpu_func, std::uint32_t dst_index, int vector_mode = static_cast<int>(VectorMode::RC), Args&&... args)
 {
     _llk_math_eltwise_sfpu_start_(dst_index);
 
-    _llk_math_eltwise_sfpu_apply_vector_mode_(std::forward<Callable>(sfpu_func), vector_mode, std::forward<Args>(args)...);
+    auto dispatch_wrapper = [&](auto&&... a) {
+        _llk_math_eltwise_unary_sfpu_dispatch_(
+            std::forward<Callable>(sfpu_func), dst_index, std::forward<decltype(a)>(a)...);
+    };
+    _llk_math_eltwise_sfpu_apply_vector_mode_(dispatch_wrapper, vector_mode, std::forward<Args>(args)...);
+
+    _llk_math_eltwise_sfpu_done_();
+}
+
+// Split-dest variant: source tile index (dst_index_in) is used to position
+// the dest face pointer at the start; the callable then receives both indices
+// so an SFPU op can read from dst_index_in and write to dst_index_out.
+// Distinct name (not an overload of _params_) so callers pick the shape
+// explicitly and overload resolution can't conflate the two.
+// The dst-bound assert lives in ckernel::_sfpu_check_and_call_ (see the
+// per-arch llk_math_eltwise_unary_sfpu_macros.h), so it is intentionally not
+// duplicated here.
+template <typename Callable, typename... Args>
+inline void _llk_math_eltwise_unary_sfpu_params_split_(
+    Callable&& sfpu_func,
+    std::uint32_t dst_index_in,
+    std::uint32_t dst_index_out,
+    int vector_mode = static_cast<int>(VectorMode::RC),
+    Args&&... args)
+{
+    _llk_math_eltwise_sfpu_start_(dst_index_in);
+
+    auto split_wrapper = [&](auto&&... a) {
+        std::forward<Callable>(sfpu_func)(dst_index_in, dst_index_out, std::forward<decltype(a)>(a)...);
+    };
+    _llk_math_eltwise_sfpu_apply_vector_mode_(split_wrapper, vector_mode, std::forward<Args>(args)...);
 
     _llk_math_eltwise_sfpu_done_();
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/experimental/ckernel_sfpu_abs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/experimental/ckernel_sfpu_abs.h
@@ -4,6 +4,8 @@
 // AI-generated — run_id: 2026-04-08_abs_quasar_2f52d870
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 #include "sfpi.h"
@@ -13,7 +15,7 @@ namespace ckernel
 namespace sfpu
 {
 // Calculates ABS for number of rows of output SFPU ops (Quasar = 2 rows)
-inline void _calculate_abs_sfp_rows_()
+inline void _calculate_abs_sfp_rows_(const int out_offset)
 {
     TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0]
 
@@ -22,17 +24,18 @@ inline void _calculate_abs_sfp_rows_()
     // which is wrong for float data.
     TTI_SFPABS(p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPABS_MOD1_FLOAT);
 
-    // Store result back to destination
-    TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0);
+    // Store result to output tile (out_offset = 0 when in-place)
+    TT_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, out_offset);
 }
 
 // Implements element-wise absolute value: abs(x)
-inline void _calculate_abs_(const int iterations)
+inline void _calculate_abs_(std::uint32_t dst_tile_index_in, std::uint32_t dst_tile_index_out, const int iterations)
 {
+    const int out_offset = (dst_tile_index_out - dst_tile_index_in) * 32;
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_abs_sfp_rows_();
+        _calculate_abs_sfp_rows_(out_offset);
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <cstdint>
+
+#include "ckernel_ops.h"
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 
@@ -23,12 +26,22 @@ inline void _calculate_exp_sfp_rows_()
 }
 
 template <bool APPROXIMATION_MODE>
-inline void _calculate_exp_(const int iterations)
+inline void _calculate_exp_(std::uint32_t dst_tile_index_in, std::uint32_t dst_tile_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_exp_sfp_rows_<APPROXIMATION_MODE>();
+        TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0,
+                   0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+
+        // SFPARECIP, approx version of reciprocal
+        if constexpr (APPROXIMATION_MODE)
+        {
+            TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::EXP_MODE); // Read value from lreg[0], approximate recip, load back into lreg[1]
+        }
+
+        // Store from lreg[1] into dest register
+        TT_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0, (dst_tile_index_out - dst_tile_index_in) * 32);
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -49,21 +49,15 @@ inline void _init_gelu_()
 }
 
 // Calculates GELU for number of rows of output SFPU ops (Quasar = 2 rows)
-inline void _calculate_gelu_sfp_rows_()
-{
-    TTI_SFPLOAD(p_sfpu::LREG3, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[3], uses ADDR_MOD_7 (set to all zeroes)
-
-    TTI_SFPLUTFP32(p_sfpu::LREG4, 0x2); // Calculate piecewise part on lreg[3] and store in lreg[4], using FP16 6-entry format mode 1 LUT
-    TTI_SFPMAD(p_sfpu::LREG6, p_sfpu::LREG3, p_sfpu::LREG4, p_sfpu::LREG5, 0); // 0.5 * x + piecewise result, store in lreg[5]
-    TTI_SFPSTORE(p_sfpu::LREG5, 0, ADDR_MOD_7, 0, 0);                          // store from lreg[5] into dest register
-}
-
-inline void _calculate_gelu_(const int iterations)
+inline void _calculate_gelu_(std::uint32_t dst_tile_index_in, std::uint32_t dst_tile_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_gelu_sfp_rows_();
+        TT_SFPLOAD(p_sfpu::LREG3, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[3]
+        TTI_SFPLUTFP32(p_sfpu::LREG4, 0x2); // Calculate piecewise part on lreg[3] and store in lreg[4], using FP16 6-entry format mode 1 LUT
+        TTI_SFPMAD(p_sfpu::LREG6, p_sfpu::LREG3, p_sfpu::LREG4, p_sfpu::LREG5, 0);                   // 0.5 * x + piecewise result, store in lreg[5]
+        TT_SFPSTORE(p_sfpu::LREG5, 0, ADDR_MOD_7, 0, (dst_tile_index_out - dst_tile_index_in) * 32); // store from lreg[5] into dest register
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <cstdint>
+
+#include "ckernel_ops.h"
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 #include "sfpi.h"
@@ -11,27 +14,22 @@ namespace ckernel::sfpu
 {
 // Calculates RECIP for number of rows of output SFPU ops (Quasar = 2 rows)
 template <bool APPROXIMATION_MODE>
-inline void _calculate_reciprocal_sfp_rows_()
-{
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
-
-    // SFPARECIP, approx version of reciprocal
-    if constexpr (APPROXIMATION_MODE)
-    {
-        TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::RECIP_MODE); // Read value from lreg[0], approximate recip, load back into lreg[1]
-    }
-
-    // Store from lreg[1] into dest register
-    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0, 0);
-}
-
-template <bool APPROXIMATION_MODE>
-inline void _calculate_reciprocal_(const int iterations)
+inline void _calculate_reciprocal_(std::uint32_t dst_tile_index_in, std::uint32_t dst_tile_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_reciprocal_sfp_rows_<APPROXIMATION_MODE>();
+        TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0,
+                   0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+
+        // SFPARECIP, approx version of reciprocal
+        if constexpr (APPROXIMATION_MODE)
+        {
+            TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::RECIP_MODE); // Read value from lreg[0], approximate recip, load back into lreg[1]
+        }
+
+        // Store from lreg[1] into dest register
+        TT_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0, (dst_tile_index_out - dst_tile_index_in) * 32);
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 
+#include "ckernel_ops.h"
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 #include "sfpi.h"
@@ -13,31 +14,26 @@ namespace ckernel
 {
 namespace sfpu
 {
-// Calculates RELU for number of rows of output SFPU ops (Quasar = 2 rows)
-inline void _calculate_relu_sfp_rows_()
-{
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
-
-    // SFPARECIP with RELU_MODE does relu eltwise
-    TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::RELU_MODE); // Read value from lreg[0], get relu value, load back into lreg[1]
-
-    // Store from lreg[1] into dest register
-    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0, 0);
-}
-
 // Implements standard relu which does max(0, x)
-inline void _calculate_relu_(const int iterations = SFPU_ITERATIONS)
+inline void _calculate_relu_(std::uint32_t dst_tile_index_in, std::uint32_t dst_tile_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_relu_sfp_rows_();
+        TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0,
+                   0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+
+        // SFPARECIP with RELU_MODE does relu eltwise
+        TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::RELU_MODE); // Read value from lreg[0], get relu value, load back into lreg[1]
+
+        // Store from lreg[1] into dest register
+        TT_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0, (dst_tile_index_out - dst_tile_index_in) * 32);
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
 }
 
 // Calculates Leaky RELU for number of rows of output SFPU ops (Quasar = 2 rows)
-inline void _calculate_lrelu_sfp_rows_()
+inline void _calculate_lrelu_sfp_rows_(int store_offset)
 {
     TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
 
@@ -48,25 +44,26 @@ inline void _calculate_lrelu_sfp_rows_()
     TTI_SFPENCC(0, 0); // clear cc result reg
 
     // Store from lreg0 into dest register
-    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0, 0);
+    TT_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0, store_offset);
 }
 
 // Implements leaky relu which return x when x > 0 and x*slope when x < 0
-inline void _calculate_lrelu_(const std::uint32_t slope, const int iterations = SFPU_ITERATIONS)
+inline void _calculate_lrelu_(std::uint32_t dst_tile_index_in, std::uint32_t dst_tile_index_out, const std::uint32_t slope, const int iterations)
 {
+    const int store_offset = (dst_tile_index_out - dst_tile_index_in) * 32;
     TTI_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_FLOATB, (slope >> 16)); // store slope in LREG2
     TTI_SFPENCC(1, 2);                                           // enable cc
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_lrelu_sfp_rows_();
+        _calculate_lrelu_sfp_rows_(store_offset);
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
     TTI_SFPENCC(0, 2); // disable cc
 }
 
 // Calculates RELU MIN for number of rows of output SFPU ops (Quasar = 2 rows)
-inline void _calculate_relu_min_sfp_rows_()
+inline void _calculate_relu_min_sfp_rows_(int store_offset)
 {
     TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
 
@@ -78,26 +75,27 @@ inline void _calculate_relu_min_sfp_rows_()
     TTI_SFPENCC(0, 0); // clear cc result reg
 
     // Store from lreg0 into dest register
-    TTI_SFPSTORE(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_FLOATB, ADDR_MOD_7, 0, 0);
+    TT_SFPSTORE(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_FLOATB, ADDR_MOD_7, 0, store_offset);
 }
 
 // Implements relu min which returns x when x > threshold, otherwise return 0
 template <int ITERATIONS = SFPU_ITERATIONS>
-inline void _relu_min_(const std::uint32_t threshold)
+inline void _relu_min_(std::uint32_t dst_tile_index_in, std::uint32_t dst_tile_index_out, const std::uint32_t threshold)
 {
+    const int store_offset = (dst_tile_index_out - dst_tile_index_in) * 32;
     TTI_SFPLOADI(p_sfpu::LREG2, 0 /*Float16_b*/, (threshold >> 16)); // store slope in LREG2
     TTI_SFPENCC(1, 2);                                               // enable cc
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        _calculate_relu_min_sfp_rows_();
+        _calculate_relu_min_sfp_rows_(store_offset);
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
     TTI_SFPENCC(0, 2); // disable cc
 }
 
 // Calculates RELU MAX for number of rows of output SFPU ops (Quasar = 2 rows)
-inline void _calculate_relu_max_sfp_rows_()
+inline void _calculate_relu_max_sfp_rows_(int store_offset)
 {
     TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
 
@@ -114,18 +112,19 @@ inline void _calculate_relu_max_sfp_rows_()
     TTI_SFPENCC(0, 0); // reset cc
 
     // Store from lreg0 into dest register
-    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0, 0);
+    TT_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0, store_offset);
 }
 
 // Implements relu max
-inline void _relu_max_(const std::uint32_t threshold, const int iterations = SFPU_ITERATIONS)
+inline void _relu_max_(std::uint32_t dst_tile_index_in, std::uint32_t dst_tile_index_out, const std::uint32_t threshold, const int iterations)
 {
+    const int store_offset = (dst_tile_index_out - dst_tile_index_in) * 32;
     TTI_SFPLOADI(p_sfpu::LREG2, 0 /*Float16_b*/, (threshold >> 16)); // store slope in LREG2
     TTI_SFPENCC(1, 2);                                               // enable cc
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_relu_max_sfp_rows_();
+        _calculate_relu_max_sfp_rows_(store_offset);
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
     TTI_SFPENCC(0, 2); // disable cc

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_rsqrt.h
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_ops.h"
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
@@ -13,26 +15,21 @@ namespace sfpu
 {
 // Calculates RSQRT (reciprocal square root) for number of rows of output SFPU ops (Quasar = 2 rows)
 // Always uses approximate mode (sqrt + recip) for optimal performance
-inline void _calculate_rsqrt_sfp_rows_()
-{
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0]
-
-    // First compute sqrt(x) into LREG1
-    TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::SQRT_MODE); // Read value from lreg[0], sqrt, load back into lreg[1]
-
-    // Then compute 1/sqrt(x) = recip(sqrt(x)) into LREG2
-    TTI_SFPNONLINEAR(p_sfpu::LREG1, p_sfpu::LREG2, p_sfpnonlinear::RECIP_MODE); // Read value from lreg[1], recip, load back into lreg[2]
-
-    // Store from lreg[2] into dest register
-    TTI_SFPSTORE(p_sfpu::LREG2, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0);
-}
-
-inline void _calculate_rsqrt_(const int iterations)
+inline void _calculate_rsqrt_(std::uint32_t dst_tile_index_in, std::uint32_t dst_tile_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_rsqrt_sfp_rows_();
+        TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0]
+
+        // First compute sqrt(x) into LREG1
+        TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::SQRT_MODE); // Read value from lreg[0], sqrt, load back into lreg[1]
+
+        // Then compute 1/sqrt(x) = recip(sqrt(x)) into LREG2
+        TTI_SFPNONLINEAR(p_sfpu::LREG1, p_sfpu::LREG2, p_sfpnonlinear::RECIP_MODE); // Read value from lreg[1], recip, load back into lreg[2]
+
+        // Store from lreg[2] into dest register
+        TT_SFPSTORE(p_sfpu::LREG2, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, (dst_tile_index_out - dst_tile_index_in) * 32);
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -47,5 +47,21 @@ inline void _calculate_sigmoid_(const int iterations = SFPU_ITERATIONS)
     }
 }
 
+// Split-dest overload: writes the sigmoid result to dst_tile_index_out while
+// reading from dst_tile_index_in. Uses TT_SFPSTORE with a runtime offset
+// because the store target diverges from the load target; the immediate
+// (TTI_) form in _calculate_sigmoid_sfp_rows_ requires offset 0.
+inline void _calculate_sigmoid_(std::uint32_t dst_tile_index_in, std::uint32_t dst_tile_index_out, const int iterations)
+{
+#pragma GCC unroll 8
+    for (int d = 0; d < iterations; d++)
+    {
+        TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0);  // load from dest into lreg[0]
+        _calculate_sigmoid_regs_(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG0); // calculate sigmoid using lreg[0] as src and dest, and lreg[1] as work register
+        TT_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0, (dst_tile_index_out - dst_tile_index_in) * 32); // store from lreg[0] into dest register at out offset
+        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>();                    // does the dest_reg++ (increments by 2 rows)
+    }
+}
+
 } // namespace sfpu
 } // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_silu.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_ops.h"
 #include "ckernel_sfpu_sigmoid.h"
 #include "ckernel_trisc_common.h"
@@ -32,6 +34,24 @@ inline void _calculate_silu_(const int iterations = SFPU_ITERATIONS)
     {
         _calculate_silu_sfp_rows_();
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
+    }
+}
+
+// Split-dest overload: writes the silu result to dst_tile_index_out while
+// reading from dst_tile_index_in. Uses TT_SFPSTORE with a runtime offset
+// because the store target diverges from the load target; the immediate
+// (TTI_) form in _calculate_silu_sfp_rows_ requires offset 0.
+inline void _calculate_silu_(std::uint32_t dst_tile_index_in, std::uint32_t dst_tile_index_out, const int iterations)
+{
+#pragma GCC unroll 8
+    for (int d = 0; d < iterations; d++)
+    {
+        TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0]
+        // Calculate sigmoid using lreg[0] as src, lreg[1] as work register, and lreg[2] as dest (since we need the original value for the final multiply)
+        _calculate_sigmoid_regs_(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG2);
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG2, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);                // Multiply lreg[0] * lreg[2], store result in lreg[1]
+        TT_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0, (dst_tile_index_out - dst_tile_index_in) * 32); // store from lreg[1] into dest register at out offset
+        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>();                    // does the dest_reg++ (increments by 2 rows)
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <cstdint>
+
+#include "ckernel_ops.h"
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 
@@ -12,27 +15,22 @@ namespace sfpu
 {
 // Calculates SQRT for number of rows of output SFPU ops (Quasar = 2 rows)
 template <bool APPROXIMATION_MODE>
-inline void _calculate_sqrt_sfp_rows_()
-{
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
-
-    // SFPARECIP, approx version of sqrt
-    if constexpr (APPROXIMATION_MODE)
-    {
-        TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::SQRT_MODE); // Read value from lreg[0], approximate sqrt, load back into lreg[1]
-    }
-
-    // Store from lreg[1] into dest register
-    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0, 0);
-}
-
-template <bool APPROXIMATION_MODE>
-inline void _calculate_sqrt_(const int iterations)
+inline void _calculate_sqrt_(std::uint32_t dst_tile_index_in, std::uint32_t dst_tile_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_sqrt_sfp_rows_<APPROXIMATION_MODE>();
+        TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0,
+                   0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+
+        // SFPARECIP, approx version of sqrt
+        if constexpr (APPROXIMATION_MODE)
+        {
+            TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::SQRT_MODE); // Read value from lreg[0], approximate sqrt, load back into lreg[1]
+        }
+
+        // Store from lreg[1] into dest register
+        TT_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0, (dst_tile_index_out - dst_tile_index_in) * 32);
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_square.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_ops.h"
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
@@ -13,22 +15,16 @@ namespace ckernel
 namespace sfpu
 {
 // Calculates SQUARE for number of rows of output SFPU ops (Quasar = 2 rows)
-template <bool APPROXIMATION_MODE>
-inline void _calculate_square_sfp_rows_()
-{
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0]
-    // Multiply LREG0 * LREG0, store result in LREG0
-    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
-    // Store result back to destination
-    TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0);
-}
-
-inline void _calculate_square_(const int iterations)
+inline void _calculate_square_(std::uint32_t dst_tile_index_in, std::uint32_t dst_tile_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_square_sfp_rows_<false>();
+        TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0]
+        // Multiply LREG0 * LREG0, store result in LREG0
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+        // Store result back to destination
+        TT_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, (dst_tile_index_out - dst_tile_index_in) * 32);
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_tanh.h
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <cstdint>
+
+#include "ckernel_ops.h"
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 
@@ -10,29 +13,24 @@ namespace ckernel
 {
 namespace sfpu
 {
-// Calculates RECIP for number of rows of output SFPU ops (Quasar = 2 rows)
+// Calculates TANH for number of rows of output SFPU ops (Quasar = 2 rows)
 template <bool APPROXIMATION_MODE>
-inline void _calculate_tanh_sfp_rows_()
-{
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
-
-    // SFPARECIP, approx version of reciprocal
-    if constexpr (APPROXIMATION_MODE)
-    {
-        TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::TANH_MODE); // Read value from lreg[0], approximate recip, load back into lreg[1]
-    }
-
-    // Store from lreg[1] into dest register
-    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0, 0);
-}
-
-template <bool APPROXIMATION_MODE>
-inline void _calculate_tanh_(const int iterations)
+inline void _calculate_tanh_(std::uint32_t dst_tile_index_in, std::uint32_t dst_tile_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_tanh_sfp_rows_<APPROXIMATION_MODE>();
+        TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0,
+                   0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
+
+        // SFPARECIP, approx version of tanh
+        if constexpr (APPROXIMATION_MODE)
+        {
+            TTI_SFPNONLINEAR(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpnonlinear::TANH_MODE); // Read value from lreg[0], approximate tanh, load back into lreg[1]
+        }
+
+        // Store from lreg[1] into dest register
+        TT_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0, (dst_tile_index_out - dst_tile_index_in) * 32);
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_typecast_fp16b_uint16.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_typecast_fp16b_uint16.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <cstdint>
+
+#include "ckernel_ops.h"
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 
@@ -12,26 +15,20 @@ namespace ckernel
 namespace sfpu
 {
 // Calculates Typecast for number of rows of output SFPU ops (Quasar = 2 rows)
-inline void _calculate_typecast_fp16b_to_uint16_rows()
-{
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::FP16B, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
-
-    TTI_SFPENCC(0, 1);                 // CC_en <= 1, CC_res <= 1 # TODO - Luka: why do we need this? Why can't we just skip this?
-    TTI_SFPSETCC(0, p_sfpu::LREG0, 0); // CC_res <= (LREG0 < 0)
-    TTI_SFPLOADI(p_sfpu::LREG0, 0, 0); // loads zeros where lreg[0] is negative
-    TTI_SFPENCC(0, 1);                 // CC_en <= 1, CC_res <= 1 (for all)
-
-    TTI_SFP_STOCH_RND(p_sfpu::sfp_stochrnd_rnd_mod::NearEven, 0, 0, p_sfpu::LREG0, p_sfpu::LREG1, (1 << 3) | ckernel::p_sfpu::sfp_stochrnd_mod::FP32_TO_UINT16);
-
-    TTI_SFPSTORE(p_sfpu::LREG1, p_sfpu::sfpmem::UINT16, ADDR_MOD_7, 0, 0); // Store from lreg[1] into dest register
-}
-
-inline void _calculate_typecast_fp16b_to_uint16_(const int iterations)
+inline void _calculate_typecast_fp16b_to_uint16_(std::uint32_t dst_tile_index_in, std::uint32_t dst_tile_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_typecast_fp16b_to_uint16_rows();
+        TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::FP16B, ADDR_MOD_7, 0, 0); // load from dest into lreg[0]
+        TTI_SFPENCC(0, 1);                                                  // CC_en <= 1, CC_res <= 1
+        TTI_SFPSETCC(0, p_sfpu::LREG0, 0);                                  // CC_res <= (LREG0 < 0)
+        TTI_SFPLOADI(p_sfpu::LREG0, 0, 0);                                  // loads zeros where lreg[0] is negative
+        TTI_SFPENCC(0, 1);                                                  // CC_en <= 1, CC_res <= 1 (for all)
+        TTI_SFP_STOCH_RND(
+            p_sfpu::sfp_stochrnd_rnd_mod::NearEven, 0, 0, p_sfpu::LREG0, p_sfpu::LREG1, (1 << 3) | ckernel::p_sfpu::sfp_stochrnd_mod::FP32_TO_UINT16);
+        TT_SFPSTORE(
+            p_sfpu::LREG1, p_sfpu::sfpmem::UINT16, ADDR_MOD_7, 0, (dst_tile_index_out - dst_tile_index_in) * 32); // Store from lreg[1] into dest register
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_typecast_int32_fp32.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_typecast_int32_fp32.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <cstdint>
+
+#include "ckernel_ops.h"
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 
@@ -12,22 +15,15 @@ namespace ckernel
 namespace sfpu
 {
 // Calculates Typecast for number of rows of output SFPU ops (Quasar = 2 rows)
-inline void _calculate_typecast_int32_to_fp32_rows()
-{
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0, 0); // load from dest into lreg[0], uses ADDR_MOD_7 (set to all zeroes)
-    // TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG2, 3); //convert from 2s complement to sign+magnitude
-
-    TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG1, 0); // convert from int32 sign+mag to fp32 using rnd nearest even
-
-    TTI_SFPSTORE(p_sfpu::LREG1, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, 0); // Store from lreg[1] into dest register
-}
-
-inline void _calculate_typecast_int32_to_fp32_(const int iterations)
+inline void _calculate_typecast_int32_to_fp32_(std::uint32_t dst_tile_index_in, std::uint32_t dst_tile_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_typecast_int32_to_fp32_rows();
+        TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0, 0); // load from dest into lreg[0]
+        // TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG2, 3); //convert from 2s complement to sign+magnitude
+        TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG1, 0); // convert from int32 sign+mag to fp32 using rnd nearest even
+        TT_SFPSTORE(p_sfpu::LREG1, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, (dst_tile_index_out - dst_tile_index_in) * 32); // Store from lreg[1] into dest register
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_sfpu_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_sfpu_common.h
@@ -28,17 +28,17 @@ inline void _llk_math_eltwise_unary_sfpu_params_(F&& sfpu_func, std::uint32_t ds
 template <class F, class... ARGS>
 inline void _llk_math_eltwise_unary_sfpu_params_split_(F&& sfpu_func, std::uint32_t dst_tile_index_in, std::uint32_t dst_tile_index_out, ARGS&&... args)
 {
-    _llk_math_eltwise_unary_sfpu_start_(dst_tile_index_in);
+    _llk_math_eltwise_sfpu_start_(dst_tile_index_in);
 
     for (std::uint32_t face = 0; face < NUM_FACES; face++)
     {
         sfpu_func(dst_tile_index_in, dst_tile_index_out, static_cast<ARGS&&>(args)...);
 
         // Move to the next face
-        _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_();
+        _llk_math_eltwise_sfpu_inc_dst_face_addr_();
     }
 
-    _llk_math_eltwise_unary_sfpu_done_();
+    _llk_math_eltwise_sfpu_done_();
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_sfpu_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_sfpu_common.h
@@ -9,10 +9,36 @@
 
 #include "llk_math_eltwise_sfpu_common.h"
 
+// Single-index variant: forwards to the legacy single-dst path.
 template <class F, class... ARGS>
 inline void _llk_math_eltwise_unary_sfpu_params_(F&& sfpu_func, std::uint32_t dst_tile_index, ARGS&&... args)
 {
     _llk_math_eltwise_sfpu_params_(std::forward<F>(sfpu_func), dst_tile_index, std::forward<ARGS>(args)...);
+}
+
+/**
+ * @brief Runs SFPU operation for a tile (default 32x32) with split dest indices.
+ * Distinct name (not an overload of _params_) so callers pick the shape
+ * explicitly and overload resolution can't conflate the two.
+ * @param sfpu_func: SFPU callback — receives (dst_tile_index_in, dst_tile_index_out, args...)
+ * @param dst_tile_index_in: tile in destination register to read from
+ * @param dst_tile_index_out: tile in destination register to write to
+ * @param args: forwarded to sfpu_func after the two tile indices
+ */
+template <class F, class... ARGS>
+inline void _llk_math_eltwise_unary_sfpu_params_split_(F&& sfpu_func, std::uint32_t dst_tile_index_in, std::uint32_t dst_tile_index_out, ARGS&&... args)
+{
+    _llk_math_eltwise_unary_sfpu_start_(dst_tile_index_in);
+
+    for (std::uint32_t face = 0; face < NUM_FACES; face++)
+    {
+        sfpu_func(dst_tile_index_in, dst_tile_index_out, static_cast<ARGS&&>(args)...);
+
+        // Move to the next face
+        _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_();
+    }
+
+    _llk_math_eltwise_unary_sfpu_done_();
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_abs.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_abs.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sfpi.h"
 
 namespace ckernel
@@ -12,13 +14,13 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_abs_(const int iterations)
+inline void _calculate_abs_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat v   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::abs(v);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::abs(v);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_abs.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_abs.h
@@ -19,8 +19,8 @@ inline void _calculate_abs_(std::uint32_t dst_index_in, std::uint32_t dst_index_
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat v   = sfpi::dst_reg[0];
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::abs(v);
+        sfpi::vFloat v                                             = sfpi::dst_reg[0];
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::abs(v);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_activations.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_activations.h
@@ -70,27 +70,27 @@ inline void apply_activation(sfpi::vFloat& v)
 }
 
 template <bool APPROXIMATION_MODE, ActivationType ACTIVATION_TYPE, int ITERATIONS = 8>
-inline void _calculate_activation_(std::uint32_t param0, std::uint32_t param1)
+inline void _calculate_activation_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, std::uint32_t param0, std::uint32_t param1)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat v = sfpi::dst_reg[0];
         apply_activation<APPROXIMATION_MODE, ACTIVATION_TYPE>(v, param0, param1);
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, ActivationType ACTIVATION_TYPE, int ITERATIONS>
-inline void _calculate_activation_()
+inline void _calculate_activation_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat v = sfpi::dst_reg[0];
         apply_activation<APPROXIMATION_MODE, ACTIVATION_TYPE>(v);
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_activations.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_activations.h
@@ -77,7 +77,7 @@ inline void _calculate_activation_(std::uint32_t dst_index_in, std::uint32_t dst
     {
         sfpi::vFloat v = sfpi::dst_reg[0];
         apply_activation<APPROXIMATION_MODE, ACTIVATION_TYPE>(v, param0, param1);
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         sfpi::dst_reg++;
     }
 }
@@ -90,7 +90,7 @@ inline void _calculate_activation_(std::uint32_t dst_index_in, std::uint32_t dst
     {
         sfpi::vFloat v = sfpi::dst_reg[0];
         apply_activation<APPROXIMATION_MODE, ACTIVATION_TYPE>(v);
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -23,7 +23,7 @@ inline void _cast_fp32_to_fp16a_(std::uint32_t dst_index_in, std::uint32_t dst_i
     {
         TTI_SFPLOAD(0, 0, 3, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, 0, 0, 8);
-        TT_SFPSTORE(0, 1, 3, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(0, 1, 3, (dst_index_out - dst_index_in) * TILE_R_DIM);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <cstdint>
+
+#include "ckernel_addrmod.h"
 #include "ckernel_ops.h"
 #include "sfpi.h"
 
@@ -13,13 +16,14 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _cast_fp32_to_fp16a_(const int iterations)
+inline void _cast_fp32_to_fp16a_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat x   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0].mode<sfpi::SFPSTORE_MOD0_FMT_FP16A>() = sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
+        TTI_SFPLOAD(0, 0, 3, 0);
+        TTI_SFP_STOCH_RND(0, 0, 0, 0, 0, 8);
+        TT_SFPSTORE(0, 1, 3, (dst_index_out - dst_index_in) * 32);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_celu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_celu.h
@@ -15,7 +15,7 @@ namespace ckernel::sfpu
 // celu(x) = x for x>=0, alpha*(exp(x/alpha)-1) for x<0
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void _calculate_celu_(std::uint32_t param0, std::uint32_t param1)
+inline void _calculate_celu_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, std::uint32_t param0, std::uint32_t param1)
 {
     sfpi::vFloat alpha       = Converter::as_float(param0);
     sfpi::vFloat alpha_recip = Converter::as_float(param1);
@@ -37,7 +37,7 @@ inline void _calculate_celu_(std::uint32_t param0, std::uint32_t param1)
         {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_celu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_celu.h
@@ -37,7 +37,7 @@ inline void _calculate_celu_(std::uint32_t dst_index_in, std::uint32_t dst_index
         {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -14,7 +14,8 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_clamp_(const int iterations, std::uint32_t param0, std::uint32_t param1, std::uint32_t param2)
+inline void _calculate_clamp_(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations, std::uint32_t param0, std::uint32_t param1, std::uint32_t param2)
 {
     // All params are in FP16 format
     // param0 = min
@@ -41,7 +42,7 @@ inline void _calculate_clamp_(const int iterations, std::uint32_t param0, std::u
         }
         v_endif;
 
-        sfpi::dst_reg[0] = val + offset;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val + offset;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_clamp.h
@@ -42,7 +42,7 @@ inline void _calculate_clamp_(
         }
         v_endif;
 
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val + offset;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val + offset;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
@@ -31,7 +31,7 @@ sfpi_inline void _calculate_comp_init_flag_(bool check, sfpi::vFloat& flag1, sfp
 }
 
 template <bool APPROXIMATION_MODE, bool invert_output, bool check_zero, bool second_check, bool is_less_than_equal_zero, int ITERATIONS>
-inline void _calculate_comp_(const int iterations, std::uint32_t exponent_size_8)
+inline void _calculate_comp_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations, std::uint32_t exponent_size_8)
 {
     // output_0 and output_1 hold the outputs use use when a zero or negative check is true/false.
     // False = 0.0 = kCONST_0 (5/8-bit exponent format)
@@ -100,7 +100,7 @@ inline void _calculate_comp_(const int iterations, std::uint32_t exponent_size_8
             result = flag1;
         }
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
 
         sfpi::dst_reg++;
     }
@@ -194,13 +194,13 @@ inline void apply_zero_comp<SfpuType::less_than_equal_zero>(sfpi::vFloat& v, std
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void _calculate_zero_comp_(std::uint32_t exponent_size_8)
+inline void _calculate_zero_comp_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, std::uint32_t exponent_size_8)
 {
     for (int d = ZERO; d < ITERATIONS; d++)
     {
         sfpi::vFloat v = sfpi::dst_reg[0];
         apply_zero_comp<COMP_MODE>(v, exponent_size_8);
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
         sfpi::dst_reg++;
     }
 }
@@ -293,13 +293,13 @@ inline void apply_zero_comp_int<SfpuType::greater_than_equal_zero>(sfpi::vInt& v
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void _calculate_zero_comp_int_()
+inline void _calculate_zero_comp_int_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     for (int d = ZERO; d < ITERATIONS; d++)
     {
         sfpi::vInt v = sfpi::dst_reg[0];
         apply_zero_comp_int<COMP_MODE>(v);
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
         sfpi::dst_reg++;
     }
 }
@@ -528,7 +528,7 @@ inline void apply_unary_comp_int<SfpuType::unary_le>(sfpi::vInt& val, const sfpi
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void _calculate_comp_unary_int_(int scalar)
+inline void _calculate_comp_unary_int_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, int scalar)
 {
 #pragma GCC unroll 8
     for (int d = ZERO; d < ITERATIONS; d++)
@@ -538,7 +538,7 @@ inline void _calculate_comp_unary_int_(int scalar)
 
         apply_unary_comp_int<COMP_MODE>(val, v, scalar);
 
-        sfpi::dst_reg[0] = val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
         sfpi::dst_reg++;
     }
 }
@@ -631,7 +631,7 @@ inline void apply_unary_comp_float<SfpuType::unary_le>(sfpi::vFloat& val, const 
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void _calculate_comp_unary_(std::uint32_t value)
+inline void _calculate_comp_unary_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, std::uint32_t value)
 {
     sfpi::vFloat s = value;
 
@@ -643,7 +643,7 @@ inline void _calculate_comp_unary_(std::uint32_t value)
 
         apply_unary_comp_float<COMP_MODE>(val, v, s);
 
-        sfpi::dst_reg[0] = val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_comp.h
@@ -100,7 +100,7 @@ inline void _calculate_comp_(std::uint32_t dst_index_in, std::uint32_t dst_index
             result = flag1;
         }
 
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
 
         sfpi::dst_reg++;
     }
@@ -200,7 +200,7 @@ inline void _calculate_zero_comp_(std::uint32_t dst_index_in, std::uint32_t dst_
     {
         sfpi::vFloat v = sfpi::dst_reg[0];
         apply_zero_comp<COMP_MODE>(v, exponent_size_8);
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         sfpi::dst_reg++;
     }
 }
@@ -299,7 +299,7 @@ inline void _calculate_zero_comp_int_(std::uint32_t dst_index_in, std::uint32_t 
     {
         sfpi::vInt v = sfpi::dst_reg[0];
         apply_zero_comp_int<COMP_MODE>(v);
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         sfpi::dst_reg++;
     }
 }
@@ -538,7 +538,7 @@ inline void _calculate_comp_unary_int_(std::uint32_t dst_index_in, std::uint32_t
 
         apply_unary_comp_int<COMP_MODE>(val, v, scalar);
 
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
         sfpi::dst_reg++;
     }
 }
@@ -643,7 +643,7 @@ inline void _calculate_comp_unary_(std::uint32_t dst_index_in, std::uint32_t dst
 
         apply_unary_comp_float<COMP_MODE>(val, v, s);
 
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cumsum.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_ops.h"
 #include "lltt.h"
 #include "sfpi.h"
@@ -14,7 +16,7 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE /*unused*/, int ITERATIONS /*unused*/>
-inline void _calculate_cumsum_(const bool first)
+inline void _calculate_cumsum_(std::uint32_t /*dst_index_in*/, std::uint32_t /*dst_index_out*/, const bool first)
 {
     if (first)
     {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_dropout.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_dropout.h
@@ -17,7 +17,7 @@ namespace sfpu
 // probability should be between 0 - INT_MAX (signed)
 // scale should be binary representation of a float32
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_dropout_(const int iterations, std::uint32_t probability, std::uint32_t scale)
+inline void _calculate_dropout_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations, std::uint32_t probability, std::uint32_t scale)
 {
     // SFPU microcode
 
@@ -30,9 +30,8 @@ inline void _calculate_dropout_(const int iterations, std::uint32_t probability,
     {
         ////////////////////////
         // Scale samples
-        // sfpi::dst_reg[0] = sfpi::dst_reg[0] * sFloat16b(scale);
         ///////////////////////
-        TTI_SFPLOAD(p_sfpu::LREG0, 0, 3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, 0, 3, 0);
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
 
         ////////////////////////
@@ -47,12 +46,12 @@ inline void _calculate_dropout_(const int iterations, std::uint32_t probability,
         ////////////////////////
         // Drop samples
         // v_if (rand < probability)
-        //   sfpi::dst_reg[0] = vConst0;
+        //   sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = vConst0;
         ///////////////////////
         TTI_SFPIADD(0, p_sfpu::LREG2, p_sfpu::LREG3, 10);
         TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
         TTI_SFPENCC(0, 0, 0, 0);
-        TTI_SFPSTORE(0, 0, 3, 0);
+        TT_SFPSTORE(0, 0, 3, (dst_index_out - dst_index_in) * 32);
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_dropout.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_dropout.h
@@ -46,12 +46,12 @@ inline void _calculate_dropout_(std::uint32_t dst_index_in, std::uint32_t dst_in
         ////////////////////////
         // Drop samples
         // v_if (rand < probability)
-        //   sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = vConst0;
+        //   sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = vConst0;
         ///////////////////////
         TTI_SFPIADD(0, p_sfpu::LREG2, p_sfpu::LREG3, 10);
         TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
         TTI_SFPENCC(0, 0, 0, 0);
-        TT_SFPSTORE(0, 0, 3, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(0, 0, 3, (dst_index_out - dst_index_in) * TILE_R_DIM);
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_elu.h
@@ -13,7 +13,7 @@ namespace ckernel::sfpu
 {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void _calculate_elu_(std::uint32_t slope)
+inline void _calculate_elu_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, std::uint32_t slope)
 {
     sfpi::vFloat alpha = Converter::as_float(slope);
 // unroll 2: with expm1_cw_clamped inlined the loop body is large enough that
@@ -34,7 +34,7 @@ inline void _calculate_elu_(std::uint32_t slope)
         {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_elu.h
@@ -34,7 +34,7 @@ inline void _calculate_elu_(std::uint32_t dst_index_in, std::uint32_t dst_index_
         {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -12,6 +12,7 @@
 #include "ckernel_sfpu_polyval.h"
 // clang-format on
 #include "ckernel_sfpu_recip.h"
+#include "cmath_common.h"
 #include "lltt.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 
@@ -394,7 +395,7 @@ sfpi_inline sfpi::vFloat _ckernel_sfpu_exp_accurate_(sfpi::vFloat val, const std
 }
 
 template <bool APPROXIMATION_MODE, bool SCALE_EN, int ITERATIONS, bool CLAMP_NEGATIVE = true, bool is_fp32_dest_acc_en = false>
-void _calculate_exponential_(const std::uint16_t exp_base_scale_factor /* 1.0f in BF16 */)
+void _calculate_exponential_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const std::uint16_t exp_base_scale_factor /* 1.0f in BF16 */)
 {
     if constexpr (!APPROXIMATION_MODE)
     {
@@ -410,15 +411,16 @@ void _calculate_exponential_(const std::uint16_t exp_base_scale_factor /* 1.0f i
 #ifdef DISABLE_SFPLOADMACRO
         for (int d = 0; d < ITERATIONS; d++)
         {
-            TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
+            TT_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
             TTI_SFPSWAP(0, p_sfpu::LREG14, p_sfpu::LREG0, 9);
             TTI_SFPMAD(p_sfpu::LREG12, p_sfpu::LREG0, p_sfpu::LREG13, p_sfpu::LREG0, 0);
             TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
             TTI_SFPSHFT(15, p_sfpu::LREG0, p_sfpu::LREG0, 1);
-            TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
+            TT_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, (dst_index_out - dst_index_in) * 32);
             sfpi::dst_reg++;
         }
 #else
+        LLK_ASSERT(dst_index_out == dst_index_in, "exp SFPLOADMACRO path requires dst_index_out == dst_index_in");
         // Code below is hand-unrolled for 8 iterations
         // so it doesn't respect ITERATIONS. TODO: tt-llk#1486
         // static_assert(ITERATIONS == 8);
@@ -519,18 +521,19 @@ void _calculate_exponential_(const std::uint16_t exp_base_scale_factor /* 1.0f i
     {
         for (int d = 0; d < ITERATIONS; d++)
         {
-            TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
+            TT_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
             TTI_SFPMAD(p_sfpu::LREG12, p_sfpu::LREG0, p_sfpu::LREG13, p_sfpu::LREG0, 0);
             TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT16);
             TTI_SFPSHFT2(p_sfpu::LREG0, p_sfpu::LREG14, p_sfpu::LREG1, 5); // lreg[1] = lreg[0] << 15
             TTI_SFPSETSGN(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);             // lreg[0] preserves sign, copies e/m from lreg[1]
-            TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
+            TT_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, (dst_index_out - dst_index_in) * 32);
             sfpi::dst_reg++;
         }
     }
 #else
     else if constexpr (APPROXIMATION_MODE && ITERATIONS == 8)
     {
+        LLK_ASSERT(dst_index_out == dst_index_in, "exp replay-buffer path requires dst_index_out == dst_index_in");
         // =======================================================================
         // 8-element version using replay buffer.
         // Total: ~20 cycles for 8 elements = 2.5 cycles/element
@@ -561,6 +564,7 @@ void _calculate_exponential_(const std::uint16_t exp_base_scale_factor /* 1.0f i
     }
     else if constexpr (APPROXIMATION_MODE && ITERATIONS == 32)
     {
+        LLK_ASSERT(dst_index_out == dst_index_in, "exp replay-buffer path requires dst_index_out == dst_index_in");
         // =======================================================================
         // 32-element version using replay buffer.
         // Total: ~68 cycles for 32 elements = 2.125 cycles/element

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -59,8 +59,9 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_bf16_unsafe_(sfpi::vFloat val)
 
     sfpi::vInt z = _float_to_int32_for_exp_21f_(xlog2);
 
-    sfpi::vInt exponential_part = sfpi::exexp(sfpi::reinterpret<sfpi::vFloat>(z), sfpi::ExponentMode::NoDebias); // Extract exponent ( = 2**(integer part of val/ln2))
-    sfpi::vInt fractional_part  = sfpi::exman(sfpi::reinterpret<sfpi::vFloat>(z));                         // Extract mantissa ( = leftover part, in [0; 1])
+    sfpi::vInt exponential_part =
+        sfpi::exexp(sfpi::reinterpret<sfpi::vFloat>(z), sfpi::ExponentMode::NoDebias); // Extract exponent ( = 2**(integer part of val/ln2))
+    sfpi::vInt fractional_part = sfpi::exman(sfpi::reinterpret<sfpi::vFloat>(z));      // Extract mantissa ( = leftover part, in [0; 1])
 
     sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, sfpi::RoundMode::NearestEven);
 
@@ -128,7 +129,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_bf16_(sfpi::vFloat val)
     sfpi::vInt z = _float_to_int32_for_exp_21f_(xlog2);
 
     sfpi::vInt exponential_part = exexp(sfpi::reinterpret<sfpi::vFloat>(z), sfpi::ExponentMode::NoDebias); // Extract exponent ( = 2**(integer part of val/ln2))
-    sfpi::vInt fractional_part  = sfpi::exman(sfpi::reinterpret<sfpi::vFloat>(z));                   // Extract mantissa ( = leftover part, in [0; 1])
+    sfpi::vInt fractional_part  = sfpi::exman(sfpi::reinterpret<sfpi::vFloat>(z));                         // Extract mantissa ( = leftover part, in [0; 1])
 
     sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, sfpi::RoundMode::NearestEven);
 
@@ -416,7 +417,7 @@ void _calculate_exponential_(std::uint32_t dst_index_in, std::uint32_t dst_index
             TTI_SFPMAD(p_sfpu::LREG12, p_sfpu::LREG0, p_sfpu::LREG13, p_sfpu::LREG0, 0);
             TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
             TTI_SFPSHFT(15, p_sfpu::LREG0, p_sfpu::LREG0, 1);
-            TT_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, (dst_index_out - dst_index_in) * 32);
+            TT_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, (dst_index_out - dst_index_in) * TILE_R_DIM);
             sfpi::dst_reg++;
         }
 #else
@@ -526,7 +527,7 @@ void _calculate_exponential_(std::uint32_t dst_index_in, std::uint32_t dst_index
             TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_INT16);
             TTI_SFPSHFT2(p_sfpu::LREG0, p_sfpu::LREG14, p_sfpu::LREG1, 5); // lreg[1] = lreg[0] << 15
             TTI_SFPSETSGN(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);             // lreg[0] preserves sign, copies e/m from lreg[1]
-            TT_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, (dst_index_out - dst_index_in) * 32);
+            TT_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, (dst_index_out - dst_index_in) * TILE_R_DIM);
             sfpi::dst_reg++;
         }
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp2.h
@@ -33,7 +33,7 @@ inline void _calculate_exp2_(std::uint32_t dst_index_in, std::uint32_t dst_index
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp2.h
@@ -13,7 +13,7 @@ namespace ckernel::sfpu
 {
 
 template <bool APPROXIMATION_MODE /*unused*/, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void _calculate_exp2_()
+inline void _calculate_exp2_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
@@ -33,7 +33,7 @@ inline void _calculate_exp2_()
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_fill.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_fill.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 
+#include "ckernel_addrmod.h"
 #include "ckernel_ops.h"
 #include "ckernel_sfpu_converter.h"
 #include "ckernel_sfpu_load_config.h"
@@ -14,20 +15,20 @@ namespace ckernel::sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_fill_(const float value)
+inline void _calculate_fill_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const float value)
 {
     // SFPU microcode
     sfpi::vFloat fill_val = value;
 
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[0] = fill_val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = fill_val;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, InstrModLoadStore INSTRUCTION_MODE, int ITERATIONS>
-inline void _calculate_fill_int_(const std::uint32_t value)
+inline void _calculate_fill_int_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const std::uint32_t value)
 {
     // SFPU microcode
     if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32)
@@ -44,20 +45,20 @@ inline void _calculate_fill_int_(const std::uint32_t value)
     }
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, (dst_index_out - dst_index_in) * 32);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_fill_bitcast_(const std::uint32_t value_bit_mask)
+inline void _calculate_fill_bitcast_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const std::uint32_t value_bit_mask)
 {
     // SFPU microcode
     sfpi::vFloat fill_val = Converter::as_float(value_bit_mask);
 
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[0] = fill_val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = fill_val;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_fill.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_fill.h
@@ -22,7 +22,7 @@ inline void _calculate_fill_(std::uint32_t dst_index_in, std::uint32_t dst_index
 
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = fill_val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = fill_val;
         sfpi::dst_reg++;
     }
 }
@@ -45,7 +45,7 @@ inline void _calculate_fill_int_(std::uint32_t dst_index_in, std::uint32_t dst_i
     }
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TT_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, (dst_index_out - dst_index_in) * TILE_R_DIM);
         sfpi::dst_reg++;
     }
 }
@@ -58,7 +58,7 @@ inline void _calculate_fill_bitcast_(std::uint32_t dst_index_in, std::uint32_t d
 
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = fill_val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = fill_val;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -37,7 +37,7 @@ inline sfpi::vFloat _calculate_gelu_core_(sfpi::vFloat in)
 }
 
 template <int ITERATIONS>
-inline void _calculate_gelu_appx_()
+inline void _calculate_gelu_appx_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
     sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
@@ -49,31 +49,15 @@ inline void _calculate_gelu_appx_()
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        // sfpi::vFloat in = sfpi::dst_reg[0];
-        // sfpi::vFloat result = calculate_gelu_core<APPROXIMATION_MODE>(in);
-
-        // sfpi::vFloat half_in = in * half;
-        // result = lut(result, l0, l1, l2);
-        // result = half_in * result + half_in;
-
-        // sfpi::dst_reg[0] = result;
-
         sfpi::vFloat in      = sfpi::dst_reg[0];
         sfpi::vFloat half    = sfpi::vConstFloatPrgm0;
         sfpi::vFloat half_in = in * half;
         sfpi::vFloat result  = lut2_sign(in, l0, l1, l2, l4, l5, l6);
         result               = half_in + result;
 
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
 
         sfpi::dst_reg++;
-
-        // sfpi::dst_reg++;
-        // TTI_SFPLOAD(3, 0, 1/*load addr mode*/,0);    // load from dest
-        ////TTI_SFPMUL(3,11,9,7,0);           // lreg7 = 0.5*lreg3
-        // TTI_SFPLUTFP32(7, 2);                // lreg7= LUT(3)
-        // TTI_SFPMAD(3,12,7,3,0);            // lreg3 = 0.5*lreg3+lregm7
-        // TTI_SFPSTORE(3, 0, 3/*store_addr_mod3*/, 0);   // and INCRWC by 4 using mode 3
     }
 
     sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
@@ -85,7 +69,7 @@ inline void _calculate_gelu_appx_()
 }
 
 template <int ITERATIONS>
-inline void _calculate_gelu_accurate_()
+inline void _calculate_gelu_accurate_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     constexpr bool scaled = true;
 #pragma GCC unroll 8
@@ -93,26 +77,26 @@ inline void _calculate_gelu_accurate_()
     {
         sfpi::vFloat in     = sfpi::dst_reg[0];
         sfpi::vFloat result = _calculate_cdf_appx_(in, scaled);
-        sfpi::dst_reg[0]    = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_gelu_()
+inline void _calculate_gelu_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     if constexpr (APPROXIMATION_MODE)
     {
-        _calculate_gelu_appx_<ITERATIONS>();
+        _calculate_gelu_appx_<ITERATIONS>(dst_index_in, dst_index_out);
     }
     else
     {
-        _calculate_gelu_accurate_<ITERATIONS>();
+        _calculate_gelu_accurate_<ITERATIONS>(dst_index_in, dst_index_out);
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_gelu_derivative_()
+inline void _calculate_gelu_derivative_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     if constexpr (APPROXIMATION_MODE)
     {
@@ -136,7 +120,7 @@ inline void _calculate_gelu_derivative_()
                 val = val + 1.0f;
             }
             v_endif;
-            sfpi::dst_reg[0] = val;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
             sfpi::dst_reg++;
         }
 
@@ -171,7 +155,7 @@ inline void _calculate_gelu_derivative_()
 
             result = lut(result, l0, l1, imm2);
 
-            sfpi::dst_reg[0] = partial + result + 0.5f;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = partial + result + 0.5f;
             sfpi::dst_reg++;
         }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
@@ -55,7 +55,7 @@ inline void _calculate_gelu_appx_(std::uint32_t dst_index_in, std::uint32_t dst_
         sfpi::vFloat result  = lut2_sign(in, l0, l1, l2, l4, l5, l6);
         result               = half_in + result;
 
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
 
         sfpi::dst_reg++;
     }
@@ -75,9 +75,9 @@ inline void _calculate_gelu_accurate_(std::uint32_t dst_index_in, std::uint32_t 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat in     = sfpi::dst_reg[0];
-        sfpi::vFloat result = _calculate_cdf_appx_(in, scaled);
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        sfpi::vFloat in                                            = sfpi::dst_reg[0];
+        sfpi::vFloat result                                        = _calculate_cdf_appx_(in, scaled);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }
@@ -120,7 +120,7 @@ inline void _calculate_gelu_derivative_(std::uint32_t dst_index_in, std::uint32_
                 val = val + 1.0f;
             }
             v_endif;
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
             sfpi::dst_reg++;
         }
 
@@ -155,7 +155,7 @@ inline void _calculate_gelu_derivative_(std::uint32_t dst_index_in, std::uint32_
 
             result = lut(result, l0, l1, imm2);
 
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = partial + result + 0.5f;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = partial + result + 0.5f;
             sfpi::dst_reg++;
         }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -14,7 +14,8 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_hardtanh_(const int iterations, std::uint32_t param0, std::uint32_t param1, std::uint32_t param2)
+inline void _calculate_hardtanh_(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations, std::uint32_t param0, std::uint32_t param1, std::uint32_t param2)
 {
     // All params are in FP16_B format
     // param0 = -(neg_threshold)
@@ -46,7 +47,7 @@ inline void _calculate_hardtanh_(const int iterations, std::uint32_t param0, std
 
         val += p2; // 12 bits
 
-        sfpi::dst_reg[0] = val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -47,7 +47,7 @@ inline void _calculate_hardtanh_(
 
         val += p2; // 12 bits
 
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "sfpi.h"
@@ -118,7 +120,7 @@ inline sfpi::vFloat _calculate_isfinite_(const sfpi::vFloat& v)
 }
 
 template <SfpuType operation, bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_sfpu_isinf_isnan_()
+inline void _calculate_sfpu_isinf_isnan_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
@@ -127,23 +129,23 @@ inline void _calculate_sfpu_isinf_isnan_()
 
         if constexpr (operation == SfpuType::isinf)
         {
-            sfpi::dst_reg[0] = _calculate_isinf_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isinf_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isposinf)
         {
-            sfpi::dst_reg[0] = _calculate_isposinf_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isposinf_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isneginf)
         {
-            sfpi::dst_reg[0] = _calculate_isneginf_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isneginf_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isnan)
         {
-            sfpi::dst_reg[0] = _calculate_isnan_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isnan_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isfinite)
         {
-            sfpi::dst_reg[0] = _calculate_isfinite_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isfinite_<APPROXIMATION_MODE>(in);
         }
 
         sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_isinf_isnan.h
@@ -129,23 +129,23 @@ inline void _calculate_sfpu_isinf_isnan_(std::uint32_t dst_index_in, std::uint32
 
         if constexpr (operation == SfpuType::isinf)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isinf_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _calculate_isinf_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isposinf)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isposinf_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _calculate_isposinf_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isneginf)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isneginf_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _calculate_isneginf_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isnan)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isnan_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _calculate_isnan_<APPROXIMATION_MODE>(in);
         }
         else if constexpr (operation == SfpuType::isfinite)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_isfinite_<APPROXIMATION_MODE>(in);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _calculate_isfinite_<APPROXIMATION_MODE>(in);
         }
 
         sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
@@ -14,7 +14,7 @@ namespace sfpu
 {
 
 template <bool HAS_BASE_SCALING>
-sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor, const std::uint32_t dst_idx = 0)
+sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor, const std::uint32_t dst_index_in = 0, const std::uint32_t dst_index_out = 0)
 {
     // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
     constexpr std::uint32_t dst_tile_size_sfpi = 32;
@@ -22,7 +22,7 @@ sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor,
     ////////////////////////////
     // Load From dest + "normalize to calculation range"
     ////////////////////////////
-    sfpi::vFloat in = sfpi::dst_reg[dst_idx * dst_tile_size_sfpi];
+    sfpi::vFloat in = sfpi::dst_reg[0];
     sfpi::vFloat x  = setexp(in, 127); // set exp to exp bias (put in range of 1-2)
 
     // XXXXXX ask Namal? if we can derive the coefficients below to higher precision
@@ -71,7 +71,7 @@ sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor,
     }
     v_endif;
 
-    sfpi::dst_reg[dst_idx * dst_tile_size_sfpi] = result;
+    sfpi::dst_reg[(dst_index_out - dst_index_in) * dst_tile_size_sfpi] = result;
 }
 
 sfpi_inline sfpi::vFloat _calculate_log_body_no_init_(sfpi::vFloat base)
@@ -106,12 +106,12 @@ sfpi_inline sfpi::vFloat _calculate_log_body_no_init_(sfpi::vFloat base)
 }
 
 template <bool APPROXIMATION_MODE, bool HAS_BASE_SCALING, int ITERATIONS>
-inline void _calculate_log_(const int iterations, std::uint32_t log_base_scale_factor)
+inline void _calculate_log_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations, std::uint32_t log_base_scale_factor)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        _calculate_log_body_<HAS_BASE_SCALING>(log_base_scale_factor);
+        _calculate_log_body_<HAS_BASE_SCALING>(log_base_scale_factor, dst_index_in, dst_index_out);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_negative.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_negative.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sfpi.h"
 
 namespace ckernel
@@ -12,19 +14,19 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_negative_()
+inline void _calculate_negative_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat val = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = -val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = -val;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_negative_int_()
+inline void _calculate_negative_int_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
@@ -32,7 +34,7 @@ inline void _calculate_negative_int_()
         sfpi::vInt val = sfpi::dst_reg[0];
         v_if (val != 0)
         {
-            sfpi::dst_reg[0] = sfpi::reinterpret<sfpi::vInt>(-sfpi::reinterpret<sfpi::vFloat>(val));
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::reinterpret<sfpi::vInt>(-sfpi::reinterpret<sfpi::vFloat>(val));
         }
         v_endif;
         sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_negative.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_negative.h
@@ -19,8 +19,8 @@ inline void _calculate_negative_(std::uint32_t dst_index_in, std::uint32_t dst_i
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat val = sfpi::dst_reg[0];
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = -val;
+        sfpi::vFloat val                                           = sfpi::dst_reg[0];
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = -val;
         sfpi::dst_reg++;
     }
 }
@@ -34,7 +34,7 @@ inline void _calculate_negative_int_(std::uint32_t dst_index_in, std::uint32_t d
         sfpi::vInt val = sfpi::dst_reg[0];
         v_if (val != 0)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::reinterpret<sfpi::vInt>(-sfpi::reinterpret<sfpi::vFloat>(val));
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::reinterpret<sfpi::vInt>(-sfpi::reinterpret<sfpi::vFloat>(val));
         }
         v_endif;
         sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_sfpu_rsqrt_compat.h"
 #include "sfpi.h"
 
@@ -76,7 +78,7 @@ sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat in)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
-inline void _calculate_reciprocal_internal_(const int iterations)
+inline void _calculate_reciprocal_internal_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
@@ -96,22 +98,22 @@ inline void _calculate_reciprocal_internal_(const int iterations)
         {
             out = _sfpu_reciprocal_<1>(in);
             out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::NearestEven);
-            }
-            sfpi::dst_reg[0] = out;
-            sfpi::dst_reg++;
+        }
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = out;
+        sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en, bool legacy_compat = false>
-inline void _calculate_reciprocal_(const int iterations)
+inline void _calculate_reciprocal_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
     if constexpr (legacy_compat)
     {
-        _calculate_reciprocal_compat_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en>(iterations);
+        _calculate_reciprocal_compat_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en>(dst_index_in, dst_index_out, iterations);
     }
     else
     {
-        _calculate_reciprocal_internal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en>(iterations);
+        _calculate_reciprocal_internal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en>(dst_index_in, dst_index_out, iterations);
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -99,7 +99,7 @@ inline void _calculate_reciprocal_internal_(std::uint32_t dst_index_in, std::uin
             out = _sfpu_reciprocal_<1>(in);
             out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = out;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = out;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reduce.h
@@ -969,7 +969,8 @@ inline void _init_reduce_(std::uint32_t block_ct_dim = 1)
  *       - MAX/MIN with Int32 format only supports block_rt_dim == 1 (single tile)
  */
 template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
-inline void _calculate_reduce_(std::uint32_t block_ct_dim = 1, std::uint32_t block_rt_dim = 1)
+inline void _calculate_reduce_(
+    [[maybe_unused]] std::uint32_t dst_index_in, [[maybe_unused]] std::uint32_t dst_index_out, std::uint32_t block_ct_dim = 1, std::uint32_t block_rt_dim = 1)
 {
     static_assert(
         reduce_dim == REDUCE_COL || (pool_type == PoolType::SUM && reduce_dim == REDUCE_ROW) || (pool_type == PoolType::MAX && reduce_dim == REDUCE_ROW),

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 
+#include "ckernel_addrmod.h"
 #include "ckernel_sfpu_converter.h"
 #include "ckernel_sfpu_load_config.h"
 #include "sfpi.h"
@@ -19,18 +20,18 @@ template <typename T>
 constexpr bool is_supported_relu_type_v = std::is_same_v<T, float> || std::is_same_v<T, std::uint32_t>;
 
 template <bool APPROXIMATION_MODE>
-inline void _calculate_lrelu_(const int iterations, std::uint32_t slope)
+inline void _calculate_lrelu_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations, std::uint32_t slope)
 {
     TT_SFPLOADI(p_sfpu::LREG2, 10, slope & 0xFFFF);
     TT_SFPLOADI(p_sfpu::LREG2, 8, slope >> 16);
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);        // load from dest into lreg[0]
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);         // load from dest into lreg[0]
         TTI_SFPSETCC(0, p_sfpu::LREG0, 0, 0);                                         // condition - if value in LREG0 is negative //will set cc result reg
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG2, p_sfpu::LCONST_0, p_sfpu::LREG0, 0); // Multiply LREG0 * LREG2 (x * slope)
         TTI_SFPENCC(0, 0, 0, 0);                                                      // clear cc result reg
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);       // store from lreg0 into dest register
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, (dst_index_out - dst_index_in) * 32); // store from lreg0 into dest register
         sfpi::dst_reg++;
     }
 }
@@ -52,7 +53,7 @@ sfpi_inline sfpi::vFloat _relu_max_body_(sfpi::vFloat val, sfpi::vFloat threshol
 }
 
 template <typename VecType, bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _relu_max_impl_(const int iterations, VecType threshold)
+inline void _relu_max_impl_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations, VecType threshold)
 {
     for (int d = 0; d < iterations; d++)
     {
@@ -67,14 +68,14 @@ inline void _relu_max_impl_(const int iterations, VecType threshold)
             result = 0;
         }
         v_endif;
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
         sfpi::dst_reg++;
     }
 }
 
 // Wrappers
 template <typename VectorType, bool APPROXIMATION_MODE, int ITERATIONS, typename T>
-inline void _relu_max_(T threshold)
+inline void _relu_max_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, T threshold)
 {
     static_assert(std::is_same_v<VectorType, sfpi::vFloat> || std::is_same_v<VectorType, sfpi::vInt>, "VectorType must be sfpi::vFloat or sfpi::vInt");
 
@@ -99,29 +100,30 @@ inline void _relu_max_(T threshold)
         static_assert(std::is_same_v<T, float> || std::is_same_v<T, std::uint32_t>, "Threshold type must be float or uint32_t");
     }
 
-    _relu_max_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold);
+    _relu_max_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out, ITERATIONS, v_threshold);
 }
 
 template <typename VecType, bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _relu_min_impl_(const int iterations, [[maybe_unused]] VecType threshold, int sfpload_instr_mod)
+inline void _relu_min_impl_(
+    std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations, [[maybe_unused]] VecType threshold, int sfpload_instr_mod)
 {
     for (int d = 0; d < iterations; d++)
     {
         // Load input tensor to lreg0
-        TTI_SFPLOAD(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_3, 0);
         // Copy value param from lreg2 to lreg1
         TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
         // Swap and store maximum in lreg1, minimum in lreg0 (sign + magnitude format)
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
         // Store the result
-        TTI_SFPSTORE(p_sfpu::LREG1, sfpload_instr_mod, ADDR_MOD_3, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, sfpload_instr_mod, ADDR_MOD_3, (dst_index_out - dst_index_in) * 32);
         sfpi::dst_reg++;
     }
 }
 
 // Wrappers
 template <typename VectorType, bool APPROXIMATION_MODE, int ITERATIONS, typename T>
-inline void _relu_min_(T threshold)
+inline void _relu_min_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, T threshold)
 {
     static_assert(std::is_same_v<VectorType, sfpi::vFloat> || std::is_same_v<VectorType, sfpi::vInt>, "VectorType must be sfpi::vFloat or sfpi::vInt");
 
@@ -155,7 +157,7 @@ inline void _relu_min_(T threshold)
         static_assert(std::is_same_v<T, float> || std::is_same_v<T, std::uint32_t>, "Threshold type must be float or uint32_t");
     }
 
-    _relu_min_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold, sfpload_instr_mod);
+    _relu_min_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out, ITERATIONS, v_threshold, sfpload_instr_mod);
 }
 
 } // namespace sfpu

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -31,7 +31,7 @@ inline void _calculate_lrelu_(std::uint32_t dst_index_in, std::uint32_t dst_inde
         TTI_SFPSETCC(0, p_sfpu::LREG0, 0, 0);                                         // condition - if value in LREG0 is negative //will set cc result reg
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG2, p_sfpu::LCONST_0, p_sfpu::LREG0, 0); // Multiply LREG0 * LREG2 (x * slope)
         TTI_SFPENCC(0, 0, 0, 0);                                                      // clear cc result reg
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, (dst_index_out - dst_index_in) * 32); // store from lreg0 into dest register
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, (dst_index_out - dst_index_in) * TILE_R_DIM); // store from lreg0 into dest register
         sfpi::dst_reg++;
     }
 }
@@ -68,7 +68,7 @@ inline void _relu_max_impl_(std::uint32_t dst_index_in, std::uint32_t dst_index_
             result = 0;
         }
         v_endif;
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }
@@ -116,7 +116,7 @@ inline void _relu_min_impl_(
         // Swap and store maximum in lreg1, minimum in lreg0 (sign + magnitude format)
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
         // Store the result
-        TT_SFPSTORE(p_sfpu::LREG1, sfpload_instr_mod, ADDR_MOD_3, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG1, sfpload_instr_mod, ADDR_MOD_3, (dst_index_out - dst_index_in) * TILE_R_DIM);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reshuffle_rows.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reshuffle_rows.h
@@ -37,7 +37,7 @@ namespace sfpu
  *
  * @param idx_addr L1 address of the mask tile containing destination row mappings (uint8_t[32])
  */
-inline void _calculate_reshuffle_rows_(const std::uint32_t idx_addr)
+inline void _calculate_reshuffle_rows_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const std::uint32_t idx_addr)
 {
     constexpr std::uint32_t output_tile_offset = 64;
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <climits>
+#include <cstdint>
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
@@ -90,42 +91,42 @@ inline constexpr std::array<float, 84> PRECOMPUTED_POW10_TABLE = {
 };
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-sfpi_inline void _calculate_floor_()
+sfpi_inline void _calculate_floor_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[0] = _floor_body_(sfpi::dst_reg[0]);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _floor_body_(sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-sfpi_inline void _calculate_ceil_()
+sfpi_inline void _calculate_ceil_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[0] = _ceil_body_(sfpi::dst_reg[0]);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _ceil_body_(sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-sfpi_inline void _calculate_trunc_()
+sfpi_inline void _calculate_trunc_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[0] = _trunc_body_(sfpi::dst_reg[0]);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _trunc_body_(sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-sfpi_inline void _calculate_frac_()
+sfpi_inline void _calculate_frac_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat x   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = x - _trunc_body_(x);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = x - _trunc_body_(x);
         sfpi::dst_reg++;
     }
 }
@@ -151,7 +152,7 @@ sfpi_inline sfpi::vFloat _round_even_(sfpi::vFloat v)
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
-void _calculate_round_(const int decimals)
+void _calculate_round_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int decimals)
 {
     const auto exp10i = [](int n)
     {
@@ -173,22 +174,22 @@ void _calculate_round_(const int decimals)
 
     for (int d = 0; d < ITERATIONS; ++d)
     {
-        sfpi::vFloat v      = sfpi::dst_reg[0];
-        sfpi::vFloat result = inverse * _round_even_(v * coeff);
-        sfpi::dst_reg[0]    = result;
+        sfpi::vFloat v                                     = sfpi::dst_reg[0];
+        sfpi::vFloat result                                = inverse * _round_even_(v * coeff);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
         sfpi::dst_reg++;
     }
 }
 
 // Performs stochastic rounding of values in DST from fp32 to fp16b format.
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-sfpi_inline void _calculate_stochastic_round_()
+sfpi_inline void _calculate_stochastic_round_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #pragma GCC unroll ITERATIONS
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat x   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::Stochastic);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::Stochastic);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -95,7 +95,7 @@ sfpi_inline void _calculate_floor_(std::uint32_t dst_index_in, std::uint32_t dst
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _floor_body_(sfpi::dst_reg[0]);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _floor_body_(sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }
@@ -105,7 +105,7 @@ sfpi_inline void _calculate_ceil_(std::uint32_t dst_index_in, std::uint32_t dst_
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _ceil_body_(sfpi::dst_reg[0]);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _ceil_body_(sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }
@@ -115,7 +115,7 @@ sfpi_inline void _calculate_trunc_(std::uint32_t dst_index_in, std::uint32_t dst
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _trunc_body_(sfpi::dst_reg[0]);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _trunc_body_(sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }
@@ -125,8 +125,8 @@ sfpi_inline void _calculate_frac_(std::uint32_t dst_index_in, std::uint32_t dst_
 {
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat x   = sfpi::dst_reg[0];
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = x - _trunc_body_(x);
+        sfpi::vFloat x                                             = sfpi::dst_reg[0];
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = x - _trunc_body_(x);
         sfpi::dst_reg++;
     }
 }
@@ -174,9 +174,9 @@ void _calculate_round_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, 
 
     for (int d = 0; d < ITERATIONS; ++d)
     {
-        sfpi::vFloat v                                     = sfpi::dst_reg[0];
-        sfpi::vFloat result                                = inverse * _round_even_(v * coeff);
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        sfpi::vFloat v                                             = sfpi::dst_reg[0];
+        sfpi::vFloat result                                        = inverse * _round_even_(v * coeff);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }
@@ -188,8 +188,8 @@ sfpi_inline void _calculate_stochastic_round_(std::uint32_t dst_index_in, std::u
 #pragma GCC unroll ITERATIONS
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat x   = sfpi::dst_reg[0];
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::Stochastic);
+        sfpi::vFloat x                                             = sfpi::dst_reg[0];
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::Stochastic);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_sfpu_rsqrt_compat.h"
 #include "ckernel_sfpu_sqrt.h"
 #include "sfpi.h"
@@ -14,15 +16,15 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat = false>
-inline void _calculate_rsqrt_(int iterations)
+inline void _calculate_rsqrt_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, int iterations)
 {
     if constexpr (legacy_compat)
     {
-        return _calculate_rsqrt_compat_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en>(iterations);
+        return _calculate_rsqrt_compat_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en>(dst_index_in, dst_index_out, iterations);
     }
     else
     {
-        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, true, FAST_APPROX>(iterations);
+        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, true, FAST_APPROX>(dst_index_in, dst_index_out, iterations);
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sfpi.h"
 
 namespace ckernel
@@ -97,14 +99,14 @@ sfpi_inline sfpi::vFloat _reciprocal_compat_(const sfpi::vFloat in)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en>
-inline void _calculate_rsqrt_compat_(const int iterations)
+inline void _calculate_rsqrt_compat_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::dst_reg[0] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
-        sfpi::vFloat in  = sfpi::dst_reg[0];
-        sfpi::vFloat out = _reciprocal_compat_<APPROXIMATION_MODE ? 2 : 3>(in);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
+        sfpi::vFloat in                                    = sfpi::dst_reg[(dst_index_out - dst_index_in) * 32];
+        sfpi::vFloat out                                   = _reciprocal_compat_<APPROXIMATION_MODE ? 2 : 3>(in);
         v_if (in < 0.0)
         {
             out = -out;
@@ -120,18 +122,18 @@ inline void _calculate_rsqrt_compat_(const int iterations)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en>
-inline void _calculate_sqrt_compat_(const int iterations)
+inline void _calculate_sqrt_compat_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::dst_reg[0] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en>
-inline void _calculate_reciprocal_compat_(const int iterations)
+inline void _calculate_reciprocal_compat_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
@@ -104,9 +104,9 @@ inline void _calculate_rsqrt_compat_(std::uint32_t dst_index_in, std::uint32_t d
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
-        sfpi::vFloat in                                    = sfpi::dst_reg[(dst_index_out - dst_index_in) * 32];
-        sfpi::vFloat out                                   = _reciprocal_compat_<APPROXIMATION_MODE ? 2 : 3>(in);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
+        sfpi::vFloat in                                            = sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM];
+        sfpi::vFloat out                                           = _reciprocal_compat_<APPROXIMATION_MODE ? 2 : 3>(in);
         v_if (in < 0.0)
         {
             out = -out;
@@ -127,7 +127,7 @@ inline void _calculate_sqrt_compat_(std::uint32_t dst_index_in, std::uint32_t ds
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _sqrt_compat_<APPROXIMATION_MODE, 2>(sfpi::dst_reg[0]);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_selu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_selu.h
@@ -38,7 +38,7 @@ inline void _calculate_selu_(std::uint32_t dst_index_in, std::uint32_t dst_index
         {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_selu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_selu.h
@@ -16,7 +16,7 @@ namespace ckernel::sfpu
 // scale ≈ 1.0507, alpha ≈ 1.6733, scale*alpha ≈ 1.7581
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void _calculate_selu_(std::uint32_t scale, std::uint32_t alpha)
+inline void _calculate_selu_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, std::uint32_t scale, std::uint32_t alpha)
 {
     const sfpi::vFloat scale_val   = Converter::as_float(scale);
     const sfpi::vFloat scale_alpha = Converter::as_float(scale) * Converter::as_float(alpha);
@@ -38,7 +38,7 @@ inline void _calculate_selu_(std::uint32_t scale, std::uint32_t alpha)
         {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_sfpu_load_config.h"
 #include "sfpi.h"
 
@@ -13,7 +15,7 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_sigmoid_(const int iterations)
+inline void _calculate_sigmoid_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
     constexpr int lut_mode = 0; // SFPLUTFP32_MOD0_FP16_6ENTRY_TABLE1
     sfpi::vUInt l0         = sfpi::l_reg[sfpi::LRegs::LReg0];
@@ -28,7 +30,7 @@ inline void _calculate_sigmoid_(const int iterations)
     {
         sfpi::vFloat val = sfpi::dst_reg[0];
 
-        sfpi::dst_reg[0] = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode) + 0.5f;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode) + 0.5f;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -30,7 +30,7 @@ inline void _calculate_sigmoid_(std::uint32_t dst_index_in, std::uint32_t dst_in
     {
         sfpi::vFloat val = sfpi::dst_reg[0];
 
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode) + 0.5f;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode) + 0.5f;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sign.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sign.h
@@ -15,7 +15,7 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_sign_(const int iterations, std::uint32_t exponent_size_8)
+inline void _calculate_sign_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations, std::uint32_t exponent_size_8)
 {
 // All params are in FP16 format
 // uint format = 1;
@@ -23,10 +23,10 @@ inline void _calculate_sign_(const int iterations, std::uint32_t exponent_size_8
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat v   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::vConst1;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::vConst1;
         v_if (v < 0.0F)
         {
-            sfpi::dst_reg[0] = sfpi::vConstNeg1;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::vConstNeg1;
         }
         v_endif;
 
@@ -34,7 +34,7 @@ inline void _calculate_sign_(const int iterations, std::uint32_t exponent_size_8
         // param0 != 0 is Float16 format and exp bias needs to be removed for zero check.
         v_if (_sfpu_is_fp16_zero_(v, exponent_size_8))
         {
-            sfpi::dst_reg[0] = sfpi::vConst0;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::vConst0;
         }
         v_endif;
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sign.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sign.h
@@ -22,11 +22,11 @@ inline void _calculate_sign_(std::uint32_t dst_index_in, std::uint32_t dst_index
 #pragma GCC unroll 0
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat v   = sfpi::dst_reg[0];
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::vConst1;
+        sfpi::vFloat v                                             = sfpi::dst_reg[0];
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::vConst1;
         v_if (v < 0.0F)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::vConstNeg1;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::vConstNeg1;
         }
         v_endif;
 
@@ -34,7 +34,7 @@ inline void _calculate_sign_(std::uint32_t dst_index_in, std::uint32_t dst_index
         // param0 != 0 is Float16 format and exp bias needs to be removed for zero check.
         v_if (_sfpu_is_fp16_zero_(v, exponent_size_8))
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::vConst0;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::vConst0;
         }
         v_endif;
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_silu.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_sfpu_polyval.h"
 #include "sfpi.h"
 
@@ -26,7 +28,7 @@ inline sfpi::vFloat _sigmoid_piecewise_linear_positive_(sfpi::vFloat val)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_silu_()
+inline void _calculate_silu_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
@@ -39,7 +41,7 @@ inline void _calculate_silu_()
             result = 1.0f - result;
         }
         v_endif;
-        sfpi::dst_reg[0] = val * result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val * result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_silu.h
@@ -41,7 +41,7 @@ inline void _calculate_silu_(std::uint32_t dst_index_in, std::uint32_t dst_index
             result = 1.0f - result;
         }
         v_endif;
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val * result;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val * result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -125,7 +125,7 @@ inline void _calculate_sqrt_internal_(std::uint32_t dst_index_in, std::uint32_t 
         {
             tmp = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::NearestEven);
         }
-        sfpi::dst_reg[0] = tmp;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = tmp;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ckernel_sfpu_rsqrt_compat.h"
 #include "sfpi.h"
 
@@ -113,7 +115,7 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool RECIPROCAL, bool FAST_APPROX>
-inline void _calculate_sqrt_internal_(const int iterations)
+inline void _calculate_sqrt_internal_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
@@ -129,15 +131,15 @@ inline void _calculate_sqrt_internal_(const int iterations)
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat = false>
-inline void _calculate_sqrt_(int iterations)
+inline void _calculate_sqrt_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, int iterations)
 {
     if constexpr (legacy_compat)
     {
-        return _calculate_sqrt_compat_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en>(iterations);
+        return _calculate_sqrt_compat_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en>(dst_index_in, dst_index_out, iterations);
     }
     else
     {
-        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, false, FAST_APPROX>(iterations);
+        return _calculate_sqrt_internal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, false, FAST_APPROX>(dst_index_in, dst_index_out, iterations);
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_square.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sfpi.h"
 
 namespace ckernel
@@ -12,18 +14,17 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_square_()
+inline void _calculate_square_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
+    // SFPI-style: addressing via sfpi::dst_reg[] keeps the read row and the write
+    // row in sync as we advance, which is required when dst_index_in != dst_index_out.
+    // Earlier TT_SFP*-based implementations only kept addressing correct for the
+    // in == out case (offset 0); see ckernel_sfpu_abs.h for the same pattern.
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        // Load input from destination into LREG0
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
-        // Multiply LREG0 * LREG0, store result in LREG0
-        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
-        TTI_SFPNOP;
-        // Store result back to destination
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+        sfpi::vFloat v                                     = sfpi::dst_reg[0];
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v * v;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_square.h
@@ -23,8 +23,8 @@ inline void _calculate_square_(std::uint32_t dst_index_in, std::uint32_t dst_ind
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        sfpi::vFloat v                                     = sfpi::dst_reg[0];
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v * v;
+        sfpi::vFloat v                                             = sfpi::dst_reg[0];
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v * v;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
@@ -15,7 +15,7 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_tanh_(const int iterations)
+inline void _calculate_tanh_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
     // SFPU microcode
     sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
@@ -27,7 +27,7 @@ inline void _calculate_tanh_(const int iterations)
     {
         sfpi::vFloat val = sfpi::dst_reg[0];
         val              = lut(val, l0, l1, l2);
-        sfpi::dst_reg[0] = val;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
@@ -25,9 +25,9 @@ inline void _calculate_tanh_(std::uint32_t dst_index_in, std::uint32_t dst_index
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
-        sfpi::vFloat val = sfpi::dst_reg[0];
-        val              = lut(val, l0, l1, l2);
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
+        sfpi::vFloat val                                           = sfpi::dst_reg[0];
+        val                                                        = lut(val, l0, l1, l2);
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sfpi.h"
 
 namespace ckernel
@@ -12,7 +14,7 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int WITH_PRECOMPUTED_TANH, int ITERATIONS>
-inline void _calculate_tanh_derivative_(const int iterations)
+inline void _calculate_tanh_derivative_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
     sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
     sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
@@ -28,8 +30,8 @@ inline void _calculate_tanh_derivative_(const int iterations)
             val = lut(val, l0, l1, l2);
         }
 
-        val              = val * (-val) + sfpi::vConst1;
-        sfpi::dst_reg[0] = val;
+        val                                                = val * (-val) + sfpi::vConst1;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
@@ -30,8 +30,8 @@ inline void _calculate_tanh_derivative_(std::uint32_t dst_index_in, std::uint32_
             val = lut(val, l0, l1, l2);
         }
 
-        val                                                = val * (-val) + sfpi::vConst1;
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = val;
+        val                                                        = val * (-val) + sfpi::vConst1;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = val;
 
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_threshold.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_threshold.h
@@ -18,7 +18,7 @@ template <typename T>
 constexpr bool is_supported_threshold_type_v = std::is_same_v<T, float> || std::is_same_v<T, std::uint32_t>;
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, typename T>
-inline void _calculate_threshold_(T threshold, T value)
+inline void _calculate_threshold_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, T threshold, T value)
 {
     static_assert(is_supported_threshold_type_v<T>, "Type T must be either float or uint32_t");
 
@@ -40,7 +40,7 @@ inline void _calculate_threshold_(T threshold, T value)
         sfpi::vFloat in = sfpi::dst_reg[0];
         v_if (in <= v_threshold)
         {
-            sfpi::dst_reg[0] = v_value;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v_value;
         }
         v_endif;
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_threshold.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_threshold.h
@@ -40,7 +40,7 @@ inline void _calculate_threshold_(std::uint32_t dst_index_in, std::uint32_t dst_
         sfpi::vFloat in = sfpi::dst_reg[0];
         v_if (in <= v_threshold)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v_value;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v_value;
         }
         v_endif;
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <limits>
 
 #include "ckernel_sfpu_log.h"
@@ -80,7 +81,7 @@ sfpi_inline sfpi::vFloat _sfpu_cosine_maclaurin_series_(sfpi::vFloat val)
 // Legacy implementation.
 // Candidate for removal in future versions. See https://github.com/tenstorrent/tt-llk/issues/225 for more details.
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_sine_(const int iterations)
+inline void _calculate_sine_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
@@ -99,7 +100,7 @@ inline void _calculate_sine_(const int iterations)
             v *= -1;
         }
         v_endif;
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
         sfpi::dst_reg++;
     }
 }
@@ -107,7 +108,7 @@ inline void _calculate_sine_(const int iterations)
 // Legacy implementation.
 // Candidate for removal in future versions. See https://github.com/tenstorrent/tt-llk/issues/225 for more details.
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_cosine_(const int iterations)
+inline void _calculate_cosine_(std::uint32_t dst_index_in, std::uint32_t dst_index_out, const int iterations)
 {
     // SFPU microcode
     for (int d = 0; d < iterations; d++)
@@ -126,7 +127,7 @@ inline void _calculate_cosine_(const int iterations)
             v *= -1;
         }
         v_endif;
-        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
         sfpi::dst_reg++;
     }
 }
@@ -134,7 +135,7 @@ inline void _calculate_cosine_(const int iterations)
 // https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions#Definitions_in_terms_of_logarithms
 // acosh(x) = log(x + sqrt(x^2 - 1))
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_acosh_()
+inline void _calculate_acosh_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
@@ -142,11 +143,11 @@ inline void _calculate_acosh_()
         sfpi::vFloat inp = sfpi::dst_reg[0];
         v_if (inp < sfpi::vConst1)
         {
-            sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN();
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = std::numeric_limits<float>::quiet_NaN();
         }
         v_elseif (inp == sfpi::vConst1)
         {
-            sfpi::dst_reg[0] = sfpi::vConst0;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::vConst0;
         }
         v_else
         {
@@ -154,7 +155,7 @@ inline void _calculate_acosh_()
             tmp              = tmp - sfpi::vConst1;
             tmp              = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
             tmp              = tmp + inp;
-            sfpi::dst_reg[0] = _calculate_log_body_no_init_(tmp);
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_log_body_no_init_(tmp);
         }
         v_endif;
         sfpi::dst_reg++;
@@ -163,7 +164,7 @@ inline void _calculate_acosh_()
 
 // asinh(x) = log(x + sqrt(x^2 + 1))
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_asinh_()
+inline void _calculate_asinh_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
@@ -178,14 +179,14 @@ inline void _calculate_asinh_()
             res = -res;
         }
         v_endif;
-        sfpi::dst_reg[0] = res;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = res;
         sfpi::dst_reg++;
     }
 }
 
 // atanh[x] = 0.5 * ln((1 + x) / (1 - x))
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void _calculate_atanh_()
+inline void _calculate_atanh_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++)
@@ -221,7 +222,7 @@ inline void _calculate_atanh_()
             res              = 0.5f * den;
         }
         v_endif;
-        sfpi::dst_reg[0] = res;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = res;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -100,7 +100,7 @@ inline void _calculate_sine_(std::uint32_t dst_index_in, std::uint32_t dst_index
             v *= -1;
         }
         v_endif;
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         sfpi::dst_reg++;
     }
 }
@@ -127,7 +127,7 @@ inline void _calculate_cosine_(std::uint32_t dst_index_in, std::uint32_t dst_ind
             v *= -1;
         }
         v_endif;
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = v;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = v;
         sfpi::dst_reg++;
     }
 }
@@ -143,19 +143,19 @@ inline void _calculate_acosh_(std::uint32_t dst_index_in, std::uint32_t dst_inde
         sfpi::vFloat inp = sfpi::dst_reg[0];
         v_if (inp < sfpi::vConst1)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = std::numeric_limits<float>::quiet_NaN();
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = std::numeric_limits<float>::quiet_NaN();
         }
         v_elseif (inp == sfpi::vConst1)
         {
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = sfpi::vConst0;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = sfpi::vConst0;
         }
         v_else
         {
-            sfpi::vFloat tmp = inp * inp;
-            tmp              = tmp - sfpi::vConst1;
-            tmp              = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-            tmp              = tmp + inp;
-            sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = _calculate_log_body_no_init_(tmp);
+            sfpi::vFloat tmp                                           = inp * inp;
+            tmp                                                        = tmp - sfpi::vConst1;
+            tmp                                                        = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
+            tmp                                                        = tmp + inp;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = _calculate_log_body_no_init_(tmp);
         }
         v_endif;
         sfpi::dst_reg++;
@@ -179,7 +179,7 @@ inline void _calculate_asinh_(std::uint32_t dst_index_in, std::uint32_t dst_inde
             res = -res;
         }
         v_endif;
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = res;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = res;
         sfpi::dst_reg++;
     }
 }
@@ -217,12 +217,12 @@ inline void _calculate_atanh_(std::uint32_t dst_index_in, std::uint32_t dst_inde
             {
                 den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::NearestEven);
             }
-            num              = num * den;
-            den              = _calculate_log_body_no_init_(num);
-            res              = 0.5f * den;
+            num = num * den;
+            den = _calculate_log_body_no_init_(num);
+            res = 0.5f * den;
         }
         v_endif;
-        sfpi::dst_reg[(dst_index_out - dst_index_in) * 32] = res;
+        sfpi::dst_reg[(dst_index_out - dst_index_in) * TILE_R_DIM] = res;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -16,16 +16,16 @@ namespace sfpu
 {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_fp32_to_uint16_()
+inline void _calculate_typecast_fp32_to_uint16_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
         TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_2, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
@@ -54,16 +54,16 @@ inline void _calculate_typecast_fp32_to_uint16_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_uint16_to_fp16b_()
+inline void _calculate_typecast_uint16_to_fp16b_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
@@ -90,13 +90,13 @@ inline void _calculate_typecast_uint16_to_fp16b_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_int32_to_fp16b_()
+inline void _calculate_typecast_int32_to_fp16b_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
         TTI_SFPABS(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);                  // lreg[1] = iabs(lreg[0])
         TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, 0);                    // lreg[2] = cast(lreg[1])
         TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG0, 0);               // lreg[0] = sign(lreg[0]) | exp_man(lreg[2])
@@ -104,7 +104,7 @@ inline void _calculate_typecast_int32_to_fp16b_()
         TTI_SFPADDI(0xcf00, p_sfpu::LREG0, 0);                           // lreg[0] += -2**31
         TTI_SFPENCC(0, 0, 0, 0);                                         // restore cc
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 4 cycles per input row.
@@ -152,12 +152,12 @@ inline void _calculate_typecast_int32_to_fp16b_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_fp32_to_int32_()
+inline void _calculate_typecast_fp32_to_int32_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
         // result = 0
         TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, 0);
 
@@ -182,17 +182,17 @@ inline void _calculate_typecast_fp32_to_int32_()
         // LaneEnabled = true
         TTI_SFPENCC(0, 0, 0, 0);
 
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_2, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_fp32_to_uint32_()
+inline void _calculate_typecast_fp32_to_uint32_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
         // result = 0
         TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, 0);
 
@@ -212,24 +212,24 @@ inline void _calculate_typecast_fp32_to_uint32_()
         // LaneEnabled = true
         TTI_SFPENCC(0, 0, 0, 0);
 
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_2, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_fp32_to_fp16b_()
+inline void _calculate_typecast_fp32_to_fp16b_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
-        TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+        TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
         TTI_SFPSHFT((-16) & 0xFFF, 0, p_sfpu::LREG0, 1);                           // lreg[0] >>= 16
         TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG0, 0);                           // lreg[0] &= 1
         TTI_SFPIADD(0, p_sfpu::LREG13, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_CC_NONE); // lreg[1] += 0x7FFF
         TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_CC_NONE);  // lreg[1] += lreg[0]
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
@@ -267,15 +267,15 @@ inline void _calculate_typecast_fp32_to_fp16b_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_uint16_to_fp32_()
+inline void _calculate_typecast_uint16_to_fp32_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_2, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
@@ -301,20 +301,20 @@ inline void _calculate_typecast_uint16_to_fp32_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_int32_to_fp32_()
+inline void _calculate_typecast_int32_to_fp32_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
         TTI_SFPABS(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);                  // lreg[1] = iabs(lreg[0])
         TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, 0);                    // lreg[2] = cast(lreg[1])
         TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG0, 0);               // lreg[0] = sign(lreg[0]) | exp_man(lreg[2])
         TTI_SFPSETCC(0, p_sfpu::LREG1, 0, sfpi::SFPSETCC_MOD1_LREG_LT0); // cc = lreg[1] < 0
         TTI_SFPADDI(0xcf00, p_sfpu::LREG0, 0);                           // lreg[0] += -2**31
         TTI_SFPENCC(0, 0, 0, 0);                                         // restore cc
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 4 cycles per input row.
@@ -360,20 +360,20 @@ inline void _calculate_typecast_int32_to_fp32_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_uint32_to_fp16b_()
+inline void _calculate_typecast_uint32_to_fp16b_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
         TTI_SFPSETSGN(0, p_sfpu::LREG0, p_sfpu::LREG1, 1);
         TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0);
         TTI_SFPSETCC(0, p_sfpu::LREG0, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
         TTI_SFPADDI(0x4f00, p_sfpu::LREG1, 0); // 2^31
         TTI_SFPENCC(0, 0, 0, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_2, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
@@ -417,19 +417,19 @@ inline void _calculate_typecast_uint32_to_fp16b_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_uint32_to_fp32_()
+inline void _calculate_typecast_uint32_to_fp32_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
         TTI_SFPSETSGN(0, p_sfpu::LREG0, p_sfpu::LREG1, 1);
         TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, 0);
         TTI_SFPSETCC(0, p_sfpu::LREG0, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
         TTI_SFPADDI(0x4f00, p_sfpu::LREG2, 0); // 2^31
         TTI_SFPENCC(0, 0, 0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::FP32, ADDR_MOD_2, 0);
+        TT_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::FP32, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
@@ -474,14 +474,14 @@ inline void _calculate_typecast_uint32_to_fp32_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_uint16_to_uint32_()
+inline void _calculate_typecast_uint16_to_uint32_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_2, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
@@ -503,18 +503,18 @@ inline void _calculate_typecast_uint16_to_uint32_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_uint32_to_uint16_()
+inline void _calculate_typecast_uint32_to_uint16_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
         TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_CC_NONE | sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST);
         TTI_SFPSHFT((-16) & 0xFFF, 0, p_sfpu::LREG0, 1);
-        TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+        TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
         TTI_SFPOR(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_2, 0);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
@@ -565,17 +565,17 @@ inline void _calculate_typecast_uint32_to_uint16_()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _calculate_typecast_int32_to_uint16_()
+inline void _calculate_typecast_int32_to_uint16_(std::uint32_t dst_index_in, std::uint32_t dst_index_out)
 {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_2, 0);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -25,7 +25,7 @@ inline void _calculate_typecast_fp32_to_uint16_(std::uint32_t dst_index_in, std:
         TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
         TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_2, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
@@ -63,7 +63,7 @@ inline void _calculate_typecast_uint16_to_fp16b_(std::uint32_t dst_index_in, std
         TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
@@ -104,7 +104,7 @@ inline void _calculate_typecast_int32_to_fp16b_(std::uint32_t dst_index_in, std:
         TTI_SFPADDI(0xcf00, p_sfpu::LREG0, 0);                           // lreg[0] += -2**31
         TTI_SFPENCC(0, 0, 0, 0);                                         // restore cc
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 4 cycles per input row.
@@ -182,7 +182,7 @@ inline void _calculate_typecast_fp32_to_int32_(std::uint32_t dst_index_in, std::
         // LaneEnabled = true
         TTI_SFPENCC(0, 0, 0, 0);
 
-        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_2, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 }
 
@@ -212,7 +212,7 @@ inline void _calculate_typecast_fp32_to_uint32_(std::uint32_t dst_index_in, std:
         // LaneEnabled = true
         TTI_SFPENCC(0, 0, 0, 0);
 
-        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_2, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 }
 
@@ -229,7 +229,7 @@ inline void _calculate_typecast_fp32_to_fp16b_(std::uint32_t dst_index_in, std::
         TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG0, 0);                           // lreg[0] &= 1
         TTI_SFPIADD(0, p_sfpu::LREG13, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_CC_NONE); // lreg[1] += 0x7FFF
         TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_CC_NONE);  // lreg[1] += lreg[0]
-        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_2, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
@@ -275,7 +275,7 @@ inline void _calculate_typecast_uint16_to_fp32_(std::uint32_t dst_index_in, std:
     {
         TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_2, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
@@ -314,7 +314,7 @@ inline void _calculate_typecast_int32_to_fp32_(std::uint32_t dst_index_in, std::
         TTI_SFPSETCC(0, p_sfpu::LREG1, 0, sfpi::SFPSETCC_MOD1_LREG_LT0); // cc = lreg[1] < 0
         TTI_SFPADDI(0xcf00, p_sfpu::LREG0, 0);                           // lreg[0] += -2**31
         TTI_SFPENCC(0, 0, 0, 0);                                         // restore cc
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 4 cycles per input row.
@@ -373,7 +373,7 @@ inline void _calculate_typecast_uint32_to_fp16b_(std::uint32_t dst_index_in, std
         TTI_SFPADDI(0x4f00, p_sfpu::LREG1, 0); // 2^31
         TTI_SFPENCC(0, 0, 0, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_2, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
@@ -429,7 +429,7 @@ inline void _calculate_typecast_uint32_to_fp32_(std::uint32_t dst_index_in, std:
         TTI_SFPSETCC(0, p_sfpu::LREG0, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
         TTI_SFPADDI(0x4f00, p_sfpu::LREG2, 0); // 2^31
         TTI_SFPENCC(0, 0, 0, 0);
-        TT_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::FP32, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::FP32, ADDR_MOD_2, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
@@ -481,7 +481,7 @@ inline void _calculate_typecast_uint16_to_uint32_(std::uint32_t dst_index_in, st
     for (int d = 0; d < ITERATIONS; d++)
     {
         TT_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_2, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
@@ -514,7 +514,7 @@ inline void _calculate_typecast_uint32_to_uint16_(std::uint32_t dst_index_in, st
         TTI_SFPSHFT((-16) & 0xFFF, 0, p_sfpu::LREG0, 1);
         TT_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
         TTI_SFPOR(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
-        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_2, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
@@ -575,7 +575,7 @@ inline void _calculate_typecast_int32_to_uint16_(std::uint32_t dst_index_in, std
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_2, (dst_index_out - dst_index_in) * 32);
+        TT_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_2, (dst_index_out - dst_index_in) * TILE_R_DIM);
     }
 #else
     // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_params.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_params.h
@@ -4,18 +4,72 @@
 
 #pragma once
 #include <cstdint>
+#include <type_traits>
 #include <utility>
 
 #include "llk_math_eltwise_sfpu_common.h"
 #include "llk_math_eltwise_unary_sfpu.h"
 
+// Dispatch the SFPU callable with or without leading dst indices, depending on
+// which signature it accepts. Some calculate functions take (dst_in, dst_out,
+// args...) — these are the split-aware ones added on top of the legacy
+// (args...) ones (e.g. TopK helpers). This helper selects the right shape at
+// compile time so the single-idx `_params_` template can drive both kinds of
+// callable while keeping in == out for the legacy single-dst contract.
+template <typename Callable, typename... Args>
+inline void _llk_math_eltwise_unary_sfpu_dispatch_(Callable&& sfpu_func, std::uint32_t dst_index, Args&&... args)
+{
+    if constexpr (std::is_invocable_v<Callable&, std::uint32_t, std::uint32_t, Args&...>)
+    {
+        std::forward<Callable>(sfpu_func)(dst_index, dst_index, std::forward<Args>(args)...);
+    }
+    else
+    {
+        std::forward<Callable>(sfpu_func)(std::forward<Args>(args)...);
+    }
+}
+
+// Single-index variant. The dispatch helper above lets a callable that
+// accepts (dst_in, dst_out, Args&...) work here by repeating dst_index for
+// both positions (in == out), so legacy single-dst paths and macro callers
+// can drive split-aware SFPU calculate functions without changing shape.
 template <typename Callable, typename... Args>
 inline void _llk_math_eltwise_unary_sfpu_params_(
     Callable&& sfpu_func, std::uint32_t dst_index, int vector_mode = static_cast<int>(VectorMode::RC), Args&&... args)
 {
     _llk_math_eltwise_sfpu_start_(dst_index);
 
-    _llk_math_eltwise_sfpu_apply_vector_mode_(std::forward<Callable>(sfpu_func), vector_mode, std::forward<Args>(args)...);
+    auto dispatch_wrapper = [&](auto&&... a) {
+        _llk_math_eltwise_unary_sfpu_dispatch_(
+            std::forward<Callable>(sfpu_func), dst_index, std::forward<decltype(a)>(a)...);
+    };
+    _llk_math_eltwise_sfpu_apply_vector_mode_(dispatch_wrapper, vector_mode, std::forward<Args>(args)...);
+
+    _llk_math_eltwise_sfpu_done_();
+}
+
+// Split-dest variant: source tile index (dst_index_in) is used to position
+// the dest face pointer at the start; the callable then receives both indices
+// so an SFPU op can read from dst_index_in and write to dst_index_out.
+// Distinct name (not an overload of _params_) so callers pick the shape
+// explicitly and overload resolution can't conflate the two.
+// The dst-bound assert lives in ckernel::_sfpu_check_and_call_ (see the
+// per-arch llk_math_eltwise_unary_sfpu_macros.h), so it is intentionally not
+// duplicated here.
+template <typename Callable, typename... Args>
+inline void _llk_math_eltwise_unary_sfpu_params_split_(
+    Callable&& sfpu_func,
+    std::uint32_t dst_index_in,
+    std::uint32_t dst_index_out,
+    int vector_mode = static_cast<int>(VectorMode::RC),
+    Args&&... args)
+{
+    _llk_math_eltwise_sfpu_start_(dst_index_in);
+
+    auto split_wrapper = [&](auto&&... a) {
+        std::forward<Callable>(sfpu_func)(dst_index_in, dst_index_out, std::forward<decltype(a)>(a)...);
+    };
+    _llk_math_eltwise_sfpu_apply_vector_mode_(split_wrapper, vector_mode, std::forward<Args>(args)...);
 
     _llk_math_eltwise_sfpu_done_();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/bias_bcast_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/bias_bcast_sfpu.h
@@ -61,7 +61,7 @@ inline void _add_bias_configure_addrmod_() {
         .set(ADDRMOD_OFFSET + ADDR_MOD_3);
 }
 
-inline void _add_bias_() {
+inline void _add_bias_(uint32_t /*dst_index_in*/, uint32_t /*dst_index_out*/) {
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
 
     // Let us load in the bias values

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top2_sum_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top2_sum_sfpu.h
@@ -60,7 +60,7 @@ inline void _top2_configure_addrmod_() {
         .set(ADDRMOD_OFFSET + ADDR_MOD_3);
 }
 
-inline void _top2_calculate_top2_() {
+inline void _top2_calculate_top2_(uint32_t /*dst_index_in*/, uint32_t /*dst_index_out*/) {
     constexpr uint16_t NEG_INF_BF16 = 0xFF80;
 
     // Reset Dst RWC to 0

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top4_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top4_sfpu.h
@@ -60,7 +60,7 @@ inline void _top4_configure_addrmod_() {
         .set(ADDRMOD_OFFSET + ADDR_MOD_3);
 }
 
-inline void _calculate_top4_() {
+inline void _calculate_top4_(uint32_t /*dst_index_in*/, uint32_t /*dst_index_out*/) {
     // Reset Dst RWC to 0
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_merge_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_merge_sfpu.h
@@ -268,7 +268,7 @@ inline void _top8_merge_two_sorted_8_() {
 
 // Main entry point for cross-core merge
 template <uint32_t column_idx>
-inline void _top8_merge_() {
+inline void _top8_merge_(uint32_t /*dst_index_in*/, uint32_t /*dst_index_out*/) {
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
 
     // Sequentially merge core 0 data with that in cores 1-7

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_sfpu.h
@@ -457,7 +457,7 @@ inline void _top8_merge_sorted_8_() {
     }
 }
 
-inline void _calculate_top8_tile_(uint32_t tile_index) {
+inline void _calculate_top8_tile_(uint32_t /*dst_index_in*/, uint32_t /*dst_index_out*/, uint32_t tile_index) {
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
 
     //-------------------------------------------------------------------------

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -221,8 +221,9 @@ void reduce_c(uint32_t out_cb, uint32_t prev_cb, uint32_t cols, bool do_eltwise_
  * recip_tile on only the columns 0:8 of a face
  */
 template <bool legacy_compat = true>
-void calculate_recip_first_column() {
+void calculate_recip_first_column(uint32_t dst_index_in, uint32_t dst_index_out) {
     constexpr int ITERATIONS_HALF_FACE = 4;
+    constexpr uint32_t SFP_DST_TILE_ROWS = 32;
     if constexpr (legacy_compat) {
         for (int d = 0; d < ITERATIONS_HALF_FACE; d++) {
             sfpi::vFloat in = sfpi::dst_reg[0];
@@ -819,15 +820,16 @@ void calculate_exponential_polynomial() {
  * exp_tile on only the columns 0:8 of a face
  */
 template <bool SDPA_EXP_APPROX_MODE, uint16_t scale_bf16>
-void calculate_exponential_first_column() {
+void calculate_exponential_first_column(uint32_t dst_index_in, uint32_t dst_index_out) {
     constexpr int ITERATIONS_HALF_FACE = 4;
+    constexpr uint32_t SFP_DST_TILE_ROWS = 32;
     if constexpr (SDPA_EXP_APPROX_MODE) {
         for (int d = 0; d < ITERATIONS_HALF_FACE; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];
             sfpi::vFloat result =
                 ckernel::sfpu::_ckernel_sfpu_exp_accurate_<true /*SCALE_EN*/, DST_ACCUM_MODE /*is_fp32_dest_acc_en*/>(
                     val, scale_bf16);
-            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg[(dst_index_out - dst_index_in) * SFP_DST_TILE_ROWS] = result;
 
             // Stride by 2 to skip columns 8:16 of the face
             sfpi::dst_reg += 2;
@@ -893,7 +895,7 @@ void sub_exp_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t n
  * fused_max_sub_exp_add_tile
  */
 template <bool SDPA_EXP_APPROX_MODE>
-void calculate_fused_max_sub_exp_add_tile(int scale_bf16) {
+void calculate_fused_max_sub_exp_add_tile(uint32_t dst_index_in, uint32_t dst_index_out, int scale_bf16) {
     constexpr int ITERATIONS_HALF_FACE = 4;
     constexpr uint32_t prev_max_base_idx = 0;      // dst_reg_0 (Tile 0)
     constexpr uint32_t worker_max_base_idx = 32;   // dst_reg_1 (Tile 1)
@@ -1097,13 +1099,15 @@ void sigmoid_sub(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num
  * softplus_tile on only the columns 0:8 of a face
  */
 template <bool SDPA_EXP_APPROX_MODE>
-void calculate_softplus_first_column(uint param0, uint param1, uint param2) {
+void calculate_softplus_first_column(
+    uint32_t dst_index_in, uint32_t dst_index_out, uint param0, uint param1, uint param2) {
     constexpr int ITERATIONS_HALF_FACE = 4;
     float beta = ckernel::sfpu::Converter::as_float(param0);
     float beta_reciprocal = ckernel::sfpu::Converter::as_float(param1);
     float threshold = ckernel::sfpu::Converter::as_float(param2);
     for (int d = 0; d < ITERATIONS_HALF_FACE; d++) {
-        ckernel::sfpu::calculate_softplus_body<APPROX, DST_ACCUM_MODE>(beta, beta_reciprocal, threshold);
+        ckernel::sfpu::calculate_softplus_body<APPROX, DST_ACCUM_MODE>(
+            dst_index_in, dst_index_out, beta, beta_reciprocal, threshold);
         sfpi::dst_reg += 2;
     }
 }
@@ -1920,7 +1924,8 @@ void sdpa_inner_loop(
             sub_exp_block_bcast_cols_inplace<cb_qk_im, Sq_chunk_t, scale_fp32, true>(
                 alias_cur_max, alias_cur_sum, Sk_chunk_t);
 
-            // Reconfigure unpackers: srcA (context 0) = cb_v_in, srcB (context 1) = cb_qk_im (operands are swapped in matmul)
+            // Reconfigure unpackers: srcA (context 0) = cb_v_in, srcB (context 1) = cb_qk_im (operands are swapped in
+            // matmul)
             reconfig_data_format(cb_v_in, cb_qk_im);
             pack_reconfig_data_format(alias_mm2_cur_out);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -112,7 +112,7 @@ ALWI void recip_tile_first_column_wh_idst0_direct() {
 
 #pragma GCC unroll 0
     for (int face = 0; face < 2; face++) {
-        calculate_recip_first_column();
+        calculate_recip_first_column(0, 0);
         TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
         TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);
         TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 8, 0, 0, p_setrwc::SET_D);


### PR DESCRIPTION
### PR Category
Feature

### Summary
Split the single `dst_index` parameter into separate `dst_index_in` and `dst_index_out` across all four layers of the SFPU unary op stack, enabling future out-of-place unary operations where the source and destination tiles in DEST differ.

Today all callers pass the same value for both (in-place), preserving existing behavior. The split threads through:

- **Layer 1 (tt-llk):** `_calculate_*_` functions take `(dst_index_in, dst_index_out, ...)`, writes use `dst_reg[(dst_index_out - dst_index_in) * 32]`. Hardware in-place constraints in `exp.h` and `recip.h` (BH) are enforced with `LLK_ASSERT(out == in)`. A new `_llk_math_eltwise_unary_sfpu_params_split_` function (distinct name, not an overload) accepts both indices and forwards them to the callback via `_llk_math_eltwise_sfpu_apply_vector_mode_` lambda wrapper. The original `_llk_math_eltwise_unary_sfpu_params_` is unchanged in signature — a `_dispatch_` helper uses `if constexpr (std::is_invocable_v)` to auto-detect callback arity. All architectures (BH, WH, Quasar) have `_params_split_` at Layer 1. All QSR unary callbacks are migrated.
- **Layer 2 (ckernels):** All `calculate_*` wrappers in WH and BH have split overloads that route through `_params_split_`. Single-index wrappers call `_params_()` with unchanged signatures. Quasar Layer 2 split wrappers deferred to follow-up PR.
- **Layer 3 (Compute API):** New `(idst_in, idst_out)` overloads for all unary tile functions across both `eltwise_unary/*.h` files and `compute_kernel_api.h`. Original single-`idst` signatures unchanged. `LLK_ASSERT(dst_index_out >= dst_index_in)` in `_sfpu_check_and_call_` guards against unsigned store offset underflow. Quasar Layer 3 split overloads deferred to follow-up PR.
- **Layer 4 (TTNN/models):** SDPA `recip_tile_first_column`, DeepSeek MOE gate kernels, and DeepSeek `llk_math_deepseek_top32_rm.h` updated to the new calling convention.

Relates to #30298

### Dispatch architecture (BH/WH)

- **`_llk_math_eltwise_unary_sfpu_params_split_`** — distinct function name (not overload of `_params_`) taking `(callable, dst_index_in, dst_index_out, vector_mode, args...)`. Uses a lambda wrapper around `_llk_math_eltwise_sfpu_apply_vector_mode_` for the face iteration loop. Callers explicitly choose split vs single-index by function name, eliminating overload resolution ambiguity.
- **Split overload of `_sfpu_check_and_call_`** in `llk_math_eltwise_unary_sfpu_macros.h` taking `(callable, dst_index_in, dst_index_out, vector_mode, args...)`. Performs dst-bound `LLK_ASSERT` for both indices plus `LLK_ASSERT(dst_index_out >= dst_index_in)`, then dispatches to `_params_split_`. BH and WH macros files remain byte-identical.
- **`SFPU_CALL_SPLIT` / `SFPU_CALL_MODE_SPLIT` / `SFPU_CALL_CAST_SPLIT` macros** mirror their non-split counterparts but accept `(DST_IDX_IN, DST_IDX_OUT)` and route through the split `_sfpu_check_and_call_`.
- **`call_unary_sfpu_operation_split<DST_SYNC, DST_ACCUM, OPERATION, ...>(dst_index_in, dst_index_out, ...)`** in `tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h` mirrors `call_unary_sfpu_operation` for the split path. The TopK family falls back to the single-idx path (anchored at `dst_index_in`) since `_bitonic_topk_*` reduces in place across DST.

### Notes for reviewers

- **Single-idx path supports both callable shapes:** Most `_calculate_*_` functions in this PR carry the split signature `(dst_index_in, dst_index_out, args...)`, but some (TopK helpers, `_calculate_add_top_row_`, the SFPI-binary helpers) only accept `(args...)`. The single-idx `_llk_math_eltwise_unary_sfpu_params_` uses a `_llk_math_eltwise_unary_sfpu_dispatch_` helper with compile-time `std::is_invocable_v<Callable&, uint32_t, uint32_t, Args&...>`: if the callable accepts leading dst indices, it's invoked as `sfpu_func(dst_index, dst_index, args...)`; otherwise as `sfpu_func(args...)`. The split function always calls with `(dst_index_in, dst_index_out, args...)`.
- **Overload ambiguity prevention (Compute API):** Defaults removed on trailing parameters of a few ops (e.g. `power`'s `exponent`, `leaky_relu`'s `slope`) so the compiler can disambiguate `(idst_in, idst_out, ...)` and `(idst, ...)` overloads at call sites that omit those trailing args.
- **`SFPU_CALL_CAST` signature for `_calculate_activation_`:** Cast type in `sfpu_operations.h` (hardsigmoid path) is `(void(*)(std::uint32_t, std::uint32_t))` to match the split signature.
- **`_calculate_square_` (BH+WH) uses SFPI addressing:** `sfpi::dst_reg[(out - in) * 32] = v * v` keeps the load and store row in sync as the loop advances. Earlier `TT_SFPLOAD`/`TT_SFPSTORE`-based bodies only addressed correctly for `in == out` because `sfpi::dst_reg++` advances the SFPI-tracked pointer but not the hardware DSTREG counter that those intrinsics use.
- **TTI_ vs TT_ in `unary_max_min` body functions:** `calculate_unary_max_min_float_body` and `calculate_unary_max_min_int32_body` use `TTI_SFPLOAD`/`TTI_SFPSTORE` for the in-place case (offset=0) and `TT_SFPLOAD`/`TT_SFPSTORE` only when the offset is non-zero. Preserves ttsim compatibility and avoids SFPI register allocator conflicts in `sfpi_inline` functions.
- **DeepSeek B1 vendored `llk_math_deepseek_top32_rm.h`:** Lambda adapters bridge the new calling convention to existing callback signatures, since those callbacks are called directly (not through the params function).
- **LLK-level tests:** `tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu_separate_tiles.py` exercises the split path on Blackhole with `(dst_in, dst_out)` ∈ {(0,0), (0,1), (0,2), (1,2)} across `Abs`, `Square`, `Gelu`, `Silu`, `Neg` (20 variants), plus `Exp` in accurate mode at (0,1) and (1,2). The kernel uses the cross-arch `_llk_math_eltwise_unary_datacopy_init_wrapper_` and `_llk_pack_*_wrapper_` helpers and dispatches the SFPU op through `call_unary_sfpu_operation_split`.

### Migration Plan

**Current state:** All layers (1-3) expose both the old `(dst_index)` and new `(dst_index_in, dst_index_out)` APIs side by side. Existing code is unchanged.

**For D2M / compiler consumers:**
1. Use the new `*_tile(idst_in, idst_out, ...)` Compute API overloads
2. Constraint: `idst_out >= idst_in` (enforced by `LLK_ASSERT`)
3. Hardware in-place constraint: `exp` (approx+clamp) and `recip` fast paths on BH assert `in == out`

**Future deprecation path:**
1. TTNN/models adopt `(idst_in, idst_out)` overloads incrementally
2. Old `(idst)` overloads marked `[[deprecated]]`
3. Old overloads removed after full migration

**Quasar:** Layer 1 complete (all unary callbacks migrated, `_params_split_` exists). Layer 2/3 split overloads deferred to a follow-up PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/issue_30298)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/issue_30298)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstamatovic/issue_30298)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstamatovic/issue_30298)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nstamatovic/issue_30298)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nstamatovic/issue_30298)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/issue_30298)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/issue_30298)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstamatovic/issue_30298)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstamatovic/issue_30298)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/issue_30298)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/issue_30298)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/issue_30298)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/issue_30298)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/issue_30298)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/issue_30298)