### PR TITLE
Replace raw fence asm with portable helpers in profiler sync_threads

### DIFF
--- a/tt_metal/tt-llk/tests/helpers/include/profiler.h
+++ b/tt_metal/tt-llk/tests/helpers/include/profiler.h
@@ -105,7 +105,6 @@ __attribute__((always_inline)) inline void sync_threads()
     // wait for all the threads to set the barrier
     barrier[TRISC_ID] = 1;
     ckernel::invalidate_data_cache();
-    ckernel::fence_compiler();
     for (std::uint32_t i = 0; i < NUM_CORES; ++i)
     {
         if (i == TRISC_ID)
@@ -115,7 +114,6 @@ __attribute__((always_inline)) inline void sync_threads()
         while (barrier[i] != 1)
         {
             ckernel::invalidate_data_cache();
-            ckernel::fence_compiler();
         }
     }
 }

--- a/tt_metal/tt-llk/tests/helpers/include/profiler.h
+++ b/tt_metal/tt-llk/tests/helpers/include/profiler.h
@@ -104,7 +104,8 @@ __attribute__((always_inline)) inline void sync_threads()
 
     // wait for all the threads to set the barrier
     barrier[TRISC_ID] = 1;
-    asm volatile("fence" ::: "memory");
+    ckernel::invalidate_data_cache();
+    ckernel::fence_compiler();
     for (std::uint32_t i = 0; i < NUM_CORES; ++i)
     {
         if (i == TRISC_ID)
@@ -113,7 +114,8 @@ __attribute__((always_inline)) inline void sync_threads()
         }
         while (barrier[i] != 1)
         {
-            asm volatile("fence" ::: "memory");
+            ckernel::invalidate_data_cache();
+            ckernel::fence_compiler();
         }
     }
 }


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Replace `asm volatile("fence" ::: "memory")` with the portable
`invalidate_data_cache()` helper in profiler
`sync_threads()`. On Wormhole, `fence` is a silicon no-op but TTSIM
explicitly rejects it.

This is largely cosmetic - perf/profiler tests are not meaningful on
TTSIM (cycle-accurate timing differs from silicon), so they would not
normally be run there. The fix just removes a spurious error if someone
does attempt it.

### Notes for reviewers
Behavior is unchanged on silicon for both WH and BH. The only effect is
TTSIM no longer sees a raw `fence` instruction on Wormhole.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/fix-profiler-fence-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/fix-profiler-fence-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstamatovic/fix-profiler-fence-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstamatovic/fix-profiler-fence-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nstamatovic/fix-profiler-fence-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nstamatovic/fix-profiler-fence-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/fix-profiler-fence-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/fix-profiler-fence-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstamatovic/fix-profiler-fence-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstamatovic/fix-profiler-fence-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/fix-profiler-fence-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/fix-profiler-fence-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/fix-profiler-fence-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/fix-profiler-fence-ttsim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/fix-profiler-fence-ttsim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/fix-profiler-fence-ttsim)