### PR TITLE
[Test]: Streamline DRISC L1 tests

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
@@ -139,11 +139,8 @@ TEST_F(DramKernelFixture, DramKernelOnMultipleCores) {
     }
 }
 
-// Test Tensix reading from DRISC L1 using a DRISC<->Tensix semaphore
-// handshake:
-//  - DRISC enters stream mode, seeds DRISC L1, and signals readiness.
-//  - Tensix waits for readiness, reads DRISC L1, then signals done.
-//  - DRISC waits for done and restores NOC2AXI.
+// Test Tensix reading from DRISC L1 in NOC2AXI mode: host seeds DRISC L1 directly,
+// Tensix reads it using the 5-arg noc_read_with_state to preserve the 64-bit DRAM_L1_NOC_OFFSET address.
 TEST_F(DramKernelFixture, DramKernelTensixReadFromDRISCL1) {
     constexpr uint32_t kMagicValue = 0xCAFEBABE;
     CoreCoord logical_core_drisc{0, 0};
@@ -152,15 +149,13 @@ TEST_F(DramKernelFixture, DramKernelTensixReadFromDRISCL1) {
 
     Program program = CreateProgram();
 
-    // Host writes magic value to DRISC L1
-    std::vector<uint32_t> write_data = {kMagicValue};
+    uint32_t magic = kMagicValue;
     MetalContext::instance().get_cluster().write_core(
-        write_data.data(), sizeof(uint32_t), tt_cxy_pair(mesh_device_->build_id(), drisc_virtual), drisc_l1_noc_addr_);
+        &magic, sizeof(uint32_t), tt_cxy_pair(mesh_device_->build_id(), drisc_virtual), drisc_l1_noc_addr_);
 
-    // DRISC L1 is 64 bit addr with the L1 NOC offset so break it down into uint32_t
-    // to be passed into kernels as compile time args
-    const uint32_t drisc_l1_noc_addr_low = (drisc_l1_noc_addr_ & 0xFFFFFFFFu);
-    const uint32_t drisc_l1_noc_addr_high = ((drisc_l1_noc_addr_ >> 32) & 0xFFFFFFFFu);
+    // Split 64-bit DRISC L1 NOC addr (with DRAM_L1_NOC_OFFSET bit 37) into two uint32_t compile args.
+    const uint32_t drisc_l1_noc_addr_low = static_cast<uint32_t>(drisc_l1_noc_addr_);
+    const uint32_t drisc_l1_noc_addr_high = static_cast<uint32_t>(drisc_l1_noc_addr_ >> 32);
 
     CreateKernel(
         program,
@@ -205,10 +200,7 @@ TEST_F(DramKernelFixture, DramKernelDRISCReadFromTensixL1) {
         program,
         "tests/tt_metal/tt_metal/test_kernels/misc/drisc_l1_transfer.cpp",
         logical_core_drisc,
-        DramConfig{
-            .noc = NOC::NOC_0,
-            .compile_args = {drisc_l1_base_, tensix_virtual.x, tensix_virtual.y},
-            .defines = {{"MODE_TENSIX_TO_DRISC", "1"}}});
+        DramConfig{.noc = NOC::NOC_0, .compile_args = {drisc_l1_base_, tensix_virtual.x, tensix_virtual.y}});
     SetRuntimeArgs(program, kid, logical_core_drisc, {tensix_l1_base_});
     run_workload(std::move(program));
 
@@ -251,18 +243,18 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCWriteToDRAM) {
 
     auto seed = std::chrono::system_clock::now().time_since_epoch().count();
     log_info(LogTest, "Random seed: {}", seed);
-    // Each Random needs to have unique random data -> proves that each endpoint has its own unique L1
+    // Unique data per endpoint proves each endpoint has independent L1.
     std::vector<uint32_t> data =
         create_random_vector_of_bfloat16(num_banks * num_endpoints * bytes_per_iter, 1000.0f, seed);
+    auto endpoint_offset = [&](uint32_t row, uint32_t col) { return (row * num_banks + col) * elements_per_endpoint; };
     Program program = CreateProgram();
 
     for (uint32_t row = 0; row < num_endpoints; row++) {
         for (uint32_t col = 0; col < num_banks; col++) {
-            uint32_t data_offset_per_endpoint = (row * num_banks + col) * elements_per_endpoint;
             CoreCoord logical_core{col, row};
             CoreCoord virtual_core = device_->virtual_core_from_logical_core(logical_core, CoreType::DRAM);
             MetalContext::instance().get_cluster().write_core(
-                data.data() + data_offset_per_endpoint,
+                data.data() + endpoint_offset(row, col),
                 bytes_per_iter,
                 tt_cxy_pair(mesh_device_->build_id(), virtual_core),
                 drisc_l1_noc_addr_);
@@ -288,22 +280,19 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCWriteToDRAM) {
     // the aggregate write bandwidth from DRISC L1 to DRAM across all endpoints
     for (uint32_t row = 0; row < num_endpoints; row++) {
         for (uint32_t col = 0; col < num_banks; col++) {
-            uint32_t data_offset_per_endpoint = (row * num_banks + col) * elements_per_endpoint;
-            std::vector<uint32_t> expected_data_per_endpoint(
-                data.begin() + data_offset_per_endpoint,
-                data.begin() + data_offset_per_endpoint + elements_per_endpoint);
+            auto begin = data.begin() + endpoint_offset(row, col);
+            std::vector<uint32_t> endpoint_data(begin, begin + elements_per_endpoint);
             uint32_t dram_channel =
                 device_->dram_channel_from_logical_core(CoreCoord{col, 0});  // channel maps by bank (col)
-            // Verify the last chunk written; all chunks hold identical data so one read suffices.
             // ReadFromDeviceDRAMChannel is slow (host-device round-trip); avoid reading all iters.
-            std::vector<uint32_t> result(bytes_per_iter / sizeof(uint32_t));
+            std::vector<uint32_t> result(elements_per_endpoint);
             tt::tt_metal::detail::ReadFromDeviceDRAMChannel(
                 device_,
                 dram_channel,
                 dram_addr + bytes_per_iter * (iters - 1) + total_bytes_per_core * row,
                 bytes_per_iter,
                 result);
-            EXPECT_EQ(result, expected_data_per_endpoint)
+            EXPECT_EQ(result, endpoint_data)
                 << "Data mismatch on DRAM from core (bank=" << col << ", endpoint=" << row << ")";
             CoreCoord virtual_core = device_->virtual_core_from_logical_core({col, row}, CoreType::DRAM);
             max_cycles = std::max(max_cycles, read_timing_cycles(virtual_core, timing_noc_addr));
@@ -352,20 +341,19 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCReadFromDRAM) {
 
     auto seed = std::chrono::system_clock::now().time_since_epoch().count();
     log_info(LogTest, "Random seed: {}", seed);
-    // Each Random needs to have unique random data -> proves that each endpoint has its own unique L1
+    // Unique data per endpoint proves each endpoint has independent L1.
     std::vector<uint32_t> data =
         create_random_vector_of_bfloat16(num_banks * num_endpoints * bytes_per_iter, 1000.0f, seed);
+    auto endpoint_offset = [&](uint32_t row, uint32_t col) { return (row * num_banks + col) * elements_per_endpoint; };
 
     // Write data from DRISCs to read to all DRAM Banks
     for (uint32_t col = 0; col < num_banks; col++) {
         uint32_t dram_channel = device_->dram_channel_from_logical_core(CoreCoord{col, 0});
         for (uint32_t row = 0; row < num_endpoints; row++) {
-            uint32_t data_offset_per_endpoint = (row * num_banks + col) * elements_per_endpoint;
-            std::vector<uint32_t> data_per_endpoint(
-                data.begin() + data_offset_per_endpoint,
-                data.begin() + data_offset_per_endpoint + elements_per_endpoint);
+            auto begin = data.begin() + endpoint_offset(row, col);
+            std::vector<uint32_t> endpoint_data(begin, begin + elements_per_endpoint);
             tt::tt_metal::detail::WriteToDeviceDRAMChannel(
-                device_, dram_channel, dram_addr + row * bytes_per_iter, data_per_endpoint);
+                device_, dram_channel, dram_addr + row * bytes_per_iter, endpoint_data);
         }
     }
 
@@ -395,15 +383,12 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCReadFromDRAM) {
     for (uint32_t row = 0; row < num_endpoints; row++) {
         for (uint32_t col = 0; col < num_banks; col++) {
             CoreCoord virtual_core = device_->virtual_core_from_logical_core({col, row}, CoreType::DRAM);
-            uint32_t data_offset_per_endpoint = (row * num_banks + col) * elements_per_endpoint;
-            std::vector<uint32_t> expected_data_per_endpoint(
-                data.begin() + data_offset_per_endpoint,
-                data.begin() + data_offset_per_endpoint + elements_per_endpoint);
-            std::vector<uint32_t> result(expected_data_per_endpoint.size());
+            auto begin = data.begin() + endpoint_offset(row, col);
+            std::vector<uint32_t> endpoint_data(begin, begin + elements_per_endpoint);
+            std::vector<uint32_t> result(elements_per_endpoint);
             MetalContext::instance().get_cluster().read_core(
                 result.data(), bytes_per_iter, tt_cxy_pair(mesh_device_->build_id(), virtual_core), drisc_l1_noc_addr_);
-            EXPECT_EQ(result, expected_data_per_endpoint)
-                << "Data mismatch on core (bank=" << col << ", endpoint=" << row << ")";
+            EXPECT_EQ(result, endpoint_data) << "Data mismatch on core (bank=" << col << ", endpoint=" << row << ")";
             max_cycles = std::max(max_cycles, read_timing_cycles(virtual_core, timing_noc_addr));
         }
     }

--- a/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
@@ -148,22 +148,19 @@ TEST_F(DramKernelFixture, DramKernelTensixReadFromDRISCL1) {
     constexpr uint32_t kMagicValue = 0xCAFEBABE;
     CoreCoord logical_core_drisc{0, 0};
     CoreCoord logical_core_tensix{0, 0};
-    CoreCoord tensix_virtual = device_->virtual_core_from_logical_core(logical_core_tensix, CoreType::WORKER);
     CoreCoord drisc_virtual = device_->virtual_core_from_logical_core(logical_core_drisc, CoreType::DRAM);
 
     Program program = CreateProgram();
-    // Two semaphores, one local to each core:
-    //   stream_ready (Tensix-local): DRISC remote-incs to 1 to indicate stream mode is on
-    //   tensix_done (DRISC-local):  Tensix remote-incs to 1 when the read is complete
-    uint32_t stream_ready_sem_id = CreateSemaphore(program, logical_core_tensix, 0, CoreType::WORKER);
-    uint32_t tensix_done_sem_id = CreateSemaphore(program, logical_core_drisc, 0, CoreType::DRAM);
 
-    auto drisc_kid = CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/test_kernels/misc/drisc_l1_transfer.cpp",
-        logical_core_drisc,
-        DramConfig{.noc = NOC::NOC_0, .compile_args = {drisc_l1_base_, tensix_virtual.x, tensix_virtual.y}});
-    SetRuntimeArgs(program, drisc_kid, logical_core_drisc, {stream_ready_sem_id, tensix_done_sem_id, kMagicValue});
+    // Host writes magic value to DRISC L1
+    std::vector<uint32_t> write_data = {kMagicValue};
+    MetalContext::instance().get_cluster().write_core(
+        write_data.data(), sizeof(uint32_t), tt_cxy_pair(mesh_device_->build_id(), drisc_virtual), drisc_l1_noc_addr_);
+
+    // DRISC L1 is 64 bit addr with the L1 NOC offset so break it down into uint32_t
+    // to be passed into kernels as compile time args
+    const uint32_t drisc_l1_noc_addr_low = (drisc_l1_noc_addr_ & 0xFFFFFFFFu);
+    const uint32_t drisc_l1_noc_addr_high = ((drisc_l1_noc_addr_ >> 32) & 0xFFFFFFFFu);
 
     CreateKernel(
         program,
@@ -173,12 +170,7 @@ TEST_F(DramKernelFixture, DramKernelTensixReadFromDRISCL1) {
             .processor = DataMovementProcessor::RISCV_0,
             .noc = NOC::NOC_0,
             .compile_args = {
-                tensix_l1_base_,
-                drisc_l1_base_,
-                drisc_virtual.x,
-                drisc_virtual.y,
-                stream_ready_sem_id,
-                tensix_done_sem_id}});
+                tensix_l1_base_, drisc_l1_noc_addr_low, drisc_l1_noc_addr_high, drisc_virtual.x, drisc_virtual.y}});
 
     run_workload(std::move(program));
 
@@ -238,6 +230,7 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCWriteToDRAM) {
     const uint32_t bytes_per_iter = 64 * 1024;
     constexpr uint32_t iters = 1000;
     const uint32_t total_bytes_per_core = iters * bytes_per_iter;
+    const uint32_t elements_per_endpoint = bytes_per_iter / sizeof(uint32_t);
 
     // Endpoints within the same bank share GDDR address space - partition by endpoint row.
     TT_FATAL(
@@ -258,15 +251,21 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCWriteToDRAM) {
 
     auto seed = std::chrono::system_clock::now().time_since_epoch().count();
     log_info(LogTest, "Random seed: {}", seed);
-    std::vector<uint32_t> data = create_random_vector_of_bfloat16(bytes_per_iter, 1000.0f, seed);
+    // Each Random needs to have unique random data -> proves that each endpoint has its own unique L1
+    std::vector<uint32_t> data =
+        create_random_vector_of_bfloat16(num_banks * num_endpoints * bytes_per_iter, 1000.0f, seed);
     Program program = CreateProgram();
 
     for (uint32_t row = 0; row < num_endpoints; row++) {
         for (uint32_t col = 0; col < num_banks; col++) {
+            uint32_t data_offset_per_endpoint = (row * num_banks + col) * elements_per_endpoint;
             CoreCoord logical_core{col, row};
             CoreCoord virtual_core = device_->virtual_core_from_logical_core(logical_core, CoreType::DRAM);
             MetalContext::instance().get_cluster().write_core(
-                data.data(), bytes_per_iter, tt_cxy_pair(mesh_device_->build_id(), virtual_core), drisc_l1_noc_addr_);
+                data.data() + data_offset_per_endpoint,
+                bytes_per_iter,
+                tt_cxy_pair(mesh_device_->build_id(), virtual_core),
+                drisc_l1_noc_addr_);
             auto k_id = CreateKernel(
                 program,
                 "tests/tt_metal/tt_metal/test_kernels/misc/drisc_l1_dram_dma.cpp",
@@ -289,6 +288,10 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCWriteToDRAM) {
     // the aggregate write bandwidth from DRISC L1 to DRAM across all endpoints
     for (uint32_t row = 0; row < num_endpoints; row++) {
         for (uint32_t col = 0; col < num_banks; col++) {
+            uint32_t data_offset_per_endpoint = (row * num_banks + col) * elements_per_endpoint;
+            std::vector<uint32_t> expected_data_per_endpoint(
+                data.begin() + data_offset_per_endpoint,
+                data.begin() + data_offset_per_endpoint + elements_per_endpoint);
             uint32_t dram_channel =
                 device_->dram_channel_from_logical_core(CoreCoord{col, 0});  // channel maps by bank (col)
             // Verify the last chunk written; all chunks hold identical data so one read suffices.
@@ -300,7 +303,8 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCWriteToDRAM) {
                 dram_addr + bytes_per_iter * (iters - 1) + total_bytes_per_core * row,
                 bytes_per_iter,
                 result);
-            EXPECT_EQ(result, data) << "Data mismatch on DRAM from core (bank=" << col << ", endpoint=" << row << ")";
+            EXPECT_EQ(result, expected_data_per_endpoint)
+                << "Data mismatch on DRAM from core (bank=" << col << ", endpoint=" << row << ")";
             CoreCoord virtual_core = device_->virtual_core_from_logical_core({col, row}, CoreType::DRAM);
             max_cycles = std::max(max_cycles, read_timing_cycles(virtual_core, timing_noc_addr));
         }
@@ -328,6 +332,7 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCReadFromDRAM) {
     const uint32_t bytes_per_iter = 64 * 1024;
     constexpr uint32_t iters = 1000;
     const uint32_t total_bytes_per_core = iters * bytes_per_iter;
+    const uint32_t elements_per_endpoint = bytes_per_iter / sizeof(uint32_t);
 
     // Each endpoint within the same bank reads from its own DRAM slot (partitioned by row).
     TT_FATAL(
@@ -347,14 +352,20 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCReadFromDRAM) {
 
     auto seed = std::chrono::system_clock::now().time_since_epoch().count();
     log_info(LogTest, "Random seed: {}", seed);
-    std::vector<uint32_t> data = create_random_vector_of_bfloat16(bytes_per_iter, 1000.0f, seed);
+    // Each Random needs to have unique random data -> proves that each endpoint has its own unique L1
+    std::vector<uint32_t> data =
+        create_random_vector_of_bfloat16(num_banks * num_endpoints * bytes_per_iter, 1000.0f, seed);
 
     // Write data from DRISCs to read to all DRAM Banks
     for (uint32_t col = 0; col < num_banks; col++) {
         uint32_t dram_channel = device_->dram_channel_from_logical_core(CoreCoord{col, 0});
         for (uint32_t row = 0; row < num_endpoints; row++) {
+            uint32_t data_offset_per_endpoint = (row * num_banks + col) * elements_per_endpoint;
+            std::vector<uint32_t> data_per_endpoint(
+                data.begin() + data_offset_per_endpoint,
+                data.begin() + data_offset_per_endpoint + elements_per_endpoint);
             tt::tt_metal::detail::WriteToDeviceDRAMChannel(
-                device_, dram_channel, dram_addr + row * bytes_per_iter, data);
+                device_, dram_channel, dram_addr + row * bytes_per_iter, data_per_endpoint);
         }
     }
 
@@ -384,10 +395,15 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCReadFromDRAM) {
     for (uint32_t row = 0; row < num_endpoints; row++) {
         for (uint32_t col = 0; col < num_banks; col++) {
             CoreCoord virtual_core = device_->virtual_core_from_logical_core({col, row}, CoreType::DRAM);
-            std::vector<uint32_t> result(data.size());
+            uint32_t data_offset_per_endpoint = (row * num_banks + col) * elements_per_endpoint;
+            std::vector<uint32_t> expected_data_per_endpoint(
+                data.begin() + data_offset_per_endpoint,
+                data.begin() + data_offset_per_endpoint + elements_per_endpoint);
+            std::vector<uint32_t> result(expected_data_per_endpoint.size());
             MetalContext::instance().get_cluster().read_core(
                 result.data(), bytes_per_iter, tt_cxy_pair(mesh_device_->build_id(), virtual_core), drisc_l1_noc_addr_);
-            EXPECT_EQ(result, data) << "Data mismatch on core (bank=" << col << ", endpoint=" << row << ")";
+            EXPECT_EQ(result, expected_data_per_endpoint)
+                << "Data mismatch on core (bank=" << col << ", endpoint=" << row << ")";
             max_cycles = std::max(max_cycles, read_timing_cycles(virtual_core, timing_noc_addr));
         }
     }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/drisc_l1_transfer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/drisc_l1_transfer.cpp
@@ -2,14 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// DRISC test kernel. Two test paths:
-//   with MODE_TENSIX_TO_DRISC defined (Tensix-to-DRISC read path):
-//     DRISC enters stream mode, reads a uint32_t from Tensix L1 into DRISC L1,
+// DRISC test kernel: DRISC enters stream mode, reads a uint32_t from Tensix L1 into DRISC L1,
 //     then restores NOC2AXI.
-//   default (DRISC-to-Tensix handshake path):
-//     DRISC writes magic_value into its L1 after switching to stream mode, remote-bumps Tensix's stream_ready
-//     (-> 1) to signal readiness, waits locally on tensix_done until Tensix
-//     finishes reading, then restores NOC2AXI.
 
 #include "api/compile_time_args.h"
 #include "experimental/drisc_mode.h"
@@ -23,13 +17,11 @@ void kernel_main() {
     constexpr uint32_t tensix_noc_x = get_compile_time_arg_val(1);
     constexpr uint32_t tensix_noc_y = get_compile_time_arg_val(2);
 
+    experimental::Noc noc;
+
     // Stream mode: required for DRISC to initiate NOC traffic and for
     // remote cores to reach DRISC L1 over NOC.
     experimental::drisc_set_stream_mode();
-
-    experimental::Noc noc;
-
-#ifdef MODE_TENSIX_TO_DRISC
     uint32_t tensix_l1_src_addr = get_arg_val<uint32_t>(0);
 
     experimental::UnicastEndpoint src;
@@ -37,24 +29,6 @@ void kernel_main() {
     noc.async_read(
         src, dst, sizeof(uint32_t), {.noc_x = tensix_noc_x, .noc_y = tensix_noc_y, .addr = tensix_l1_src_addr}, {});
     noc.async_read_barrier();
-#else
-    uint32_t stream_ready_sem_id = get_arg_val<uint32_t>(0);
-    uint32_t tensix_done_sem_id = get_arg_val<uint32_t>(1);
-    uint32_t magic_value = get_arg_val<uint32_t>(2);
-
-    // Write magic value into DRISC L1 for Tensix to read back.
-    experimental::CoreLocalMem<uint32_t> dst(drisc_l1_dst_addr);
-    dst[0] = magic_value;
-
-    // Signal Tensix (remote inc to 1) that stream mode is on and DRISC L1 is ready.
-    experimental::Semaphore<ProgrammableCoreType::TENSIX> stream_ready(stream_ready_sem_id);
-    stream_ready.up(noc, tensix_noc_x, tensix_noc_y, 1);
-    noc.async_atomic_barrier();
-
-    // Wait locally for Tensix to confirm completion.
-    experimental::Semaphore<ProgrammableCoreType::DRAM> tensix_done(tensix_done_sem_id);
-    tensix_done.wait(1);
-#endif
 
     // Always restore NOC2AXI so subsequent context observes the default.
     experimental::drisc_set_noc2axi_mode();

--- a/tests/tt_metal/tt_metal/test_kernels/misc/drisc_l1_transfer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/drisc_l1_transfer.cpp
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// DRISC test kernel: DRISC enters stream mode, reads a uint32_t from Tensix L1 into DRISC L1,
-//     then restores NOC2AXI.
+// DRISC test kernel: enters stream mode, reads a uint32_t from Tensix L1 into DRISC L1, restores NOC2AXI.
 
 #include "api/compile_time_args.h"
 #include "experimental/drisc_mode.h"

--- a/tests/tt_metal/tt_metal/test_kernels/misc/tensix_read_from_drisc.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/tensix_read_from_drisc.cpp
@@ -14,7 +14,12 @@ void kernel_main() {
     constexpr uint32_t drisc_noc_x = get_compile_time_arg_val(3);
     constexpr uint32_t drisc_noc_y = get_compile_time_arg_val(4);
 
-    uint64_t drisc_l1_src_addr = (((uint64_t)drisc_l1_src_addr_high << 32) | drisc_l1_src_addr_low);
+    // In NOC2AXI mode, DRISC L1 is accessed via DRAM_L1_NOC_OFFSET (bit 37),
+    // making the address 64-bit. The standard noc_async_read / get_noc_addr APIs
+    // truncate addr to 32 bits and mask NOC_TARG_ADDR_MID, dropping bit 37.
+    // The _with_state 5-arg overload takes coordinates and address separately,
+    // writing TARG_ADDR_MID unmasked so bit 37 is preserved
+    uint64_t drisc_l1_src_addr = (static_cast<uint64_t>(drisc_l1_src_addr_high) << 32) | drisc_l1_src_addr_low;
     uint32_t drisc_src_coord = NOC_XY_COORD(drisc_noc_x, drisc_noc_y);
     noc_read_init_state<BRISC_RD_CMD_BUF>(NOC_INDEX);
     noc_read_with_state<DM_DEDICATED_NOC, BRISC_RD_CMD_BUF, CQ_NOC_SNDL>(

--- a/tests/tt_metal/tt_metal/test_kernels/misc/tensix_read_from_drisc.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/tensix_read_from_drisc.cpp
@@ -2,40 +2,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Reads from DRISC L1 into Tensix L1, handshaking via two semaphores:
-//   - stream_ready (local to Tensix): Tensix waits for DRISC to remote-inc to 1.
-//   - tensix_done (local to DRISC): Tensix remote-incs to 1 once the read completes.
+// Reads from DRISC L1 into Tensix L1
 
 #include "api/dataflow/dataflow_api.h"
-#include "experimental/noc.h"
-#include "experimental/endpoints.h"
-#include "experimental/noc_semaphore.h"
-#include "experimental/core_local_mem.h"
+#include "noc_nonblocking_api.h"
 
 void kernel_main() {
     constexpr uint32_t tensix_dst_addr = get_compile_time_arg_val(0);
-    constexpr uint32_t drisc_l1_src_addr = get_compile_time_arg_val(1);
-    constexpr uint32_t drisc_noc_x = get_compile_time_arg_val(2);
-    constexpr uint32_t drisc_noc_y = get_compile_time_arg_val(3);
-    constexpr uint32_t stream_ready_sem_id = get_compile_time_arg_val(4);
-    constexpr uint32_t tensix_done_sem_id = get_compile_time_arg_val(5);
+    constexpr uint32_t drisc_l1_src_addr_low = get_compile_time_arg_val(1);
+    constexpr uint32_t drisc_l1_src_addr_high = get_compile_time_arg_val(2);
+    constexpr uint32_t drisc_noc_x = get_compile_time_arg_val(3);
+    constexpr uint32_t drisc_noc_y = get_compile_time_arg_val(4);
 
-    experimental::Noc noc;
-
-    // Wait locally for DRISC to signal stream mode is ready.
-    experimental::Semaphore<ProgrammableCoreType::TENSIX> stream_ready(stream_ready_sem_id);
-    stream_ready.wait(1);
-
-    // Read one uint32_t from DRISC L1 into Tensix L1.
-    experimental::UnicastEndpoint src;
-    experimental::CoreLocalMem<uint32_t> dst(tensix_dst_addr);
-    noc.async_read(
-        src, dst, sizeof(uint32_t), {.noc_x = drisc_noc_x, .noc_y = drisc_noc_y, .addr = drisc_l1_src_addr}, {});
-    noc.async_read_barrier();
-
-    // Signal DRISC (remote inc to 1) that the read is complete, and flush the
-    // non-posted atomic before kernel exit so watcher doesn't flag a pending txn.
-    experimental::Semaphore<ProgrammableCoreType::DRAM> tensix_done(tensix_done_sem_id);
-    tensix_done.up(noc, drisc_noc_x, drisc_noc_y, 1);
-    noc.async_atomic_barrier();
+    uint64_t drisc_l1_src_addr = (((uint64_t)drisc_l1_src_addr_high << 32) | drisc_l1_src_addr_low);
+    uint32_t drisc_src_coord = NOC_XY_COORD(drisc_noc_x, drisc_noc_y);
+    noc_read_init_state<BRISC_RD_CMD_BUF>(NOC_INDEX);
+    noc_read_with_state<DM_DEDICATED_NOC, BRISC_RD_CMD_BUF, CQ_NOC_SNDL>(
+        NOC_INDEX, drisc_src_coord, drisc_l1_src_addr, tensix_dst_addr, sizeof(uint32_t));
+    noc_async_read_barrier();
 }


### PR DESCRIPTION
### PR Category
Test only.

### Summary
Streamlines the DRISC L1 tests in `test_dram_kernels.cpp`:

1. Unique L1 verification (`DramKernelDRISCWriteToDRAM`, `DramKernelDRISCReadFromDRAM`): Each endpoint now gets unique random data seeded into its L1 before the workload runs. This proves each DRISC endpoint has independent L1.
2. Remove stream mode from Tensix --> DRISC L1 read (`DramKernelTensixReadFromDRISCL1`): Host seeds DRISC L1 directly via `write_core`, Tensix reads it using `noc_read_with_state` which preserves bit 37 (`DRAM_L1_NOC_OFFSET`) that the standard `noc_async_read` silently drops.

### Notes for reviewers

- `noc_read_with_state` (5-arg overload) writes `NOC_TARG_ADDR_MID` as (uint32_t)(src_addr >> 32) with no mask, preserving bit 37. This is why the lower-level API is needed here.
- `drisc_l1_transfer.cpp` is still active: used by `DramKernelDRISCReadFromTensixL1` only the semaphore-handshake #else path was removed.


Runtime unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/25411927051

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/streamline_drisc_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/streamline_drisc_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/streamline_drisc_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/streamline_drisc_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/streamline_drisc_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/streamline_drisc_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/streamline_drisc_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/streamline_drisc_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/streamline_drisc_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/streamline_drisc_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/streamline_drisc_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/streamline_drisc_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/streamline_drisc_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/streamline_drisc_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/streamline_drisc_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/streamline_drisc_tests)