### PR TITLE
Remove tile to row-major conversion at the end of MoE

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -530,10 +530,6 @@ class TtMoe(LightweightModule):
         final_output = ttnn.add(routed_output, shared_output)
         logger.debug(f"[TtMoe.forward] final_output (tiled) shape: {final_output.shape}")
 
-        # Convert to ROW_MAJOR for output consistency
-        final_output = ttnn.to_layout(final_output, ttnn.ROW_MAJOR_LAYOUT)
-        logger.debug(f"[TtMoe.forward] Final output shape: {final_output.shape}")
-
         # Build intermediates if requested
         intermediates = None
         if return_intermediates:


### PR DESCRIPTION
### Summary
Removes unnecessary untilize -> tilize pattern at the end of MoE. There is an explicit conversion of MoE output to row major layout, while the next eltwise op (residual Add in prefill block) then implicitly tilizes the tensor.

Saves 77us (untilize) + 109us (tilize) ~186us per MoE layer.
```

ID     Total %  Bound  OP Code                                   Device Time  Op-to-Op Gap  Cores  DRAM      DRAM %  FLOPs         FLOPs %  Math Fidelity            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 2332    0.1 %         ReduceScatterDeviceOperation                   836 us     31,762 us     34                                                        BF16 => BF16
 2334    0.0 %         BinaryNgDeviceOperation                         86 us        194 us    130                                                  BF16, BF16 => BF16
 2341    0.7 %         UntilizeDeviceOperation                         77 us    172,922 us    120                                                        BF16 => BF16
 2351    0.7 %         TilizeDeviceOperation                          109 us    173,969 us    120                                                        BF16 => BF16
 2362    0.0 %         BinaryNgDeviceOperation                         91 us        535 us    130                                                  BF16, BF16 => BF16
```

### DeepSeek Prefill CI

- [ ] [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nbabin/moe_tile_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nbabin/moe_tile_output)
- [ ] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=nbabin/moe_tile_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:nbabin/moe_tile_output)
- [ ] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=nbabin/moe_tile_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:nbabin/moe_tile_output)
- [ ] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=nbabin/moe_tile_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:nbabin/moe_tile_output)
- [ ] [![(Release) Model Status for Console Deployment](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=nbabin/moe_tile_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:nbabin/moe_tile_output)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nbabin/moe_tile_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nbabin/moe_tile_output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nbabin/moe_tile_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nbabin/moe_tile_output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nbabin/moe_tile_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nbabin/moe_tile_output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nbabin/moe_tile_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nbabin/moe_tile_output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nbabin/moe_tile_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nbabin/moe_tile_output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nbabin/moe_tile_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nbabin/moe_tile_output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nbabin/moe_tile_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nbabin/moe_tile_output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nbabin/moe_tile_output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nbabin/moe_tile_output)