### PR TITLE
Cleanup: Remove unused LLK pack parameters

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_pack_block_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_pack_block_api.h
@@ -29,7 +29,7 @@ template <bool zero_output = false>
 inline void llk_pack_block_contiguous_mop_config(const std::uint32_t output) {
     const std::uint32_t output_id = get_output_id(output);
     _llk_pack_block_contiguous_mop_config_<zero_output>(
-        pack_dst_format[output_id], get_output_face_r_dim(output_id), get_output_num_faces(output_id));
+        get_output_face_r_dim(output_id), get_output_num_faces(output_id));
 }
 
 // Pack num_tiles tiles from sparse DEST to dense L1 in a single call.

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -107,17 +107,12 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t nu
     LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
         pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
 
-#ifdef ARCH_BLACKHOLE
     // For pack with tilize enabled, check if the original input format is 8-bit.
     // 8-bit datums (Int8, UInt8, Fp8_e4m3, Lf8) do not require the tilize workaround on Blackhole.
     const std::uint32_t src_format = static_cast<std::uint32_t>(unpack_src_format[input_operand]);
     const bool is_input_8bit_format = IS_8BIT_FORMAT(src_format);
     _llk_pack_init_<untilize, zero_output, tilize>(
         pack_src_format[output_id], face_r_dim, tile_c_dim, num_faces, num_tiles, is_input_8bit_format);
-#else
-    _llk_pack_init_<untilize, zero_output, tilize>(
-        pack_src_format[output_id], face_r_dim, tile_c_dim, num_faces, num_tiles);
-#endif
 }
 
 template <bool out_of_order_output, bool untilize>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -31,11 +31,8 @@ inline void llk_pack_mop_config(const uint32_t output, std::uint32_t num_tiles =
     const std::uint32_t num_faces = get_output_num_faces(output_id);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
-    const bool partial_face = get_output_partial_face(output_id) && IS_BFP_FORMAT((uint)pack_dst_format[output_id]);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_mop_config_<untilize, zero_output, tilize>(
-        pack_dst_format[output_id], face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
+    _llk_pack_mop_config_<untilize, zero_output, tilize>(face_r_dim, tile_c_dim, num_faces, num_tiles);
 }
 
 inline void llk_pack_set_fp32_dest_acc(bool enable) { _llk_pack_set_fp32_dest_acc_(enable); }
@@ -58,7 +55,6 @@ inline void llk_pack_hw_configure(std::uint32_t pack_output) {
         tile_c_dim,
         num_faces,
         partial_face,
-        false,  // narrow_tile,
         0 /*relu_config*/);
 }
 
@@ -79,7 +75,6 @@ inline void llk_pack_untilize_hw_configure(
         tile_c_dim,
         num_faces,
         partial_face,
-        false,  // narrow_tile,
         pack_params->relu_config.val);
 }
 
@@ -231,11 +226,7 @@ inline void llk_pack_untilize(
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
         _llk_pack_untilize_<block_ct_dim, full_ct_dim, narrow_row, tile_dst_ct_offset, dense>(
-            pack_tile_addr,
-            pack_dst_format[output_id],
-            face_r_dim,
-            num_faces,
-            block_rt * block_ct_dim + tile_dst_rt_offset);
+            pack_tile_addr, num_faces, block_rt * block_ct_dim + tile_dst_rt_offset);
 
         pack_tile_addr += full_ct_dim * get_local_cb_interface(output_id).fifo_page_size;
     }
@@ -330,12 +321,8 @@ inline void llk_pack_dest_section_done() {
 }
 
 template <bool untilize = false, bool diagonal = false>
-inline void llk_init_packer_dest_offset_registers(const std::uint32_t pack_output = 16) {
-    const std::uint32_t output_id = get_output_id(pack_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
-
-    _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE>(face_r_dim, narrow_tile);
+inline void llk_init_packer_dest_offset_registers([[maybe_unused]] const std::uint32_t pack_output = 16) {
+    _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE>();
 }
 
 template <bool is_fp32_dest_acc_en, bool untilize = false>
@@ -417,7 +404,6 @@ inline void llk_pack_reduce_config_v2(uint32_t icb_out) {
             tile_c_dim,
             num_faces,
             partial_face,
-            false,  // narrow_tile,
             relu_config.val);
     }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -113,25 +113,10 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t nu
     const std::uint32_t src_format = static_cast<std::uint32_t>(unpack_src_format[input_operand]);
     const bool is_input_8bit_format = IS_8BIT_FORMAT(src_format);
     _llk_pack_init_<untilize, zero_output, tilize>(
-        pack_src_format[output_id],
-        pack_dst_format[output_id],
-        face_r_dim,
-        tile_c_dim,
-        num_faces,
-        false,  // partial_face,
-        false,  // narrow_tile,
-        num_tiles,
-        is_input_8bit_format);
+        pack_src_format[output_id], face_r_dim, tile_c_dim, num_faces, num_tiles, is_input_8bit_format);
 #else
     _llk_pack_init_<untilize, zero_output, tilize>(
-        pack_src_format[output_id],
-        pack_dst_format[output_id],
-        face_r_dim,
-        tile_c_dim,
-        num_faces,
-        false,  // partial_face,
-        false,  // narrow_tile,
-        num_tiles);
+        pack_src_format[output_id], face_r_dim, tile_c_dim, num_faces, num_tiles);
 #endif
 }
 
@@ -322,11 +307,13 @@ inline void llk_pack_dest_section_done() {
 
 template <bool untilize = false, bool diagonal = false>
 inline void llk_init_packer_dest_offset_registers([[maybe_unused]] const std::uint32_t pack_output = 16) {
+    LLK_ASSERT(pack_output == 16, "pack_output is unused for blackhole and must remain default value.");
     _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE>();
 }
 
 template <bool is_fp32_dest_acc_en, bool untilize = false>
 inline void llk_pack_dest_init([[maybe_unused]] const std::uint32_t pack_output = 16) {
+    LLK_ASSERT(pack_output == 16, "pack_output is unused for blackhole and must remain default value.");
     _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
@@ -348,8 +335,7 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
         face_r_dim,
         tile_c_dim,
         num_faces,
-        false,   // partial_face
-        false);  // narrow_tile
+        false);  // partial_face
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -302,13 +302,11 @@ inline void llk_pack_dest_section_done() {
 
 template <bool untilize = false, bool diagonal = false>
 inline void llk_init_packer_dest_offset_registers([[maybe_unused]] const std::uint32_t pack_output = 16) {
-    LLK_ASSERT(pack_output == 16, "pack_output is unused for blackhole and must remain default value.");
     _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE>();
 }
 
 template <bool is_fp32_dest_acc_en, bool untilize = false>
 inline void llk_pack_dest_init([[maybe_unused]] const std::uint32_t pack_output = 16) {
-    LLK_ASSERT(pack_output == 16, "pack_output is unused for blackhole and must remain default value.");
     _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -111,13 +111,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t nu
         pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
 
     _llk_pack_init_<untilize, zero_output>(
-        pack_dst_format[output_id],
-        pack_src_format[output_id],
-        face_r_dim,
-        num_faces,
-        partial_face,
-        narrow_tile,
-        num_tiles);
+        pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
 }
 
 template <bool out_of_order_output, bool untilize>
@@ -225,7 +219,7 @@ inline void llk_pack_untilize(
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
         _llk_pack_untilize_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums, tile_dst_ct_offset>(
-            pack_tile_addr, pack_dst_format[output_id], face_r_dim, 4, block_rt * block_ct_dim + tile_dst_rt_offset);
+            pack_tile_addr, pack_dst_format[output_id], face_r_dim, block_rt * block_ct_dim + tile_dst_rt_offset);
 
         pack_tile_addr += full_ct_dim * get_local_cb_interface(output_id).fifo_page_size;
     }
@@ -390,8 +384,8 @@ inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
 }
 
 template <bool mail2math = true, bool mail2pack = true>
-inline void llk_pack_get_tile(std::uint32_t output, std::uint32_t tile_index, std::uint32_t* p_tile) {
-    _llk_pack_get_tile_<mail2math, mail2pack>(tile_index, p_tile);
+inline void llk_pack_get_tile(std::uint32_t output, std::uint32_t* p_tile) {
+    _llk_pack_get_tile_<mail2math, mail2pack>(p_tile);
 }
 
 template <bool mail2math = true, bool mail2pack = true>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -383,16 +383,6 @@ inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
     _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en, untilize>(face_r_dim, narrow_tile);
 }
 
-template <bool mail2math = true, bool mail2pack = true>
-inline void llk_pack_get_tile(std::uint32_t output, std::uint32_t* p_tile) {
-    _llk_pack_get_tile_<mail2math, mail2pack>(p_tile);
-}
-
-template <bool mail2math = true, bool mail2pack = true>
-inline void llk_pack_release_tile(std::uint32_t output) {
-    _llk_pack_release_tile_<mail2math, mail2pack>();
-}
-
 inline void llk_pack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _llk_pack_debug_dump_(data, byte_size); }
 
 inline void llk_pack_debug_dump_seek(std::uint8_t offset) { _llk_pack_debug_dump_seek_(offset); }

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "llk_pack.h"
+
+using ckernel::FACE_R_DIM;
+using ckernel::TILE_C_DIM;
+
+#ifdef ARCH_WORMHOLE
+
+template <bool untilize = false, bool zero_output = false, bool tilize = false>
+inline void _llk_pack_init_wrapper_(
+    const std::uint32_t pack_dst_format,
+    const std::uint32_t face_r_dim = FACE_R_DIM,
+    const std::uint32_t tile_c_dim = TILE_C_DIM,
+    const std::uint32_t num_faces  = 4,
+    const bool partial_face        = false,
+    const bool narrow_tile         = false,
+    const std::uint32_t num_tiles  = 1)
+{
+    (void)tile_c_dim;
+    (void)tilize;
+    _llk_pack_init_<untilize, zero_output>(pack_dst_format, face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
+}
+
+template <
+    std::uint32_t block_ct_dim,
+    std::uint32_t full_ct_dim        = block_ct_dim,
+    bool diagonal                    = false,
+    bool narrow_row                  = false,
+    std::uint32_t row_num_datums     = TILE_C_DIM,
+    std::uint32_t tile_dst_ct_offset = 0,
+    bool dense                       = false>
+inline void _llk_pack_untilize_wrapper_(
+    const std::uint32_t address,
+    const std::uint32_t pack_dst_format,
+    const std::uint32_t face_r_dim         = FACE_R_DIM,
+    const std::uint32_t num_faces          = 4,
+    const std::uint32_t tile_dst_rt_offset = 0)
+{
+    (void)num_faces;
+    (void)dense;
+    _llk_pack_untilize_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums, tile_dst_ct_offset>(
+        address, pack_dst_format, face_r_dim, tile_dst_rt_offset);
+}
+
+#else // ARCH_BLACKHOLE version of the wrappers
+
+template <bool untilize = false, bool zero_output = false, bool tilize = false>
+inline void _llk_pack_init_wrapper_(
+    const std::uint32_t pack_dst_format,
+    const std::uint32_t face_r_dim = FACE_R_DIM,
+    const std::uint32_t tile_c_dim = TILE_C_DIM,
+    const std::uint32_t num_faces  = 4,
+    const bool partial_face        = false,
+    const bool narrow_tile         = false,
+    const std::uint32_t num_tiles  = 1)
+{
+    (void)pack_dst_format;
+    (void)partial_face;
+    (void)narrow_tile;
+    _llk_pack_init_<untilize, zero_output, tilize>(face_r_dim, tile_c_dim, num_faces, num_tiles);
+}
+
+template <
+    std::uint32_t block_ct_dim,
+    std::uint32_t full_ct_dim        = block_ct_dim,
+    bool diagonal                    = false,
+    bool narrow_row                  = false,
+    std::uint32_t row_num_datums     = TILE_C_DIM,
+    std::uint32_t tile_dst_ct_offset = 0,
+    bool dense                       = false>
+inline void _llk_pack_untilize_wrapper_(
+    const std::uint32_t address,
+    const std::uint32_t pack_dst_format,
+    const std::uint32_t face_r_dim         = FACE_R_DIM,
+    const std::uint32_t num_faces          = 4,
+    const std::uint32_t tile_dst_rt_offset = 0)
+{
+    static_assert(!diagonal, "Blackhole pack untilize does not support diagonal mode");
+    (void)pack_dst_format;
+    (void)face_r_dim;
+    (void)row_num_datums;
+    _llk_pack_untilize_<block_ct_dim, full_ct_dim, narrow_row, tile_dst_ct_offset, dense>(address, num_faces, tile_dst_rt_offset);
+}
+
+#endif

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/packer.py
@@ -45,7 +45,7 @@ class Packer(BasePacker):
         dest_sync = f"DstSync::Sync{operation.dest_sync.name}"
         return (
             f"    _llk_pack_init_<false, false, {bh_tilize}>(\n"
-            f"        {config.sentinel.pack_dst_format}, {face_r_dim}, TILE_C_DIM, {num_faces}, 1\n"
+            f"        {config.sentinel.pack_src_format}, {face_r_dim}, TILE_C_DIM, {num_faces}, 1\n"
             f"    );\n"
             f"    _llk_pack_dest_init_<{dest_sync}, {dest_acc}>();\n"
         )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/packer.py
@@ -45,7 +45,7 @@ class Packer(BasePacker):
         dest_sync = f"DstSync::Sync{operation.dest_sync.name}"
         return (
             f"    _llk_pack_init_<false, false, {bh_tilize}>(\n"
-            f"        {config.sentinel.pack_dst_format}, {config.sentinel.pack_dst_format}, {face_r_dim}, TILE_C_DIM, {num_faces}, false, false\n"
+            f"        {config.sentinel.pack_dst_format}, {face_r_dim}, TILE_C_DIM, {num_faces}, 1\n"
             f"    );\n"
             f"    _llk_pack_dest_init_<{dest_sync}, {dest_acc}>();\n"
         )

--- a/tt_metal/tt-llk/tests/sources/ai_gen/eltwise_binary_sfpu_pack_untilize.cpp
+++ b/tt_metal/tt-llk/tests/sources/ai_gen/eltwise_binary_sfpu_pack_untilize.cpp
@@ -97,7 +97,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     _llk_packer_wait_for_math_done_();
-    _llk_pack_untilize_<ct_dim>(L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, FACE_R_DIM, 4, 0);
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_untilize_<ct_dim>(L1_ADDRESS(params.buffer_Res[0]), 4, 0);
+#else
+    _llk_pack_untilize_<ct_dim>(L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, FACE_R_DIM, 0);
+#endif
     _llk_pack_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
 }
 

--- a/tt_metal/tt-llk/tests/sources/ai_gen/eltwise_binary_sfpu_pack_untilize.cpp
+++ b/tt_metal/tt-llk/tests/sources/ai_gen/eltwise_binary_sfpu_pack_untilize.cpp
@@ -80,6 +80,7 @@ void run_kernel(RUNTIME_PARAMETERS /*params*/)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -97,11 +98,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     _llk_packer_wait_for_math_done_();
-#ifdef ARCH_BLACKHOLE
-    _llk_pack_untilize_<ct_dim>(L1_ADDRESS(params.buffer_Res[0]), 4, 0);
-#else
-    _llk_pack_untilize_<ct_dim>(L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, FACE_R_DIM, 0);
-#endif
+    _llk_pack_untilize_wrapper_<ct_dim>(L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, FACE_R_DIM, 4, 0);
     _llk_pack_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
 }
 

--- a/tt_metal/tt-llk/tests/sources/ai_gen/eltwise_binary_sfpu_unary.cpp
+++ b/tt_metal/tt-llk/tests/sources/ai_gen/eltwise_binary_sfpu_unary.cpp
@@ -80,6 +80,7 @@ void run_kernel(RUNTIME_PARAMETERS /*params*/)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -93,11 +94,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-#ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false, false>();
-#else
-    _llk_pack_init_<false, false>(formats.pack_dst);
-#endif
+    _llk_pack_init_wrapper_<false, false>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/ai_gen/eltwise_binary_sfpu_unary.cpp
+++ b/tt_metal/tt-llk/tests/sources/ai_gen/eltwise_binary_sfpu_unary.cpp
@@ -93,7 +93,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_init_<false, false>();
+#else
     _llk_pack_init_<false, false>(formats.pack_dst);
+#endif
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/ai_gen/reduce_sfpu_unary.cpp
+++ b/tt_metal/tt-llk/tests/sources/ai_gen/reduce_sfpu_unary.cpp
@@ -119,6 +119,7 @@ void run_kernel(RUNTIME_PARAMETERS /*params*/)
 // -----------------------------------------------------------------------------
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -126,17 +127,12 @@ void run_kernel(RUNTIME_PARAMETERS /*params*/)
 void run_kernel(RUNTIME_PARAMETERS params)
 {
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false, false>();
-#else
-    _llk_pack_init_<false, false>(formats.pack_dst);
-#endif
-
-#ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
+    _llk_pack_init_<false, false>(formats.pack_dst);
     _llk_pack_reduce_mask_config_<false, REDUCE_DIM>();
 
 #ifdef ARCH_BLACKHOLE

--- a/tt_metal/tt-llk/tests/sources/ai_gen/reduce_sfpu_unary.cpp
+++ b/tt_metal/tt-llk/tests/sources/ai_gen/reduce_sfpu_unary.cpp
@@ -125,7 +125,11 @@ void run_kernel(RUNTIME_PARAMETERS /*params*/)
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_init_<false, false>();
+#else
     _llk_pack_init_<false, false>(formats.pack_dst);
+#endif
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);

--- a/tt_metal/tt-llk/tests/sources/ai_gen/unpack_tilize_sfpu_pack.cpp
+++ b/tt_metal/tt-llk/tests/sources/ai_gen/unpack_tilize_sfpu_pack.cpp
@@ -94,7 +94,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, TILIZE>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
-    _llk_pack_init_<UNTILIZE, false, TILIZE>(formats.pack_dst);
+    _llk_pack_init_<UNTILIZE, false, TILIZE>();
     _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en>();
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);

--- a/tt_metal/tt-llk/tests/sources/dense_pack_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/dense_pack_untilize_test.cpp
@@ -87,8 +87,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats.pack_src, formats.pack_dst, params.in0_tile_r_dim, params.num_faces / 2);
 
     _llk_packer_wait_for_math_done_();
-    _llk_pack_untilize_<BLOCK_CT_DIM * 2, FULL_CT_DIM * 2, false, 0, true>(
-        L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, params.in0_tile_r_dim, params.num_faces / 2, 0 /* tile_dst_rt_offset */);
+    _llk_pack_untilize_<BLOCK_CT_DIM * 2, FULL_CT_DIM * 2, false, 0, true>(L1_ADDRESS(params.buffer_Res[0]), params.num_faces / 2, 0 /* tile_dst_rt_offset */);
     _llk_pack_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 

--- a/tt_metal/tt-llk/tests/sources/eltwise_bcast_col_custom_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_bcast_col_custom_perf.cpp
@@ -156,7 +156,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT);
+#ifdef ARCH_BLACKHOLE
+        _llk_pack_init_<false, false>();
+#else
         _llk_pack_init_<false, false>(formats.pack_dst);
+#endif
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/eltwise_bcast_col_custom_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_bcast_col_custom_perf.cpp
@@ -141,6 +141,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 
@@ -156,11 +157,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT);
-#ifdef ARCH_BLACKHOLE
-        _llk_pack_init_<false, false>();
-#else
-        _llk_pack_init_<false, false>(formats.pack_dst);
-#endif
+        _llk_pack_init_wrapper_<false, false>(formats.pack_dst);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_fpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_fpu_perf.cpp
@@ -161,7 +161,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT);
+#ifdef ARCH_BLACKHOLE
+        _llk_pack_init_<false, false>();
+#else
         _llk_pack_init_<false, false>(formats.pack_dst);
+#endif
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_fpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_fpu_perf.cpp
@@ -145,6 +145,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 
@@ -161,11 +162,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT);
-#ifdef ARCH_BLACKHOLE
-        _llk_pack_init_<false, false>();
-#else
-        _llk_pack_init_<false, false>(formats.pack_dst);
-#endif
+        _llk_pack_init_wrapper_<false, false>(formats.pack_dst);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_sfpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_sfpu_perf.cpp
@@ -277,7 +277,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * num_faces);
 
 #ifdef ARCH_BLACKHOLE
-        _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, num_faces);
+        _llk_pack_init_<false, false>(FACE_R_DIM, TILE_C_DIM, num_faces);
 #else
         _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, num_faces);
 #endif

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_test.cpp
@@ -155,9 +155,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
 #ifdef ARCH_BLACKHOLE
-    // BH configure_pack uses partial_face for BFP exp_section_size, but narrow_tile is unused (defaults to false)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false /* untilize */, false /* tilize */>(
-        formats.pack_src, formats.pack_dst, tile_size, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face, false /* narrow_tile */);
+        formats.pack_src, formats.pack_dst, tile_size, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face);
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false /* untilize */>(
 

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_test.cpp
@@ -164,7 +164,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false /* untilize */, false /* zero_output */>(formats.pack_dst, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces);
+    _llk_pack_init_<false /* untilize */, false /* zero_output */>(tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces);
 #else
     _llk_pack_init_<false /* untilize */, false /* zero_output */>(formats.pack_dst, tensor_shape.face_r_dim, num_faces, partial_face, narrow_tile);
 #endif

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_transpose_bcast_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_transpose_bcast_test.cpp
@@ -95,7 +95,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false /* untilize */>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_init_<false /* untilize */, false /* zero_output */>();
+#else
     _llk_pack_init_<false /* untilize */, false /* zero_output */>(formats.pack_dst);
+#endif
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_transpose_bcast_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_transpose_bcast_test.cpp
@@ -80,6 +80,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -95,11 +96,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false /* untilize */>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-#ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false /* untilize */, false /* zero_output */>();
-#else
-    _llk_pack_init_<false /* untilize */, false /* zero_output */>(formats.pack_dst);
-#endif
+    _llk_pack_init_wrapper_<false /* untilize */, false /* zero_output */>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_custom_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_custom_test.cpp
@@ -71,7 +71,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<false, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, 4);
-    _llk_pack_init_<false, false, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, 4);
+    _llk_pack_init_<false, false, false>(FACE_R_DIM, TILE_C_DIM, 4);
     _llk_pack_dest_init_<DstSync::SyncHalf, false>();
 #else
     _llk_pack_hw_configure_<false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, 4);

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
@@ -125,7 +125,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, tilize_en>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, params.num_faces);
-    _llk_pack_init_<false, false, tilize_en>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+    _llk_pack_init_<false, false, tilize_en>(FACE_R_DIM, TILE_C_DIM, params.num_faces);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, params.num_faces);

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_perf.cpp
@@ -275,7 +275,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * num_faces);
 
 #ifdef ARCH_BLACKHOLE
-        _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, num_faces);
+        _llk_pack_init_<false, false>(FACE_R_DIM, TILE_C_DIM, num_faces);
 #else
         _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, num_faces);
 #endif

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_test.cpp
@@ -112,7 +112,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);
-    _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, TILE_NUM_FACES);
+    _llk_pack_init_<false, false>(FACE_R_DIM, TILE_C_DIM, TILE_NUM_FACES);
     _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en>();
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);

--- a/tt_metal/tt-llk/tests/sources/math_matmul_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/math_matmul_perf.cpp
@@ -225,12 +225,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             TILE_C_DIM,
             num_faces,
             PARTIAL_FACE_PACK);
-        _llk_pack_init_<false, false, false>(
-            formats.pack_dst,
-            in0_tile_r_dim < FACE_R_DIM ? in0_tile_r_dim : FACE_R_DIM,
-            TILE_C_DIM,
-            num_faces,
-            false /* partial_face parameter is unused on BH */);
+        _llk_pack_init_<false, false, false>(in0_tile_r_dim < FACE_R_DIM ? in0_tile_r_dim : FACE_R_DIM, TILE_C_DIM, num_faces);
         _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();
 #else
         _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(

--- a/tt_metal/tt-llk/tests/sources/math_matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/math_matmul_test.cpp
@@ -123,12 +123,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         TILE_C_DIM,
         params.num_faces,
         params.PARTIAL_FACE_PACK);
-    _llk_pack_init_<false, false, false>(
-        formats.pack_dst,
-        params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM,
-        TILE_C_DIM,
-        params.num_faces,
-        false /* partial_face parameter is unused on BH */);
+    _llk_pack_init_<false, false, false>(params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM, TILE_C_DIM, params.num_faces);
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(

--- a/tt_metal/tt-llk/tests/sources/math_transpose_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/math_transpose_perf.cpp
@@ -153,7 +153,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT);
+#ifdef ARCH_BLACKHOLE
+        _llk_pack_init_<false, false>();
+#else
         _llk_pack_init_<false, false>(formats.pack_dst);
+#endif
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/math_transpose_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/math_transpose_perf.cpp
@@ -138,6 +138,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 
@@ -153,11 +154,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT);
-#ifdef ARCH_BLACKHOLE
-        _llk_pack_init_<false, false>();
-#else
-        _llk_pack_init_<false, false>(formats.pack_dst);
-#endif
+        _llk_pack_init_wrapper_<false, false>(formats.pack_dst);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/matmul_and_unary_sfpu_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_and_unary_sfpu_test.cpp
@@ -115,6 +115,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -145,11 +146,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     run = 1; // second L1-to-L1 run, we access the second set of formats_array in our array
     _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(formats_array[run].pack_src, formats_array[run].pack_dst, params.TILE_SIZE_PACK);
 
-#ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false, false>();
-#else
-    _llk_pack_init_<false, false>(formats_array[run].pack_dst);
-#endif
+    _llk_pack_init_wrapper_<false, false>(formats_array[run].pack_dst);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/matmul_and_unary_sfpu_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_and_unary_sfpu_test.cpp
@@ -127,7 +127,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     int run = 0; // first L1-to-L1 run, we access the first set of formats_array in our array
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
-    _llk_pack_init_<false, false, false>(formats_array[run].pack_dst);
+    _llk_pack_init_<false, false, false>();
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
@@ -145,7 +145,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     run = 1; // second L1-to-L1 run, we access the second set of formats_array in our array
     _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(formats_array[run].pack_src, formats_array[run].pack_dst, params.TILE_SIZE_PACK);
 
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_init_<false, false>();
+#else
     _llk_pack_init_<false, false>(formats_array[run].pack_dst);
+#endif
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/matmul_custom_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_custom_test.cpp
@@ -105,7 +105,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false /* untilize */, false /* tilize */>(formats.pack_src, formats.pack_dst, params.TILE_SIZE_PACK);
-    _llk_pack_init_<false /* untilize */, false /* zero_output */, false /* tilize */>(formats.pack_dst);
+    _llk_pack_init_<false /* untilize */, false /* zero_output */, false /* tilize */>();
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false /* untilize */>(formats.pack_src, formats.pack_dst, params.TILE_SIZE_PACK);

--- a/tt_metal/tt-llk/tests/sources/matmul_pack_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_pack_untilize_test.cpp
@@ -64,6 +64,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -83,11 +84,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_untilize_init_<ct_dim>(formats.pack_dst, FACE_R_DIM, 4);
 #endif
     _llk_packer_wait_for_math_done_();
-#ifdef ARCH_BLACKHOLE
-    _llk_pack_untilize_<ct_dim>(L1_ADDRESS(params.buffer_Res[0]), 4, 0);
-#else
-    _llk_pack_untilize_<ct_dim>(L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, FACE_R_DIM, 0);
-#endif
+    _llk_pack_untilize_wrapper_<ct_dim>(L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, FACE_R_DIM, 4, 0);
     _llk_pack_dest_section_done_<sync, is_fp32_dest_acc_en>();
 }
 

--- a/tt_metal/tt-llk/tests/sources/matmul_pack_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_pack_untilize_test.cpp
@@ -83,7 +83,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_untilize_init_<ct_dim>(formats.pack_dst, FACE_R_DIM, 4);
 #endif
     _llk_packer_wait_for_math_done_();
-    _llk_pack_untilize_<ct_dim>(L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, FACE_R_DIM, 4, 0);
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_untilize_<ct_dim>(L1_ADDRESS(params.buffer_Res[0]), 4, 0);
+#else
+    _llk_pack_untilize_<ct_dim>(L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, FACE_R_DIM, 0);
+#endif
     _llk_pack_dest_section_done_<sync, is_fp32_dest_acc_en>();
 }
 

--- a/tt_metal/tt-llk/tests/sources/matmul_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_perf.cpp
@@ -209,6 +209,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 
@@ -227,15 +228,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, TILE_C_DIM * TILE_R_DIM);
-#ifdef ARCH_BLACKHOLE
-        _llk_pack_init_<
-            /* untilize */ false,
-            /* zero_output */ false>();
-#else
-        _llk_pack_init_<
+        _llk_pack_init_wrapper_<
             /* untilize */ false,
             /* zero_output */ false>(formats.pack_dst);
-#endif
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/matmul_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_perf.cpp
@@ -227,9 +227,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, TILE_C_DIM * TILE_R_DIM);
+#ifdef ARCH_BLACKHOLE
+        _llk_pack_init_<
+            /* untilize */ false,
+            /* zero_output */ false>();
+#else
         _llk_pack_init_<
             /* untilize */ false,
             /* zero_output */ false>(formats.pack_dst);
+#endif
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_test.cpp
@@ -100,7 +100,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, params.TILE_SIZE_PACK);
-    _llk_pack_init_<false, false, false>(formats.pack_dst);
+    _llk_pack_init_<false, false, false>();
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, params.TILE_SIZE_PACK);

--- a/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
@@ -160,7 +160,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifdef ARCH_BLACKHOLE
     const bool TILIZE = true;
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, TILIZE>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
-    _llk_pack_init_<UNTILIZE, false, TILIZE>(formats_array[run].pack_dst);
+    _llk_pack_init_<UNTILIZE, false, TILIZE>();
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
@@ -187,7 +187,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         tile_size); // need to reconfigure data formats_array for next pack, also calls set_packer_strides to readjust strides after pack tilizing
 
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false, false, false>(formats_array[run].pack_dst);
+    _llk_pack_init_<false, false, false>();
 #endif
 
     _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_custom_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_custom_test.cpp
@@ -60,6 +60,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -75,11 +76,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-#ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false, false>();
-#else
-    _llk_pack_init_<false, false>(formats.pack_dst);
-#endif
+    _llk_pack_init_wrapper_<false, false>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_custom_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_custom_test.cpp
@@ -75,7 +75,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_init_<false, false>();
+#else
     _llk_pack_init_<false, false>(formats.pack_dst);
+#endif
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_test.cpp
@@ -70,6 +70,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -85,11 +86,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-#ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false, false>();
-#else
-    _llk_pack_init_<false, false>(formats.pack_dst);
-#endif
+    _llk_pack_init_wrapper_<false, false>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_test.cpp
@@ -85,7 +85,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_init_<false, false>();
+#else
     _llk_pack_init_<false, false>(formats.pack_dst);
+#endif
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/pack_dest_bank_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_dest_bank_perf.cpp
@@ -216,7 +216,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
 #ifdef ARCH_BLACKHOLE
         _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT, FACE_R_DIM, TILE_C_DIM, 4);
-        _llk_pack_init_<false, false, false>(formats.pack_src, formats.pack_dst, FACE_R_DIM, TILE_C_DIM, num_faces, false, false, TILE_CNT);
+        _llk_pack_init_<false, false, false>(formats.pack_src, FACE_R_DIM, TILE_C_DIM, num_faces, TILE_CNT);
         reconfigure_packer_l1_acc(L1_ACC);
 #else
         _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT, FACE_R_DIM, 4);

--- a/tt_metal/tt-llk/tests/sources/pack_dest_bank_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_dest_bank_test.cpp
@@ -53,7 +53,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
             const std::uint32_t read_offset = i * params.BLOCK_RT_DIM;
             for (std::uint32_t j = 0; j < params.BLOCK_CT_DIM; j++)
             {
+#ifdef ARCH_BLACKHOLE
                 _llk_unpack_tilize_(L1_ADDRESS(params.buffer_A[read_offset]), j, formats.unpack_A_src, 0, FACE_R_DIM, 4, false);
+#else
+                _llk_unpack_tilize_(L1_ADDRESS(params.buffer_A[read_offset]), j, formats.unpack_A_src, 0, params.BLOCK_CT_DIM, FACE_R_DIM, 4, false);
+#endif
             }
         }
     }

--- a/tt_metal/tt-llk/tests/sources/pack_dest_bank_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_dest_bank_test.cpp
@@ -133,7 +133,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, tilize_en>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, params.num_faces);
 
-    _llk_pack_init_<false, false, tilize_en>(formats.pack_src, formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces, false, false, num_tiles_in_block);
+    _llk_pack_init_<false, false, tilize_en>(formats.pack_src, FACE_R_DIM, TILE_C_DIM, params.num_faces, num_tiles_in_block);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 
     reconfigure_packer_l1_acc(params.L1_ACC);

--- a/tt_metal/tt-llk/tests/sources/pack_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_test.cpp
@@ -106,7 +106,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, tilize_en>(
-        formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, params.num_faces, false, false, params.RELU_CONFIG);
+        formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, params.num_faces, false, params.RELU_CONFIG);
     _llk_pack_init_<false, false, tilize_en>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();
 #else

--- a/tt_metal/tt-llk/tests/sources/pack_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_test.cpp
@@ -107,7 +107,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, tilize_en>(
         formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, params.num_faces, false, params.RELU_CONFIG);
-    _llk_pack_init_<false, false, tilize_en>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+    _llk_pack_init_<false, false, tilize_en>(FACE_R_DIM, TILE_C_DIM, params.num_faces);
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(

--- a/tt_metal/tt-llk/tests/sources/pack_tiny_tile_block_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_tiny_tile_block_test.cpp
@@ -131,7 +131,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats.pack_src, formats.pack_dst, 16 * 16 * 4, params.TEST_FACE_R_DIM, params.in0_tile_c_dim, params.num_faces);
 
     // Standard init sets addr_mods and strides for the tile shape.
-    _llk_pack_init_<false, false, false>(formats.pack_src, formats.pack_dst, params.TEST_FACE_R_DIM, params.in0_tile_c_dim, params.num_faces, false, false, 1);
+    _llk_pack_init_<false, false, false>(formats.pack_src, params.TEST_FACE_R_DIM, params.in0_tile_c_dim, params.num_faces, 1);
 
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     reconfigure_packer_l1_acc(params.L1_ACC);

--- a/tt_metal/tt-llk/tests/sources/pack_tiny_tile_block_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_tiny_tile_block_test.cpp
@@ -141,7 +141,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // num_tiles is intentionally NOT passed here — the execute function
     // sets mop_cfg[0] = num_tiles at runtime, so mop_config only needs
     // the tile shape (face_r_dim, num_faces).
-    _llk_pack_block_contiguous_mop_config_<>(formats.pack_dst, params.TEST_FACE_R_DIM, params.num_faces);
+    _llk_pack_block_contiguous_mop_config_<>(params.TEST_FACE_R_DIM, params.num_faces);
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, params.TEST_FACE_R_DIM, params.num_faces);
     _llk_pack_init_<false, false>(formats.pack_dst, params.TEST_FACE_R_DIM, params.num_faces);

--- a/tt_metal/tt-llk/tests/sources/pack_tiny_tile_reconfig_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_tiny_tile_reconfig_test.cpp
@@ -146,7 +146,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_init_<false, false, false>(formats.pack_src, formats.pack_dst, params.TEST_FACE_R_DIM, params.in0_tile_c_dim, params.num_faces, false, false, 1);
 
     // Replace MOP with the block-contiguous version (REPLAY + W-per-tile).
-    _llk_pack_block_contiguous_mop_config_<>(formats.pack_dst, params.TEST_FACE_R_DIM, params.num_faces);
+    _llk_pack_block_contiguous_mop_config_<>(params.TEST_FACE_R_DIM, params.num_faces);
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, params.TEST_FACE_R_DIM, params.num_faces);
     _llk_pack_init_<false, false>(formats.pack_dst, params.TEST_FACE_R_DIM, params.num_faces);

--- a/tt_metal/tt-llk/tests/sources/pack_tiny_tile_reconfig_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_tiny_tile_reconfig_test.cpp
@@ -132,7 +132,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // --- Phase 1: Init for standard 32x32 tiles ---
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, 4);
 
-    _llk_pack_init_<false, false, false>(formats.pack_src, formats.pack_dst, FACE_R_DIM, TILE_C_DIM, 4, false, false, 1);
+    _llk_pack_init_<false, false, false>(formats.pack_src, FACE_R_DIM, TILE_C_DIM, 4, 1);
 
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     reconfigure_packer_l1_acc(params.L1_ACC);
@@ -143,7 +143,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(
         formats.pack_src, formats.pack_dst, 16 * 16 * 4, params.TEST_FACE_R_DIM, params.in0_tile_c_dim, params.num_faces);
 
-    _llk_pack_init_<false, false, false>(formats.pack_src, formats.pack_dst, params.TEST_FACE_R_DIM, params.in0_tile_c_dim, params.num_faces, false, false, 1);
+    _llk_pack_init_<false, false, false>(formats.pack_src, params.TEST_FACE_R_DIM, params.in0_tile_c_dim, params.num_faces, 1);
 
     // Replace MOP with the block-contiguous version (REPLAY + W-per-tile).
     _llk_pack_block_contiguous_mop_config_<>(params.TEST_FACE_R_DIM, params.num_faces);

--- a/tt_metal/tt-llk/tests/sources/pack_untilize_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_untilize_perf.cpp
@@ -177,6 +177,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 
@@ -216,11 +217,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 for (std::uint32_t tile = 0; tile < TILE_CNT; tile += BLOCK_CT_DIM)
                 {
-#ifdef ARCH_BLACKHOLE
-                    _llk_pack_untilize_<BLOCK_CT_DIM, FULL_CT_DIM>(PERF_ADDRESS(PERF_OUTPUT, tile), 4, 0);
-#else
-                    _llk_pack_untilize_<BLOCK_CT_DIM, FULL_CT_DIM>(PERF_ADDRESS(PERF_OUTPUT, tile), formats.pack_dst, FACE_R_DIM, 0);
-#endif
+                    _llk_pack_untilize_wrapper_<BLOCK_CT_DIM, FULL_CT_DIM>(PERF_ADDRESS(PERF_OUTPUT, tile), formats.pack_dst, FACE_R_DIM, 4, 0);
                 }
             }
             PROFILER_SYNC();
@@ -232,11 +229,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             for (std::uint32_t i = 0; i < TILE_CNT; i += BLOCK_CT_DIM)
             {
                 _llk_packer_wait_for_math_done_();
-#ifdef ARCH_BLACKHOLE
-                _llk_pack_untilize_<BLOCK_CT_DIM, FULL_CT_DIM>(PERF_ADDRESS(PERF_OUTPUT, i), 4, 0);
-#else
-                _llk_pack_untilize_<BLOCK_CT_DIM, FULL_CT_DIM>(PERF_ADDRESS(PERF_OUTPUT, i), formats.pack_dst, FACE_R_DIM, 0);
-#endif
+                _llk_pack_untilize_wrapper_<BLOCK_CT_DIM, FULL_CT_DIM>(PERF_ADDRESS(PERF_OUTPUT, i), formats.pack_dst, FACE_R_DIM, 4, 0);
                 _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             }
         }

--- a/tt_metal/tt-llk/tests/sources/pack_untilize_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_untilize_perf.cpp
@@ -216,7 +216,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 for (std::uint32_t tile = 0; tile < TILE_CNT; tile += BLOCK_CT_DIM)
                 {
-                    _llk_pack_untilize_<BLOCK_CT_DIM, FULL_CT_DIM>(PERF_ADDRESS(PERF_OUTPUT, tile), formats.pack_dst, FACE_R_DIM, 4, 0);
+#ifdef ARCH_BLACKHOLE
+                    _llk_pack_untilize_<BLOCK_CT_DIM, FULL_CT_DIM>(PERF_ADDRESS(PERF_OUTPUT, tile), 4, 0);
+#else
+                    _llk_pack_untilize_<BLOCK_CT_DIM, FULL_CT_DIM>(PERF_ADDRESS(PERF_OUTPUT, tile), formats.pack_dst, FACE_R_DIM, 0);
+#endif
                 }
             }
             PROFILER_SYNC();
@@ -228,7 +232,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
             for (std::uint32_t i = 0; i < TILE_CNT; i += BLOCK_CT_DIM)
             {
                 _llk_packer_wait_for_math_done_();
-                _llk_pack_untilize_<BLOCK_CT_DIM, FULL_CT_DIM>(PERF_ADDRESS(PERF_OUTPUT, i), formats.pack_dst, FACE_R_DIM, 4, 0);
+#ifdef ARCH_BLACKHOLE
+                _llk_pack_untilize_<BLOCK_CT_DIM, FULL_CT_DIM>(PERF_ADDRESS(PERF_OUTPUT, i), 4, 0);
+#else
+                _llk_pack_untilize_<BLOCK_CT_DIM, FULL_CT_DIM>(PERF_ADDRESS(PERF_OUTPUT, i), formats.pack_dst, FACE_R_DIM, 0);
+#endif
                 _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             }
         }

--- a/tt_metal/tt-llk/tests/sources/pack_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_untilize_test.cpp
@@ -155,11 +155,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
             _llk_packer_wait_for_math_done_();
 #ifdef ARCH_BLACKHOLE
-            _llk_pack_untilize_<BLOCK_CT_DIM, FULL_CT_DIM, false, TILE_DST_CT_OFFSET>(
-                pack_addr_16B, formats.pack_dst, FACE_R_DIM, params.num_faces, 0 /* tile_dst_rt_offset */);
+            _llk_pack_untilize_<BLOCK_CT_DIM, FULL_CT_DIM, false, TILE_DST_CT_OFFSET>(pack_addr_16B, params.num_faces, 0 /* tile_dst_rt_offset */);
 #else
             _llk_pack_untilize_<BLOCK_CT_DIM, FULL_CT_DIM, false, false, TILE_C_DIM, TILE_DST_CT_OFFSET>(
-                pack_addr_16B, formats.pack_dst, FACE_R_DIM, params.num_faces, 0 /* tile_dst_rt_offset */);
+                pack_addr_16B, formats.pack_dst, FACE_R_DIM, 0 /* tile_dst_rt_offset */);
 #endif
             _llk_pack_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
         }

--- a/tt_metal/tt-llk/tests/sources/reduce_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_perf.cpp
@@ -162,6 +162,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 
@@ -177,15 +178,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT);
-#ifdef ARCH_BLACKHOLE
-        _llk_pack_init_<
-            /* untilize */ false,
-            /* zero output */ false>();
-#else
-        _llk_pack_init_<
+        _llk_pack_init_wrapper_<
             /* untilize */ false,
             /* zero output */ false>(formats.pack_dst);
-#endif
         _llk_pack_reduce_mask_config_<
             /* untilize */ false,
             REDUCE_DIM>();

--- a/tt_metal/tt-llk/tests/sources/reduce_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_perf.cpp
@@ -177,9 +177,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT);
+#ifdef ARCH_BLACKHOLE
+        _llk_pack_init_<
+            /* untilize */ false,
+            /* zero output */ false>();
+#else
         _llk_pack_init_<
             /* untilize */ false,
             /* zero output */ false>(formats.pack_dst);
+#endif
         _llk_pack_reduce_mask_config_<
             /* untilize */ false,
             REDUCE_DIM>();

--- a/tt_metal/tt-llk/tests/sources/reduce_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_test.cpp
@@ -131,7 +131,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false /* untilize */, false /* tilize */>(
-        formats.pack_src, formats.pack_dst, tile_size, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face, false /* narrow_tile */);
+        formats.pack_src, formats.pack_dst, tile_size, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face);
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false /* untilize */>(
         formats.pack_src, formats.pack_dst, tile_size, tensor_shape.face_r_dim, num_faces, partial_face, narrow_tile);

--- a/tt_metal/tt-llk/tests/sources/reduce_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_test.cpp
@@ -138,7 +138,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false /* untilize */, false /* zero_output */>(formats.pack_dst, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces);
+    _llk_pack_init_<false /* untilize */, false /* zero_output */>(tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces);
 #else
     _llk_pack_init_<false /* untilize */, false /* zero_output */>(formats.pack_dst, tensor_shape.face_r_dim, num_faces, partial_face, narrow_tile);
 #endif

--- a/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
@@ -218,7 +218,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t pack_dst_format0 = ckernel::to_underlying(DataFormat::Float16_b);
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<false, false, false>(pack_src_format0, pack_dst_format0, 128);
-    _llk_pack_init_<false, false, false>(pack_dst_format0, pack_dst_format0, 16, TILE_C_DIM, 4, false, false);
+    _llk_pack_init_<false, false, false>(pack_src_format0, 16, TILE_C_DIM, 4, 1);
     _llk_pack_dest_init_<DstSync::SyncHalf, false>();
 #else
     _llk_pack_hw_configure_<false, false>(pack_src_format0, pack_dst_format0, 128);
@@ -243,7 +243,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t pack_dst_format1 = ckernel::to_underlying(DataFormat::Float16_b);
     _llk_pack_reconfig_data_format_<false, false>(pack_src_format1, pack_dst_format1, 128);
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false, false, false>(pack_dst_format1, pack_dst_format1, 16, TILE_C_DIM, 4, false, false);
+    _llk_pack_init_<false, false, false>(pack_src_format1, 16, TILE_C_DIM, 4, 1);
     _llk_pack_dest_init_<DstSync::SyncHalf, false>();
 #else
     _llk_pack_init_<false, false>(pack_dst_format1);
@@ -269,7 +269,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t pack_dst_format2 = ckernel::to_underlying(DataFormat::Float16_b);
     _llk_pack_reconfig_data_format_<false, false>(pack_src_format2, pack_dst_format2, 128);
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false, false, false>(pack_dst_format2, pack_dst_format2, 16, TILE_C_DIM, 4, false, false);
+    _llk_pack_init_<false, false, false>(pack_src_format2, 16, TILE_C_DIM, 4, 1);
     _llk_pack_dest_init_<DstSync::SyncHalf, false>();
 #else
     _llk_pack_init_<false, false>(pack_dst_format2);
@@ -293,7 +293,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t pack_dst_format3 = ckernel::to_underlying(DataFormat::Float16_b);
     _llk_pack_reconfig_data_format_<false, false>(pack_src_format3, pack_dst_format3, 128);
 #ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false, false, false>(pack_dst_format3, pack_dst_format3, 16, TILE_C_DIM, 4, false, false);
+    _llk_pack_init_<false, false, false>(pack_src_format3, 16, TILE_C_DIM, 4, 1);
     _llk_pack_dest_init_<DstSync::SyncHalf, false>();
 #else
     _llk_pack_init_<false, false>(pack_dst_format3);

--- a/tt_metal/tt-llk/tests/sources/sfpu_binary_bcast_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_binary_bcast_test.cpp
@@ -106,7 +106,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);
-    _llk_pack_init_<false, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, TILE_NUM_FACES);
+    _llk_pack_init_<false, false>(FACE_R_DIM, TILE_C_DIM, TILE_NUM_FACES);
     _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en>();
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);

--- a/tt_metal/tt-llk/tests/sources/sfpu_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_binary_test.cpp
@@ -87,6 +87,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -99,11 +100,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16);
 #endif
 
-#ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false, false>();
-#else
-    _llk_pack_init_<false, false>(formats.pack_dst);
-#endif
+    _llk_pack_init_wrapper_<false, false>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/sfpu_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_binary_test.cpp
@@ -99,7 +99,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16);
 #endif
 
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_init_<false, false>();
+#else
     _llk_pack_init_<false, false>(formats.pack_dst);
+#endif
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_row_max_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_row_max_perf.cpp
@@ -167,6 +167,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 
@@ -188,11 +189,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-#ifdef ARCH_BLACKHOLE
-        _llk_pack_init_<false, false>();
-#else
-        _llk_pack_init_<false, false>(formats.pack_dst);
-#endif
+        _llk_pack_init_wrapper_<false, false>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_row_max_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_row_max_perf.cpp
@@ -188,7 +188,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
+#ifdef ARCH_BLACKHOLE
+        _llk_pack_init_<false, false>();
+#else
         _llk_pack_init_<false, false>(formats.pack_dst);
+#endif
 
 #ifdef ARCH_BLACKHOLE
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_perf.cpp
@@ -221,7 +221,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
+#ifdef ARCH_BLACKHOLE
+        _llk_pack_init_<false, false>();
+#else
         _llk_pack_init_<false, false>(formats.pack_dst);
+#endif
 
         // Initialize destination for packing
 #ifdef ARCH_BLACKHOLE

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_perf.cpp
@@ -199,6 +199,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 
@@ -221,11 +222,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-#ifdef ARCH_BLACKHOLE
-        _llk_pack_init_<false, false>();
-#else
-        _llk_pack_init_<false, false>(formats.pack_dst);
-#endif
+        _llk_pack_init_wrapper_<false, false>(formats.pack_dst);
 
         // Initialize destination for packing
 #ifdef ARCH_BLACKHOLE

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_test.cpp
@@ -106,7 +106,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_init_<false, false>();
+#else
     _llk_pack_init_<false, false>(formats.pack_dst);
+#endif
 
     // Initialize destination for packing
 #ifdef ARCH_BLACKHOLE

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_test.cpp
@@ -90,6 +90,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifdef LLK_TRISC_PACK
 
 #include "ckernel_sfpu_reduce_custom.h"
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -106,11 +107,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-#ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false, false>();
-#else
-    _llk_pack_init_<false, false>(formats.pack_dst);
-#endif
+    _llk_pack_init_wrapper_<false, false>(formats.pack_dst);
 
     // Initialize destination for packing
 #ifdef ARCH_BLACKHOLE

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_test.cpp
@@ -144,6 +144,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -159,11 +160,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-#ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false, false>();
-#else
-    _llk_pack_init_<false, false>(formats.pack_dst);
-#endif
+    _llk_pack_init_wrapper_<false, false>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_test.cpp
@@ -159,7 +159,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_init_<false, false>();
+#else
     _llk_pack_init_<false, false>(formats.pack_dst);
+#endif
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/tilize_calculate_untilize_L1.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_calculate_untilize_L1.cpp
@@ -173,7 +173,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifdef ARCH_BLACKHOLE
     const bool TILIZE = true;
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, TILIZE>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
-    _llk_pack_init_<UNTILIZE, false, TILIZE>(formats_array[run].pack_dst);
+    _llk_pack_init_<UNTILIZE, false, TILIZE>();
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
@@ -194,7 +194,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     run = 1;                                   // second L1-to-L1 run, we access the second set of formats_array in our array
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, !TILIZE>(formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4);
-    _llk_pack_init_<UNTILIZE, false, !TILIZE>(formats_array[run].pack_dst);
+    _llk_pack_init_<UNTILIZE, false, !TILIZE>();
 #endif
 
     _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/topk_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/topk_test.cpp
@@ -396,6 +396,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 // ============================================================================
 
 #ifdef LLK_TRISC_PACK
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 
@@ -483,11 +484,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
                     }
 
-#ifdef ARCH_BLACKHOLE
-                    _llk_pack_init_<false, false>();
-#else
-                    _llk_pack_init_<false, false>(pack_dst_format);
-#endif
+                    _llk_pack_init_wrapper_<false, false>(pack_dst_format);
 
                     const int tile_dest_offset = stage_index * NUM_TILES_PER_STAGE;
 

--- a/tt_metal/tt-llk/tests/sources/topk_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/topk_test.cpp
@@ -476,7 +476,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
                             TILE_C_DIM,
                             4 /* num_faces */,
                             false /* partial_face */,
-                            false /* narrow_tile */,
                             1 /* num_tiles */);
 #else
                         _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en, false /* is_tile_dim_reconfig_en */>(

--- a/tt_metal/tt-llk/tests/sources/topk_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/topk_test.cpp
@@ -484,7 +484,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
                     }
 
+#ifdef ARCH_BLACKHOLE
+                    _llk_pack_init_<false, false>();
+#else
                     _llk_pack_init_<false, false>(pack_dst_format);
+#endif
 
                     const int tile_dest_offset = stage_index * NUM_TILES_PER_STAGE;
 

--- a/tt_metal/tt-llk/tests/sources/transpose_dest_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/transpose_dest_test.cpp
@@ -109,7 +109,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, params.num_faces);
-    _llk_pack_init_<false, false, false>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+    _llk_pack_init_<false, false, false>(FACE_R_DIM, TILE_C_DIM, params.num_faces);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, params.num_faces);

--- a/tt_metal/tt-llk/tests/sources/ttnn_where_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/ttnn_where_test.cpp
@@ -125,6 +125,7 @@ void run_kernel(RUNTIME_PARAMETERS)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -158,11 +159,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(PACK_FMT, PACK_FMT, 16 * 16 * 4);
 #endif
 
-#ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false, false>();
-#else
-    _llk_pack_init_<false, false>(PACK_FMT);
-#endif
+    _llk_pack_init_wrapper_<false, false>(PACK_FMT);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/ttnn_where_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/ttnn_where_test.cpp
@@ -158,7 +158,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(PACK_FMT, PACK_FMT, 16 * 16 * 4);
 #endif
 
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_init_<false, false>();
+#else
     _llk_pack_init_<false, false>(PACK_FMT);
+#endif
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/unpack_A_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_A_test.cpp
@@ -131,7 +131,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false, false>(
         formats.pack_src, formats.pack_dst, params.TEST_FACE_R_DIM * params.TEST_FACE_C_DIM * 4, params.TEST_FACE_R_DIM, TILE_C_DIM, params.num_faces);
-    _llk_pack_init_<false, false>(formats.pack_dst, params.TEST_FACE_R_DIM, TILE_C_DIM, params.num_faces);
+    _llk_pack_init_<false, false>(params.TEST_FACE_R_DIM, TILE_C_DIM, params.num_faces);
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(
         formats.pack_src, formats.pack_dst, params.TEST_FACE_R_DIM * params.TEST_FACE_C_DIM * 4, params.TEST_FACE_R_DIM, params.num_faces);

--- a/tt_metal/tt-llk/tests/sources/unpack_a_bcast_eltwise_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_a_bcast_eltwise_perf.cpp
@@ -152,7 +152,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT);
+#ifdef ARCH_BLACKHOLE
+        _llk_pack_init_<>();
+#else
         _llk_pack_init_<>(formats.pack_dst);
+#endif
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/unpack_a_bcast_eltwise_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_a_bcast_eltwise_perf.cpp
@@ -137,6 +137,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 
@@ -152,11 +153,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT);
-#ifdef ARCH_BLACKHOLE
-        _llk_pack_init_<>();
-#else
-        _llk_pack_init_<>(formats.pack_dst);
-#endif
+        _llk_pack_init_wrapper_<>(formats.pack_dst);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/unpack_a_bcast_eltwise_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_a_bcast_eltwise_test.cpp
@@ -85,7 +85,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_init_<false, false>();
+#else
     _llk_pack_init_<false, false>(formats.pack_dst);
+#endif
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/unpack_a_bcast_eltwise_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_a_bcast_eltwise_test.cpp
@@ -70,6 +70,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -85,11 +86,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-#ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<false, false>();
-#else
-    _llk_pack_init_<false, false>(formats.pack_dst);
-#endif
+    _llk_pack_init_wrapper_<false, false>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/unpack_matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_matmul_test.cpp
@@ -120,12 +120,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         TILE_C_DIM,
         params.num_faces,
         params.PARTIAL_FACE_PACK);
-    _llk_pack_init_<false, false, false>(
-        formats.pack_dst,
-        params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM,
-        TILE_C_DIM,
-        params.num_faces,
-        false /* partial_face parameter is unused on BH */);
+    _llk_pack_init_<false, false, false>(params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM, TILE_C_DIM, params.num_faces);
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, false>(

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_perf.cpp
@@ -212,7 +212,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef ARCH_BLACKHOLE
         _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, TILIZE>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
-        _llk_pack_init_<UNTILIZE, false, TILIZE>(formats.pack_dst);
+        _llk_pack_init_<UNTILIZE, false, TILIZE>();
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
         _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
@@ -135,7 +135,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, TILIZE>(formats.pack_src, formats.pack_dst, DATUM_COUNT, FACE_R_DIM, TILE_C_DIM, params.num_faces);
-    _llk_pack_init_<UNTILIZE, false, TILIZE>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+    _llk_pack_init_<UNTILIZE, false, TILIZE>(FACE_R_DIM, TILE_C_DIM, params.num_faces);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, DATUM_COUNT, FACE_R_DIM, params.num_faces);

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_test.cpp
@@ -128,15 +128,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const bool is_8bit_format = IS_8BIT_FORMAT(formats.unpack_A_src);
 
     _llk_pack_init_<UNTILIZE, false, TILIZE>(
-        formats.pack_src,
-        formats.pack_dst,
-        FACE_R_DIM,
-        TILE_C_DIM,
-        num_faces,
-        false /* partial_face */,
-        false /* narrow_tile */,
-        1 /* num_tiles */,
-        is_8bit_format /* skip_bh_tilize_workaround */);
+        formats.pack_src, FACE_R_DIM, TILE_C_DIM, num_faces, 1 /* num_tiles */, is_8bit_format /* skip_bh_tilize_workaround */);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, num_faces);

--- a/tt_metal/tt-llk/tests/sources/unpack_transpose_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_transpose_perf.cpp
@@ -120,6 +120,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 
@@ -136,11 +137,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
 
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT);
-#ifdef ARCH_BLACKHOLE
-        _llk_pack_init_<false, false>();
-#else
-        _llk_pack_init_<false, false>(formats.pack_dst);
-#endif
+        _llk_pack_init_wrapper_<false, false>(formats.pack_dst);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/unpack_transpose_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_transpose_perf.cpp
@@ -136,7 +136,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
 
         _llk_pack_hw_configure_<is_fp32_dest_acc_en>(formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT);
+#ifdef ARCH_BLACKHOLE
+        _llk_pack_init_<false, false>();
+#else
         _llk_pack_init_<false, false>(formats.pack_dst);
+#endif
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/unpack_untilize_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_untilize_perf.cpp
@@ -158,7 +158,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef ARCH_BLACKHOLE
         _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE, false>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
-        _llk_pack_init_<UNTILIZE, false, false>(formats.pack_dst);
+        _llk_pack_init_<UNTILIZE, false, false>();
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 #else
         _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);

--- a/tt_metal/tt-llk/tests/sources/unpack_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_untilize_test.cpp
@@ -94,7 +94,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_init_<UNTILIZE, false>();
+#else
     _llk_pack_init_<UNTILIZE, false>(formats.pack_dst);
+#endif
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/unpack_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_untilize_test.cpp
@@ -77,6 +77,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_lib_pack_wrappers.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -94,11 +95,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, UNTILIZE>(formats.pack_src, formats.pack_dst, 16 * 16 * 4);
 #endif
 
-#ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<UNTILIZE, false>();
-#else
-    _llk_pack_init_<UNTILIZE, false>(formats.pack_dst);
-#endif
+    _llk_pack_init_wrapper_<UNTILIZE, false>(formats.pack_dst);
 
 #ifdef ARCH_BLACKHOLE
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
@@ -479,7 +479,7 @@ inline void reconfig_packer_data_format(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    [[maybe_unused]] const std::uint32_t face_r_dim,
+    const std::uint32_t face_r_dim,
     const std::uint32_t tile_c_dim,
     const std::uint32_t num_faces,
     const bool partial_face)
@@ -570,15 +570,13 @@ inline void configure_pack(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    const std::uint32_t face_r_dim          = FACE_R_DIM,
-    const std::uint32_t tile_c_dim          = TILE_C_DIM,
-    const std::uint32_t num_faces           = 4,
-    const bool partial_face                 = false,
-    [[maybe_unused]] const bool narrow_tile = false,
-    const std::uint32_t relu_config         = 0)
+    const std::uint32_t face_r_dim  = FACE_R_DIM,
+    const std::uint32_t tile_c_dim  = TILE_C_DIM,
+    const std::uint32_t num_faces   = 4,
+    const bool partial_face         = false,
+    const std::uint32_t relu_config = 0)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    LLK_ASSERT(!narrow_tile, "narrow_tile: this parameter is unused");
     LLK_ASSERT(
         is_packer_to_L1_conversion_supported(static_cast<DataFormat>(pack_src_format & 0xF), static_cast<DataFormat>(pack_dst_format & 0xF)),
         "Unsupported packer to L1 conversion.");

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_pack_block.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_pack_block.h
@@ -44,8 +44,7 @@ using namespace ckernel::packer;
 
 // Program the REPLAY buffer and MOP for block-contiguous packing.
 template <bool zero_output = false>
-inline void _llk_pack_block_contiguous_mop_config_(
-    [[maybe_unused]] const std::uint32_t pack_dst_format, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4)
+inline void _llk_pack_block_contiguous_mop_config_(const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4)
 {
     constexpr std::uint32_t ZERO_OUTPUT_FLAG = zero_output ? p_pacr::P_ZERO_OUTPUT_ENABLED : p_pacr::P_ZERO_OUTPUT_DISABLED;
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
@@ -71,17 +71,12 @@ inline void _llk_pack_configure_addrmod_()
 
 template <bool untilize = false, bool zero_output = false, bool tilize = false>
 inline void _llk_pack_mop_config_(
-    [[maybe_unused]] const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim           = FACE_R_DIM,
-    const std::uint32_t tile_c_dim           = TILE_C_DIM,
-    const std::uint32_t num_faces            = 4,
-    [[maybe_unused]] const bool partial_face = false,
-    [[maybe_unused]] const bool narrow_tile  = false,
-    const std::uint32_t num_tiles            = 1)
+    const std::uint32_t face_r_dim = FACE_R_DIM,
+    const std::uint32_t tile_c_dim = TILE_C_DIM,
+    const std::uint32_t num_faces  = 4,
+    const std::uint32_t num_tiles  = 1)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    LLK_ASSERT(!partial_face, "partial_face: this parameter is unused");
-    LLK_ASSERT(!narrow_tile, "narrow_tile: this parameter is unused");
 
     constexpr std::uint32_t MEGAROW          = 1;
     constexpr std::uint32_t ZERO_OUTPUT_FLAG = zero_output ? p_pacr::P_ZERO_OUTPUT_ENABLED : p_pacr::P_ZERO_OUTPUT_DISABLED;
@@ -320,19 +315,19 @@ inline void _llk_pack_reconfig_data_format_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    const std::uint32_t face_r_dim = FACE_R_DIM,
-    const std::uint32_t tile_c_dim = TILE_C_DIM,
-    const std::uint32_t num_faces  = 4,
-    const bool partial_face        = false,
-    const bool narrow_tile         = false,
-    const std::uint32_t num_tiles  = 1)
+    const std::uint32_t face_r_dim          = FACE_R_DIM,
+    const std::uint32_t tile_c_dim          = TILE_C_DIM,
+    const std::uint32_t num_faces           = 4,
+    const bool partial_face                 = false,
+    [[maybe_unused]] const bool narrow_tile = false,
+    const std::uint32_t num_tiles           = 1)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     reconfig_packer_data_format<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim, num_faces, partial_face);
 
     if constexpr (is_tile_dim_reconfig_en)
     {
-        _llk_pack_mop_config_<false, false>(pack_dst_format, face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
+        _llk_pack_mop_config_<false, false>(face_r_dim, tile_c_dim, num_faces, num_tiles);
     }
 }
 
@@ -353,42 +348,41 @@ inline void _llk_pack_hw_configure_(
     const std::uint32_t tile_c_dim  = TILE_C_DIM,
     const std::uint32_t num_faces   = 4,
     const bool partial_face         = false,
-    const bool narrow_tile          = false,
     const std::uint32_t relu_config = 0)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     configure_pack<is_fp32_dest_acc_en, untilize, tilize>(
-        pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, relu_config);
+        pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim, num_faces, partial_face, relu_config);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34587
 template <bool untilize = false, bool zero_output = false, bool tilize = false>
 inline void _llk_pack_init_(
-    const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim = FACE_R_DIM,
-    const std::uint32_t tile_c_dim = TILE_C_DIM,
-    const std::uint32_t num_faces  = 4,
-    const bool partial_face        = false,
-    const bool narrow_tile         = false,
-    const std::uint32_t num_tiles  = 1)
+    [[maybe_unused]] const std::uint32_t pack_dst_format,
+    const std::uint32_t face_r_dim           = FACE_R_DIM,
+    const std::uint32_t tile_c_dim           = TILE_C_DIM,
+    const std::uint32_t num_faces            = 4,
+    [[maybe_unused]] const bool partial_face = false,
+    [[maybe_unused]] const bool narrow_tile  = false,
+    const std::uint32_t num_tiles            = 1)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     _llk_pack_configure_addrmod_<untilize, tilize>();
-    _llk_pack_mop_config_<untilize, zero_output, tilize>(pack_dst_format, face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
+    _llk_pack_mop_config_<untilize, zero_output, tilize>(face_r_dim, tile_c_dim, num_faces, num_tiles);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34587
 template <bool untilize = false, bool zero_output = false, bool tilize = false>
 inline void _llk_pack_init_(
     const std::uint32_t pack_src_format,
-    const std::uint32_t pack_dst_format,
+    [[maybe_unused]] const std::uint32_t pack_dst_format,
     const std::uint32_t face_r_dim,
     const std::uint32_t tile_c_dim,
     const std::uint32_t num_faces,
-    const bool partial_face              = false,
-    const bool narrow_tile               = false,
-    const std::uint32_t num_tiles        = 1,
-    const bool skip_bh_tilize_workaround = false)
+    [[maybe_unused]] const bool partial_face = false,
+    [[maybe_unused]] const bool narrow_tile  = false,
+    const std::uint32_t num_tiles            = 1,
+    const bool skip_bh_tilize_workaround     = false)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     const DataFormat src_format = static_cast<DataFormat>(pack_src_format);
@@ -406,14 +400,13 @@ inline void _llk_pack_init_(
     if (skip_bh_tilize_workaround)
     {
         _llk_pack_configure_addrmod_<untilize, false /* tilize */>();
-        _llk_pack_mop_config_<untilize, zero_output, false /* tilize */>(
-            pack_dst_format, face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
+        _llk_pack_mop_config_<untilize, zero_output, false /* tilize */>(face_r_dim, tile_c_dim, num_faces, num_tiles);
         set_packer_strides<untilize, false /* tilize */>(pack_src_format, tile_c_dim);
     }
     else
     {
         _llk_pack_configure_addrmod_<untilize, tilize>();
-        _llk_pack_mop_config_<untilize, zero_output, tilize>(pack_dst_format, face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
+        _llk_pack_mop_config_<untilize, zero_output, tilize>(face_r_dim, tile_c_dim, num_faces, num_tiles);
         set_packer_strides<untilize, tilize>(pack_src_format, tile_c_dim);
     }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
@@ -315,12 +315,11 @@ inline void _llk_pack_reconfig_data_format_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    const std::uint32_t face_r_dim          = FACE_R_DIM,
-    const std::uint32_t tile_c_dim          = TILE_C_DIM,
-    const std::uint32_t num_faces           = 4,
-    const bool partial_face                 = false,
-    [[maybe_unused]] const bool narrow_tile = false,
-    const std::uint32_t num_tiles           = 1)
+    const std::uint32_t face_r_dim = FACE_R_DIM,
+    const std::uint32_t tile_c_dim = TILE_C_DIM,
+    const std::uint32_t num_faces  = 4,
+    const bool partial_face        = false,
+    const std::uint32_t num_tiles  = 1)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     reconfig_packer_data_format<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim, num_faces, partial_face);
@@ -358,13 +357,10 @@ inline void _llk_pack_hw_configure_(
 // TODO NC: Clean up as the part of tt-metal#34587
 template <bool untilize = false, bool zero_output = false, bool tilize = false>
 inline void _llk_pack_init_(
-    [[maybe_unused]] const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim           = FACE_R_DIM,
-    const std::uint32_t tile_c_dim           = TILE_C_DIM,
-    const std::uint32_t num_faces            = 4,
-    [[maybe_unused]] const bool partial_face = false,
-    [[maybe_unused]] const bool narrow_tile  = false,
-    const std::uint32_t num_tiles            = 1)
+    const std::uint32_t face_r_dim = FACE_R_DIM,
+    const std::uint32_t tile_c_dim = TILE_C_DIM,
+    const std::uint32_t num_faces  = 4,
+    const std::uint32_t num_tiles  = 1)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     _llk_pack_configure_addrmod_<untilize, tilize>();
@@ -375,14 +371,11 @@ inline void _llk_pack_init_(
 template <bool untilize = false, bool zero_output = false, bool tilize = false>
 inline void _llk_pack_init_(
     const std::uint32_t pack_src_format,
-    [[maybe_unused]] const std::uint32_t pack_dst_format,
     const std::uint32_t face_r_dim,
     const std::uint32_t tile_c_dim,
     const std::uint32_t num_faces,
-    [[maybe_unused]] const bool partial_face = false,
-    [[maybe_unused]] const bool narrow_tile  = false,
-    const std::uint32_t num_tiles            = 1,
-    const bool skip_bh_tilize_workaround     = false)
+    const std::uint32_t num_tiles,
+    const bool skip_bh_tilize_workaround = false)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     const DataFormat src_format = static_cast<DataFormat>(pack_src_format);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
@@ -59,11 +59,8 @@ inline void _llk_pack_dest_section_done_()
 }
 
 template <DstSync Dst>
-inline void _llk_init_packer_dest_offset_registers_(
-    [[maybe_unused]] const std::uint32_t face_r_dim = FACE_R_DIM, [[maybe_unused]] const bool narrow_tile = false)
+inline void _llk_init_packer_dest_offset_registers_()
 {
-    LLK_ASSERT(face_r_dim == FACE_R_DIM, "face_r_dim: this parameter is unused");
-    LLK_ASSERT(!narrow_tile, "narrow_tile: this parameter is unused");
     TTI_STALLWAIT(p_stall::STALL_TDMA | p_stall::STALL_THCON, p_stall::PACK); // wait for pack to finish
 
     // RowMajor order
@@ -75,17 +72,17 @@ inline void _llk_init_packer_dest_offset_registers_(
 }
 
 template <DstSync Dst, bool is_fp32_dest_acc_en>
-inline void _llk_pack_dest_init_(const std::uint32_t face_r_dim = FACE_R_DIM, const bool narrow_tile = false)
+inline void _llk_pack_dest_init_()
 {
     tensix_sync();
     reset_dest_offset_id();
-    _llk_init_packer_dest_offset_registers_<Dst>(face_r_dim, narrow_tile);
+    _llk_init_packer_dest_offset_registers_<Dst>();
     packer_addr_counter_init();
     pack_sync_tile_dst_ptr = 0;
 }
 
 template <bool mail2math = true, bool mail2pack = true>
-inline void _llk_pack_get_tile_(std::uint32_t tile_index, std::uint32_t *p_tile)
+inline void _llk_pack_get_tile_([[maybe_unused]] std::uint32_t tile_index, std::uint32_t *p_tile)
 {
     if constexpr (mail2pack)
     {

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
@@ -81,28 +81,6 @@ inline void _llk_pack_dest_init_()
     pack_sync_tile_dst_ptr = 0;
 }
 
-template <bool mail2math = true, bool mail2pack = true>
-inline void _llk_pack_get_tile_([[maybe_unused]] std::uint32_t tile_index, std::uint32_t *p_tile)
-{
-    if constexpr (mail2pack)
-    {
-        *p_tile = mailbox_read(ThreadId::UnpackThreadId);
-    }
-    else
-    {
-        *p_tile = 0x0;
-    }
-}
-
-template <bool mail2math = true, bool mail2pack = true>
-inline void _llk_pack_release_tile_()
-{
-    if constexpr (mail2pack)
-    {
-        semaphore_get(semaphore::UNPACK_OPERAND_SYNC);
-    }
-}
-
 inline void set_dst_write_addr(const std::uint32_t tile_index)
 {
     TT_SETADC(p_setadc::PAC, p_setadc::CH_0, p_setadc::SET_W, tile_index);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_untilize.h
@@ -198,12 +198,7 @@ template <
     bool narrow_row                  = false,
     std::uint32_t tile_dst_ct_offset = 0,
     bool dense                       = false>
-inline void _llk_pack_untilize_(
-    const std::uint32_t address,
-    [[maybe_unused]] const std::uint32_t pack_dst_format,
-    [[maybe_unused]] const std::uint32_t face_r_dim = FACE_R_DIM,
-    const std::uint32_t num_faces                   = 4,
-    const std::uint32_t tile_dst_rt_offset          = 0)
+inline void _llk_pack_untilize_(const std::uint32_t address, const std::uint32_t num_faces = 4, const std::uint32_t tile_dst_rt_offset = 0)
 {
     static_assert(block_ct_dim <= (dense ? 16 : 8), "block_ct_dim must be <= 8 when not dense, <= 16 when dense");
     static_assert(!dense || (block_ct_dim % 2 == 0), "block_ct_dim must be even when dense");

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -260,27 +260,6 @@ inline void _llk_pack_init_(
     TT_SETADCXX(p_setadc::PAC, pack_x_dim - 1, 0x0);
 }
 
-// TODO NC: Clean up as the part of tt-metal#34587
-template <bool untilize = false, bool zero_output = false>
-inline void _llk_pack_init_(
-    const std::uint32_t pack_dst_format,
-    const std::uint32_t pack_src_format,
-    const std::uint32_t face_r_dim,
-    const std::uint32_t num_faces,
-    const bool partial_face       = false,
-    const bool narrow_tile        = false,
-    const std::uint32_t num_tiles = 1)
-{
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    _llk_pack_configure_addrmod_<untilize>();
-    _llk_pack_mop_config_<untilize, zero_output>(pack_dst_format, face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
-
-    set_packer_l1_offset(pack_dst_format);
-    const std::uint32_t face_dim   = face_r_dim * FACE_C_DIM;
-    const std::uint32_t pack_x_dim = (narrow_tile || !untilize) ? face_dim : FACE_R_DIM;
-    TT_SETADCXX(p_setadc::PAC, pack_x_dim - 1, 0x0);
-}
-
 inline void _llk_pack_uninit_(const std::uint32_t face_r_dim)
 {
     TT_SETADCXX(p_setadc::PAC, face_r_dim * FACE_C_DIM - 1, 0x0);
@@ -381,9 +360,8 @@ inline void _llk_pack_fast_tilize_addrmod_config_(const std::uint32_t unit_dim)
         .set(ADDR_MOD_3);
 }
 
-inline void _llk_pack_fast_tilize_mop_config_([[maybe_unused]] const std::uint32_t unit_dim)
+inline void _llk_pack_fast_tilize_mop_config_()
 {
-    // UNPACR instructions are used with unit_dim 1 and 2 and SKIP instructions are used with unit_dim 3
     ckernel_unpack_template tmp = ckernel_unpack_template(
         false,
         false,
@@ -487,7 +465,9 @@ inline void _llk_pack_fast_tilize_init_(
 
     _llk_pack_fast_tilize_addrmod_config_(unit_dim);
 
-    _llk_pack_fast_tilize_mop_config_(unit_dim);
+    // UNPACR instructions are used with unit_dim 1 and 2 and SKIP instructions are used with unit_dim 3
+    LLK_ASSERT(unit_dim == 1 || unit_dim == 2 || unit_dim == 3, "unit_dim must be 1, 2, or 3");
+    _llk_pack_fast_tilize_mop_config_();
 }
 
 template <DstSync Dst, bool is_fp32_dest_acc_en>

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
@@ -126,7 +126,7 @@ inline void _llk_pack_dest_init_(const std::uint32_t face_r_dim = FACE_R_DIM, co
 }
 
 template <bool mail2math = true, bool mail2pack = true>
-inline void _llk_pack_get_tile_(std::uint32_t tile_index, std::uint32_t *p_tile)
+inline void _llk_pack_get_tile_(std::uint32_t *p_tile)
 {
     constexpr std::uint32_t wait_sem = (mail2math && mail2pack) ? (2) : (1);
     while (semaphore_read(semaphore::UNPACK_OPERAND_SYNC) < wait_sem)

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
@@ -125,31 +125,6 @@ inline void _llk_pack_dest_init_(const std::uint32_t face_r_dim = FACE_R_DIM, co
     pack_sync_tile_dst_ptr = 0;
 }
 
-template <bool mail2math = true, bool mail2pack = true>
-inline void _llk_pack_get_tile_(std::uint32_t *p_tile)
-{
-    constexpr std::uint32_t wait_sem = (mail2math && mail2pack) ? (2) : (1);
-    while (semaphore_read(semaphore::UNPACK_OPERAND_SYNC) < wait_sem)
-        ;
-    if constexpr (mail2pack)
-    {
-        *p_tile = mailbox_read(ThreadId::UnpackThreadId);
-    }
-    else
-    {
-        *p_tile = 0x0;
-    }
-}
-
-template <bool mail2math = true, bool mail2pack = true>
-inline void _llk_pack_release_tile_()
-{
-    if constexpr (mail2pack)
-    {
-        semaphore_get(semaphore::UNPACK_OPERAND_SYNC);
-    }
-}
-
 inline void set_dst_write_addr(const std::uint32_t tile_index)
 {
     TT_SETADC(p_setadc::PAC, p_setadc::CH_0, p_setadc::SET_W, tile_index);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_untilize.h
@@ -173,14 +173,9 @@ template <
     std::uint32_t row_num_datums     = TILE_C_DIM,
     std::uint32_t tile_dst_ct_offset = 0>
 inline void _llk_pack_untilize_(
-    const std::uint32_t address,
-    const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim                 = FACE_R_DIM,
-    [[maybe_unused]] const std::uint32_t num_faces = 4,
-    const std::uint32_t tile_dst_rt_offset         = 0)
+    const std::uint32_t address, const std::uint32_t pack_dst_format, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t tile_dst_rt_offset = 0)
 {
     static_assert(full_ct_dim % block_ct_dim == 0, "full_ct_dim must be divisible by block_ct_dim");
-    LLK_ASSERT(num_faces == 4, "num_faces: this parameter is unused");
 
     program_packer_untilized_destination<block_ct_dim, full_ct_dim, diagonal, row_num_datums>(address, pack_dst_format);
 


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Remove unused LLK pack parameters from Blackhole and Wormhole pack helpers and update LLK API/test callsites to match the narrowed signatures. This keeps pack configuration APIs aligned with the values that actually affect MOP setup, pack init, pack untilize, and destination synchronization.

### Test pack wrappers
This PR adds `tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h` for LLK test sources that are compiled for both Wormhole and Blackhole but now need to call pack APIs whose signatures differ by architecture.

The wrappers are intentionally limited to the test callsites that would otherwise need local `#ifdef ARCH_BLACKHOLE` branches:
- `_llk_pack_init_wrapper_` keeps one callsite for pack init while Wormhole still consumes `pack_dst_format` and Blackhole ignores it.
- `_llk_pack_untilize_wrapper_` keeps one callsite for pack untilize while Wormhole still consumes destination format / face dimensions and Blackhole uses the reduced signature.

Tests that already call APIs with matching signatures, or whose callsites are already architecture-specific for other reasons, continue to call the LLK APIs directly instead of using these wrappers.
Created the follow-up issue to move other similar cases to wrappers:
https://github.com/tenstorrent/tt-metal/issues/43718

### Notes for reviewers
Please focus on the architecture-specific callsite updates, especially shared LLK tests where Blackhole now omits pack-destination format arguments while Wormhole still passes them. The branch also includes follow-up cleanup for Blackhole `_llk_pack_init_` overloads so parameters previously marked `[[maybe_unused]]` are no longer part of the signature.

### Validation
Sanity - [latest run](https://github.com/tenstorrent/tt-metal/actions/runs/25400181929) passed.

BPC - [latest run](https://github.com/tenstorrent/tt-metal/actions/runs/25400181882) has the same failure as [main](https://github.com/tenstorrent/tt-metal/actions/runs/25435296580).

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/llk-unused-params-pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/llk-unused-params-pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/llk-unused-params-pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/llk-unused-params-pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/llk-unused-params-pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/llk-unused-params-pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/llk-unused-params-pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/llk-unused-params-pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/llk-unused-params-pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/llk-unused-params-pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/llk-unused-params-pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/llk-unused-params-pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/llk-unused-params-pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/llk-unused-params-pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/llk-unused-params-pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/llk-unused-params-pack)