### PR TITLE
ci: increase fabric-cpu-only-tests timeout from 10 to 15 minutes

### DIFF
--- a/.github/workflows/fabric-cpu-only-tests-impl.yaml
+++ b/.github/workflows/fabric-cpu-only-tests-impl.yaml
@@ -9,7 +9,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 10
+        default: 15
       build-artifact-name:
         required: true
         type: string


### PR DESCRIPTION
## Summary

- Increases the \`timeout-minutes\` default for the \`fabric-cpu-only-tests-impl\` workflow from **10 → 15 minutes**
- The \`TestBlitzDecodePipelineBuilder\` test (64-rank superpod, 64 MPI ranks) takes ~10–13 min on loaded runners; the old 10-min limit was killing the job right as it finished, causing intermittent false-failure "hangs"

## Single-line change

\`.github/workflows/fabric-cpu-only-tests-impl.yaml\`: \`default: 10\` → \`default: 15\`

## Merge Gate Runs (10x validation)

| Run | Status | Link |
|-----|--------|------|
| 1 | ✅ Passed | [25410203273](https://github.com/tenstorrent/tt-metal/actions/runs/25410203273) |
| 2 | ❌ Failed (cancelled) | [25411085026](https://github.com/tenstorrent/tt-metal/actions/runs/25411085026) |
| 3 | ✅ Passed | [25411614101](https://github.com/tenstorrent/tt-metal/actions/runs/25411614101) |
| 4 | ⏳ Pending | — |
| 5 | ⏳ Pending | — |
| 6 | ⏳ Pending | — |
| 7 | ⏳ Pending | — |
| 8 | ⏳ Pending | — |
| 9 | ⏳ Pending | — |
| 10 | ⏳ Pending | — |

> ⚠️ **Note**: PR was merged and branch `brain/fabric-timeout-15min` was deleted before all 10 sequential runs could be completed. Runs 2–10 could not be triggered via `workflow_dispatch` (branch no longer exists). Runs 1–3 reflect actual CI history on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)