### PR TITLE
[Bug fix] Fix UB float<->uint32_t bitcast in LLK SFPU headers

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_converter.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_converter.h
@@ -14,13 +14,7 @@ class Converter
 public:
     static float as_float(std::uint32_t value)
     {
-        union
-        {
-            std::uint32_t u;
-            float f;
-        } converter {value};
-
-        return converter.f;
+        return __builtin_bit_cast(float, value);
     }
 };
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_welfords.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_welfords.h
@@ -6,29 +6,10 @@
 
 #include <array>
 #include <cstdint>
-#include <type_traits>
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "sfpi.h"
-
-// C++17 compatible bit_cast replacement using union
-template <typename To, typename From>
-inline To _bit_cast_(const From& from) noexcept
-{
-    static_assert(sizeof(To) == sizeof(From), "Types must have same size");
-    static_assert(std::is_trivially_copyable_v<From>, "From must be trivially copyable");
-    static_assert(std::is_trivially_copyable_v<To>, "To must be trivially copyable");
-
-    union
-    {
-        From f;
-        To t;
-    } u;
-
-    u.f = from;
-    return u.t;
-}
 
 // Optimized float to 16-bit parts conversion
 struct FloatBits
@@ -38,7 +19,7 @@ struct FloatBits
 
     explicit FloatBits(float value)
     {
-        const std::uint32_t bits = _bit_cast_<std::uint32_t>(value);
+        const std::uint32_t bits = __builtin_bit_cast(std::uint32_t, value);
         high16                   = static_cast<std::uint16_t>(bits >> 16);
         low16                    = static_cast<std::uint16_t>(bits & 0xFFFF);
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_converter.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_converter.h
@@ -14,13 +14,7 @@ class Converter
 public:
     static float as_float(std::uint32_t value)
     {
-        union
-        {
-            std::uint32_t u;
-            float f;
-        } converter {value};
-
-        return converter.f;
+        return __builtin_bit_cast(float, value);
     }
 };
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_welfords.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_welfords.h
@@ -6,29 +6,10 @@
 
 #include <array>
 #include <cstdint>
-#include <type_traits>
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "sfpi.h"
-
-// C++17 compatible bit_cast replacement using union
-template <typename To, typename From>
-inline To _bit_cast_(const From& from) noexcept
-{
-    static_assert(sizeof(To) == sizeof(From), "Types must have same size");
-    static_assert(std::is_trivially_copyable_v<From>, "From must be trivially copyable");
-    static_assert(std::is_trivially_copyable_v<To>, "To must be trivially copyable");
-
-    union
-    {
-        From f;
-        To t;
-    } u;
-
-    u.f = from;
-    return u.t;
-}
 
 // Optimized float to 16-bit parts conversion
 struct FloatBits
@@ -38,7 +19,7 @@ struct FloatBits
 
     explicit FloatBits(float value)
     {
-        const std::uint32_t bits = _bit_cast_<std::uint32_t>(value);
+        const std::uint32_t bits = __builtin_bit_cast(std::uint32_t, value);
         high16                   = static_cast<std::uint16_t>(bits >> 16);
         low16                    = static_cast<std::uint16_t>(bits & 0xFFFF);
     }


### PR DESCRIPTION
### Summary
Fixes #43572 

Replace union-based bitcast with __builtin_bit_cast in ckernel_sfpu_welfords.h (FloatBits) and ckernel_sfpu_converter.h (Converter::as_float) for both wormhole_b0 and blackhole.

Writing one union member and reading another is undefined behavior in C++. __builtin_bit_cast is well-defined, available in C++17, and already used in ckernel_sfpu_exp.h in the same directory.

### Notes for reviewers
Note that the proposed way of fixing the undefined behavior is through the __builtin_bit_cast builtin function

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/ckernel_ub)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/ckernel_ub)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/ckernel_ub)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/ckernel_ub)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/ckernel_ub)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/ckernel_ub)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/ckernel_ub)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/ckernel_ub)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/ckernel_ub)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/ckernel_ub)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/ckernel_ub)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/ckernel_ub)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/ckernel_ub)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/ckernel_ub)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/ckernel_ub)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/ckernel_ub)