### PR TITLE
Extend descriptor fast cache-hit path to optional inputs and resources

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
+++ b/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
@@ -94,6 +94,28 @@ TEST(DescriptorPatching, EmplaceCommonRuntimeArgs_AllUint32_NoBindings) {
     EXPECT_TRUE(kd.common_buffer_bindings.empty());
 }
 
+// Regression: emplace_runtime_args must accept nullptr Buffer* as a placeholder for
+// an absent optional tensor.  It emits 0u into the runtime arg slot and registers no
+// binding, so the cache-hit fast path stays valid for ops with optional inputs.
+TEST(DescriptorPatching, EmplaceRuntimeArgs_NullBuffer_EmitsZero_NoBinding) {
+    KernelDescriptor kd;
+    Buffer* null_buf = nullptr;
+    kd.emplace_runtime_args({0, 0}, {1u, null_buf, 3u});
+
+    ASSERT_EQ(kd.runtime_args.size(), 1u);
+    EXPECT_EQ(kd.runtime_args[0].second, (std::vector<uint32_t>{1u, 0u, 3u}));
+    EXPECT_TRUE(kd.buffer_bindings.empty());
+}
+
+TEST(DescriptorPatching, EmplaceCommonRuntimeArgs_NullBuffer_EmitsZero_NoBinding) {
+    KernelDescriptor kd;
+    Buffer* null_buf = nullptr;
+    kd.emplace_common_runtime_args({7u, null_buf, 9u});
+
+    EXPECT_EQ(kd.common_runtime_args, (std::vector<uint32_t>{7u, 0u, 9u}));
+    EXPECT_TRUE(kd.common_buffer_bindings.empty());
+}
+
 TEST(DescriptorPatching, RTArgList_Uint32Only_NoBufferBindings) {
     KernelDescriptor kd;
     KernelDescriptor::RTArgList args;

--- a/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
+++ b/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
@@ -179,7 +179,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_PerCoreBuffer_Correc
     desc.kernels = {kd};
 
     Program program{desc};
-    ResolvedBindings resolved = resolve_bindings(program, desc, {buf_a.get()});
+    ResolvedBindings resolved = resolve_bindings(program, desc, std::vector<Buffer*>{buf_a.get()});
 
     ASSERT_EQ(resolved.rt_args.size(), 1u);
     EXPECT_TRUE(resolved.cbs.empty());
@@ -205,7 +205,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_BufferAtNonZeroArgId
     desc.kernels = {kd};
 
     Program program{desc};
-    ResolvedBindings resolved = resolve_bindings(program, desc, {buf_a.get()});
+    ResolvedBindings resolved = resolve_bindings(program, desc, std::vector<Buffer*>{buf_a.get()});
 
     ASSERT_EQ(resolved.rt_args.size(), 1u);
     EXPECT_EQ(resolved.rt_args[0].arg_idx, 1u);
@@ -226,7 +226,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_TwoBuffers_CorrectIn
     desc.kernels = {kd};
 
     Program program{desc};
-    ResolvedBindings resolved = resolve_bindings(program, desc, {buf_a.get(), buf_b.get()});
+    ResolvedBindings resolved = resolve_bindings(program, desc, std::vector<Buffer*>{buf_a.get(), buf_b.get()});
 
     ASSERT_EQ(resolved.rt_args.size(), 2u);
     // Bindings should be recorded in arg-index order.
@@ -248,7 +248,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_CommonBuffer_IsCommo
     desc.kernels = {kd};
 
     Program program{desc};
-    ResolvedBindings resolved = resolve_bindings(program, desc, {buf_a.get()});
+    ResolvedBindings resolved = resolve_bindings(program, desc, std::vector<Buffer*>{buf_a.get()});
 
     ASSERT_EQ(resolved.rt_args.size(), 1u);
     const auto& b = resolved.rt_args[0];
@@ -267,7 +267,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_NoBufferArgs_Returns
     desc.kernels = {kd};
 
     Program program{desc};
-    ResolvedBindings resolved = resolve_bindings(program, desc, {});
+    ResolvedBindings resolved = resolve_bindings(program, desc, std::vector<Buffer*>{});
 
     EXPECT_TRUE(resolved.empty());
 }
@@ -284,7 +284,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyResolvedBindings_PatchesPerCore
     desc.kernels = {kd};
 
     Program program{desc};
-    ResolvedBindings resolved = resolve_bindings(program, desc, {buf_a.get()});
+    ResolvedBindings resolved = resolve_bindings(program, desc, std::vector<Buffer*>{buf_a.get()});
 
     // Pre-apply: arg[0] should be buf_a's address.
     RuntimeArgsData& before = GetRuntimeArgs(program, 0, {0, 0});
@@ -292,7 +292,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyResolvedBindings_PatchesPerCore
     EXPECT_EQ(before[1], 42u);  // uint32 arg unchanged
 
     // Apply with buf_b.
-    apply_resolved_bindings(program, resolved, {buf_b.get()});
+    apply_resolved_bindings(program, resolved, std::vector<Buffer*>{buf_b.get()});
 
     RuntimeArgsData& after = GetRuntimeArgs(program, 0, {0, 0});
     EXPECT_EQ(after[0], buf_b->address());
@@ -311,14 +311,14 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyResolvedBindings_PatchesCommonA
     desc.kernels = {kd};
 
     Program program{desc};
-    ResolvedBindings resolved = resolve_bindings(program, desc, {buf_a.get()});
+    ResolvedBindings resolved = resolve_bindings(program, desc, std::vector<Buffer*>{buf_a.get()});
 
     // Pre-apply: common arg[1] should be buf_a's address.
     RuntimeArgsData& before = GetCommonRuntimeArgs(program, 0);
     EXPECT_EQ(before[0], 77u);
     EXPECT_EQ(before[1], buf_a->address());
 
-    apply_resolved_bindings(program, resolved, {buf_b.get()});
+    apply_resolved_bindings(program, resolved, std::vector<Buffer*>{buf_b.get()});
 
     RuntimeArgsData& after = GetCommonRuntimeArgs(program, 0);
     EXPECT_EQ(after[0], 77u);
@@ -339,16 +339,16 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ApplyResolvedBindings_RepeatedApplic
     desc.kernels = {kd};
 
     Program program{desc};
-    ResolvedBindings resolved = resolve_bindings(program, desc, {buf_a.get()});
+    ResolvedBindings resolved = resolve_bindings(program, desc, std::vector<Buffer*>{buf_a.get()});
 
-    apply_resolved_bindings(program, resolved, {buf_b.get()});
+    apply_resolved_bindings(program, resolved, std::vector<Buffer*>{buf_b.get()});
     EXPECT_EQ(GetRuntimeArgs(program, 0, {0, 0})[0], buf_b->address());
 
-    apply_resolved_bindings(program, resolved, {buf_c.get()});
+    apply_resolved_bindings(program, resolved, std::vector<Buffer*>{buf_c.get()});
     EXPECT_EQ(GetRuntimeArgs(program, 0, {0, 0})[0], buf_c->address());
 
     // Apply back to buf_a.
-    apply_resolved_bindings(program, resolved, {buf_a.get()});
+    apply_resolved_bindings(program, resolved, std::vector<Buffer*>{buf_a.get()});
     EXPECT_EQ(GetRuntimeArgs(program, 0, {0, 0})[0], buf_a->address());
 }
 
@@ -380,7 +380,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_CbOnlyBuffers_Return
     });
 
     Program program{desc};
-    ResolvedBindings resolved = resolve_bindings(program, desc, {buf_l1.get()});
+    ResolvedBindings resolved = resolve_bindings(program, desc, std::vector<Buffer*>{buf_l1.get()});
 
     // No rt_arg bindings were declared, so both rt_args and cbs must be empty.
     EXPECT_TRUE(resolved.rt_args.empty());
@@ -413,7 +413,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_DuplicateBuffer_Retu
     // tensor_buffers reflects "X used twice" — the same Buffer* appears at
     // both slots.  resolve_bindings must report empty so the adapter takes
     // the slow path.
-    ResolvedBindings resolved = resolve_bindings(program, desc, {buf_a.get(), buf_a.get()});
+    ResolvedBindings resolved = resolve_bindings(program, desc, std::vector<Buffer*>{buf_a.get(), buf_a.get()});
 
     EXPECT_TRUE(resolved.empty());
     EXPECT_TRUE(resolved.rt_args.empty());
@@ -434,7 +434,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_BufferNotInTensorLis
     Program program{desc};
 
     // buf_a is not in the tensor list — should throw.
-    EXPECT_ANY_THROW(resolve_bindings(program, desc, {buf_other.get()}));
+    EXPECT_ANY_THROW(resolve_bindings(program, desc, std::vector<Buffer*>{buf_other.get()}));
 }
 
 // Regression: a scalar runtime arg whose value happens to numerically equal a
@@ -464,7 +464,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_ScalarMatchingBuffer
     desc.kernels = {kd};
 
     Program program{desc};
-    EXPECT_NO_THROW(resolve_bindings(program, desc, {buf_a.get()}));
+    EXPECT_NO_THROW(resolve_bindings(program, desc, std::vector<Buffer*>{buf_a.get()}));
 }
 
 // Regression: same idea for common runtime args.
@@ -479,7 +479,7 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_CommonScalarMatching
     desc.kernels = {kd};
 
     Program program{desc};
-    EXPECT_NO_THROW(resolve_bindings(program, desc, {buf_a.get()}));
+    EXPECT_NO_THROW(resolve_bindings(program, desc, std::vector<Buffer*>{buf_a.get()}));
 }
 
 }  // namespace

--- a/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
+++ b/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
@@ -31,6 +31,7 @@
 #include <tt-metalium/program_descriptors.hpp>
 
 #include <cstdint>
+#include <span>
 #include <vector>
 
 namespace tt::tt_metal {
@@ -84,7 +85,7 @@ struct ResolvedBindings {
 //
 // Call immediately after Program{desc} on cache miss; store in shared_variables.
 ResolvedBindings resolve_bindings(
-    Program& program, const ProgramDescriptor& desc, const std::vector<Buffer*>& tensor_buffers);
+    Program& program, const ProgramDescriptor& desc, std::span<Buffer* const> tensor_buffers);
 
 // Apply resolved bindings to the cached program on a cache hit.
 // current_buffers must be the output of collect_tensor_buffers() for the
@@ -94,6 +95,6 @@ ResolvedBindings resolve_bindings(
 // reference on each call, so the write targets the correct storage (pre- or
 // post-first-enqueue) without any cross-call pointer state.
 void apply_resolved_bindings(
-    Program& program, const ResolvedBindings& bindings, const std::vector<Buffer*>& current_buffers);
+    Program& program, const ResolvedBindings& bindings, std::span<Buffer* const> current_buffers);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <span>
 #include <string_view>
 #include <unordered_set>
 #include <vector>
@@ -23,7 +24,7 @@
 namespace tt::tt_metal {
 
 ResolvedBindings resolve_bindings(
-    Program& program, const ProgramDescriptor& desc, const std::vector<Buffer*>& tensor_buffers) {
+    Program& program, const ProgramDescriptor& desc, std::span<Buffer* const> tensor_buffers) {
     ResolvedBindings result;
 
     // If the same Buffer* appears in tensor_buffers more than once (e.g. matmul(X, X),
@@ -114,19 +115,60 @@ ResolvedBindings resolve_bindings(
         }
     }
 
+    // Sort rt_args by (is_common, kernel_idx, core, arg_idx) so that bindings sharing
+    // the same (kernel, core) RuntimeArgsData are contiguous.  apply_resolved_bindings
+    // amortises the GetRuntimeArgs lookup across each group instead of doing one
+    // lookup per binding — significant win on multi-core ops with several Buffer*
+    // slots per core.
+    std::sort(result.rt_args.begin(), result.rt_args.end(), [](const auto& a, const auto& b) {
+        if (a.is_common != b.is_common) {
+            return !a.is_common;  // per-core first, then common
+        }
+        if (a.kernel_idx != b.kernel_idx) {
+            return a.kernel_idx < b.kernel_idx;
+        }
+        if (!a.is_common) {
+            if (a.core.x != b.core.x) {
+                return a.core.x < b.core.x;
+            }
+            if (a.core.y != b.core.y) {
+                return a.core.y < b.core.y;
+            }
+        }
+        return a.arg_idx < b.arg_idx;
+    });
+
     return result;
 }
 
 void apply_resolved_bindings(
-    Program& program, const ResolvedBindings& bindings, const std::vector<Buffer*>& current_buffers) {
+    Program& program, const ResolvedBindings& bindings, std::span<Buffer* const> current_buffers) {
+    // bindings.rt_args is sorted by (is_common, kernel_idx, core, arg_idx) at resolve
+    // time, so consecutive entries share the same RuntimeArgsData reference whenever
+    // they target the same (is_common, kernel_idx, core).  Cache the live reference
+    // across that run instead of re-deriving it via GetRuntimeArgs per binding.
+    //
+    // The reference is re-derived on every apply call (not stored across calls) so
+    // first-enqueue retargeting of rt_args_data to the command-sequence buffer is
+    // observed correctly.
+    RuntimeArgsData* current_data = nullptr;
+    uint32_t prev_kernel_idx = 0;
+    CoreCoord prev_core{};
+    bool prev_is_common = false;
+    bool first = true;
+
     for (const auto& b : bindings.rt_args) {
-        // Re-derive the RuntimeArgsData reference on every call via GetRuntimeArgs /
-        // GetCommonRuntimeArgs rather than storing a cross-call raw pointer.  This is
-        // safe across first-enqueue (when the dispatch path retargets rt_args_data to
-        // the command-sequence buffer) because we look up the live struct each time.
-        RuntimeArgsData& data =
-            b.is_common ? GetCommonRuntimeArgs(program, b.kernel_idx) : GetRuntimeArgs(program, b.kernel_idx, b.core);
-        data[b.arg_idx] = current_buffers[b.tensor_buffer_idx]->address();
+        const bool group_changed = first || b.is_common != prev_is_common || b.kernel_idx != prev_kernel_idx ||
+                                   (!b.is_common && b.core != prev_core);
+        if (group_changed) {
+            current_data = b.is_common ? &GetCommonRuntimeArgs(program, b.kernel_idx)
+                                       : &GetRuntimeArgs(program, b.kernel_idx, b.core);
+            prev_is_common = b.is_common;
+            prev_kernel_idx = b.kernel_idx;
+            prev_core = b.core;
+            first = false;
+        }
+        (*current_data)[b.arg_idx] = current_buffers[b.tensor_buffer_idx]->address();
     }
     for (const auto& cb : bindings.cbs) {
         UpdateDynamicCircularBufferAddress(

--- a/tt_metal/impl/program/program_descriptors.cpp
+++ b/tt_metal/impl/program/program_descriptors.cpp
@@ -203,8 +203,14 @@ static void emplace_runtime_args_impl(KernelDescriptor& kd, const CoreCoord& cor
     values.reserve(args.size());
     for (const auto& arg : args) {
         if (const auto* buf = std::get_if<tt::tt_metal::Buffer*>(&arg)) {
-            kd.buffer_bindings.push_back({core, static_cast<uint32_t>(values.size()), *buf});
-            values.push_back((*buf)->address());
+            // nullptr Buffer* represents an absent optional tensor.  Emit 0u with no
+            // binding so the fast cache-hit path is not invalidated by optional inputs.
+            if (*buf == nullptr) {
+                values.push_back(0u);
+            } else {
+                kd.buffer_bindings.push_back({core, static_cast<uint32_t>(values.size()), *buf});
+                values.push_back((*buf)->address());
+            }
         } else {
             values.push_back(std::get<uint32_t>(arg));
         }
@@ -217,8 +223,12 @@ static void emplace_common_runtime_args_impl(KernelDescriptor& kd, const Range& 
     kd.common_runtime_args.reserve(args.size());
     for (const auto& arg : args) {
         if (const auto* buf = std::get_if<tt::tt_metal::Buffer*>(&arg)) {
-            kd.common_buffer_bindings.push_back({static_cast<uint32_t>(kd.common_runtime_args.size()), *buf});
-            kd.common_runtime_args.push_back((*buf)->address());
+            if (*buf == nullptr) {
+                kd.common_runtime_args.push_back(0u);
+            } else {
+                kd.common_buffer_bindings.push_back({static_cast<uint32_t>(kd.common_runtime_args.size()), *buf});
+                kd.common_runtime_args.push_back((*buf)->address());
+            }
         } else {
             kd.common_runtime_args.push_back(std::get<uint32_t>(arg));
         }

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -232,15 +232,21 @@ public:
         };
         using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
 
-        // Enumerate all Buffer* reachable from tensor_args and tensor_return_value,
-        // in a stable field-declaration order via reflection.  Used to map buffer
-        // bindings to indices that survive across calls without storing raw pointers.
+        // Enumerate all Buffer* reachable from tensor_args, tensor_return_value, and
+        // any Tensor fields inside resources (from prepare_resources).  Stable field
+        // order via reflection.  Used to map buffer bindings to indices that survive
+        // across calls without storing raw pointers.  Resource tensors are included
+        // so factories can bind kernel runtime args to halo lookup tables and other
+        // op-owned buffers via emplace_runtime_args() / Buffer*.
         static std::vector<tt::tt_metal::Buffer*> collect_tensor_buffers(
-            const tensor_args_t& tensor_args, const tensor_return_value_t& tensor_return_value) {
+            const tensor_args_t& tensor_args,
+            const tensor_return_value_t& tensor_return_value,
+            const resource_t& resources) {
             std::vector<tt::tt_metal::Buffer*> buffers;
             auto collect = [&buffers](const Tensor& t) { buffers.push_back(t.buffer()); };
             ttsl::reflection::visit_object_of_type<Tensor>(collect, tensor_args);
             ttsl::reflection::visit_object_of_type<Tensor>(collect, tensor_return_value);
+            ttsl::reflection::visit_object_of_type<Tensor>(collect, resources);
             return buffers;
         }
 
@@ -328,7 +334,7 @@ public:
                     auto desc = invoke_create_descriptor(
                         attrs, tensor_args, tensor_return_value, resources, mesh_dispatch_coordinate);
                     tt::tt_metal::Program program{desc};
-                    auto tensor_buffers = collect_tensor_buffers(tensor_args, tensor_return_value);
+                    auto tensor_buffers = collect_tensor_buffers(tensor_args, tensor_return_value, resources);
                     auto resolved = tt::tt_metal::resolve_bindings(program, desc, tensor_buffers);
                     mesh_workload.add_program(device_range, std::move(program));
                     shared_variables[device_range] = shared_variables_t{
@@ -357,7 +363,7 @@ public:
                 if (!sv.resolved_bindings.empty()) {
                     // Fast path: patch only the buffer positions using current tensor addresses.
                     // No create_descriptor() call — tensor_buffers enumeration is O(n_tensors).
-                    auto current_buffers = collect_tensor_buffers(tensor_args, tensor_return_value);
+                    auto current_buffers = collect_tensor_buffers(tensor_args, tensor_return_value, sv.resources);
                     tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, current_buffers);
                 } else {
                     // Slow path: full descriptor rebuild + bulk copy.

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -238,6 +238,10 @@ public:
         // across calls without storing raw pointers.  Resource tensors are included
         // so factories can bind kernel runtime args to halo lookup tables and other
         // op-owned buffers via emplace_runtime_args() / Buffer*.
+        //
+        // The resources visit is gated on has_prepare_resources because empty_resource_t
+        // is not guaranteed to be reflectable, and visit_object_of_type would throw at
+        // runtime on an unreflectable type that is not the target object_t.
         static std::vector<tt::tt_metal::Buffer*> collect_tensor_buffers(
             const tensor_args_t& tensor_args,
             const tensor_return_value_t& tensor_return_value,
@@ -246,7 +250,9 @@ public:
             auto collect = [&buffers](const Tensor& t) { buffers.push_back(t.buffer()); };
             ttsl::reflection::visit_object_of_type<Tensor>(collect, tensor_args);
             ttsl::reflection::visit_object_of_type<Tensor>(collect, tensor_return_value);
-            ttsl::reflection::visit_object_of_type<Tensor>(collect, resources);
+            if constexpr (has_prepare_resources) {
+                ttsl::reflection::visit_object_of_type<Tensor>(collect, resources);
+            }
             return buffers;
         }
 

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -26,6 +26,91 @@ namespace ttnn::device_operation {
 template <typename T>
 using AdaptedCachedMeshWorkload = tt::tt_metal::program_cache::detail::AdaptedCachedMeshWorkload<T>;
 
+// Extracts every Tensor reachable from an aggregate `T` and pushes its buffer()
+// onto `out`.  Generated per-T at compile time so the compiler emits a
+// straight-line walk of T's tensor fields with no runtime reflection visit,
+// no lambda dispatch, and no virtual call.  Equivalent in semantics to
+// ttsl::reflection::visit_object_of_type<Tensor> but keeps the call chain
+// short enough that the optimiser inlines through it for typical tensor_args.
+//
+// Default specialisation is a no-op; a second specialisation handles
+// Reflectable aggregates by unrolling over their fields.  Container/leaf
+// specialisations follow.
+template <typename T, typename = void>
+struct extract_tensor_buffers_t {
+    template <typename Out>
+    static void call(const T&, Out&) {}
+};
+
+template <typename T, typename Out>
+inline void extract_tensor_buffers_into(const T& obj, Out& out) {
+    extract_tensor_buffers_t<std::decay_t<T>>::call(obj, out);
+}
+
+// Tensor leaf — push the buffer.
+template <>
+struct extract_tensor_buffers_t<tt::tt_metal::Tensor, void> {
+    template <typename Out>
+    static void call(const tt::tt_metal::Tensor& t, Out& out) {
+        out.push_back(t.buffer());
+    }
+};
+
+// Aggregate — unroll over fields at compile time.
+template <typename T>
+struct extract_tensor_buffers_t<
+    T,
+    std::enable_if_t<ttsl::concepts::Reflectable<T> and not std::is_same_v<T, tt::tt_metal::Tensor>>> {
+    template <typename Out>
+    static void call(const T& obj, Out& out) {
+        reflect::for_each([&obj, &out](auto I) { extract_tensor_buffers_into(reflect::get<I>(obj), out); }, obj);
+    }
+};
+
+// Optional — visit value if present.
+template <typename T>
+struct extract_tensor_buffers_t<std::optional<T>, void> {
+    template <typename Out>
+    static void call(const std::optional<T>& v, Out& out) {
+        if (v.has_value()) {
+            extract_tensor_buffers_into(v.value(), out);
+        }
+    }
+};
+
+// Vector — runtime loop (unavoidable, count is dynamic).
+template <typename T>
+struct extract_tensor_buffers_t<std::vector<T>, void> {
+    template <typename Out>
+    static void call(const std::vector<T>& v, Out& out) {
+        for (const auto& e : v) {
+            extract_tensor_buffers_into(e, out);
+        }
+    }
+};
+
+// Array — unroll at compile time.
+template <typename T, std::size_t N>
+struct extract_tensor_buffers_t<std::array<T, N>, void> {
+    template <typename Out>
+    static void call(const std::array<T, N>& v, Out& out) {
+        [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+            (extract_tensor_buffers_into(v[Is], out), ...);
+        }(std::make_index_sequence<N>{});
+    }
+};
+
+// Tuple — unroll at compile time.
+template <typename... Ts>
+struct extract_tensor_buffers_t<std::tuple<Ts...>, void> {
+    template <typename Out>
+    static void call(const std::tuple<Ts...>& v, Out& out) {
+        [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+            (extract_tensor_buffers_into(std::get<Is>(v), out), ...);
+        }(std::make_index_sequence<sizeof...(Ts)>{});
+    }
+};
+
 /**
  * A generic adapter that adds mesh device capabilities to any existing device operation.
  * This adapter delegates to the base operation for standard functionality while providing
@@ -242,16 +327,20 @@ public:
         // The resources visit is gated on has_prepare_resources because empty_resource_t
         // is not guaranteed to be reflectable, and visit_object_of_type would throw at
         // runtime on an unreflectable type that is not the target object_t.
-        static std::vector<tt::tt_metal::Buffer*> collect_tensor_buffers(
+        //
+        // Returns a stack-allocated SmallVector (16 inline slots) instead of a heap
+        // vector so the cache-hit fast path avoids one allocation per dispatch.
+        // The reflection itself is already compile-time generated; this just removes
+        // the runtime allocation tax.
+        static ttsl::SmallVector<tt::tt_metal::Buffer*, 16> collect_tensor_buffers(
             const tensor_args_t& tensor_args,
             const tensor_return_value_t& tensor_return_value,
             const resource_t& resources) {
-            std::vector<tt::tt_metal::Buffer*> buffers;
-            auto collect = [&buffers](const Tensor& t) { buffers.push_back(t.buffer()); };
-            ttsl::reflection::visit_object_of_type<Tensor>(collect, tensor_args);
-            ttsl::reflection::visit_object_of_type<Tensor>(collect, tensor_return_value);
+            ttsl::SmallVector<tt::tt_metal::Buffer*, 16> buffers;
+            extract_tensor_buffers_into(tensor_args, buffers);
+            extract_tensor_buffers_into(tensor_return_value, buffers);
             if constexpr (has_prepare_resources) {
-                ttsl::reflection::visit_object_of_type<Tensor>(collect, resources);
+                extract_tensor_buffers_into(resources, buffers);
             }
             return buffers;
         }


### PR DESCRIPTION
## Summary

Two framework changes that unlock the `BufferBinding` fast cache-hit path for migrated factories that currently fall through to the full descriptor rebuild on cache hits.

### 1. `emplace_runtime_args` accepts `nullptr` Buffer* as `0u` with no binding

Today, passing `nullptr` to `emplace_runtime_args(core, {Buffer*})` would try to register a binding for a null buffer. Factories migrating ops with optional inputs (e.g. `batch_norm`'s weight/bias, `attention_optimized_softmax`'s mask) currently work around this by using `runtime_args.emplace_back(buffer ? buffer->address() : 0u)` — which falls off the fast path because the slot is no longer registered.

After this change: `emplace_runtime_args(core, {maybe_null_buffer})` emits `0u` when the pointer is null and registers no binding for that slot. When the pointer is non-null it registers a binding as before. The fast path stays valid regardless of which optionals are present.

### 2. `collect_tensor_buffers` enumerates Tensor fields in `resource_t`

Resource tensors produced by `prepare_resources` (e.g. halo lookup tables) were not previously enumerated, so any factory that bound a kernel runtime arg to a resource Buffer* via `emplace_runtime_args` would fail in `resolve_bindings` with \"Buffer* not found in tensor_args/tensor_return_value enumeration.\"

After this change: `collect_tensor_buffers` also walks the `resources` struct via `ttsl::reflection::visit_object_of_type<Tensor>`. Resource Buffer* now resolves to a stable index, and the fast path can patch resource buffer addresses on cache hits like any other tensor.

## Test plan

- [x] Builds cleanly on the worktree
- [x] Smoke test: add + layer_norm + softmax repeated across iterations to exercise cache-hit path — passes
- [ ] Sanity: `runtime-sanity-tests.yaml`
- [ ] Sanity: `blackhole-post-commit.yaml`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/descriptor-framework-fast-path-extensions)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/descriptor-framework-fast-path-extensions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/descriptor-framework-fast-path-extensions)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/descriptor-framework-fast-path-extensions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/descriptor-framework-fast-path-extensions)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/descriptor-framework-fast-path-extensions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/descriptor-framework-fast-path-extensions)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/descriptor-framework-fast-path-extensions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/descriptor-framework-fast-path-extensions)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/descriptor-framework-fast-path-extensions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/descriptor-framework-fast-path-extensions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/descriptor-framework-fast-path-extensions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/descriptor-framework-fast-path-extensions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/descriptor-framework-fast-path-extensions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/descriptor-framework-fast-path-extensions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/descriptor-framework-fast-path-extensions)