### PR TITLE
Wan2.2 adds support for arbitrary temporal chunking in I2V VAE encoder

### DIFF
--- a/models/tt_dit/models/vae/vae_wan2_1.py
+++ b/models/tt_dit/models/vae/vae_wan2_1.py
@@ -22,6 +22,7 @@ from ...utils.conv3d import (
     _ntuple,
     aligned_channels,
     compute_decoder_dims,
+    compute_encoder_dims,
     conv_pad_height,
     conv_pad_in_channels,
     count_convs,
@@ -999,7 +1000,14 @@ class WanResample(Module):
                     feat_cache[idx] = cache_x_BTHWC
                     feat_idx[0] += 1
             else:
-                raise ValueError("feat_cache cannot be None")
+                # Full-T mode: frame 0 passes through without time_conv (matches
+                # the cached path's first-iteration behavior), remaining frames
+                # get the strided temporal conv with frame 0 prepended as context.
+                x_first = x_conv_BTHWC[:, :1, :, :, :]
+                if x_conv_BTHWC.shape[1] > 1:
+                    x_rest_input = ttnn.concat([x_first, x_conv_BTHWC[:, 1:, :, :, :]], dim=1)
+                    x_rest_output = self.time_conv(x_rest_input, logical_h)
+                    x_conv_BTHWC = ttnn.concat([x_first, x_rest_output], dim=1)
         return x_conv_BTHWC, logical_h
 
 
@@ -1098,8 +1106,8 @@ class WanDecoder3d(Module):
         ccl_manager: CCLManager,
         dtype: ttnn.DataType = ttnn.bfloat16,
         sdpa_t_fracture_w_only: bool = False,
-        target_height: int = 0,
-        target_width: int = 0,
+        height: int = 0,
+        width: int = 0,
         t_chunk_size: int | None = None,
         cached: bool = False,
     ) -> None:
@@ -1122,8 +1130,8 @@ class WanDecoder3d(Module):
         h_factor = parallel_config.height_parallel.factor
         w_factor = parallel_config.width_parallel.factor
         stage_hw, stage_t = compute_decoder_dims(
-            target_height,
-            target_width,
+            height,
+            width,
             h_factor,
             w_factor,
             t_chunk_size,
@@ -1330,8 +1338,8 @@ class WanDecoder(Module):
         ccl_manager: CCLManager,
         dtype: ttnn.DataType = ttnn.bfloat16,
         sdpa_t_fracture_w_only: bool = False,
-        target_height: int = 0,
-        target_width: int = 0,
+        height: int = 0,
+        width: int = 0,
         t_chunk_size: int | None = None,
         cached: bool = False,
     ) -> None:
@@ -1370,8 +1378,8 @@ class WanDecoder(Module):
             parallel_config=parallel_config,
             dtype=dtype,
             sdpa_t_fracture_w_only=sdpa_t_fracture_w_only,
-            target_height=target_height,
-            target_width=target_width,
+            height=height,
+            width=width,
             t_chunk_size=t_chunk_size,
             cached=cached,
         )
@@ -1454,6 +1462,9 @@ class WanEncoder3D(Module):
         ccl_manager=None,
         parallel_config=None,
         dtype: ttnn.DataType = ttnn.bfloat16,
+        height: int = 0,
+        width: int = 0,
+        encoder_t_chunk_size: int | None = None,
     ) -> None:
         super().__init__()
 
@@ -1468,11 +1479,25 @@ class WanEncoder3D(Module):
         self.ccl_manager = ccl_manager
         self.parallel_config = parallel_config
 
+        num_stages = len(dim_mult) - 1
+        h_factor = parallel_config.height_parallel.factor
+        w_factor = parallel_config.width_parallel.factor
+        stage_hw, stage_t = compute_encoder_dims(
+            height,
+            width,
+            h_factor,
+            w_factor,
+            encoder_t_chunk_size,
+            temperal_downsample=temperal_downsample,
+            num_stages=num_stages,
+        )
+
         # dimensions
         dims = [dim * u for u in [1] + dim_mult]
         scale = 1.0
 
         # init block
+        full_h, full_w = stage_hw[0]
         self.conv_in = WanCausalConv3d(
             in_channels,
             dims[0],
@@ -1482,11 +1507,15 @@ class WanEncoder3D(Module):
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
             dtype=dtype,
+            conv_dims=ConvDims(stage_t[0].T_res, full_h, full_w),
         )
 
         # downsample blocks.
         self.down_blocks = ModuleList()
         for i, (in_dim, out_dim) in enumerate(zip(dims[:-1], dims[1:])):
+            stage_h, stage_w = stage_hw[i]
+            res_dims = ConvDims(stage_t[i].T_res, stage_h, stage_w)
+
             for _ in range(num_res_blocks):
                 self.down_blocks.append(
                     WanResidualBlock(
@@ -1496,6 +1525,7 @@ class WanEncoder3D(Module):
                         ccl_manager=ccl_manager,
                         parallel_config=parallel_config,
                         dtype=dtype,
+                        conv_dims=res_dims,
                     )
                 )
                 if scale in attn_scales:
@@ -1513,6 +1543,7 @@ class WanEncoder3D(Module):
             # downsample block
             if i != len(dim_mult) - 1:
                 mode = "downsample3d" if temperal_downsample[i] else "downsample2d"
+                next_h, next_w = stage_hw[i + 1]
                 self.down_blocks.append(
                     WanResample(
                         dim=out_dim,
@@ -1521,11 +1552,15 @@ class WanEncoder3D(Module):
                         ccl_manager=ccl_manager,
                         parallel_config=parallel_config,
                         dtype=dtype,
+                        tconv_dims=ConvDims(stage_t[i].T_tconv, next_h, next_w),
+                        spatial_dims=ConvDims(stage_t[i].T_spatial, stage_h, stage_w),
                     )
                 )
                 scale /= 2.0
 
         # middle blocks
+        lat_h, lat_w = stage_hw[-1]
+        lat_dims = ConvDims(stage_t[-1].T_res, lat_h, lat_w)
         self.mid_block = WanMidBlock(
             dim=out_dim,
             num_layers=1,
@@ -1533,6 +1568,7 @@ class WanEncoder3D(Module):
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
             dtype=dtype,
+            conv_dims=lat_dims,
         )
 
         # output blocks
@@ -1554,6 +1590,7 @@ class WanEncoder3D(Module):
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
             dtype=dtype,
+            conv_dims=lat_dims,
         )
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
@@ -1633,6 +1670,9 @@ class WanEncoder(Module):
         ccl_manager=None,
         parallel_config=None,
         dtype: ttnn.DataType = ttnn.bfloat16,
+        height: int = 0,
+        width: int = 0,
+        encoder_t_chunk_size: int | None = None,
     ) -> None:
         super().__init__()
 
@@ -1651,6 +1691,9 @@ class WanEncoder(Module):
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
             dtype=dtype,
+            height=height,
+            width=width,
+            encoder_t_chunk_size=encoder_t_chunk_size,
         )
         # Linear for quant_conv
         self.quant_conv = Linear(
@@ -1674,29 +1717,48 @@ class WanEncoder(Module):
         self._conv_idx = [0]
         self._feat_cache = [None] * self.cached_conv_count
 
-    def forward(self, x_BTHWC: ttnn.Tensor, logical_h: int) -> tuple[ttnn.Tensor, int]:
+    def forward(
+        self, x_BTHWC: ttnn.Tensor, logical_h: int, encoder_t_chunk_size: int | None = 4
+    ) -> tuple[ttnn.Tensor, int]:
+        """
+        encoder_t_chunk_size controls how the T dimension is processed:
+            None  - full-T single pass, no caching (fastest, most memory)
+            N     - frame 0 alone, then N frames at a time with caching
+        """
+        assert (
+            encoder_t_chunk_size is None or encoder_t_chunk_size >= 3
+        ), f"encoder_t_chunk_size must be None or >= 3, got {encoder_t_chunk_size}"
         B, T, H, W, C = x_BTHWC.shape
+        logger.info(f"WanEncoder.forward: T={T}, encoder_t_chunk_size={encoder_t_chunk_size}")
 
-        self.clear_cache()
+        if encoder_t_chunk_size is None:
+            output_BTHWC, new_logical_h = self.encoder(x_BTHWC, logical_h, feat_cache=None, feat_idx=None)
+        else:
+            self.clear_cache()
+            output_BTHWC = None
 
-        output_BTHWC = None
-        T_encoded = 1 + (T - 1) // 4
-        for i in range(T_encoded):
-            # Process one frame at a time
+            # Frame 0 alone (required by downsample3d cache initialization)
             self._conv_idx = [0]
-            if i == 0:
-                x_BTHWC_chunk = x_BTHWC[:, :1, :, :, :]
-            else:
-                x_BTHWC_chunk = x_BTHWC[:, 1 + 4 * (i - 1) : 1 + 4 * i, :, :, :]
-
             out_BTHWC, new_logical_h = self.encoder(
-                x_BTHWC_chunk, logical_h, feat_cache=self._feat_cache, feat_idx=self._conv_idx
+                x_BTHWC[:, :1, :, :, :],
+                logical_h,
+                feat_cache=self._feat_cache,
+                feat_idx=self._conv_idx,
             )
+            output_BTHWC = out_BTHWC
 
-            if output_BTHWC is None:
-                output_BTHWC = out_BTHWC
-            else:
+            for t_start in range(1, T, encoder_t_chunk_size):
+                self._conv_idx = [0]
+                t_end = min(t_start + encoder_t_chunk_size, T)
+                out_BTHWC, new_logical_h = self.encoder(
+                    x_BTHWC[:, t_start:t_end, :, :, :],
+                    logical_h,
+                    feat_cache=self._feat_cache,
+                    feat_idx=self._conv_idx,
+                )
                 output_BTHWC = ttnn.concat([output_BTHWC, out_BTHWC], dim=1)
+
+            self.clear_cache()
 
         output_tile_BTHWC = ttnn.to_layout(output_BTHWC, ttnn.TILE_LAYOUT)
         output_tile_BTHWC = self.quant_conv(output_tile_BTHWC)
@@ -1705,7 +1767,6 @@ class WanEncoder(Module):
         output_BCTHW = ttnn.permute(output_BTHWC, (0, 4, 1, 2, 3))
         # Trim padding on output channels
         output_BCTHW = output_BCTHW[:, : self.z_dim, :, :, :]  # Get the mean
-        self.clear_cache()
         return (output_BCTHW, new_logical_h)
 
 

--- a/models/tt_dit/models/vae/vae_wan2_1.py
+++ b/models/tt_dit/models/vae/vae_wan2_1.py
@@ -1726,8 +1726,8 @@ class WanEncoder(Module):
             N     - frame 0 alone, then N frames at a time with caching
         """
         assert (
-            encoder_t_chunk_size is None or encoder_t_chunk_size >= 3
-        ), f"encoder_t_chunk_size must be None or >= 3, got {encoder_t_chunk_size}"
+            encoder_t_chunk_size is None or encoder_t_chunk_size >= 4
+        ), f"encoder_t_chunk_size must be None or >= 4, got {encoder_t_chunk_size}"
         B, T, H, W, C = x_BTHWC.shape
         logger.info(f"WanEncoder.forward: T={T}, encoder_t_chunk_size={encoder_t_chunk_size}")
 

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -43,8 +43,6 @@ from ...utils.tensor import (
     typed_tensor_2dshard,
 )
 
-_UNSET = object()  # sentinel for "use config default" in create_pipeline
-
 EXAMPLE_DOC_STRING = """
     Examples:
         ```python
@@ -285,10 +283,10 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             parallel_config=self.vae_parallel_config,
             dtype=vae_dtype,
             sdpa_t_fracture_w_only=sdpa_t_fracture_w_only,
-            target_height=target_height,
-            target_width=target_width,
-            t_chunk_size=t_chunk_size,
-            cached=(vae_t_chunk_size is not None),
+            height=height,
+            width=width,
+            t_chunk_size=(num_frames - 1) // 4 + 1 if vae_t_chunk_size is None else vae_t_chunk_size,
+            cached=vae_t_chunk_size is not None,
         )
 
         self.transformer_states = [
@@ -373,10 +371,9 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         topology=None,
         is_fsdp=None,
         pipeline_class=None,
-        vae_t_chunk_size=_UNSET,
         sdpa_t_fracture_w_only=None,
-        target_height: int = 0,
-        target_width: int = 0,
+        height: int = 0,
+        width: int = 0,
         num_frames: int = 81,
     ):
         device_configs = {}
@@ -388,6 +385,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 "dynamic_load": False,
                 "topology": ttnn.Topology.Linear,
                 "is_fsdp": True,
+                "vae_t_chunk_size": 1,
             }
             device_configs[(2, 2)] = device_configs[(1, 4)]
             device_configs[(2, 4)] = {
@@ -406,7 +404,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 "dynamic_load": False,
                 "topology": ttnn.Topology.Ring,
                 "is_fsdp": False,
-                "vae_t_chunk_size": None,  # full-T
+                "vae_t_chunk_size": None,  # full-T single pass
             }
             device_configs[(4, 32)] = {
                 "sp_axis": 1,
@@ -415,7 +413,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 "dynamic_load": False,
                 "topology": ttnn.Topology.Ring,
                 "is_fsdp": False,
-                "vae_t_chunk_size": None,
+                "vae_t_chunk_size": None,  # full-T single pass
                 "sdpa_t_fracture_w_only": True,
             }
             config = device_configs[tuple(mesh_device.shape)]
@@ -427,6 +425,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 "dynamic_load": True,
                 "topology": ttnn.Topology.Linear,
                 "is_fsdp": True,
+                "vae_t_chunk_size": 1,
             }
             device_configs[(4, 8)] = {
                 "sp_axis": 1,
@@ -435,16 +434,14 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 "dynamic_load": False,
                 "topology": ttnn.Topology.Ring,
                 "is_fsdp": True,
+                "vae_t_chunk_size": 1,
             }
 
             config = device_configs[tuple(mesh_device.shape)]
 
         sp_axis = config["sp_axis"] if sp_axis is None else sp_axis
         tp_axis = config["tp_axis"] if tp_axis is None else tp_axis
-        if vae_t_chunk_size is _UNSET:
-            vae_t_chunk_size = config.get("vae_t_chunk_size", 1)
-        full_latent_T = (num_frames - 1) // 4 + 1
-        decoder_t_chunk_size = full_latent_T if vae_t_chunk_size is None else vae_t_chunk_size
+        vae_t_chunk_size = config["vae_t_chunk_size"]
 
         h_factor = tuple(mesh_device.shape)[tp_axis]
         w_factor = tuple(mesh_device.shape)[sp_axis]
@@ -484,9 +481,9 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             sdpa_t_fracture_w_only=sdpa_t_fracture_w_only
             if sdpa_t_fracture_w_only is not None
             else config.get("sdpa_t_fracture_w_only", False),
-            target_height=target_height,
-            target_width=target_width,
-            t_chunk_size=decoder_t_chunk_size,
+            height=height,
+            width=width,
+            num_frames=num_frames,
         )
 
     def _prepare_text_encoder(self):

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -165,9 +165,9 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         vae_dtype: ttnn.DataType = ttnn.bfloat16,
         vae_t_chunk_size: int | None = 1,
         sdpa_t_fracture_w_only: bool = False,
-        target_height: int = 0,
-        target_width: int = 0,
-        t_chunk_size: int = 0,
+        height: int = 0,
+        width: int = 0,
+        num_frames: int = 81,
         run_warmup: bool = True,
     ):
         super().__init__()
@@ -338,7 +338,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
         # TODO: Reset buffers for change in resolution. Also reinitialize trace
         if run_warmup:
-            self.warmup_buffers(height=target_height, width=target_width)
+            self.warmup_buffers(height=height, width=width)
 
     def prepare_text_conditioning(self, tt_model, prompt_embeds, buffer, traced=False):
         prompt_1BLP = tt_model.prepare_text_conditioning(prompt_embeds)

--- a/models/tt_dit/pipelines/wan/pipeline_wan_i2v.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan_i2v.py
@@ -26,7 +26,7 @@ class ImagePrompt(NamedTuple):
 
 
 class WanPipelineI2V(WanPipeline):
-    def __init__(self, *args, target_height: int = 0, target_width: int = 0, **kwargs):
+    def __init__(self, *args, height: int = 0, width: int = 0, **kwargs):
         # Update I2V specific defaults
         if "checkpoint_name" not in kwargs:
             kwargs["checkpoint_name"] = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
@@ -35,8 +35,8 @@ class WanPipelineI2V(WanPipeline):
                 kwargs["checkpoint_name"], subfolder="scheduler", trust_remote_code=True
             )
 
-        # initialize without warmup
-        super().__init__(*args, model_type="i2v", run_warmup=False, **kwargs)
+        # initialize without warmup; pass height/width so the decoder also gets production blocking dims
+        super().__init__(*args, model_type="i2v", run_warmup=False, height=height, width=width, **kwargs)
 
         self.tt_vae_encoder = WanEncoder(
             base_dim=self.vae.config.base_dim,
@@ -62,9 +62,7 @@ class WanPipelineI2V(WanPipeline):
         )
 
         # warmup buffers
-        self.warmup_buffers(
-            height=target_height, width=target_width, image_prompt=Image.new("RGB", (target_width, target_height))
-        )
+        self.warmup_buffers(height=height, width=width, image_prompt=Image.new("RGB", (width, height)))
 
     @staticmethod
     def create_pipeline(*args, **kwargs):

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -325,7 +325,11 @@ def test_pipeline_performance(
     # Calculate statistics
     text_encoder_times = [benchmark_profiler.get_duration("encoder", i) for i in range(num_perf_runs)]
     prepare_latents_times = [benchmark_profiler.get_duration("prepare_latents", i) for i in range(num_perf_runs)]
-    vae_encode_times = [benchmark_profiler.get_duration("vae_encode", i) for i in range(num_perf_runs)]
+    vae_encode_times = (
+        [benchmark_profiler.get_duration("vae_encode", i) for i in range(num_perf_runs)]
+        if model_type == "i2v" and benchmark_profiler.contains_step("vae_encode")
+        else []
+    )
     denoising_times = [benchmark_profiler.get_duration("denoising", i) for i in range(num_perf_runs)]
     vae_times = [benchmark_profiler.get_duration("vae", i) for i in range(num_perf_runs)]
     total_times = [benchmark_profiler.get_duration("run", i) for i in range(num_perf_runs)]

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -238,8 +238,8 @@ def test_pipeline_performance(
         dynamic_load=dynamic_load,
         topology=topology,
         is_fsdp=is_fsdp,
-        target_height=height,
-        target_width=width,
+        height=height,
+        width=width,
         num_frames=num_frames,
     )
 
@@ -324,6 +324,8 @@ def test_pipeline_performance(
 
     # Calculate statistics
     text_encoder_times = [benchmark_profiler.get_duration("encoder", i) for i in range(num_perf_runs)]
+    prepare_latents_times = [benchmark_profiler.get_duration("prepare_latents", i) for i in range(num_perf_runs)]
+    vae_encode_times = [benchmark_profiler.get_duration("vae_encode", i) for i in range(num_perf_runs)]
     denoising_times = [benchmark_profiler.get_duration("denoising", i) for i in range(num_perf_runs)]
     vae_times = [benchmark_profiler.get_duration("vae", i) for i in range(num_perf_runs)]
     total_times = [benchmark_profiler.get_duration("run", i) for i in range(num_perf_runs)]
@@ -353,6 +355,9 @@ def test_pipeline_performance(
         )
 
     print_stats("Text Encoding", text_encoder_times)
+    if model_type == "i2v":
+        print_stats("Image Encoding (total)", prepare_latents_times)
+        print_stats("  VAE Encoder only", vae_encode_times)
     print_stats("Denoising", denoising_times)
     print_stats("VAE Decoding", vae_times)
     print_stats("Total Pipeline", total_times)

--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
@@ -85,8 +85,8 @@ def test_pipeline_inference(
         topology=topology,
         is_fsdp=is_fsdp,
         checkpoint_name="Wan-AI/Wan2.2-T2V-A14B-Diffusers",
-        target_height=height,
-        target_width=width,
+        height=height,
+        width=width,
         num_frames=num_frames,
     )
 

--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_wan_i2v.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_wan_i2v.py
@@ -86,8 +86,8 @@ def test_pipeline_inference(
         dynamic_load=dynamic_load,
         topology=topology,
         is_fsdp=is_fsdp,
-        target_height=height,
-        target_width=width,
+        height=height,
+        width=width,
         num_frames=num_frames,
     )
 

--- a/models/tt_dit/tests/models/wan2_2/test_stability_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_stability_wan.py
@@ -76,8 +76,8 @@ def test_stability(
         dynamic_load=dynamic_load,
         topology=topology,
         is_fsdp=is_fsdp,
-        target_height=height,
-        target_width=width,
+        height=height,
+        width=width,
         num_frames=num_frames,
     )
 

--- a/models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py
+++ b/models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py
@@ -1514,10 +1514,10 @@ def test_wan_decoder(
 
 
 @pytest.mark.parametrize(
-    "B, C, T, H, W, target_height, target_width, t_chunk_size, cached",
+    "B, C, T, H, W, height, width, t_chunk_size",
     [
-        (1, 16, 7, 60, 104, 480, 832, 7, True),
-        (1, 16, 21, 90, 160, 720, 1280, 21, False),
+        (1, 16, 7, 60, 104, 480, 832, 7),
+        (1, 16, 21, 90, 160, 720, 1280, None),
     ],
     ids=["480p_t7_cached", "720p_t21_fullT"],
 )
@@ -1538,17 +1538,16 @@ def test_wan_decoder_production_blocking(
     T,
     H,
     W,
-    target_height,
-    target_width,
+    height,
+    width,
     t_chunk_size,
-    cached,
     h_axis,
     w_axis,
     num_links,
 ):
     """Verify that the VAE decoder runs end-to-end with production blocking configs.
 
-    Uses the exact (target_height, target_width, t_chunk_size, cached) values
+    Uses the exact (height, width, t_chunk_size) values
     from the pipeline so that WanDecoder -> compute_decoder_dims -> _BLOCKINGS
     exercises the optimized per-layer blocking table rather than the fallback.
     """
@@ -1600,10 +1599,10 @@ def test_wan_decoder_production_blocking(
         ccl_manager=ccl_manager,
         parallel_config=parallel_config,
         dtype=dtype,
-        target_height=target_height,
-        target_width=target_width,
+        height=height,
+        width=width,
         t_chunk_size=t_chunk_size,
-        cached=cached,
+        cached=t_chunk_size is not None,
     )
     tt_model.load_torch_state_dict(torch_model.state_dict())
 
@@ -1621,7 +1620,7 @@ def test_wan_decoder_production_blocking(
         dtype=ttnn.bfloat16,
     )
 
-    logger.info(f"running tt model with production blocking (t_chunk_size={t_chunk_size}, cached={cached})")
+    logger.info(f"running tt model with production blocking (t_chunk_size={t_chunk_size})")
     start = time.time()
     tt_output, new_logical_h = tt_model(tt_input_tensor, logical_h, t_chunk_size=t_chunk_size)
 

--- a/models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py
+++ b/models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py
@@ -1514,10 +1514,10 @@ def test_wan_decoder(
 
 
 @pytest.mark.parametrize(
-    "B, C, T, H, W, height, width, t_chunk_size",
+    "B, C, T, H, W, height, width, t_chunk_size, cached",
     [
-        (1, 16, 7, 60, 104, 480, 832, 7),
-        (1, 16, 21, 90, 160, 720, 1280, None),
+        (1, 16, 7, 60, 104, 480, 832, 7, True),
+        (1, 16, 21, 90, 160, 720, 1280, 21, False),
     ],
     ids=["480p_t7_cached", "720p_t21_fullT"],
 )
@@ -1541,6 +1541,7 @@ def test_wan_decoder_production_blocking(
     height,
     width,
     t_chunk_size,
+    cached,
     h_axis,
     w_axis,
     num_links,
@@ -1602,7 +1603,7 @@ def test_wan_decoder_production_blocking(
         height=height,
         width=width,
         t_chunk_size=t_chunk_size,
-        cached=t_chunk_size is not None,
+        cached=cached,
     )
     tt_model.load_torch_state_dict(torch_model.state_dict())
 
@@ -1698,7 +1699,7 @@ def test_wan_encoder_production_blocking(
     dim_mult = [1, 2, 4, 4]
     num_res_blocks = 2
     attn_scales = []
-    temperal_downsample = [True, True, False]
+    temperal_downsample = [False, True, True]
     in_channels = out_channels = 3
     is_residual = False
 

--- a/models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py
+++ b/models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py
@@ -1652,6 +1652,141 @@ def test_wan_decoder_production_blocking(
 
 
 @pytest.mark.parametrize(
+    "B, C, T, height, width, encoder_t_chunk_size",
+    [
+        (1, 3, 33, 720, 1280, 33),
+        (1, 3, 33, 720, 1280, 16),
+    ],
+    ids=["720p_t33_fullT", "720p_t33_chunked16"],
+)
+@pytest.mark.parametrize(
+    "mesh_device, h_axis, w_axis, num_links",
+    [
+        ((4, 8), 0, 1, 2),
+    ],
+    ids=["bh_4x8_h0_w1"],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+def test_wan_encoder_production_blocking(
+    mesh_device,
+    B,
+    C,
+    T,
+    height,
+    width,
+    encoder_t_chunk_size,
+    h_axis,
+    w_axis,
+    num_links,
+):
+    """Verify that the VAE encoder runs end-to-end with production blocking configs.
+
+    Uses the exact (height, width, encoder_t_chunk_size) values from the I2V
+    pipeline so that WanEncoder -> compute_encoder_dims -> _BLOCKINGS exercises
+    the optimized per-layer blocking table rather than the fallback.
+    """
+    from diffusers.models.autoencoders.autoencoder_kl_wan import AutoencoderKLWan as TorchAutoencoderKLWan
+
+    torch.manual_seed(0)
+    MIN_PCC = 0.993
+    MAX_RMSE = 0.12
+
+    torch_dtype = torch.float32
+    base_dim = 96
+    z_dim = 16
+    dim_mult = [1, 2, 4, 4]
+    num_res_blocks = 2
+    attn_scales = []
+    temperal_downsample = [True, True, False]
+    in_channels = out_channels = 3
+    is_residual = False
+
+    torch_model = TorchAutoencoderKLWan(
+        base_dim=base_dim,
+        in_channels=in_channels,
+        z_dim=z_dim,
+        dim_mult=dim_mult,
+        num_res_blocks=num_res_blocks,
+        attn_scales=attn_scales,
+        temperal_downsample=temperal_downsample,
+        dropout=0.0,
+        out_channels=out_channels,
+        is_residual=is_residual,
+    )
+    torch_model.eval()
+
+    ccl_manager = CCLManager(mesh_device, topology=ttnn.Topology.Linear, num_links=num_links)
+    parallel_config = VaeHWParallelConfig(
+        height_parallel=ParallelFactor(factor=tuple(mesh_device.shape)[h_axis], mesh_axis=h_axis),
+        width_parallel=ParallelFactor(factor=tuple(mesh_device.shape)[w_axis], mesh_axis=w_axis),
+    )
+
+    # Forward-mode controls chunking; constructor encoder_t_chunk_size
+    # selects which blocking table entries compute_encoder_dims will hit.
+    forward_chunk = None if encoder_t_chunk_size == T else encoder_t_chunk_size
+
+    tt_model = WanEncoder(
+        base_dim=base_dim,
+        in_channels=in_channels,
+        z_dim=z_dim,
+        dim_mult=dim_mult,
+        num_res_blocks=num_res_blocks,
+        attn_scales=attn_scales,
+        temperal_downsample=temperal_downsample,
+        is_residual=is_residual,
+        mesh_device=mesh_device,
+        ccl_manager=ccl_manager,
+        parallel_config=parallel_config,
+        dtype=ttnn.bfloat16,
+        height=height,
+        width=width,
+        encoder_t_chunk_size=encoder_t_chunk_size,
+    )
+    tt_model.load_torch_state_dict(torch_model.state_dict())
+
+    torch_input_tensor = torch.randn(B, C, T, height, width, dtype=torch_dtype)
+    tt_input_tensor = torch_input_tensor.permute(0, 2, 3, 4, 1)
+    tt_input_tensor = conv_pad_in_channels(tt_input_tensor)
+    tt_input_tensor, logical_h = conv_pad_height(tt_input_tensor, parallel_config.height_parallel.factor * 8)
+    if logical_h != tt_input_tensor.shape[2]:
+        logger.info(f"padding from {logical_h} to {tt_input_tensor.shape[2]}")
+    tt_input_tensor = bf16_tensor_2dshard(
+        tt_input_tensor, mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, shard_mapping={h_axis: 2, w_axis: 3}
+    )
+
+    logger.info(f"running tt encoder (encoder_t_chunk_size={encoder_t_chunk_size}, forward_chunk={forward_chunk})")
+    start = time.time()
+    tt_output, new_logical_h = tt_model(tt_input_tensor, logical_h, encoder_t_chunk_size=forward_chunk)
+
+    concat_dims = [None, None]
+    concat_dims[h_axis] = 3
+    concat_dims[w_axis] = 4
+    tt_output_torch = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=concat_dims),
+    )
+    logger.info(f"tt time taken: {time.time() - start}")
+    logger.info(f"tt output shape: {tt_output_torch.shape}")
+
+    logger.info("running torch model")
+    start = time.time()
+    with torch.no_grad():
+        torch_output = torch_model.encode(torch_input_tensor, return_dict=False)[0].mode()
+    logger.info(f"torch time taken: {time.time() - start}")
+    logger.info(f"torch output shape: {torch_output.shape}")
+
+    logger.info("checking output")
+    if tt_output_torch.shape[1] != torch_output.shape[1]:
+        tt_output_torch = tt_output_torch[:, : torch_output.shape[1]]
+        logger.warning(f"Trimmed tt_output_torch channels to {tt_output_torch.shape}")
+    if new_logical_h != tt_output_torch.shape[3]:
+        tt_output_torch = tt_output_torch[:, :, :, :new_logical_h, :]
+        logger.warning(f"Trimmed tt_output_torch height to {tt_output_torch.shape}")
+    assert_quality(torch_output, tt_output_torch, pcc=MIN_PCC, relative_rmse=MAX_RMSE)
+
+
+@pytest.mark.parametrize(
     ("B, C, H, W"),
     [
         (1, 16, 60, 104),  # 480p

--- a/models/tt_dit/utils/conv3d.py
+++ b/models/tt_dit/utils/conv3d.py
@@ -52,7 +52,7 @@ class StageT(NamedTuple):
 
 
 def compute_decoder_dims(
-    target_height, target_width, h_factor, w_factor, t_chunk_size, *, temperal_upsample, num_stages=3, cached=False
+    height, width, h_factor, w_factor, t_chunk_size, *, temperal_upsample, num_stages=3, cached=False
 ):
     """Compute per-stage spatial and temporal dimensions for a VAE decoder.
 
@@ -60,13 +60,18 @@ def compute_decoder_dims(
       stage_hw: list of StageHW per stage (length num_stages + 1), latent -> full resolution
       stage_t:  list of StageT per stage (length num_stages + 1)
 
+    t_chunk_size must be a concrete integer — the latent T that will be processed:
+      full-T:   pass the full latent frame count (e.g. 21), with cached=False
+      chunked:  pass the chunk size (e.g. 1, 7), with cached=True
+    Returns zero dims when t_chunk_size is None or < 1 (constructor default fallback).
+
     Temporal formulas differ between uncached and cached paths because
     WanResample splits off frame-0 in the uncached path but not in the cached path:
 
-      uncached: T_tconv = cur_T + 1   (frames[1:] = cur_T-1, +2 causal pad)
-                T_spatial = 2*(cur_T-1) + 1   (frame-0 + doubled rest)
-      cached:   T_tconv = cur_T + 2   (all frames + 2 causal pad from cache)
-                T_spatial = 2 * cur_T         (all frames doubled)
+      uncached: T_tconv   = cur_T + 1           (frames[1:] = cur_T-1, +2 causal pad)
+                T_spatial = 2*(cur_T-1) + 1     (frame-0 + doubled rest)
+      cached:   T_tconv   = cur_T + 2           (all frames + 2 causal pad from cache)
+                T_spatial = 2 * cur_T           (all frames doubled)
     """
     if t_chunk_size is None or t_chunk_size < 1:
         n = num_stages + 1
@@ -76,8 +81,8 @@ def compute_decoder_dims(
     # Height uses ceil because some configs don't divide evenly (e.g. 720/8/4=22.5 → 23);
     # the hardware pads height via conv_pad_height.  Width always divides evenly for
     # production targets and is not padded the same way, so floor division is correct.
-    lat_h = math.ceil(target_height / vae_scale / h_factor)
-    lat_w = target_width // vae_scale // w_factor
+    lat_h = math.ceil(height / vae_scale / h_factor)
+    lat_w = width // vae_scale // w_factor
     stage_hw = [StageHW(lat_h * (2**s), lat_w * (2**s)) for s in range(num_stages + 1)]
 
     cur_T = t_chunk_size
@@ -90,15 +95,45 @@ def compute_decoder_dims(
         else:
             T_tconv = (cur_T + 1) if has_temporal_up else 0
             T_spatial = (2 * (cur_T - 1) + 1) if has_temporal_up else cur_T
-        stage_t.append(
-            StageT(
-                T_res=cur_T + 2,
-                T_tconv=T_tconv,
-                T_spatial=T_spatial,
-            )
-        )
+        stage_t.append(StageT(T_res=cur_T + 2, T_tconv=T_tconv, T_spatial=T_spatial))
         if has_temporal_up:
             cur_T = T_spatial
+
+    return stage_hw, stage_t
+
+
+def compute_encoder_dims(height, width, h_factor, w_factor, encoder_t_chunk_size, *, temperal_downsample, num_stages=3):
+    """Compute per-stage spatial and temporal dimensions for a cached VAE encoder.
+
+    Returns (stage_hw, stage_t) where:
+      stage_hw: list of StageHW per stage (length num_stages + 1), full → latent resolution
+      stage_t:  list of StageT per stage (length num_stages + 1)
+
+    encoder_t_chunk_size must be a concrete integer — the pixel-frame count being encoded
+    (e.g. _I2V_ENCODE_FRAMES=33). Returns zero dims when None or < 1 (constructor default fallback).
+
+    Downsample order: spatial WanConv2d at current res → 2x2 slice → WanCausalConv3d time_conv at halved res.
+    T_res     = cur_T + 2  (3D causal convs: residual blocks, conv_in, conv_out)
+    T_spatial = cur_T      (WanConv2d (1,3,3): no causal cache needed, sees exactly cur_T frames)
+    T_tconv   = cur_T      (time_conv (3,1,1) at next spatial res: input from spatial output = cur_T frames)
+    after_down = (cur_T - 1) // 2 + 1  (strided temporal conv output → next stage cur_T)
+    """
+    n = num_stages + 1
+    if encoder_t_chunk_size is None or encoder_t_chunk_size < 1:
+        return [StageHW(0, 0)] * n, [StageT(T_res=0, T_tconv=0, T_spatial=0)] * n
+
+    full_h = math.ceil(height / h_factor)
+    full_w = width // w_factor
+    stage_hw = [StageHW(full_h // (2**s), full_w // (2**s)) for s in range(n)]
+
+    cur_T = encoder_t_chunk_size
+    stage_t = []
+    for i in range(n):
+        has_temporal_down = i < len(temperal_downsample) and temperal_downsample[i]
+        T_tconv = cur_T if has_temporal_down else 0
+        stage_t.append(StageT(T_res=cur_T + 2, T_tconv=T_tconv, T_spatial=cur_T))
+        if has_temporal_down:
+            cur_T = (cur_T - 1) // 2 + 1
 
     return stage_hw, stage_t
 
@@ -270,6 +305,101 @@ _BLOCKINGS = {
     # Stage 3 (cur_T=28): T_res=30 (no temporal upsample)
     (2, 4, 96, 96, (3, 3, 3), 30, 240, 208): (96, 96, 7, 2, 16),  # up3_res — swept 9364us
     (2, 4, 96, 3, (3, 3, 3), 30, 240, 208): (96, 32, 4, 16, 2),  # conv_out — partial 5990us
+    # ===================================================================
+    # BH Galaxy 4x8, 720p image encoder, T=33 output frames
+    # h_factor=4, w_factor=8. Per-device H/W are unpadded output dims.
+    # ===================================================================
+    # Stage 0 (full res, H_out=180, W_out=160)
+    (4, 8, 32, 96, (3, 3, 3), 35, 180, 160): (32, 96, 5, 16, 2),  # conv_in — 4444us
+    (4, 8, 96, 96, (3, 3, 3), 35, 180, 160): (96, 96, 7, 4, 8),  # res_s0  — 5225us
+    (4, 8, 96, 96, (1, 3, 3), 33, 180, 160): (96, 96, 1, 16, 2),  # sp_s0   — 3462us
+    # Stage 1 (half res, H_out=90, W_out=80)
+    (4, 8, 96, 192, (3, 3, 3), 35, 90, 80): (96, 96, 7, 16, 2),  # down0   — 3539us
+    (4, 8, 192, 192, (3, 3, 3), 35, 90, 80): (96, 96, 7, 16, 2),  # res_s1  — 7376us
+    (4, 8, 192, 192, (1, 3, 3), 33, 90, 80): (192, 64, 1, 16, 2),  # sp_s1   — 2877us
+    (4, 8, 192, 192, (3, 1, 1), 33, 45, 40): (192, 96, 5, 4, 8),  # tc_s1   — 620us PARTIAL
+    # Stage 2 (quarter res, H_out=45, W_out=40)
+    (4, 8, 192, 384, (3, 3, 3), 19, 45, 40): (64, 128, 1, 8, 4),  # down1   — TODO
+    (4, 8, 384, 384, (3, 3, 3), 19, 45, 40): (96, 96, 1, 8, 4),  # res_s2  — TODO
+    (4, 8, 384, 384, (1, 3, 3), 17, 45, 40): (96, 96, 1, 8, 4),  # sp_s2   — TODO
+    (4, 8, 384, 384, (3, 1, 1), 17, 22, 20): (96, 96, 1, 8, 4),  # tc_s2   — TODO
+    # Stage 3 (eighth res, H_out=22, W_out=20)
+    (4, 8, 384, 384, (3, 3, 3), 11, 22, 20): (96, 96, 1, 8, 4),  # res_s3  — TODO
+    (4, 8, 384, 32, (3, 3, 3), 11, 22, 20): (96, 32, 1, 8, 4),  # conv_out — TODO
+    # ===================================================================
+    # BH Galaxy 4x32, 720p image encoder, T=33 output frames
+    # h_factor=4, w_factor=32. Per-device H/W are unpadded output dims.
+    # Per-device (H,W): stage0(180,40) stage1(90,20) stage2(45,10) stage3(22,5)
+    # Swept 2026-04-27 on 1x1 mesh; results in sweep_results_h4w32_enc_t33/.
+    # hw_product=32 + max_t_block=8. T=5-7 wins. (16,2) dominant spatial.
+    # ===================================================================
+    # Stage 0 (full res, H_out=180, W_out=40)
+    (4, 32, 32, 96, (3, 3, 3), 35, 180, 40): (32, 96, 5, 16, 2),  # conv_in_enc — 1317us
+    (4, 32, 96, 96, (3, 3, 3), 35, 180, 40): (96, 96, 7, 4, 8),  # res_s0 — 1881us
+    (4, 32, 96, 96, (1, 3, 3), 33, 180, 40): (96, 96, 1, 16, 2),  # sp_s0 — 970us
+    # Stage 1 (half res, H_out=90, W_out=20)
+    (4, 32, 96, 192, (3, 3, 3), 35, 90, 20): (96, 96, 7, 8, 4),  # down0 — 962us
+    (4, 32, 192, 192, (3, 3, 3), 35, 90, 20): (96, 96, 7, 8, 4),  # res_s1 — 1889us
+    (4, 32, 192, 192, (1, 3, 3), 33, 90, 20): (192, 64, 1, 16, 2),  # sp_s1 — 803us
+    (4, 32, 192, 192, (3, 1, 1), 33, 45, 10): (192, 96, 5, 16, 2),  # tc_s1 — 242us
+    # Stage 2 (quarter res, H_out=45, W_out=10)
+    (4, 32, 192, 384, (3, 3, 3), 19, 45, 10): (64, 128, 6, 16, 2),  # down1 — 721us
+    (4, 32, 384, 384, (3, 3, 3), 19, 45, 10): (128, 64, 3, 16, 2),  # res_s2 — 1294us
+    (4, 32, 384, 384, (1, 3, 3), 17, 45, 10): (192, 64, 1, 16, 2),  # sp_s2 — 526us
+    (4, 32, 384, 384, (3, 1, 1), 17, 22, 5): (192, 96, 5, 8, 4),  # tc_s2 — 160us
+    # Stage 3 (eighth res, H_out=22, W_out=5)
+    (4, 32, 384, 384, (3, 3, 3), 11, 22, 5): (128, 64, 3, 16, 2),  # res_s3 — 454us
+    (4, 32, 384, 32, (3, 3, 3), 11, 22, 5): (96, 32, 1, 16, 2),  # conv_out_enc — 157us
+    # ===================================================================
+    # BH Galaxy 4x8, 720p image encoder, T=16 output frames
+    # Same blockings as T=33; T dims recomputed for encoder_t_chunk_size=16.
+    # Stage 0: cur_T=16 → T_res=18, T_sp=16
+    # Stage 1: cur_T=16 → T_res=18, T_tc=16, after_down=8
+    # Stage 2: cur_T=8  → T_res=10, T_tc=8,  after_down=4
+    # Stage 3: cur_T=4  → T_res=6
+    # ===================================================================
+    # Stage 0 (full res, H_out=180, W_out=160)
+    (4, 8, 32, 96, (3, 3, 3), 18, 180, 160): (32, 96, 5, 16, 2),  # conv_in
+    (4, 8, 96, 96, (3, 3, 3), 18, 180, 160): (96, 96, 7, 4, 8),  # res_s0
+    (4, 8, 96, 96, (1, 3, 3), 16, 180, 160): (96, 96, 1, 16, 2),  # sp_s0
+    # Stage 1 (half res, H_out=90, W_out=80)
+    (4, 8, 96, 192, (3, 3, 3), 18, 90, 80): (96, 96, 7, 16, 2),  # down0
+    (4, 8, 192, 192, (3, 3, 3), 18, 90, 80): (96, 96, 7, 16, 2),  # res_s1
+    (4, 8, 192, 192, (1, 3, 3), 16, 90, 80): (192, 64, 1, 16, 2),  # sp_s1
+    (4, 8, 192, 192, (3, 1, 1), 16, 45, 40): (192, 96, 5, 4, 8),  # tc_s1
+    # Stage 2 (quarter res, H_out=45, W_out=40)
+    (4, 8, 192, 384, (3, 3, 3), 10, 45, 40): (64, 128, 1, 8, 4),  # down1
+    (4, 8, 384, 384, (3, 3, 3), 10, 45, 40): (96, 96, 1, 8, 4),  # res_s2
+    (4, 8, 384, 384, (1, 3, 3), 8, 45, 40): (96, 96, 1, 8, 4),  # sp_s2
+    (4, 8, 384, 384, (3, 1, 1), 8, 22, 20): (96, 96, 1, 8, 4),  # tc_s2
+    # Stage 3 (eighth res, H_out=22, W_out=20)
+    (4, 8, 384, 384, (3, 3, 3), 6, 22, 20): (96, 96, 1, 8, 4),  # res_s3
+    (4, 8, 384, 32, (3, 3, 3), 6, 22, 20): (96, 32, 1, 8, 4),  # conv_out
+    # ===================================================================
+    # BH Galaxy 4x32, 720p image encoder, T=16 output frames
+    # Same blockings as T=33; T dims recomputed for encoder_t_chunk_size=16.
+    # Stage 0: cur_T=16 → T_res=18, T_sp=16
+    # Stage 1: cur_T=16 → T_res=18, T_tc=16, after_down=8
+    # Stage 2: cur_T=8  → T_res=10, T_tc=8,  after_down=4
+    # Stage 3: cur_T=4  → T_res=6
+    # ===================================================================
+    # Stage 0 (full res, H_out=180, W_out=40)
+    (4, 32, 32, 96, (3, 3, 3), 18, 180, 40): (32, 96, 5, 16, 2),  # conv_in_enc
+    (4, 32, 96, 96, (3, 3, 3), 18, 180, 40): (96, 96, 7, 4, 8),  # res_s0
+    (4, 32, 96, 96, (1, 3, 3), 16, 180, 40): (96, 96, 1, 16, 2),  # sp_s0
+    # Stage 1 (half res, H_out=90, W_out=20)
+    (4, 32, 96, 192, (3, 3, 3), 18, 90, 20): (96, 96, 7, 8, 4),  # down0
+    (4, 32, 192, 192, (3, 3, 3), 18, 90, 20): (96, 96, 7, 8, 4),  # res_s1
+    (4, 32, 192, 192, (1, 3, 3), 16, 90, 20): (192, 64, 1, 16, 2),  # sp_s1
+    (4, 32, 192, 192, (3, 1, 1), 16, 45, 10): (192, 96, 5, 16, 2),  # tc_s1
+    # Stage 2 (quarter res, H_out=45, W_out=10)
+    (4, 32, 192, 384, (3, 3, 3), 10, 45, 10): (64, 128, 6, 16, 2),  # down1
+    (4, 32, 384, 384, (3, 3, 3), 10, 45, 10): (128, 64, 3, 16, 2),  # res_s2
+    (4, 32, 384, 384, (1, 3, 3), 8, 45, 10): (192, 64, 1, 16, 2),  # sp_s2
+    (4, 32, 384, 384, (3, 1, 1), 8, 22, 5): (192, 96, 4, 8, 4),  # tc_s2 — T_out=4, capped from 5
+    # Stage 3 (eighth res, H_out=22, W_out=5)
+    (4, 32, 384, 384, (3, 3, 3), 6, 22, 5): (128, 64, 3, 16, 2),  # res_s3
+    (4, 32, 384, 32, (3, 3, 3), 6, 22, 5): (96, 32, 1, 16, 2),  # conv_out_enc
 }
 
 # Fallback table: (C_in, C_out, kernel) -> blocking.


### PR DESCRIPTION
## Summary
- Add `WanEncoder3D`/`WanEncoder` with `height`, `width`, `encoder_t_chunk_size` params and `compute_encoder_dims()` for per-layer `ConvDims`
- Support full-T single-pass (`encoder_t_chunk_size=None`) and chunked frame-by-frame caching (`encoder_t_chunk_size>=3`) in `WanEncoder.forward`
- Add `WanResample` full-T fallback path instead of raising `ValueError` when `feat_cache` is None
- Add `compute_encoder_dims()` for encoder spatial/temporal dim computation
- Add BH Galaxy 4x8 and 4x32 720p encoder blocking tables (T=33)
- Add `register_conv3d_configs()` API for external blocking registration
- Rename `target_height`/`target_width` to `height`/`width` across decoder, pipeline, and test APIs for consistency
- Simplify `vae_t_chunk_size` handling in `create_pipeline`

## Test plan
- [ ] Run `test_wan_encoder_production_blocking` with updated height/width params
- [ ] Run `test_pipeline_wan` (T2V) end-to-end on BH Galaxy
- [ ] Run `test_pipeline_wan_i2v` (I2V) end-to-end on BH Galaxy
- [ ] Verify encoder blocking table hits for 4x8 and 4x32 720p T=33

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kevinmi/wan22-i2v-encoder-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kevinmi/wan22-i2v-encoder-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kevinmi/wan22-i2v-encoder-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kevinmi/wan22-i2v-encoder-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kevinmi/wan22-i2v-encoder-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kevinmi/wan22-i2v-encoder-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kevinmi/wan22-i2v-encoder-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kevinmi/wan22-i2v-encoder-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kevinmi/wan22-i2v-encoder-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kevinmi/wan22-i2v-encoder-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kevinmi/wan22-i2v-encoder-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kevinmi/wan22-i2v-encoder-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kevinmi/wan22-i2v-encoder-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kevinmi/wan22-i2v-encoder-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kevinmi/wan22-i2v-encoder-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kevinmi/wan22-i2v-encoder-support)