### PR TITLE
Bug Fix: SR Combine revert to old combine offset behavior when unfused, fix GPT-OSS

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -168,7 +168,8 @@ ttnn::device_operation::CachedProgram<UnifiedSelectReduce::shared_variables_t> U
     const GlobalSemaphore& cross_device_semaphore) {
     tt::tt_metal::Program program{};
     const ttnn::CoreRangeSet worker_core_range_set(operation_attributes.worker_cores);
-    const uint32_t metadata_sync_semaphore_id = tt::tt_metal::CreateSemaphore(program, worker_core_range_set, 1);
+    const uint32_t metadata_sync_semaphore_id =
+        tt::tt_metal::CreateSemaphore(program, CoreRangeSet(worker_core_range_set.bounding_box()), 1);
     const uint32_t compute_sync_semaphore_id = tt::tt_metal::CreateSemaphore(program, worker_core_range_set, 0);
     auto artifacts = build_selective_reduce_combine_program_artifacts(
         program,
@@ -257,6 +258,7 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
     const uint32_t src_chip_id = (uint32_t)fabric_node_id.chip_id;
 
     const uint32_t num_devices_total = mesh_view.num_devices();
+    const bool double_buffer_source = compute_cores_by_ring_id.has_value();
 
     // NOTE: shared experts are slightly delicate since they show up as an additional entry in the mapping tensor the
     // result is fractional experts per device so div_up is required to get the right value here.
@@ -295,18 +297,27 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
     const auto token_segment_buffer_size_bytes =
         *std::max_element(data_parallel_sizes_bytes.begin(), data_parallel_sizes_bytes.end());
 
-    // slightly awkward. we want the token dimension but the underlying shape might not represent the data layout.
-    //  This is in line with the assumption that tokens are split across the entirety of the shard, regardless of
-    //  number of tokens
     constexpr auto double_buffer = 2;
+    const auto num_buffers = (double_buffer_source) ? double_buffer : experts_per_device;
 
-    const auto input_shards = input_tensor.memory_config().shard_spec()->grid.num_cores();
-    const auto token_expert_row_offset = input_tensor.logical_shape().volume() / input_shards /
-                                         (hidden_size / num_data_parallel_cores / double_buffer) /
-                                         num_token_parallel_cores;
+    // TODO (AFM) this is an ugly kludge until we can get GPT-OSS on the mainline op #43645
+    uint32_t expert_token_segment_buffer_block_size_bytes;
+    if (double_buffer_source) {
+        // slightly awkward. we want the token dimension but the underlying shape might not represent the data layout.
+        //  This is in line with the assumption that tokens are split across the entirety of the shard, regardless of
+        //  number of tokens
+        const auto input_shards = input_tensor.memory_config().shard_spec()->grid.num_cores();
+        const auto token_expert_row_offset = input_tensor.logical_shape().volume() / input_shards /
+                                             (hidden_size / num_data_parallel_cores / double_buffer) /
+                                             num_token_parallel_cores;
 
-    const auto expert_token_segment_buffer_block_size_bytes = token_segment_buffer_size_bytes * token_expert_row_offset;
-    const auto buffer_size_bytes = expert_token_segment_buffer_block_size_bytes * double_buffer;
+        expert_token_segment_buffer_block_size_bytes = token_segment_buffer_size_bytes * token_expert_row_offset;
+    } else {
+        expert_token_segment_buffer_block_size_bytes =
+            token_segment_buffer_size_bytes * total_tokens / num_token_parallel_cores;
+    }
+
+    const auto buffer_size_bytes = expert_token_segment_buffer_block_size_bytes * num_buffers;
 
     const auto input_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     // input sharded buffer


### PR DESCRIPTION
### Summary
https://github.com/tenstorrent/tt-metal/pull/42982 changed some offset calculations in `selective_reduce_combine`, for the sake of the fused `moe_compute` op but this broke GPT-OSS, which uses SRC as a standalone op. This PR introduces a conditional to switch back to the original behavior in the case that SRC is used unfused.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amorrison/fix-gpt-oss)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amorrison/fix-gpt-oss)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amorrison/fix-gpt-oss)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amorrison/fix-gpt-oss)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amorrison/fix-gpt-oss)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amorrison/fix-gpt-oss)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amorrison/fix-gpt-oss)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amorrison/fix-gpt-oss)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amorrison/fix-gpt-oss)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amorrison/fix-gpt-oss)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amorrison/fix-gpt-oss)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amorrison/fix-gpt-oss)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amorrison/fix-gpt-oss)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amorrison/fix-gpt-oss)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amorrison/fix-gpt-oss)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amorrison/fix-gpt-oss)