### PR TITLE
Fix groupnorm sharded reconfiguration order

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
@@ -235,8 +235,8 @@ void kernel_main() {
         cb_ex_global.wait_front(2 * num_groups);
         cb_ex2pe.reserve_back(num_groups);
         // (Var + eps)
-        add_tiles_init(cb_ex_global_id, cb_eps_id);
         reconfig_data_format_srcb(cb_eps_id);
+        add_tiles_init(cb_ex_global_id, cb_eps_id);
         for (uint32_t g = 0; g < num_groups; ++g) {
             tile_regs_acquire();
             add_tiles(cb_ex_global_id, cb_eps_id, 1 + (g << 1), 0, dst0);
@@ -281,8 +281,8 @@ void kernel_main() {
 
                     // // Now let us do the actual computation for the current group here
                     // // a. x-u
-                    sub_tiles_bcast_scalar_init_short(cb_in0_id, cb_ex_global_id);
                     reconfig_data_format(cb_in0_id, cb_ex_global_id);
+                    sub_tiles_bcast_scalar_init_short(cb_in0_id, cb_ex_global_id);
 
                     tile_regs_acquire();
 #ifdef TILIZE_IN
@@ -299,8 +299,8 @@ void kernel_main() {
                     const uint32_t mask_offset = g * block_w;
                     const uint32_t mask_index = mask_offset + block_w_index;
 
-                    mul_tiles_bcast_scalar_init_short(cb_input_mask_id, cb_ex2pe_id);
                     reconfig_data_format(cb_in0_id, cb_input_mask_id, cb_ex_global_id, cb_ex2pe_id);
+                    mul_tiles_bcast_scalar_init_short(cb_input_mask_id, cb_ex2pe_id);
                     tile_regs_acquire();
                     mul_tiles_bcast_scalar(cb_input_mask_id, cb_ex2pe_id, mask_index, g, dst0);
                     tile_regs_commit();
@@ -311,8 +311,8 @@ void kernel_main() {
 
                     // // c. a * b
                     cb_xmm.wait_front(2);
-                    mul_tiles_init(cb_xmm_id, cb_xmm_id);
                     reconfig_data_format(cb_input_mask_id, cb_xmm_id, cb_ex2pe_id, cb_xmm_id);
+                    mul_tiles_init(cb_xmm_id, cb_xmm_id);
                     tile_regs_acquire();
                     mul_tiles(cb_xmm_id, cb_xmm_id, 0, 1, dst0);
                     tile_regs_commit();
@@ -387,8 +387,8 @@ void kernel_main() {
                 ++tile_id;
 
                 if constexpr (do_gamma) {
-                    mul_bcast_rows_init_short(cb_x_id, cb_gamma_id);
                     reconfig_data_format_srcb(cb_xmm_id, cb_gamma_id);
+                    mul_bcast_rows_init_short(cb_x_id, cb_gamma_id);
 
                     cb_x.wait_front(1);
                     tile_regs_acquire();
@@ -403,8 +403,8 @@ void kernel_main() {
                 }
 
                 if constexpr (do_beta) {
-                    add_bcast_rows_init_short(cb_x_id, cb_beta_id);
                     reconfig_data_format_srcb(do_gamma ? cb_gamma_id : cb_xmm_id, cb_beta_id);
+                    add_bcast_rows_init_short(cb_x_id, cb_beta_id);
 
                     cb_x.wait_front(1);
                     tile_regs_acquire();
@@ -419,8 +419,8 @@ void kernel_main() {
                 }
 
                 // Write out the final output
-                copy_tile_init(cb_x_id);
                 reconfig_data_format_srcb(do_beta ? cb_beta_id : cb_xmm_id, cb_x_id);
+                copy_tile_init(cb_x_id);
 
                 cb_x.wait_front(1);
                 tile_regs_acquire();


### PR DESCRIPTION
### Summary
This PR fixes order of LLK HW reconfig and init calls in sharded Welford groupnorm. The issue is caught by running the kernel with LLK_ASSERT enabled.

### Notes for reviewers
- Related run context: https://github.com/tenstorrent/tt-metal/actions/runs/25385572898

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fix-groupnorm-sharded-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix-groupnorm-sharded-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/fix-groupnorm-sharded-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/fix-groupnorm-sharded-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/fix-groupnorm-sharded-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/fix-groupnorm-sharded-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix-groupnorm-sharded-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix-groupnorm-sharded-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/fix-groupnorm-sharded-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/fix-groupnorm-sharded-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix-groupnorm-sharded-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix-groupnorm-sharded-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix-groupnorm-sharded-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix-groupnorm-sharded-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix-groupnorm-sharded-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix-groupnorm-sharded-llk-assert)