### PR TITLE
tools/triage: galaxy views 

### DIFF
--- a/tools/tests/triage/test_galaxy_topology.py
+++ b/tools/tests/triage/test_galaxy_topology.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure-helper tests for tools/triage/galaxy_topology.py.
+
+Does not require any hardware. Run from repo root:
+    pytest tools/tests/triage/test_galaxy_topology.py -v
+"""
+
+import os
+import sys
+
+import pytest
+
+
+_metal_home = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+_triage_home = os.path.join(_metal_home, "tools", "triage")
+sys.path.insert(0, _triage_home)
+
+
+from galaxy_topology import device_to_cell  # noqa: E402
+
+
+# Tray membership matches the user-verified diagram (matches tt-smi -glx_list_tray_to_device).
+T1 = [0, 1, 2, 3, 4, 5, 6, 7]
+T2 = [16, 17, 18, 19, 20, 21, 22, 23]
+T3 = [8, 9, 10, 11, 12, 13, 14, 15]
+T4 = [24, 25, 26, 27, 28, 29, 30, 31]
+
+
+def _expected_8x4():
+    """Return {(row, col): (tray_num, dev_id)} for the 8x4 layout from the diagram."""
+    grid = {
+        # rows 0..3 — top half: T1 (cols 0-1) | T3 (cols 2-3)
+        # T1: idx 0..3 in col 0, 4..7 in col 1, sub-row = idx %4
+        (0, 0): (1, 0),
+        (0, 1): (1, 4),
+        (0, 2): (3, 8),
+        (0, 3): (3, 12),
+        (1, 0): (1, 1),
+        (1, 1): (1, 5),
+        (1, 2): (3, 9),
+        (1, 3): (3, 13),
+        (2, 0): (1, 2),
+        (2, 1): (1, 6),
+        (2, 2): (3, 10),
+        (2, 3): (3, 14),
+        (3, 0): (1, 3),
+        (3, 1): (1, 7),
+        (3, 2): (3, 11),
+        (3, 3): (3, 15),
+        # rows 4..7 — bottom half: T2 (cols 0-1) | T4 (cols 2-3)
+        (4, 0): (2, 16),
+        (4, 1): (2, 20),
+        (4, 2): (4, 24),
+        (4, 3): (4, 28),
+        (5, 0): (2, 17),
+        (5, 1): (2, 21),
+        (5, 2): (4, 25),
+        (5, 3): (4, 29),
+        (6, 0): (2, 18),
+        (6, 1): (2, 22),
+        (6, 2): (4, 26),
+        (6, 3): (4, 30),
+        (7, 0): (2, 19),
+        (7, 1): (2, 23),
+        (7, 2): (4, 27),
+        (7, 3): (4, 31),
+    }
+    return grid
+
+
+def _expected_4x8():
+    """Return {(row, col): (tray_num, dev_id)} for the 4x8 layout from the diagram."""
+    grid = {
+        # rows 0-1: T1 (cols 0-3) | T2 (cols 4-7), within tray idx 0..3 in row 0, 4..7 in row 1
+        (0, 0): (1, 0),
+        (0, 1): (1, 1),
+        (0, 2): (1, 2),
+        (0, 3): (1, 3),
+        (0, 4): (2, 16),
+        (0, 5): (2, 17),
+        (0, 6): (2, 18),
+        (0, 7): (2, 19),
+        (1, 0): (1, 4),
+        (1, 1): (1, 5),
+        (1, 2): (1, 6),
+        (1, 3): (1, 7),
+        (1, 4): (2, 20),
+        (1, 5): (2, 21),
+        (1, 6): (2, 22),
+        (1, 7): (2, 23),
+        # rows 2-3: T3 (cols 0-3) | T4 (cols 4-7)
+        (2, 0): (3, 8),
+        (2, 1): (3, 9),
+        (2, 2): (3, 10),
+        (2, 3): (3, 11),
+        (2, 4): (4, 24),
+        (2, 5): (4, 25),
+        (2, 6): (4, 26),
+        (2, 7): (4, 27),
+        (3, 0): (3, 12),
+        (3, 1): (3, 13),
+        (3, 2): (3, 14),
+        (3, 3): (3, 15),
+        (3, 4): (4, 28),
+        (3, 5): (4, 29),
+        (3, 6): (4, 30),
+        (3, 7): (4, 31),
+    }
+    return grid
+
+
+_TRAYS = {1: T1, 2: T2, 3: T3, 4: T4}
+
+
+@pytest.mark.parametrize(
+    "expected_cell,tray_num,dev_id",
+    [(cell, tray, dev) for cell, (tray, dev) in _expected_8x4().items()],
+)
+def test_device_to_cell_8x4_full(expected_cell, tray_num, dev_id):
+    assert device_to_cell(dev_id, tray_num, _TRAYS[tray_num], (8, 4)) == expected_cell
+
+
+@pytest.mark.parametrize(
+    "expected_cell,tray_num,dev_id",
+    [(cell, tray, dev) for cell, (tray, dev) in _expected_4x8().items()],
+)
+def test_device_to_cell_4x8_full(expected_cell, tray_num, dev_id):
+    assert device_to_cell(dev_id, tray_num, _TRAYS[tray_num], (4, 8)) == expected_cell
+
+
+@pytest.mark.parametrize("bad_shape", [(2, 16), (16, 2), (1, 32), (32, 1), (5, 7)])
+def test_device_to_cell_unsupported_shape(bad_shape):
+    with pytest.raises(ValueError, match="Unsupported Galaxy shape"):
+        device_to_cell(0, 1, T1, bad_shape)

--- a/tools/triage/device_locations.py
+++ b/tools/triage/device_locations.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Usage:
+    device_locations
+
+Description:
+    Data provider that resolves each ttexalens Device to its physical location:
+    PCI BDF (e.g. "0000:01:00.0") and Galaxy tray number / tray bus id.
+
+    Wraps `galaxy_topology.get_pci_bdf` + `compute_tray` so dump scripts that
+    want tray-aware output don't have to repeat the per-device walk or reach
+    into the name-mangled ttexalens UMD attributes themselves.
+
+    Cached with @triage_singleton — computed once per triage run.
+
+Owner:
+    miacim
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from galaxy_topology import compute_tray, get_pci_bdf, ubb_table_for_devices
+from run_checks import run as get_run_checks, RunChecks
+from triage import ScriptConfig, triage_singleton, run_script
+from ttexalens.context import Context
+
+
+script_config = ScriptConfig(
+    data_provider=True,
+    depends=["run_checks"],
+)
+
+
+@dataclass
+class DeviceLocation:
+    """Per-device physical-location summary."""
+
+    pci_bdf: str | None
+    tray_num: int | None
+    tray_bus_id: int | None
+
+
+class DeviceLocations:
+    """Lookup table from logical device id -> DeviceLocation, plus cached arch / tray map."""
+
+    def __init__(
+        self,
+        by_device_id: dict[int, DeviceLocation],
+        ubb_table: dict[int, int] | None,
+    ):
+        self._by_id = by_device_id
+        self._ubb_table = ubb_table
+
+    def __len__(self) -> int:
+        return len(self._by_id)
+
+    def get(self, device_id: int) -> DeviceLocation | None:
+        return self._by_id.get(device_id)
+
+    def pci_bdf(self, device_id: int) -> str | None:
+        loc = self._by_id.get(device_id)
+        return loc.pci_bdf if loc is not None else None
+
+    def tray_num(self, device_id: int) -> int | None:
+        loc = self._by_id.get(device_id)
+        return loc.tray_num if loc is not None else None
+
+    def tray_bus_id(self, device_id: int) -> int | None:
+        loc = self._by_id.get(device_id)
+        return loc.tray_bus_id if loc is not None else None
+
+    def tray_to_devices(self) -> dict[int, list[int]]:
+        """Return {tray_num: sorted list of device ids on that tray}."""
+        result: dict[int, list[int]] = {}
+        for device_id, loc in self._by_id.items():
+            if loc.tray_num is None:
+                continue
+            result.setdefault(loc.tray_num, []).append(device_id)
+        for tray in result:
+            result[tray].sort()
+        return result
+
+    @property
+    def ubb_table(self) -> dict[int, int] | None:
+        """Return the UBB tray->bus_id table for the host's arch (WH or BH), or None."""
+        return self._ubb_table
+
+
+@triage_singleton
+def run(args, context: Context) -> DeviceLocations:
+    """Build per-device PCI/tray info. Cached per (args, context)."""
+    run_checks: RunChecks = get_run_checks(args, context)
+
+    by_id: dict[int, DeviceLocation] = {}
+    for device in run_checks.devices:
+        bdf = get_pci_bdf(device)
+        arch = getattr(getattr(device, "_umd_device", None), "arch", None)
+        tray_num, tray_bus_id = compute_tray(bdf, arch)
+        by_id[int(device.id)] = DeviceLocation(
+            pci_bdf=bdf,
+            tray_num=tray_num,
+            tray_bus_id=tray_bus_id,
+        )
+
+    return DeviceLocations(by_id, ubb_table_for_devices(run_checks.devices))
+
+
+if __name__ == "__main__":
+    run_script()

--- a/tools/triage/dump_galaxy_mesh.py
+++ b/tools/triage/dump_galaxy_mesh.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Usage:
+    dump_galaxy_mesh [--galaxy-shape=<RxC>]
+
+Options:
+    --galaxy-shape=<RxC>   Mesh shape, "<rows>x<cols>". Only "8x4" (default) and "4x8" are
+                           supported because they correspond to the physical Galaxy tray
+                           topology. Anything else falls back to 8x4 with a warning.
+
+Description:
+    Prints two tables for Galaxy hosts:
+      1. tt-smi-style "Mapping of trays to devices on the galaxy" (Tray Number / Tray Bus ID /
+         PCI Dev ID).
+      2. A topology-aware mesh, each cell labelled `T<tray>:N<idx_in_tray> (Device <id>)` and
+         showing `(idle)` or `{host_assigned_id}: {op_name}` lines for any op currently
+         running there.
+
+    The device label is suffixed with ⚠️ when any op on that device is **not the majority op**
+    (the op running on the most distinct devices). Tie-break is deterministic — alphabetical by
+    op name.
+
+    Depends on:
+      - `running_ops_aggregation` for the per-host_assigned_id aggregation,
+      - `device_locations` for per-device PCI/tray info.
+
+Owner:
+    miacim
+"""
+
+from __future__ import annotations
+
+from operation_runtime_map import _decode_base_program_id
+from device_locations import run as get_device_locations
+from galaxy_topology import (
+    SUPPORTED_GALAXY_SHAPES,
+    device_to_cell,
+)
+from rich.console import Console
+from rich.table import Table
+from running_ops_aggregation import run as get_running_ops_aggregation
+from triage import ScriptConfig, log_check, run_script
+from ttexalens.context import Context
+
+
+script_config = ScriptConfig(depends=["running_ops_aggregation", "device_locations"])
+
+
+def _parse_galaxy_shape(shape: str | None) -> tuple[int, int] | None:
+    """Parse "<rows>x<cols>" and return it only if it's in SUPPORTED_GALAXY_SHAPES."""
+    if not shape:
+        return None
+    parts = shape.lower().replace(" ", "").split("x")
+    if len(parts) != 2:
+        return None
+    try:
+        rows, cols = int(parts[0]), int(parts[1])
+    except ValueError:
+        return None
+    candidate = (rows, cols)
+    if candidate not in SUPPORTED_GALAXY_SHAPES:
+        return None
+    return candidate
+
+
+def run(args, context: Context):
+    raw_shape = args["--galaxy-shape"]
+    parsed_shape = _parse_galaxy_shape(raw_shape) if raw_shape else None
+    if raw_shape and parsed_shape is None:
+        supported = sorted(f"{r}x{c}" for r, c in SUPPORTED_GALAXY_SHAPES)
+        log_check(
+            False,
+            f"Unsupported --galaxy-shape={raw_shape!r}; only {supported} match the physical "
+            f"Galaxy tray topology. Falling back to 8x4.",
+        )
+    rows, cols = parsed_shape if parsed_shape is not None else (8, 4)
+
+    bundle = get_running_ops_aggregation(args, context)
+    aggregations = bundle.aggregations
+    runtime_id_to_operation = bundle.runtime_id_to_operation
+
+    locations = get_device_locations(args, context)
+    tray_to_devices = locations.tray_to_devices()
+
+    if not tray_to_devices:
+        log_check(
+            False,
+            "Galaxy mesh suppressed: no devices map to a UBB tray (non-Galaxy host or PCI " "BDF lookup failed).",
+        )
+        return None
+
+    # device_id -> set of (host_assigned_id, op_name)
+    device_to_ops: dict[int, set[tuple[int, str]]] = {}
+    # op_name -> set of device labels running it (used to find the majority op)
+    running_ops: dict[str, set[str]] = {}
+    for host_assigned_id, agg in aggregations.items():
+        # Resolve the raw runtime id (raw or decoded) so we can look up the op name.
+        op_info = runtime_id_to_operation.get_raw(host_assigned_id)
+        if op_info is None:
+            op_info = runtime_id_to_operation.get_raw(_decode_base_program_id(host_assigned_id))
+        op_name = (op_info.name if op_info else "") or "N/A"
+        running_ops.setdefault(op_name, set()).update(agg.device_labels)
+        for dev_label in agg.device_labels:
+            try:
+                dev_id = int(dev_label, 0)
+            except (TypeError, ValueError):
+                continue
+            device_to_ops.setdefault(dev_id, set()).add((host_assigned_id, op_name))
+
+    running_ops_count: dict[str, int] = {name: len(devs) for name, devs in running_ops.items()}
+    # Deterministic tie-break: highest count first, alphabetical name on tie.
+    majority_op: str | None = (
+        sorted(running_ops_count.items(), key=lambda kv: (-kv[1], kv[0]))[0][0] if running_ops_count else None
+    )
+
+    console = Console()
+
+    # 1. tt-smi-style "Mapping of trays to devices" table.
+    ubb_table = locations.ubb_table or {}
+    tray_table = Table(title="Mapping of trays to devices on the galaxy:", title_justify="left")
+    tray_table.add_column("Tray Number")
+    tray_table.add_column("Tray Bus ID")
+    tray_table.add_column("PCI Dev ID")
+    for tray_num in sorted(tray_to_devices):
+        bus_id = ubb_table.get(tray_num)
+        bus_id_str = f"0x{bus_id:02x}" if bus_id is not None else "?"
+        tray_table.add_row(
+            f"{tray_num}",
+            bus_id_str,
+            ",".join(str(d) for d in tray_to_devices[tray_num]),
+        )
+    console.print(tray_table)
+
+    # 2. Topology-aware Galaxy mesh.
+    mesh = Table(
+        title=f"Galaxy mesh ({rows}x{cols}) — current op per device",
+        title_justify="left",
+        show_lines=True,
+    )
+    for c in range(cols):
+        mesh.add_column(f"col {c}", justify="left")
+
+    grid: list[list[str]] = [["" for _ in range(cols)] for _ in range(rows)]
+    for tray_num, devs in tray_to_devices.items():
+        for dev_id in devs:
+            try:
+                r, c = device_to_cell(dev_id, tray_num, devs, (rows, cols))
+            except (ValueError, KeyError):
+                continue
+            idx_in_tray = devs.index(dev_id)
+            label = f"T{tray_num}:N{idx_in_tray} (Device {dev_id})"
+            entries = device_to_ops.get(dev_id)
+            if entries:
+                # If any op on this device isn't the majority op, mark the device label so
+                # outlier devices jump out at a glance. Greppable: `grep '\[!\]'`. ASCII-only
+                # because emoji break rich.Table column-width math.
+                if majority_op is not None and any((name or "N/A") != majority_op for _, name in entries):
+                    label = f"{label} [!]"
+                ops_lines = "\n".join(f"{hid}: {name or 'N/A'}" for hid, name in sorted(entries))
+                grid[r][c] = f"{label}\n{ops_lines}"
+            else:
+                grid[r][c] = f"{label}\n(idle)"
+
+    for r in range(rows):
+        mesh.add_row(*grid[r])
+
+    console.print(mesh)
+    return None
+
+
+if __name__ == "__main__":
+    run_script()

--- a/tools/triage/dump_galaxy_mesh.py
+++ b/tools/triage/dump_galaxy_mesh.py
@@ -20,9 +20,9 @@ Description:
          showing `(idle)` or `{host_assigned_id}: {op_name}` lines for any op currently
          running there.
 
-    The device label is suffixed with ⚠️ when any op on that device is **not the majority op**
-    (the op running on the most distinct devices). Tie-break is deterministic — alphabetical by
-    op name.
+    The device label is suffixed with `[!]` when any op on that device is **not the majority
+    op** (the op running on the most distinct devices). Tie-break is deterministic —
+    alphabetical by op name.
 
     Depends on:
       - `running_ops_aggregation` for the per-host_assigned_id aggregation,

--- a/tools/triage/dump_op_window.py
+++ b/tools/triage/dump_op_window.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Usage:
+    dump_op_window [--op-window=<n>] [--full-devices]
+
+Options:
+    --op-window=<n>    Render ops with id in [min_running_op_id - n, max_running_op_id + n].
+                       Use this to see what ran just before / what should have run next around
+                       the currently-running set. [default: 10]
+    --full-devices     Print the full list of devices per row instead of truncating with "...".
+
+Description:
+    Companion to `dump_running_operations`. Reads the same aggregation, then prints a
+    context-window table sourced from the Inspector runtime map. Each row shows:
+      - Op Id (raw runtime id)
+      - Status (`RUNNING` if currently observed in dispatcher mailboxes, blank otherwise)
+      - Op Name (Inspector)
+      - Devices (set of device labels currently running this op id; blank for neighbors)
+
+Owner:
+    miacim
+"""
+
+from __future__ import annotations
+
+from operation_runtime_map import OperationRuntimeMap, _decode_base_program_id
+from running_ops_aggregation import (
+    run as get_running_ops_aggregation,
+    RunningOperationAggregation,
+)
+from triage import ScriptConfig, log_check, run_script
+from ttexalens.context import Context
+
+
+script_config = ScriptConfig(depends=["running_ops_aggregation"])
+
+
+MAX_DEVICES_DISPLAYED = 5
+
+
+def _resolve_running_raw_id(
+    host_assigned_id: int,
+    runtime_id_to_operation: OperationRuntimeMap,
+) -> int | None:
+    """Return the raw runtime_id matching a mailbox host_assigned_id, or None."""
+    if runtime_id_to_operation.get_raw(host_assigned_id) is not None:
+        return host_assigned_id
+    decoded = _decode_base_program_id(host_assigned_id)
+    if runtime_id_to_operation.get_raw(decoded) is not None:
+        return decoded
+    return None
+
+
+def _build_raw_id_to_devices(
+    aggregations: dict[int, RunningOperationAggregation],
+    runtime_id_to_operation: OperationRuntimeMap,
+) -> dict[int, set[str]]:
+    """Map each running raw runtime_id to the set of device labels running it."""
+    raw_to_devices: dict[int, set[str]] = {}
+    for host_assigned_id, agg in aggregations.items():
+        raw_id = _resolve_running_raw_id(host_assigned_id, runtime_id_to_operation)
+        if raw_id is None:
+            continue
+        raw_to_devices.setdefault(raw_id, set()).update(agg.device_labels)
+    return raw_to_devices
+
+
+def _device_sort_key(device_label: str):
+    """Sort numerically when possible, lexicographically otherwise."""
+    try:
+        return (0, int(device_label, 0))
+    except (TypeError, ValueError):
+        return (1, device_label)
+
+
+def run(args, context: Context):
+    try:
+        window: int = int(args["--op-window"])
+    except (TypeError, ValueError):
+        window = 0
+    full_devices: bool = args["--full-devices"]
+
+    if window <= 0:
+        log_check(False, f"Op-id window suppressed: --op-window={window} (must be > 0).")
+        return None
+
+    bundle = get_running_ops_aggregation(args, context)
+    aggregations = bundle.aggregations
+    runtime_id_to_operation = bundle.runtime_id_to_operation
+
+    if not aggregations:
+        log_check(False, "Op-id window suppressed: no running ops found in dispatcher mailboxes.")
+        return None
+
+    raw_to_devices = _build_raw_id_to_devices(aggregations, runtime_id_to_operation)
+    running_raw_ids = set(raw_to_devices.keys())
+    if not running_raw_ids:
+        log_check(
+            False,
+            "Op-id window suppressed: no running host_assigned_id resolved to a known Inspector "
+            "runtime id (Inspector data may be empty / out of sync).",
+        )
+        return None
+
+    min_id = min(running_raw_ids) - window
+    max_id = max(running_raw_ids) + window
+
+    entries = sorted(
+        (raw_id, op_info) for raw_id, op_info in runtime_id_to_operation.items() if min_id <= raw_id <= max_id
+    )
+    if not entries:
+        log_check(
+            False,
+            f"Op-id window suppressed: no Inspector entries in range [{min_id}, {max_id}].",
+        )
+        return None
+
+    # Render via rich.Table — emitted directly so the script returns None to triage's
+    # auto-renderer (its standard list-of-dataclasses pipeline doesn't fit a "context"
+    # table whose columns are non-uniform).
+    from rich.console import Console
+    from rich.table import Table
+
+    table = Table(
+        title=f"Op Id context window (running ids ± {window})",
+        title_justify="left",
+    )
+    table.add_column("Op Id", justify="right")
+    table.add_column("Status")
+    table.add_column("Op Name")
+    table.add_column("Devices")
+
+    for raw_id, op_info in entries:
+        status = "RUNNING" if raw_id in running_raw_ids else ""
+        device_labels = sorted(raw_to_devices.get(raw_id, set()), key=_device_sort_key)
+        if full_devices or len(device_labels) <= MAX_DEVICES_DISPLAYED:
+            devices_cell = ", ".join(device_labels)
+        else:
+            devices_cell = ", ".join(device_labels[:MAX_DEVICES_DISPLAYED] + ["..."])
+        table.add_row(str(raw_id), status, op_info.name or "N/A", devices_cell)
+
+    Console().print(table)
+    return None
+
+
+if __name__ == "__main__":
+    run_script()

--- a/tools/triage/dump_running_operations.py
+++ b/tools/triage/dump_running_operations.py
@@ -5,10 +5,11 @@
 
 """
 Usage:
-    dump_running_operations [--include-done]
+    dump_running_operations [--full-devices] [--full-cores]
 
 Options:
-    --include-done     Show all cores including ones with Go Message = DONE. By default, DONE cores are filtered out.
+    --full-devices   Print the full list of devices per operation instead of truncating with "...".
+    --full-cores     Print the full list of cores per operation instead of truncating with "...".
 
 Description:
     Summarizes currently running operations across all inspected cores.
@@ -20,22 +21,14 @@ Description:
           - Device Cnt / Core Cnt: total unique devices/cores running this Op Id
           - Devices / Cores: enumerated lists (may be truncated with "..." for readability)
 
+    Companion scripts:
+      - `dump_op_window` — context table of ops with id near the currently-running set.
+      - `dump_galaxy_mesh` — tt-smi-style tray table + Galaxy mesh laid out by physical topology.
+      All three share the same aggregation via `running_ops_aggregation` (use `--include-done`
+      on the triage CLI to surface DONE cores in every consumer).
+
     Data sources:
-      - Dispatcher mailboxes (`dispatcher_data.py`):
-          - Provides Op Id (host_assigned_id) per core, plus the previous launch entry’s Op Id.
-      - Inspector mesh workloads (`operation_runtime_map.py`, derived from `inspector_data.py`):
-          - Provides mapping: runtime_id -> (operation name, operation parameters).
-
-    Key assumptions / caveats:
-      - Op Id (dispatcher host_assigned_id) is expected to match Inspector runtime_id.
-
-    Heuristic:
-      - The smallest Op Id among currently-running cores can sometimes indicate
-        an older operation that has not completed.
-
-    Caveat:
-      - In replay / cached execution modes, Op Id may not monotonically increase,
-        so this heuristic can be wrong.
+      - `running_ops_aggregation` (per-core dispatcher data + Inspector runtime map).
 
 Owner:
     miacim
@@ -43,45 +36,30 @@ Owner:
 
 from dataclasses import dataclass
 
-from dispatcher_data import run as get_dispatcher_data, DispatcherData, DispatcherCoreData
-from operation_runtime_map import run as get_operation_runtime_map, OperationRuntimeMap, OperationInfo
 from operation_param_parser import ParameterParser
-from run_checks import (
-    run as get_run_checks,
-    RunChecks,
-    device_description_serializer,
+from running_ops_aggregation import (
+    run as get_running_ops_aggregation,
+    RunningOperationAggregation,
 )
 from triage import (
     ScriptConfig,
+    ScriptPriority,
     collection_serializer,
-    hex_serializer,
-    log_check,
-    log_check_risc,
     triage_field,
     run_script,
-    ScriptPriority,
 )
 from ttexalens.context import Context
-from ttexalens.coordinate import OnChipCoordinate
-from ttexalens.elf import ElfVariable
-from ttexalens.umd_device import TimeoutDeviceRegisterError
+
 
 script_config = ScriptConfig(
-    depends=["run_checks", "dispatcher_data", "operation_runtime_map"],
+    depends=["running_ops_aggregation"],
     priority=ScriptPriority.HIGH,
 )
 
-# Core filtering
-BLOCK_TYPES_TO_CHECK = ["tensix", "idle_eth", "active_eth", "dram"]
 
 # Display limits
-MAX_CORES_DISPLAYED = 5  # Maximum cores shown per operation
-MAX_DEVICES_DISPLAYED = 5  # Maximum devices shown per operation
-
-
-# ============================================================================
-# Running Operation Data Structures
-# ============================================================================
+MAX_CORES_DISPLAYED = 5
+MAX_DEVICES_DISPLAYED = 5
 
 
 @dataclass
@@ -100,251 +78,64 @@ class RunningOperationSummary:
     cores: list[str] = triage_field("Cores", collection_serializer("\n"))
 
 
-class RunningOperationAggregation:
-    """Mutable accumulator for all cores running operations under the same host assigned ID."""
-
-    def __init__(
-        self,
-        host_assigned_id: int,
-        operation_name: str = "",
-        operation_parameters: str = "",
-        trace_id: int | None = None,
-        previous_host_assigned_id: int | None = None,
-        previous_operation_name: str = "",
-        previous_operation_parameters: str = "",
-    ):
-        self.host_assigned_id = host_assigned_id
-        self.operation_name = operation_name
-        self.operation_parameters = operation_parameters
-        self.trace_id = trace_id
-        self.previous_host_assigned_id = previous_host_assigned_id
-        self.previous_operation_name = previous_operation_name
-        self.previous_operation_parameters = previous_operation_parameters
-        self.core_locations: set[str] = set()
-        self.device_labels: set[str] = set()
-
-    def add_core(
-        self,
-        device_label: str,
-        location: OnChipCoordinate,
-        risc_name: str,
-        dispatcher_core_data: DispatcherCoreData,
-    ):
-        """Add a core to this operation aggregation."""
-        self.core_locations.add(_format_core_location(device_label, location))
-        self.device_labels.add(device_label)
-
-    def to_summary(self) -> RunningOperationSummary:
-        """Convert aggregation to immutable summary with limited display."""
-        devices = sorted(self.device_labels)
-        devices_to_display = (
-            devices if len(devices) <= MAX_DEVICES_DISPLAYED else devices[:MAX_DEVICES_DISPLAYED] + ["..."]
-        )
-
-        unique_cores = sorted(self.core_locations)
-        cores_to_display = (
-            unique_cores if len(unique_cores) <= MAX_CORES_DISPLAYED else unique_cores[:MAX_CORES_DISPLAYED] + ["..."]
-        )
-
-        # Format operation parameters for display
-        # If parameters are available, parse them; otherwise show N/A
-        operation_params_display = "N/A"
-        if self.operation_parameters:
-            operation_params_display = ParameterParser.format_multiline(self.operation_parameters)
-
-        prev_operation_params_display = "N/A"
-        if self.previous_operation_parameters:
-            prev_operation_params_display = ParameterParser.format_multiline(self.previous_operation_parameters)
-
-        # Flag replayed ops inline with the name so the triage table makes it
-        # obvious which dispatches are coming from trace replay.
-        display_name = self.operation_name or "N/A"
-        if self.operation_name and self.trace_id is not None:
-            display_name = f"{display_name} (trace id: {self.trace_id})"
-
-        return RunningOperationSummary(
-            host_assigned_id=self.host_assigned_id,
-            operation_name=display_name,
-            operation_parameters=operation_params_display,
-            previous_host_assigned_id=self.previous_host_assigned_id,
-            previous_operation_name=self.previous_operation_name or "N/A",
-            previous_operation_parameters=prev_operation_params_display,
-            device_count=len(self.device_labels),
-            core_count=len(self.core_locations),
-            devices=devices_to_display,
-            cores=cores_to_display,
-        )
-
-
-# ============================================================================
-# Script Logic - Data Collection and Aggregation
-# ============================================================================
-
-
-def _format_core_location(device_label: str | None, location: OnChipCoordinate | None) -> str:
-    """Format a core location as device:coordinate string."""
-    if location is None:
-        return "N/A"
-    if device_label is None:
-        return location.to_user_str()
-    return f"{device_label}:{location.to_user_str()}"
-
-
-def _collect_dispatcher_data(
-    dispatcher_data: DispatcherData, location: OnChipCoordinate, risc_name: str, show_all_cores: bool = False
-) -> DispatcherCoreData | None:
-    """Collect dispatcher data for a single core.
-
-    Args:
-        dispatcher_data: Dispatcher data cache
-        location: Core location
-        risc_name: RISC-V core name
-        show_all_cores: If False, filter out DONE cores
-
-    Returns:
-        DispatcherCoreData if relevant, None otherwise
-    """
-    if not dispatcher_data.risc_enabled(risc_name):
-        return None
-
-    try:
-        dispatcher_core_data = dispatcher_data.get_cached_core_data(location, risc_name)
-    except TimeoutDeviceRegisterError:
-        raise
-    except Exception as e:
-        log_check_risc(
-            risc_name,
-            location,
-            False,
-            f"Failed to read dispatcher data for running operations aggregation: {e}",
-        )
-        return None
-
-    # Filter out DONE cores unless explicitly requested
-    if not show_all_cores and dispatcher_core_data.go_message == "DONE":
-        return None
-
-    # Skip cores with no host assigned ID or ID of 0
-    host_assigned_id = dispatcher_core_data.host_assigned_id
-    if host_assigned_id in (None, 0):
-        return None
-
-    return dispatcher_core_data
-
-
-def _collect_running_operations(
-    dispatcher_data: DispatcherData,
-    run_checks: RunChecks,
-    runtime_id_to_operation: OperationRuntimeMap,
-    show_all_cores: bool = False,
-) -> list[RunningOperationSummary] | None:
-    """Collect and aggregate running operations across all cores.
-
-    Args:
-        dispatcher_data: Dispatcher data cache
-        run_checks: Run checks infrastructure for core iteration
-        runtime_id_to_operation: Mapping from runtime_id -> (operation_name, operation_parameters)
-        show_all_cores: If False, filter out DONE cores
-
-    Returns:
-        List of operation summaries, one per unique host assigned ID
-    """
-    # Use run_checks infrastructure to iterate over all cores
-    collected_results = run_checks.run_per_core_check(
-        lambda location, risc_name: _collect_dispatcher_data(
-            dispatcher_data,
-            location,
-            risc_name,
-            show_all_cores,
-        ),
-        block_filter=BLOCK_TYPES_TO_CHECK,
+def _to_summary(
+    agg: RunningOperationAggregation,
+    full_devices: bool,
+    full_cores: bool,
+) -> RunningOperationSummary:
+    devices = sorted(agg.device_labels)
+    devices_to_display = (
+        devices if full_devices or len(devices) <= MAX_DEVICES_DISPLAYED else devices[:MAX_DEVICES_DISPLAYED] + ["..."]
     )
 
-    if not collected_results:
-        return None
+    unique_cores = sorted(agg.core_locations)
+    cores_to_display = (
+        unique_cores
+        if full_cores or len(unique_cores) <= MAX_CORES_DISPLAYED
+        else unique_cores[:MAX_CORES_DISPLAYED] + ["..."]
+    )
 
-    aggregations: dict[int, RunningOperationAggregation] = {}
+    operation_params_display = (
+        ParameterParser.format_multiline(agg.operation_parameters) if agg.operation_parameters else "N/A"
+    )
+    prev_operation_params_display = (
+        ParameterParser.format_multiline(agg.previous_operation_parameters)
+        if agg.previous_operation_parameters
+        else "N/A"
+    )
 
-    try:
-        # Process results and aggregate by host_assigned_id
-        for check_result in collected_results:
-            if check_result.result is None:
-                continue
+    # Flag replayed ops inline with the name so the table makes it
+    # obvious which dispatches are coming from trace replay.
+    display_name = agg.operation_name or "N/A"
+    if agg.operation_name and agg.trace_id is not None:
+        display_name = f"{display_name} (trace id: {agg.trace_id})"
 
-            if not isinstance(check_result.result, DispatcherCoreData):
-                continue
-
-            dispatcher_core_data: DispatcherCoreData = check_result.result
-
-            if dispatcher_core_data.host_assigned_id in (None, 0):
-                continue
-
-            dispatch_mode = dispatcher_core_data.dispatch_mode
-
-            # The mailbox host_assigned_id is raw in fast dispatch but EncodePerDeviceProgramID-encoded
-            # in slow dispatch; the map handles both via `lookup`. lookup returns None on miss.
-            op_info = (
-                runtime_id_to_operation.lookup(dispatcher_core_data.host_assigned_id, dispatch_mode)
-                or OperationInfo.empty()
-            )
-
-            # Slow dispatch overwrites a single launch slot, so the "previous" entry is stale/invalid.
-            if dispatch_mode == "HOST":
-                prev_runtime_id = None
-                prev_op_info = OperationInfo.empty()
-            else:
-                prev_runtime_id = dispatcher_core_data.previous_host_assigned_id
-                if prev_runtime_id not in (None, 0):
-                    prev_op_info = (
-                        runtime_id_to_operation.lookup(prev_runtime_id, dispatch_mode) or OperationInfo.empty()
-                    )
-                else:
-                    prev_op_info = OperationInfo.empty()
-
-            # Get or create aggregation for this host_assigned_id
-            aggregation = aggregations.setdefault(
-                dispatcher_core_data.host_assigned_id,
-                RunningOperationAggregation(
-                    dispatcher_core_data.host_assigned_id,
-                    op_info.name,
-                    op_info.parameters,
-                    op_info.trace_id,
-                    prev_runtime_id if prev_runtime_id and prev_runtime_id > 0 else None,
-                    prev_op_info.name,
-                    prev_op_info.parameters,
-                ),
-            )
-
-            # Add this core to the aggregation
-            aggregation.add_core(
-                device_description_serializer(check_result.device_description),
-                check_result.location,
-                check_result.risc_name,
-                dispatcher_core_data,
-            )
-    except Exception as e:
-        log_check(False, f"Failed to collect running operations: {e}")
-        return None
-
-    if not aggregations:
-        return None
-
-    # Convert aggregations to summaries, sorted by host_assigned_id
-    return [aggregations[host_assigned_id].to_summary() for host_assigned_id in sorted(aggregations.keys())]
-
-
-# ============================================================================
-# Entry Point
-# ============================================================================
+    return RunningOperationSummary(
+        host_assigned_id=agg.host_assigned_id,
+        operation_name=display_name,
+        operation_parameters=operation_params_display,
+        previous_host_assigned_id=agg.previous_host_assigned_id,
+        previous_operation_name=agg.previous_operation_name or "N/A",
+        previous_operation_parameters=prev_operation_params_display,
+        device_count=len(agg.device_labels),
+        core_count=len(agg.core_locations),
+        devices=devices_to_display,
+        cores=cores_to_display,
+    )
 
 
 def run(args, context: Context):
-    """Main entry point for the script."""
-    show_all_cores: bool = args["--include-done"]
-    dispatcher_data = get_dispatcher_data(args, context)
-    run_checks = get_run_checks(args, context)
-    runtime_id_to_operation = get_operation_runtime_map(args, context)
-    return _collect_running_operations(dispatcher_data, run_checks, runtime_id_to_operation, show_all_cores)
+    """Pure renderer: read aggregations from the data provider, emit summaries."""
+    full_devices: bool = args["--full-devices"]
+    full_cores: bool = args["--full-cores"]
+
+    bundle = get_running_ops_aggregation(args, context)
+    if not bundle.aggregations:
+        return None
+
+    return [
+        _to_summary(bundle.aggregations[hid], full_devices, full_cores) for hid in sorted(bundle.aggregations.keys())
+    ]
 
 
 if __name__ == "__main__":

--- a/tools/triage/galaxy_topology.py
+++ b/tools/triage/galaxy_topology.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for mapping ttexalens devices to Galaxy tray topology.
+
+Mirrors the logic tt-smi already uses for `-glx_list_tray_to_device`:
+  - PCI BDF is read from the underlying tt_umd device.
+  - Tray number is derived from `bus_id & 0xF0` via the WH/BH UBB tables.
+"""
+
+from __future__ import annotations
+
+# UBB bus-id tables. Sourced from tt_smi.constants when available; fall back to
+# inline literals so triage still works on hosts without tt-smi installed.
+try:
+    from tt_smi import constants as _tt_smi_constants
+
+    WH_UBB_BUS_IDS: dict[int, int] = dict(_tt_smi_constants.WH_UBB_BUS_IDS)
+    BH_UBB_BUS_IDS: dict[int, int] = dict(_tt_smi_constants.BH_UBB_BUS_IDS)
+except ImportError:
+    WH_UBB_BUS_IDS = {1: 0xC0, 2: 0x80, 3: 0x00, 4: 0x40}
+    BH_UBB_BUS_IDS = {1: 0x00, 2: 0x40, 3: 0xC0, 4: 0x80}
+
+
+SUPPORTED_GALAXY_SHAPES: set[tuple[int, int]] = {(8, 4), (4, 8)}
+
+
+# One-shot warning state so a UMD-ABI break (the name-mangled access path
+# below stops working) shows up loudly on the first device but doesn't spam
+# every subsequent one.
+_pci_bdf_warned = False
+
+
+def get_pci_bdf(device) -> str | None:
+    """Return the PCI BDF (e.g. "0000:01:00.0") for a ttexalens Device, or None.
+
+    Mirrors tt_smi's UMD path: device.get_pci_device().get_device_info().pci_bdf.
+    Returns None silently for remote/JTAG-only devices (legitimate skip).
+    On a name-mangled access break (UMD ABI change), emits a one-shot
+    triage warning so the regression is visible instead of degrading to
+    "no devices map to a UBB tray; skipping".
+
+    TODO(ttexalens): UmdDevice should grow a public `pci_bdf` property so we
+    don't have to reach through `_UmdDevice__device`.
+    """
+    global _pci_bdf_warned
+    umd_device = getattr(device, "_umd_device", None)
+    if umd_device is None:
+        return None
+    if not getattr(umd_device, "is_mmio_capable", True):
+        return None
+    try:
+        tt_dev = umd_device._UmdDevice__device  # name-mangled — fragile, see TODO
+        return tt_dev.get_pci_device().get_device_info().pci_bdf
+    except AttributeError as e:
+        if not _pci_bdf_warned:
+            try:
+                from triage import log_check
+
+                log_check(
+                    False,
+                    f"galaxy_topology.get_pci_bdf: UMD attribute access failed ({e}); "
+                    f"the name-mangled `_UmdDevice__device.get_pci_device().get_device_info().pci_bdf` "
+                    f"path is broken — likely a tt_umd ABI change. Tray mapping will be unavailable.",
+                )
+            except Exception:
+                pass
+            _pci_bdf_warned = True
+        return None
+
+
+def ubb_table_for_arch(arch) -> dict[int, int] | None:
+    """Pick WH or BH UBB table from a tt_umd ARCH enum, or None for unknown arch."""
+    name = getattr(arch, "name", str(arch) if arch is not None else "").upper()
+    if "WORMHOLE" in name:
+        return WH_UBB_BUS_IDS
+    if "BLACKHOLE" in name:
+        return BH_UBB_BUS_IDS
+    return None
+
+
+def ubb_table_for_devices(devices) -> dict[int, int] | None:
+    """Pick the WH/BH UBB table from the arch of the first available device."""
+    for device in devices:
+        arch = getattr(getattr(device, "_umd_device", None), "arch", None)
+        if arch is not None:
+            table = ubb_table_for_arch(arch)
+            if table is not None:
+                return table
+    return None
+
+
+def compute_tray(bdf: str | None, arch) -> tuple[int | None, int | None]:
+    """Return (tray_num, tray_bus_id) for a BDF + arch, or (None, None) if not on a UBB tray."""
+    if not bdf:
+        return None, None
+    table = ubb_table_for_arch(arch)
+    if table is None:
+        return None, None
+    try:
+        bus_id = int(bdf.split(":")[1], 16)
+    except (IndexError, ValueError):
+        return None, None
+    tray_bus_id = bus_id & 0xF0
+    bus_id_to_tray = {bus: tray for tray, bus in table.items()}
+    tray_num = bus_id_to_tray.get(tray_bus_id)
+    if tray_num is None:
+        return None, None
+    return tray_num, tray_bus_id
+
+
+def build_tray_to_devices(devices) -> dict[int, list[int]]:
+    """Map tray number -> sorted list of logical device ids running on that tray.
+
+    Devices that don't resolve to a UBB tray (single-card hosts, remote chips,
+    unknown arch) are simply omitted.
+    """
+    tray_to_devices: dict[int, list[int]] = {}
+    for device in devices:
+        bdf = get_pci_bdf(device)
+        arch = getattr(getattr(device, "_umd_device", None), "arch", None)
+        tray_num, _ = compute_tray(bdf, arch)
+        if tray_num is None:
+            continue
+        tray_to_devices.setdefault(tray_num, []).append(int(device.id))
+    for tray in tray_to_devices:
+        tray_to_devices[tray].sort()
+    return tray_to_devices
+
+
+def device_to_cell(
+    device_id: int,
+    tray_num: int,
+    sorted_tray_devices: list[int],
+    shape: tuple[int, int],
+) -> tuple[int, int]:
+    """Map a logical device id to its (row, col) in the Galaxy mesh.
+
+    Layout matches the physical Galaxy topology that `tt-smi
+    -glx_list_tray_to_device` reflects:
+
+      8x4 — 2x2 tray quadrants {T1:TL, T3:TR, T2:BL, T4:BR}, each tray a 4x2
+            sub-grid arranged column-major (idx %4 -> sub-row, idx //4 -> sub-col).
+      4x8 — 2x2 tray quadrants {T1:TL, T2:TR, T3:BL, T4:BR}, each tray a 2x4
+            sub-grid arranged row-major (idx //4 -> sub-row, idx %4 -> sub-col).
+
+    `sorted_tray_devices` must be the sorted list of device ids on `tray_num`;
+    `idx` (0..7) is the device's position within that list.
+    """
+    if shape not in SUPPORTED_GALAXY_SHAPES:
+        raise ValueError(f"Unsupported Galaxy shape {shape!r}; expected one of {SUPPORTED_GALAXY_SHAPES}")
+    idx = sorted_tray_devices.index(device_id)
+    if shape == (8, 4):
+        quadrant = {1: (0, 0), 2: (1, 0), 3: (0, 1), 4: (1, 1)}[tray_num]
+        sub_r, sub_c = idx % 4, idx // 4
+        return quadrant[0] * 4 + sub_r, quadrant[1] * 2 + sub_c
+    # shape == (4, 8)
+    quadrant = {1: (0, 0), 2: (0, 1), 3: (1, 0), 4: (1, 1)}[tray_num]
+    sub_r, sub_c = idx // 4, idx % 4
+    return quadrant[0] * 2 + sub_r, quadrant[1] * 4 + sub_c

--- a/tools/triage/operation_runtime_map.py
+++ b/tools/triage/operation_runtime_map.py
@@ -71,6 +71,14 @@ class OperationRuntimeMap:
     def __len__(self) -> int:
         return len(self._map)
 
+    def items(self):
+        """Iterate over (raw_runtime_id, OperationInfo) pairs in the underlying map."""
+        return self._map.items()
+
+    def get_raw(self, raw_runtime_id: int) -> OperationInfo | None:
+        """Look up by raw runtime_id without any decoding/fallback logic."""
+        return self._map.get(raw_runtime_id)
+
     def lookup(self, host_assigned_id: int, dispatch_mode: str | None) -> OperationInfo | None:
         """Resolve host_assigned_id to its Inspector entry, or None if not found.
 

--- a/tools/triage/running_ops_aggregation.py
+++ b/tools/triage/running_ops_aggregation.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Usage:
+    running_ops_aggregation [--include-done]
+
+Options:
+    --include-done   Show all cores including ones with Go Message = DONE.
+                     By default, DONE cores are filtered out.
+
+Description:
+    Data provider that scans every dispatcher core, filters DONE/idle cores
+    (unless --include-done is set), looks up each running mailbox host_assigned_id
+    in the Inspector runtime map, and produces a `RunningOpsAggregation` (the
+    per-host_assigned_id `RunningOperationAggregation` dict + the runtime map).
+
+    Cached with @triage_singleton so dump_running_operations, dump_op_window,
+    and dump_galaxy_mesh share a single iteration over the dispatcher cores.
+
+Owner:
+    miacim
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from dispatcher_data import run as get_dispatcher_data, DispatcherData, DispatcherCoreData
+from operation_runtime_map import (
+    run as get_operation_runtime_map,
+    OperationRuntimeMap,
+    OperationInfo,
+)
+from run_checks import (
+    run as get_run_checks,
+    RunChecks,
+    device_description_serializer,
+)
+from triage import (
+    ScriptConfig,
+    log_check,
+    log_check_risc,
+    triage_singleton,
+    run_script,
+)
+from ttexalens.context import Context
+from ttexalens.coordinate import OnChipCoordinate
+from ttexalens.umd_device import TimeoutDeviceRegisterError
+
+
+script_config = ScriptConfig(
+    data_provider=True,
+    depends=["run_checks", "dispatcher_data", "operation_runtime_map"],
+)
+
+
+# Core filtering — matches the historical block list from dump_running_operations.
+BLOCK_TYPES_TO_CHECK = ["tensix", "idle_eth", "active_eth", "dram"]
+
+
+def _format_core_location(device_label: str | None, location: OnChipCoordinate | None) -> str:
+    """Format a core location as device:coordinate string."""
+    if location is None:
+        return "N/A"
+    if device_label is None:
+        return location.to_user_str()
+    return f"{device_label}:{location.to_user_str()}"
+
+
+class RunningOperationAggregation:
+    """Mutable accumulator for all cores running operations under the same host assigned ID."""
+
+    def __init__(
+        self,
+        host_assigned_id: int,
+        operation_name: str = "",
+        operation_parameters: str = "",
+        trace_id: int | None = None,
+        previous_host_assigned_id: int | None = None,
+        previous_operation_name: str = "",
+        previous_operation_parameters: str = "",
+    ):
+        self.host_assigned_id = host_assigned_id
+        self.operation_name = operation_name
+        self.operation_parameters = operation_parameters
+        self.trace_id = trace_id
+        self.previous_host_assigned_id = previous_host_assigned_id
+        self.previous_operation_name = previous_operation_name
+        self.previous_operation_parameters = previous_operation_parameters
+        self.core_locations: set[str] = set()
+        self.device_labels: set[str] = set()
+
+    def add_core(
+        self,
+        device_label: str,
+        location: OnChipCoordinate,
+        risc_name: str,
+        dispatcher_core_data: DispatcherCoreData,
+    ) -> None:
+        self.core_locations.add(_format_core_location(device_label, location))
+        self.device_labels.add(device_label)
+
+
+@dataclass
+class RunningOpsAggregation:
+    """Bundle of aggregations + runtime map shared by all running-ops consumers."""
+
+    aggregations: dict[int, "RunningOperationAggregation"]
+    runtime_id_to_operation: OperationRuntimeMap
+
+
+def _collect_dispatcher_data(
+    dispatcher_data: DispatcherData,
+    location: OnChipCoordinate,
+    risc_name: str,
+    show_all_cores: bool,
+) -> DispatcherCoreData | None:
+    if not dispatcher_data.risc_enabled(risc_name):
+        return None
+
+    try:
+        dispatcher_core_data = dispatcher_data.get_cached_core_data(location, risc_name)
+    except TimeoutDeviceRegisterError:
+        raise
+    except Exception as e:
+        log_check_risc(
+            risc_name,
+            location,
+            False,
+            f"Failed to read dispatcher data for running operations aggregation: {e}",
+        )
+        return None
+
+    if not show_all_cores and dispatcher_core_data.go_message == "DONE":
+        return None
+
+    if dispatcher_core_data.host_assigned_id in (None, 0):
+        return None
+
+    return dispatcher_core_data
+
+
+@triage_singleton
+def run(args, context: Context) -> RunningOpsAggregation:
+    """Build the running-ops aggregation. Cached per (args, context)."""
+    show_all_cores: bool = args["--include-done"]
+
+    dispatcher_data = get_dispatcher_data(args, context)
+    run_checks: RunChecks = get_run_checks(args, context)
+    runtime_id_to_operation = get_operation_runtime_map(args, context)
+
+    collected_results = run_checks.run_per_core_check(
+        lambda location, risc_name: _collect_dispatcher_data(dispatcher_data, location, risc_name, show_all_cores),
+        block_filter=BLOCK_TYPES_TO_CHECK,
+    )
+
+    aggregations: dict[int, RunningOperationAggregation] = {}
+
+    if not collected_results:
+        return RunningOpsAggregation(aggregations, runtime_id_to_operation)
+
+    # Per-iteration error isolation: a single bad row should not drop the whole table.
+    for check_result in collected_results:
+        try:
+            if check_result.result is None:
+                continue
+            if not isinstance(check_result.result, DispatcherCoreData):
+                continue
+
+            dispatcher_core_data: DispatcherCoreData = check_result.result
+            if dispatcher_core_data.host_assigned_id in (None, 0):
+                continue
+
+            dispatch_mode = dispatcher_core_data.dispatch_mode
+
+            op_info = (
+                runtime_id_to_operation.lookup(dispatcher_core_data.host_assigned_id, dispatch_mode)
+                or OperationInfo.empty()
+            )
+
+            if dispatch_mode == "HOST":
+                prev_runtime_id = None
+                prev_op_info = OperationInfo.empty()
+            else:
+                prev_runtime_id = dispatcher_core_data.previous_host_assigned_id
+                if prev_runtime_id not in (None, 0):
+                    prev_op_info = (
+                        runtime_id_to_operation.lookup(prev_runtime_id, dispatch_mode) or OperationInfo.empty()
+                    )
+                else:
+                    prev_op_info = OperationInfo.empty()
+
+            aggregation = aggregations.setdefault(
+                dispatcher_core_data.host_assigned_id,
+                RunningOperationAggregation(
+                    dispatcher_core_data.host_assigned_id,
+                    op_info.name,
+                    op_info.parameters,
+                    op_info.trace_id,
+                    prev_runtime_id if prev_runtime_id and prev_runtime_id > 0 else None,
+                    prev_op_info.name,
+                    prev_op_info.parameters,
+                ),
+            )
+
+            aggregation.add_core(
+                device_description_serializer(check_result.device_description),
+                check_result.location,
+                check_result.risc_name,
+                dispatcher_core_data,
+            )
+        except Exception as e:
+            log_check(False, f"Failed to aggregate one core's running-op data: {e}")
+            continue
+
+    return RunningOpsAggregation(aggregations, runtime_id_to_operation)
+
+
+if __name__ == "__main__":
+    run_script()


### PR DESCRIPTION
- New galaxy_topology.py: WH/BH UBB tables, tray-from-BDF, pure layout function for 8x4/4x8 Galaxy mesh shapes.
- New running_ops_aggregation.py (data provider): shared per-host_assigned_id aggregation; --include-done filter.
- New device_locations.py (data provider): per-device PCI BDF + tray.
- New dump_op_window.py: context table of ops near the currently-running set.
- New dump_galaxy_mesh.py: tt-smi-style tray table + topology-aware mesh, with [!] marker on devices running a non-majority op.
- dump_running_operations.py: slimmed to a pure renderer over the new data provider.
- operation_runtime_map.py: add items() and get_raw() for window/mesh use.
- tools/tests/triage/test_galaxy_topology.py: 69 parametrized cases for device_to_cell across 8x4 / 4x8 / unsupported shapes.

### PR Category
Handy features to debug multi device / galaxy problems 

### Summary
**dump_galaxy_mesh** shows 4x8 or 8x4 chip layout with currently running ops on devices
**dump_op_window** shows partial op graph of currently running ops on all devices 

`python tools/triage/triage.py     --run=dump_galaxy_mesh    --galaxy-shape=8x4
`<img width="2204" height="1092" alt="image" src="https://github.com/user-attachments/assets/7e8200ad-16b2-423d-a45b-a4ee6841e103" />

`python tools/triage/triage.py --run=dump_op_window --full-devices --op-window=10
`<img width="2084" height="1342" alt="image" src="https://github.com/user-attachments/assets/00c6520a-b7a4-424f-bdf2-e040e83b4e8a" />

### Notes for reviewers
This is completely claude coded; guided by my ideas and I found it very useful. If this is not the right way to add this feature - I'm fine with that let's turn it to feature request :)

Note: The commit is signed by @pavlepopovic as he is logged in on the bare machine I used.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2605-triage-galaxy-tooling)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2605-triage-galaxy-tooling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/2605-triage-galaxy-tooling)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/2605-triage-galaxy-tooling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2605-triage-galaxy-tooling)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2605-triage-galaxy-tooling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2605-triage-galaxy-tooling)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2605-triage-galaxy-tooling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/2605-triage-galaxy-tooling)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/2605-triage-galaxy-tooling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2605-triage-galaxy-tooling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2605-triage-galaxy-tooling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2605-triage-galaxy-tooling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2605-triage-galaxy-tooling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2605-triage-galaxy-tooling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2605-triage-galaxy-tooling)