### PR TITLE
Fix for the argmax_cpu not implemented for UInt32 issue

### DIFF
--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -1197,8 +1197,8 @@ def test_demo_text(
 
                 if teacher_forcing:
                     out_tok = ref_tokens[max_encoded_prompt_len + iteration + 1]
-                elif pcc_check:
-                    out_tok = tt_out_tok.argmax(dim=-1)
+                elif pcc_check and tt_out_tok.shape[-1] >= vocab_size:
+                    out_tok = tt_out_tok.float().argmax(dim=-1)
                 else:
                     out_tok = tt_out_tok.reshape(-1).to(torch.long)
 


### PR DESCRIPTION
### Bug fix

### Summary
We are experiencing "argmax_cpu" not implemented for 'UInt32' in the pcc-80L test on Llama 3 70B on Galaxy machine. The reason for this is that output tensor is in the Uint32 format and argmax is not supporting this format. Because of that the output tensor is now converted to float before the argmax function.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=uint32_output_token_to_float)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:uint32_output_token_to_float)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=uint32_output_token_to_float)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:uint32_output_token_to_float)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=uint32_output_token_to_float)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:uint32_output_token_to_float)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=uint32_output_token_to_float)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:uint32_output_token_to_float)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=uint32_output_token_to_float)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:uint32_output_token_to_float)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=uint32_output_token_to_float)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:uint32_output_token_to_float)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=uint32_output_token_to_float)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:uint32_output_token_to_float)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=uint32_output_token_to_float)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:uint32_output_token_to_float)