### PR TITLE
metal_BERT_large_11: re-enable qkv bias caching with v2 cache key

### DIFF
--- a/models/demos/metal_BERT_large_11/tt/mha.py
+++ b/models/demos/metal_BERT_large_11/tt/mha.py
@@ -191,7 +191,7 @@ class TtMultiHeadAttentionModel:
             )
             qkv_bias_cache_path = str(
                 f"{tt_cache_path}/"
-                f"{layer_name}.qkv.bias_{interleaved_str}{model_config['OP1_FUSED_QKV_MM_BIAS_DTYPE'].name}.tensorbin"
+                f"{layer_name}.qkv.bias_{interleaved_str}{model_config['OP1_FUSED_QKV_MM_BIAS_DTYPE'].name}_v2.tensorbin"
             )
 
         def compute_qkv_weight():

--- a/models/demos/metal_BERT_large_11/tt/mha.py
+++ b/models/demos/metal_BERT_large_11/tt/mha.py
@@ -250,7 +250,7 @@ class TtMultiHeadAttentionModel:
         )
 
         qkv_bias = load_or_compute_and_cache(
-            None,
+            qkv_bias_cache_path,
             compute_qkv_bias,
             device=device,
             mem_config=model_config["OP1_FUSED_QKV_MM_BIAS_MEMCFG"],


### PR DESCRIPTION
## Summary

- Pass `qkv_bias_cache_path` (instead of `None`) to `load_or_compute_and_cache` for the QKV bias in `metal_BERT_large_11`, restoring the cached fast path that was disabled in #43063.
- Bump the bias cache filename to `..._v2.tensorbin` so the stale on-disk tensors (with the pre-#43063 `[1,1,32,n]` shape) are bypassed and a freshly-shaped `[1,1,1,n]` tensor is written.

Fixes #43088.

## Background

When #43063 fixed the bias shape for the matmul/linear op (now requires `[1,1,1,n]` or `[1,1,m,n]`), bias caching for `metal_BERT_large_11` had to be turned off because the on-disk caches contained the old `[1,1,32,n]` layout. The previous `_v2` rename attempt failed in CI with a read-only filesystem error on `/mnt/MLPerf`. With the mount briefly flipped to `:rw` on the `mtairum/bert_caching` branch, the freshly-shaped `_v2` cache files have now been populated on the shared cache, so caching can be re-enabled with no further CI infra changes.

## Test plan

- [x] `perf-models.yaml` run on `mtairum/bert_caching` — `metal_BERT_large_11` perf test green on both N300 WH B0 and P150 BH (https://github.com/tenstorrent/tt-metal/actions/runs/25379374425).
- [x] Job log confirms the `_v2.tensorbin` files are loaded from `/mnt/MLPerf` (no recompute, no FS write needed by post-merge runs).

## Notes

- This PR contains no workflow changes — `/mnt/MLPerf` remains mounted `:ro` in `perf-models-impl.yaml`.
- If the cache ever needs to be re-populated again (e.g. another bias-shape change), the same procedure applies: temporarily flip the mount to `:rw`, bump the cache key to `_v3`, run the perf workflow, then revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/bert_caching)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/bert_caching)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/bert_caching)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/bert_caching)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/bert_caching)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/bert_caching)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/bert_caching)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/bert_caching)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/bert_caching)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/bert_caching)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/bert_caching)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/bert_caching)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/bert_caching)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/bert_caching)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/bert_caching)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/bert_caching)