### PR TITLE
[Watcher] Fix NOC circular-buffer overflow in `ttnn.plus_one` in SDPA Flash MLA unit test 

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
@@ -9,6 +9,7 @@
 #include "ttnn/operations/math.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/hal.hpp>
 #include "ttnn/operation.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
 
@@ -39,9 +40,11 @@ PlusOneProgramFactory::cached_program_t PlusOneProgramFactory::create(
 
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_units = W;
-    uint32_t aligned_input_page_size = round_up_to_mul32(num_input_units * input_unit_size);
     auto* src_buffer = input.buffer();
     bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    const uint32_t page_alignment =
+        src_is_dram ? tt::tt_metal::hal::get_dram_alignment() : tt::tt_metal::hal::get_l1_alignment();
+    uint32_t aligned_input_page_size = tt::align(num_input_units * input_unit_size, page_alignment);
 
     tt::tt_metal::CircularBufferConfig cb_src0_config =
         tt::tt_metal::CircularBufferConfig(aligned_input_page_size, {{src0_cb_index, input_cb_data_format}})

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/tt_align.hpp>
 #include "ttnn/operation.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
 


### PR DESCRIPTION
### PR Category
Bug fix

## Summary                                                                                                                                                                                                                         
  Fix NOC circular-buffer overflow in `ttnn.plus_one` when the input tensor's                                                 
  unaligned page size is smaller than the device's NOC page alignment (e.g. 64B                                               
  DRAM alignment on Blackhole).                                                                                               
                                                                                                                                                                                                                                         
  Running FlashMLA decode tests that call `ttnn.plus_one(tt_start_indices)` to                                                
  increment per-batch position indices triggers a watcher NOC error and halts the
  device:                                                                                                                     
                                                                                                                              
  NCRISC using noc0 tried to unicast read 64 bytes to local L1[0x01b200]                                                      
  from DRAM core w/ virtual coords (x=17,y=14) DRAM[addr=0x004e0680]                                                          
  (NOC transaction overflows a circular buffer).                                                                              
  While running kernels:
    NCRISC: ttnn/cpp/ttnn/operations/experimental/plusone/device/kernels/reader_plusone_interleaved.cpp                       
  TT_THROW @ tt_metal/impl/debug/watcher_device_reader.cpp:773                                                                
                                                                                                                              
  ## Root cause                                                                                                               
                                                                                                                              
  In `plusone_program_factory.cpp`, the scratch CB was sized with:                                                            
   
  ```cpp                                                                                                                      
  uint32_t aligned_input_page_size = round_up_to_mul32(num_input_units * input_unit_size);
  ```                                                                                                      
  i.e. only 32B aligned. The reader kernel does noc_async_read_page(h, s0, cb_addr),                                          
  which transfers the buffer's actual NOC page size. For start_indices with                                                   
  shape [1] and int32 dtype (4B), that rounds to 32B for the CB. But on Blackhole                                             
  DRAM alignment is 64B, so the buffer's page is 64B and the NOC transaction                                                  
  writes 64B into a 32B CB — overflow.                                                                                        
                                                                                                                              
  ### Fix                                                                                                                         
                  
  Align the scratch CB page to the buffer's actual alignment                                                                  
  (hal::get_dram_alignment() for DRAM, hal::get_l1_alignment() for L1) instead
  of a hardcoded 32B:
                                              
   ```                                                                                                                           
  const uint32_t page_alignment =                                                                                             
      src_is_dram ? tt::tt_metal::hal::get_dram_alignment()                                                                   
                  : tt::tt_metal::hal::get_l1_alignment();
  uint32_t aligned_input_page_size = tt::align(num_input_units * input_unit_size, page_alignment);                            
   ```
  
 ### Checklist 
- [x]  https://github.com/tenstorrent/tt-metal/actions/runs/25390114561

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aling/sdpa-plus-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aling/sdpa-plus-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aling/sdpa-plus-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aling/sdpa-plus-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aling/sdpa-plus-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aling/sdpa-plus-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aling/sdpa-plus-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aling/sdpa-plus-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aling/sdpa-plus-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aling/sdpa-plus-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aling/sdpa-plus-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aling/sdpa-plus-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aling/sdpa-plus-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aling/sdpa-plus-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aling/sdpa-plus-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aling/sdpa-plus-fix)