### PR TITLE
Allow runtime tile counts in BH pack block

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_pack_block_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_pack_block_api.h
@@ -39,8 +39,7 @@ inline void llk_pack_block_contiguous_mop_config(const std::uint32_t output) {
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_block_contiguous(std::uint32_t tile_index, std::uint32_t output, std::uint32_t num_tiles) {
     LLK_ASSERT(
-        (num_tiles >= 1 && num_tiles <= 8 &&
-         ((tile_index + num_tiles - 1) < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>())),
+        (num_tiles >= 1 && ((tile_index + num_tiles - 1) < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>())),
         "num_tiles must be in the range [1, 8], and the destination tile range must fit within the packer "
         "capacity for the configured W-stride.");
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_pack_block_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_pack_block_api.h
@@ -35,13 +35,13 @@ inline void llk_pack_block_contiguous_mop_config(const std::uint32_t output) {
 // Pack num_tiles tiles from sparse DEST to dense L1 in a single call.
 // tile_index: starting DEST tile slot (typically 0).
 // output: CB identifier.
-// num_tiles: number of tiles to pack (1-8, runtime parameter).
+// num_tiles: number of tiles to pack; the destination tile range must fit within DEST capacity.
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_block_contiguous(std::uint32_t tile_index, std::uint32_t output, std::uint32_t num_tiles) {
     LLK_ASSERT(
         (num_tiles >= 1 && ((tile_index + num_tiles - 1) < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>())),
-        "num_tiles must be in the range [1, 8], and the destination tile range must fit within the packer "
-        "capacity for the configured W-stride.");
+        "num_tiles must be at least 1, and the destination tile range must fit within the packer capacity "
+        "for the configured W-stride.");
 
     std::uint8_t output_id = get_output_id(output);
     std::uint32_t pack_tile_addr =


### PR DESCRIPTION
### Summary
- Relaxes the Blackhole contiguous pack-block assert to rely on DEST capacity instead of a fixed 8-tile cap.
Issue caught by nightly debug run with LLK_ASSERTS enabled

### Notes for reviewers
- Ran and verified locally
- Related run context: https://github.com/tenstorrent/tt-metal/actions/runs/25355605579/job/74464992529
- Failing test: models/demos/deepseek_v3_b1/tests/unit_tests/test_matmul.py::test_matmul_single_core[1-128-512-DataType.BFLOAT16-DataType.BFLOAT8_B-False-None-False]

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fix-bh-pack-block-tile-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix-bh-pack-block-tile-count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/fix-bh-pack-block-tile-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/fix-bh-pack-block-tile-count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/fix-bh-pack-block-tile-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/fix-bh-pack-block-tile-count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix-bh-pack-block-tile-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix-bh-pack-block-tile-count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/fix-bh-pack-block-tile-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/fix-bh-pack-block-tile-count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix-bh-pack-block-tile-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix-bh-pack-block-tile-count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix-bh-pack-block-tile-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix-bh-pack-block-tile-count)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix-bh-pack-block-tile-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix-bh-pack-block-tile-count)