### PR TITLE
Remove unused LLK matmul parameters

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
@@ -23,14 +23,20 @@ constexpr int get_math_num_fidelity_phases(const MathFidelity math_fidelity)
     return ckernel::to_underlying(math_fidelity);
 }
 
+inline void matmul_validate_no_mop_contract(
+    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
+    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
+    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
+    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
+    const bool partial_face            = false)
+{
+    LLK_ASSERT(
+        in0_tile_r_dim == TILE_R_DIM && in0_tile_c_dim == TILE_C_DIM && in1_tile_r_dim == TILE_R_DIM && in1_tile_c_dim == TILE_C_DIM && !partial_face,
+        "Blackhole custom no-mop matmul currently supports only full 32x32 tiles with partial_face disabled");
+}
+
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL>
-inline void matmul_configure_addrmod_no_mop(
-    const bool transpose,
-    [[maybe_unused]] const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    [[maybe_unused]] const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    [[maybe_unused]] const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    [[maybe_unused]] const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    [[maybe_unused]] const bool partial_face            = false)
+inline void matmul_configure_addrmod_no_mop(const bool transpose)
 {
     static_assert(THROTTLE_LEVEL >= 0 && THROTTLE_LEVEL <= 5, "THROTTLE_LEVEL must be in range [0, 5]");
     constexpr bool high_fidelity     = math_fidelity != MathFidelity::LoFi;
@@ -130,14 +136,7 @@ inline void matmul_configure_addrmod_reinit(const bool transpose = false)
 }
 
 template <MathFidelity math_fidelity>
-inline void matmul_configure_mop_custom(
-    const std::uint32_t ct_dim,
-    const std::uint32_t rt_dim,
-    [[maybe_unused]] const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    [[maybe_unused]] const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    [[maybe_unused]] const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    [[maybe_unused]] const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    [[maybe_unused]] const bool partial_face            = false)
+inline void matmul_configure_mop_custom(const std::uint32_t ct_dim, const std::uint32_t rt_dim)
 {
     // in0 - loaded to SrcB
     // in1 - loaded to SrcA
@@ -147,11 +146,9 @@ inline void matmul_configure_mop_custom(
     // Col major layout in dest only impacts destination address increment
     // if col major layout faces are ordered as f0,f2,f1,f3
 
-    [[maybe_unused]] constexpr int num_fidelity_phases = get_math_num_fidelity_phases(math_fidelity);
     constexpr bool high_fidelity                       = math_fidelity != MathFidelity::LoFi;
 
-    const bool reuse_a                         = ct_dim >= rt_dim;
-    [[maybe_unused]] const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;
+    const bool reuse_a = ct_dim >= rt_dim;
 
     const std::uint32_t replay_buf_len = 16;
 
@@ -297,15 +294,8 @@ void run_throttled_sequence_no_mop<5>()
  * Level 4: throttle to 40% of max
  * Level 5: throttle to 33% of max
  */
-template <MathFidelity math_fidelity, int THROTTLE_LEVEL>
-inline void matmul_configure_mop_throttled_no_mop(
-    const std::uint32_t ct_dim,
-    const std::uint32_t rt_dim,
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false)
+template <int THROTTLE_LEVEL>
+inline void matmul_configure_mop_throttled_no_mop()
 {
     // in0 - loaded to SrcB
     // in1 - loaded to SrcA
@@ -315,14 +305,7 @@ inline void matmul_configure_mop_throttled_no_mop(
     // Col major layout in dest only impacts destination address increment
     // if col major layout faces are ordered as f0,f2,f1,f3
 
-    constexpr int num_fidelity_phases = get_math_num_fidelity_phases(math_fidelity);
-    constexpr bool high_fidelity      = math_fidelity != MathFidelity::LoFi;
     static_assert((THROTTLE_LEVEL > 0) && (THROTTLE_LEVEL <= 5), "MM throttling only enabled for THROTTLE_LEVEL={1,2,3,4,5}");
-    LLK_ASSERT(
-        (in0_tile_r_dim == TILE_R_DIM) && (in0_tile_c_dim == TILE_C_DIM) && (in1_tile_r_dim == TILE_R_DIM) && (in1_tile_c_dim == TILE_C_DIM) && !partial_face,
-        "MM throttling only enabled for full 32x32 tile size");
-
-    const bool reuse_a = ct_dim >= rt_dim;
 
     constexpr std::uint32_t replay_buf_len = (THROTTLE_LEVEL > 3) ? (1 + THROTTLE_LEVEL * 2) : ((THROTTLE_LEVEL > 1) ? (3 + THROTTLE_LEVEL * 4) : 10);
 
@@ -346,15 +329,15 @@ inline void _llk_math_matmul_init_no_mop_(
     const std::uint32_t ct_dim         = 1,
     const std::uint32_t rt_dim         = 1)
 {
-    matmul_configure_addrmod_no_mop<math_fidelity, THROTTLE_LEVEL>(transpose, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    matmul_validate_no_mop_contract(in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    matmul_configure_addrmod_no_mop<math_fidelity, THROTTLE_LEVEL>(transpose);
     if constexpr (THROTTLE_LEVEL > 0)
     {
-        matmul_configure_mop_throttled_no_mop<math_fidelity, THROTTLE_LEVEL>(
-            ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+        matmul_configure_mop_throttled_no_mop<THROTTLE_LEVEL>();
     }
     else
     {
-        matmul_configure_mop_custom<math_fidelity>(ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+        matmul_configure_mop_custom<math_fidelity>(ct_dim, rt_dim);
     }
     math::reset_counters(p_setrwc::SET_ABD_F);
 }
@@ -365,15 +348,7 @@ inline void _llk_math_matmul_uninit_no_mop_()
 }
 
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
-inline void _llk_math_matmul_no_mop_(
-    std::uint32_t dst_index,
-    const std::uint32_t ct_dim                          = 1,
-    const std::uint32_t rt_dim                          = 1,
-    [[maybe_unused]] const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    [[maybe_unused]] const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    [[maybe_unused]] const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    [[maybe_unused]] const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    [[maybe_unused]] const bool partial_face            = false)
+inline void _llk_math_matmul_no_mop_(std::uint32_t dst_index, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1)
 {
     const bool reuse_a                = ct_dim >= rt_dim;
     const std::uint32_t t_dim         = reuse_a ? rt_dim : ct_dim;

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -29,6 +29,10 @@ inline void matmul_configure_addrmod(
     const bool partial_face            = false)
 {
     constexpr std::uint32_t fidelity_increment = is_high_fidelity(math_fidelity) ? 1 : 0;
+    // 16x16 inputs not supported - no dedicated math path; falls to 32x32 default which is incorrect for < 4 faces
+    LLK_ASSERT(
+        !((in0_tile_r_dim == FACE_R_DIM) && (in0_tile_c_dim == FACE_C_DIM) && (in1_tile_r_dim == FACE_R_DIM) && (in1_tile_c_dim == FACE_C_DIM)),
+        "16x16 by 16x16 matmul is not supported");
 
     const bool is_in0_16x32 = (in0_tile_r_dim <= FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
     const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
@@ -599,10 +603,6 @@ inline void _llk_math_matmul_init_(
     const std::uint32_t ct_dim         = 1,
     const std::uint32_t rt_dim         = 1)
 {
-    // 16x16 inputs not supported - no dedicated math path; falls to 32x32 default which is incorrect for < 4 faces
-    LLK_ASSERT(
-        !((in0_tile_r_dim == FACE_R_DIM) && (in0_tile_c_dim == FACE_C_DIM) && (in1_tile_r_dim == FACE_R_DIM) && (in1_tile_c_dim == FACE_C_DIM)),
-        "16x16 by 16x16 matmul is not supported");
     // in1=32x16 NOT supported with transpose (no addr_mod handling)
     LLK_ASSERT(!(transpose && (in1_tile_r_dim == TILE_R_DIM) && (in1_tile_c_dim == FACE_C_DIM)), "Transpose with input 1 dimensions 32x16 not supported");
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
@@ -22,12 +22,7 @@ inline void matmul_validate_no_mop_contract(
         "Wormhole custom no-mop matmul currently supports only full 32x32 tiles with partial_face disabled");
 }
 
-inline std::uint32_t matmul_get_replay_buf_len_no_mop(
-    [[maybe_unused]] const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    [[maybe_unused]] const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    [[maybe_unused]] const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    [[maybe_unused]] const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    [[maybe_unused]] const bool partial_face            = false)
+inline std::uint32_t matmul_get_replay_buf_len_no_mop()
 {
     // The narrowed WH full-tile path uses a fixed replay image.
     return 16;
@@ -79,14 +74,7 @@ inline void matmul_configure_addrmod_no_mop(
 }
 
 template <MathFidelity math_fidelity>
-inline void matmul_emit_replay_program_no_mop(
-    const std::uint32_t ct_dim,
-    const std::uint32_t rt_dim,
-    [[maybe_unused]] const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    [[maybe_unused]] const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    [[maybe_unused]] const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    [[maybe_unused]] const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    [[maybe_unused]] const bool partial_face            = false)
+inline void matmul_emit_replay_program_no_mop(const std::uint32_t ct_dim, const std::uint32_t rt_dim)
 {
     const bool reuse_a        = ct_dim >= rt_dim;
     const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;
@@ -171,21 +159,14 @@ inline void matmul_emit_replay_program_no_mop(
 }
 
 template <MathFidelity math_fidelity>
-inline void matmul_load_replay_no_mop(
-    const std::uint32_t ct_dim,
-    const std::uint32_t rt_dim,
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false)
+inline void matmul_load_replay_no_mop(const std::uint32_t ct_dim, const std::uint32_t rt_dim)
 {
-    const std::uint32_t replay_buf_len = matmul_get_replay_buf_len_no_mop(in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    const std::uint32_t replay_buf_len = matmul_get_replay_buf_len_no_mop();
 
     // WH records the replay image explicitly at init/reinit time rather than
     // assuming it persists like the BH path does.
     lltt::record<lltt::NoExec>(ckernel::math::replay_buf_offset, replay_buf_len);
-    matmul_emit_replay_program_no_mop<math_fidelity>(ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    matmul_emit_replay_program_no_mop<math_fidelity>(ct_dim, rt_dim);
 }
 
 template <MathFidelity math_fidelity>
@@ -221,8 +202,7 @@ inline void matmul_execute_replay_no_mop(const std::uint32_t replay_buf_len, con
 }
 
 template <MathFidelity math_fidelity>
-inline void matmul_run_no_mop_tdim1_reuse_a(
-    const std::uint32_t dst_index, [[maybe_unused]] const std::uint32_t ct_dim, const std::uint32_t rut_dim, const std::uint32_t replay_buf_len)
+inline void matmul_run_no_mop_tdim1_reuse_a(const std::uint32_t dst_index, const std::uint32_t rut_dim, const std::uint32_t replay_buf_len)
 {
     for (std::uint32_t rut = 0; (rut + 1) < rut_dim; rut++)
     {
@@ -365,7 +345,7 @@ inline void _llk_math_matmul_init_no_mop_(
         transpose, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, ct_dim, rt_dim);
     // Initial entry records the replay image once; later calls just replay it
     // after restoring the addrmod/counter contract.
-    matmul_load_replay_no_mop<math_fidelity>(ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    matmul_load_replay_no_mop<math_fidelity>(ct_dim, rt_dim);
     math::reset_counters(p_setrwc::SET_ABD_F);
 }
 
@@ -394,13 +374,13 @@ inline void _llk_math_matmul_no_mop_(
     // reused. This matches the BH helper naming and is effectively the
     // "reuse-dim" for the no-mop path.
     const std::uint32_t rut_dim        = reuse_a ? ct_dim : rt_dim;
-    const std::uint32_t replay_buf_len = matmul_get_replay_buf_len_no_mop(in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    const std::uint32_t replay_buf_len = matmul_get_replay_buf_len_no_mop();
 
     if (t_dim == 1)
     {
         if (reuse_a)
         {
-            matmul_run_no_mop_tdim1_reuse_a<math_fidelity>(dst_index, ct_dim, rut_dim, replay_buf_len);
+            matmul_run_no_mop_tdim1_reuse_a<math_fidelity>(dst_index, rut_dim, replay_buf_len);
         }
         else
         {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
@@ -30,6 +30,10 @@ inline void matmul_configure_addrmod(
     const bool partial_face            = false)
 {
     constexpr std::uint32_t fidelity_increment = is_high_fidelity(math_fidelity) ? 1 : 0;
+    // 16x16 inputs not supported - no dedicated math path; falls to 32x32 default which is incorrect for < 4 faces
+    LLK_ASSERT(
+        !((in0_tile_r_dim == FACE_R_DIM) && (in0_tile_c_dim == FACE_C_DIM) && (in1_tile_r_dim == FACE_R_DIM) && (in1_tile_c_dim == FACE_C_DIM)),
+        "16x16 by 16x16 matmul is not supported");
 
     const bool is_in0_16x32 = (in0_tile_r_dim <= FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
     const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
@@ -686,10 +690,6 @@ inline void _llk_math_matmul_init_(
     const std::uint32_t ct_dim         = 1,
     const std::uint32_t rt_dim         = 1)
 {
-    // 16x16 inputs not supported - no dedicated math path; falls to 32x32 default which is incorrect for < 4 faces
-    LLK_ASSERT(
-        !((in0_tile_r_dim == FACE_R_DIM) && (in0_tile_c_dim == FACE_C_DIM) && (in1_tile_r_dim == FACE_R_DIM) && (in1_tile_c_dim == FACE_C_DIM)),
-        "16x16 by 16x16 matmul is not supported");
     // in1=32x16 NOT supported with transpose (no addr_mod handling)
     LLK_ASSERT(
         !(transpose && (in1_tile_r_dim == TILE_R_DIM) && (in1_tile_c_dim == FACE_C_DIM)), "in1=32x16 not supported with transpose (no addr_mod handling)");


### PR DESCRIPTION
### Summary
Remove unused parameters from the Blackhole and Wormhole LLK matmul helpers, especially the custom no-mop paths. This keeps validation at the entry points that still receive tile-shape inputs while narrowing internal helpers to the values they actually use.

### Notes for reviewers
Please focus on the no-mop matmul helper signatures and the moved 16x16 unsupported-shape assertion in regular matmul addrmod configuration.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/llk-unused-params-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/llk-unused-params-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/llk-unused-params-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/llk-unused-params-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/llk-unused-params-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/llk-unused-params-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/llk-unused-params-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/llk-unused-params-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/llk-unused-params-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/llk-unused-params-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/llk-unused-params-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/llk-unused-params-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/llk-unused-params-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/llk-unused-params-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/llk-unused-params-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/llk-unused-params-matmul)