### PR TITLE
Ebanerjee/triage assign owners test

### DIFF
--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -1,48 +1,38 @@
-name: "(triage) Cursor CLI smoke test"
+name: "(triage) Auto Issue Creation"
 
 on:
   workflow_dispatch:
+    inputs:
+      create-issues:
+        description: "Create GitHub issues for deterministic failures"
+        type: boolean
+        default: false
+      issue-repo:
+        description: "Repository to create issues in"
+        type: string
+        default: "ebanerjeeTT/issue_dump"
+      target-repo:
+        description: "Repository to analyze workflow data from"
+        type: string
+        default: "tenstorrent/tt-metal"
+      max-issues:
+        description: "Maximum issues to create (0 = unlimited, useful for testing)"
+        type: number
+        default: 0
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
-  cursor-cli-smoke-test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Ensure CURSOR_API_KEY is configured
-        env:
-          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
-        run: |
-          if [ -z "$CURSOR_API_KEY" ]; then
-            echo "Missing secret CURSOR_API_KEY"
-            exit 1
-          fi
-
-      - name: Install Cursor CLI
-        run: |
-          set -euo pipefail
-          install_script="$(mktemp)"
-          curl --fail --show-error --silent --location \
-            --proto '=https' --tlsv1.2 \
-            https://cursor.com/install \
-            -o "$install_script"
-          bash "$install_script"
-          rm -f "$install_script"
-          echo "$HOME/.cursor/bin" >> "$GITHUB_PATH"
-
-      - name: Run simple Cursor prompt
-        env:
-          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
-        run: |
-          set -euo pipefail
-          output="$(agent -p "Reply with exactly: CURSOR_CI_OK")"
-          echo "Agent output: $output"
-          if [[ "$output" != *"CURSOR_CI_OK"* ]]; then
-            echo "Unexpected agent output; expected CURSOR_CI_OK"
-            exit 1
-          fi
+  auto-issues:
+    uses: tenstorrent/tt-auto-triage/.github/workflows/triage-ci.yaml@main
+    with:
+      create-issues: ${{ inputs.create-issues }}
+      issue-repo: ${{ inputs.issue-repo }}
+      target-repo: ${{ inputs.target-repo }}
+      max-issues: ${{ fromJSON(inputs.max-issues) }}
+    secrets:
+      AGGREGATE_READ_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE_WRITE_TOKEN: ${{ secrets.EVAN_RESTRICTED_TOKEN }}
+      CURSOR_API_KEY: ${{ secrets.EVAN_CURSOR_API_KEY }}

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -40,12 +40,9 @@ jobs:
   assign-owners:
     uses: tenstorrent/tt-auto-triage/.github/workflows/triage-ci.yaml@ebanerjee/triage-assign-owners
     with:
-      create-issues: false
       assign-owners: true
-      slack-notify: false
       issue-repo: ebanerjeeTT/issue_dump
       target-repo: tenstorrent/tt-metal
-      slack-channel-id: C0APK6215B5
     secrets:
       AGGREGATE_READ_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ISSUE_WRITE_TOKEN: ${{ secrets.AUTO_TRIAGE_TOKEN }}

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -1,4 +1,4 @@
-name: "(triage) Auto Issue Creation"
+name: "(triage) CI Triage Orchestrator"
 
 on:
   workflow_dispatch:
@@ -36,3 +36,17 @@ jobs:
       AGGREGATE_READ_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ISSUE_WRITE_TOKEN: ${{ secrets.EVAN_RESTRICTED_TOKEN }}
       CURSOR_API_KEY: ${{ secrets.EVAN_CURSOR_API_KEY }}
+
+  assign-owners:
+    uses: tenstorrent/tt-auto-triage/.github/workflows/triage-ci.yaml@ebanerjee/triage-assign-owners
+    with:
+      create-issues: false
+      assign-owners: true
+      slack-notify: false
+      issue-repo: ebanerjee/issue_dump
+      target-repo: tenstorrent/tt-metal
+      slack-channel-id: C0APK6215B5
+    secrets:
+      AGGREGATE_READ_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE_WRITE_TOKEN: ${{ secrets.AUTO_TRIAGE_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -46,4 +46,5 @@ jobs:
     secrets:
       AGGREGATE_READ_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ISSUE_WRITE_TOKEN: ${{ secrets.AUTO_TRIAGE_TOKEN }}
+      CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -35,6 +35,28 @@ on:
         required: false
         type: boolean
         default: true
+      reassign-to-someone-else:
+        description: >-
+          Re-resolve and exclude the prior owner(s); requires the skip flag
+          above to be false. Mutually exclusive with refresh-owner-recommendation.
+        required: false
+        type: boolean
+        default: false
+      refresh-owner-recommendation:
+        description: >-
+          Re-resolve without excluding prior owners; requires the skip flag
+          above to be false. Mutually exclusive with reassign-to-someone-else.
+        required: false
+        type: boolean
+        default: false
+      extra-context-for-agent:
+        description: >-
+          Optional dev hint appended to the agent prompt under EXTRA INPUT FROM
+          DEVS. When set, the pipeline_reorg fast path is bypassed. Requires the
+          skip flag above to be false.
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -61,6 +83,9 @@ jobs:
       target-repo: tenstorrent/tt-metal
       issue-numbers: ${{ inputs.issue-numbers }}
       skip-assigning-for-issues-that-already-have-owners: ${{ inputs.skip-assigning-for-issues-that-already-have-owners }}
+      reassign-to-someone-else: ${{ inputs.reassign-to-someone-else }}
+      refresh-owner-recommendation: ${{ inputs.refresh-owner-recommendation }}
+      extra-context-for-agent: ${{ inputs.extra-context-for-agent }}
     secrets:
       AGGREGATE_READ_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ISSUE_WRITE_TOKEN: ${{ secrets.AUTO_TRIAGE_TOKEN }}

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -46,5 +46,5 @@ jobs:
     secrets:
       AGGREGATE_READ_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ISSUE_WRITE_TOKEN: ${{ secrets.AUTO_TRIAGE_TOKEN }}
-      CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+      CURSOR_API_KEY: ${{ secrets.EVAN_CURSOR_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -43,7 +43,7 @@ jobs:
       create-issues: false
       assign-owners: true
       slack-notify: false
-      issue-repo: ebanerjee/issue_dump
+      issue-repo: ebanerjeeTT/issue_dump
       target-repo: tenstorrent/tt-metal
       slack-channel-id: C0APK6215B5
     secrets:

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -19,6 +19,14 @@ on:
         description: "Maximum issues to create (0 = unlimited, useful for testing)"
         type: number
         default: 0
+      issue-numbers:
+        description: >-
+          Optional. Comma/whitespace-separated list of issue numbers, `#123`
+          tokens, or full GitHub issue URLs. Leave empty to process every
+          open CI-triage issue.
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -43,6 +51,7 @@ jobs:
       assign-owners: true
       issue-repo: ebanerjeeTT/issue_dump
       target-repo: tenstorrent/tt-metal
+      issue-numbers: ${{ inputs.issue-numbers }}
     secrets:
       AGGREGATE_READ_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ISSUE_WRITE_TOKEN: ${{ secrets.AUTO_TRIAGE_TOKEN }}

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -27,6 +27,14 @@ on:
         required: false
         type: string
         default: ""
+      skip-assigning-for-issues-that-already-have-owners:
+        description: >-
+          When true (default), any issue that already has a recommended-owner
+          comment is skipped before any expensive work runs. Uncheck to force
+          re-resolution on every issue.
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -52,6 +60,7 @@ jobs:
       issue-repo: ebanerjeeTT/issue_dump
       target-repo: tenstorrent/tt-metal
       issue-numbers: ${{ inputs.issue-numbers }}
+      skip-assigning-for-issues-that-already-have-owners: ${{ inputs.skip-assigning-for-issues-that-already-have-owners }}
     secrets:
       AGGREGATE_READ_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ISSUE_WRITE_TOKEN: ${{ secrets.AUTO_TRIAGE_TOKEN }}

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -57,6 +57,11 @@ on:
         required: false
         type: string
         default: ""
+      llm-backend:
+        description: "LLM backend for the resolver agent fallback: 'cursor' (default) or 'copilot' (uses AUTO_TRIAGE_TOKEN, no Cursor quota)"
+        required: false
+        type: string
+        default: "cursor"
 
 permissions:
   contents: read
@@ -86,8 +91,10 @@ jobs:
       reassign-to-someone-else: ${{ inputs.reassign-to-someone-else }}
       refresh-owner-recommendation: ${{ inputs.refresh-owner-recommendation }}
       extra-context-for-agent: ${{ inputs.extra-context-for-agent }}
+      llm-backend: ${{ inputs.llm-backend }}
     secrets:
       AGGREGATE_READ_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ISSUE_WRITE_TOKEN: ${{ secrets.AUTO_TRIAGE_TOKEN }}
       CURSOR_API_KEY: ${{ secrets.EVAN_CURSOR_API_KEY }}
+      COPILOT_PAT: ${{ secrets.AUTO_TRIAGE_TOKEN }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Summary

Test-harness wrapper that dispatches `tenstorrent/tt-auto-triage`'s `triage-ci.yaml` against `tenstorrent/tt-metal` data so the new `assign-owners` stage from [tt-auto-triage#1108](https://github.com/tenstorrent/tt-auto-triage/pull/1108) can be exercised on real issues in `ebanerjeeTT/issue_dump` without merging anything to either main first.

This PR is **not intended to merge as-is**: the inner caller pins
```
uses: tenstorrent/tt-auto-triage/.github/workflows/triage-ci.yaml@ebanerjee/triage-assign-owners
```
which is the in-flight branch on tt-auto-triage. Once #1108 lands, that ref flips to `@main` (and ideally this whole workflow is replaced by the production caller in `triage-ci.yaml` rather than living on a long-lived test branch).

## Inputs surfaced

The wrapper threads through every input the resolver actually cares about so dispatches can be tuned without editing YAML each time:

| input | default | purpose |
| --- | --- | --- |
| `create-issues` | `false` | Sibling `auto-issues` job — left here for parity with the create-issues test wrapper. |
| `issue-numbers` | `""` | Optional scoped run; accepts bare numbers, `#NNN`, or full issue URLs (comma/whitespace separated). |
| `skip-assigning-for-issues-that-already-have-owners` | `true` | Pre-pass short-circuit; flip to `false` to force re-resolution. |
| `reassign-to-someone-else` | `false` | Re-resolve while excluding all prior recommendations. Mutually exclusive with `refresh-owner-recommendation`. |
| `refresh-owner-recommendation` | `false` | Re-resolve without excluding prior owners (use after a `pipeline_reorg` edit). |
| `extra-context-for-agent` | `""` | Free-form dev hint appended to the agent prompt under `EXTRA INPUT FROM DEVS`. When set, bypasses the `pipeline_reorg` fast path. |
| `llm-backend` | `"cursor"` | New: routes the slow-path resolver agent through Cursor CLI or GitHub Copilot CLI. |

## Secret wiring

```yaml
AGGREGATE_READ_TOKEN: ${{ secrets.GITHUB_TOKEN }}
ISSUE_WRITE_TOKEN:    ${{ secrets.AUTO_TRIAGE_TOKEN }}
CURSOR_API_KEY:       ${{ secrets.EVAN_CURSOR_API_KEY }}   # used when llm-backend=cursor
COPILOT_PAT:          ${{ secrets.AUTO_TRIAGE_TOKEN }}     # used when llm-backend=copilot
SLACK_BOT_TOKEN:      ${{ secrets.SLACK_BOT_TOKEN }}
```

`AUTO_TRIAGE_TOKEN` doubles as both the issue-write token and the Copilot PAT — same scope, no need for a second secret in the harness.

## Test evidence

All runs were dispatched from this branch and target `ebanerjeeTT/issue_dump` issues. They cover the legacy resolver path, the skip pre-pass, scoped runs, ex-employee fall-through, and both LLM backends.

Earlier runs (resolver, skip pre-pass, scoped runs, ex-employee fall-through) are tabulated in detail on [tt-auto-triage#1108](https://github.com/tenstorrent/tt-auto-triage/pull/1108) under "End-to-end on real infrastructure".

The three runs proving the new `llm-backend` dispatcher:

| # | scenario | run | what it proves |
| -: | --- | --- | --- |
| 1 | `llm-backend=cursor`, scoped `#888`, `refresh-owner-recommendation=true` | [25396912708](https://github.com/tenstorrent/tt-metal/actions/runs/25396912708) | Cursor regression. Cursor install step ran, Copilot install steps skipped. Agent invoked → `#888: source=agent owner='Djordje Ivanovic' gh=['djordje-tt'] slack=['U053W15B6JF']`. Same active owner picked as in earlier Cursor-only runs — the dispatcher refactor in #1108 doesn't move the answer. |
| 2 | `llm-backend=copilot`, scoped `#887`, `refresh-owner-recommendation=true` | [25396939665](https://github.com/tenstorrent/tt-metal/actions/runs/25396939665) | Copilot install + secret-gating smoke test. Cursor install skipped, Node 24 + `npm install -g @github/copilot` ran, `copilot --version` exit 0. #887 lives in `pipeline_reorg`, so resolution short-circuited deterministically: `#887: source=pipeline_reorg owner='Samuel Adesoye'`. Confirms the conditional install plumbing without spending a Copilot call. |
| 3 | `llm-backend=copilot`, scoped `#886`, `refresh-owner-recommendation=true`, `extra-context-for-agent` set | [25397158987](https://github.com/tenstorrent/tt-metal/actions/runs/25397158987) | Copilot end-to-end. `extra-context-for-agent` forces the slow path. Logs: `Flags: extra_context=set (fast-path bypassed: True)` → Copilot CLI invoked → output parsed via the shared `===FINAL===` marker → `#886: source=agent owner='Samuel Adesoye' gh=['sadesoyeTT'] slack=['U08TED0JM9D']`. Server-side `is_active_employee` re-check accepted the pick. Proves the Copilot binary actually runs the resolver prompt, returns parseable JSON, and survives the same active-employee gate Cursor does. |
| 4 | `llm-backend=cursor`, scoped `#889` (easy: not in `pipeline_reorg`), no `extra-context-for-agent` | [25407370289](https://github.com/tenstorrent/tt-metal/actions/runs/25407370289) | Cursor on a clean easy case. Agent invoked → `source=agent owner='Sean Nijjar' gh=['SeanNijjar']`. With temporary `DEBUG_AGENT_STDOUT=1` instrumentation, agent's stdout shows reasoning over 5+ candidates (SeanNijjar, yugaoTT, aagarwalTT, ubcheema, aliuTT) all marked ACTIVE via inline check, CODEOWNERS for `tests/tt_metal/tt_fabric/` cited. |
| 5 | `llm-backend=copilot`, scoped `#889`, no `extra-context-for-agent` | [25407371308](https://github.com/tenstorrent/tt-metal/actions/runs/25407371308) | Copilot on the same easy case. Agent invoked → `source=agent owner='Ridvan Song' gh=['Riddy21']`. Stdout trace shows ~13 explicit shell tool calls (`find`, `cat`, `grep`, `sed`, `git log -n200 --format='%an...' -- tests/tt_metal/tt_fabric/`, CODEOWNERS scan) AND TWO explicit `python3 -m tools.ci.assign_owners.check_active --slack-id ... --login ...` invocations (Riddy21 ACTIVE, tlevin checked). **Definitive proof Copilot iterates the resolver protocol with real tool use.** Different person from Cursor's pick but equally valid — both are CODEOWNERS for the affected path. |
| 6 | `llm-backend=cursor`, scoped `#888` (hard: pipeline_reorg points at ex-employee Salar Hosseini), no `extra-context-for-agent` | [25407372277](https://github.com/tenstorrent/tt-metal/actions/runs/25407372277) | Cursor regression check. `active-check: U05RWH3QUPM -> inactive (not present in Slack workspace dump)` (Salar correctly rejected) → agent invoked → `owner='Djordje Ivanovic'`. Same answer as run 1, confirms the dispatcher refactor doesn't drift Cursor. |
| 7 | `llm-backend=copilot`, scoped `#888`, no `extra-context-for-agent` (re-dispatched alone after a 429-rate-limited initial attempt) | [25407903459](https://github.com/tenstorrent/tt-metal/actions/runs/25407903459) | Copilot on the hard case. Same Salar-inactive → agent-invoked path as run 6. Result: `source=agent owner='Djordje Ivanovic' gh=['djordje-tt'] slack=['U053W15B6JF']` — **same exact pick as Cursor**. Stdout (7671b) shows ~20 tool calls including `git log -n200 -- tests/pipeline_reorg/t3k_perf_tests.yaml`, owners.json scan, `gh api /users/djordje-tt`, `gh api /search/users?q=...`, AND two explicit `python3 -m tools.ci.assign_owners.check_active --slack-id U053W15B6JF --login djordje-tt` and `--slack-id U08TED0JM9D --login sadesoye` invocations. Final reasoning: Djordje owns the neighboring `falcon40b` perf test, semantically closest to the failing falcon7b. |

The initial attempt at run 7 ([25407373163](https://github.com/tenstorrent/tt-metal/actions/runs/25407373163)) was discarded because four parallel dispatches saturated Slack's `users.list` rate limit, the empty Slack dump silently passed `is_active_employee` for the ex-employee, and the fast path resolved to Salar without ever invoking the agent. **This surfaced a pre-existing fail-open bug (empty Slack dump → assigns ex-employees) that is NOT introduced by this PR but should be filed as a follow-up.** Re-dispatching B2 alone with a clean Slack download produced the correct result documented in row 7.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ebanerjee/triage-assign-owners-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ebanerjee/triage-assign-owners-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ebanerjee/triage-assign-owners-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ebanerjee/triage-assign-owners-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ebanerjee/triage-assign-owners-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ebanerjee/triage-assign-owners-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ebanerjee/triage-assign-owners-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ebanerjee/triage-assign-owners-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ebanerjee/triage-assign-owners-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ebanerjee/triage-assign-owners-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ebanerjee/triage-assign-owners-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ebanerjee/triage-assign-owners-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ebanerjee/triage-assign-owners-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ebanerjee/triage-assign-owners-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ebanerjee/triage-assign-owners-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ebanerjee/triage-assign-owners-test)

