### PR TITLE
[fuser] pack relu

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/packer.py
@@ -11,6 +11,8 @@ from fuser.fused_loop import FusedLoop
 from fuser.fused_operation import FusedOperation
 from fuser.fused_packer import Packer as BasePacker
 from fuser.fuser_config import GlobalConfig
+from helpers.golden_generators import PackGolden
+from helpers.llk_params import PackerReluType
 
 
 class Packer(BasePacker):
@@ -29,6 +31,12 @@ class Packer(BasePacker):
         operation: FusedOperation,
         config: GlobalConfig,
     ) -> torch.Tensor:
+        if operation.pack_relu != PackerReluType.NoRelu:
+            intermediate_format = operation.output.data_format
+            relu_config = PackGolden.generate_relu_config(
+                operation.pack_relu, operation.relu_threshold, intermediate_format
+            )
+            tensor = PackGolden.apply_relu(tensor, relu_config, intermediate_format)
         return tensor
 
     def init(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/packer.py
@@ -32,7 +32,7 @@ class Packer(BasePacker):
         config: GlobalConfig,
     ) -> torch.Tensor:
         if operation.pack_relu != PackerReluType.NoRelu:
-            intermediate_format = operation.output.data_format
+            intermediate_format = config.sentinel.golden_format.pack_src
             relu_config = PackGolden.generate_relu_config(
                 operation.pack_relu, operation.relu_threshold, intermediate_format
             )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
@@ -18,6 +18,7 @@ from helpers.llk_params import (
     EnforceFP32Accumulation,
     MathFidelity,
     MathOperation,
+    PackerReluType,
     ReduceDimension,
     ReducePool,
     Tilize,
@@ -435,6 +436,8 @@ class OperationSchema(BaseModel):
     packer: PackerEnum = PackerEnum.Packer
     dest_sync: Optional[DestSync] = None
     block_size: Annotated[List[int], Field(min_length=2, max_length=2)] = [32, 32]
+    pack_relu: PackerReluType = PackerReluType.NoRelu
+    relu_threshold: float = 0.0
     bh_tilize: Optional[Tilize] = None
 
     @field_validator("packer", mode="before")
@@ -494,6 +497,10 @@ class OperationSchema(BaseModel):
             kwargs["dest_sync"] = self.dest_sync
         if self.block_size:
             kwargs["block_size"] = self.block_size
+        if self.pack_relu:
+            kwargs["pack_relu"] = self.pack_relu
+        if self.relu_threshold:
+            kwargs["relu_threshold"] = self.relu_threshold
         if self.bh_tilize:
             kwargs["bh_tilize"] = self.bh_tilize
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
@@ -307,11 +307,13 @@ class ComputePipeline:
         return code
 
     @staticmethod
-    def _pack_relu_config(operation: "FusedOperation"):
+    def _pack_relu_config(config: "GlobalConfig", operation: "FusedOperation"):
         from helpers.golden_generators import PackGolden
 
+        pack_src_format = config.sentinel._pack_format.pack_src
+
         relu_config = PackGolden.generate_relu_config(
-            operation.pack_relu, operation.relu_threshold, operation.output.data_format
+            operation.pack_relu, operation.relu_threshold, pack_src_format
         )
         return f"_llk_pack_relu_config_({relu_config});\n"
 
@@ -325,7 +327,7 @@ class ComputePipeline:
         code += config.sentinel.hw_configure_pack(config, operation)
         code += self._pack_reduce_mask_config()
         code += self.packer().init(operation, config, None, None)
-        code += self._pack_relu_config(operation)
+        code += self._pack_relu_config(config, operation)
 
         if config.profiler_enabled:
             code += "PROFILER_SYNC();\n"
@@ -372,6 +374,7 @@ class ComputePipeline:
         tensor_b = torch.zeros(operation.math.operations[0].src_b.dimensions)
         tensor_dst = torch.zeros(operation.max_output_dimensions)
         for op in self.operations:
+            config.sentinel.configure_golden(config, operation, op)
             if op.src_a is not None:
                 input_tensor_a = (
                     op.src_a.raw_data

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
@@ -306,6 +306,15 @@ class ComputePipeline:
 
         return code
 
+    @staticmethod
+    def _pack_relu_config(operation: "FusedOperation"):
+        from helpers.golden_generators import PackGolden
+
+        relu_config = PackGolden.generate_relu_config(
+            operation.pack_relu, operation.relu_threshold, operation.output.data_format
+        )
+        return f"_llk_pack_relu_config_({relu_config});\n"
+
     def pack_body(self, operation: "FusedOperation", config: "GlobalConfig") -> str:
         code = self._pack_constants(operation, config)
 
@@ -316,6 +325,7 @@ class ComputePipeline:
         code += config.sentinel.hw_configure_pack(config, operation)
         code += self._pack_reduce_mask_config()
         code += self.packer().init(operation, config, None, None)
+        code += self._pack_relu_config(operation)
 
         if config.profiler_enabled:
             code += "PROFILER_SYNC();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operation.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operation.py
@@ -9,6 +9,7 @@ import torch
 from helpers.llk_params import (
     DestSync,
     GoldenType,
+    PackerReluType,
     StochasticRounding,
     Tilize,
 )
@@ -29,6 +30,8 @@ class FusedOperation:
     tiny_tiles: bool = False
     dest_sync: DestSync = DestSync.Half
     block_size: Tuple[int, int] = (32, 32)
+    pack_relu: PackerReluType = PackerReluType.NoRelu
+    relu_threshold: float = 0.0
     bh_tilize: Tilize = Tilize.No
 
     def __post_init__(self):
@@ -54,7 +57,7 @@ class FusedOperation:
         )
         l1_golden_tensor = self.math.packer().golden(l1_golden_tensor, self, config)
 
-        self.output.l1_golden = l1_golden_tensor.flatten()
+        self.output.l1_golden = l1_golden_tensor
 
         # calculate master golden
         master_golden_tensor = self.math.golden(
@@ -64,7 +67,7 @@ class FusedOperation:
             master_golden_tensor, self, config
         )
 
-        self.output._master_golden = master_golden_tensor.flatten()
+        self.output._master_golden = master_golden_tensor
 
         return master_golden_tensor
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
@@ -28,6 +28,7 @@ class FuserSentinel:
     _unpack_format: Optional[FormatConfig] = field(default=None, repr=False)
     _math_format: Optional[FormatConfig] = field(default=None, repr=False)
     _pack_format: Optional[FormatConfig] = field(default=None, repr=False)
+    golden_format: Optional[FormatConfig] = field(default=None, repr=False)
 
     @staticmethod
     def _find_format_node(
@@ -399,3 +400,34 @@ class FuserSentinel:
             f"    {self._fmt(fmt.pack_src)}, {self._fmt(fmt.pack_dst)}, {pack_size}, {face_r_dim}, {num_faces}\n"
             f");\n"
         )
+
+    def configure_golden(
+        self,
+        config: "GlobalConfig",
+        operation: "FusedOperation",
+        compute_node: "ComputeNode" = None,
+    ):
+        """Compute and store the FormatConfig for golden generation.
+
+        Called per compute node during golden computation. When called without
+        a compute_node (at operation start), initializes from the first format
+        node or from the output format. When called with a compute_node,
+        recomputes only if the node's formats differ from the current state.
+        """
+        if compute_node is None:
+            fmt_node = self._find_format_node(operation)
+            if fmt_node is not None:
+                self.golden_format = self._compute_format_config(
+                    config, operation, fmt_node
+                )
+            else:
+                self.golden_format = self._compute_format_config_from_output(
+                    config, operation
+                )
+            return
+
+        if compute_node.src_a is None and compute_node.src_b is None:
+            return
+
+        new_fmt = self._compute_format_config(config, operation, compute_node)
+        self.golden_format = new_fmt

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/packer.py
@@ -11,6 +11,8 @@ from fuser.fused_math import ComputeNode
 from fuser.fused_operation import FusedOperation
 from fuser.fused_packer import Packer as BasePacker
 from fuser.fuser_config import GlobalConfig
+from helpers.golden_generators import PackGolden
+from helpers.llk_params import DataFormat, PackerReluType
 
 
 class Packer(BasePacker):
@@ -28,6 +30,12 @@ class Packer(BasePacker):
         operation: FusedOperation,
         config: GlobalConfig,
     ) -> torch.Tensor:
+        if operation.pack_relu != PackerReluType.NoRelu:
+            intermediate_format = DataFormat.Float16_b
+            relu_config = PackGolden.generate_relu_config(
+                operation.pack_relu, operation.relu_threshold, intermediate_format
+            )
+            tensor = PackGolden.apply_relu(tensor, relu_config, intermediate_format)
         return tensor
 
     def init(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/packer.py
@@ -12,7 +12,7 @@ from fuser.fused_operation import FusedOperation
 from fuser.fused_packer import Packer as BasePacker
 from fuser.fuser_config import GlobalConfig
 from helpers.golden_generators import PackGolden
-from helpers.llk_params import DataFormat, PackerReluType
+from helpers.llk_params import PackerReluType
 
 
 class Packer(BasePacker):
@@ -31,7 +31,7 @@ class Packer(BasePacker):
         config: GlobalConfig,
     ) -> torch.Tensor:
         if operation.pack_relu != PackerReluType.NoRelu:
-            intermediate_format = DataFormat.Float16_b
+            intermediate_format = config.sentinel.golden_format.pack_src
             relu_config = PackGolden.generate_relu_config(
                 operation.pack_relu, operation.relu_threshold, intermediate_format
             )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/parser.py
@@ -18,6 +18,7 @@ from helpers.llk_params import (
     EnforceFP32Accumulation,
     MathFidelity,
     MathOperation,
+    PackerReluType,
     ReduceDimension,
     ReducePool,
     Transpose,
@@ -434,6 +435,8 @@ class OperationSchema(BaseModel):
     packer: PackerEnum = PackerEnum.Packer
     dest_sync: Optional[DestSync] = None
     block_size: Annotated[List[int], Field(min_length=2, max_length=2)] = [32, 32]
+    pack_relu: PackerReluType = PackerReluType.NoRelu
+    relu_threshold: float = 0.0
 
     @field_validator("packer", mode="before")
     @classmethod
@@ -471,6 +474,10 @@ class OperationSchema(BaseModel):
             kwargs["dest_sync"] = self.dest_sync
         if self.block_size:
             kwargs["block_size"] = self.block_size
+        if self.pack_relu:
+            kwargs["pack_relu"] = self.pack_relu
+        if self.relu_threshold:
+            kwargs["relu_threshold"] = self.relu_threshold
 
         return FusedOperation(
             math=ComputePipeline(math_ops, self.packer.to_runtime()),

--- a/tt_metal/tt-llk/tests/python_tests/fuser_config/pack_relu.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_config/pack_relu.yaml
@@ -36,7 +36,6 @@ operations:
     packer: "Packer"
     pack_relu: "NO_RELU"
     block_size: [32, 32]
-
   # Stage 2: ZERO_RELU — Elwsub(A, B).
   # A - B ∈ [-1.1, 1.1], mix of pos/neg. ZERO_RELU zeros negatives.
   - output: "out_zero_relu"
@@ -50,7 +49,6 @@ operations:
     packer: "Packer"
     pack_relu: "ZERO_RELU"
     block_size: [32, 32]
-
   # Stage 3: MIN_THRESHOLD_RELU — Datacopy A.
   # A ∈ [0.0, 1.1]. Values ≤ 0.5 zeroed, values > 0.5 kept.
   - output: "out_min_thresh"
@@ -65,7 +63,6 @@ operations:
     pack_relu: "MIN_THRESHOLD_RELU"
     relu_threshold: 0.5
     block_size: [32, 32]
-
   # Stage 4: MAX_THRESHOLD_RELU — Elwmul(A, B).
   # A * B ∈ [0, 1.21]. Clamped to [0, 0.5] by max threshold=0.5.
   - output: "out_max_thresh"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_config/pack_relu.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_config/pack_relu.yaml
@@ -51,7 +51,7 @@ operations:
     pack_relu: "ZERO_RELU"
     block_size: [32, 32]
 
-  # Stage 3: MIN_THRESHOLD_RELU — Elwsub(A, B).
+  # Stage 3: MIN_THRESHOLD_RELU — Datacopy A.
   # A ∈ [0.0, 1.1]. Values ≤ 0.5 zeroed, values > 0.5 kept.
   - output: "out_min_thresh"
     math:

--- a/tt_metal/tt-llk/tests/python_tests/fuser_config/pack_relu.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_config/pack_relu.yaml
@@ -1,0 +1,82 @@
+operands:
+  - name: "input_A"
+    dims: [32, 32]
+    format: "Float16_b"
+  - name: "input_B"
+    dims: [32, 32]
+    format: "Float16_b"
+  - name: "out_no_relu"
+    dims: [32, 32]
+    format: "Float16_b"
+  - name: "out_zero_relu"
+    dims: [32, 32]
+    format: "Float16_b"
+  - name: "out_min_thresh"
+    dims: [32, 32]
+    format: "Float16_b"
+  - name: "out_max_thresh"
+    dims: [32, 32]
+    format: "Float16_b"
+
+operations:
+  # Stage 1: NO_RELU — Datacopy A then negate.
+  # Input [0, 1.1] → Neg → [-1.1, 0]. No relu, negatives preserved.
+  - output: "out_no_relu"
+    math:
+      - type: "Fpu"
+        src_a: "input_A"
+        src_b: "input_B"
+        operation: "Datacopy"
+        unpacker: "UnpackerA"
+        math_fidelity: "LoFi"
+      - type: "UnarySfpu"
+        operation: "Neg"
+        approximation_mode: false
+        iterations: 32
+    packer: "Packer"
+    pack_relu: "NO_RELU"
+    block_size: [32, 32]
+
+  # Stage 2: ZERO_RELU — Elwsub(A, B).
+  # A - B ∈ [-1.1, 1.1], mix of pos/neg. ZERO_RELU zeros negatives.
+  - output: "out_zero_relu"
+    math:
+      - type: "Fpu"
+        src_a: "input_A"
+        src_b: "input_B"
+        operation: "Elwsub"
+        unpacker: "UnpackerAB"
+        math_fidelity: "LoFi"
+    packer: "Packer"
+    pack_relu: "ZERO_RELU"
+    block_size: [32, 32]
+
+  # Stage 3: MIN_THRESHOLD_RELU — Elwsub(A, B).
+  # A ∈ [0.0, 1.1]. Values ≤ 0.5 zeroed, values > 0.5 kept.
+  - output: "out_min_thresh"
+    math:
+      - type: "Fpu"
+        src_a: "input_A"
+        src_b: "input_B"
+        operation: "Datacopy"
+        unpacker: "UnpackerA"
+        math_fidelity: "LoFi"
+    packer: "Packer"
+    pack_relu: "MIN_THRESHOLD_RELU"
+    relu_threshold: 0.5
+    block_size: [32, 32]
+
+  # Stage 4: MAX_THRESHOLD_RELU — Elwmul(A, B).
+  # A * B ∈ [0, 1.21]. Clamped to [0, 0.5] by max threshold=0.5.
+  - output: "out_max_thresh"
+    math:
+      - type: "Fpu"
+        src_a: "input_A"
+        src_b: "input_B"
+        operation: "Elwmul"
+        unpacker: "UnpackerAB"
+        math_fidelity: "LoFi"
+    packer: "Packer"
+    pack_relu: "MAX_THRESHOLD_RELU"
+    relu_threshold: 0.5
+    block_size: [32, 32]

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -1464,7 +1464,7 @@ class PackGolden:
         """
         Get the ReLU type from the configuration.
         """
-        relu_type = PackerReluType(relu_config & 0x3)
+        relu_type = PackerReluType.from_bits(relu_config & 0x3)
         return relu_type
 
     @staticmethod
@@ -1481,7 +1481,7 @@ class PackGolden:
         Returns:
             float: The threshold value, or None if ReLU is disabled
         """
-        relu_type = PackerReluType(relu_config & 0x3)
+        relu_type = PackerReluType.from_bits(relu_config & 0x3)
 
         match relu_type:
             case PackerReluType.NoRelu:

--- a/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
@@ -227,11 +227,20 @@ class PackerReluType(Enum):
 
     @property
     def bits(self) -> int:
-        return list(PackerReluType).index(self)
+        return _PACKER_RELU_BITS[self.value]
 
     @classmethod
     def from_bits(cls, bits: int) -> "PackerReluType":
-        return list(cls)[bits]
+        return cls(_PACKER_RELU_BITS_INV[bits])
+
+
+_PACKER_RELU_BITS = {
+    "NO_RELU": 0,
+    "ZERO_RELU": 1,
+    "MIN_THRESHOLD_RELU": 2,
+    "MAX_THRESHOLD_RELU": 3,
+}
+_PACKER_RELU_BITS_INV = {v: k for k, v in _PACKER_RELU_BITS.items()}
 
 
 def pack_relu_config(mode: "PackerReluType", threshold_bits: int) -> int:

--- a/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
@@ -216,28 +216,27 @@ class PackerReluType(Enum):
     Relu activation function types for packer operations.
     """
 
-    NoRelu = 0
-    ZeroRelu = 1
-    MinThresholdRelu = 2
-    MaxThresholdRelu = 3
+    NoRelu = "NO_RELU"
+    ZeroRelu = "ZERO_RELU"
+    MinThresholdRelu = "MIN_THRESHOLD_RELU"
+    MaxThresholdRelu = "MAX_THRESHOLD_RELU"
 
-    def __str__(self):
-        match self:
-            case PackerReluType.NoRelu:
-                return "NO_RELU"
-            case PackerReluType.ZeroRelu:
-                return "ZERO_RELU"
-            case PackerReluType.MinThresholdRelu:
-                return "MIN_THRESHOLD_RELU"
-            case PackerReluType.MaxThresholdRelu:
-                return "MAX_THRESHOLD_RELU"
-            case _:
-                raise ValueError(f"Unsupported PackerReluType: {self!r}")
+    @property
+    def cpp_enum_value(self):
+        return f"ReluType::{self.value}"
+
+    @property
+    def bits(self) -> int:
+        return list(PackerReluType).index(self)
+
+    @classmethod
+    def from_bits(cls, bits: int) -> "PackerReluType":
+        return list(cls)[bits]
 
 
 def pack_relu_config(mode: "PackerReluType", threshold_bits: int) -> int:
     """Pack ReLU mode (2 bits) and threshold (16 bits) into a 32-bit config word."""
-    return (mode.value & 0x3) | ((threshold_bits & 0xFFFF) << 16)
+    return (mode.bits & 0x3) | ((threshold_bits & 0xFFFF) << 16)
 
 
 class Haloize(Enum):


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Add pack relu support to the fuser. All four relu modes are supported: `NO_RELU`, `ZERO_RELU`, `MIN_THRESHOLD_RELU`, and `MAX_THRESHOLD_RELU`. The `pack_relu` and `relu_threshold` fields can now be configured per operation in the YAML config. The codegen emits `_llk_pack_relu_config_()` with the packed mode and threshold bits, and the packer golden applies matching relu. A dedicated `pack_relu.yaml` test exercises all four mdes.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=markoradosavljevic/fuser-reduce-relu)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:markoradosavljevic/fuser-reduce-relu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=markoradosavljevic/fuser-reduce-relu)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:markoradosavljevic/fuser-reduce-relu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=markoradosavljevic/fuser-reduce-relu)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:markoradosavljevic/fuser-reduce-relu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=markoradosavljevic/fuser-reduce-relu)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:markoradosavljevic/fuser-reduce-relu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=markoradosavljevic/fuser-reduce-relu)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:markoradosavljevic/fuser-reduce-relu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=markoradosavljevic/fuser-reduce-relu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:markoradosavljevic/fuser-reduce-relu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=markoradosavljevic/fuser-reduce-relu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:markoradosavljevic/fuser-reduce-relu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=markoradosavljevic/fuser-reduce-relu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:markoradosavljevic/fuser-reduce-relu)