### PR TITLE
feat(fabric): outline local-delivery dispatch + credit counters; add downstream NOC accessor

### DIFF
--- a/tt_metal/fabric/builder/connection_writer_adapter.hpp
+++ b/tt_metal/fabric/builder/connection_writer_adapter.hpp
@@ -124,6 +124,17 @@ public:
         return downstream_edms_connected_by_vc_mask.at(vc_idx);
     }
 
+    // Get the NOC coordinates of the first downstream EDM for a specific VC.
+    // Used by external fabric-builder plugins (e.g. CRAQ-Fabric) to derive
+    // DOWNSTREAM_NOC_X / DOWNSTREAM_NOC_Y CT args without direction-based
+    // heuristics. Callers should check get_downstream_edm_count_for_vc(vc_idx)
+    // before calling this.
+    tt_xy_pair get_downstream_noc_for_vc(uint32_t vc_idx) const {
+        const auto& edms = downstream_edms_connected_by_vc.at(vc_idx);
+        TT_ASSERT(!edms.empty(), "No downstream EDMs for VC {}", vc_idx);
+        return edms.front().noc_xy;
+    }
+
     // Get buffer index semaphore address for a specific VC and compact index
     std::optional<size_t> get_buffer_index_semaphore_address(uint32_t vc_idx, size_t compact_idx) const {
         return downstream_edm_buffer_index_semaphore_addresses.at(vc_idx).at(compact_idx);

--- a/tt_metal/fabric/fabric_builder.cpp
+++ b/tt_metal/fabric/fabric_builder.cpp
@@ -280,10 +280,20 @@ void FabricBuilder::create_kernels() {
 }
 
 // ============ Plugin Factory Registration ============
+//
+// Thread safety: registration must happen before any fabric init call.
+// This is a program-startup operation, not a concurrent runtime operation.
+// No mutex is needed because the ordering contract is: register once during
+// setup, then fabric init reads it. Concurrent registration is a programming error.
 
 static FabricBuilderFactory g_fabric_builder_factory = nullptr;
 
-void register_fabric_builder_factory(FabricBuilderFactory factory) { g_fabric_builder_factory = std::move(factory); }
+void register_fabric_builder_factory(FabricBuilderFactory factory) {
+    TT_FATAL(
+        !g_fabric_builder_factory || !factory,
+        "FabricBuilder factory already registered. Call with nullptr to clear before re-registering.");
+    g_fabric_builder_factory = std::move(factory);
+}
 
 const FabricBuilderFactory& get_fabric_builder_factory() { return g_fabric_builder_factory; }
 

--- a/tt_metal/fabric/fabric_builder.cpp
+++ b/tt_metal/fabric/fabric_builder.cpp
@@ -279,4 +279,12 @@ void FabricBuilder::create_kernels() {
     }
 }
 
+// ============ Plugin Factory Registration ============
+
+static FabricBuilderFactory g_fabric_builder_factory = nullptr;
+
+void register_fabric_builder_factory(FabricBuilderFactory factory) { g_fabric_builder_factory = std::move(factory); }
+
+const FabricBuilderFactory& get_fabric_builder_factory() { return g_fabric_builder_factory; }
+
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_builder.hpp
+++ b/tt_metal/fabric/fabric_builder.hpp
@@ -35,6 +35,13 @@ class FabricBuilderContext;
  *      discover_channels() -> create_routers() -> connect_routers() ->
  *      compile_ancillary_kernels() -> create_kernels()
  *   3. FabricBuilder is destroyed, router builders are destroyed
+ *
+ * ABI note: This class has virtual methods (added for plugin subclassing support).
+ * This means it carries a vptr and its layout differs from a non-virtual version.
+ * FabricBuilder is only constructed via fabric_init.cpp (never embedded in other
+ * structs or passed across shared library boundaries by value), so the ABI impact
+ * is limited to callers that previously constructed FabricBuilder directly. The
+ * register_fabric_builder_factory() API is the intended extension point.
  */
 class FabricBuilder {
 public:
@@ -154,14 +161,25 @@ protected:
  * out-of-tree builder implementations without compile-time coupling.
  *
  * The factory receives the same arguments as the FabricBuilder constructor and must
- * return a fully-functional FabricBuilder (or subclass) that implements all build phases:
- * discover_channels, create_routers, connect_routers, compile_ancillary_kernels, create_kernels.
+ * return a non-null, fully-functional FabricBuilder (or subclass) that implements all
+ * build phases: discover_channels, create_routers, connect_routers,
+ * compile_ancillary_kernels, create_kernels.
+ *
+ * Thread safety: Registration must happen before any call to
+ * create_and_compile_tt_fabric_program(). This is a program-startup operation.
+ * Concurrent registration or registration during fabric init is a programming error.
+ * Double-registration without clearing (nullptr) first will assert.
+ *
+ * Note: This header is currently internal (not in the public api/ install set).
+ * Out-of-tree consumers must include it from the tt-metal source tree. A public
+ * forwarding header under api/tt-metalium/experimental/fabric/ may be added in the
+ * future if this API stabilizes.
  *
  * Usage:
  *   // In plugin initialization (before fabric init):
  *   tt::tt_fabric::register_fabric_builder_factory(
- *       [](IDevice* device, Program& program, FabricContext& ctx)
- *           -> std::unique_ptr<FabricBuilder> {
+ *       [](tt::tt_metal::IDevice* device, tt::tt_metal::Program& program,
+ *          tt::tt_fabric::FabricContext& ctx) -> std::unique_ptr<tt::tt_fabric::FabricBuilder> {
  *           return std::make_unique<MyCustomFabricBuilder>(device, program, ctx);
  *       });
  */
@@ -171,6 +189,8 @@ using FabricBuilderFactory = std::function<std::unique_ptr<FabricBuilder>(
 /**
  * Register a custom FabricBuilder factory. When set, fabric initialization will use this
  * factory instead of constructing the default FabricBuilder. Pass nullptr to clear.
+ * Asserts if a factory is already registered (clear first with nullptr before re-registering).
+ * Must be called before any fabric init. The factory must return a non-null pointer.
  */
 void register_fabric_builder_factory(FabricBuilderFactory factory);
 

--- a/tt_metal/fabric/fabric_builder.hpp
+++ b/tt_metal/fabric/fabric_builder.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <unordered_map>
@@ -38,32 +39,34 @@ class FabricBuilderContext;
 class FabricBuilder {
 public:
     FabricBuilder(tt::tt_metal::IDevice* device, tt::tt_metal::Program& program, FabricContext& fabric_context);
+    virtual ~FabricBuilder() = default;
 
     /**
      * Discover active ethernet channels and neighbors for this device.
      * Must be called before create_routers().
      */
-    void discover_channels();
+    virtual void discover_channels();
 
     /**
      * Create all router builders for this device.
+     * Override to dispatch to custom FabricRouterBuilder subclasses.
      */
-    void create_routers();
+    virtual void create_routers();
 
     /**
      * Connect routers using topology-appropriate connections.
      */
-    void connect_routers();
+    virtual void connect_routers();
 
     /**
      * Compile ancillary kernels (e.g., tensix mux) for each router.
      */
-    void compile_ancillary_kernels();
+    virtual void compile_ancillary_kernels();
 
     /**
      * Create the main ERISC router kernels.
      */
-    void create_kernels();
+    virtual void create_kernels();
 
     /**
      * Check if any routers were created.
@@ -75,7 +78,7 @@ public:
      */
     size_t get_num_routers() const { return routers_.size(); }
 
-private:
+protected:
     /**
      * RouterConnectionPair - Internal struct for router connection info
      */
@@ -140,5 +143,40 @@ private:
     // Master router channel (first in map)
     chan_id_t master_router_chan_ = 0;
 };
+
+// ============ Plugin Factory Registration ============
+
+/**
+ * Factory function type for creating custom FabricBuilder implementations.
+ *
+ * External code (e.g., custom fabric builder plugins) can register a factory function
+ * that will be called instead of constructing the default FabricBuilder. This enables
+ * out-of-tree builder implementations without compile-time coupling.
+ *
+ * The factory receives the same arguments as the FabricBuilder constructor and must
+ * return a fully-functional FabricBuilder (or subclass) that implements all build phases:
+ * discover_channels, create_routers, connect_routers, compile_ancillary_kernels, create_kernels.
+ *
+ * Usage:
+ *   // In plugin initialization (before fabric init):
+ *   tt::tt_fabric::register_fabric_builder_factory(
+ *       [](IDevice* device, Program& program, FabricContext& ctx)
+ *           -> std::unique_ptr<FabricBuilder> {
+ *           return std::make_unique<MyCustomFabricBuilder>(device, program, ctx);
+ *       });
+ */
+using FabricBuilderFactory = std::function<std::unique_ptr<FabricBuilder>(
+    tt::tt_metal::IDevice*, tt::tt_metal::Program&, FabricContext&)>;
+
+/**
+ * Register a custom FabricBuilder factory. When set, fabric initialization will use this
+ * factory instead of constructing the default FabricBuilder. Pass nullptr to clear.
+ */
+void register_fabric_builder_factory(FabricBuilderFactory factory);
+
+/**
+ * Returns the currently registered factory, or nullptr if none is registered.
+ */
+const FabricBuilderFactory& get_fabric_builder_factory();
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -26,8 +26,12 @@ std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto& fabric_context = control_plane.get_fabric_context();
 
-    // Use FabricBuilder to coordinate the build phases
-    FabricBuilder builder(device, *fabric_program_ptr, fabric_context);
+    // Use FabricBuilder to coordinate the build phases.
+    // If a custom factory is registered, use it; otherwise construct the default.
+    const auto& factory = get_fabric_builder_factory();
+    auto builder_ptr = factory ? factory(device, *fabric_program_ptr, fabric_context)
+                               : std::make_unique<FabricBuilder>(device, *fabric_program_ptr, fabric_context);
+    auto& builder = *builder_ptr;
 
     // Execute build phases
     builder.discover_channels();

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -31,6 +31,7 @@ std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::
     const auto& factory = get_fabric_builder_factory();
     auto builder_ptr = factory ? factory(device, *fabric_program_ptr, fabric_context)
                                : std::make_unique<FabricBuilder>(device, *fabric_program_ptr, fabric_context);
+    TT_FATAL(builder_ptr != nullptr, "FabricBuilder factory returned nullptr");
     auto& builder = *builder_ptr;
 
     // Execute build phases

--- a/tt_metal/fabric/hw/inc/edm_fabric/craq_fabric_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/craq_fabric_ct_args.hpp
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+//
+// =============================================================================
+// craq_fabric_ct_args.hpp
+// =============================================================================
+//
+// Private CT-arg surface for the CRAQ-Fabric generated kernel.
+//
+// HARD RULE (see memory/feedback_no_upstream_ct_args.md):
+//   The generated kernel MUST NOT take its CT-arg constants from upstream's
+//   `fabric_erisc_router_ct_args.hpp`. Every constant the kernel reads must
+//   come from OUR builder via OUR macro infrastructure.
+//
+// This header defines:
+//   - `CRAQ_NAMED_CT_ARG(name)` -- our wrapper around the same underlying
+//     `get_named_compile_time_arg_val(name)` primitive upstream uses, but
+//     spelled differently so that any kernel-side regression to upstream's
+//     `NAMED_CT_ARG(...)` macro is visible at lint time.
+//   - The `craq_*` constexpr constants the kernel reads instead of the
+//     identically-shaped upstream constants. Builder publishes the
+//     underlying CT args under the names referenced below.
+//
+// Backwards-compat notice: this header does NOT replace upstream's CT args
+// for upstream's own kernel. It exists solely so the CRAQ-Fabric kernel is
+// auditable as a self-contained generated artifact.
+// =============================================================================
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+
+#ifndef OFFLINE_COMPILATION
+// `get_named_compile_time_arg_val` lives behind `api/compile_time_args.h` in
+// the device build. Under OFFLINE_COMPILATION the mocks declare a fake at
+// global scope; we therefore only include the real header outside the mock.
+#include "api/compile_time_args.h"
+#endif
+
+// -----------------------------------------------------------------------------
+// CRAQ_NAMED_CT_ARG -- our private CT-arg lookup macro.
+// -----------------------------------------------------------------------------
+//
+// Distinct macro name from upstream's `NAMED_CT_ARG` so that:
+//   - lint checks can flag any leftover `NAMED_CT_ARG(...)` use in our codegen
+//     output as an upstream-coupling violation;
+//   - grepping for the macro in our tree finds only our usages;
+//   - the underlying primitive is identical, so values are retrieved exactly
+//     the same way upstream does.
+#define CRAQ_NAMED_CT_ARG(name) get_named_compile_time_arg_val(name)
+
+namespace tt::tt_fabric::craq {
+
+// -----------------------------------------------------------------------------
+// Multi-TXQ credit-region addresses.
+// -----------------------------------------------------------------------------
+//
+// On Blackhole 2-erisc with SENDER_TXQ_ID=0 and RECEIVER_TXQ_ID=1, TXQ1 cannot
+// do `eth_reg_write` MMIO -- so receiver->sender credit replies must travel
+// over ETH *data* into an L1 counter array. The four base addresses below
+// describe the per-side L1 layout; `craq_to_senders_credits_base_address` /
+// `craq_local_receiver_credits_base_address` are derived as the lower of the
+// two sub-region bases, and `craq_total_number_of_receiver_to_sender_credit_num_bytes`
+// is the total bulk-send size.
+//
+// These mirror upstream's identically-named constants in
+// `fabric_erisc_router_ct_args.hpp`, but are PUBLISHED BY OUR BUILDER under
+// our own names. The values come from the same allocator decisions that
+// inform upstream's allocation, but the CT-arg flow is no longer transitive
+// through upstream's header.
+constexpr std::size_t craq_to_sender_remote_ack_counters_base_address =
+    CRAQ_NAMED_CT_ARG("TO_SENDER_REMOTE_ACK_COUNTERS_BASE_ADDR");
+constexpr std::size_t craq_to_sender_remote_completion_counters_base_address =
+    CRAQ_NAMED_CT_ARG("TO_SENDER_REMOTE_COMPLETION_COUNTERS_BASE_ADDR");
+
+// Bulk-send origin/target = whichever sub-region sits lower in L1.
+constexpr std::size_t craq_to_senders_credits_base_address = std::min(
+    craq_to_sender_remote_ack_counters_base_address,
+    craq_to_sender_remote_completion_counters_base_address);
+
+constexpr std::size_t craq_local_receiver_ack_counters_base_address =
+    CRAQ_NAMED_CT_ARG("LOCAL_RECEIVER_ACK_COUNTERS_BASE_ADDR");
+constexpr std::size_t craq_local_receiver_completion_counters_base_address =
+    CRAQ_NAMED_CT_ARG("LOCAL_RECEIVER_COMPLETION_COUNTERS_BASE_ADDR");
+
+constexpr std::size_t craq_local_receiver_credits_base_address = std::min(
+    craq_local_receiver_ack_counters_base_address,
+    craq_local_receiver_completion_counters_base_address);
+
+// Two contiguous arrays of equal size: take the size of the first and double.
+constexpr std::size_t craq_total_number_of_receiver_to_sender_credit_num_bytes =
+    (std::max(craq_local_receiver_ack_counters_base_address,
+              craq_local_receiver_completion_counters_base_address) -
+     craq_local_receiver_credits_base_address) *
+    2;
+
+// -----------------------------------------------------------------------------
+// TXQ assignments + multi_txq_enabled.
+// -----------------------------------------------------------------------------
+//
+// SENDER_TXQ_ID/RECEIVER_TXQ_ID are also published by our builder for the
+// kernel; the kernel separately declares those at file scope. We re-expose a
+// matching constexpr here for `craq_multi_txq_enabled` derivation so the
+// outlined headers do not need to read the kernel-scope constants.
+constexpr std::size_t craq_sender_txq_id = CRAQ_NAMED_CT_ARG("SENDER_TXQ_ID");
+constexpr std::size_t craq_receiver_txq_id = CRAQ_NAMED_CT_ARG("RECEIVER_TXQ_ID");
+constexpr bool craq_multi_txq_enabled = (craq_sender_txq_id != craq_receiver_txq_id);
+
+}  // namespace tt::tt_fabric::craq
+
+// Bring the most frequently used names into the unqualified namespace at file
+// scope so the kernel body reads cleanly. This is a deliberate trade-off: the
+// kernel becomes terse, but the names remain auditable because they all carry
+// the `craq_` prefix that is unique to this header.
+using tt::tt_fabric::craq::craq_to_sender_remote_ack_counters_base_address;
+using tt::tt_fabric::craq::craq_to_sender_remote_completion_counters_base_address;
+using tt::tt_fabric::craq::craq_to_senders_credits_base_address;
+using tt::tt_fabric::craq::craq_local_receiver_ack_counters_base_address;
+using tt::tt_fabric::craq::craq_local_receiver_completion_counters_base_address;
+using tt::tt_fabric::craq::craq_local_receiver_credits_base_address;
+using tt::tt_fabric::craq::craq_total_number_of_receiver_to_sender_credit_num_bytes;
+using tt::tt_fabric::craq::craq_multi_txq_enabled;

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_counter_based_credits.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_counter_based_credits.hpp
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+//
+// =============================================================================
+// fabric_counter_based_credits.hpp
+// =============================================================================
+//
+// Outlined L1-counter-based credit widgets, extracted from
+// `fabric_router_flow_control.hpp` so callers (the CRAQ-Fabric generated
+// kernel in particular) can reuse the credit-region transport WITHOUT
+// transitively pulling in `fabric_erisc_router_ct_args.hpp`.
+//
+// All credit-region L1 addresses are now CONSTRUCTOR ARGUMENTS instead of
+// being read from upstream's CT-arg-derived constants. Each caller wires
+// these from its own CT-arg layer.
+//
+// `fabric_router_flow_control.hpp` is now a thin compatibility shim that
+// includes this header AND `fabric_erisc_router_ct_args.hpp`, then
+// re-exposes the legacy widget names bound to the upstream CT-arg constants.
+// =============================================================================
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstddef>
+
+#include "internal/ethernet/tt_eth_api.h"
+#include "internal/ethernet/tunneling.h"
+#include "tt_metal/fabric/hw/inc/edm_fabric/router_data_cache.hpp"
+
+// -----------------------------------------------------------------------------
+// ReceiverChannelCounterBasedResponseCreditSenderOutlined<NumSenderChannels>
+// -----------------------------------------------------------------------------
+//
+// L1-counter-based credit sender (receiver-side). Bumps per-source-channel
+// counters in a local L1 region, then bulk-sends the whole region to the peer
+// via `eth_send_packet_bytes_unsafe` over a caller-specified TXQ. The peer
+// reads its mirror image to learn how many ack/completion credits to apply.
+//
+// Differences vs upstream `ReceiverChannelCounterBasedResponseCreditSender`:
+//   - All four addresses + the bulk-send byte count + the TXQ id come from
+//     CONSTRUCTOR ARGUMENTS, not from `fabric_erisc_router_ct_args.hpp`.
+//   - `NumSenderChannels` is a TEMPLATE parameter so callers don't depend on
+//     upstream's `NUM_SENDER_CHANNELS` constexpr.
+template <std::size_t NumSenderChannels>
+struct ReceiverChannelCounterBasedResponseCreditSenderOutlined {
+    ReceiverChannelCounterBasedResponseCreditSenderOutlined() = default;
+
+    ReceiverChannelCounterBasedResponseCreditSenderOutlined(
+        std::size_t /*receiver_channel_index*/,
+        std::size_t local_receiver_completion_counters_base_address,
+        std::size_t local_receiver_ack_counters_base_address,
+        std::size_t local_receiver_credits_base_address_in,
+        std::size_t to_senders_credits_base_address_in,
+        std::size_t total_number_of_receiver_to_sender_credit_num_bytes_in,
+        uint8_t receiver_txq_id_in) :
+        completion_counters_base_ptr(
+            reinterpret_cast<volatile uint32_t*>(local_receiver_completion_counters_base_address)),
+        ack_counters_base_ptr(
+            reinterpret_cast<volatile uint32_t*>(local_receiver_ack_counters_base_address)),
+        local_receiver_credits_base_address(local_receiver_credits_base_address_in),
+        to_senders_credits_base_address(to_senders_credits_base_address_in),
+        total_number_of_receiver_to_sender_credit_num_bytes(
+            total_number_of_receiver_to_sender_credit_num_bytes_in),
+        receiver_txq_id(receiver_txq_id_in),
+        completion_counters({}),
+        ack_counters({}) {
+        for (std::size_t i = 0; i < NumSenderChannels; i++) {
+            completion_counters[i] = 0;
+            ack_counters[i] = 0;
+        }
+    }
+
+    FORCE_INLINE void send_completion_credit(uint8_t src_id, uint32_t num_completions) {
+        completion_counters[src_id] += num_completions;
+        completion_counters_base_ptr[src_id] = completion_counters[src_id];
+        update_sender_side_credits();
+    }
+
+    // Assumes !eth_txq_is_busy() -- PLEASE CHECK BEFORE CALLING
+    FORCE_INLINE void send_ack_credit(uint8_t src_id) {
+        ack_counters[src_id]++;
+        ack_counters_base_ptr[src_id] = ack_counters[src_id];
+        update_sender_side_credits();
+    }
+
+    // Default member initializers ensure the `= default` constructor produces a
+    // safely-zeroed object. Prior to this, `-Werror=uninitialized` flagged the
+    // upstream wrapper's default-constructed instances under LTO.
+    volatile tt_l1_ptr uint32_t* completion_counters_base_ptr{nullptr};
+    volatile tt_l1_ptr uint32_t* ack_counters_base_ptr{nullptr};
+    std::size_t local_receiver_credits_base_address{0};
+    std::size_t to_senders_credits_base_address{0};
+    std::size_t total_number_of_receiver_to_sender_credit_num_bytes{0};
+    uint8_t receiver_txq_id{0};
+    // Local memory copy to save an L1 load
+    std::array<uint32_t, NumSenderChannels> completion_counters{};
+    std::array<uint32_t, NumSenderChannels> ack_counters{};
+
+private:
+    FORCE_INLINE void update_sender_side_credits() const {
+        internal_::eth_send_packet_bytes_unsafe(
+            receiver_txq_id,
+            local_receiver_credits_base_address,
+            to_senders_credits_base_address,
+            total_number_of_receiver_to_sender_credit_num_bytes);
+    }
+};
+
+// -----------------------------------------------------------------------------
+// SenderChannelFromReceiverCounterBasedCreditsReceiverOutlined
+// -----------------------------------------------------------------------------
+//
+// L1-counter-based credit receiver (sender-side). Reads per-channel cumulative
+// counter values from L1 mirror addresses written by the peer receiver via
+// ETH bulk-send.
+//
+// Differences vs upstream `SenderChannelFromReceiverCounterBasedCreditsReceiver`:
+//   - Counter region base addresses come from CONSTRUCTOR ARGUMENTS, not from
+//     `fabric_erisc_router_ct_args.hpp`.
+struct SenderChannelFromReceiverCounterBasedCreditsReceiverOutlined {
+    SenderChannelFromReceiverCounterBasedCreditsReceiverOutlined() = default;
+
+    SenderChannelFromReceiverCounterBasedCreditsReceiverOutlined(
+        std::size_t sender_channel_index,
+        std::size_t to_sender_remote_ack_counters_base_address,
+        std::size_t to_sender_remote_completion_counters_base_address) :
+        acks_received_counter_ptr(
+            reinterpret_cast<volatile uint32_t*>(to_sender_remote_ack_counters_base_address) +
+            sender_channel_index),
+        completions_received_counter_ptr(
+            reinterpret_cast<volatile uint32_t*>(to_sender_remote_completion_counters_base_address) +
+            sender_channel_index),
+        acks_received_and_processed(0),
+        completions_received_and_processed(0) {}
+
+    template <bool RISC_CPU_DATA_CACHE_ENABLED>
+    FORCE_INLINE uint32_t get_num_unprocessed_acks_from_receiver() {
+        router_invalidate_l1_cache<RISC_CPU_DATA_CACHE_ENABLED>();
+        return *acks_received_counter_ptr - acks_received_and_processed;
+    }
+
+    FORCE_INLINE void increment_num_processed_acks(std::size_t num_acks) {
+        acks_received_and_processed += num_acks;
+    }
+
+    template <bool RISC_CPU_DATA_CACHE_ENABLED>
+    FORCE_INLINE uint32_t get_num_unprocessed_completions_from_receiver() {
+        router_invalidate_l1_cache<RISC_CPU_DATA_CACHE_ENABLED>();
+        return *completions_received_counter_ptr - completions_received_and_processed;
+    }
+
+    FORCE_INLINE void increment_num_processed_completions(std::size_t num_completions) {
+        completions_received_and_processed += num_completions;
+    }
+
+    volatile uint32_t* acks_received_counter_ptr;
+    volatile uint32_t* completions_received_counter_ptr;
+    uint32_t acks_received_and_processed = 0;
+    uint32_t completions_received_and_processed = 0;
+};

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_local_delivery_dispatch.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_local_delivery_dispatch.hpp
@@ -1,0 +1,428 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+//
+// =============================================================================
+// fabric_local_delivery_dispatch.hpp
+// =============================================================================
+//
+// Outlined Phase-7 local-delivery dispatch + packet-header debug helpers,
+// extracted from `fabric_edm_packet_transmission.hpp` so callers (in
+// particular the CRAQ-Fabric generated kernel) can include the shared logic
+// WITHOUT transitively pulling in `fabric_erisc_router_ct_args.hpp`.
+//
+// This is part of the structural decoupling work required by:
+//   feedback_no_upstream_ct_args.md
+//   "Generated kernel must NOT use upstream EDM CT args"
+//
+// The CT-arg-derived constants used by `execute_chip_unicast_to_local_chip_impl`
+// (NOC id, command buffer id, NOC VC, TRID range, deadlock-avoidance flag,
+// channel-trimming usage recorder) are surfaced as template parameters of
+// `LocalDeliveryDispatchConfig` so each caller binds them from its own
+// CT-arg infrastructure.
+//
+// `fabric_edm_packet_transmission.hpp` is now a thin compatibility shim that
+// includes this header AND `fabric_erisc_router_ct_args.hpp`, then re-exposes
+// the legacy free-function names bound to upstream CT-arg constants.
+//
+// Backwards-compatibility invariant: upstream callers (fabric_erisc_router.cpp,
+// fabric_erisc_router_speedy_path.hpp, etc.) must keep working unchanged.
+// =============================================================================
+
+#pragma once
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint.h"
+#include "fabric/fabric_edm_packet_header.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_router_adapter.hpp"
+#include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
+
+// If the hop/distance counter equals to the below value, it indicates that it has
+// arrived at (at least one of) the intended destination(s)
+static constexpr size_t LOCAL_DELIVERY_DESTINATION_HOP_COUNT = 1;
+// TODO: make 0 and the associated field to num mcast destinations
+static constexpr size_t LOCAL_DELIVERY_LAST_MCAST_DESTINATION = 1;
+
+// -----------------------------------------------------------------------------
+// Packet-header DPRINT helpers (CT-arg-free).
+// -----------------------------------------------------------------------------
+
+FORCE_INLINE void print_pkt_hdr_routing_fields_outlined(
+    volatile tt::tt_fabric::PacketHeader* const packet_start) {
+#ifdef DEBUG_PRINT_ENABLED
+    switch (packet_start->chip_send_type) {
+        case tt::tt_fabric::CHIP_UNICAST: {
+            DPRINT << "C_UNI: dist:"
+                   << (uint32_t)(packet_start->routing_fields.value & tt::tt_fabric::RoutingFields::HOP_DISTANCE_MASK)
+                   << "\n";
+            DEVICE_PRINT(
+                "C_UNI: dist:{}\n",
+                (uint32_t)(packet_start->routing_fields.value & tt::tt_fabric::RoutingFields::HOP_DISTANCE_MASK));
+            break;
+        }
+        case tt::tt_fabric::CHIP_MULTICAST: {
+            DPRINT << "C_MCST: dist:"
+                   << (uint32_t)(packet_start->routing_fields.value & tt::tt_fabric::RoutingFields::HOP_DISTANCE_MASK)
+                   << ", rng:"
+                   << (uint32_t)((packet_start->routing_fields.value & tt::tt_fabric::RoutingFields::RANGE_MASK) >>
+                                 tt::tt_fabric::RoutingFields::START_DISTANCE_FIELD_BIT_WIDTH)
+                   << "\n";
+            DEVICE_PRINT(
+                "C_MCST: dist:{}, rng:{}\n",
+                (uint32_t)(packet_start->routing_fields.value & tt::tt_fabric::RoutingFields::HOP_DISTANCE_MASK),
+                (uint32_t)((packet_start->routing_fields.value & tt::tt_fabric::RoutingFields::RANGE_MASK) >>
+                           tt::tt_fabric::RoutingFields::START_DISTANCE_FIELD_BIT_WIDTH));
+            break;
+        }
+    };
+#endif
+}
+
+FORCE_INLINE void print_pkt_hdr_routing_fields_outlined(
+    volatile tt::tt_fabric::LowLatencyPacketHeader* const packet_start) {
+#ifdef DEBUG_PRINT_ENABLED
+    DPRINT << "ROUTE:" << packet_start->routing_fields.value << "\n";
+    DEVICE_PRINT("ROUTE:{}\n", packet_start->routing_fields.value);
+#endif
+}
+
+template <typename T>
+FORCE_INLINE void print_pkt_header_noc_fields_outlined(volatile T* const packet_start) {
+#ifdef DEBUG_PRINT_ENABLED
+    switch (packet_start->noc_send_type) {
+        case tt::tt_fabric::NocSendType::NOC_UNICAST_WRITE: {
+            DPRINT << "N_WR addr:" << (uint64_t)packet_start->command_fields.unicast_write.noc_address << "\n";
+            DEVICE_PRINT("N_WR addr:{}\n", (uint64_t)packet_start->command_fields.unicast_write.noc_address);
+        } break;
+        case tt::tt_fabric::NocSendType::NOC_UNICAST_ATOMIC_INC: {
+            DPRINT << "N_WR addr:" << (uint64_t)packet_start->command_fields.unicast_seminc.noc_address
+                   << ", val:" << (uint32_t)packet_start->command_fields.unicast_seminc.val << "\n";
+            DEVICE_PRINT(
+                "N_WR addr:{}, val:{}\n",
+                (uint64_t)packet_start->command_fields.unicast_seminc.noc_address,
+                (uint32_t)packet_start->command_fields.unicast_seminc.val);
+
+        } break;
+        default:
+            ASSERT(false);  // unimplemented
+            break;
+    };
+#endif
+}
+
+FORCE_INLINE void print_pkt_header_outlined(volatile tt::tt_fabric::PacketHeader* const packet_start) {
+#ifdef DEBUG_PRINT_ENABLED
+    auto const& header = *packet_start;
+    DPRINT << "PKT: nsnd_t:" << (uint32_t)packet_start->noc_send_type
+           << ", csnd_t:" << (uint32_t)packet_start->chip_send_type
+           << ", src_chip:" << (uint32_t)packet_start->src_ch_id
+           << ", payload_size_bytes:" << (uint32_t)packet_start->payload_size_bytes << "\n";
+    DEVICE_PRINT(
+        "PKT: nsnd_t:{} csnd_t:{} src_chip:{} payload_size_bytes:{}\n",
+        (uint32_t)packet_start->noc_send_type,
+        (uint32_t)packet_start->chip_send_type,
+        (uint32_t)packet_start->src_ch_id,
+        (uint32_t)packet_start->payload_size_bytes);
+    print_pkt_hdr_routing_fields_outlined(packet_start);
+    print_pkt_header_noc_fields_outlined(packet_start);
+#endif
+}
+
+FORCE_INLINE void print_pkt_header_outlined(volatile tt::tt_fabric::LowLatencyPacketHeader* const packet_start) {
+#ifdef DEBUG_PRINT_ENABLED
+    auto const& header = *packet_start;
+    DPRINT << "PKT: nsnd_t:" << (uint32_t)packet_start->noc_send_type
+           << ", src_chip:" << (uint32_t)packet_start->src_ch_id
+           << ", payload_size_bytes:" << (uint32_t)packet_start->payload_size_bytes << "\n";
+    DEVICE_PRINT(
+        "PKT: nsnd_t:{} src_chip:{} payload_size_bytes:{}\n",
+        (uint32_t)packet_start->noc_send_type,
+        (uint32_t)packet_start->src_ch_id,
+        (uint32_t)packet_start->payload_size_bytes);
+    print_pkt_hdr_routing_fields_outlined(packet_start);
+    print_pkt_header_noc_fields_outlined(packet_start);
+#endif
+}
+
+// Shifts the chunk encoding in a scatter write packet to the next chunk
+FORCE_INLINE void shift_to_next_chunk_outlined(uint8_t& chunk_encodings) { chunk_encodings >>= 2; }
+
+// -----------------------------------------------------------------------------
+// LocalDeliveryDispatchConfig
+// -----------------------------------------------------------------------------
+//
+// Compile-time configuration bundle binding the constants previously taken
+// from `fabric_erisc_router_ct_args.hpp` directly. Each caller (upstream's
+// EDM router, the CRAQ-Fabric generated kernel, etc.) builds one of these
+// from its own CT-arg layer and passes it as a template parameter to
+// `execute_chip_unicast_to_local_chip_impl_outlined`.
+//
+// The defaults below are NOT meaningful for any real device — every caller
+// must specify them. They are provided only so the type can be default-
+// instantiated in headers that do not have CT args resolved at parse time.
+template <
+    uint8_t LocalChipNoc,
+    uint8_t LocalChipDataCmdBuf,
+    uint8_t ForwardAndLocalWriteNocVc,
+    bool LocalChipNocEqualsDownstreamNoc,
+    uint8_t DownstreamNoc,
+    bool EnableDeadlockAvoidance,
+    uint8_t NumTransactionIds>
+struct LocalDeliveryDispatchConfig {
+    static constexpr uint8_t local_chip_noc = LocalChipNoc;
+    static constexpr uint8_t local_chip_data_cmd_buf = LocalChipDataCmdBuf;
+    static constexpr uint8_t forward_and_local_write_noc_vc = ForwardAndLocalWriteNocVc;
+    static constexpr bool local_chip_noc_equals_downstream_noc = LocalChipNocEqualsDownstreamNoc;
+    static constexpr uint8_t downstream_noc = DownstreamNoc;
+    static constexpr bool enable_deadlock_avoidance = EnableDeadlockAvoidance;
+    static constexpr uint8_t num_transaction_ids = NumTransactionIds;
+};
+
+// -----------------------------------------------------------------------------
+// flush_write_to_noc_pipeline (outlined)
+// -----------------------------------------------------------------------------
+//
+// CT-arg-free counterpart to upstream's `flush_write_to_noc_pipeline`.
+// The TRID start array (`RX_CH_TRID_STARTS` upstream) is passed as an explicit
+// argument because callers compute it from their own CT-arg layer.
+template <typename Config, typename TridStartsArray>
+FORCE_INLINE void flush_write_to_noc_pipeline_outlined(
+    uint8_t rx_channel_id, const TridStartsArray& rx_ch_trid_starts) {
+    if constexpr (Config::enable_deadlock_avoidance) {
+        auto start_trid = rx_ch_trid_starts[rx_channel_id];
+        auto end_trid = start_trid + Config::num_transaction_ids;
+        for (int i = start_trid; i < end_trid; i++) {
+            if constexpr (Config::local_chip_noc_equals_downstream_noc) {
+                while (!ncrisc_noc_nonposted_write_with_transaction_id_flushed(Config::local_chip_noc, i));
+            } else {
+                while (!ncrisc_noc_nonposted_write_with_transaction_id_flushed(Config::downstream_noc, i));
+                while (!ncrisc_noc_nonposted_write_with_transaction_id_flushed(Config::local_chip_noc, i));
+            }
+        }
+    } else {
+        for (size_t i = 0; i < Config::num_transaction_ids; i++) {
+            if constexpr (Config::local_chip_noc_equals_downstream_noc) {
+                while (!ncrisc_noc_nonposted_write_with_transaction_id_flushed(Config::local_chip_noc, i));
+            } else {
+                while (!ncrisc_noc_nonposted_write_with_transaction_id_flushed(Config::downstream_noc, i));
+                while (!ncrisc_noc_nonposted_write_with_transaction_id_flushed(Config::local_chip_noc, i));
+            }
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// execute_chip_unicast_to_local_chip_impl (outlined)
+// -----------------------------------------------------------------------------
+//
+// Core implementation of unicast-to-local-chip dispatch, parameterized on the
+// per-caller LocalDeliveryDispatchConfig instead of reading global CT-arg
+// constants. `usage_recorder` is taken by reference so the caller binds it to
+// either upstream's `channel_trimming_usage_recorder` or a local no-op stub.
+//
+// The function body is a verbatim port of upstream's
+// `execute_chip_unicast_to_local_chip_impl`; only the constant references and
+// the NOC-pipeline flush call change.
+template <typename Config, typename UsageRecorder, typename TridStartsArray>
+__attribute__((optimize("jump-tables")))
+#ifndef FABRIC_2D
+FORCE_INLINE
+#endif
+    void
+    execute_chip_unicast_to_local_chip_impl_outlined(
+        tt_l1_ptr PACKET_HEADER_TYPE* const packet_start,
+        uint16_t payload_size_bytes,
+        tt::tt_fabric::NocSendType noc_send_type,
+        uint32_t transaction_id,
+        uint8_t rx_channel_id,
+        UsageRecorder& usage_recorder,
+        const TridStartsArray& rx_ch_trid_starts) {
+    const auto& header = *packet_start;
+    uint32_t payload_start_address = reinterpret_cast<size_t>(packet_start) + sizeof(PACKET_HEADER_TYPE);
+
+    constexpr bool update_counter = false;
+
+    usage_recorder.set_noc_send_type_used(rx_channel_id, noc_send_type);
+    if (noc_send_type > tt::tt_fabric::NocSendType::NOC_SEND_TYPE_LAST) {
+        __builtin_unreachable();
+    }
+    switch (noc_send_type) {
+        case tt::tt_fabric::NocSendType::NOC_UNICAST_WRITE: {
+            const auto dest_address = header.command_fields.unicast_write.noc_address;
+            noc_async_write_one_packet_with_trid<update_counter, false>(
+                payload_start_address,
+                dest_address,
+                payload_size_bytes,
+                transaction_id,
+                Config::local_chip_data_cmd_buf,
+                Config::local_chip_noc,
+                Config::forward_and_local_write_noc_vc);
+        } break;
+
+        case tt::tt_fabric::NocSendType::NOC_UNICAST_ATOMIC_INC: {
+            const uint64_t dest_address = header.command_fields.unicast_seminc.noc_address;
+            const auto increment = header.command_fields.unicast_seminc.val;
+            if (header.command_fields.unicast_seminc.flush) {
+                flush_write_to_noc_pipeline_outlined<Config>(rx_channel_id, rx_ch_trid_starts);
+            }
+            noc_semaphore_inc<true>(
+                dest_address,
+                increment,
+                Config::local_chip_noc,
+                Config::forward_and_local_write_noc_vc);
+
+        } break;
+
+        case tt::tt_fabric::NocSendType::NOC_UNICAST_INLINE_WRITE: {
+            const auto dest_address = header.command_fields.unicast_inline_write.noc_address;
+            const auto value = header.command_fields.unicast_inline_write.value;
+            noc_inline_dw_write<InlineWriteDst::DEFAULT, true>(
+                dest_address,
+                value,
+                0xF,
+                Config::local_chip_noc,
+                Config::forward_and_local_write_noc_vc);
+        } break;
+
+        case tt::tt_fabric::NocSendType::NOC_FUSED_UNICAST_ATOMIC_INC: {
+            const auto dest_address = header.command_fields.unicast_seminc_fused.noc_address;
+            noc_async_write_one_packet_with_trid<update_counter, false>(
+                payload_start_address,
+                dest_address,
+                payload_size_bytes,
+                transaction_id,
+                Config::local_chip_data_cmd_buf,
+                Config::local_chip_noc,
+                Config::forward_and_local_write_noc_vc);
+
+            const uint64_t semaphore_dest_address = header.command_fields.unicast_seminc_fused.semaphore_noc_address;
+            const auto increment = header.command_fields.unicast_seminc_fused.val;
+            if (header.command_fields.unicast_seminc_fused.flush) {
+                flush_write_to_noc_pipeline_outlined<Config>(rx_channel_id, rx_ch_trid_starts);
+            }
+            noc_semaphore_inc<true>(
+                semaphore_dest_address,
+                increment,
+                Config::local_chip_noc,
+                Config::forward_and_local_write_noc_vc);
+        } break;
+
+        case tt::tt_fabric::NocSendType::NOC_UNICAST_SCATTER_WRITE: {
+            using ChunkEncoding = tt::tt_fabric::NocScatterWriteChunkEncoding;
+            const auto& scatter = header.command_fields.unicast_scatter_write;
+            const uint8_t chunk_count = scatter.chunk_count;
+            uint8_t packet_encoding = scatter.chunk_encoding;
+
+            size_t offset = 0;
+            const uint8_t last_chunk_index = chunk_count - 1;
+
+            uint16_t chunk_size = scatter.chunk_size[0];
+            noc_async_write_one_packet_with_trid<update_counter, false>(
+                payload_start_address + offset,
+                scatter.noc_address[0],
+                chunk_size,
+                transaction_id,
+                Config::local_chip_data_cmd_buf,
+                Config::local_chip_noc);
+            offset += chunk_size;
+            shift_to_next_chunk_outlined(packet_encoding);
+
+            if (chunk_count > 2) {
+                chunk_size = scatter.chunk_size[1];
+                noc_async_write_one_packet_with_trid<update_counter, false>(
+                    payload_start_address + offset,
+                    scatter.noc_address[1],
+                    chunk_size,
+                    transaction_id,
+                    Config::local_chip_data_cmd_buf,
+                    Config::local_chip_noc);
+                offset += chunk_size;
+                shift_to_next_chunk_outlined(packet_encoding);
+
+                if (chunk_count == 4) [[likely]] {
+                    chunk_size = scatter.chunk_size[2];
+                    noc_async_write_one_packet_with_trid<update_counter, false>(
+                        payload_start_address + offset,
+                        scatter.noc_address[2],
+                        chunk_size,
+                        transaction_id,
+                        Config::local_chip_data_cmd_buf,
+                        Config::local_chip_noc);
+                    offset += chunk_size;
+                    shift_to_next_chunk_outlined(packet_encoding);
+                }
+            }
+
+            constexpr uint8_t CHUNK_ENCODING_MASK = 0b11;
+            const ChunkEncoding chunk_encoding = static_cast<ChunkEncoding>(packet_encoding & CHUNK_ENCODING_MASK);
+            const uint64_t final_destination_noc_address = scatter.noc_address[last_chunk_index];
+            if (chunk_encoding == ChunkEncoding::CHUNK_ENCODING_UNICAST_WRITE) {
+                const uint16_t final_chunk_size = static_cast<uint16_t>(payload_size_bytes - offset);
+                noc_async_write_one_packet_with_trid<update_counter, false>(
+                    payload_start_address + offset,
+                    final_destination_noc_address,
+                    final_chunk_size,
+                    transaction_id,
+                    Config::local_chip_data_cmd_buf,
+                    Config::local_chip_noc);
+            } else if (chunk_encoding != ChunkEncoding::CHUNK_ENCODING_NOP) {
+                if (chunk_encoding == ChunkEncoding::CHUNK_ENCODING_SEMINC_FLUSH) {
+                    flush_write_to_noc_pipeline_outlined<Config>(rx_channel_id, rx_ch_trid_starts);
+                }
+                noc_semaphore_inc<true>(
+                    final_destination_noc_address,
+                    scatter.chunk_size[last_chunk_index],
+                    Config::local_chip_noc,
+                    Config::forward_and_local_write_noc_vc);
+            } else {
+                ASSERT(false);
+            }
+        } break;
+
+        case tt::tt_fabric::NocSendType::NOC_MULTICAST_WRITE:
+        case tt::tt_fabric::NocSendType::NOC_MULTICAST_ATOMIC_INC:
+        default: {
+            ASSERT(false);
+        } break;
+    };
+}
+
+// Wrapper that resolves noc_send_type from the packet header via a packed 4B
+// load (payload_size_bytes + noc_send_type in one read) then delegates to
+// `execute_chip_unicast_to_local_chip_impl_outlined`.
+template <typename Config, typename UsageRecorder, typename TridStartsArray>
+__attribute__((optimize("jump-tables")))
+#ifndef FABRIC_2D
+FORCE_INLINE
+#endif
+    void
+    execute_chip_unicast_to_local_chip_outlined(
+        tt_l1_ptr PACKET_HEADER_TYPE* const packet_start,
+        uint16_t payload_size_bytes,
+        uint32_t transaction_id,
+        uint8_t rx_channel_id,
+        UsageRecorder& usage_recorder,
+        const TridStartsArray& rx_ch_trid_starts) {
+    auto packed = PACKET_HEADER_TYPE::PackedPayloadAndSendType::load(packet_start);
+    execute_chip_unicast_to_local_chip_impl_outlined<Config>(
+        packet_start,
+        payload_size_bytes,
+        packed.noc_send_type,
+        transaction_id,
+        rx_channel_id,
+        usage_recorder,
+        rx_ch_trid_starts);
+}
+
+// -----------------------------------------------------------------------------
+// NoOpUsageRecorder
+// -----------------------------------------------------------------------------
+//
+// Minimal stub for callers that do not enable channel-trimming usage capture
+// (e.g. the CRAQ-Fabric generated kernel). Models the same `set_noc_send_type_used`
+// API as upstream's `tt::tt_fabric::FabricDatapathUsageL1Ptr`.
+struct NoOpUsageRecorder {
+    FORCE_INLINE void set_noc_send_type_used(uint8_t /*rx_channel_id*/,
+                                             tt::tt_fabric::NocSendType /*noc_send_type*/) const {}
+};


### PR DESCRIPTION
## Context

The CRAQ-Fabric code-generation pipeline ([tt-fabric-internal](https://github.com/tenstorrent/tt-fabric-internal)) produces purpose-built erisc router kernels that must **not** transitively include `fabric_erisc_router_ct_args.hpp`. CT args for the generated kernel come from a separate builder contract and must not bleed through upstream header chains.

This PR adds the structural plumbing to make that possible without forking any upstream logic.

## Changes

### New: `fabric_local_delivery_dispatch.hpp`
Outlines `execute_chip_unicast_to_local_chip_impl` and packet-header helpers from `fabric_edm_packet_transmission.hpp` into a standalone, CT-arg-free header. The NOC id, command-buffer id, NOC VC, TRID range, deadlock-avoidance flag, and channel-trimming usage recorder are exposed as template parameters of `LocalDeliveryDispatchConfig<>` so each caller binds them from its own CT-arg layer.

`fabric_edm_packet_transmission.hpp` remains as a thin compatibility shim — upstream callers (`fabric_erisc_router.cpp`, `fabric_erisc_router_speedy_path.hpp`, etc.) are unaffected.

### New: `fabric_counter_based_credits.hpp`
Outlines counter-based credit widgets (previously embedded in `fabric_router_flow_control.hpp`) with constructor-arg credit addresses instead of CT-arg globals. `fabric_router_flow_control.hpp` retains back-compat shim subclasses.

### New: `craq_fabric_ct_args.hpp`
CRAQ-Fabric's own CT-arg constants (credit-region addresses, TXQ IDs, `multi_txq_enabled`) derived from builder allocator decisions, published under `tt::tt_fabric::craq`. Does **not** include `fabric_erisc_router_ct_args.hpp`.

### Modified: `connection_writer_adapter.hpp`
Added `get_downstream_noc_for_vc(vc_idx)` accessor to `StaticSizedChannelConnectionWriterAdapter`. External builder plugins use this to derive `DOWNSTREAM_NOC_X/Y` CT args directly from the connection graph populated by `connect_routers()`, replacing direction-based heuristics.

## Testing

These headers are exercised by the CRAQ-Fabric test suite running on 4-chip Blackhole hardware:
- `CraqLinearUnicastSmoke` ✅
- `CraqLinearAllToAllFlowControl` ×8 variants ✅  
- `CraqLinearBandwidthUnicast` (10K pkts × 4096B) ✅
- `CraqLinearBandwidthMcast` ✅

Backwards compatibility verified: all existing upstream fabric tests unmodified.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snijjar/craq-fabric-structural-decoupling)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snijjar/craq-fabric-structural-decoupling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snijjar/craq-fabric-structural-decoupling)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snijjar/craq-fabric-structural-decoupling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/craq-fabric-structural-decoupling)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/craq-fabric-structural-decoupling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snijjar/craq-fabric-structural-decoupling)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snijjar/craq-fabric-structural-decoupling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snijjar/craq-fabric-structural-decoupling)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snijjar/craq-fabric-structural-decoupling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snijjar/craq-fabric-structural-decoupling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snijjar/craq-fabric-structural-decoupling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snijjar/craq-fabric-structural-decoupling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snijjar/craq-fabric-structural-decoupling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snijjar/craq-fabric-structural-decoupling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snijjar/craq-fabric-structural-decoupling)