### PR TITLE
ds_prefill(combine potential hang fix)

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -370,9 +370,9 @@ void kernel_main() {
                 // row directly to output DRAM, then set c_9[0] = batch_count as the signal.
                 uint32_t metadata_unicast_bytes = batch_count * aligned_dispatched_metadata_page_size;
                 noc_async_write(metadata_base, idle_metadata_noc_addrs[current_idle_core], metadata_unicast_bytes);
-                noc_async_write_barrier();
                 noc_inline_dw_write(idle_metadata_noc_addrs[current_idle_core], batch_count);
             }
+            noc_async_write_barrier();
 
             // Signal the idle core that the metadata batch is ready in its c_9.
             noc_semaphore_inc(idle_start_noc_addrs[current_idle_core], 1);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -370,6 +370,7 @@ void kernel_main() {
                 // row directly to output DRAM, then set c_9[0] = batch_count as the signal.
                 uint32_t metadata_unicast_bytes = batch_count * aligned_dispatched_metadata_page_size;
                 noc_async_write(metadata_base, idle_metadata_noc_addrs[current_idle_core], metadata_unicast_bytes);
+                noc_async_write_barrier();
                 noc_inline_dw_write(idle_metadata_noc_addrs[current_idle_core], batch_count);
             }
             noc_async_write_barrier();


### PR DESCRIPTION
## Summary
- **combine/reader_combine.cpp**: add `noc_async_write_barrier()` so the `noc_inline_dw_write() `write lands before the atomic inc wakes the idle core.

### DeepSeek Prefill CI
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=pmilojevic/combine-flaky-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:pmilojevic/combine-flaky-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pmilojevic/combine-flaky-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pmilojevic/combine-flaky-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=pmilojevic/combine-flaky-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:pmilojevic/combine-flaky-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pmilojevic/combine-flaky-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pmilojevic/combine-flaky-fix)