### PR TITLE
Add SafeDeviceGuard for cross-process device sharing

### DIFF
--- a/tests/tt_metal/tt_metal/device/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/device/CMakeLists.txt
@@ -43,3 +43,29 @@ target_link_libraries(
         TT::Metalium::Test::Device::Smoke
         test_metal_common_libs
 )
+
+# SafeDeviceGuard unit tests — no hardware required; exercises /dev/shm mutex + dirty-bit logic.
+add_executable(unit_tests_safe_device_open test_safe_device_open.cpp)
+target_precompile_headers(unit_tests_safe_device_open REUSE_FROM metal_common_pch)
+target_include_directories(
+    unit_tests_safe_device_open
+    PRIVATE
+        "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
+        ${PROJECT_SOURCE_DIR}/tests
+        ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+set_target_properties(
+    unit_tests_safe_device_open
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${PROJECT_BINARY_DIR}/test/tt_metal
+)
+target_link_libraries(
+    unit_tests_safe_device_open
+    PRIVATE
+        test_metal_common_libs
+        gmock
+        gtest
+        gtest_main
+)

--- a/tests/tt_metal/tt_metal/device/test_safe_device_open.cpp
+++ b/tests/tt_metal/tt_metal/device/test_safe_device_open.cpp
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <string>
+
+#include <gtest/gtest.h>
+#include <umd/device/utils/robust_mutex.hpp>
+
+#include "impl/device/safe_device_open.hpp"
+
+namespace tt::tt_metal {
+namespace {
+
+// High chip ID that won't correspond to a real device on any test host.
+constexpr tt::ChipId kTestId = 250;
+
+// Names that match SafeDeviceGuard's internal naming for kTestId.
+const std::string kDirtyShmName = "/TT_METAL_DEVICE_DIRTY." + std::to_string(kTestId);
+// RobustMutex opens "/dev/shm/<SHM_FILE_PREFIX><mutex_name>".
+const std::string kMutexShmName =
+    std::string(tt::umd::RobustMutex::SHM_FILE_PREFIX) + "tt-metal-device-" + std::to_string(kTestId);
+
+// Remove any leftover shm objects from a previous run.
+void wipe_shm() {
+    shm_unlink(kDirtyShmName.c_str());
+    shm_unlink(kMutexShmName.c_str());
+}
+
+// Read the dirty byte directly. Returns 0 if the shm doesn't exist.
+uint8_t read_dirty() {
+    int fd = shm_open(kDirtyShmName.c_str(), O_RDONLY, 0);
+    if (fd == -1) {
+        return 0;
+    }
+    void* ptr = mmap(nullptr, 1, PROT_READ, MAP_SHARED, fd, 0);
+    uint8_t val = 0;
+    if (ptr != MAP_FAILED) {
+        val = *static_cast<uint8_t*>(ptr);
+        munmap(ptr, 1);
+    }
+    close(fd);
+    return val;
+}
+
+class SafeDeviceGuardTest : public ::testing::Test {
+protected:
+    void SetUp() override { wipe_shm(); }
+    void TearDown() override { wipe_shm(); }
+};
+
+// Dirty bit is set to 1 after construction and cleared to 0 after graceful destruction.
+TEST_F(SafeDeviceGuardTest, DirtyBitLifecycle) {
+    {
+        SafeDeviceGuard guard({kTestId});
+        EXPECT_EQ(read_dirty(), 1) << "dirty bit must be 1 while guard is live";
+    }
+    EXPECT_EQ(read_dirty(), 0) << "dirty bit must be cleared on graceful exit";
+}
+
+// After on_hang(), the dirty bit persists through destruction.
+// The next acquirer will see dirty=1 and trigger a reset before starting work.
+TEST_F(SafeDeviceGuardTest, HangLeavesDeviceDirty) {
+    {
+        SafeDeviceGuard guard({kTestId});
+        guard.on_hang();
+    }
+    EXPECT_EQ(read_dirty(), 1) << "dirty bit must stay set when the guard exits via hang path";
+}
+
+// on_hang() must be safe to call from multiple threads or repeated calls (idempotent).
+TEST_F(SafeDeviceGuardTest, OnHangIsIdempotent) {
+    SafeDeviceGuard guard({kTestId});
+    EXPECT_NO_THROW({
+        guard.on_hang();
+        guard.on_hang();
+        guard.on_hang();
+    });
+}
+
+// A child process holds the guard; the parent verifies the dirty bit is set while the child
+// is alive, then acquires the guard itself after the child exits cleanly.
+TEST_F(SafeDeviceGuardTest, MutexSerializesAcrossProcesses) {
+    int to_child[2], to_parent[2];
+    ASSERT_EQ(pipe(to_child), 0);
+    ASSERT_EQ(pipe(to_parent), 0);
+
+    pid_t pid = fork();
+    ASSERT_NE(pid, -1) << "fork failed: " << errno;
+
+    if (pid == 0) {
+        close(to_child[1]);
+        close(to_parent[0]);
+        {
+            SafeDeviceGuard guard({kTestId});
+            char locked = 'L';
+            write(to_parent[1], &locked, 1);
+            char go = 0;
+            read(to_child[0], &go, 1);
+        }
+        close(to_child[0]);
+        close(to_parent[1]);
+        _exit(0);
+    }
+
+    close(to_child[0]);
+    close(to_parent[1]);
+
+    char locked = 0;
+    ASSERT_EQ(read(to_parent[0], &locked, 1), 1);
+    EXPECT_EQ(locked, 'L');
+    EXPECT_EQ(read_dirty(), 1) << "dirty bit must be 1 while the child holds the guard";
+
+    char go = 'G';
+    write(to_child[1], &go, 1);
+    close(to_child[1]);
+    close(to_parent[0]);
+
+    int status = 0;
+    waitpid(pid, &status, 0);
+    EXPECT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+
+    // Child exited cleanly, so it cleared the dirty bit. Parent can now re-acquire.
+    {
+        SafeDeviceGuard guard({kTestId});
+        EXPECT_EQ(read_dirty(), 1);
+    }
+    EXPECT_EQ(read_dirty(), 0);
+}
+
+// A process that dies without releasing the guard (simulated via _exit without running dtors)
+// leaves the dirty bit set. The next acquirer must be able to construct a guard (the robust
+// mutex recovers from EOWNERDEAD) and will observe dirty=1, triggering the reset path.
+TEST_F(SafeDeviceGuardTest, CrashLeavesDeviceDirtyNextAcquirerRecovers) {
+    pid_t pid = fork();
+    ASSERT_NE(pid, -1);
+
+    if (pid == 0) {
+        SafeDeviceGuard* guard = new SafeDeviceGuard({kTestId});
+        (void)guard;
+        _exit(0);  // skip destructors — mutex is abandoned, dirty bit stays 1
+    }
+
+    int status = 0;
+    waitpid(pid, &status, 0);
+    EXPECT_TRUE(WIFEXITED(status));
+
+    EXPECT_EQ(read_dirty(), 1) << "crash must leave dirty bit set";
+
+    // Guard construction must succeed despite the abandoned mutex (RobustMutex handles EOWNERDEAD).
+    // It will attempt tt-smi -r 250 which fails on non-hardware hosts; that is acceptable here.
+    EXPECT_NO_THROW({
+        SafeDeviceGuard guard({kTestId});
+        EXPECT_EQ(read_dirty(), 1);
+    });
+    EXPECT_EQ(read_dirty(), 0);
+}
+
+}  // namespace
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/device/test_safe_device_open.cpp
+++ b/tests/tt_metal/tt_metal/device/test_safe_device_open.cpp
@@ -28,7 +28,9 @@ std::string mesh_key(std::vector<tt::ChipId> ids) {
     std::sort(ids.begin(), ids.end());
     std::string key;
     for (size_t i = 0; i < ids.size(); ++i) {
-        if (i > 0) key += '-';
+        if (i > 0) {
+            key += '-';
+        }
         key += std::to_string(ids[i]);
     }
     return key;
@@ -42,7 +44,7 @@ std::string mutex_shm_name(std::vector<tt::ChipId> ids) {
     return std::string(tt::umd::RobustMutex::SHM_FILE_PREFIX) + "tt-metal-mesh-" + mesh_key(std::move(ids));
 }
 
-void wipe_shm(std::vector<tt::ChipId> ids) {
+void wipe_shm(const std::vector<tt::ChipId>& ids) {
     shm_unlink(dirty_shm_name(ids).c_str());
     shm_unlink(mutex_shm_name(ids).c_str());
 }

--- a/tests/tt_metal/tt_metal/device/test_safe_device_open.cpp
+++ b/tests/tt_metal/tt_metal/device/test_safe_device_open.cpp
@@ -7,7 +7,9 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 #include <umd/device/utils/robust_mutex.hpp>
@@ -17,24 +19,38 @@
 namespace tt::tt_metal {
 namespace {
 
-// High chip ID that won't correspond to a real device on any test host.
-constexpr tt::ChipId kTestId = 250;
+// High chip IDs that won't correspond to real devices on any test host.
+constexpr tt::ChipId kA = 250;
+constexpr tt::ChipId kB = 251;
 
-// Names that match SafeDeviceGuard's internal naming for kTestId.
-const std::string kDirtyShmName = "/TT_METAL_DEVICE_DIRTY." + std::to_string(kTestId);
-// RobustMutex opens "/dev/shm/<SHM_FILE_PREFIX><mutex_name>".
-const std::string kMutexShmName =
-    std::string(tt::umd::RobustMutex::SHM_FILE_PREFIX) + "tt-metal-device-" + std::to_string(kTestId);
-
-// Remove any leftover shm objects from a previous run.
-void wipe_shm() {
-    shm_unlink(kDirtyShmName.c_str());
-    shm_unlink(kMutexShmName.c_str());
+// Canonical mesh key: sorted chip IDs joined with '-'.
+std::string mesh_key(std::vector<tt::ChipId> ids) {
+    std::sort(ids.begin(), ids.end());
+    std::string key;
+    for (size_t i = 0; i < ids.size(); ++i) {
+        if (i > 0) key += '-';
+        key += std::to_string(ids[i]);
+    }
+    return key;
 }
 
-// Read the dirty byte directly. Returns 0 if the shm doesn't exist.
-uint8_t read_dirty() {
-    int fd = shm_open(kDirtyShmName.c_str(), O_RDONLY, 0);
+std::string dirty_shm_name(std::vector<tt::ChipId> ids) {
+    return "/TT_METAL_DEVICE_DIRTY.mesh-" + mesh_key(std::move(ids));
+}
+
+std::string mutex_shm_name(std::vector<tt::ChipId> ids) {
+    return std::string(tt::umd::RobustMutex::SHM_FILE_PREFIX) + "tt-metal-mesh-" + mesh_key(std::move(ids));
+}
+
+void wipe_shm(std::vector<tt::ChipId> ids) {
+    shm_unlink(dirty_shm_name(ids).c_str());
+    shm_unlink(mutex_shm_name(ids).c_str());
+}
+
+// Read the dirty byte directly. Returns 0 if the shm doesn't exist yet.
+uint8_t read_dirty(std::vector<tt::ChipId> ids) {
+    const std::string name = dirty_shm_name(std::move(ids));
+    int fd = shm_open(name.c_str(), O_RDONLY, 0);
     if (fd == -1) {
         return 0;
     }
@@ -50,32 +66,39 @@ uint8_t read_dirty() {
 
 class SafeDeviceGuardTest : public ::testing::Test {
 protected:
-    void SetUp() override { wipe_shm(); }
-    void TearDown() override { wipe_shm(); }
+    void SetUp() override {
+        wipe_shm({kA});
+        wipe_shm({kB});
+        wipe_shm({kA, kB});
+    }
+    void TearDown() override {
+        wipe_shm({kA});
+        wipe_shm({kB});
+        wipe_shm({kA, kB});
+    }
 };
 
 // Dirty bit is set to 1 after construction and cleared to 0 after graceful destruction.
 TEST_F(SafeDeviceGuardTest, DirtyBitLifecycle) {
     {
-        SafeDeviceGuard guard({kTestId});
-        EXPECT_EQ(read_dirty(), 1) << "dirty bit must be 1 while guard is live";
+        SafeDeviceGuard guard({kA});
+        EXPECT_EQ(read_dirty({kA}), 1) << "dirty bit must be 1 while guard is live";
     }
-    EXPECT_EQ(read_dirty(), 0) << "dirty bit must be cleared on graceful exit";
+    EXPECT_EQ(read_dirty({kA}), 0) << "dirty bit must be cleared on graceful exit";
 }
 
-// After on_hang(), the dirty bit persists through destruction.
-// The next acquirer will see dirty=1 and trigger a reset before starting work.
+// After on_hang(), the dirty bit persists through destruction so the next acquirer resets.
 TEST_F(SafeDeviceGuardTest, HangLeavesDeviceDirty) {
     {
-        SafeDeviceGuard guard({kTestId});
+        SafeDeviceGuard guard({kA});
         guard.on_hang();
     }
-    EXPECT_EQ(read_dirty(), 1) << "dirty bit must stay set when the guard exits via hang path";
+    EXPECT_EQ(read_dirty({kA}), 1) << "dirty bit must stay set when the guard exits via hang path";
 }
 
-// on_hang() must be safe to call from multiple threads or repeated calls (idempotent).
+// on_hang() must be safe to call multiple times (idempotent).
 TEST_F(SafeDeviceGuardTest, OnHangIsIdempotent) {
-    SafeDeviceGuard guard({kTestId});
+    SafeDeviceGuard guard({kA});
     EXPECT_NO_THROW({
         guard.on_hang();
         guard.on_hang();
@@ -83,8 +106,7 @@ TEST_F(SafeDeviceGuardTest, OnHangIsIdempotent) {
     });
 }
 
-// A child process holds the guard; the parent verifies the dirty bit is set while the child
-// is alive, then acquires the guard itself after the child exits cleanly.
+// A child holds the guard; parent verifies dirty=1 while child is live, then re-acquires cleanly.
 TEST_F(SafeDeviceGuardTest, MutexSerializesAcrossProcesses) {
     int to_child[2], to_parent[2];
     ASSERT_EQ(pipe(to_child), 0);
@@ -97,7 +119,7 @@ TEST_F(SafeDeviceGuardTest, MutexSerializesAcrossProcesses) {
         close(to_child[1]);
         close(to_parent[0]);
         {
-            SafeDeviceGuard guard({kTestId});
+            SafeDeviceGuard guard({kA});
             char locked = 'L';
             write(to_parent[1], &locked, 1);
             char go = 0;
@@ -114,7 +136,7 @@ TEST_F(SafeDeviceGuardTest, MutexSerializesAcrossProcesses) {
     char locked = 0;
     ASSERT_EQ(read(to_parent[0], &locked, 1), 1);
     EXPECT_EQ(locked, 'L');
-    EXPECT_EQ(read_dirty(), 1) << "dirty bit must be 1 while the child holds the guard";
+    EXPECT_EQ(read_dirty({kA}), 1) << "dirty bit must be 1 while child holds the guard";
 
     char go = 'G';
     write(to_child[1], &go, 1);
@@ -126,40 +148,97 @@ TEST_F(SafeDeviceGuardTest, MutexSerializesAcrossProcesses) {
     EXPECT_TRUE(WIFEXITED(status));
     EXPECT_EQ(WEXITSTATUS(status), 0);
 
-    // Child exited cleanly, so it cleared the dirty bit. Parent can now re-acquire.
     {
-        SafeDeviceGuard guard({kTestId});
-        EXPECT_EQ(read_dirty(), 1);
+        SafeDeviceGuard guard({kA});
+        EXPECT_EQ(read_dirty({kA}), 1);
     }
-    EXPECT_EQ(read_dirty(), 0);
+    EXPECT_EQ(read_dirty({kA}), 0);
 }
 
-// A process that dies without releasing the guard (simulated via _exit without running dtors)
-// leaves the dirty bit set. The next acquirer must be able to construct a guard (the robust
-// mutex recovers from EOWNERDEAD) and will observe dirty=1, triggering the reset path.
+// A process that exits without running destructors leaves the dirty bit set; the next acquirer
+// recovers via RobustMutex EOWNERDEAD handling.
 TEST_F(SafeDeviceGuardTest, CrashLeavesDeviceDirtyNextAcquirerRecovers) {
     pid_t pid = fork();
     ASSERT_NE(pid, -1);
 
     if (pid == 0) {
-        SafeDeviceGuard* guard = new SafeDeviceGuard({kTestId});
+        SafeDeviceGuard* guard = new SafeDeviceGuard({kA});
         (void)guard;
-        _exit(0);  // skip destructors — mutex is abandoned, dirty bit stays 1
+        _exit(0);  // skip destructors — mutex abandoned, dirty bit stays 1
     }
 
     int status = 0;
     waitpid(pid, &status, 0);
     EXPECT_TRUE(WIFEXITED(status));
 
-    EXPECT_EQ(read_dirty(), 1) << "crash must leave dirty bit set";
+    EXPECT_EQ(read_dirty({kA}), 1) << "crash must leave dirty bit set";
 
-    // Guard construction must succeed despite the abandoned mutex (RobustMutex handles EOWNERDEAD).
-    // It will attempt tt-smi -r 250 which fails on non-hardware hosts; that is acceptable here.
     EXPECT_NO_THROW({
-        SafeDeviceGuard guard({kTestId});
-        EXPECT_EQ(read_dirty(), 1);
+        SafeDeviceGuard guard({kA});
+        EXPECT_EQ(read_dirty({kA}), 1);
     });
-    EXPECT_EQ(read_dirty(), 0);
+    EXPECT_EQ(read_dirty({kA}), 0);
+}
+
+// A multi-chip mesh uses a single, mesh-scoped dirty shm distinct from any single-chip shm.
+TEST_F(SafeDeviceGuardTest, MultiChipMeshUsesSingleShm) {
+    {
+        SafeDeviceGuard guard({kA, kB});
+        // The mesh shm is set; the individual per-chip shms are untouched.
+        EXPECT_EQ(read_dirty({kA, kB}), 1) << "mesh dirty bit must be 1";
+        EXPECT_EQ(read_dirty({kA}), 0) << "single-chip shm must be untouched by mesh guard";
+        EXPECT_EQ(read_dirty({kB}), 0) << "single-chip shm must be untouched by mesh guard";
+    }
+    EXPECT_EQ(read_dirty({kA, kB}), 0);
+}
+
+// Two non-overlapping meshes can be held simultaneously — they use different mutex names.
+TEST_F(SafeDeviceGuardTest, NonOverlappingMeshesRunInParallel) {
+    int to_child[2], to_parent[2];
+    ASSERT_EQ(pipe(to_child), 0);
+    ASSERT_EQ(pipe(to_parent), 0);
+
+    pid_t pid = fork();
+    ASSERT_NE(pid, -1);
+
+    if (pid == 0) {
+        close(to_child[1]);
+        close(to_parent[0]);
+        {
+            SafeDeviceGuard guard_b({kB});  // child holds mesh {kB}
+            char locked = 'L';
+            write(to_parent[1], &locked, 1);
+            char go = 0;
+            read(to_child[0], &go, 1);
+        }
+        close(to_child[0]);
+        close(to_parent[1]);
+        _exit(0);
+    }
+
+    close(to_child[0]);
+    close(to_parent[1]);
+
+    char locked = 0;
+    ASSERT_EQ(read(to_parent[0], &locked, 1), 1);
+    EXPECT_EQ(locked, 'L');
+
+    // Parent can acquire mesh {kA} immediately — different lock from child's {kB}.
+    EXPECT_NO_THROW({
+        SafeDeviceGuard guard_a({kA});
+        EXPECT_EQ(read_dirty({kA}), 1);
+        EXPECT_EQ(read_dirty({kB}), 1);
+
+        char go = 'G';
+        write(to_child[1], &go, 1);
+        close(to_child[1]);
+        close(to_parent[0]);
+
+        int status = 0;
+        waitpid(pid, &status, 0);
+        EXPECT_TRUE(WIFEXITED(status));
+        EXPECT_EQ(WEXITSTATUS(status), 0);
+    });
 }
 
 }  // namespace

--- a/tools/tests/triage/hang_apps/CMakeLists.txt
+++ b/tools/tests/triage/hang_apps/CMakeLists.txt
@@ -3,3 +3,4 @@ link_libraries(TT::STL)
 add_compile_definitions(OVERRIDE_KERNEL_PREFIX="tools/tests/triage/hang_apps/")
 
 add_subdirectory(add_2_integers_hang)
+add_subdirectory(open_and_close)

--- a/tools/tests/triage/hang_apps/open_and_close/CMakeLists.txt
+++ b/tools/tests/triage/hang_apps/open_and_close/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(triage_open_and_close open_and_close.cpp)
+target_link_libraries(triage_open_and_close PUBLIC TT::Metalium)
+
+add_executable(triage_hold_device hold_device.cpp)
+target_link_libraries(triage_hold_device PUBLIC TT::Metalium)

--- a/tools/tests/triage/hang_apps/open_and_close/hold_device.cpp
+++ b/tools/tests/triage/hang_apps/open_and_close/hold_device.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Opens device 0 and sleeps until killed — for SIGKILL recovery test.
+
+#include <unistd.h>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+int main() {
+    printf("hold_device: acquiring device\n");
+    fflush(stdout);
+
+    std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(0);
+
+    printf("hold_device: device acquired, sleeping until killed\n");
+    fflush(stdout);
+
+    while (true) {
+        sleep(1);
+    }
+}

--- a/tools/tests/triage/hang_apps/open_and_close/open_and_close.cpp
+++ b/tools/tests/triage/hang_apps/open_and_close/open_and_close.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Process B in the SafeDeviceGuard race scenario:
+// Opens device 0, waits briefly, then closes cleanly.
+// Intended to be run concurrently with triage_hang_app_add_2_integers_hang.
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+int main() {
+    printf("open_and_close: acquiring device\n");
+    fflush(stdout);
+
+    std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(0);
+
+    printf("open_and_close: device acquired, closing\n");
+    fflush(stdout);
+
+    mesh_device->close();
+
+    printf("open_and_close: done\n");
+    fflush(stdout);
+
+    return 0;
+}

--- a/tools/tests/triage/hang_apps/race_test.sh
+++ b/tools/tests/triage/hang_apps/race_test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Race scenario: Process A (hang app) vs Process B (open_and_close).
+#
+# Expected sequence:
+#   A starts, acquires SafeDeviceGuard, dispatches hanging kernel.
+#   B starts 3s later, blocks on the SafeDeviceGuard mutex.
+#   A's timeout fires → on_hang() marks dirty + runs tt-smi -r, exception propagates.
+#   Hang app catches the exception and calls _Exit(0) — mutex abandoned, dirty=1 persists.
+#   B acquires the abandoned mutex (EOWNERDEAD recovery), sees dirty=1, runs tt-smi -r.
+#   B opens the device cleanly and exits 0.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/../../../../.build/default"
+
+HANG_APP="${BUILD_DIR}/tools/tests/triage/hang_apps/add_2_integers_hang/Release/triage_hang_app_add_2_integers_hang"
+OPEN_CLOSE="${BUILD_DIR}/tools/tests/triage/hang_apps/open_and_close/Release/triage_open_and_close"
+
+echo "=== SafeDeviceGuard race test ==="
+echo "A: $HANG_APP"
+echo "B: $OPEN_CLOSE"
+echo ""
+
+export TT_METAL_SAFE_DEVICE_OPEN=1
+# 15s timeout: enough for A to acquire the device and start the workload but not run forever.
+export TT_METAL_OPERATION_TIMEOUT_SECONDS=15
+
+# Launch A first.  After 3 s it will have acquired the SafeDeviceGuard and started the
+# hanging workload.  Then launch B, which will block on the mutex until A exits.
+echo "--- Launching A (hang app) ---"
+"$HANG_APP" >"$SCRIPT_DIR/A.log" 2>&1 &
+PID_A=$!
+echo "A pid=$PID_A"
+
+echo "--- Sleeping 3s so A can acquire the lock before B starts ---"
+sleep 3
+
+echo "--- Launching B (open_and_close) ---"
+"$OPEN_CLOSE" >"$SCRIPT_DIR/B.log" 2>&1 &
+PID_B=$!
+echo "B pid=$PID_B"
+
+wait "$PID_A"; RC_A=$?
+wait "$PID_B"; RC_B=$?
+
+echo ""
+echo "=== A log ==="
+cat "$SCRIPT_DIR/A.log"
+echo ""
+echo "=== B log ==="
+cat "$SCRIPT_DIR/B.log"
+echo ""
+echo "=== Results ==="
+echo "A exit code: $RC_A"
+echo "B exit code: $RC_B"
+
+PASS=1
+
+if [[ $RC_A -ne 0 ]]; then
+    echo "FAIL: A exited with $RC_A (expected 0)"
+    PASS=0
+fi
+if [[ $RC_B -ne 0 ]]; then
+    echo "FAIL: B exited with $RC_B (expected 0)"
+    PASS=0
+fi
+
+# A must have hit the timeout path.
+if ! grep -q "Timeout detected\|device timeout" "$SCRIPT_DIR/A.log"; then
+    echo "FAIL: A log missing timeout signal"
+    PASS=0
+fi
+
+# SafeDeviceGuard::on_hang() must have fired.
+if ! grep -q "SafeDeviceGuard: mesh dirty" "$SCRIPT_DIR/A.log"; then
+    echo "FAIL: A log missing SafeDeviceGuard on_hang signal"
+    PASS=0
+fi
+
+# B must have acquired the device.
+if ! grep -q "device acquired" "$SCRIPT_DIR/B.log"; then
+    echo "FAIL: B log missing 'device acquired'"
+    PASS=0
+fi
+
+if [[ $PASS -eq 1 ]]; then
+    echo "PASS"
+else
+    echo "FAIL"
+    exit 1
+fi

--- a/tools/tests/triage/hang_apps/race_test.sh
+++ b/tools/tests/triage/hang_apps/race_test.sh
@@ -13,8 +13,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="${SCRIPT_DIR}/../../../../.build/default"
 
-HANG_APP="${BUILD_DIR}/tools/tests/triage/hang_apps/add_2_integers_hang/Release/triage_hang_app_add_2_integers_hang"
-OPEN_CLOSE="${BUILD_DIR}/tools/tests/triage/hang_apps/open_and_close/Release/triage_open_and_close"
+HANG_APP="${BUILD_DIR}/tools/tests/triage/hang_apps/add_2_integers_hang/Debug/triage_hang_app_add_2_integers_hang"
+OPEN_CLOSE="${BUILD_DIR}/tools/tests/triage/hang_apps/open_and_close/Debug/triage_open_and_close"
 
 echo "=== SafeDeviceGuard race test ==="
 echo "A: $HANG_APP"

--- a/tools/tests/triage/hang_apps/sequential_recovery_test.sh
+++ b/tools/tests/triage/hang_apps/sequential_recovery_test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Sequential recovery test: validates the "A crashed, B recovers" path.
+#
+# Step 1: A runs with TT_METAL_SAFE_DEVICE_OPEN=1 and hangs.
+#         on_hang() fires, tt-smi -r runs, A exits via _Exit(0).
+#         The SafeDeviceGuard mutex is abandoned and dirty=1 persists.
+#
+# Step 2: B runs with TT_METAL_SAFE_DEVICE_OPEN=1.
+#         Acquires the abandoned mutex (EOWNERDEAD recovery), sees dirty=1,
+#         runs tt-smi -r, then opens and closes the device cleanly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/../../../../.build/default"
+
+HANG_APP="${BUILD_DIR}/tools/tests/triage/hang_apps/add_2_integers_hang/Release/triage_hang_app_add_2_integers_hang"
+OPEN_CLOSE="${BUILD_DIR}/tools/tests/triage/hang_apps/open_and_close/Release/triage_open_and_close"
+
+export TT_METAL_SAFE_DEVICE_OPEN=1
+export TT_METAL_OPERATION_TIMEOUT_SECONDS=15
+
+echo "=== Step 1: A (hang app) — expect timeout → on_hang() → _Exit(0) ==="
+"$HANG_APP" >"$SCRIPT_DIR/A.log" 2>&1
+RC_A=$?
+
+echo "=== A log ==="
+cat "$SCRIPT_DIR/A.log"
+echo ""
+echo "A exit code: $RC_A"
+echo ""
+
+PASS=1
+if [[ $RC_A -ne 0 ]]; then
+    echo "FAIL: A exited with $RC_A (expected 0)"
+    PASS=0
+fi
+if ! grep -q "Timeout detected\|device timeout" "$SCRIPT_DIR/A.log"; then
+    echo "FAIL: A log missing timeout signal"
+    PASS=0
+fi
+if ! grep -q "SafeDeviceGuard: mesh dirty" "$SCRIPT_DIR/A.log"; then
+    echo "FAIL: A log missing SafeDeviceGuard on_hang signal"
+    PASS=0
+fi
+if ! grep -q "mesh reset complete" "$SCRIPT_DIR/A.log"; then
+    echo "FAIL: A log missing tt-smi reset completion"
+    PASS=0
+fi
+
+echo "--- Sleeping 20s to let the device settle after A's tt-smi -r reset ---"
+sleep 20
+echo ""
+echo "=== Step 2: B (open_and_close) — expect EOWNERDEAD recovery, dirty check, clean run ==="
+"$OPEN_CLOSE" >"$SCRIPT_DIR/B.log" 2>&1
+RC_B=$?
+
+echo "=== B log ==="
+cat "$SCRIPT_DIR/B.log"
+echo ""
+echo "B exit code: $RC_B"
+echo ""
+
+if [[ $RC_B -ne 0 ]]; then
+    echo "FAIL: B exited with $RC_B (expected 0)"
+    PASS=0
+fi
+if ! grep -q "device acquired" "$SCRIPT_DIR/B.log"; then
+    echo "FAIL: B log missing 'device acquired'"
+    PASS=0
+fi
+
+echo "=== Results ==="
+if [[ $PASS -eq 1 ]]; then
+    echo "PASS"
+else
+    echo "FAIL"
+    exit 1
+fi

--- a/tools/tests/triage/hang_apps/sequential_recovery_test.sh
+++ b/tools/tests/triage/hang_apps/sequential_recovery_test.sh
@@ -13,8 +13,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="${SCRIPT_DIR}/../../../../.build/default"
 
-HANG_APP="${BUILD_DIR}/tools/tests/triage/hang_apps/add_2_integers_hang/Release/triage_hang_app_add_2_integers_hang"
-OPEN_CLOSE="${BUILD_DIR}/tools/tests/triage/hang_apps/open_and_close/Release/triage_open_and_close"
+HANG_APP="${BUILD_DIR}/tools/tests/triage/hang_apps/add_2_integers_hang/Debug/triage_hang_app_add_2_integers_hang"
+OPEN_CLOSE="${BUILD_DIR}/tools/tests/triage/hang_apps/open_and_close/Debug/triage_open_and_close"
 
 export TT_METAL_SAFE_DEVICE_OPEN=1
 export TT_METAL_OPERATION_TIMEOUT_SECONDS=15

--- a/tools/tests/triage/hang_apps/sigkill_recovery_test.sh
+++ b/tools/tests/triage/hang_apps/sigkill_recovery_test.sh
@@ -10,8 +10,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="${SCRIPT_DIR}/../../../../.build/default"
-OPEN_CLOSE="${BUILD_DIR}/tools/tests/triage/hang_apps/open_and_close/Release/triage_open_and_close"
-HOLD_DEVICE="${BUILD_DIR}/tools/tests/triage/hang_apps/open_and_close/Release/triage_hold_device"
+OPEN_CLOSE="${BUILD_DIR}/tools/tests/triage/hang_apps/open_and_close/Debug/triage_open_and_close"
+HOLD_DEVICE="${BUILD_DIR}/tools/tests/triage/hang_apps/open_and_close/Debug/triage_hold_device"
 
 export TT_METAL_SAFE_DEVICE_OPEN=1
 export TT_METAL_OPERATION_TIMEOUT_SECONDS=60

--- a/tools/tests/triage/hang_apps/sigkill_recovery_test.sh
+++ b/tools/tests/triage/hang_apps/sigkill_recovery_test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Validates the SafeDeviceGuard recovery path without corrupt device state.
+#
+# Step 1: Start open_and_close as "A", let it open the device (dirty=1 set),
+#         then SIGKILL it — mutex abandoned, dirty=1 persists, device is NOT corrupted.
+#
+# Step 2: B (another open_and_close) acquires the abandoned mutex, sees dirty=1,
+#         runs tt-smi -r as a precaution, then opens and closes cleanly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/../../../../.build/default"
+OPEN_CLOSE="${BUILD_DIR}/tools/tests/triage/hang_apps/open_and_close/Release/triage_open_and_close"
+HOLD_DEVICE="${BUILD_DIR}/tools/tests/triage/hang_apps/open_and_close/Release/triage_hold_device"
+
+export TT_METAL_SAFE_DEVICE_OPEN=1
+export TT_METAL_OPERATION_TIMEOUT_SECONDS=60
+
+echo "=== Step 1: A opens device, gets SIGKILL while holding SafeDeviceGuard ==="
+"$HOLD_DEVICE" >"$SCRIPT_DIR/A.log" 2>&1 &
+PID_A=$!
+# Give A enough time to acquire SafeDeviceGuard and open the device, then kill it.
+sleep 15
+echo "Sending SIGKILL to A (pid=$PID_A)"
+kill -KILL "$PID_A" 2>/dev/null || true
+wait "$PID_A" 2>/dev/null || true
+echo ""
+echo "=== A log ==="
+cat "$SCRIPT_DIR/A.log"
+echo ""
+
+# Confirm dirty bit is set.
+DIRTY=$(cat /dev/shm/TT_METAL_DEVICE_DIRTY.mesh-0 2>/dev/null | od -An -tu1 | tr -d ' ' || echo "0")
+echo "dirty byte after SIGKILL: $DIRTY"
+if [[ "$DIRTY" != "1" ]]; then
+    echo "FAIL: dirty bit should be 1 after SIGKILL (got $DIRTY)"
+    exit 1
+fi
+echo "PASS: dirty bit is 1 as expected"
+echo ""
+
+echo "--- Sleeping 15s to let any UMD state settle ---"
+sleep 15
+
+echo ""
+echo "=== Step 2: B recovers (EOWNERDEAD + dirty=1 → tt-smi -r → clean open) ==="
+"$OPEN_CLOSE" >"$SCRIPT_DIR/B.log" 2>&1
+RC_B=$?
+
+echo "=== B log ==="
+cat "$SCRIPT_DIR/B.log"
+echo ""
+echo "B exit code: $RC_B"
+
+PASS=1
+if [[ $RC_B -ne 0 ]]; then
+    echo "FAIL: B exited with $RC_B"
+    PASS=0
+fi
+if ! grep -q "SafeDeviceGuard: mesh dirty" "$SCRIPT_DIR/B.log"; then
+    echo "FAIL: B did not detect dirty state"
+    PASS=0
+fi
+if ! grep -q "mesh reset complete" "$SCRIPT_DIR/B.log"; then
+    echo "FAIL: B did not complete tt-smi reset"
+    PASS=0
+fi
+if ! grep -q "device acquired" "$SCRIPT_DIR/B.log"; then
+    echo "FAIL: B did not acquire device"
+    PASS=0
+fi
+
+if [[ $PASS -eq 1 ]]; then
+    echo "PASS"
+else
+    echo "FAIL"
+    exit 1
+fi

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -43,6 +43,7 @@
 #include <experimental/fabric/control_plane.hpp>
 #include <experimental/mock_device.hpp>
 #include "device/device_manager.hpp"
+#include "device/safe_device_open.hpp"
 #include <distributed_context.hpp>
 #include <experimental/fabric/fabric.hpp>
 #include <system_mesh.hpp>
@@ -142,6 +143,25 @@ void MetalContext::initialize_device_manager(
     size_t worker_l1_size,
     bool init_profiler,
     bool initialize_fabric_and_dispatch_fw) {
+    // TT_METAL_SAFE_DEVICE_OPEN=1 enables cross-process device cooperation: per-device mutex,
+    // dirty-bit tracking, and auto-reset via tt-smi -r. Skip on mock/emulated clusters.
+    if (!safe_device_guard_) {
+        const char* env = std::getenv("TT_METAL_SAFE_DEVICE_OPEN");
+        const bool enabled = env != nullptr && std::string_view(env) == "1";
+        if (enabled && !get_cluster().is_mock_or_emulated()) {
+            // Without an operation timeout, a hang holds the lock indefinitely. Default to 30s
+            // when the user hasn't set TT_METAL_OPERATION_TIMEOUT_SECONDS explicitly.
+            using namespace std::chrono_literals;
+            if (rtoptions().get_timeout_duration_for_operations() == std::chrono::duration<float>(0.0f)) {
+                rtoptions().set_timeout_duration_for_operations(std::chrono::duration<float>(30.0f));
+                log_info(
+                    tt::LogMetal,
+                    "TT_METAL_SAFE_DEVICE_OPEN=1: defaulting TT_METAL_OPERATION_TIMEOUT_SECONDS to 30");
+            }
+            safe_device_guard_ = std::make_unique<SafeDeviceGuard>(device_ids);
+        }
+    }
+
     initialize(dispatch_core_config, num_hw_cqs, {l1_bank_remap.begin(), l1_bank_remap.end()}, worker_l1_size);
     init_context_descriptor(num_hw_cqs, l1_small_size, trace_region_size, worker_l1_size);
     device_manager_->initialize(device_ids, init_profiler, initialize_fabric_and_dispatch_fw, context_descriptor_);
@@ -752,6 +772,12 @@ void MetalContext::on_dispatch_timeout_detected() {
                 log_warning(
                     tt::LogMetal, "Timeout command '{}' returned non-zero exit code: {}", command, WEXITSTATUS(result));
             }
+        }
+
+        // Under TT_METAL_SAFE_DEVICE_OPEN, the guard owns the recovery: run tt-smi -r so the
+        // device is clean by the time this process exits and the next runner picks it up.
+        if (safe_device_guard_) {
+            safe_device_guard_->on_hang();
         }
     }
 }

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -43,7 +43,6 @@
 #include <experimental/fabric/control_plane.hpp>
 #include <experimental/mock_device.hpp>
 #include "device/device_manager.hpp"
-#include "device/safe_device_open.hpp"
 #include <distributed_context.hpp>
 #include <experimental/fabric/fabric.hpp>
 #include <system_mesh.hpp>
@@ -143,25 +142,6 @@ void MetalContext::initialize_device_manager(
     size_t worker_l1_size,
     bool init_profiler,
     bool initialize_fabric_and_dispatch_fw) {
-    // TT_METAL_SAFE_DEVICE_OPEN=1 enables cross-process device cooperation: per-device mutex,
-    // dirty-bit tracking, and auto-reset via tt-smi -r. Skip on mock/emulated clusters.
-    if (!safe_device_guard_) {
-        const char* env = std::getenv("TT_METAL_SAFE_DEVICE_OPEN");
-        const bool enabled = env != nullptr && std::string_view(env) == "1";
-        if (enabled && !get_cluster().is_mock_or_emulated()) {
-            // Without an operation timeout, a hang holds the lock indefinitely. Default to 30s
-            // when the user hasn't set TT_METAL_OPERATION_TIMEOUT_SECONDS explicitly.
-            using namespace std::chrono_literals;
-            if (rtoptions().get_timeout_duration_for_operations() == std::chrono::duration<float>(0.0f)) {
-                rtoptions().set_timeout_duration_for_operations(std::chrono::duration<float>(30.0f));
-                log_info(
-                    tt::LogMetal,
-                    "TT_METAL_SAFE_DEVICE_OPEN=1: defaulting TT_METAL_OPERATION_TIMEOUT_SECONDS to 30");
-            }
-            safe_device_guard_ = std::make_unique<SafeDeviceGuard>(device_ids);
-        }
-    }
-
     initialize(dispatch_core_config, num_hw_cqs, {l1_bank_remap.begin(), l1_bank_remap.end()}, worker_l1_size);
     init_context_descriptor(num_hw_cqs, l1_small_size, trace_region_size, worker_l1_size);
     device_manager_->initialize(device_ids, init_profiler, initialize_fabric_and_dispatch_fw, context_descriptor_);
@@ -776,9 +756,7 @@ void MetalContext::on_dispatch_timeout_detected() {
 
         // Under TT_METAL_SAFE_DEVICE_OPEN, the guard owns the recovery: run tt-smi -r so the
         // device is clean by the time this process exits and the next runner picks it up.
-        if (safe_device_guard_) {
-            safe_device_guard_->on_hang();
-        }
+        MetalEnvAccessor(*env_).impl().on_dispatch_hang();
     }
 }
 

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -44,6 +44,7 @@ class DPrintServer;
 class WatcherServer;
 class DispatchMemMap;
 class NOCDebugState;
+class SafeDeviceGuard;
 
 // A class to manage one-time initialization and teardown (FW, dispatch, fabric, cluster) and access to related state.
 // Dispatch-independent state (Cluster) is initialized with the creation of MetalContext and accessible right after.
@@ -234,6 +235,11 @@ private:
     std::unique_ptr<WatcherServer> watcher_server_;
     std::unique_ptr<ProfilerStateManager> profiler_state_manager_;
     std::unique_ptr<DataCollector> data_collector_;
+    // Cooperative cross-process device guard. Constructed in initialize_device_manager when
+    // TT_METAL_SAFE_DEVICE_OPEN=1 is set; otherwise null. See safe_device_open.hpp.
+    // Declared before device_manager_ so it is destroyed AFTER (members destroy in reverse
+    // declaration order): the lock is released only after all devices are closed.
+    std::unique_ptr<SafeDeviceGuard> safe_device_guard_;
     std::unique_ptr<DeviceManager> device_manager_;
     std::unique_ptr<NOCDebugState> noc_debug_state_;
     // The context descriptor used for runtime components.

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -44,8 +44,6 @@ class DPrintServer;
 class WatcherServer;
 class DispatchMemMap;
 class NOCDebugState;
-class SafeDeviceGuard;
-
 // A class to manage one-time initialization and teardown (FW, dispatch, fabric, cluster) and access to related state.
 // Dispatch-independent state (Cluster) is initialized with the creation of MetalContext and accessible right after.
 // Dispatch-dependent state (FW, dispatch, fabric) is initialized explicitly with a MetalContext::initialize() call, and
@@ -235,11 +233,6 @@ private:
     std::unique_ptr<WatcherServer> watcher_server_;
     std::unique_ptr<ProfilerStateManager> profiler_state_manager_;
     std::unique_ptr<DataCollector> data_collector_;
-    // Cooperative cross-process device guard. Constructed in initialize_device_manager when
-    // TT_METAL_SAFE_DEVICE_OPEN=1 is set; otherwise null. See safe_device_open.hpp.
-    // Declared before device_manager_ so it is destroyed AFTER (members destroy in reverse
-    // declaration order): the lock is released only after all devices are closed.
-    std::unique_ptr<SafeDeviceGuard> safe_device_guard_;
     std::unique_ptr<DeviceManager> device_manager_;
     std::unique_ptr<NOCDebugState> noc_debug_state_;
     // The context descriptor used for runtime components.

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -103,6 +103,12 @@ MetalEnvImpl::~MetalEnvImpl() {
 void MetalEnvImpl::acquire() { use_count_.fetch_add(1, std::memory_order_acq_rel); }
 void MetalEnvImpl::release() { use_count_.fetch_sub(1, std::memory_order_acq_rel); }
 
+void MetalEnvImpl::on_dispatch_hang() {
+    if (safe_device_guard_) {
+        safe_device_guard_->on_hang();
+    }
+}
+
 bool MetalEnvImpl::check_use_count_zero() const {
     const int use_count = use_count_.load(std::memory_order_acquire);
     if (use_count > 0) {
@@ -129,9 +135,33 @@ void MetalEnvImpl::initialize_base_objects() {
         this->rtoptions_->set_mock_cluster_desc(std::string(descriptor_.mock_cluster_desc_path()));
     }
 
-    const bool is_base_routing_fw_enabled =
-        Cluster::is_base_routing_fw_enabled(Cluster::get_cluster_type_from_cluster_desc(*this->rtoptions_));
+    // Run topology discovery once. We capture the ClusterDescriptor so we can:
+    //   1. Construct SafeDeviceGuard (dirty-bit check + tt-smi -r) before the persistent UMD
+    //      open, which is the ordering fix for the recovery-reset-vs-live-FW race.
+    //   2. Pass the descriptor into the Cluster constructor to avoid a second topology probe.
+    auto [cluster_type, cluster_desc] =
+        Cluster::get_cluster_type_from_cluster_desc(*this->rtoptions_);
+    const bool is_base_routing_fw_enabled = Cluster::is_base_routing_fw_enabled(cluster_type);
     const auto platform_arch = get_platform_architecture(*this->rtoptions_);
+
+    // Construct SafeDeviceGuard before the persistent UMD open so that:
+    //   - the dirty-bit check (and any tt-smi -r reset) fires on a quiescent device, and
+    //   - the mutex is held for the full lifetime of the UMD cluster.
+    // Skip on mock/simulator — they don't need cross-process device serialization.
+    const char* safe_open_env = std::getenv("TT_METAL_SAFE_DEVICE_OPEN");
+    const bool safe_open_enabled = safe_open_env != nullptr && std::string_view(safe_open_env) == "1";
+    if (safe_open_enabled && !rtoptions_->get_mock_enabled() && !rtoptions_->is_simulator_or_emulated()) {
+        using namespace std::chrono_literals;
+        if (rtoptions_->get_timeout_duration_for_operations() == std::chrono::duration<float>(0.0f)) {
+            rtoptions_->set_timeout_duration_for_operations(std::chrono::duration<float>(30.0f));
+            log_info(
+                tt::LogMetal,
+                "TT_METAL_SAFE_DEVICE_OPEN=1: defaulting TT_METAL_OPERATION_TIMEOUT_SECONDS to 30");
+        }
+        std::vector<tt::ChipId> chip_ids(
+            cluster_desc->get_all_chips().begin(), cluster_desc->get_all_chips().end());
+        safe_device_guard_ = std::make_unique<SafeDeviceGuard>(chip_ids);
+    }
 
     cluster_ = std::make_unique<Cluster>(*this->rtoptions_);
     this->verify_fw_capabilities();

--- a/tt_metal/impl/context/metal_env_impl.hpp
+++ b/tt_metal/impl/context/metal_env_impl.hpp
@@ -14,6 +14,7 @@
 #include "tt_metal/llrt/hal.hpp"
 #include "tt_metal/llrt/tt_cluster.hpp"
 #include "tt_metal/llrt/rtoptions.hpp"
+#include "tt_metal/impl/device/safe_device_open.hpp"
 
 namespace tt::tt_fabric {
 class ControlPlane;
@@ -44,6 +45,9 @@ public:
 
     void acquire();
     void release();
+
+    // Called from MetalContext::on_dispatch_timeout_detected(); forwards to SafeDeviceGuard::on_hang().
+    void on_dispatch_hang();
 
     // --- Fabric config ---
     tt_fabric::FabricConfig get_fabric_config() const;
@@ -101,6 +105,9 @@ private:
     MetalEnvDescriptor descriptor_;
 
     std::unique_ptr<llrt::RunTimeOptions> rtoptions_;
+    // Declared before cluster_ so it destructs after cluster_ (C++ reverses declaration order),
+    // ensuring the mutex is held until devices are fully closed.
+    std::unique_ptr<SafeDeviceGuard> safe_device_guard_;
     std::unique_ptr<Cluster> cluster_;
     std::unique_ptr<Hal> hal_;
 

--- a/tt_metal/impl/device/safe_device_open.cpp
+++ b/tt_metal/impl/device/safe_device_open.cpp
@@ -53,10 +53,19 @@ std::string dirty_shm_name_for(const std::vector<tt::ChipId>& ids) {
     return fmt::format("{}{}", kDirtyShmPrefix, mesh_key(ids));
 }
 
+void verify_tt_smi_available() {
+    if (std::system("which tt-smi > /dev/null 2>&1") != 0) {
+        TT_THROW(
+            "TT_METAL_SAFE_DEVICE_OPEN=1 requires 'tt-smi' on PATH for device recovery. "
+            "Install it with: pip install tt-smi");
+    }
+}
+
 }  // namespace
 
 SafeDeviceGuard::SafeDeviceGuard(const std::vector<tt::ChipId>& device_ids)
     : device_ids_(device_ids), mutex_(mutex_name_for(device_ids)) {
+    verify_tt_smi_available();
     try {
         mutex_.initialize();
         mutex_.lock();

--- a/tt_metal/impl/device/safe_device_open.cpp
+++ b/tt_metal/impl/device/safe_device_open.cpp
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "safe_device_open.hpp"
+
+#include <fcntl.h>
+#include <sys/file.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+#include <fmt/format.h>
+#include <tt-logger/tt-logger.hpp>
+#include <tt_stl/assert.hpp>
+
+namespace tt::tt_metal {
+
+namespace {
+
+constexpr const char* kDirtyShmPrefix = "TT_METAL_DEVICE_DIRTY.";
+constexpr const char* kMutexNamePrefix = "tt-metal-device-";
+
+std::string mutex_name_for(tt::ChipId id) { return fmt::format("{}{}", kMutexNamePrefix, id); }
+
+std::string dirty_shm_name_for(tt::ChipId id) { return fmt::format("/{}{}", kDirtyShmPrefix, id); }
+
+}  // namespace
+
+SafeDeviceGuard::PerDevice::PerDevice(tt::ChipId id_in) : id(id_in), mutex(mutex_name_for(id_in)) {}
+
+SafeDeviceGuard::DirtyShm SafeDeviceGuard::open_dirty_shm(tt::ChipId id) {
+    DirtyShm s;
+    const std::string name = dirty_shm_name_for(id);
+
+    auto old_umask = umask(0);
+    s.fd = shm_open(name.c_str(), O_RDWR | O_CREAT, 0666);
+    umask(old_umask);
+
+    if (s.fd == -1) {
+        TT_THROW("shm_open failed for {} errno: {}", name, errno);
+    }
+
+    struct stat sb {};
+    if (fstat(s.fd, &sb) != 0) {
+        const int e = errno;
+        ::close(s.fd);
+        s.fd = -1;
+        TT_THROW("fstat failed for {} errno: {}", name, e);
+    }
+    if (sb.st_size < static_cast<off_t>(sizeof(uint8_t))) {
+        if (ftruncate(s.fd, sizeof(uint8_t)) != 0) {
+            const int e = errno;
+            ::close(s.fd);
+            s.fd = -1;
+            TT_THROW("ftruncate failed for {} errno: {}", name, e);
+        }
+    }
+
+    void* addr = mmap(nullptr, sizeof(uint8_t), PROT_READ | PROT_WRITE, MAP_SHARED, s.fd, 0);
+    if (addr == MAP_FAILED) {
+        const int e = errno;
+        ::close(s.fd);
+        s.fd = -1;
+        TT_THROW("mmap failed for {} errno: {}", name, e);
+    }
+    s.ptr = static_cast<uint8_t*>(addr);
+    return s;
+}
+
+void SafeDeviceGuard::close_dirty_shm(DirtyShm& s) {
+    if (s.ptr != nullptr) {
+        if (munmap(s.ptr, sizeof(uint8_t)) != 0) {
+            log_warning(tt::LogMetal, "munmap failed for dirty shm errno: {}", errno);
+        }
+        s.ptr = nullptr;
+    }
+    if (s.fd != -1) {
+        if (::close(s.fd) != 0) {
+            log_warning(tt::LogMetal, "close failed for dirty shm errno: {}", errno);
+        }
+        s.fd = -1;
+    }
+}
+
+void SafeDeviceGuard::run_tt_smi_reset(tt::ChipId id) {
+    // tt-smi -r <int> resets by UMD logical ID — same id space tt-metal's Cluster exposes.
+    const std::string cmd = fmt::format("tt-smi -r {}", id);
+    log_warning(tt::LogMetal, "SafeDeviceGuard: device {} dirty, running: {}", id, cmd);
+    int rc = std::system(cmd.c_str());
+    if (rc != 0) {
+        log_warning(
+            tt::LogMetal,
+            "SafeDeviceGuard: '{}' returned non-zero exit code: {} (is tt-smi on PATH?)",
+            cmd,
+            WEXITSTATUS(rc));
+    } else {
+        log_info(tt::LogMetal, "SafeDeviceGuard: device {} reset complete", id);
+    }
+}
+
+SafeDeviceGuard::SafeDeviceGuard(const std::vector<tt::ChipId>& device_ids) {
+    per_device_.reserve(device_ids.size());
+    try {
+        for (auto id : device_ids) {
+            auto pd = std::make_unique<PerDevice>(id);
+
+            // Acquire the cross-process mutex first, then act on the dirty bit under the lock.
+            pd->mutex.initialize();
+            pd->mutex.lock();
+            pd->locked = true;
+
+            pd->dirty = open_dirty_shm(pd->id);
+
+            if (*pd->dirty.ptr != 0) {
+                run_tt_smi_reset(pd->id);
+            }
+            // Pessimistic: assume this process will dirty the device. Cleared in destructor on
+            // graceful exit; persists if the process is killed before we get there.
+            *pd->dirty.ptr = 1;
+
+            per_device_.push_back(std::move(pd));
+        }
+    } catch (...) {
+        // Roll back partial acquisitions before propagating.
+        for (auto& pd : per_device_) {
+            if (pd->dirty.ptr != nullptr) {
+                *pd->dirty.ptr = 0;
+                close_dirty_shm(pd->dirty);
+            }
+            if (pd->locked) {
+                try {
+                    pd->mutex.unlock();
+                } catch (...) {
+                    // best-effort
+                }
+                pd->locked = false;
+            }
+        }
+        per_device_.clear();
+        throw;
+    }
+}
+
+SafeDeviceGuard::~SafeDeviceGuard() {
+    for (auto& pd : per_device_) {
+        if (pd->dirty.ptr != nullptr) {
+            // If on_hang() fired, leave dirty=1 so the next process double-checks via tt-smi -r.
+            // Otherwise this was a graceful run — clear the bit.
+            if (!hang_handled_.load(std::memory_order_acquire)) {
+                *pd->dirty.ptr = 0;
+            }
+            close_dirty_shm(pd->dirty);
+        }
+        if (pd->locked) {
+            try {
+                pd->mutex.unlock();
+            } catch (const std::exception& e) {
+                log_warning(tt::LogMetal, "SafeDeviceGuard: unlock failed for device {}: {}", pd->id, e.what());
+            }
+            pd->locked = false;
+        }
+    }
+}
+
+void SafeDeviceGuard::on_hang() {
+    bool expected = false;
+    if (!hang_handled_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+        return;  // already handled
+    }
+    for (auto& pd : per_device_) {
+        // Mark dirty in shmem first so any handler crash before the reset completes still leaves
+        // the next acquirer with a definitive "must reset" signal.
+        if (pd->dirty.ptr != nullptr) {
+            *pd->dirty.ptr = 1;
+        }
+        run_tt_smi_reset(pd->id);
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/device/safe_device_open.cpp
+++ b/tt_metal/impl/device/safe_device_open.cpp
@@ -87,7 +87,8 @@ SafeDeviceGuard::SafeDeviceGuard(const std::vector<tt::ChipId>& device_ids)
         if (locked_) {
             try {
                 mutex_.unlock();
-            } catch (...) {
+            } catch (const std::exception& e) {
+                log_warning(tt::LogMetal, "SafeDeviceGuard: mutex unlock failed during cleanup: {}", e.what());
             }
             locked_ = false;
         }

--- a/tt_metal/impl/device/safe_device_open.cpp
+++ b/tt_metal/impl/device/safe_device_open.cpp
@@ -11,6 +11,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cerrno>
 #include <cstdio>
 #include <cstdlib>
@@ -26,20 +27,100 @@ namespace tt::tt_metal {
 
 namespace {
 
-constexpr const char* kDirtyShmPrefix = "TT_METAL_DEVICE_DIRTY.";
-constexpr const char* kMutexNamePrefix = "tt-metal-device-";
+constexpr std::string_view kDirtyShmPrefix = "/TT_METAL_DEVICE_DIRTY.mesh-";
+constexpr std::string_view kMutexNamePrefix = "tt-metal-mesh-";
 
-std::string mutex_name_for(tt::ChipId id) { return fmt::format("{}{}", kMutexNamePrefix, id); }
+// Canonical string for a set of chip IDs: sorted, joined with '-'.
+// e.g. {3,0,2,1} -> "0-1-2-3"
+std::string mesh_key(const std::vector<tt::ChipId>& ids) {
+    std::vector<tt::ChipId> sorted(ids);
+    std::sort(sorted.begin(), sorted.end());
+    std::string key;
+    for (size_t i = 0; i < sorted.size(); ++i) {
+        if (i > 0) {
+            key += '-';
+        }
+        key += std::to_string(sorted[i]);
+    }
+    return key;
+}
 
-std::string dirty_shm_name_for(tt::ChipId id) { return fmt::format("/{}{}", kDirtyShmPrefix, id); }
+std::string mutex_name_for(const std::vector<tt::ChipId>& ids) {
+    return fmt::format("{}{}", kMutexNamePrefix, mesh_key(ids));
+}
+
+std::string dirty_shm_name_for(const std::vector<tt::ChipId>& ids) {
+    return fmt::format("{}{}", kDirtyShmPrefix, mesh_key(ids));
+}
 
 }  // namespace
 
-SafeDeviceGuard::PerDevice::PerDevice(tt::ChipId id_in) : id(id_in), mutex(mutex_name_for(id_in)) {}
+SafeDeviceGuard::SafeDeviceGuard(const std::vector<tt::ChipId>& device_ids)
+    : device_ids_(device_ids), mutex_(mutex_name_for(device_ids)) {
+    try {
+        mutex_.initialize();
+        mutex_.lock();
+        locked_ = true;
 
-SafeDeviceGuard::DirtyShm SafeDeviceGuard::open_dirty_shm(tt::ChipId id) {
+        dirty_ = open_dirty_shm(dirty_shm_name_for(device_ids));
+
+        if (*dirty_.ptr != 0) {
+            run_tt_smi_reset();
+        }
+        // Pessimistic: assume this process will dirty the mesh. Cleared in destructor on graceful
+        // exit; persists if the process is killed before we get there.
+        *dirty_.ptr = 1;
+    } catch (...) {
+        if (dirty_.ptr != nullptr) {
+            *dirty_.ptr = 0;
+            close_dirty_shm(dirty_);
+        }
+        if (locked_) {
+            try {
+                mutex_.unlock();
+            } catch (...) {
+            }
+            locked_ = false;
+        }
+        throw;
+    }
+}
+
+SafeDeviceGuard::~SafeDeviceGuard() {
+    if (dirty_.ptr != nullptr) {
+        // If on_hang() fired, leave dirty=1 so the next process double-checks via tt-smi -r.
+        // Otherwise this was a graceful run — clear the bit.
+        if (!hang_handled_.load(std::memory_order_acquire)) {
+            *dirty_.ptr = 0;
+        }
+        close_dirty_shm(dirty_);
+    }
+    if (locked_) {
+        try {
+            mutex_.unlock();
+        } catch (const std::exception& e) {
+            log_warning(tt::LogMetal, "SafeDeviceGuard: mesh unlock failed: {}", e.what());
+        }
+        locked_ = false;
+    }
+}
+
+void SafeDeviceGuard::on_hang() {
+    bool expected = false;
+    if (!hang_handled_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+        return;  // already handled
+    }
+    // Mark dirty before the reset so a crash mid-reset still leaves the next acquirer with a
+    // definitive "must reset" signal.
+    if (dirty_.ptr != nullptr) {
+        *dirty_.ptr = 1;
+    }
+    run_tt_smi_reset();
+}
+
+SafeDeviceGuard::DirtyShm SafeDeviceGuard::open_dirty_shm(std::string_view shm_name) {
     DirtyShm s;
-    const std::string name = dirty_shm_name_for(id);
+    const std::string name(shm_name);
 
     auto old_umask = umask(0);
     s.fd = shm_open(name.c_str(), O_RDWR | O_CREAT, 0666);
@@ -91,98 +172,16 @@ void SafeDeviceGuard::close_dirty_shm(DirtyShm& s) {
     }
 }
 
-void SafeDeviceGuard::run_tt_smi_reset(tt::ChipId id) {
-    // tt-smi -r <int> resets by UMD logical ID — same id space tt-metal's Cluster exposes.
-    const std::string cmd = fmt::format("tt-smi -r {}", id);
-    log_warning(tt::LogMetal, "SafeDeviceGuard: device {} dirty, running: {}", id, cmd);
-    int rc = std::system(cmd.c_str());
+void SafeDeviceGuard::run_tt_smi_reset() {
+    log_warning(tt::LogMetal, "SafeDeviceGuard: mesh dirty, running: tt-smi -r");
+    int rc = std::system("tt-smi -r");
     if (rc != 0) {
         log_warning(
             tt::LogMetal,
-            "SafeDeviceGuard: '{}' returned non-zero exit code: {} (is tt-smi on PATH?)",
-            cmd,
+            "SafeDeviceGuard: 'tt-smi -r' returned non-zero exit code: {} (is tt-smi on PATH?)",
             WEXITSTATUS(rc));
     } else {
-        log_info(tt::LogMetal, "SafeDeviceGuard: device {} reset complete", id);
-    }
-}
-
-SafeDeviceGuard::SafeDeviceGuard(const std::vector<tt::ChipId>& device_ids) {
-    per_device_.reserve(device_ids.size());
-    try {
-        for (auto id : device_ids) {
-            auto pd = std::make_unique<PerDevice>(id);
-
-            // Acquire the cross-process mutex first, then act on the dirty bit under the lock.
-            pd->mutex.initialize();
-            pd->mutex.lock();
-            pd->locked = true;
-
-            pd->dirty = open_dirty_shm(pd->id);
-
-            if (*pd->dirty.ptr != 0) {
-                run_tt_smi_reset(pd->id);
-            }
-            // Pessimistic: assume this process will dirty the device. Cleared in destructor on
-            // graceful exit; persists if the process is killed before we get there.
-            *pd->dirty.ptr = 1;
-
-            per_device_.push_back(std::move(pd));
-        }
-    } catch (...) {
-        // Roll back partial acquisitions before propagating.
-        for (auto& pd : per_device_) {
-            if (pd->dirty.ptr != nullptr) {
-                *pd->dirty.ptr = 0;
-                close_dirty_shm(pd->dirty);
-            }
-            if (pd->locked) {
-                try {
-                    pd->mutex.unlock();
-                } catch (...) {
-                    // best-effort
-                }
-                pd->locked = false;
-            }
-        }
-        per_device_.clear();
-        throw;
-    }
-}
-
-SafeDeviceGuard::~SafeDeviceGuard() {
-    for (auto& pd : per_device_) {
-        if (pd->dirty.ptr != nullptr) {
-            // If on_hang() fired, leave dirty=1 so the next process double-checks via tt-smi -r.
-            // Otherwise this was a graceful run — clear the bit.
-            if (!hang_handled_.load(std::memory_order_acquire)) {
-                *pd->dirty.ptr = 0;
-            }
-            close_dirty_shm(pd->dirty);
-        }
-        if (pd->locked) {
-            try {
-                pd->mutex.unlock();
-            } catch (const std::exception& e) {
-                log_warning(tt::LogMetal, "SafeDeviceGuard: unlock failed for device {}: {}", pd->id, e.what());
-            }
-            pd->locked = false;
-        }
-    }
-}
-
-void SafeDeviceGuard::on_hang() {
-    bool expected = false;
-    if (!hang_handled_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
-        return;  // already handled
-    }
-    for (auto& pd : per_device_) {
-        // Mark dirty in shmem first so any handler crash before the reset completes still leaves
-        // the next acquirer with a definitive "must reset" signal.
-        if (pd->dirty.ptr != nullptr) {
-            *pd->dirty.ptr = 1;
-        }
-        run_tt_smi_reset(pd->id);
+        log_info(tt::LogMetal, "SafeDeviceGuard: mesh reset complete");
     }
 }
 

--- a/tt_metal/impl/device/safe_device_open.hpp
+++ b/tt_metal/impl/device/safe_device_open.hpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <vector>
+
+#include <tt-metalium/device_types.hpp>
+#include <umd/device/utils/robust_mutex.hpp>
+
+namespace tt::tt_metal {
+
+// Cooperative cross-process device guard.
+//
+// On construction, acquires a per-device cross-process mutex (RobustMutex via /dev/shm) and
+// checks a sibling /dev/shm "dirty" bit. If the previous holder did not release cleanly
+// (process killed mid-workload, or the dispatch timeout handler tagged the device on hang),
+// shells out to `tt-smi -r <chip_id>` to recover before proceeding. Sets the dirty bit for
+// the duration of this guard's lifetime.
+//
+// Replaces the flock + dirty-file + tt-smi shellout choreography in scripts/run_safe_pytest.sh,
+// moving it inside tt-metal device open. This is a userspace stopgap until the KMD lock-63
+// pattern (auto-release on FD close) becomes viable.
+//
+// Gated externally on TT_METAL_SAFE_DEVICE_OPEN=1.
+class SafeDeviceGuard {
+public:
+    // Acquires the lock for each device id. Reset-on-dirty happens before this returns.
+    explicit SafeDeviceGuard(const std::vector<tt::ChipId>& device_ids);
+
+    // Clears the dirty bit and releases the locks. If on_hang() was called, leaves the dirty
+    // bit set so the next process resets again as a belt-and-suspenders measure.
+    ~SafeDeviceGuard();
+
+    SafeDeviceGuard(const SafeDeviceGuard&) = delete;
+    SafeDeviceGuard& operator=(const SafeDeviceGuard&) = delete;
+
+    // Called by MetalContext::on_dispatch_timeout_detected. Runs `tt-smi -r <id>` synchronously
+    // for each held device. Idempotent — safe to call from multiple threads; second call is a no-op.
+    void on_hang();
+
+private:
+    struct DirtyShm {
+        // Backed by /dev/shm/TT_METAL_DEVICE_DIRTY.<id>, a single byte mmap'd as uint8_t.
+        // Set to 1 before workload, 0 on graceful release. Persists across crash/SIGKILL.
+        uint8_t* ptr = nullptr;
+        int fd = -1;
+    };
+
+    struct PerDevice {
+        tt::ChipId id;
+        tt::umd::RobustMutex mutex;
+        DirtyShm dirty;
+        bool locked = false;
+
+        explicit PerDevice(tt::ChipId id);
+    };
+
+    static DirtyShm open_dirty_shm(tt::ChipId id);
+    static void close_dirty_shm(DirtyShm& s);
+    static void run_tt_smi_reset(tt::ChipId id);
+
+    std::vector<std::unique_ptr<PerDevice>> per_device_;
+    std::atomic<bool> hang_handled_{false};
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/device/safe_device_open.hpp
+++ b/tt_metal/impl/device/safe_device_open.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <atomic>
-#include <memory>
+#include <string_view>
 #include <vector>
 
 #include <tt-metalium/device_types.hpp>
@@ -15,55 +15,56 @@ namespace tt::tt_metal {
 
 // Cooperative cross-process device guard.
 //
-// On construction, acquires a per-device cross-process mutex (RobustMutex via /dev/shm) and
-// checks a sibling /dev/shm "dirty" bit. If the previous holder did not release cleanly
-// (process killed mid-workload, or the dispatch timeout handler tagged the device on hang),
-// shells out to `tt-smi -r <chip_id>` to recover before proceeding. Sets the dirty bit for
-// the duration of this guard's lifetime.
+// On construction, acquires a single cross-process mutex covering the full mesh (all device IDs
+// together) and checks a sibling /dev/shm dirty bit. If the previous holder did not release
+// cleanly (process killed mid-workload, or the dispatch timeout handler tagged the mesh on hang),
+// shells out to `tt-smi -r` to reset all devices before proceeding. Sets the dirty bit for the
+// duration of this guard's lifetime.
 //
-// Replaces the flock + dirty-file + tt-smi shellout choreography in scripts/run_safe_pytest.sh,
-// moving it inside tt-metal device open. This is a userspace stopgap until the KMD lock-63
-// pattern (auto-release on FD close) becomes viable.
+// A single mesh-scoped mutex is correct for multi-device setups: acquisition is all-or-nothing for
+// the whole set of chips, avoiding the partial-acquisition races that per-chip locks introduce.
+// Using `tt-smi -r` with no device ID also sidesteps the BH GLX /dev/tenstorrent/<N> shuffle that
+// can occur after a per-device reset.
+//
+// The mutex name and dirty shm are derived from the sorted set of chip IDs, so two processes
+// sharing the same mesh contend on the same lock, while non-overlapping meshes run in parallel.
+//
+// Replaces the flock + dirty-file + tt-smi shellout choreography in scripts/run_safe_pytest.sh.
+// This is a userspace stopgap until the KMD lock-63 pattern (auto-release on FD close) is viable.
 //
 // Gated externally on TT_METAL_SAFE_DEVICE_OPEN=1.
 class SafeDeviceGuard {
 public:
-    // Acquires the lock for each device id. Reset-on-dirty happens before this returns.
+    // Acquires the mesh-scoped lock. Reset-on-dirty happens before this returns.
     explicit SafeDeviceGuard(const std::vector<tt::ChipId>& device_ids);
 
-    // Clears the dirty bit and releases the locks. If on_hang() was called, leaves the dirty
-    // bit set so the next process resets again as a belt-and-suspenders measure.
+    // Clears the dirty bit and releases the lock. If on_hang() was called, leaves the dirty bit
+    // set so the next process resets again as a belt-and-suspenders measure.
     ~SafeDeviceGuard();
 
     SafeDeviceGuard(const SafeDeviceGuard&) = delete;
     SafeDeviceGuard& operator=(const SafeDeviceGuard&) = delete;
 
-    // Called by MetalContext::on_dispatch_timeout_detected. Runs `tt-smi -r <id>` synchronously
-    // for each held device. Idempotent — safe to call from multiple threads; second call is a no-op.
+    // Called by MetalContext::on_dispatch_timeout_detected. Runs `tt-smi -r` synchronously.
+    // Idempotent — safe to call from multiple threads; second call is a no-op.
     void on_hang();
 
 private:
     struct DirtyShm {
-        // Backed by /dev/shm/TT_METAL_DEVICE_DIRTY.<id>, a single byte mmap'd as uint8_t.
+        // Single byte in /dev/shm, mmap'd as uint8_t.
         // Set to 1 before workload, 0 on graceful release. Persists across crash/SIGKILL.
         uint8_t* ptr = nullptr;
         int fd = -1;
     };
 
-    struct PerDevice {
-        tt::ChipId id;
-        tt::umd::RobustMutex mutex;
-        DirtyShm dirty;
-        bool locked = false;
-
-        explicit PerDevice(tt::ChipId id);
-    };
-
-    static DirtyShm open_dirty_shm(tt::ChipId id);
+    static DirtyShm open_dirty_shm(std::string_view shm_name);
     static void close_dirty_shm(DirtyShm& s);
-    static void run_tt_smi_reset(tt::ChipId id);
+    static void run_tt_smi_reset();
 
-    std::vector<std::unique_ptr<PerDevice>> per_device_;
+    std::vector<tt::ChipId> device_ids_;  // for logging
+    tt::umd::RobustMutex mutex_;
+    DirtyShm dirty_;
+    bool locked_ = false;
     std::atomic<bool> hang_handled_{false};
 };
 

--- a/tt_metal/impl/device/safe_device_open.hpp
+++ b/tt_metal/impl/device/safe_device_open.hpp
@@ -29,6 +29,16 @@ namespace tt::tt_metal {
 // The mutex name and dirty shm are derived from the sorted set of chip IDs, so two processes
 // sharing the same mesh contend on the same lock, while non-overlapping meshes run in parallel.
 //
+// Requires 'tt-smi' on PATH; construction throws if it's absent.
+//
+// Known limitation: the guard is constructed inside initialize_device_manager(), which is called
+// after MetalEnvImpl::initialize_base_objects() has already opened the UMD cluster. As a result,
+// the dirty-bit check and tt-smi reset run while the UMD driver is already live. If a previous
+// process left the device with dispatch firmware still running, the tt-smi reset issued by the
+// new acquirer will corrupt that firmware mid-initialization, causing FW init failures. The
+// practical fix is to move SafeDeviceGuard construction to before the UMD cluster is created; that
+// requires knowing the device IDs before topology discovery, which needs a refactor.
+//
 // Replaces the flock + dirty-file + tt-smi shellout choreography in scripts/run_safe_pytest.sh.
 // This is a userspace stopgap until the KMD lock-63 pattern (auto-release on FD close) is viable.
 //

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -19,6 +19,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/device/mock_device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/mock_device_util.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device_manager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/device/safe_device_open.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/dispatch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/per_core_allocation/buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/per_core_allocation/memory_config.cpp

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -746,6 +746,7 @@ public:
     TargetDevice get_target_device() const { return runtime_target_device_; }
 
     std::chrono::duration<float> get_timeout_duration_for_operations() const { return timeout_duration_for_operations; }
+    void set_timeout_duration_for_operations(std::chrono::duration<float> d) { timeout_duration_for_operations = d; }
     std::string get_dispatch_timeout_command_to_execute() const { return dispatch_timeout_command_to_execute; }
     uint32_t get_dispatch_progress_update_ms() const { return dispatch_progress_update_ms; }
     // Mesh graph descriptor version accessor

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -84,22 +84,23 @@ std::unique_ptr<tt::umd::ClusterDescriptor> get_mock_cluster_desc(const tt::llrt
 }  // namespace
 namespace tt {
 
-tt::tt_metal::ClusterType Cluster::get_cluster_type_from_cluster_desc(
+std::pair<tt::tt_metal::ClusterType, std::unique_ptr<tt::umd::ClusterDescriptor>>
+Cluster::get_cluster_type_from_cluster_desc(
     const llrt::RunTimeOptions& rtoptions, const umd::ClusterDescriptor* cluster_desc) {
     if (rtoptions.get_simulator_enabled() && !rtoptions.get_mock_enabled()) {
         auto soc_desc =
             tt::umd::SimulationChip::get_soc_descriptor_path_from_simulator_path(rtoptions.get_simulator_path());
         auto arch = tt::umd::SocDescriptor::get_arch_from_soc_descriptor_path(soc_desc);
         if (arch == tt::ARCH::WORMHOLE_B0) {
-            return tt::tt_metal::ClusterType::SIMULATOR_WORMHOLE_B0;
+            return {tt::tt_metal::ClusterType::SIMULATOR_WORMHOLE_B0, nullptr};
         }
         if (arch == tt::ARCH::BLACKHOLE) {
-            return tt::tt_metal::ClusterType::SIMULATOR_BLACKHOLE;
+            return {tt::tt_metal::ClusterType::SIMULATOR_BLACKHOLE, nullptr};
         }
         if (arch == tt::ARCH::QUASAR) {
-            return tt::tt_metal::ClusterType::SIMULATOR_QUASAR;
+            return {tt::tt_metal::ClusterType::SIMULATOR_QUASAR, nullptr};
         }
-        return tt::tt_metal::ClusterType::INVALID;
+        return {tt::tt_metal::ClusterType::INVALID, nullptr};
     }
 
     std::unique_ptr<umd::ClusterDescriptor> temp_cluster_desc = nullptr;
@@ -205,7 +206,7 @@ tt::tt_metal::ClusterType Cluster::get_cluster_type_from_cluster_desc(
             cluster_type = tt::tt_metal::ClusterType::BLACKHOLE_GALAXY;
         }
     }
-    return cluster_type;
+    return {cluster_type, std::move(temp_cluster_desc)};
 }
 
 bool Cluster::is_base_routing_fw_enabled(tt::tt_metal::ClusterType cluster_type) {
@@ -270,7 +271,7 @@ bool Cluster::is_base_routing_fw_enabled() const { return Cluster::is_base_routi
 
 void Cluster::generate_cluster_descriptor() {
     this->cluster_desc_ = this->driver_->get_cluster_description();
-    this->cluster_type_ = Cluster::get_cluster_type_from_cluster_desc(this->rtoptions_, this->cluster_desc_);
+    this->cluster_type_ = Cluster::get_cluster_type_from_cluster_desc(this->rtoptions_, this->cluster_desc_).first;
     if (this->cluster_type_ == tt::tt_metal::ClusterType::CUSTOM) {
         TT_FATAL(
             this->rtoptions_.is_custom_fabric_mesh_graph_desc_path_specified(),

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -61,8 +61,14 @@ enum class EthRouterMode : uint32_t {
 class Cluster {
 public:
     // TODO: #21245: Remove these workaround APIs and instead refactor UMD component out of Cluster
-    static tt::tt_metal::ClusterType get_cluster_type_from_cluster_desc(
-        const llrt::RunTimeOptions& rtoptions, const umd::ClusterDescriptor* cluster_desc = nullptr);
+    //
+    // Returns the cluster type and, when cluster_desc is nullptr (the caller has no pre-existing
+    // descriptor), the newly-created ClusterDescriptor so the caller can reuse it instead of
+    // running topology discovery a second time. When cluster_desc is non-null the returned
+    // unique_ptr is null (the caller already owns the descriptor).
+    static std::pair<tt::tt_metal::ClusterType, std::unique_ptr<umd::ClusterDescriptor>>
+        get_cluster_type_from_cluster_desc(
+            const llrt::RunTimeOptions& rtoptions, const umd::ClusterDescriptor* cluster_desc = nullptr);
     static bool is_base_routing_fw_enabled(tt::tt_metal::ClusterType cluster_type);
     Cluster& operator=(const Cluster&) = delete;
     Cluster& operator=(Cluster&& other) noexcept = delete;


### PR DESCRIPTION
Enable multiple processes or even docker containers to share a single device/mesh-device.

Migrates the lock + dirty-flag + auto-reset choreography from scripts/run_safe_pytest.sh into tt-metal device open, gated on TT_METAL_SAFE_DEVICE_OPEN=1.

When enabled, MetalContext::initialize_device_manager constructs a SafeDeviceGuard that:
  - acquires a per-device cross-process mutex (UMD's RobustMutex via /dev/shm) to serialize device access between processes,
  - checks a sibling /dev/shm dirty bit and shells out to `tt-smi -r <id>` if a previous holder did not release cleanly (SIGKILL/OOM or hang),
  - marks the device dirty for this process's lifetime and clears it on graceful destruction.

On dispatch timeout, the guard's on_hang() runs `tt-smi -r` synchronously so the device is recovered before the process exits, and the next runner finds a clean board. The guard also auto-defaults
TT_METAL_OPERATION_TIMEOUT_SECONDS to 30 if unset, since without a timeout a hang would hold the lock indefinitely.

This is a userspace stopgap. Once the KMD lock-63 deadlock (blocking LOCK_CTL acquire vs RESET) is fixed, the same hook points can be re-pointed at kernel locks with auto-release on FD close.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsmith/safe-device-open)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsmith/safe-device-open)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsmith/safe-device-open)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsmith/safe-device-open)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsmith/safe-device-open)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsmith/safe-device-open)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsmith/safe-device-open)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsmith/safe-device-open)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsmith/safe-device-open)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsmith/safe-device-open)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsmith/safe-device-open)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsmith/safe-device-open)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsmith/safe-device-open)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsmith/safe-device-open)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsmith/safe-device-open)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsmith/safe-device-open)