### PR TITLE
[tt-train] Fix AdamW gradient zeroing

### DIFF
--- a/tt-train/sources/ttml/optimizers/adamw.cpp
+++ b/tt-train/sources/ttml/optimizers/adamw.cpp
@@ -42,7 +42,7 @@ AdamW::AdamW(ttml::serialization::NamedParameters parameters, const AdamWConfig&
 void AdamW::zero_grad() {
     for (auto& [name, tensor_ptr] : m_parameters) {
         if (tensor_ptr->get_requires_grad() && tensor_ptr->is_grad_initialized()) {
-            tensor_ptr->set_grad(core::zeros_like(tensor_ptr->get_value()));
+            tensor_ptr->set_grad(ttnn::Tensor());
         }
     }
 }


### PR DESCRIPTION
### Ticket

### Problem description
The fused `AdamW::zero_grad()` previously allocated a fresh zero-filled DRAM tensor for every parameter. This can be avoided as the next add_grad call will take ownership of the freshly produced gradient instead of accumulating into a zeroed tensor. This way we avoid costly `core::zeros_like(...)` call for every parameter.

### What's changed
Replace `tensor_ptr->set_grad(core::zeros_like(tensor_ptr->get_value()));` with 
`tensor_ptr->set_grad(ttnn::Tensor());` in `AdamW::zero_grad()`. Drop the existing gradient tensor instead of replacing it with a freshly allocated zero-filled one.

#### TinyLlama 1.1B (batch_size=1, seq=2048) Blackhole P100a

| Metric | BEFORE | AFTER | Δ |
| --- | ---: | ---: | ---: |
| **Peak DRAM** | **11155.81 MB** | **9305.81 MB** | **−1850.00 MB (−16.6%)** |

The reason for memory reduction is that the gradient tensors do not coexist with activations during the next forward pass, reducing the peak roughly by the gradient footprint. Note that this does not apply if gradient accumulation is enabled.

| Metric | BEFORE | AFTER | Δ |
  | --- | ---: | ---: | ---: |
  | **Avg step time (ms)** | **467.441** | **445.944** | **−21.50 ms (−4.60%)** |

(First 20 steps omitted)

These numbers pertain to `gradient_accumulation_steps = 1`. With gradient accumulation enabled, peak memory usage remains the same and the time saving is amortized by number of gradient accumulation steps.

This change brings the fused version in line with the existing `zero_grad` implementation in the composite path.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=zbaczewski/zero-grad-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:zbaczewski/zero-grad-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=zbaczewski/zero-grad-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:zbaczewski/zero-grad-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=zbaczewski/zero-grad-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:zbaczewski/zero-grad-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=zbaczewski/zero-grad-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:zbaczewski/zero-grad-fix)