### PR TITLE
Add AI summaries to DeepSeek CI

### DIFF
--- a/.github/workflows/galaxy-deepseek-prefill-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-prefill-tests-impl.yaml
@@ -112,7 +112,13 @@ jobs:
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
-          ${{ matrix.test-group.cmd }}
+          mkdir -p generated/test_logs
+          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' /' '__')
+          LOG_FILE="generated/test_logs/${SAFE_NAME}_${{ job.check_run_id }}.log"
+          {
+            ${{ matrix.test-group.cmd }}
+          } 2>&1 | tee "$LOG_FILE"
+          exit ${PIPESTATUS[0]}
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
@@ -123,5 +129,56 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: AI job summary
+        if: always() && !cancelled()
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
+
+  ai-run-summary:
+    name: "AI Run Summary"
+    needs: [load-test-matrix, galaxy-deepseek-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: ai-run-summary
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/run@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE",
+              "input_dir": "ai_job_summaries",
+              "output_dir": "ai_run_summaries"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          expected-jobs: ${{ needs.load-test-matrix.outputs.matrix }}
+          run-result: ${{ needs.galaxy-deepseek-tests.result }}
+      - name: Show report
+        if: always() && steps.ai-run-summary.outputs.report-file != ''
+        continue-on-error: true
+        shell: bash
+        env:
+          REPORT_FILE: ${{ steps.ai-run-summary.outputs.report-file }}
+        run: |
+          if [ -f "$REPORT_FILE" ]; then
+            cat "$REPORT_FILE"
+            cat "$REPORT_FILE" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::Report file not found: $REPORT_FILE"
+          fi

--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -162,32 +162,47 @@ jobs:
         if: ${{ matrix.test-group.test-type == 'unit' }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
-          uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-          pytest models/demos/deepseek_v3/tests/unit --timeout 60 --durations=0
+          mkdir -p generated/test_logs
+          LOG_FILE="generated/test_logs/deepseek_${{ matrix.test-group.test-type }}_${{ job.check_run_id }}.log"
+          {
+            uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
+            pytest models/demos/deepseek_v3/tests/unit --timeout 60 --durations=0
+          } 2>&1 | tee "$LOG_FILE"
+          exit ${PIPESTATUS[0]}
       - name: Run DeepSeek module tests
         if: ${{ matrix.test-group.test-type == 'module' }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
-          uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-          pytest models/demos/deepseek_v3/tests -x \
-            --ignore=models/demos/deepseek_v3/tests/unit \
-            --ignore=models/demos/deepseek_v3/tests/fused_op_unit_tests \
-            -m "not t3k_compat" \
-            --timeout 600 --durations=0
+          mkdir -p generated/test_logs
+          LOG_FILE="generated/test_logs/deepseek_${{ matrix.test-group.test-type }}_${{ job.check_run_id }}.log"
+          {
+            uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
+            pytest models/demos/deepseek_v3/tests -x \
+              --ignore=models/demos/deepseek_v3/tests/unit \
+              --ignore=models/demos/deepseek_v3/tests/fused_op_unit_tests \
+              -m "not t3k_compat" \
+              --timeout 600 --durations=0
+          } 2>&1 | tee "$LOG_FILE"
+          exit ${PIPESTATUS[0]}
       - name: Run DeepSeek op unit tests (Device Performance)
         if: ${{ matrix.test-group.test-type == 'final-op-unit' }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
-          uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
+          mkdir -p generated/test_logs
+          LOG_FILE="generated/test_logs/deepseek_${{ matrix.test-group.test-type }}_${{ job.check_run_id }}.log"
+          {
+            uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
 
-          echo "=============================================="
-          echo "Device Performance Tests"
-          echo "=============================================="
-          bash models/demos/deepseek_v3/tests/fused_op_unit_tests/run_ci_device_perf_tracy.sh
+            echo "=============================================="
+            echo "Device Performance Tests"
+            echo "=============================================="
+            bash models/demos/deepseek_v3/tests/fused_op_unit_tests/run_ci_device_perf_tracy.sh
 
-          echo "=============================================="
-          echo "All device perf tests completed!"
-          echo "=============================================="
+            echo "=============================================="
+            echo "All device perf tests completed!"
+            echo "=============================================="
+          } 2>&1 | tee "$LOG_FILE"
+          exit ${PIPESTATUS[0]}
       - name: Validate regenerated DeepSeek cache directory
         # The shared CI cache root is still on the legacy format. Only validate
         # branch-created/recreated cache directories that this workflow owns,
@@ -195,21 +210,31 @@ jobs:
         if: ${{ inputs.recreate_weights_cache == 'Yes' && (matrix.test-group.test-type == 'module' || matrix.test-group.test-type == 'final-op-unit') }}
         timeout-minutes: 10
         run: |
-          if [[ -d "$DEEPSEEK_V3_CACHE/tests_cache" ]]; then
-            python3 models/demos/deepseek_v3/scripts/validate_weight_cache.py --root "$DEEPSEEK_V3_CACHE/tests_cache"
-          else
-            echo "No DeepSeek tests_cache present under $DEEPSEEK_V3_CACHE after regeneration; skipping cache validation."
-          fi
+          mkdir -p generated/test_logs
+          LOG_FILE="generated/test_logs/deepseek_${{ matrix.test-group.test-type }}_cache_validation_${{ job.check_run_id }}.log"
+          {
+            if [[ -d "$DEEPSEEK_V3_CACHE/tests_cache" ]]; then
+              python3 models/demos/deepseek_v3/scripts/validate_weight_cache.py --root "$DEEPSEEK_V3_CACHE/tests_cache"
+            else
+              echo "No DeepSeek tests_cache present under $DEEPSEEK_V3_CACHE after regeneration; skipping cache validation."
+            fi
+          } 2>&1 | tee "$LOG_FILE"
+          exit ${PIPESTATUS[0]}
       - name: Run DeepSeek long seq len module tests
         if: ${{ matrix.test-group.test-type == 'long-seq-module' }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
-          uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-          DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=16384 pytest models/demos/deepseek_v3/tests/test_mla.py -k "mode_decode" --timeout 900 --durations=0
-          DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=12288 pytest models/demos/deepseek_v3/tests/test_decoder_block.py -k "mode_decode" --timeout 2400 --durations=0
-          # TODO: set DEEPSEEK_MAX_SEQ_LEN_OVERRIDE to large value if test does not get killed in CI.
-          DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=1024 pytest models/demos/deepseek_v3/tests/test_model.py -k "mode_decode" --timeout 1250 --durations=0
-          DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=32768 pytest models/demos/deepseek_v3/tests/test_model.py -k "mode_prefill" --timeout 1250 --durations=0
+          mkdir -p generated/test_logs
+          LOG_FILE="generated/test_logs/deepseek_${{ matrix.test-group.test-type }}_${{ job.check_run_id }}.log"
+          {
+            uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
+            DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=16384 pytest models/demos/deepseek_v3/tests/test_mla.py -k "mode_decode" --timeout 900 --durations=0
+            DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=12288 pytest models/demos/deepseek_v3/tests/test_decoder_block.py -k "mode_decode" --timeout 2400 --durations=0
+            # TODO: set DEEPSEEK_MAX_SEQ_LEN_OVERRIDE to large value if test does not get killed in CI.
+            DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=1024 pytest models/demos/deepseek_v3/tests/test_model.py -k "mode_decode" --timeout 1250 --durations=0
+            DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=32768 pytest models/demos/deepseek_v3/tests/test_model.py -k "mode_prefill" --timeout 1250 --durations=0
+          } 2>&1 | tee "$LOG_FILE"
+          exit ${PIPESTATUS[0]}
       # - name: Save environment data
       #   id: save-environment-data
       #   if: ${{ !cancelled() }}
@@ -235,4 +260,55 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: AI job summary
+        if: always() && !cancelled()
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+
+  ai-run-summary:
+    name: "AI Run Summary"
+    needs: [generate-matrix, galaxy-deepseek-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: ai-run-summary
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/run@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE",
+              "input_dir": "ai_job_summaries",
+              "output_dir": "ai_run_summaries"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          expected-jobs: ${{ needs.generate-matrix.outputs.matrix }}
+          run-result: ${{ needs.galaxy-deepseek-tests.result }}
+      - name: Show report
+        if: always() && steps.ai-run-summary.outputs.report-file != ''
+        continue-on-error: true
+        shell: bash
+        env:
+          REPORT_FILE: ${{ steps.ai-run-summary.outputs.report-file }}
+        run: |
+          if [ -f "$REPORT_FILE" ]; then
+            cat "$REPORT_FILE"
+            cat "$REPORT_FILE" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::Report file not found: $REPORT_FILE"
+          fi

--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -114,7 +114,13 @@ jobs:
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
-          ${{ matrix.test-group.cmd }}
+          mkdir -p generated/test_logs
+          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' /' '__')
+          LOG_FILE="generated/test_logs/${SAFE_NAME}_${{ job.check_run_id }}.log"
+          {
+            ${{ matrix.test-group.cmd }}
+          } 2>&1 | tee "$LOG_FILE"
+          exit ${PIPESTATUS[0]}
       - name: Save environment data
         id: save-environment-data
         if: ${{ !cancelled() }}
@@ -140,5 +146,56 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: AI job summary
+        if: always() && !cancelled()
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
+
+  ai-run-summary:
+    name: "AI Run Summary"
+    needs: [load-test-matrix, galaxy-demo-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: ai-run-summary
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/run@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE",
+              "input_dir": "ai_job_summaries",
+              "output_dir": "ai_run_summaries"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          expected-jobs: ${{ needs.load-test-matrix.outputs.matrix }}
+          run-result: ${{ needs.galaxy-demo-tests.result }}
+      - name: Show report
+        if: always() && steps.ai-run-summary.outputs.report-file != ''
+        continue-on-error: true
+        shell: bash
+        env:
+          REPORT_FILE: ${{ steps.ai-run-summary.outputs.report-file }}
+        run: |
+          if [ -f "$REPORT_FILE" ]; then
+            cat "$REPORT_FILE"
+            cat "$REPORT_FILE" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::Report file not found: $REPORT_FILE"
+          fi


### PR DESCRIPTION
## Summary
- Add per-job AI summaries to the Galaxy DeepSeek, DeepSeek prefill, and Galaxy demo reusable workflows.
- Tee test output into `generated/test_logs` so `ai_summary/job@main` has stable input files.
- Add terminal `AI Run Summary` jobs that aggregate per-job summaries, upload the run summary artifact, print the report, and append it to `$GITHUB_STEP_SUMMARY`.

## Testing
- [x] `(Galaxy) DeepSeek tests` dispatched with `test-type=unit`: [run 25426304184](https://github.com/tenstorrent/tt-metal/actions/runs/25426304184), [AI Run Summary](https://github.com/tenstorrent/tt-metal/actions/runs/25426304184/job/74583999772#step:4) succeeded and printed a healthy summary.
- [x] `(Galaxy) DeepSeek Prefill tests` dispatched with `test-type=module`: [run 25426304177](https://github.com/tenstorrent/tt-metal/actions/runs/25426304177), [AI Run Summary](https://github.com/tenstorrent/tt-metal/actions/runs/25426304177/job/74583313104#step:4) succeeded and printed a healthy summary.
- [x] `(Galaxy) demo tests` dispatched with `model=deepseek_v3`: [run 25426304122](https://github.com/tenstorrent/tt-metal/actions/runs/25426304122), [AI Run Summary](https://github.com/tenstorrent/tt-metal/actions/runs/25426304122/job/74601620248#step:4) succeeded and classified the underlying demo failure as `tt-metal:dispatch` / device timeout. The summary plumbing worked; the workflow itself is red because `tg_stress` hit `TIMEOUT: device timeout, potential hang detected, the device is unrecoverable`, then `tg_upr8` failed firmware initialization.

## CI Badge
[![(Galaxy) DeepSeek tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=yieldthought%2Fdeepseek-ai-ci-summaries)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml?query=branch%3Ayieldthought%2Fdeepseek-ai-ci-summaries)
[![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=yieldthought%2Fdeepseek-ai-ci-summaries)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch%3Ayieldthought%2Fdeepseek-ai-ci-summaries)
[![(Galaxy) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=yieldthought%2Fdeepseek-ai-ci-summaries)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch%3Ayieldthought%2Fdeepseek-ai-ci-summaries)
