### PR TITLE
ci: Wire AI job/run summary into blackhole-e2e-tests

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -282,7 +282,7 @@ jobs:
         with:
           config: |
             {
-              "model": "anthropic/claude-sonnet-4-6",
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
               "workspace": "$GITHUB_WORKSPACE/docker-job",
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries"
@@ -321,7 +321,7 @@ jobs:
         with:
           config: |
             {
-              "model": "anthropic/claude-sonnet-4-6",
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
               "workspace": "$GITHUB_WORKSPACE",
               "input_dir": "ai_job_summaries",
               "output_dir": "ai_run_summaries"

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -224,7 +224,16 @@ jobs:
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
-          ${{ matrix.test-group.cmd }}
+          mkdir -p generated/test_logs
+          # tee combined stdout+stderr to a per-leg .log for ai-summary.
+          # Brace group: cmd may be multiple shell statements.
+          # PIPESTATUS: preserve real exit code (tee would mask it).
+          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' /' '__')
+          LOG_FILE="generated/test_logs/${SAFE_NAME}_${{ job.check_run_id }}.log"
+          {
+            ${{ matrix.test-group.cmd }}
+          } 2>&1 | tee "$LOG_FILE"
+          exit ${PIPESTATUS[0]}
       - name: Check latency/BW results
         id: check-data
         if: ${{ !cancelled() && matrix.test-group.name == 'fabric sanity benchmark' }}
@@ -266,3 +275,70 @@ jobs:
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
         if: ${{ failure() }}
+      - name: 🤖 AI job summary
+        if: always() && !cancelled()
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "anthropic/claude-sonnet-4-6",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
+
+  ai-run-summary:
+    name: "AI Run Summary"
+    needs: [generate-matrix, multi-card-unit-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: extract-matrix
+        env:
+          MATRIX_WRAPPER: ${{ needs.generate-matrix.outputs.matrix }}
+        run: |
+          # generate-matrix exposes a `{"test-group": [...]}` wrapper for
+          # GitHub `matrix:` consumption; ai_summary/run wants the flat
+          # array of leg dicts. Extract it (or default to []).
+          if [ -z "$MATRIX_WRAPPER" ]; then
+            EXPECTED="[]"
+          else
+            EXPECTED=$(echo "$MATRIX_WRAPPER" | jq -c '.["test-group"] // []')
+          fi
+          {
+            echo "matrix<<EOF"
+            echo "$EXPECTED"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - id: ai-run-summary
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/run@main
+        with:
+          config: |
+            {
+              "model": "anthropic/claude-sonnet-4-6",
+              "workspace": "$GITHUB_WORKSPACE",
+              "input_dir": "ai_job_summaries",
+              "output_dir": "ai_run_summaries"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          expected-jobs: ${{ steps.extract-matrix.outputs.matrix }}
+          run-result: ${{ needs.multi-card-unit-tests.result }}
+      - name: Show report
+        if: always() && steps.ai-run-summary.outputs.report-file != ''
+        continue-on-error: true
+        shell: bash
+        env:
+          REPORT_FILE: ${{ steps.ai-run-summary.outputs.report-file }}
+        run: |
+          if [ -f "$REPORT_FILE" ]; then
+            cat "$REPORT_FILE"
+          else
+            echo "::warning::Report file not found: $REPORT_FILE"
+          fi

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -339,6 +339,7 @@ jobs:
         run: |
           if [ -f "$REPORT_FILE" ]; then
             cat "$REPORT_FILE"
+            cat "$REPORT_FILE" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "::warning::Report file not found: $REPORT_FILE"
           fi


### PR DESCRIPTION
Capture per-leg logs and add ai_summary/{job,run} steps from tt-github-actions.
Both are continue-on-error and never flip the crash flag.

Example run: [AI Run Summary](https://github.com/tenstorrent/tt-metal/actions/runs/25372379254)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ppetrovic/blackhole-e2e-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ppetrovic/blackhole-e2e-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ppetrovic/blackhole-e2e-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ppetrovic/blackhole-e2e-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ppetrovic/blackhole-e2e-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ppetrovic/blackhole-e2e-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ppetrovic/blackhole-e2e-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ppetrovic/blackhole-e2e-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ppetrovic/blackhole-e2e-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ppetrovic/blackhole-e2e-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ppetrovic/blackhole-e2e-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ppetrovic/blackhole-e2e-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ppetrovic/blackhole-e2e-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ppetrovic/blackhole-e2e-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ppetrovic/blackhole-e2e-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ppetrovic/blackhole-e2e-tests)