### PR TITLE
Fix SDPA related tests hitting LLK_ASSERTS on data format configurations

### DIFF
--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/device/kernels/compute/sdpa_bw_compute_utils.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/device/kernels/compute/sdpa_bw_compute_utils.hpp
@@ -107,7 +107,6 @@ void apply_softmax_statistics_on_dst(const uint32_t scores_reg, const uint32_t c
 
     // Reconfigure only SrcB for the B2D broadcast (Float32 intermediates).
     // SrcA is left as-is from the preceding matmul to preserve its format.
-    reconfig_data_format_srca(cb_intermediates);
     reconfig_data_format_srcb(cb_intermediates);
 
     // Lightweight MOP reinit for unary_bcast<COL> with B2D path.

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/device/kernels/compute/sdpa_bw_compute_utils.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/device/kernels/compute/sdpa_bw_compute_utils.hpp
@@ -107,6 +107,7 @@ void apply_softmax_statistics_on_dst(const uint32_t scores_reg, const uint32_t c
 
     // Reconfigure only SrcB for the B2D broadcast (Float32 intermediates).
     // SrcA is left as-is from the preceding matmul to preserve its format.
+    reconfig_data_format_srca(cb_intermediates);
     reconfig_data_format_srcb(cb_intermediates);
 
     // Lightweight MOP reinit for unary_bcast<COL> with B2D path.

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_compute_utils.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_compute_utils.hpp
@@ -196,8 +196,8 @@ void matmul_qk_by_v(
 
     // matmul maps: in0(attention_weights)→SrcB, in1(value)→SrcA
     reconfig_data_format(cb_value, cb_attention_weights);
-    pack_reconfig_data_format(cb_cur_mm_out);
     mm_init_short(cb_attention_weights, cb_value, /* transpose */ 0);
+    pack_reconfig_data_format(cb_cur_mm_out);
     for (uint32_t tile_idx = 0; tile_idx < Wt; tile_idx += block_size) {
         tile_regs_acquire();
         for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
@@ -256,10 +256,10 @@ void update_cur_exp_sum_inplace(uint32_t cb_prev_sum_exp, uint32_t cb_cur_sum_ex
     cb_wait_front(cb_exp_max_diff, onetile);
 
     const uint32_t exp_sum_dst_idx = 0;
+    reconfig_data_format(cb_prev_sum_exp, cb_exp_max_diff);  // reconfig data format to precise
     mul_bcast_cols_init_short(cb_prev_sum_exp, cb_exp_max_diff);
     tile_regs_acquire();
     // multiply previous exp sum with exp_max_diff
-    reconfig_data_format(cb_prev_sum_exp, cb_exp_max_diff);  // reconfig data format to precise
     mul_tiles_bcast_cols(cb_prev_sum_exp, cb_exp_max_diff, 0, 0, exp_sum_dst_idx);
 
     // copy current sum exp to next register
@@ -285,6 +285,7 @@ void update_cur_exp_sum_inplace(uint32_t cb_prev_sum_exp, uint32_t cb_cur_sum_ex
 // Only reprograms UNPACK and MATH MOPs — safe inside a tile_regs_acquire block.
 // Uses reconfig_data_format_srcb so SrcA format register is preserved for the caller.
 void init_unary_bcast_col(uint32_t cb_col_vec) {
+    reconfig_data_format_srca(cb_col_vec);
     reconfig_data_format_srcb(cb_col_vec);
     UNPACK((llk_unpack_A_init<BroadcastType::COL, false, EltwiseBinaryReuseDestType::NONE, false>(
         false, false, cb_col_vec)));

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_compute_utils.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_compute_utils.hpp
@@ -194,10 +194,10 @@ void matmul_qk_by_v(
     cb_wait_front(cb_value, Wt);
     cb_reserve_back(cb_cur_mm_out, Wt);
 
-    mm_init_short(cb_attention_weights, cb_value, /* transpose */ 0);
-    pack_reconfig_data_format(cb_cur_mm_out);
     // matmul maps: in0(attention_weights)→SrcB, in1(value)→SrcA
     reconfig_data_format(cb_value, cb_attention_weights);
+    pack_reconfig_data_format(cb_cur_mm_out);
+    mm_init_short(cb_attention_weights, cb_value, /* transpose */ 0);
     for (uint32_t tile_idx = 0; tile_idx < Wt; tile_idx += block_size) {
         tile_regs_acquire();
         for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_compute_utils.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_compute_utils.hpp
@@ -285,7 +285,6 @@ void update_cur_exp_sum_inplace(uint32_t cb_prev_sum_exp, uint32_t cb_cur_sum_ex
 // Only reprograms UNPACK and MATH MOPs — safe inside a tile_regs_acquire block.
 // Uses reconfig_data_format_srcb so SrcA format register is preserved for the caller.
 void init_unary_bcast_col(uint32_t cb_col_vec) {
-    reconfig_data_format_srca(cb_col_vec);
     reconfig_data_format_srcb(cb_col_vec);
     UNPACK((llk_unpack_A_init<BroadcastType::COL, false, EltwiseBinaryReuseDestType::NONE, false>(
         false, false, cb_col_vec)));

--- a/tt-train/tests/ops/sdpa_bw_op_test.cpp
+++ b/tt-train/tests/ops/sdpa_bw_op_test.cpp
@@ -781,6 +781,7 @@ TEST_F(SDPABackwardTest, CausalMask_GQA) {
 }
 
 TEST_F(SDPABackwardTest, NIGHTLY_CausalMask_NanoGPTConfig) {
+    SKIP_FOR_LLK_ASSERTS("Skip due to too large code size when assert is enabled.");
     // D=128 + S=1024: wider tolerance for accumulated BF16 rounding
     SDPABackwardTestConfig config{
         .batch_size = 64U,
@@ -798,6 +799,7 @@ TEST_F(SDPABackwardTest, NIGHTLY_CausalMask_NanoGPTConfig) {
 }
 
 TEST_F(SDPABackwardTest, NIGHTLY_CausalMask_LargerSequence) {
+    SKIP_FOR_LLK_ASSERTS("Skip due to too large code size when assert is enabled.");
     // D=128 + S=1024: wider tolerance (see NIGHTLY_LargerSequence comment)
     SDPABackwardTestConfig config{
         .batch_size = 4U,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -46,8 +46,10 @@ inline void llk_unpack_A_init(
         llk_unpack_dbg_feature_disable();
     }
 
-    LLK_ASSERT_BLOCK(is_unpacker_A_configured_correctly<UnpackerProgramType::ProgramByTile>(
-        operand_unpack_src_format, operand_unpack_dst_format, face_r_dim, num_faces));
+    LLK_ASSERT_BLOCK((is_unpacker_A_configured_correctly<
+                      UnpackerProgramType::ProgramByTile,
+                      (BType != BroadcastType::NONE && !unpack_to_dest)>(
+        operand_unpack_src_format, operand_unpack_dst_format, face_r_dim, num_faces)));
 
     _llk_unpack_A_init_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
         transpose_of_faces,
@@ -71,11 +73,13 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
 
     LLK_ASSERT(cb_access_within_bounds(operand_id, tile_index, 1), "Indexed tile read exceeds CB boundary");
 
-    LLK_ASSERT_BLOCK(is_unpacker_A_configured_correctly<UnpackerProgramType::ProgramByTile>(
+    LLK_ASSERT_BLOCK((is_unpacker_A_configured_correctly<
+                      UnpackerProgramType::ProgramByTile,
+                      (BType != BroadcastType::NONE && !unpack_to_dest)>(
         unpack_src_format[operand_id],
         unpack_dst_format[operand_id],
         get_operand_face_r_dim(operand_id),
-        get_operand_num_faces(operand_id)));
+        get_operand_num_faces(operand_id))));
 
     WAYPOINT("UPAW");
     _llk_unpack_A_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -46,8 +46,10 @@ inline void llk_unpack_A_init(
         llk_unpack_dbg_feature_disable();
     }
 
-    LLK_ASSERT_BLOCK(is_unpacker_A_configured_correctly<UnpackerProgramType::ProgramByTile>(
-        operand_unpack_src_format, operand_unpack_dst_format, face_r_dim, num_faces));
+    LLK_ASSERT_BLOCK((is_unpacker_A_configured_correctly<
+                      UnpackerProgramType::ProgramByTile,
+                      (BType != BroadcastType::NONE && !unpack_to_dest)>(
+        operand_unpack_src_format, operand_unpack_dst_format, face_r_dim, num_faces)));
 
     _llk_unpack_A_init_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
         transpose_of_faces,
@@ -71,11 +73,13 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
 
     LLK_ASSERT(cb_access_within_bounds(operand_id, tile_index, 1), "Indexed tile read exceeds CB boundary");
 
-    LLK_ASSERT_BLOCK(is_unpacker_A_configured_correctly<UnpackerProgramType::ProgramByTile>(
+    LLK_ASSERT_BLOCK((is_unpacker_A_configured_correctly<
+                      UnpackerProgramType::ProgramByTile,
+                      (BType != BroadcastType::NONE && !unpack_to_dest)>(
         unpack_src_format[operand_id],
         unpack_dst_format[operand_id],
         get_operand_face_r_dim(operand_id),
-        get_operand_num_faces(operand_id)));
+        get_operand_num_faces(operand_id))));
 
     WAYPOINT("UPAW");
     _llk_unpack_A_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -1037,23 +1037,23 @@ enum class UnpackerProgramType
 };
 
 /**
- * Checks whether unpacker A tile descriptor and config match the expected formats and dimensions.
+ * Checks whether the selected single-unpacker tile descriptor and config match the expected formats and dimensions.
  * On any mismatch the function fires an `LLK_ASSERT` for the offending field with a descriptive
  * message; otherwise it returns normally.
  *
- * @param unpA_src_format   Expected input data format for unpacker A (context 0)
- * @param unpA_dst_format   Expected output data format for unpacker A (context 0)
- * @param unpA_face_r_dim   Expected face row dimension for unpacker A (default FACE_R_DIM)
- * @param unpA_num_faces    Expected number of faces for unpacker A (default TILE_NUM_FACES)
- * @param nop_count         Number of nop operations to ensure configuration writes complete (default 10)
+ * @param expected_src_format Expected input data format for the selected unpacker
+ * @param expected_dst_format Expected output data format for the selected unpacker
+ * @param expected_face_r_dim Expected face row dimension for the selected unpacker (default FACE_R_DIM)
+ * @param expected_num_faces  Expected number of faces for the selected unpacker (default TILE_NUM_FACES)
+ * @param nop_count           Number of nop operations to ensure configuration writes complete (default 10)
  */
-template <UnpackerProgramType program_type = UnpackerProgramType::ProgramByTile>
+template <UnpackerProgramType program_type = UnpackerProgramType::ProgramByTile, bool check_unpacker_b = false>
 __attribute__((noinline)) void is_unpacker_A_configured_correctly(
-    const std::uint32_t unpA_src_format,
-    const std::uint32_t unpA_dst_format,
-    const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
-    const std::uint32_t unpA_num_faces  = TILE_NUM_FACES,
-    const std::uint32_t nop_count       = 10)
+    const std::uint32_t expected_src_format,
+    const std::uint32_t expected_dst_format,
+    const std::uint32_t expected_face_r_dim = FACE_R_DIM,
+    const std::uint32_t expected_num_faces  = TILE_NUM_FACES,
+    const std::uint32_t nop_count           = 10)
 {
     // Ensure configuration writes complete before subsequent operations
     tensix_sync();
@@ -1064,47 +1064,89 @@ __attribute__((noinline)) void is_unpacker_A_configured_correctly(
 
     volatile std::uint32_t tt_reg_ptr *cfg = get_cfg_pointer();
 
-    // tile_descriptor[0] word 0: in_data_format at bits [3:0]
-    const std::uint32_t td_word0 = cfg[THCON_SEC0_REG0_TileDescriptor_ADDR32];
-    // unpack_config[0] word 0: out_data_format at bits [3:0]
-    const std::uint32_t cfg_word0 = cfg[THCON_SEC0_REG2_Out_data_format_ADDR32];
+    constexpr std::uint32_t tile_descriptor_addr = check_unpacker_b ? THCON_SEC1_REG0_TileDescriptor_ADDR32 : THCON_SEC0_REG0_TileDescriptor_ADDR32;
+    constexpr std::uint32_t unpack_config_addr   = check_unpacker_b ? THCON_SEC1_REG2_Out_data_format_ADDR32 : THCON_SEC0_REG2_Out_data_format_ADDR32;
 
-    const std::uint32_t expected_unpA_src_format = masked_data_format(unpA_src_format);
-    const std::uint32_t actual_unpA_src_format   = masked_data_format(td_word0);
-    if (expected_unpA_src_format != actual_unpA_src_format)
+    // tile_descriptor word 0: in_data_format at bits [3:0]
+    const std::uint32_t td_word0 = cfg[tile_descriptor_addr];
+    // unpack_config word 0: out_data_format at bits [3:0]
+    const std::uint32_t cfg_word0 = cfg[unpack_config_addr];
+
+    const std::uint32_t expected_unpack_src_format = masked_data_format(expected_src_format);
+    const std::uint32_t actual_unpack_src_format   = masked_data_format(td_word0);
+    if (expected_unpack_src_format != actual_unpack_src_format)
     {
-        // DEVICE_PRINT("#1001 unp_A_src_format mismatch. expected: {}, actual: {}\n", expected_unpA_src_format, actual_unpA_src_format);
-        LLK_ASSERT((expected_unpA_src_format == actual_unpA_src_format), "unp_A_src_format mismatch. Uncomment DEVICE_PRINT #1001 to inspect expected/actual.");
+        if constexpr (check_unpacker_b)
+        {
+            // DEVICE_PRINT("#1013 unp_B_src_format mismatch. expected: {}, actual: {}\n", expected_unpack_src_format, actual_unpack_src_format);
+            LLK_ASSERT(
+                expected_unpack_src_format == actual_unpack_src_format, "unp_B_src_format mismatch. Uncomment DEVICE_PRINT #1013 to inspect expected/actual.");
+        }
+        else
+        {
+            // DEVICE_PRINT("#1001 unp_A_src_format mismatch. expected: {}, actual: {}\n", expected_unpack_src_format, actual_unpack_src_format);
+            LLK_ASSERT(
+                expected_unpack_src_format == actual_unpack_src_format, "unp_A_src_format mismatch. Uncomment DEVICE_PRINT #1001 to inspect expected/actual.");
+        }
     }
 
-    const std::uint32_t expected_unpA_dst_format = masked_data_format(unpA_dst_format);
-    const std::uint32_t actual_unpA_dst_format   = masked_data_format(cfg_word0);
-    if (expected_unpA_dst_format != actual_unpA_dst_format)
+    const std::uint32_t expected_unpack_dst_format = masked_data_format(expected_dst_format);
+    const std::uint32_t actual_unpack_dst_format   = masked_data_format(cfg_word0);
+    if (expected_unpack_dst_format != actual_unpack_dst_format)
     {
-        // DEVICE_PRINT("#1002 unp_A_dst_format mismatch. expected: {}, actual: {}\n", expected_unpA_dst_format, actual_unpA_dst_format);
-        LLK_ASSERT(expected_unpA_dst_format == actual_unpA_dst_format, "unp_A_dst_format mismatch. Uncomment DEVICE_PRINT #1002 to inspect expected/actual.");
+        if constexpr (check_unpacker_b)
+        {
+            // DEVICE_PRINT("#1014 unp_B_dst_format mismatch. expected: {}, actual: {}\n", expected_unpack_dst_format, actual_unpack_dst_format);
+            LLK_ASSERT(
+                expected_unpack_dst_format == actual_unpack_dst_format, "unp_B_dst_format mismatch. Uncomment DEVICE_PRINT #1014 to inspect expected/actual.");
+        }
+        else
+        {
+            // DEVICE_PRINT("#1002 unp_A_dst_format mismatch. expected: {}, actual: {}\n", expected_unpack_dst_format, actual_unpack_dst_format);
+            LLK_ASSERT(
+                expected_unpack_dst_format == actual_unpack_dst_format, "unp_A_dst_format mismatch. Uncomment DEVICE_PRINT #1002 to inspect expected/actual.");
+        }
     }
 
     if constexpr (program_type == UnpackerProgramType::ProgramByTile)
     {
-        const std::uint32_t face_dim               = unpA_face_r_dim * FACE_C_DIM;
-        const std::uint32_t tile_x_dim_cntx0_value = cfg[THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32];
-        if (tile_x_dim_cntx0_value != (face_dim | (face_dim << 16)))
+        const std::uint32_t face_dim = expected_face_r_dim * FACE_C_DIM;
+        if constexpr (check_unpacker_b)
         {
-            // DEVICE_PRINT("#1003 unp_A_face_r_dim mismatch. expected: {}, actual: {}\n", face_dim, tile_x_dim_cntx0_value);
-            LLK_ASSERT(
-                (tile_x_dim_cntx0_value == (face_dim | (face_dim << 16))),
-                "unp_A_face_r_dim mismatch. Uncomment DEVICE_PRINT #1003 to inspect expected/actual.");
+            if ((td_word0 >> 16) != face_dim)
+            {
+                // DEVICE_PRINT("#1015 unp_B_face_r_dim mismatch. expected: {}, actual: {}\n", face_dim, (td_word0 >> 16));
+                LLK_ASSERT((td_word0 >> 16) == face_dim, "unp_B_face_r_dim mismatch. Uncomment DEVICE_PRINT #1015 to inspect expected/actual.");
+            }
+        }
+        else
+        {
+            const std::uint32_t tile_x_dim_cntx0_value = cfg[THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32];
+            if (tile_x_dim_cntx0_value != (face_dim | (face_dim << 16)))
+            {
+                // DEVICE_PRINT("#1003 unp_A_face_r_dim mismatch. expected: {}, actual: {}\n", face_dim, tile_x_dim_cntx0_value);
+                LLK_ASSERT(
+                    (tile_x_dim_cntx0_value == (face_dim | (face_dim << 16))),
+                    "unp_A_face_r_dim mismatch. Uncomment DEVICE_PRINT #1003 to inspect expected/actual.");
+            }
         }
     }
     else
     {
-        // tile_descriptor[0] word 1: z_dim at bits [31:16]
-        const std::uint32_t td_word1 = (cfg[THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1]) >> 16;
-        if (td_word1 != unpA_num_faces)
+        // tile_descriptor word 1: z_dim at bits [31:16]
+        const std::uint32_t td_word1 = (cfg[tile_descriptor_addr + 1]) >> 16;
+        if (td_word1 != expected_num_faces)
         {
-            // DEVICE_PRINT("#1004 unp_A_num_faces mismatch. expected: {}, actual: {}\n", unpA_num_faces, td_word1);
-            LLK_ASSERT((td_word1 == unpA_num_faces), "unp_A_num_faces mismatch. Uncomment DEVICE_PRINT #1004 to inspect expected/actual.");
+            if constexpr (check_unpacker_b)
+            {
+                // DEVICE_PRINT("#1016 unp_B_num_faces mismatch. expected: {}, actual: {}\n", expected_num_faces, td_word1);
+                LLK_ASSERT((td_word1 == expected_num_faces), "unp_B_num_faces mismatch. Uncomment DEVICE_PRINT #1016 to inspect expected/actual.");
+            }
+            else
+            {
+                // DEVICE_PRINT("#1004 unp_A_num_faces mismatch. expected: {}, actual: {}\n", expected_num_faces, td_word1);
+                LLK_ASSERT((td_word1 == expected_num_faces), "unp_A_num_faces mismatch. Uncomment DEVICE_PRINT #1004 to inspect expected/actual.");
+            }
         }
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -1028,23 +1028,23 @@ enum class UnpackerProgramType
 };
 
 /**
- * Checks whether unpacker A tile descriptor and config match the expected formats and dimensions.
+ * Checks whether the selected single-unpacker tile descriptor and config match the expected formats and dimensions.
  * On any mismatch the function fires an `LLK_ASSERT` for the offending field with a descriptive
  * message; otherwise it returns normally.
  *
- * @param unpA_src_format   Expected input data format for unpacker A (context 0)
- * @param unpA_dst_format   Expected output data format for unpacker A (context 0)
- * @param unpA_face_r_dim   Expected face row dimension for unpacker A (default FACE_R_DIM)
- * @param unpA_num_faces    Expected number of faces for unpacker A (default TILE_NUM_FACES)
- * @param nop_count         Number of nop operations to ensure configuration writes complete (default 10)
+ * @param expected_src_format Expected input data format for the selected unpacker
+ * @param expected_dst_format Expected output data format for the selected unpacker
+ * @param expected_face_r_dim Expected face row dimension for the selected unpacker (default FACE_R_DIM)
+ * @param expected_num_faces  Expected number of faces for the selected unpacker (default TILE_NUM_FACES)
+ * @param nop_count           Number of nop operations to ensure configuration writes complete (default 10)
  */
-template <UnpackerProgramType program_type = UnpackerProgramType::ProgramByTile>
+template <UnpackerProgramType program_type = UnpackerProgramType::ProgramByTile, bool check_unpacker_b = false>
 __attribute__((noinline)) void is_unpacker_A_configured_correctly(
-    const std::uint32_t unpA_src_format,
-    const std::uint32_t unpA_dst_format,
-    const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
-    const std::uint32_t unpA_num_faces  = TILE_NUM_FACES,
-    const std::uint32_t nop_count       = 10)
+    const std::uint32_t expected_src_format,
+    const std::uint32_t expected_dst_format,
+    const std::uint32_t expected_face_r_dim = FACE_R_DIM,
+    const std::uint32_t expected_num_faces  = TILE_NUM_FACES,
+    const std::uint32_t nop_count           = 10)
 {
     // Ensure configuration writes complete before subsequent operations
     tensix_sync();
@@ -1055,47 +1055,89 @@ __attribute__((noinline)) void is_unpacker_A_configured_correctly(
 
     volatile std::uint32_t tt_reg_ptr *cfg = get_cfg_pointer();
 
-    // tile_descriptor[0] word 0: in_data_format at bits [3:0]
-    const std::uint32_t td_word0 = cfg[THCON_SEC0_REG0_TileDescriptor_ADDR32];
-    // unpack_config[0] word 0: out_data_format at bits [3:0]
-    const std::uint32_t cfg_word0 = cfg[THCON_SEC0_REG2_Out_data_format_ADDR32];
+    constexpr std::uint32_t tile_descriptor_addr = check_unpacker_b ? THCON_SEC1_REG0_TileDescriptor_ADDR32 : THCON_SEC0_REG0_TileDescriptor_ADDR32;
+    constexpr std::uint32_t unpack_config_addr   = check_unpacker_b ? THCON_SEC1_REG2_Out_data_format_ADDR32 : THCON_SEC0_REG2_Out_data_format_ADDR32;
 
-    const std::uint32_t expected_unpA_src_format = masked_data_format(unpA_src_format);
-    const std::uint32_t actual_unpA_src_format   = masked_data_format(td_word0);
-    if (expected_unpA_src_format != actual_unpA_src_format)
+    // tile_descriptor word 0: in_data_format at bits [3:0]
+    const std::uint32_t td_word0 = cfg[tile_descriptor_addr];
+    // unpack_config word 0: out_data_format at bits [3:0]
+    const std::uint32_t cfg_word0 = cfg[unpack_config_addr];
+
+    const std::uint32_t expected_unpack_src_format = masked_data_format(expected_src_format);
+    const std::uint32_t actual_unpack_src_format   = masked_data_format(td_word0);
+    if (expected_unpack_src_format != actual_unpack_src_format)
     {
-        // DEVICE_PRINT("#2001 unp_A_src_format mismatch. expected: {}, actual: {}\n", expected_unpA_src_format, actual_unpA_src_format);
-        LLK_ASSERT((expected_unpA_src_format == actual_unpA_src_format), "unp_A_src_format mismatch. Uncomment DEVICE_PRINT #2001 to inspect expected/actual.");
+        if constexpr (check_unpacker_b)
+        {
+            // DEVICE_PRINT("#2013 unp_B_src_format mismatch. expected: {}, actual: {}\n", expected_unpack_src_format, actual_unpack_src_format);
+            LLK_ASSERT(
+                expected_unpack_src_format == actual_unpack_src_format, "unp_B_src_format mismatch. Uncomment DEVICE_PRINT #2013 to inspect expected/actual.");
+        }
+        else
+        {
+            // DEVICE_PRINT("#2001 unp_A_src_format mismatch. expected: {}, actual: {}\n", expected_unpack_src_format, actual_unpack_src_format);
+            LLK_ASSERT(
+                expected_unpack_src_format == actual_unpack_src_format, "unp_A_src_format mismatch. Uncomment DEVICE_PRINT #2001 to inspect expected/actual.");
+        }
     }
 
-    const std::uint32_t expected_unpA_dst_format = masked_data_format(unpA_dst_format);
-    const std::uint32_t actual_unpA_dst_format   = masked_data_format(cfg_word0);
-    if (expected_unpA_dst_format != actual_unpA_dst_format)
+    const std::uint32_t expected_unpack_dst_format = masked_data_format(expected_dst_format);
+    const std::uint32_t actual_unpack_dst_format   = masked_data_format(cfg_word0);
+    if (expected_unpack_dst_format != actual_unpack_dst_format)
     {
-        // DEVICE_PRINT("#2002 unp_A_dst_format mismatch. expected: {}, actual: {}\n", expected_unpA_dst_format, actual_unpA_dst_format);
-        LLK_ASSERT(expected_unpA_dst_format == actual_unpA_dst_format, "unp_A_dst_format mismatch. Uncomment DEVICE_PRINT #2002 to inspect expected/actual.");
+        if constexpr (check_unpacker_b)
+        {
+            // DEVICE_PRINT("#2014 unp_B_dst_format mismatch. expected: {}, actual: {}\n", expected_unpack_dst_format, actual_unpack_dst_format);
+            LLK_ASSERT(
+                expected_unpack_dst_format == actual_unpack_dst_format, "unp_B_dst_format mismatch. Uncomment DEVICE_PRINT #2014 to inspect expected/actual.");
+        }
+        else
+        {
+            // DEVICE_PRINT("#2002 unp_A_dst_format mismatch. expected: {}, actual: {}\n", expected_unpack_dst_format, actual_unpack_dst_format);
+            LLK_ASSERT(
+                expected_unpack_dst_format == actual_unpack_dst_format, "unp_A_dst_format mismatch. Uncomment DEVICE_PRINT #2002 to inspect expected/actual.");
+        }
     }
 
     if constexpr (program_type == UnpackerProgramType::ProgramByTile)
     {
-        const std::uint32_t face_dim               = unpA_face_r_dim * FACE_C_DIM;
-        const std::uint32_t tile_x_dim_cntx0_value = cfg[THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32];
-        if (tile_x_dim_cntx0_value != (face_dim | (face_dim << 16)))
+        const std::uint32_t face_dim = expected_face_r_dim * FACE_C_DIM;
+        if constexpr (check_unpacker_b)
         {
-            // DEVICE_PRINT("#2003 unp_A_face_r_dim mismatch. expected: {}, actual: {}\n", face_dim, tile_x_dim_cntx0_value);
-            LLK_ASSERT(
-                (tile_x_dim_cntx0_value == (face_dim | (face_dim << 16))),
-                "unp_A_face_r_dim mismatch. Uncomment DEVICE_PRINT #2003 to inspect expected/actual.");
+            if ((td_word0 >> 16) != face_dim)
+            {
+                // DEVICE_PRINT("#2015 unp_B_face_r_dim mismatch. expected: {}, actual: {}\n", face_dim, (td_word0 >> 16));
+                LLK_ASSERT((td_word0 >> 16) == face_dim, "unp_B_face_r_dim mismatch. Uncomment DEVICE_PRINT #2015 to inspect expected/actual.");
+            }
+        }
+        else
+        {
+            const std::uint32_t tile_x_dim_cntx0_value = cfg[THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32];
+            if (tile_x_dim_cntx0_value != (face_dim | (face_dim << 16)))
+            {
+                // DEVICE_PRINT("#2003 unp_A_face_r_dim mismatch. expected: {}, actual: {}\n", face_dim, tile_x_dim_cntx0_value);
+                LLK_ASSERT(
+                    (tile_x_dim_cntx0_value == (face_dim | (face_dim << 16))),
+                    "unp_A_face_r_dim mismatch. Uncomment DEVICE_PRINT #2003 to inspect expected/actual.");
+            }
         }
     }
     else
     {
-        // tile_descriptor[0] word 1: z_dim at bits [31:16]
-        const std::uint32_t td_word1 = (cfg[THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1]) >> 16;
-        if (td_word1 != unpA_num_faces)
+        // tile_descriptor word 1: z_dim at bits [31:16]
+        const std::uint32_t td_word1 = (cfg[tile_descriptor_addr + 1]) >> 16;
+        if (td_word1 != expected_num_faces)
         {
-            // DEVICE_PRINT("#2004 unp_A_num_faces mismatch. expected: {}, actual: {}\n", unpA_num_faces, td_word1);
-            LLK_ASSERT((td_word1 == unpA_num_faces), "unp_A_num_faces mismatch. Uncomment DEVICE_PRINT #2004 to inspect expected/actual.");
+            if constexpr (check_unpacker_b)
+            {
+                // DEVICE_PRINT("#2016 unp_B_num_faces mismatch. expected: {}, actual: {}\n", expected_num_faces, td_word1);
+                LLK_ASSERT((td_word1 == expected_num_faces), "unp_B_num_faces mismatch. Uncomment DEVICE_PRINT #2016 to inspect expected/actual.");
+            }
+            else
+            {
+                // DEVICE_PRINT("#2004 unp_A_num_faces mismatch. expected: {}, actual: {}\n", expected_num_faces, td_word1);
+                LLK_ASSERT((td_word1 == expected_num_faces), "unp_A_num_faces mismatch. Uncomment DEVICE_PRINT #2004 to inspect expected/actual.");
+            }
         }
     }
 }


### PR DESCRIPTION
### Summary
Fixes SDPA FW compute-kernel data format setup ordering in `sdpa_compute_utils.hpp`.
Addresses the issue: https://github.com/tenstorrent/tt-metal/issues/43706

### Notes for reviewers
LLK_ASSERT hit on this kernel was caught as part of nightly debug run with LLK_ASSERTS enabled: https://github.com/tenstorrent/tt-metal/actions/runs/25355605579

TT-train related tests fixed:
https://github.com/tenstorrent/tt-metal/actions/runs/25428943705

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fix-sdpa-fw-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix-sdpa-fw-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/fix-sdpa-fw-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/fix-sdpa-fw-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/fix-sdpa-fw-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/fix-sdpa-fw-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix-sdpa-fw-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix-sdpa-fw-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/fix-sdpa-fw-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/fix-sdpa-fw-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix-sdpa-fw-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix-sdpa-fw-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix-sdpa-fw-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix-sdpa-fw-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix-sdpa-fw-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix-sdpa-fw-llk-assert)