### PR TITLE
[WATCHER] Enabling t3k fast tests as part of sanity debug tests with watcher

### DIFF
--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -97,6 +97,7 @@ runs:
         echo "TT_METAL_WATCHER=2" >> $GITHUB_ENV
         echo "TT_METAL_WATCHER_APPEND=1" >> $GITHUB_ENV
         echo "TT_METAL_WATCHER_NOINLINE=1" >> $GITHUB_ENV
+        echo "TT_METAL_WATCHER_DISABLE_ETH=1" >> $GITHUB_ENV
       shell: bash
 
     - name: Set up env vars for lightweight kernel asserts

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -68,6 +68,8 @@ jobs:
           echo "TT_METAL_WATCHER=2" >> $GITHUB_ENV
           echo "TT_METAL_WATCHER_APPEND=1" >> $GITHUB_ENV
           echo "TT_METAL_WATCHER_NOINLINE=1" >> $GITHUB_ENV
+          echo "TT_METAL_WATCHER_DISABLE_ETH=1" >> $GITHUB_ENV
+
 
       - name: Run a test
         id: test

--- a/.github/workflows/sanity-tests-debug.yaml
+++ b/.github/workflows/sanity-tests-debug.yaml
@@ -152,7 +152,6 @@ jobs:
       enable-llk-asserts: ${{ needs.determine-debug-flags.outputs.enable-llk-asserts == 'true' }}
       run-profiler-regression: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
       run-ops-unit-tests: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
-      run-t3000-apc-fast-tests: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
       run-ttsim-integration-tests: false # ttsim requires gcc-12 which is not available on Ubuntu 24.04
       dev-docker-image: ${{ needs.build-artifacts-ubuntu-24.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifacts-ubuntu-24.outputs.build-artifact-name }}

--- a/.github/workflows/sanity-tests-debug.yaml
+++ b/.github/workflows/sanity-tests-debug.yaml
@@ -114,7 +114,6 @@ jobs:
       enable-llk-asserts: ${{ needs.determine-debug-flags.outputs.enable-llk-asserts == 'true' }}
       run-profiler-regression: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
       run-ops-unit-tests: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
-      run-t3000-apc-fast-tests: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
       dev-docker-image: ${{ needs.build-artifacts-ubuntu-22.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifacts-ubuntu-22.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifacts-ubuntu-22.outputs.wheel-artifact-name }}

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -387,7 +387,7 @@ jobs:
       enable-watcher: ${{ inputs.enable-watcher || false }}
       enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
-      timeout: ${{ inputs.enable-watcher && 40 || 20 }}
+      timeout: ${{ inputs.enable-watcher && 80 || 20 }}
       ref: ${{ inputs.ref || github.sha }}
 
   ops-unit-tests:

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -387,6 +387,7 @@ jobs:
       enable-watcher: ${{ inputs.enable-watcher || false }}
       enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
+      timeout: ${{ inputs.enable-watcher && 40 || 20 }}
       ref: ${{ inputs.ref || github.sha }}
 
   ops-unit-tests:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -119,6 +119,7 @@ jobs:
           echo "TT_METAL_WATCHER=2" >> $GITHUB_ENV
           echo "TT_METAL_WATCHER_APPEND=1" >> $GITHUB_ENV
           echo "TT_METAL_WATCHER_NOINLINE=1" >> $GITHUB_ENV
+          echo "TT_METAL_WATCHER_DISABLE_ETH=1" >> $GITHUB_ENV
 
       - name: Run a test
         id: test

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -91,7 +91,7 @@ jobs:
           enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
       - name: Run t3k fabric tests
         id: t3k-fabric-tests
-        timeout-minutes: 20
+        timeout-minutes: ${{ inputs.timeout }}
         if: ${{ inputs.run-fabric-tests == 'true' }}
         run: |
           mkdir -p generated/test_reports


### PR DESCRIPTION
### Description
There is a need to add as much coverage to the tests run with watcher. Currently there are no t3k tests run with watcher. 
T3k fast tests which are part of sanity test group should not be skipped. The timeout for this test group if watcher enabled is prolongated and watcher is not enabled on ethernet cores since this is producing errors which was the root cause to skip this test group with watcher in the first place.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dstoiljkovic/t3k_sanity_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dstoiljkovic/t3k_sanity_enabled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dstoiljkovic/t3k_sanity_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dstoiljkovic/t3k_sanity_enabled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dstoiljkovic/t3k_sanity_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dstoiljkovic/t3k_sanity_enabled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dstoiljkovic/t3k_sanity_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dstoiljkovic/t3k_sanity_enabled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dstoiljkovic/t3k_sanity_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dstoiljkovic/t3k_sanity_enabled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dstoiljkovic/t3k_sanity_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dstoiljkovic/t3k_sanity_enabled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dstoiljkovic/t3k_sanity_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dstoiljkovic/t3k_sanity_enabled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dstoiljkovic/t3k_sanity_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dstoiljkovic/t3k_sanity_enabled)