### PR TITLE
[Bug fix] Release the GIL during ttnn op nanobind

### DIFF
--- a/ttnn/cpp/ttnn-nanobind/bind_function.hpp
+++ b/ttnn/cpp/ttnn-nanobind/bind_function.hpp
@@ -61,7 +61,11 @@ auto make_method_wrapper(Ret (*func)(FuncArgs...)) {
 template <typename Wrapper, typename Class, typename Func, typename... Args>
 void add_call_overload(Class& cls, const overload_t<Func, Args...>& spec) {
     auto method = make_method_wrapper<Wrapper>(spec.func);
-    std::apply([&cls, &method](const Args&... args) { cls.def("__call__", method, args...); }, spec.args);
+    std::apply(
+        [&cls, &method](const Args&... args) {
+            cls.def("__call__", method, args..., nb::call_guard<nb::gil_scoped_release>());
+        },
+        spec.args);
 }
 
 }  // namespace detail

--- a/ttnn/cpp/ttnn-nanobind/operations/trace.cpp
+++ b/ttnn/cpp/ttnn-nanobind/operations/trace.cpp
@@ -36,7 +36,8 @@ void py_module(nb::module_& mod) {
         },
         nb::arg("mesh_device"),
         nb::kw_only(),
-        nb::arg("cq_id") = nb::none());
+        nb::arg("cq_id") = nb::none(),
+        nb::call_guard<nb::gil_scoped_release>());
 
     mod.def(
         "end_trace_capture",
@@ -46,7 +47,8 @@ void py_module(nb::module_& mod) {
         nb::arg("mesh_device"),
         nb::arg("trace_id"),
         nb::kw_only(),
-        nb::arg("cq_id") = nb::none());
+        nb::arg("cq_id") = nb::none(),
+        nb::call_guard<nb::gil_scoped_release>());
 
     mod.def(
         "execute_trace",
@@ -57,13 +59,15 @@ void py_module(nb::module_& mod) {
         nb::arg("trace_id"),
         nb::kw_only(),
         nb::arg("cq_id") = nb::none(),
-        nb::arg("blocking") = true);
+        nb::arg("blocking") = true,
+        nb::call_guard<nb::gil_scoped_release>());
 
     mod.def(
         "release_trace",
         [](MeshDevice* device, MeshTraceId trace_id) { ttnn::operations::trace::release_trace(device, trace_id); },
         nb::arg("mesh_device"),
-        nb::arg("trace_id"));
+        nb::arg("trace_id"),
+        nb::call_guard<nb::gil_scoped_release>());
 }
 
 } // namespace ttnn::operations::trace

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -738,6 +738,7 @@ void pytensor_module(nb::module_& mod) {
             "deallocate",
             [](Tensor& self, bool force) { self.deallocate(force); },
             nb::arg("force") = false,
+            nb::call_guard<nb::gil_scoped_release>(),
             R"doc(
                 Deallocates all data of a tensor. This either deletes all host data or deallocates tensor data from device memory.
             )doc")
@@ -751,6 +752,7 @@ void pytensor_module(nb::module_& mod) {
             nb::arg("mem_config").noconvert() = nb::none(),
             nb::arg("cq_id") = nb::none(),
             nb::keep_alive<0, 2>(),
+            nb::call_guard<nb::gil_scoped_release>(),
             R"doc(
             Move TT Tensor from host device to TT accelerator device.
 
@@ -827,6 +829,7 @@ void pytensor_module(nb::module_& mod) {
             },
             nb::arg("blocking") = true,
             nb::arg("cq_id") = nb::none(),
+            nb::call_guard<nb::gil_scoped_release>(),
             R"doc(
             Move TT Tensor from TT accelerator device to host device.
 
@@ -841,18 +844,23 @@ void pytensor_module(nb::module_& mod) {
                     self.logical_volume() == 1,
                     "tensor.item() requires tensor to have exactly one element, but got {} elements",
                     self.logical_volume());
-                switch (self.dtype()) {
-                    case DataType::FLOAT32: return nb::cast(self.to_vector<float>()[0]);
-                    case DataType::BFLOAT16: return nb::cast(static_cast<float>(self.to_vector<bfloat16>()[0]));
-                    case DataType::BFLOAT8_B:
-                    case DataType::BFLOAT4_B: return nb::cast(self.to_vector<float>()[0]);
-                    case DataType::INT32: return nb::cast(self.to_vector<int32_t>()[0]);
-                    case DataType::UINT32: return nb::cast(self.to_vector<uint32_t>()[0]);
-                    case DataType::UINT16: return nb::cast(self.to_vector<uint16_t>()[0]);
-                    case DataType::UINT8: return nb::cast(self.to_vector<uint8_t>()[0]);
-                    case DataType::INVALID: TT_THROW("Unsupported DataType");
-                }
-                TT_THROW("Unreachable");
+                auto dtype = self.dtype();
+                auto get_scalar = [&]() -> std::variant<float, int32_t, uint32_t, uint16_t, uint8_t> {
+                    nb::gil_scoped_release release;
+                    switch (dtype) {
+                        case DataType::FLOAT32: return self.to_vector<float>()[0];
+                        case DataType::BFLOAT16: return static_cast<float>(self.to_vector<bfloat16>()[0]);
+                        case DataType::BFLOAT8_B:
+                        case DataType::BFLOAT4_B: return self.to_vector<float>()[0];
+                        case DataType::INT32: return self.to_vector<int32_t>()[0];
+                        case DataType::UINT32: return self.to_vector<uint32_t>()[0];
+                        case DataType::UINT16: return self.to_vector<uint16_t>()[0];
+                        case DataType::UINT8: return self.to_vector<uint8_t>()[0];
+                        case DataType::INVALID: TT_THROW("Unsupported DataType");
+                    }
+                    TT_THROW("Unreachable");
+                };
+                return std::visit([](auto v) -> nb::object { return nb::cast(v); }, get_scalar());
             },
             // nb::rv_policy::copy,
             R"doc(
@@ -877,6 +885,7 @@ void pytensor_module(nb::module_& mod) {
             "to",
             [](const Tensor& self, Layout target_layout) { return ttnn::to_layout(self, target_layout); },
             nb::arg("target_layout").noconvert(),
+            nb::call_guard<nb::gil_scoped_release>(),
             R"doc(
             Convert TT Tensor to provided memory layout. Available layouts conversions are:
 
@@ -1236,7 +1245,10 @@ void pytensor_module(nb::module_& mod) {
             [](const Tensor& self) -> nb::ndarray<nb::pytorch> {
                 using namespace CMAKE_UNIQUE_NAMESPACE;
 
-                auto buffer = convert_to_row_major_host_buffer(self, /*padded_output=*/true);
+                auto buffer = [&] {
+                    nb::gil_scoped_release release;
+                    return convert_to_row_major_host_buffer(self, /*padded_output=*/true);
+                }();
                 return convert_tt_tensor_to_framework_tensor<nb::pytorch>(buffer);
             },
             nb::rv_policy::take_ownership,
@@ -1255,8 +1267,11 @@ void pytensor_module(nb::module_& mod) {
             "to_torch",
             [](const Tensor& self, const ttnn::distributed::MeshToTensor* mesh_composer) -> nb::ndarray<nb::pytorch> {
                 using namespace CMAKE_UNIQUE_NAMESPACE;
-                auto buffer = mesh_composer ? convert_to_row_major_host_buffer(self, *mesh_composer)
-                                            : convert_to_row_major_host_buffer(self, /*padded_output=*/false);
+                auto buffer = [&] {
+                    nb::gil_scoped_release release;
+                    return mesh_composer ? convert_to_row_major_host_buffer(self, *mesh_composer)
+                                         : convert_to_row_major_host_buffer(self, /*padded_output=*/false);
+                }();
                 return convert_tt_tensor_to_framework_tensor<nb::pytorch>(buffer);
             },
             nb::rv_policy::take_ownership,
@@ -1276,8 +1291,11 @@ void pytensor_module(nb::module_& mod) {
             [](const Tensor& self, const ttnn::distributed::MeshToTensor* mesh_composer) -> nb::ndarray<nb::numpy> {
                 using namespace CMAKE_UNIQUE_NAMESPACE;
 
-                auto buffer = mesh_composer ? convert_to_row_major_host_buffer(self, *mesh_composer)
-                                            : convert_to_row_major_host_buffer(self, /*padded_output=*/false);
+                auto buffer = [&] {
+                    nb::gil_scoped_release release;
+                    return mesh_composer ? convert_to_row_major_host_buffer(self, *mesh_composer)
+                                         : convert_to_row_major_host_buffer(self, /*padded_output=*/false);
+                }();
                 return convert_tt_tensor_to_framework_tensor<nb::numpy>(buffer);
             },
             nb::rv_policy::take_ownership,
@@ -1487,6 +1505,7 @@ void pytensor_module(nb::module_& mod) {
             [](Tensor& self, int N, int C, int H, int W) {
                 return ttnn::reshape(self, ttnn::SmallVector<int>{N, C, H, W});
             },
+            nb::call_guard<nb::gil_scoped_release>(),
             R"doc(
                 Reshapes TT tensor
 
@@ -1497,6 +1516,7 @@ void pytensor_module(nb::module_& mod) {
         .def(
             "reshape",
             [](Tensor& self, const ttnn::Shape& shape) -> Tensor { return ttnn::reshape(self, shape); },
+            nb::call_guard<nb::gil_scoped_release>(),
             R"doc(
                 Reshapes TT tensor
 
@@ -1507,6 +1527,7 @@ void pytensor_module(nb::module_& mod) {
         .def(
             "reshape",
             [](Tensor& self, const ttnn::SmallVector<int32_t>& shape) -> Tensor { return ttnn::reshape(self, shape); },
+            nb::call_guard<nb::gil_scoped_release>(),
             R"doc(
                 Reshapes TT tensor
 

--- a/ttnn/cpp/ttnn/operations/creation/creation_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/creation/creation_nanobind.cpp
@@ -8,11 +8,13 @@
 #include <functional>
 #include <optional>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include <fmt/format.h>
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/variant.h>
 #include <nanobind/stl/vector.h>
 
 #include "ttnn-nanobind/bfloat16_type_caster.hpp"  // NOLINT - for nanobind bfloat16 binding support.
@@ -495,38 +497,36 @@ void bind_empty_like(nb::module_& mod) {
         nb::arg("memory_config") = nb::none());
 }
 
+// nanobind variant caster converts the Python sequence to the matching C++
+// vector at the wrapper boundary (GIL held), so the body runs with the GIL
+// released (call_guard applied by bind_function) and uses only C++ values.
+using BufferVariant = std::variant<
+    std::vector<uint8_t>,
+    std::vector<uint16_t>,
+    std::vector<int32_t>,
+    std::vector<uint32_t>,
+    std::vector<float>,
+    std::vector<::bfloat16>>;
+
 Tensor from_buffer_impl(
-    const nb::object& buffer,
+    BufferVariant buffer,
     const Shape& shape,
     const DataType dtype,
     MeshDevice* device,
     const std::optional<Layout>& layout,
     const std::optional<MemoryConfig>& memory_config) {
     switch (dtype) {
-        case DataType::UINT8: {
-            auto cpp_buffer = nb::cast<std::vector<uint8_t>>(buffer);
-            return ttnn::from_buffer(std::move(cpp_buffer), shape, dtype, device, layout, memory_config);
-        }
-        case DataType::UINT16: {
-            auto cpp_buffer = nb::cast<std::vector<uint16_t>>(buffer);
-            return ttnn::from_buffer(std::move(cpp_buffer), shape, dtype, device, layout, memory_config);
-        }
-        case DataType::INT32: {
-            auto cpp_buffer = nb::cast<std::vector<int32_t>>(buffer);
-            return ttnn::from_buffer(std::move(cpp_buffer), shape, dtype, device, layout, memory_config);
-        }
-        case DataType::UINT32: {
-            auto cpp_buffer = nb::cast<std::vector<uint32_t>>(buffer);
-            return ttnn::from_buffer(std::move(cpp_buffer), shape, dtype, device, layout, memory_config);
-        }
-        case DataType::FLOAT32: {
-            auto cpp_buffer = nb::cast<std::vector<float>>(buffer);
-            return ttnn::from_buffer(std::move(cpp_buffer), shape, dtype, device, layout, memory_config);
-        }
-        case DataType::BFLOAT16: {
-            auto cpp_buffer = nb::cast<std::vector<::bfloat16>>(buffer);
-            return ttnn::from_buffer(std::move(cpp_buffer), shape, dtype, device, layout, memory_config);
-        }
+        case DataType::UINT8:
+        case DataType::UINT16:
+        case DataType::INT32:
+        case DataType::UINT32:
+        case DataType::FLOAT32:
+        case DataType::BFLOAT16:
+            return std::visit(
+                [&](auto&& cpp_buffer) {
+                    return ttnn::from_buffer(std::move(cpp_buffer), shape, dtype, device, layout, memory_config);
+                },
+                std::move(buffer));
         case DataType::BFLOAT8_B:
         case DataType::BFLOAT4_B:
         case DataType::INVALID: {

--- a/ttnn/cpp/ttnn/operations/creation/creation_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/creation/creation_nanobind.cpp
@@ -8,13 +8,11 @@
 #include <functional>
 #include <optional>
 #include <string>
-#include <variant>
 #include <vector>
 
 #include <fmt/format.h>
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
-#include <nanobind/stl/variant.h>
 #include <nanobind/stl/vector.h>
 
 #include "ttnn-nanobind/bfloat16_type_caster.hpp"  // NOLINT - for nanobind bfloat16 binding support.
@@ -497,36 +495,40 @@ void bind_empty_like(nb::module_& mod) {
         nb::arg("memory_config") = nb::none());
 }
 
-// nanobind variant caster converts the Python sequence to the matching C++
-// vector at the wrapper boundary (GIL held), so the body runs with the GIL
-// released (call_guard applied by bind_function) and uses only C++ values.
-using BufferVariant = std::variant<
-    std::vector<uint8_t>,
-    std::vector<uint16_t>,
-    std::vector<int32_t>,
-    std::vector<uint32_t>,
-    std::vector<float>,
-    std::vector<::bfloat16>>;
-
 Tensor from_buffer_impl(
-    BufferVariant buffer,
+    const nb::object& buffer,
     const Shape& shape,
     const DataType dtype,
     MeshDevice* device,
     const std::optional<Layout>& layout,
     const std::optional<MemoryConfig>& memory_config) {
+    // bind_function releases the GIL across the C++ body; nb::cast requires it, so re-acquire GIL.
+    nb::gil_scoped_acquire acquire;
     switch (dtype) {
-        case DataType::UINT8:
-        case DataType::UINT16:
-        case DataType::INT32:
-        case DataType::UINT32:
-        case DataType::FLOAT32:
-        case DataType::BFLOAT16:
-            return std::visit(
-                [&](auto&& cpp_buffer) {
-                    return ttnn::from_buffer(std::move(cpp_buffer), shape, dtype, device, layout, memory_config);
-                },
-                std::move(buffer));
+        case DataType::UINT8: {
+            auto cpp_buffer = nb::cast<std::vector<uint8_t>>(buffer);
+            return ttnn::from_buffer(std::move(cpp_buffer), shape, dtype, device, layout, memory_config);
+        }
+        case DataType::UINT16: {
+            auto cpp_buffer = nb::cast<std::vector<uint16_t>>(buffer);
+            return ttnn::from_buffer(std::move(cpp_buffer), shape, dtype, device, layout, memory_config);
+        }
+        case DataType::INT32: {
+            auto cpp_buffer = nb::cast<std::vector<int32_t>>(buffer);
+            return ttnn::from_buffer(std::move(cpp_buffer), shape, dtype, device, layout, memory_config);
+        }
+        case DataType::UINT32: {
+            auto cpp_buffer = nb::cast<std::vector<uint32_t>>(buffer);
+            return ttnn::from_buffer(std::move(cpp_buffer), shape, dtype, device, layout, memory_config);
+        }
+        case DataType::FLOAT32: {
+            auto cpp_buffer = nb::cast<std::vector<float>>(buffer);
+            return ttnn::from_buffer(std::move(cpp_buffer), shape, dtype, device, layout, memory_config);
+        }
+        case DataType::BFLOAT16: {
+            auto cpp_buffer = nb::cast<std::vector<::bfloat16>>(buffer);
+            return ttnn::from_buffer(std::move(cpp_buffer), shape, dtype, device, layout, memory_config);
+        }
         case DataType::BFLOAT8_B:
         case DataType::BFLOAT4_B:
         case DataType::INVALID: {

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze_nanobind.cpp
@@ -4,7 +4,12 @@
 
 #include "squeeze_nanobind.hpp"
 
+#include <optional>
+#include <variant>
+
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/variant.h>
 
 #include "ttnn-nanobind/bind_function.hpp"
 #include "ttnn-nanobind/small_vector_caster.hpp"
@@ -13,18 +18,15 @@
 namespace ttnn::operations::data_movement {
 
 namespace {
-ttnn::Tensor squeeze_wrapper(const ttnn::Tensor& input_tensor, const nb::object& dim) {
-    if (dim.is_none()) {  // None
+// nanobind variant/optional casters perform the Python -> C++ conversion at
+// the wrapper boundary (GIL held), so the body runs with the GIL released
+// (call_guard applied by bind_function).
+ttnn::Tensor squeeze_wrapper(
+    const ttnn::Tensor& input_tensor, std::optional<std::variant<int, ttnn::SmallVector<int>>> dim) {
+    if (!dim.has_value()) {  // None
         return ttnn::squeeze(input_tensor);
     }
-    if (nb::isinstance<nb::int_>(dim)) {  // int
-        return ttnn::squeeze(input_tensor, nb::cast<int>(dim));
-    }
-    if (nb::isinstance<nb::list>(dim)) {  // List[int]
-        auto dims = nb::cast<ttnn::SmallVector<int>>(dim);
-        return ttnn::squeeze(input_tensor, dims);
-    }
-    throw std::invalid_argument("dim must be an int, a list of ints, or None");
+    return std::visit([&](const auto& d) { return ttnn::squeeze(input_tensor, d); }, *dim);
 }
 }  // namespace
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_nanobind.cpp
@@ -21,8 +21,11 @@
 
 namespace ttnn::operations::pool {
 
-// Helper function for max_pool2d nanobind that handles the return type conversion
-static nb::object max_pool2d_nanobind_wrapper(
+// Helper function for max_pool2d nanobind that handles the return type conversion.
+// Returns a std::variant whose nanobind caster does the Python conversion at the
+// wrapper boundary (GIL held); the body runs with the GIL released (call_guard
+// applied by bind_function) and returns only C++ values.
+static std::variant<ttnn::Tensor, std::vector<ttnn::Tensor>> max_pool2d_nanobind_wrapper(
     const ttnn::Tensor& input_tensor,
     uint32_t batch_size,
     uint32_t input_h,
@@ -63,11 +66,10 @@ static nb::object max_pool2d_nanobind_wrapper(
         output_layout,
         config_tensor_in_dram);
 
-    // Return single tensor or tuple based on vector size
     if (result.size() == 1) {
-        return nb::cast(std::move(result[0]));
+        return std::move(result[0]);
     }
-    return nb::cast(std::move(result));
+    return std::move(result);
 }
 
 void bind_max_pool2d_operation(nb::module_& mod) {

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
@@ -82,6 +82,11 @@ Tensor generic_reduction_with_deprecated_correction(
     std::optional<bool> correction,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     if (correction.has_value()) {
+        // Re-acquire the GIL: this function is registered via bind_function<>(),
+        // which applies nb::call_guard<nb::gil_scoped_release>(), so the GIL is
+        // released by default. PyErr_WarnEx / PyExc_DeprecationWarning are Python
+        // C API and require the GIL.
+        nb::gil_scoped_acquire acquire;
         PyErr_WarnEx(
             PyExc_DeprecationWarning,
             "The 'correction' parameter is deprecated and will be removed in a future release.",

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -176,12 +176,15 @@ ttnn::Tensor flash_mla_prefill_wrapper_input_tensor(
 }
 
 // Dispatch: chunk_start_idx_tensor present → flexible (runtime offset); else legacy (chunk_start_idx int).
+// nanobind optional caster converts Python None|int at the wrapper boundary
+// (GIL held); the body runs with the GIL released (call_guard applied by
+// bind_function) and uses only C++ values.
 ttnn::Tensor chunked_scaled_dot_product_attention_wrapper(
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
     const ttnn::Tensor& input_tensor_v,
     const ttnn::Tensor& page_table_tensor,
-    const nb::object& chunk_start_idx_arg,
+    std::optional<int64_t> chunk_start_idx_arg,
     std::optional<ttnn::Tensor> chunk_start_idx_tensor_opt,
     std::optional<float> scale,
     const std::optional<MemoryConfig>& memory_config,
@@ -199,18 +202,17 @@ ttnn::Tensor chunked_scaled_dot_product_attention_wrapper(
             program_config,
             compute_kernel_config);
     }
-    if (chunk_start_idx_arg.is_none()) {
+    if (!chunk_start_idx_arg.has_value()) {
         throw std::runtime_error(
             "chunk_start_idx (int) is required for legacy chunked SDPA. For flexible path use "
             "chunk_start_idx_tensor=...");
     }
-    int64_t chunk_start_idx = nb::cast<int64_t>(chunk_start_idx_arg);
     return ttnn::transformer::chunked_scaled_dot_product_attention(
         input_tensor_q,
         input_tensor_k,
         input_tensor_v,
         page_table_tensor,
-        chunk_start_idx,
+        *chunk_start_idx_arg,
         scale,
         memory_config,
         program_config,


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Fixes #43691. ttnn nanobind op bindings currently hold the Python GIL across the entire C++ body, so any other Python thread in the same process is blocked until the op returns. See the linked issue for the minimal repro and the before/after measurement of GIL contention on a single matmul. 
This PR adds `nb::call_guard<nb::gil_scoped_release>()` to op binding sites so the GIL is released across the C++ call.

### Changes
- **Common op binding helper**: `ttnn/cpp/ttnn-nanobind/bind_function.hpp`. Adding the call guard once here covers every op registered through `bind_registered_operation()`.
- **`Tensor` methods**: `ttnn/cpp/ttnn-nanobind/pytensor.cpp`. Methods like `deallocate`, `cpu`, `to`, and `reshape` are registered directly via `cls.def(...)` rather than through `bind_registered_operation()`, so the helper-level call guard does not reach them; each `def` site has `nb::call_guard<nb::gil_scoped_release>()` added individually. For `item`, `to_torch`, `to_numpy`, the lambda body mixes the D2H copy (e.g. `convert_to_row_major_host_buffer`, `to_vector<...>`) with Python C API calls (e.g. `nb::cast`, `convert_tt_tensor_to_framework_tensor`) that require the GIL. A whole-lambda call guard would crash on those Python C API calls, so only the D2H copy section is wrapped in an inner `nb::gil_scoped_release` scope; the Python C API portion runs with the GIL still held.
- **Op bindings with custom dispatch lambdas**: `squeeze_nanobind.cpp`, `generic_pools_nanobind.cpp`, `sdpa_nanobind.cpp`. The lambda bodies previously contained `nb::cast` / `nb::isinstance` calls, which require the GIL. Instead of leaving those Python C API calls inside the body (where the GIL is now released by the call guard), the dispatch is moved to the function signature via `std::variant` / `std::optional`, so nanobind's type caster performs the Python-to-C++ conversion at the wrapper boundary while the GIL is still held. The body then runs on plain C++ values and is safe under the released GIL.
- **Trace**: `ttnn/cpp/ttnn-nanobind/operations/trace.cpp`. Same pattern as the others.
- **Re-acquire the GIL where the Python C API is needed**:
    - `ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp`: `generic_reduction_with_deprecated_correction()` is registered via `bind_function`, which releases the GIL across the C++ body. Its body calls `PyErr_WarnEx` (Python C API for the deprecation warning), so this patch wraps that call in `nb::gil_scoped_acquire` to restore the GIL for that section only.
    - `ttnn/cpp/ttnn/operations/creation/creation_nanobind.cpp`: `from_buffer_impl()` dispatches on the `dtype` argument and uses `nb::cast<std::vector<T>>(buffer)` per case to convert the Python sequence to a C++ vector of the exact target type. Since `nb::cast` is Python C API, the function re-acquires the GIL with `nb::gil_scoped_acquire` at entry.

### Notes for reviewers
- **Coverage of binding sites**: `bind_function.hpp` covers most ops; the rest are hand-written dispatch lambdas that needed the call guard added individually. Please flag any binding site that may have been missed.
- **`pytensor.cpp` partial wrapping**: `item`, `to_torch`, `to_numpy` wrap only the D2H copy section, not the whole lambda, because the rest of the body uses the Python C API. Please confirm the wrapped scope is correct.
- **Refactor safety**: in `squeeze_nanobind.cpp`, `generic_pools_nanobind.cpp`, `sdpa_nanobind.cpp`, dispatch was moved from runtime branching (`nb::cast` / `nb::isinstance`) into the signature via `std::variant` / `std::optional`. Behavior should be unchanged, but reviewers familiar with each op should sanity-check that the `std::variant` / `std::optional` casters resolve each input to the intended type.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=moreh/gil-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:moreh/gil-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=moreh/gil-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:moreh/gil-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=moreh/gil-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:moreh/gil-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=moreh/gil-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:moreh/gil-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=moreh/gil-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:moreh/gil-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=moreh/gil-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:moreh/gil-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=moreh/gil-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:moreh/gil-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=moreh/gil-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:moreh/gil-patch)