### PR TITLE
[Feature]: Adding multi-threaded variants of tensor accessor iterator for Quasar

### DIFF
--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/copy_strided_shards.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/copy_strided_shards.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/copy_strided_shards.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/copy_strided_shards.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Strided shard pages copy kernel — whole-shard granularity.
+
+Each core (simulating one DM thread) copies the shards assigned to it:
+  shards at indices: first_shard_id, first_shard_id + num_cores, ...
+
+Runtime args (slots 0–4):
+  0: input_base_address
+  1: output_base_address
+  2: first_shard_id   — first shard index owned by this core (== core rank / tid)
+  3: num_cores        — stride between consecutive shards owned by the same core
+  4: n_shards         — number of shards assigned to THIS core
+
+total_shards sentinel passed to StridedShardPages is derived as:
+  first_shard_id + n_shards * num_cores
+This is the first shard index that would exceed this core's assignment, making the
+range equivalent to { first_shard_id, first_shard_id+num_cores, ... } for n_shards steps.
+
+Uses StridedShardPages proxy to iterate over the assigned shard subset.
+*/
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "api/tensor/tensor_accessor.h"
+
+void kernel_main() {
+    uint32_t aligned_page_size = get_compile_time_arg_val(0);
+    auto args_src = TensorAccessorArgs<1, 0>();
+    auto args_dst =
+        TensorAccessorArgs<args_src.next_compile_time_args_offset(), args_src.next_common_runtime_args_offset()>();
+
+    uint32_t input_base_address  = get_arg_val<uint32_t>(0);
+    uint32_t output_base_address = get_arg_val<uint32_t>(1);
+    uint32_t first_shard_id      = get_arg_val<uint32_t>(2);
+    uint32_t num_cores           = get_arg_val<uint32_t>(3);
+    uint32_t n_shards            = get_arg_val<uint32_t>(4);  // per-core count, not global total
+
+    // Derive the sentinel: one stride past the last shard this core owns.
+    uint32_t total_shards = first_shard_id + n_shards * num_cores;
+
+    auto tensor_accessor_src = TensorAccessor(args_src, input_base_address, aligned_page_size);
+    auto tensor_accessor_dst = TensorAccessor(args_dst, output_base_address, aligned_page_size);
+
+    // Iterate over shards assigned to this core: first_shard_id, first_shard_id+num_cores, ...
+    tensor_accessor::StridedShardPages strided_shards(
+        tensor_accessor_src, first_shard_id, total_shards, num_cores);
+
+    for (const auto& shard_range : strided_shards) {
+        for (const auto& page : shard_range) {
+            noc_async_write_page(page.page_id(), tensor_accessor_dst, page.noc_addr());
+            noc_async_writes_flushed();
+        }
+    }
+    noc_async_write_barrier();
+}

--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/reader_strided_pages_dfb.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/reader_strided_pages_dfb.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Strided pages DFB producer kernel.
+
+Reads strided tensor pages and pushes each into the DFB.
+Works for WH/BH (1 thread → all pages) and Quasar (N threads → every N-th page each).
+On Quasar, strided_pages() uses get_my_thread_id() / get_num_threads() directly.
+
+Compile-time args: TensorAccessorArgs CTAs starting at index 0.
+    Host passes these via the KERNEL_COMPILE_TIME_ARGS compiler define.
+Runtime args (positional, accessed via get_arg_val):
+    [0] input tensor base address
+    [1] total number of pages
+DFB binding: local accessor name "my_dfb" (PRODUCER endpoint)
+*/
+
+#include "experimental/noc.h"
+#include "experimental/tensor.h"
+#include "experimental/dataflow_buffer.h"
+#include "api/tensor/tensor_accessor.h"
+
+void kernel_main() {
+    auto args_src = TensorAccessorArgs<0, 0>();
+    uint32_t base_addr = get_arg_val<uint32_t>(0);
+    uint32_t total_pages = get_arg_val<uint32_t>(1);
+
+    auto accessor = TensorAccessor(args_src, base_addr);
+    experimental::DataflowBuffer buf(dfb::my_dfb);
+    experimental::Noc noc;
+    uint32_t page_size = args_src.get_aligned_page_size();
+
+    for (const auto& page : accessor.strided_pages(total_pages)) {
+        buf.reserve_back(1);
+        noc.async_read(page, buf, page_size, {}, {});
+        noc.async_read_barrier();
+        buf.push_back(1);
+    }
+    buf.finish();
+}

--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/writer_strided_pages_dfb.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/writer_strided_pages_dfb.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Strided pages DFB consumer kernel.
+
+Pops DFB entries and writes each to its strided tensor page.
+Works for WH/BH (1 thread → all pages) and Quasar (N threads → every N-th page each).
+On Quasar, strided_pages() uses get_my_thread_id() / get_num_threads() directly.
+
+Compile-time args: TensorAccessorArgs CTAs starting at index 0.
+    Host passes these via the KERNEL_COMPILE_TIME_ARGS compiler define.
+Runtime args (positional, accessed via get_arg_val):
+    [0] output tensor base address
+    [1] total number of pages
+DFB binding: local accessor name "my_dfb" (CONSUMER endpoint)
+*/
+
+#include "experimental/noc.h"
+#include "experimental/tensor.h"
+#include "experimental/dataflow_buffer.h"
+#include "api/tensor/tensor_accessor.h"
+
+void kernel_main() {
+    auto args_dst = TensorAccessorArgs<0, 0>();
+    uint32_t base_addr = get_arg_val<uint32_t>(0);
+    uint32_t total_pages = get_arg_val<uint32_t>(1);
+
+    auto accessor = TensorAccessor(args_dst, base_addr);
+    experimental::DataflowBuffer buf(dfb::my_dfb);
+    experimental::Noc noc;
+    uint32_t page_size = args_dst.get_aligned_page_size();
+
+    for (const auto& page : accessor.strided_pages(total_pages)) {
+        buf.wait_front(1);
+        noc.async_write(buf, page, page_size, {}, {});
+        noc.async_write_barrier();
+        buf.pop_front(1);
+    }
+    buf.finish();
+    buf.write_barrier(noc);
+}

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor.cpp
@@ -546,6 +546,7 @@ using namespace strided_threading_tests;
 TEST(StridedPagesTests, Interleaved_4Threads_CoverageAndOrder) {
     constexpr uint32_t N = 12;
     constexpr uint32_t num_banks = 4;
+    constexpr uint32_t num_threads = 4;
     using TensorShape = ArrayWrapperU32<N>;
     using ShardShape = ArrayWrapperU32<N>;
     using BankCoords = ArrayWrapperDynamic;
@@ -555,17 +556,18 @@ TEST(StridedPagesTests, Interleaved_4Threads_CoverageAndOrder) {
     auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
 
     const std::vector<std::vector<uint32_t>> expected = {{0, 4, 8}, {1, 5, 9}, {2, 6, 10}, {3, 7, 11}};
-    for (uint32_t tid = 0; tid < 4; tid++) {
-        auto ids = collect_page_ids(pages_for_thread(accessor, tid, 4));
+    for (uint32_t tid = 0; tid < num_threads; tid++) {
+        auto ids = collect_page_ids(pages_for_thread(accessor, tid, num_threads));
         EXPECT_EQ(ids, expected[tid]) << "Thread " << tid << " page_ids mismatch";
     }
-    assert_full_coverage_no_overlap(accessor, 4);
+    assert_full_coverage_no_overlap(accessor, num_threads);
 }
 
 // Tensor volume=10, num_threads=3 (not a divisor) — lengths differ by at most 1
 TEST(StridedPagesTests, NonDivisorThreadCount_FullCoverage) {
     constexpr uint32_t N = 10;
     constexpr uint32_t num_banks = 2;
+    constexpr uint32_t num_threads = 3;
     using TensorShape = ArrayWrapperU32<N>;
     using ShardShape = ArrayWrapperU32<N>;
     using BankCoords = ArrayWrapperDynamic;
@@ -575,18 +577,19 @@ TEST(StridedPagesTests, NonDivisorThreadCount_FullCoverage) {
     auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
 
     // thread 0: {0,3,6,9}, thread 1: {1,4,7}, thread 2: {2,5,8}
-    auto ids0 = collect_page_ids(pages_for_thread(accessor, 0, 3));
-    auto ids1 = collect_page_ids(pages_for_thread(accessor, 1, 3));
-    auto ids2 = collect_page_ids(pages_for_thread(accessor, 2, 3));
+    auto ids0 = collect_page_ids(pages_for_thread(accessor, 0, num_threads));
+    auto ids1 = collect_page_ids(pages_for_thread(accessor, 1, num_threads));
+    auto ids2 = collect_page_ids(pages_for_thread(accessor, 2, num_threads));
     EXPECT_EQ(ids0, (std::vector<uint32_t>{0, 3, 6, 9}));
     EXPECT_EQ(ids1, (std::vector<uint32_t>{1, 4, 7}));
     EXPECT_EQ(ids2, (std::vector<uint32_t>{2, 5, 8}));
-    assert_full_coverage_no_overlap(accessor, 3);
+    assert_full_coverage_no_overlap(accessor, num_threads);
 }
 
 // Single thread behaves identically to pages(0, total) — regression guard
 TEST(StridedPagesTests, SingleThread_FullTensorInOrder) {
     constexpr uint32_t num_banks = 4;
+    constexpr uint32_t num_threads = 1;
     using TensorShape = ArrayWrapperU32<2, 3>;
     using ShardShape = ArrayWrapperU32<1, 2>;
     using BankCoords = ArrayWrapperDynamic;
@@ -595,7 +598,7 @@ TEST(StridedPagesTests, SingleThread_FullTensorInOrder) {
     std::array<uint16_t, num_banks> bank_coords{};
     auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
 
-    auto strided_ids = collect_page_ids(pages_for_thread(accessor, 0, 1));
+    auto strided_ids = collect_page_ids(pages_for_thread(accessor, 0, num_threads));
     auto contiguous_ids = collect_page_ids(accessor.pages());
     EXPECT_EQ(strided_ids, contiguous_ids) << "stride=1 must yield identical results to pages()";
 }
@@ -612,13 +615,15 @@ TEST(StridedPagesTests, EmptyRange_NoPagesYielded) {
     auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
 
     // start == end means empty range
-    auto ids = collect_page_ids(tensor_accessor::Pages(accessor, 5u, 5u, 1u, (uint8_t)0));
+    constexpr uint32_t page_start_end = 5;
+    auto ids = collect_page_ids(tensor_accessor::Pages(accessor, page_start_end, page_start_end, 1u, (uint8_t)0));
     EXPECT_TRUE(ids.empty()) << "Empty range should produce no pages";
 }
 
 // 2D sharded tensor [4,4], shard [2,2], 4 banks, 4 threads
 TEST(StridedPagesTests, Sharded2D_4Threads_FullCoverage) {
     constexpr uint32_t num_banks = 4;
+    constexpr uint32_t num_threads = 4;
     using TensorShape = ArrayWrapperU32<4, 4>;
     using ShardShape = ArrayWrapperU32<2, 2>;
     using BankCoords = ArrayWrapperDynamic;
@@ -628,13 +633,14 @@ TEST(StridedPagesTests, Sharded2D_4Threads_FullCoverage) {
     auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
 
     EXPECT_EQ(accessor.dspec().tensor_volume(), 16u);
-    assert_full_coverage_no_overlap(accessor, 4);
+    assert_full_coverage_no_overlap(accessor, num_threads);
 }
 
 // 1D sharded tensor [16], shard [4], 4 banks, 4 threads
 // Thread i gets pages {i, i+4, i+8, i+12}
 TEST(StridedPagesTests, Sharded1D_4Threads_CoverageAndOrder) {
     constexpr uint32_t num_banks = 4;
+    constexpr uint32_t num_threads = 4;
     using TensorShape = ArrayWrapperU32<16>;
     using ShardShape = ArrayWrapperU32<4>;
     using BankCoords = ArrayWrapperDynamic;
@@ -645,11 +651,11 @@ TEST(StridedPagesTests, Sharded1D_4Threads_CoverageAndOrder) {
 
     const std::vector<std::vector<uint32_t>> expected = {
         {0, 4, 8, 12}, {1, 5, 9, 13}, {2, 6, 10, 14}, {3, 7, 11, 15}};
-    for (uint32_t tid = 0; tid < 4; tid++) {
-        auto ids = collect_page_ids(pages_for_thread(accessor, tid, 4));
+    for (uint32_t tid = 0; tid < num_threads; tid++) {
+        auto ids = collect_page_ids(pages_for_thread(accessor, tid, num_threads));
         EXPECT_EQ(ids, expected[tid]) << "Thread " << tid << " page_ids mismatch";
     }
-    assert_full_coverage_no_overlap(accessor, 4);
+    assert_full_coverage_no_overlap(accessor, num_threads);
 }
 
 // -----------------------------------------------------------------------
@@ -699,6 +705,7 @@ TEST(ShardPagesTests, PaddedShard_SkipsOutOfBounds) {
 // 4 shards, 4 threads: thread i owns exactly shard i
 TEST(StridedShardPagesTests, FourShards_FourThreads_OneShardEach) {
     constexpr uint32_t num_banks = 4;
+    constexpr uint32_t num_threads = 4;
     using TensorShape = ArrayWrapperU32<8>;
     using ShardShape = ArrayWrapperU32<2>;
     using BankCoords = ArrayWrapperDynamic;
@@ -709,16 +716,16 @@ TEST(StridedShardPagesTests, FourShards_FourThreads_OneShardEach) {
 
     ASSERT_EQ(accessor.dspec().tensor_volume() / accessor.dspec().shard_volume(), 4u);
 
-    for (uint32_t tid = 0; tid < 4; tid++) {
-        auto shards = shard_ids_for_thread(accessor, tid, 4);
+    for (uint32_t tid = 0; tid < num_threads; tid++) {
+        auto shards = shard_ids_for_thread(accessor, tid, num_threads);
         ASSERT_EQ(shards.size(), 1u) << "Thread " << tid << " should own exactly 1 shard";
         EXPECT_EQ(shards[0], tid) << "Thread " << tid << " should own shard " << tid;
     }
 
     // Full coverage: all 4 shards seen exactly once
     std::vector<uint32_t> all_shards;
-    for (uint32_t tid = 0; tid < 4; tid++) {
-        auto s = shard_ids_for_thread(accessor, tid, 4);
+    for (uint32_t tid = 0; tid < num_threads; tid++) {
+        auto s = shard_ids_for_thread(accessor, tid, num_threads);
         all_shards.insert(all_shards.end(), s.begin(), s.end());
     }
     std::sort(all_shards.begin(), all_shards.end());
@@ -728,6 +735,7 @@ TEST(StridedShardPagesTests, FourShards_FourThreads_OneShardEach) {
 // 8 shards, 4 threads: thread 0 gets shards {0,4}, thread 1: {1,5}, etc.
 TEST(StridedShardPagesTests, EightShards_FourThreads_TwoShardsEach) {
     constexpr uint32_t num_banks = 4;
+    constexpr uint32_t num_threads = 4;
     using TensorShape = ArrayWrapperU32<16>;
     using ShardShape = ArrayWrapperU32<2>;
     using BankCoords = ArrayWrapperDynamic;
@@ -739,15 +747,15 @@ TEST(StridedShardPagesTests, EightShards_FourThreads_TwoShardsEach) {
     ASSERT_EQ(accessor.dspec().tensor_volume() / accessor.dspec().shard_volume(), 8u);
 
     const std::vector<std::vector<uint32_t>> expected_shards = {{0, 4}, {1, 5}, {2, 6}, {3, 7}};
-    for (uint32_t tid = 0; tid < 4; tid++) {
-        auto shards = shard_ids_for_thread(accessor, tid, 4);
+    for (uint32_t tid = 0; tid < num_threads; tid++) {
+        auto shards = shard_ids_for_thread(accessor, tid, num_threads);
         EXPECT_EQ(shards, expected_shards[tid]) << "Thread " << tid << " shard assignment mismatch";
     }
 
     // Full coverage
     std::vector<uint32_t> all_shards;
-    for (uint32_t tid = 0; tid < 4; tid++) {
-        auto s = shard_ids_for_thread(accessor, tid, 4);
+    for (uint32_t tid = 0; tid < num_threads; tid++) {
+        auto s = shard_ids_for_thread(accessor, tid, num_threads);
         all_shards.insert(all_shards.end(), s.begin(), s.end());
     }
     std::sort(all_shards.begin(), all_shards.end());
@@ -757,6 +765,7 @@ TEST(StridedShardPagesTests, EightShards_FourThreads_TwoShardsEach) {
 // 5 shards, 4 threads: thread 0 gets shards {0,4}, threads 1-3 get 1 shard each
 TEST(StridedShardPagesTests, FiveShards_FourThreads_NonDivisor) {
     constexpr uint32_t num_banks = 5;
+    constexpr uint32_t num_threads = 4;
     using TensorShape = ArrayWrapperU32<10>;
     using ShardShape = ArrayWrapperU32<2>;
     using BankCoords = ArrayWrapperDynamic;
@@ -767,10 +776,10 @@ TEST(StridedShardPagesTests, FiveShards_FourThreads_NonDivisor) {
 
     ASSERT_EQ(accessor.dspec().tensor_volume() / accessor.dspec().shard_volume(), 5u);
 
-    auto shards0 = shard_ids_for_thread(accessor, 0, 4);
-    auto shards1 = shard_ids_for_thread(accessor, 1, 4);
-    auto shards2 = shard_ids_for_thread(accessor, 2, 4);
-    auto shards3 = shard_ids_for_thread(accessor, 3, 4);
+    auto shards0 = shard_ids_for_thread(accessor, 0, num_threads);
+    auto shards1 = shard_ids_for_thread(accessor, 1, num_threads);
+    auto shards2 = shard_ids_for_thread(accessor, 2, num_threads);
+    auto shards3 = shard_ids_for_thread(accessor, 3, num_threads);
 
     EXPECT_EQ(shards0, (std::vector<uint32_t>{0, 4}));
     EXPECT_EQ(shards1, (std::vector<uint32_t>{1}));
@@ -779,8 +788,8 @@ TEST(StridedShardPagesTests, FiveShards_FourThreads_NonDivisor) {
 
     // Full coverage, no shard visited twice
     std::vector<uint32_t> all_shards;
-    for (uint32_t tid = 0; tid < 4; tid++) {
-        auto s = shard_ids_for_thread(accessor, tid, 4);
+    for (uint32_t tid = 0; tid < num_threads; tid++) {
+        auto s = shard_ids_for_thread(accessor, tid, num_threads);
         all_shards.insert(all_shards.end(), s.begin(), s.end());
     }
     std::sort(all_shards.begin(), all_shards.end());
@@ -790,6 +799,7 @@ TEST(StridedShardPagesTests, FiveShards_FourThreads_NonDivisor) {
 // Single thread must visit all shards in order 0..num_shards-1
 TEST(StridedShardPagesTests, SingleThread_AllShardsInOrder) {
     constexpr uint32_t num_banks = 4;
+    constexpr uint32_t num_threads = 1;
     using TensorShape = ArrayWrapperU32<8>;
     using ShardShape = ArrayWrapperU32<2>;
     using BankCoords = ArrayWrapperDynamic;
@@ -798,7 +808,7 @@ TEST(StridedShardPagesTests, SingleThread_AllShardsInOrder) {
     std::array<uint16_t, num_banks> bank_coords{};
     auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
 
-    auto shards = shard_ids_for_thread(accessor, 0, 1);
+    auto shards = shard_ids_for_thread(accessor, 0, num_threads);
     EXPECT_EQ(shards, (std::vector<uint32_t>{0, 1, 2, 3}));
 }
 
@@ -843,6 +853,7 @@ TEST(StridedShardPagesTests, InnerPagesFullCoverage) {
 //   shard 2 → page  {6}      (partial — shard memory has 3 slots, only 1 is logical)
 TEST(StridedShardPagesTests, PartialLastShard_NotTruncated) {
     constexpr uint32_t num_banks = 3;
+    constexpr uint32_t num_threads = 1;
     using TensorShape = ArrayWrapperU32<7>;
     using ShardShape  = ArrayWrapperU32<3>;
     using BankCoords  = ArrayWrapperDynamic;
@@ -851,11 +862,8 @@ TEST(StridedShardPagesTests, PartialLastShard_NotTruncated) {
     std::array<uint16_t, num_banks> bank_coords{};
     auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
 
-    ASSERT_EQ(accessor.dspec().tensor_volume(), 7u);
-    ASSERT_EQ(accessor.dspec().shard_volume(),  3u);
-
     // Single thread visits all 3 shards (including the partial one).
-    auto shards = shard_ids_for_thread(accessor, 0, 1);
+    auto shards = shard_ids_for_thread(accessor, 0, num_threads);
     EXPECT_EQ(shards, (std::vector<uint32_t>{0, 1, 2}))
         << "Partial last shard must not be truncated by floor division";
 
@@ -865,8 +873,8 @@ TEST(StridedShardPagesTests, PartialLastShard_NotTruncated) {
     const uint32_t total_shards  = (tensor_volume + shard_volume - 1) / shard_volume;
     std::vector<uint32_t> all_page_ids;
 
-    for (uint32_t tid = 0; tid < 1; tid++) {
-        tensor_accessor::StridedShardPages range(accessor, tid, total_shards, 1, (uint8_t)0);
+    for (uint32_t tid = 0; tid < num_threads; tid++) {
+        tensor_accessor::StridedShardPages range(accessor, tid, total_shards, num_threads, (uint8_t)0);
         for (const auto& shard_range : range) {
             for (const auto& page : shard_range) {
                 all_page_ids.push_back(page.page_id());
@@ -887,6 +895,7 @@ TEST(StridedShardPagesTests, PartialLastShard_NotTruncated) {
 //   thread 1 → shard  {1}
 TEST(StridedShardPagesTests, PartialLastShard_MultiThread_NoPagesLost) {
     constexpr uint32_t num_banks = 3;
+    constexpr uint32_t num_threads = 2;
     using TensorShape = ArrayWrapperU32<7>;
     using ShardShape  = ArrayWrapperU32<3>;
     using BankCoords  = ArrayWrapperDynamic;
@@ -895,8 +904,8 @@ TEST(StridedShardPagesTests, PartialLastShard_MultiThread_NoPagesLost) {
     std::array<uint16_t, num_banks> bank_coords{};
     auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
 
-    auto shards0 = shard_ids_for_thread(accessor, 0, 2);
-    auto shards1 = shard_ids_for_thread(accessor, 1, 2);
+    auto shards0 = shard_ids_for_thread(accessor, 0, num_threads);
+    auto shards1 = shard_ids_for_thread(accessor, 1, num_threads);
 
     EXPECT_EQ(shards0, (std::vector<uint32_t>{0, 2})) << "Thread 0 should own shards 0 and 2 (partial)";
     EXPECT_EQ(shards1, (std::vector<uint32_t>{1}))    << "Thread 1 should own shard 1";
@@ -907,8 +916,8 @@ TEST(StridedShardPagesTests, PartialLastShard_MultiThread_NoPagesLost) {
     const uint32_t total_shards  = (tensor_volume + shard_volume - 1) / shard_volume;
     std::vector<uint32_t> all_page_ids;
 
-    for (uint32_t tid = 0; tid < 2; tid++) {
-        tensor_accessor::StridedShardPages range(accessor, tid, total_shards, 2, (uint8_t)0);
+    for (uint32_t tid = 0; tid < num_threads; tid++) {
+        tensor_accessor::StridedShardPages range(accessor, tid, total_shards, num_threads, (uint8_t)0);
         for (const auto& shard_range : range) {
             for (const auto& page : shard_range) {
                 all_page_ids.push_back(page.page_id());

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor.cpp
@@ -26,7 +26,7 @@ constexpr auto get_ct_arg();
 #define get_compile_time_arg_val(arg_idx) get_ct_arg<arg_idx>()
 
 namespace tensor_accessor {
-uint64_t get_dram_bank_base_offset(uint32_t base_address, uint32_t bank_id, uint8_t noc);
+uint64_t get_dram_bank_base_offset(uint32_t bank_id, uint8_t noc);
 }
 
 [[maybe_unused]] static uint32_t my_x[1] = {0};
@@ -42,6 +42,11 @@ uint64_t get_dram_bank_base_offset(uint32_t base_address, uint32_t bank_id, uint
 #define DPRINT_MATH(x) x
 #define NOC_UNICAST_ADDR_X(addr) addr
 #define NOC_UNICAST_ADDR_Y(addr) addr
+// Stubs for L1 NOC address macros (used in TensorAccessor::get_noc_addr for !is_dram path).
+// Host-side tests only check page_id(), not actual NOC addresses, so the values don't matter.
+#define DYNAMIC_NOC_X(noc, x) (x)
+#define DYNAMIC_NOC_Y(noc, y) (y)
+#define NOC_XY_ADDR(x, y, addr) (static_cast<uint64_t>(x) << 32 | static_cast<uint64_t>(y) << 16 | static_cast<uint64_t>(addr))
 #endif
 
 #include "api/tensor/tensor_accessor.h"
@@ -54,6 +59,9 @@ uint64_t get_dram_bank_base_offset(uint32_t base_address, uint32_t bank_id, uint
 #undef DPRINT_DATA1
 #undef DPRINT_MATH
 #undef FORCE_INLINE
+#undef DYNAMIC_NOC_X
+#undef DYNAMIC_NOC_Y
+#undef NOC_XY_ADDR
 
 template <size_t... Dims>
 using ArrayWrapperU32 = tensor_accessor::ArrayStaticWrapperU32<Dims...>;
@@ -448,4 +456,469 @@ TEST(TensorAccessorTestsCRTA, CompiletimeTensorCompileTimeShardShapeRuntimeBanks
     auto sharded_accessor = TensorAccessor<dspec_t>(std::move(dspec_val), 0);
 
     crta_params::assert_sharded_accessor(sharded_accessor);
+}
+
+// ============================================================================
+// Strided DM threading model — host-side tests
+//
+// These tests validate the Pages / StridedShardPages proxies with explicit stride
+// arguments, simulating multiple DM threads without running on device.
+// strided_pages() / strided_shard_pages() expand to the same constructors internally;
+// here we drive them directly to test any tid/num_threads combination.
+// ============================================================================
+
+namespace strided_threading_tests {
+
+// Helper: collect all page_ids produced by a Pages range into a vector.
+template <typename PagesRange>
+std::vector<uint32_t> collect_page_ids(const PagesRange& range) {
+    std::vector<uint32_t> ids;
+    for (const auto& page : range) {
+        ids.push_back(page.page_id());
+    }
+    return ids;
+}
+
+// Helper: simulate strided_pages() for a specific (tid, num_threads) pair.
+template <typename AccessorT>
+auto pages_for_thread(const AccessorT& accessor, uint32_t tid, uint32_t num_threads, uint8_t noc = 0) {
+    return tensor_accessor::Pages(accessor, tid, accessor.dspec().tensor_volume(), num_threads, noc);
+}
+
+// Helper: assert that num_threads threads collectively cover every page in [0, tensor_volume) exactly once.
+template <typename AccessorT>
+void assert_full_coverage_no_overlap(const AccessorT& accessor, uint32_t num_threads) {
+    uint32_t tensor_volume = accessor.dspec().tensor_volume();
+    std::vector<uint32_t> all_seen;
+    for (uint32_t tid = 0; tid < num_threads; tid++) {
+        auto ids = collect_page_ids(pages_for_thread(accessor, tid, num_threads));
+        all_seen.insert(all_seen.end(), ids.begin(), ids.end());
+    }
+    std::sort(all_seen.begin(), all_seen.end());
+    ASSERT_EQ(all_seen.size(), tensor_volume) << "Total pages seen != tensor_volume";
+    for (uint32_t i = 0; i < tensor_volume; i++) {
+        EXPECT_EQ(all_seen[i], i) << "Missing or duplicate page_id " << i;
+    }
+}
+
+// Helper: simulate strided_shard_pages() for a specific (tid, num_threads) pair.
+// Returns the list of shard_ids visited by that thread.
+template <typename AccessorT>
+std::vector<uint32_t> shard_ids_for_thread(const AccessorT& accessor, uint32_t tid, uint32_t num_threads, uint8_t noc = 0) {
+    const uint32_t tensor_volume = accessor.dspec().tensor_volume();
+    const uint32_t shard_volume = accessor.dspec().shard_volume();
+    const uint32_t total_shards = (tensor_volume + shard_volume - 1) / shard_volume;
+    tensor_accessor::StridedShardPages range(accessor, tid, total_shards, num_threads, noc);
+    std::vector<uint32_t> shards;
+    uint32_t expected_shard_id = tid;
+    for (const auto& shard_range : range) {
+        // Verify shard range produces pages in order (by collecting and checking)
+        auto page_ids = collect_page_ids(shard_range);
+        EXPECT_FALSE(page_ids.empty()) << "Shard range should not be empty";
+        shards.push_back(expected_shard_id);
+        expected_shard_id += num_threads;
+    }
+    return shards;
+}
+
+// Helpers to create common test accessors
+template <uint32_t N, uint32_t NumBanks>
+auto make_1d_interleaved_accessor(uint32_t /*tensor_size*/) {
+    using TensorShape = ArrayWrapperU32<N>;
+    using ShardShape = ArrayWrapperU32<N>;
+    using BankCoords = ArrayWrapperDynamic;
+    using dspec_t = tensor_accessor::DistributionSpec<
+        1, NumBanks, TensorShape, ShardShape, BankCoords, /* IsInterleaved */ false>;
+    std::array<uint16_t, NumBanks> bank_coord_array{};
+    auto dspec_val = dspec_t({}, {}, bank_coord_array);
+    return TensorAccessor<dspec_t>(std::move(dspec_val), 0, 4096);
+}
+
+}  // namespace strided_threading_tests
+
+using namespace strided_threading_tests;
+
+// -----------------------------------------------------------------------
+// pages() with stride > 1 — interleaved-style (no shards)
+// -----------------------------------------------------------------------
+
+// Tensor [12], 4 banks, 4 threads: thread i gets pages {i, i+4, i+8}
+TEST(StridedPagesTests, Interleaved_4Threads_CoverageAndOrder) {
+    constexpr uint32_t N = 12;
+    constexpr uint32_t num_banks = 4;
+    using TensorShape = ArrayWrapperU32<N>;
+    using ShardShape = ArrayWrapperU32<N>;
+    using BankCoords = ArrayWrapperDynamic;
+    using dspec_t = tensor_accessor::DistributionSpec<1, num_banks, TensorShape, ShardShape, BankCoords>;
+
+    std::array<uint16_t, num_banks> bank_coords{};
+    auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
+
+    const std::vector<std::vector<uint32_t>> expected = {{0, 4, 8}, {1, 5, 9}, {2, 6, 10}, {3, 7, 11}};
+    for (uint32_t tid = 0; tid < 4; tid++) {
+        auto ids = collect_page_ids(pages_for_thread(accessor, tid, 4));
+        EXPECT_EQ(ids, expected[tid]) << "Thread " << tid << " page_ids mismatch";
+    }
+    assert_full_coverage_no_overlap(accessor, 4);
+}
+
+// Tensor volume=10, num_threads=3 (not a divisor) — lengths differ by at most 1
+TEST(StridedPagesTests, NonDivisorThreadCount_FullCoverage) {
+    constexpr uint32_t N = 10;
+    constexpr uint32_t num_banks = 2;
+    using TensorShape = ArrayWrapperU32<N>;
+    using ShardShape = ArrayWrapperU32<N>;
+    using BankCoords = ArrayWrapperDynamic;
+    using dspec_t = tensor_accessor::DistributionSpec<1, num_banks, TensorShape, ShardShape, BankCoords>;
+
+    std::array<uint16_t, num_banks> bank_coords{};
+    auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
+
+    // thread 0: {0,3,6,9}, thread 1: {1,4,7}, thread 2: {2,5,8}
+    auto ids0 = collect_page_ids(pages_for_thread(accessor, 0, 3));
+    auto ids1 = collect_page_ids(pages_for_thread(accessor, 1, 3));
+    auto ids2 = collect_page_ids(pages_for_thread(accessor, 2, 3));
+    EXPECT_EQ(ids0, (std::vector<uint32_t>{0, 3, 6, 9}));
+    EXPECT_EQ(ids1, (std::vector<uint32_t>{1, 4, 7}));
+    EXPECT_EQ(ids2, (std::vector<uint32_t>{2, 5, 8}));
+    assert_full_coverage_no_overlap(accessor, 3);
+}
+
+// Single thread behaves identically to pages(0, total) — regression guard
+TEST(StridedPagesTests, SingleThread_FullTensorInOrder) {
+    constexpr uint32_t num_banks = 4;
+    using TensorShape = ArrayWrapperU32<2, 3>;
+    using ShardShape = ArrayWrapperU32<1, 2>;
+    using BankCoords = ArrayWrapperDynamic;
+    using dspec_t = tensor_accessor::DistributionSpec<2, num_banks, TensorShape, ShardShape, BankCoords>;
+
+    std::array<uint16_t, num_banks> bank_coords{};
+    auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
+
+    auto strided_ids = collect_page_ids(pages_for_thread(accessor, 0, 1));
+    auto contiguous_ids = collect_page_ids(accessor.pages());
+    EXPECT_EQ(strided_ids, contiguous_ids) << "stride=1 must yield identical results to pages()";
+}
+
+// Empty range: Pages(accessor, 5, 5) — begin == end, no pages emitted
+TEST(StridedPagesTests, EmptyRange_NoPagesYielded) {
+    constexpr uint32_t num_banks = 4;
+    using TensorShape = ArrayWrapperU32<2, 3>;
+    using ShardShape = ArrayWrapperU32<1, 2>;
+    using BankCoords = ArrayWrapperDynamic;
+    using dspec_t = tensor_accessor::DistributionSpec<2, num_banks, TensorShape, ShardShape, BankCoords>;
+
+    std::array<uint16_t, num_banks> bank_coords{};
+    auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
+
+    // start == end means empty range
+    auto ids = collect_page_ids(tensor_accessor::Pages(accessor, 5u, 5u, 1u, (uint8_t)0));
+    EXPECT_TRUE(ids.empty()) << "Empty range should produce no pages";
+}
+
+// 2D sharded tensor [4,4], shard [2,2], 4 banks, 4 threads
+TEST(StridedPagesTests, Sharded2D_4Threads_FullCoverage) {
+    constexpr uint32_t num_banks = 4;
+    using TensorShape = ArrayWrapperU32<4, 4>;
+    using ShardShape = ArrayWrapperU32<2, 2>;
+    using BankCoords = ArrayWrapperDynamic;
+    using dspec_t = tensor_accessor::DistributionSpec<2, num_banks, TensorShape, ShardShape, BankCoords>;
+
+    std::array<uint16_t, num_banks> bank_coords{};
+    auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
+
+    EXPECT_EQ(accessor.dspec().tensor_volume(), 16u);
+    assert_full_coverage_no_overlap(accessor, 4);
+}
+
+// 1D sharded tensor [16], shard [4], 4 banks, 4 threads
+// Thread i gets pages {i, i+4, i+8, i+12}
+TEST(StridedPagesTests, Sharded1D_4Threads_CoverageAndOrder) {
+    constexpr uint32_t num_banks = 4;
+    using TensorShape = ArrayWrapperU32<16>;
+    using ShardShape = ArrayWrapperU32<4>;
+    using BankCoords = ArrayWrapperDynamic;
+    using dspec_t = tensor_accessor::DistributionSpec<1, num_banks, TensorShape, ShardShape, BankCoords>;
+
+    std::array<uint16_t, num_banks> bank_coords{};
+    auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
+
+    const std::vector<std::vector<uint32_t>> expected = {
+        {0, 4, 8, 12}, {1, 5, 9, 13}, {2, 6, 10, 14}, {3, 7, 11, 15}};
+    for (uint32_t tid = 0; tid < 4; tid++) {
+        auto ids = collect_page_ids(pages_for_thread(accessor, tid, 4));
+        EXPECT_EQ(ids, expected[tid]) << "Thread " << tid << " page_ids mismatch";
+    }
+    assert_full_coverage_no_overlap(accessor, 4);
+}
+
+// -----------------------------------------------------------------------
+// shard_pages() — existing API, no change (regression tests)
+// -----------------------------------------------------------------------
+
+TEST(ShardPagesTests, SingleShard_AllPages) {
+    constexpr uint32_t num_banks = 4;
+    using TensorShape = ArrayWrapperU32<2, 3>;
+    using ShardShape = ArrayWrapperU32<1, 2>;
+    using BankCoords = ArrayWrapperDynamic;
+    using dspec_t = tensor_accessor::DistributionSpec<2, num_banks, TensorShape, ShardShape, BankCoords>;
+
+    std::array<uint16_t, num_banks> bank_coords{};
+    auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
+
+    // Shard 0 contains global pages 0 and 1
+    auto ids0 = collect_page_ids(accessor.shard_pages(0));
+    EXPECT_EQ(ids0, (std::vector<uint32_t>{0, 1}));
+
+    // Shard 1 contains global page 2
+    auto ids1 = collect_page_ids(accessor.shard_pages(1));
+    EXPECT_EQ(ids1, (std::vector<uint32_t>{2}));
+}
+
+// Padded shard: tensor [3], shard [2], 2 banks — last shard has 1 valid + 1 padded page
+TEST(ShardPagesTests, PaddedShard_SkipsOutOfBounds) {
+    constexpr uint32_t num_banks = 2;
+    using TensorShape = ArrayWrapperU32<3>;
+    using ShardShape = ArrayWrapperU32<2>;
+    using BankCoords = ArrayWrapperDynamic;
+    using dspec_t = tensor_accessor::DistributionSpec<1, num_banks, TensorShape, ShardShape, BankCoords>;
+
+    std::array<uint16_t, num_banks> bank_coords{};
+    auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
+
+    // Shard 1 has only 1 valid page (page_id 2), the second slot is padding
+    auto ids = collect_page_ids(accessor.shard_pages(1));
+    EXPECT_EQ(ids.size(), 1u) << "Padded shard should yield only 1 valid page";
+    EXPECT_EQ(ids[0], 2u);
+}
+
+// -----------------------------------------------------------------------
+// strided_shard_pages() — whole-shard granularity (new)
+// -----------------------------------------------------------------------
+
+// 4 shards, 4 threads: thread i owns exactly shard i
+TEST(StridedShardPagesTests, FourShards_FourThreads_OneShardEach) {
+    constexpr uint32_t num_banks = 4;
+    using TensorShape = ArrayWrapperU32<8>;
+    using ShardShape = ArrayWrapperU32<2>;
+    using BankCoords = ArrayWrapperDynamic;
+    using dspec_t = tensor_accessor::DistributionSpec<1, num_banks, TensorShape, ShardShape, BankCoords>;
+
+    std::array<uint16_t, num_banks> bank_coords{};
+    auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
+
+    ASSERT_EQ(accessor.dspec().tensor_volume() / accessor.dspec().shard_volume(), 4u);
+
+    for (uint32_t tid = 0; tid < 4; tid++) {
+        auto shards = shard_ids_for_thread(accessor, tid, 4);
+        ASSERT_EQ(shards.size(), 1u) << "Thread " << tid << " should own exactly 1 shard";
+        EXPECT_EQ(shards[0], tid) << "Thread " << tid << " should own shard " << tid;
+    }
+
+    // Full coverage: all 4 shards seen exactly once
+    std::vector<uint32_t> all_shards;
+    for (uint32_t tid = 0; tid < 4; tid++) {
+        auto s = shard_ids_for_thread(accessor, tid, 4);
+        all_shards.insert(all_shards.end(), s.begin(), s.end());
+    }
+    std::sort(all_shards.begin(), all_shards.end());
+    EXPECT_EQ(all_shards, (std::vector<uint32_t>{0, 1, 2, 3}));
+}
+
+// 8 shards, 4 threads: thread 0 gets shards {0,4}, thread 1: {1,5}, etc.
+TEST(StridedShardPagesTests, EightShards_FourThreads_TwoShardsEach) {
+    constexpr uint32_t num_banks = 4;
+    using TensorShape = ArrayWrapperU32<16>;
+    using ShardShape = ArrayWrapperU32<2>;
+    using BankCoords = ArrayWrapperDynamic;
+    using dspec_t = tensor_accessor::DistributionSpec<1, num_banks, TensorShape, ShardShape, BankCoords>;
+
+    std::array<uint16_t, num_banks> bank_coords{};
+    auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
+
+    ASSERT_EQ(accessor.dspec().tensor_volume() / accessor.dspec().shard_volume(), 8u);
+
+    const std::vector<std::vector<uint32_t>> expected_shards = {{0, 4}, {1, 5}, {2, 6}, {3, 7}};
+    for (uint32_t tid = 0; tid < 4; tid++) {
+        auto shards = shard_ids_for_thread(accessor, tid, 4);
+        EXPECT_EQ(shards, expected_shards[tid]) << "Thread " << tid << " shard assignment mismatch";
+    }
+
+    // Full coverage
+    std::vector<uint32_t> all_shards;
+    for (uint32_t tid = 0; tid < 4; tid++) {
+        auto s = shard_ids_for_thread(accessor, tid, 4);
+        all_shards.insert(all_shards.end(), s.begin(), s.end());
+    }
+    std::sort(all_shards.begin(), all_shards.end());
+    EXPECT_EQ(all_shards, (std::vector<uint32_t>{0, 1, 2, 3, 4, 5, 6, 7}));
+}
+
+// 5 shards, 4 threads: thread 0 gets shards {0,4}, threads 1-3 get 1 shard each
+TEST(StridedShardPagesTests, FiveShards_FourThreads_NonDivisor) {
+    constexpr uint32_t num_banks = 5;
+    using TensorShape = ArrayWrapperU32<10>;
+    using ShardShape = ArrayWrapperU32<2>;
+    using BankCoords = ArrayWrapperDynamic;
+    using dspec_t = tensor_accessor::DistributionSpec<1, num_banks, TensorShape, ShardShape, BankCoords>;
+
+    std::array<uint16_t, num_banks> bank_coords{};
+    auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
+
+    ASSERT_EQ(accessor.dspec().tensor_volume() / accessor.dspec().shard_volume(), 5u);
+
+    auto shards0 = shard_ids_for_thread(accessor, 0, 4);
+    auto shards1 = shard_ids_for_thread(accessor, 1, 4);
+    auto shards2 = shard_ids_for_thread(accessor, 2, 4);
+    auto shards3 = shard_ids_for_thread(accessor, 3, 4);
+
+    EXPECT_EQ(shards0, (std::vector<uint32_t>{0, 4}));
+    EXPECT_EQ(shards1, (std::vector<uint32_t>{1}));
+    EXPECT_EQ(shards2, (std::vector<uint32_t>{2}));
+    EXPECT_EQ(shards3, (std::vector<uint32_t>{3}));
+
+    // Full coverage, no shard visited twice
+    std::vector<uint32_t> all_shards;
+    for (uint32_t tid = 0; tid < 4; tid++) {
+        auto s = shard_ids_for_thread(accessor, tid, 4);
+        all_shards.insert(all_shards.end(), s.begin(), s.end());
+    }
+    std::sort(all_shards.begin(), all_shards.end());
+    EXPECT_EQ(all_shards, (std::vector<uint32_t>{0, 1, 2, 3, 4}));
+}
+
+// Single thread must visit all shards in order 0..num_shards-1
+TEST(StridedShardPagesTests, SingleThread_AllShardsInOrder) {
+    constexpr uint32_t num_banks = 4;
+    using TensorShape = ArrayWrapperU32<8>;
+    using ShardShape = ArrayWrapperU32<2>;
+    using BankCoords = ArrayWrapperDynamic;
+    using dspec_t = tensor_accessor::DistributionSpec<1, num_banks, TensorShape, ShardShape, BankCoords>;
+
+    std::array<uint16_t, num_banks> bank_coords{};
+    auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
+
+    auto shards = shard_ids_for_thread(accessor, 0, 1);
+    EXPECT_EQ(shards, (std::vector<uint32_t>{0, 1, 2, 3}));
+}
+
+// strided_shard_pages() also covers all pages — inner loop delivers all pages within each shard
+TEST(StridedShardPagesTests, InnerPagesFullCoverage) {
+    constexpr uint32_t num_banks = 4;
+    using TensorShape = ArrayWrapperU32<8>;
+    using ShardShape = ArrayWrapperU32<2>;
+    using BankCoords = ArrayWrapperDynamic;
+    using dspec_t = tensor_accessor::DistributionSpec<1, num_banks, TensorShape, ShardShape, BankCoords>;
+
+    std::array<uint16_t, num_banks> bank_coords{};
+    auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
+
+    uint32_t num_threads = 2;
+    const uint32_t tensor_volume = accessor.dspec().tensor_volume();
+    const uint32_t shard_volume = accessor.dspec().shard_volume();
+    const uint32_t total_shards = (tensor_volume + shard_volume - 1) / shard_volume;
+    std::vector<uint32_t> all_page_ids;
+
+    for (uint32_t tid = 0; tid < num_threads; tid++) {
+        tensor_accessor::StridedShardPages range(accessor, tid, total_shards, num_threads, (uint8_t)0);
+        for (const auto& shard_range : range) {
+            for (const auto& page : shard_range) {
+                all_page_ids.push_back(page.page_id());
+            }
+        }
+    }
+
+    std::sort(all_page_ids.begin(), all_page_ids.end());
+    ASSERT_EQ(all_page_ids.size(), accessor.dspec().tensor_volume());
+    for (uint32_t i = 0; i < accessor.dspec().tensor_volume(); i++) {
+        EXPECT_EQ(all_page_ids[i], i) << "Missing or duplicate page_id " << i;
+    }
+}
+
+// Partial last shard: tensor_volume is not evenly divisible by shard_volume.
+//
+// Layout (tensor_shape={7}, shard_shape={3}, 3 banks):
+//   shard 0 → pages {0,1,2}  (full)
+//   shard 1 → pages {3,4,5}  (full)
+//   shard 2 → page  {6}      (partial — shard memory has 3 slots, only 1 is logical)
+TEST(StridedShardPagesTests, PartialLastShard_NotTruncated) {
+    constexpr uint32_t num_banks = 3;
+    using TensorShape = ArrayWrapperU32<7>;
+    using ShardShape  = ArrayWrapperU32<3>;
+    using BankCoords  = ArrayWrapperDynamic;
+    using dspec_t = tensor_accessor::DistributionSpec<1, num_banks, TensorShape, ShardShape, BankCoords>;
+
+    std::array<uint16_t, num_banks> bank_coords{};
+    auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
+
+    ASSERT_EQ(accessor.dspec().tensor_volume(), 7u);
+    ASSERT_EQ(accessor.dspec().shard_volume(),  3u);
+
+    // Single thread visits all 3 shards (including the partial one).
+    auto shards = shard_ids_for_thread(accessor, 0, 1);
+    EXPECT_EQ(shards, (std::vector<uint32_t>{0, 1, 2}))
+        << "Partial last shard must not be truncated by floor division";
+
+    // Full page coverage across all threads: all 7 logical pages must appear exactly once.
+    const uint32_t tensor_volume = accessor.dspec().tensor_volume();
+    const uint32_t shard_volume  = accessor.dspec().shard_volume();
+    const uint32_t total_shards  = (tensor_volume + shard_volume - 1) / shard_volume;
+    std::vector<uint32_t> all_page_ids;
+
+    for (uint32_t tid = 0; tid < 1; tid++) {
+        tensor_accessor::StridedShardPages range(accessor, tid, total_shards, 1, (uint8_t)0);
+        for (const auto& shard_range : range) {
+            for (const auto& page : shard_range) {
+                all_page_ids.push_back(page.page_id());
+            }
+        }
+    }
+
+    std::sort(all_page_ids.begin(), all_page_ids.end());
+    ASSERT_EQ(all_page_ids.size(), 7u) << "All 7 logical pages must be visited";
+    for (uint32_t i = 0; i < 7u; i++) {
+        EXPECT_EQ(all_page_ids[i], i) << "Missing or duplicate page_id " << i;
+    }
+}
+
+// Partial last shard with multiple threads: verify per-thread assignment and no page is lost.
+// tensor_shape={7}, shard_shape={3}, 2 threads:
+//   thread 0 → shards {0, 2}  (shard 2 is the partial one)
+//   thread 1 → shard  {1}
+TEST(StridedShardPagesTests, PartialLastShard_MultiThread_NoPagesLost) {
+    constexpr uint32_t num_banks = 3;
+    using TensorShape = ArrayWrapperU32<7>;
+    using ShardShape  = ArrayWrapperU32<3>;
+    using BankCoords  = ArrayWrapperDynamic;
+    using dspec_t = tensor_accessor::DistributionSpec<1, num_banks, TensorShape, ShardShape, BankCoords>;
+
+    std::array<uint16_t, num_banks> bank_coords{};
+    auto accessor = TensorAccessor<dspec_t>(dspec_t({}, {}, bank_coords), 0, 4096);
+
+    auto shards0 = shard_ids_for_thread(accessor, 0, 2);
+    auto shards1 = shard_ids_for_thread(accessor, 1, 2);
+
+    EXPECT_EQ(shards0, (std::vector<uint32_t>{0, 2})) << "Thread 0 should own shards 0 and 2 (partial)";
+    EXPECT_EQ(shards1, (std::vector<uint32_t>{1}))    << "Thread 1 should own shard 1";
+
+    // Collect all pages from both threads; expect exactly pages 0..6.
+    const uint32_t tensor_volume = accessor.dspec().tensor_volume();
+    const uint32_t shard_volume  = accessor.dspec().shard_volume();
+    const uint32_t total_shards  = (tensor_volume + shard_volume - 1) / shard_volume;
+    std::vector<uint32_t> all_page_ids;
+
+    for (uint32_t tid = 0; tid < 2; tid++) {
+        tensor_accessor::StridedShardPages range(accessor, tid, total_shards, 2, (uint8_t)0);
+        for (const auto& shard_range : range) {
+            for (const auto& page : shard_range) {
+                all_page_ids.push_back(page.page_id());
+            }
+        }
+    }
+
+    std::sort(all_page_ids.begin(), all_page_ids.end());
+    ASSERT_EQ(all_page_ids.size(), 7u);
+    for (uint32_t i = 0; i < 7u; i++) {
+        EXPECT_EQ(all_page_ids[i], i) << "Missing or duplicate page_id " << i;
+    }
 }

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
@@ -1,0 +1,360 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Test pipeline (one core):
+//   Input tensor (DRAM/L1) → reader kernel (producer) → DFB → writer kernel (consumer) → output tensor
+//
+// WH/BH: 1 DM thread each — Gen1 BRISC (producer) + NCRISC (consumer), STRIDED DFB
+// Quasar: 3 DM threads each — Gen2 reader (producer) + Gen2 writer (consumer), STRIDED DFB
+//
+
+#include <gtest/gtest.h>
+#include <fmt/format.h>
+#include <cstdint>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/shape.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_params.hpp>
+
+#include "tests/tt_metal/tt_metal/common/device_fixture.hpp"
+#include "tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/api/ttnn/distributed/api.hpp"
+
+namespace {
+
+using namespace tt;
+using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::metal2_host_api;
+using namespace tt::tt_metal::experimental::metal2_host_api::test_helpers;
+using namespace ttnn;
+
+// ============================================================================
+// Kernel source paths
+// ============================================================================
+
+constexpr const char* kReaderKernelPath =
+    "tests/ttnn/unit_tests/gtests/accessor/kernels/reader_strided_pages_dfb.cpp";
+constexpr const char* kWriterKernelPath =
+    "tests/ttnn/unit_tests/gtests/accessor/kernels/writer_strided_pages_dfb.cpp";
+
+// ============================================================================
+// Helper: build KERNEL_COMPILE_TIME_ARGS define value from TensorAccessorArgs CTAs
+// ============================================================================
+
+// Returns the comma-separated CTA value string for the KERNEL_COMPILE_TIME_ARGS define.
+// This enables device kernels that use TensorAccessorArgs<0, 0>() (positional CTA access)
+// to compile correctly under the Metal 2.0 API, which does not pass positional CTAs through
+// compile_time_arg_bindings.
+std::string build_cta_define(const TensorAccessorArgs& accessor_args) {
+    const auto ctas = accessor_args.get_compile_time_args();
+    std::ostringstream ss;
+    for (size_t i = 0; i < ctas.size(); ++i) {
+        if (i > 0) {
+            ss << ',';
+        }
+        ss << ctas[i];
+    }
+    return ss.str();
+}
+
+// ============================================================================
+// Helper: map DataType to a DM-safe DataFormat for DFB data_format_metadata
+// ============================================================================
+tt::DataFormat dtype_to_dm_data_format(DataType dtype) {
+    switch (dtype) {
+        case DataType::BFLOAT16: return tt::DataFormat::Float16_b;
+        case DataType::FLOAT32:  return tt::DataFormat::Float32;
+        case DataType::UINT8:    return tt::DataFormat::RawUInt8;
+        case DataType::UINT16:   return tt::DataFormat::RawUInt16;
+        case DataType::UINT32:   return tt::DataFormat::RawUInt32;
+        case DataType::INT32:    return tt::DataFormat::Int32;
+        default:                 return tt::DataFormat::Float16_b;
+    }
+}
+
+// ============================================================================
+// Test parameters
+// ============================================================================
+
+struct StridedDFBTestParams {
+    tt::tt_metal::Shape tensor_shape;
+    Layout layout;
+    DataType dtype;
+    BufferType buffer_type;
+};
+
+// ============================================================================
+// Core test helper
+// ============================================================================
+
+// Runs a strided_pages copy test via the Metal 2.0 Host API + DFB.
+//
+// Pipeline: input_tensor → reader (producer) → DFB → writer (consumer) → output_tensor
+//
+// The same kernel source is used for both architectures. On WH/BH (1 DM thread per RISC),
+// strided_pages() degenerates to pages(0, total_pages) — every page, single thread.
+// On Quasar (num_dm_threads DM threads), each thread handles every N-th page.
+//
+// kernel_builder_fn: a callable (KernelSpec& reader, KernelSpec& writer) → void
+//    that sets the arch-specific fields (num_threads, config_spec, DFB bindings).
+template <typename T, typename KernelBuilderFn>
+void run_strided_dfb_copy_test(
+    const StridedDFBTestParams& params,
+    tt::tt_metal::distributed::MeshDevice* mesh_device,
+    uint32_t num_dfb_entries,
+    KernelBuilderFn kernel_builder_fn) {
+    auto* device = mesh_device->get_devices().at(0);
+
+    MemoryConfig mem_config(TensorMemoryLayout::INTERLEAVED, params.buffer_type);
+    TensorSpec tensor_spec(params.tensor_shape, TensorLayout(params.dtype, PageConfig(params.layout), mem_config));
+
+    const auto src = tt::test_utils::generate_uniform_random_vector<T>(0, UINT8_MAX, params.tensor_shape.volume());
+    auto input_tensor = Tensor::from_vector(src, tensor_spec, mesh_device);
+    auto output_tensor =
+        Tensor::from_vector(std::vector<T>(params.tensor_shape.volume()), tensor_spec, mesh_device);
+
+    auto input_buffer = input_tensor.buffer();
+    auto output_buffer = output_tensor.buffer();
+
+    ASSERT_NE(input_buffer, nullptr);
+    ASSERT_NE(output_buffer, nullptr);
+
+    const uint32_t aligned_page_size = static_cast<uint32_t>(input_buffer->aligned_page_size());
+    const uint32_t total_pages = static_cast<uint32_t>(input_buffer->num_pages());
+
+    // -----------------------------------------------------------------------
+    // Build ProgramSpec
+    // -----------------------------------------------------------------------
+    const NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "strided_pages_dfb_copy";
+
+    const TensorAccessorArgs input_accessor_args(*input_buffer);
+    const TensorAccessorArgs output_accessor_args(*output_buffer);
+    const std::string input_cta_str = build_cta_define(input_accessor_args);
+    const std::string output_cta_str = build_cta_define(output_accessor_args);
+
+    // Placeholder kernel specs — filled in by the arch-specific builder lambda
+    KernelSpec reader = MakeMinimalDMKernel("reader");  // overwritten by builder
+    KernelSpec writer = MakeMinimalDMKernel("writer");  // overwritten by builder
+
+    // Let the arch-specific caller configure kernel specs and DFB bindings
+    kernel_builder_fn(reader, writer);
+
+    // Inject CTA define so TensorAccessorArgs<0, 0>() resolves at compile time
+    reader.source = KernelSpec::SourceFilePath{kReaderKernelPath};
+    writer.source = KernelSpec::SourceFilePath{kWriterKernelPath};
+    reader.compiler_options.defines.push_back({"KERNEL_COMPILE_TIME_ARGS", input_cta_str});
+    writer.compiler_options.defines.push_back({"KERNEL_COMPILE_TIME_ARGS", output_cta_str});
+
+    // Runtime varargs: [0]=base_addr, [1]=total_pages
+    reader.runtime_arguments_schema.num_runtime_varargs = 2;
+    writer.runtime_arguments_schema.num_runtime_varargs = 2;
+
+    // DFB: one entry per page, pipelined depth = num_dfb_entries.
+    // data_format_metadata must be set — set_dfb_tile_dims calls get_tile_size() unconditionally
+    // and throws on DataFormat::Invalid. Use Raw variants so all dtypes are valid on Quasar too.
+    auto dfb = MakeMinimalDFB("staging_dfb", aligned_page_size, num_dfb_entries);
+    dfb.data_format_metadata = dtype_to_dm_data_format(params.dtype);
+
+    spec.kernels = {reader, writer};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = {MakeMinimalWorkUnit("work_unit_0", node, {"reader", "writer"})};
+
+    // -----------------------------------------------------------------------
+    // Create Program and set runtime args
+    // -----------------------------------------------------------------------
+    Program program = MakeProgramFromSpec(*mesh_device, spec);
+
+    ProgramRunParams run_params;
+    run_params.kernel_run_params = {
+        ProgramRunParams::KernelRunParams{
+            .kernel_spec_name = "reader",
+            .runtime_varargs = {{node, {input_buffer->address(), total_pages}}},
+        },
+        ProgramRunParams::KernelRunParams{
+            .kernel_spec_name = "writer",
+            .runtime_varargs = {{node, {output_buffer->address(), total_pages}}},
+        },
+    };
+    SetProgramRunParameters(program, run_params);
+
+    // -----------------------------------------------------------------------
+    // Dispatch and verify
+    // -----------------------------------------------------------------------
+    detail::LaunchProgram(device, program);
+
+    const auto output_cpu = output_tensor.cpu(true);
+    const auto output_shard = ttnn::distributed::get_device_tensors(output_cpu).front();
+    EXPECT_EQ(output_shard.template to_vector<T>(), src);
+}
+
+// ============================================================================
+// Test fixture
+// ============================================================================
+
+class TensorAccessorStridedDFBTest : public tt::tt_metal::MeshDeviceFixture,
+                                     public ::testing::WithParamInterface<StridedDFBTestParams> {};
+
+// ============================================================================
+// Gen1 (WH/BH) tests: single DM thread, BRISC producer + NCRISC consumer
+// ============================================================================
+
+TEST_P(TensorAccessorStridedDFBTest, Gen1StridedPagesCopy) {
+    if (this->IsSkipped()) {
+        return;
+    }
+    const tt::ARCH arch = devices_.at(0)->arch();
+    if (arch != tt::ARCH::WORMHOLE_B0 && arch != tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP() << "Gen1 strided_pages DFB test requires Wormhole B0 or Blackhole hardware";
+    }
+
+    const auto& params = GetParam();
+
+    auto kernel_builder = [&](KernelSpec& reader, KernelSpec& writer) {
+        reader = MakeMinimalGen1DMKernel("reader", DataMovementProcessor::RISCV_0);
+        writer = MakeMinimalGen1DMKernel("writer", DataMovementProcessor::RISCV_1);
+        // STRIDED with 1 thread: stride=1, each thread accesses all DFB entries
+        BindDFBToKernel(reader, "staging_dfb", "my_dfb", KernelSpec::DFBEndpointType::PRODUCER);
+        BindDFBToKernel(writer, "staging_dfb", "my_dfb", KernelSpec::DFBEndpointType::CONSUMER);
+    };
+
+    switch (params.dtype) {
+        case DataType::UINT8:
+            run_strided_dfb_copy_test<uint8_t>(params, devices_.at(0).get(), /*num_dfb_entries=*/2, kernel_builder);
+            break;
+        case DataType::UINT16:
+            run_strided_dfb_copy_test<uint16_t>(params, devices_.at(0).get(), /*num_dfb_entries=*/2, kernel_builder);
+            break;
+        case DataType::BFLOAT16:
+            run_strided_dfb_copy_test<bfloat16>(params, devices_.at(0).get(), /*num_dfb_entries=*/2, kernel_builder);
+            break;
+        default: TT_THROW("Unsupported data type");
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Gen1StridedPagesCopy,
+    TensorAccessorStridedDFBTest,
+    testing::ValuesIn({
+        StridedDFBTestParams{
+            .tensor_shape = tt::tt_metal::Shape{64, 128},
+            .layout = Layout::TILE,
+            .dtype = DataType::BFLOAT16,
+            .buffer_type = BufferType::DRAM,
+        },
+        StridedDFBTestParams{
+            .tensor_shape = tt::tt_metal::Shape{96, 64},
+            .layout = Layout::ROW_MAJOR,
+            .dtype = DataType::UINT16,
+            .buffer_type = BufferType::L1,
+        },
+        StridedDFBTestParams{
+            .tensor_shape = tt::tt_metal::Shape{128, 96},
+            .layout = Layout::TILE,
+            .dtype = DataType::UINT8,
+            .buffer_type = BufferType::DRAM,
+        },
+        StridedDFBTestParams{
+            .tensor_shape = tt::tt_metal::Shape{4, 64, 96},
+            .layout = Layout::TILE,
+            .dtype = DataType::BFLOAT16,
+            .buffer_type = BufferType::DRAM,
+        },
+    }));
+
+// ============================================================================
+// Quasar tests: 3 DM threads each, Gen2 producer + Gen2 consumer, STRIDED DFB
+// ============================================================================
+//
+// Each of the 3 DM threads calls accessor.strided_pages(total_pages) which uses
+// get_my_thread_id() / get_num_threads() directly to select pages i, i+3, i+6, ...
+// The STRIDED DFB routes each thread to DFB entries N, N+3, N+6, ... so producer
+// and consumer thread partitions align without any explicit coordination.
+
+TEST_P(TensorAccessorStridedDFBTest, QuasarStridedPagesCopy) {
+    if (this->IsSkipped()) {
+        return;
+    }
+    const tt::ARCH arch = devices_.at(0)->arch();
+    if (arch != tt::ARCH::QUASAR) {
+        GTEST_SKIP() << "Quasar strided_pages DFB test requires Quasar hardware";
+    }
+
+    constexpr uint8_t kNumDMThreads = 3;
+
+    auto kernel_builder = [&](KernelSpec& reader, KernelSpec& writer) {
+        reader = MakeMinimalDMKernel("reader", kNumDMThreads);
+        writer = MakeMinimalDMKernel("writer", kNumDMThreads);
+        // STRIDED with 3 threads: each thread owns every 3rd DFB entry
+        BindDFBToKernel(reader, "staging_dfb", "my_dfb", KernelSpec::DFBEndpointType::PRODUCER);
+        BindDFBToKernel(writer, "staging_dfb", "my_dfb", KernelSpec::DFBEndpointType::CONSUMER);
+    };
+
+    // DFB depth: 2 entries per DM thread (double-buffer) × 3 threads = 6 entries
+    constexpr uint32_t kNumDFBEntries = kNumDMThreads * 2;
+    const auto& params = GetParam();
+
+    switch (params.dtype) {
+        case DataType::UINT8:
+            run_strided_dfb_copy_test<uint8_t>(
+                params, devices_.at(0).get(), kNumDFBEntries, kernel_builder);
+            break;
+        case DataType::UINT16:
+            run_strided_dfb_copy_test<uint16_t>(
+                params, devices_.at(0).get(), kNumDFBEntries, kernel_builder);
+            break;
+        case DataType::BFLOAT16:
+            run_strided_dfb_copy_test<bfloat16>(
+                params, devices_.at(0).get(), kNumDFBEntries, kernel_builder);
+            break;
+        default: TT_THROW("Unsupported data type");
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarStridedPagesCopy,
+    TensorAccessorStridedDFBTest,
+    testing::ValuesIn({
+        StridedDFBTestParams{
+            .tensor_shape = tt::tt_metal::Shape{64, 128},
+            .layout = Layout::TILE,
+            .dtype = DataType::BFLOAT16,
+            .buffer_type = BufferType::DRAM,
+        },
+        StridedDFBTestParams{
+            .tensor_shape = tt::tt_metal::Shape{128, 96},
+            .layout = Layout::TILE,
+            .dtype = DataType::UINT16,
+            .buffer_type = BufferType::DRAM,
+        },
+        StridedDFBTestParams{
+            .tensor_shape = tt::tt_metal::Shape{4, 64, 96},
+            .layout = Layout::TILE,
+            .dtype = DataType::BFLOAT16,
+            .buffer_type = BufferType::DRAM,
+        },
+        // {6,64,64} → 6×2×2 = 24 tiles, evenly divisible by 3 (num_dm_threads)
+        StridedDFBTestParams{
+            .tensor_shape = tt::tt_metal::Shape{6, 64, 64},
+            .layout = Layout::TILE,
+            .dtype = DataType::UINT8,
+            .buffer_type = BufferType::DRAM,
+        },
+    }));
+
+}  // namespace

--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -62,6 +62,7 @@ set(UNIT_TESTS_TTNN_ACCESSOR_SOURCES
     accessor/test_accessor_benchmarks.cpp
     accessor/test_tensor_accessor.cpp
     accessor/test_tensor_accessor_on_device.cpp
+    accessor/test_tensor_accessor_strided_dfb.cpp
 )
 
 set(UNIT_TESTS_TTNN_TENSOR_SOURCES

--- a/tt_metal/hw/inc/api/tensor/pages_address_iterator.h
+++ b/tt_metal/hw/inc/api/tensor/pages_address_iterator.h
@@ -26,8 +26,9 @@ public:
     using pointer = const Page*;
 
     // Constructor that initializes the iterator at a starting position
-    PagesAddressIteratorSharded(const Accessor& accessor, uint32_t start_page_id = 0, uint8_t noc = noc_index) :
-        accessor(accessor), current_page_id(start_page_id), noc(noc) {
+    PagesAddressIteratorSharded(
+        const Accessor& accessor, uint32_t start_page_id = 0, uint32_t stride = 1, uint8_t noc = noc_index) :
+        accessor(accessor), current_page_id(start_page_id), stride_(stride), noc(noc) {
         if (current_page_id < accessor.dspec().tensor_volume()) {
             // Initialize coordinates and state from page_id
             initialize_from_page_id(start_page_id);
@@ -47,14 +48,18 @@ public:
             return *this;  // End iterator
         }
 
-        current_page_id++;
+        current_page_id += stride_;
         if (current_page_id >= accessor.dspec().tensor_volume()) {
             current_page_id = accessor.dspec().tensor_volume();
             return *this;
         }
 
-        // Efficiently update coordinates and address without divisions
-        increment_page_coordinate();
+        // Efficiently update coordinates and address without divisions when possible
+        if (can_use_simple_increment()) {
+            apply_simple_increment();
+        } else {
+            initialize_from_page_id(current_page_id);
+        }
         update_current_page();
         return *this;
     }
@@ -71,7 +76,7 @@ public:
             return *this;  // End iterator
         }
 
-        current_page_id += steps;
+        current_page_id += steps * stride_;
         if (current_page_id >= accessor.dspec().tensor_volume()) {
             current_page_id = accessor.dspec().tensor_volume();
             return *this;
@@ -112,6 +117,7 @@ private:
     const Accessor& accessor;
     uint32_t current_page_id = 0;   // current page id
     uint64_t current_noc_addr = 0;  // current NOC address for this page
+    uint32_t stride_ = 1;           // step size per operator++ (1 for contiguous, N for DM thread stride)
     uint8_t noc = noc_index;
     uint32_t current_shard_id = 0;  // Which shard this page belongs to
 
@@ -182,12 +188,12 @@ private:
         recalculate_mapping_from_coordinates();
     }
 
-    // Check if we can just increment the address (consecutive pages in same bank)
+    // Check if we can just add stride_ to the address (stays in same shard, no boundary crossing)
     bool can_use_simple_increment() const {
         const auto& dspec = accessor.dspec();
 
-        // Check if incrementing rightmost coordinate would stay in same row
-        uint32_t next_coord = page_coord[dspec.rank() - 1] + 1;
+        // Check if incrementing rightmost coordinate by stride_ stays within the same row
+        uint32_t next_coord = page_coord[dspec.rank() - 1] + stride_;
         if (next_coord >= dspec.tensor_shape()[dspec.rank() - 1]) {
             return false;  // Would overflow tensor bounds
         }
@@ -204,12 +210,12 @@ private:
         const auto& dspec = accessor.dspec();
 
         // Update coordinate tracking
-        page_coord[dspec.rank() - 1]++;
-        page_offset_within_shard += dspec.shard_strides()[dspec.rank() - 1];
+        page_coord[dspec.rank() - 1] += stride_;
+        page_offset_within_shard += dspec.shard_strides()[dspec.rank() - 1] * stride_;
 
         // Update NOC address and bank offset
-        current_noc_addr += accessor.get_aligned_page_size();
-        current_page_mapping.bank_page_offset++;
+        current_noc_addr += accessor.get_aligned_page_size() * stride_;
+        current_page_mapping.bank_page_offset += stride_;
     }
 
     // Increment coordinates like a multi-dimensional counter
@@ -263,8 +269,12 @@ public:
     using pointer = const Page*;
 
     PagesAddressIteratorInterleaved(
-        const Accessor& accessor, uint32_t start_page_id, uint32_t end_page_id, uint8_t noc) :
-        accessor(accessor), current_page_id(start_page_id), end_page_id_(end_page_id), noc(noc) {
+        const Accessor& accessor,
+        uint32_t start_page_id,
+        uint32_t end_page_id,
+        uint32_t stride,
+        uint8_t noc) :
+        accessor(accessor), current_page_id(start_page_id), end_page_id_(end_page_id), stride_(stride), noc(noc) {
         // If start_page_id is beyond end_page_id, create an end iterator
         if (current_page_id >= end_page_id_) {
             current_page_id = end_page_id_;
@@ -281,7 +291,7 @@ public:
 
     // Arithmetic operators
     PagesAddressIteratorInterleaved& operator++() {
-        current_page_id++;
+        current_page_id += stride_;
         if (current_page_id >= end_page_id_) {
             current_page_id = end_page_id_;
             return *this;
@@ -299,7 +309,7 @@ public:
 
     PagesAddressIteratorInterleaved& operator+=(difference_type steps) {
         ASSERT(steps >= 0);
-        current_page_id += steps;
+        current_page_id += steps * stride_;
         if (current_page_id >= end_page_id_) {
             current_page_id = end_page_id_;
             return *this;
@@ -342,6 +352,7 @@ private:
     const Accessor& accessor;
     uint32_t current_page_id = 0;
     const uint32_t end_page_id_ = 0;
+    const uint32_t stride_ = 1;
     const uint8_t noc = noc_index;
     mutable Page current_page{0, 0};
 
@@ -365,22 +376,31 @@ public:
         PagesAddressIteratorSharded<Accessor>>;
     using const_iterator = iterator;
 
-    Pages(const Accessor& accessor, uint32_t start_page_id, uint32_t end_page_id, uint8_t noc = noc_index) :
-        accessor_(accessor), start_page_id_(start_page_id), end_page_id_(end_page_id), noc_(noc) {}
+    Pages(
+        const Accessor& accessor,
+        uint32_t start_page_id,
+        uint32_t end_page_id,
+        uint32_t stride = 1,
+        uint8_t noc = noc_index) :
+        accessor_(accessor),
+        start_page_id_(start_page_id),
+        end_page_id_(end_page_id),
+        stride_(stride),
+        noc_(noc) {}
 
     iterator begin() const {
         if constexpr (Accessor::DSpec::is_interleaved) {
-            return PagesAddressIteratorInterleaved<Accessor>(accessor_, start_page_id_, end_page_id_, noc_);
+            return PagesAddressIteratorInterleaved<Accessor>(accessor_, start_page_id_, end_page_id_, stride_, noc_);
         } else {
-            return PagesAddressIteratorSharded<Accessor>(accessor_, start_page_id_, noc_);
+            return PagesAddressIteratorSharded<Accessor>(accessor_, start_page_id_, stride_, noc_);
         }
     }
 
     iterator end() const {
         if constexpr (Accessor::DSpec::is_interleaved) {
-            return PagesAddressIteratorInterleaved<Accessor>(accessor_, end_page_id_, end_page_id_, noc_);
+            return PagesAddressIteratorInterleaved<Accessor>(accessor_, end_page_id_, end_page_id_, stride_, noc_);
         } else {
-            return PagesAddressIteratorSharded<Accessor>(accessor_, end_page_id_, noc_);
+            return PagesAddressIteratorSharded<Accessor>(accessor_, end_page_id_, stride_, noc_);
         }
     }
 
@@ -391,6 +411,7 @@ private:
     const Accessor& accessor_;
     uint32_t start_page_id_;
     uint32_t end_page_id_;
+    uint32_t stride_;
     uint8_t noc_;
 };
 

--- a/tt_metal/hw/inc/api/tensor/pages_address_iterator.h
+++ b/tt_metal/hw/inc/api/tensor/pages_address_iterator.h
@@ -386,7 +386,10 @@ public:
         start_page_id_(start_page_id),
         end_page_id_(end_page_id),
         stride_(stride),
-        noc_(noc) {}
+        noc_(noc) {
+        ASSERT(stride > 0);                    // stride=0 would make the iterator never advance
+        ASSERT(start_page_id <= end_page_id);  // inverted range silently produces no iterations
+    }
 
     iterator begin() const {
         if constexpr (Accessor::DSpec::is_interleaved) {

--- a/tt_metal/hw/inc/api/tensor/shard_pages_address_iterator.h
+++ b/tt_metal/hw/inc/api/tensor/shard_pages_address_iterator.h
@@ -318,9 +318,13 @@ public:
     }
 
     bool operator==(const StridedShardPagesIterator& other) const {
-        // Normalize past-end: treat any id >= end_shard_id as "at end"
+        // Normalize past-end: treat any id >= end_shard_id as "at end".
+        // Stride overshoot is expected (stride > 1 means the last ++ may skip past the sentinel),
+        // but the overshoot must be < stride.
         bool lhs_done = current_shard_id_ >= end_shard_id_;
         bool rhs_done = other.current_shard_id_ >= other.end_shard_id_;
+        ASSERT(!lhs_done || (current_shard_id_ - end_shard_id_ < stride_));
+        ASSERT(!rhs_done || (other.current_shard_id_ - other.end_shard_id_ < other.stride_));
         if (lhs_done && rhs_done) {
             return true;
         }

--- a/tt_metal/hw/inc/api/tensor/shard_pages_address_iterator.h
+++ b/tt_metal/hw/inc/api/tensor/shard_pages_address_iterator.h
@@ -279,4 +279,108 @@ private:
     uint32_t end_page_offset_;
     uint8_t noc_;
 };
+/**
+ * Iterator over a strided subset of shards, yielding one ShardPages range per assigned shard.
+ *
+ * Each DM owns shards at indices: start_shard_id, start_shard_id + stride, ...
+ * This implements the whole-shard granularity for multi-threaded shard iteration.
+ */
+template <typename Accessor>
+class StridedShardPagesIterator {
+public:
+    using value_type = ShardPages<Accessor>;
+
+    StridedShardPagesIterator(
+        const Accessor& accessor,
+        uint32_t current_shard_id,
+        uint32_t end_shard_id,
+        uint32_t stride,
+        uint8_t noc) :
+        accessor_(accessor),
+        current_shard_id_(current_shard_id),
+        end_shard_id_(end_shard_id),
+        stride_(stride),
+        noc_(noc) {}
+
+    value_type operator*() const {
+        return ShardPages<Accessor>(accessor_, current_shard_id_, 0, accessor_.dspec().shard_volume(), noc_);
+    }
+
+    StridedShardPagesIterator& operator++() {
+        current_shard_id_ += stride_;
+        return *this;
+    }
+
+    StridedShardPagesIterator operator++(int) {
+        StridedShardPagesIterator tmp = *this;
+        ++(*this);
+        return tmp;
+    }
+
+    bool operator==(const StridedShardPagesIterator& other) const {
+        // Normalize past-end: treat any id >= end_shard_id as "at end"
+        bool lhs_done = current_shard_id_ >= end_shard_id_;
+        bool rhs_done = other.current_shard_id_ >= other.end_shard_id_;
+        if (lhs_done && rhs_done) {
+            return true;
+        }
+        if (lhs_done || rhs_done) {
+            return false;
+        }
+        return current_shard_id_ == other.current_shard_id_;
+    }
+
+    bool operator!=(const StridedShardPagesIterator& other) const { return !(*this == other); }
+
+private:
+    const Accessor& accessor_;
+    uint32_t current_shard_id_;
+    uint32_t end_shard_id_;
+    uint32_t stride_;
+    uint8_t noc_;
+};
+
+/**
+ * Proxy that enables range-based for over the shards owned by this DM.
+ *
+ * Each iteration yields a ShardPages range covering all pages within one assigned shard.
+ * Thread i owns shards at indices: i, i + num_threads, i + 2*num_threads, ...
+ */
+template <typename Accessor>
+class StridedShardPages {
+public:
+    using iterator = StridedShardPagesIterator<Accessor>;
+    using const_iterator = iterator;
+
+    StridedShardPages(
+        const Accessor& accessor,
+        uint32_t start_shard_id,
+        uint32_t total_shards,
+        uint32_t stride,
+        uint8_t noc = noc_index) :
+        accessor_(accessor),
+        start_shard_id_(start_shard_id),
+        total_shards_(total_shards),
+        stride_(stride),
+        noc_(noc) {}
+
+    iterator begin() const {
+        return StridedShardPagesIterator<Accessor>(accessor_, start_shard_id_, total_shards_, stride_, noc_);
+    }
+
+    iterator end() const {
+        return StridedShardPagesIterator<Accessor>(accessor_, total_shards_, total_shards_, stride_, noc_);
+    }
+
+    const_iterator cbegin() const { return begin(); }
+    const_iterator cend() const { return end(); }
+
+private:
+    const Accessor& accessor_;
+    uint32_t start_shard_id_;
+    uint32_t total_shards_;
+    uint32_t stride_;
+    uint8_t noc_;
+};
+
 }  // namespace tensor_accessor

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -246,8 +246,8 @@ public:
     // Returns a proxy that iterates over the pages owned by the calling DM (strided iteration).
     // Each DM thread i (0..N-1) visits pages i, i+N, i+2N, ...
     tensor_accessor::Pages<TensorAccessor> strided_pages(uint8_t noc = noc_index) const {
-        uint32_t tid = get_my_thread_id();
-        uint32_t num_threads = get_num_threads();
+        const uint32_t tid = get_my_thread_id();
+        const uint32_t num_threads = get_num_threads();
         return tensor_accessor::Pages<TensorAccessor>(
             *this, tid, dspec().tensor_volume(), num_threads, noc);
     }
@@ -259,10 +259,13 @@ public:
         static_assert(DSpec::has_static_rank, "strided_shard_pages is only supported for static rank");
         const uint32_t tensor_volume = dspec().tensor_volume();
         const uint32_t shard_volume = dspec().shard_volume();
+        const uint32_t num_threads = get_num_threads();
+        const uint32_t tid = get_my_thread_id();
+        ASSERT(shard_volume > 0);
         // ShardPagesAddressIterator skips padded slots beyond tensor bounds, so ceiling division is safe.
         const uint32_t total_shards = (tensor_volume + shard_volume - 1) / shard_volume;
         return tensor_accessor::StridedShardPages<TensorAccessor>(
-            *this, get_my_thread_id(), total_shards, get_num_threads(), noc);
+            *this, tid, total_shards, num_threads, noc);
     }
 
 private:

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -12,6 +12,7 @@
 #include "api/tensor/shard_pages_address_iterator.h"
 #include "api/tensor/pages_address_iterator.h"
 #include "api/compile_time_args.h"
+#include "api/kernel_thread_globals.h"
 
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 #include "internal/dataflow/dataflow_api_addrgen.h"
@@ -239,7 +240,29 @@ public:
     tensor_accessor::Pages<TensorAccessor> pages(
         uint32_t start_page_id = 0, uint32_t end_page_id = 0, uint8_t noc = noc_index) const {
         uint32_t actual_end_page_id = (end_page_id == 0) ? dspec().tensor_volume() : end_page_id;
-        return tensor_accessor::Pages<TensorAccessor>(*this, start_page_id, actual_end_page_id, noc);
+        return tensor_accessor::Pages<TensorAccessor>(*this, start_page_id, actual_end_page_id, 1, noc);
+    }
+
+    // Returns a proxy that iterates over the pages owned by the calling DM (strided iteration).
+    // Each DM thread i (0..N-1) visits pages i, i+N, i+2N, ...
+    tensor_accessor::Pages<TensorAccessor> strided_pages(uint8_t noc = noc_index) const {
+        uint32_t tid = get_my_thread_id();
+        uint32_t num_threads = get_num_threads();
+        return tensor_accessor::Pages<TensorAccessor>(
+            *this, tid, dspec().tensor_volume(), num_threads, noc);
+    }
+
+    // Returns a range of ShardPages, one per shard owned by the calling DM (whole-shard granularity).
+    // The calling DM owns shards i, i+N, i+2N, ..., where N = get_num_threads().
+    // Each yielded ShardPages covers all pages within its assigned shard.
+    tensor_accessor::StridedShardPages<TensorAccessor> strided_shard_pages(uint8_t noc = noc_index) const {
+        static_assert(DSpec::has_static_rank, "strided_shard_pages is only supported for static rank");
+        const uint32_t tensor_volume = dspec().tensor_volume();
+        const uint32_t shard_volume = dspec().shard_volume();
+        // ShardPagesAddressIterator skips padded slots beyond tensor bounds, so ceiling division is safe.
+        const uint32_t total_shards = (tensor_volume + shard_volume - 1) / shard_volume;
+        return tensor_accessor::StridedShardPages<TensorAccessor>(
+            *this, get_my_thread_id(), total_shards, get_num_threads(), noc);
     }
 
 private:
@@ -286,6 +309,7 @@ private:
 
 public:
     friend class tensor_accessor::ShardPagesAddressIterator<TensorAccessor>;
+    friend class tensor_accessor::StridedShardPagesIterator<TensorAccessor>;
     friend class tensor_accessor::PagesAddressIteratorSharded<TensorAccessor>;
     friend class tensor_accessor::PagesAddressIteratorInterleaved<TensorAccessor>;
 };
@@ -384,7 +408,23 @@ struct TensorAccessor<tensor_accessor::DistributionSpec<
     // volume
     tensor_accessor::Pages<TensorAccessor> pages(
         uint32_t start_page_id, uint32_t end_page_id, uint8_t noc = noc_index) const {
-        return tensor_accessor::Pages<TensorAccessor>(*this, start_page_id, end_page_id, noc);
+        return tensor_accessor::Pages<TensorAccessor>(*this, start_page_id, end_page_id, 1, noc);
+    }
+
+    // Returns a proxy that iterates over the pages owned by the calling DM (strided iteration).
+    // Each DM thread i (0..N-1) visits pages i, i+N, i+2N, ...
+    tensor_accessor::Pages<TensorAccessor> strided_pages(
+        uint32_t total_pages, uint8_t noc = noc_index) const {
+        uint32_t tid = get_my_thread_id();
+        uint32_t num_threads = get_num_threads();
+        return tensor_accessor::Pages<TensorAccessor>(*this, tid, total_pages, num_threads, noc);
+    }
+
+    tensor_accessor::StridedShardPages<TensorAccessor> strided_shard_pages(uint8_t noc = noc_index) const {
+        static_assert(
+            tensor_accessor::detail::always_false_v<TensorAccessor>,
+            "TensorAccessor::strided_shard_pages is not supported by the interleaved tensor accessor");
+        return {};
     }
 
 private:

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -20,6 +20,7 @@ set(HW_JIT_API_HEADERS
     inc/api/numeric/bfloat16.h
     inc/api/numeric/float32.h
     inc/api/numeric/int32.h
+    inc/api/kernel_thread_globals.h
     inc/api/tensor/tensor_accessor.h
     inc/api/tensor/tensor_accessor_args.h
     inc/api/tensor/shard_pages_address_iterator.h


### PR DESCRIPTION
### Summary
Quasar introduces multi-threaded kernels. Multiple reader and writer DM threads can now cooperatively read from/write to the same Tensor. The typical use case is to access and compute on tensor data in a strided manner. This PR introduces APIs that allow each thread to iterate over a subset of the Tensor pages. 

Existing `pages` iterator needs a page range. Stride is not added to `pages` API to hide the threading logic from kernels. 


API | Semantics | When to use
-- | -- | --
pages(start, end, noc) | Contiguous range, stride=1, unchanged | Single-threaded, or caller owns a contiguous chunk
strided_pages(noc) | This thread's pages only, stride=get_num_threads() | Multi-threaded cooperative iteration
shard_pages(shard_id, start, end, noc) | Pages within one shard, stride=1, unchanged | Single-threaded per-shard work
strided_shard_pages(shard_id, noc) | This thread's pages within one shard | Multi-threaded per-shard work

### Notes for reviewers
Blocked access pattern will introduce different modes of iterating over a tensor

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/mt-ta)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/mt-ta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/mt-ta)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/mt-ta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abhullar/mt-ta)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/mt-ta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/mt-ta)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/mt-ta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/mt-ta)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/mt-ta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/mt-ta)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/mt-ta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/mt-ta)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/mt-ta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/mt-ta)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/mt-ta)