### PR TITLE
Fix Conv3d auto-blocking L1 overflow for large kernels

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv3d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv3d.py
@@ -398,8 +398,9 @@ def test_conv3d_qwen_shapes(
         [(1, 64, 8, 10, 9), 64, (3, 3, 3), (1, 1, 1), 1, (0, 1, 1), "zeros"],
         [(1, 64, 8, 10, 9), 64, (1, 1, 1), (1, 1, 1), 1, (0, 1, 1), "zeros"],
         [(1, 32, 4, 8, 8), 32, (3, 3, 3), (2, 2, 2), 1, (0, 1, 1), "zeros"],
+        [(2, 3, 2, 14, 14), 1280, (2, 14, 14), (2, 14, 14), 1, (0, 0, 0), "zeros"],
     ],
-    ids=["auto_block_k333", "auto_block_k111", "auto_block_stride222"],
+    ids=["auto_block_k333", "auto_block_k111", "auto_block_stride222", "auto_block_large_kernel"],
 )
 def test_conv3d_no_config(device, input_shape, out_channels, kernel_size, stride, groups, padding, padding_mode):
     """Test Conv3d with no config (auto-blocking with conservative defaults)."""

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.cpp
@@ -7,7 +7,9 @@
 #include "ttnn/operations/experimental/conv3d/prepare_conv3d_weights.hpp"
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/hal.hpp>
 #include "ttnn/common/constants.hpp"
+#include <numeric>
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 using namespace tt::tt_metal;
@@ -54,8 +56,14 @@ ttnn::Tensor conv3d(
     uint32_t groups_,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
-    // If no config provided, use conservative default blocking:
-    // minimal spatial blocks (1,1,1), smallest valid channel blocks (TILE_WIDTH) to minimize L1 pressure
+    // Conservative default blocking: minimal spatial blocks, smallest valid C_in_block.
+    // C_in_block must satisfy: kernel_vol * C_in_block ≡ 0 (mod TILE_WIDTH) for weight tile
+    // alignment, and C_in_block % l1_alignment == 0 for L1 alignment.
+    uint32_t kernel_vol = kernel_size_[0] * kernel_size_[1] * kernel_size_[2];
+    uint32_t tile_align_factor = tt::constants::TILE_WIDTH / std::gcd(kernel_vol, (uint32_t)tt::constants::TILE_WIDTH);
+    uint32_t l1_alignment = tt::tt_metal::hal::get_l1_alignment();
+    uint32_t min_c_in_block = std::lcm(l1_alignment, tile_align_factor);
+
     auto config = config_opt.value_or(ttnn::experimental::prim::Conv3dConfig(
         tt::tt_metal::DataType::BFLOAT16,                        // weights_dtype
         tt::tt_metal::Layout::ROW_MAJOR,                         // output_layout
@@ -63,7 +71,7 @@ ttnn::Tensor conv3d(
         1,                                                       // W_out_block
         1,                                                       // H_out_block
         tt::constants::TILE_WIDTH,                               // C_out_block (one tile width)
-        tt::constants::TILE_WIDTH,                               // C_in_block (one tile width, min L1)
+        min_c_in_block,                                          // C_in_block (min valid for this kernel)
         dilation_,                                               // dilation (match the op's dilation)
         32,                                                      // alignment
         input_tensor.device()->compute_with_storage_grid_size()  // use full device grid


### PR DESCRIPTION
## Summary

- The auto-blocking default `C_in_block = TILE_WIDTH` was not actually the minimum valid value — it just happened to work for small kernels. The true minimum must satisfy weight-tile alignment (`kernel_vol * C_in_block` divisible by `TILE_WIDTH`) and L1 alignment, giving `C_in_block = lcm(l1_alignment, TILE_WIDTH / gcd(kernel_vol, TILE_WIDTH))`.
- For Qwen 2.5 VL's `(2,14,14)` kernel this yields `C_in_block = 16` instead of `32`, fixing the L1 overflow without any runtime estimation or duplication of the program-factory CB formula.
- Adds the large-kernel case as a parametrized entry in `test_conv3d_no_config`.

Resolves #42146.
Co-authored with @pavlejosipovic — supersedes the runtime-estimator approach in #42147.

## Test plan

- [x] `test_conv3d_no_config` — all 4 cases pass (`auto_block_k333`, `auto_block_k111`, `auto_block_stride222`, `auto_block_large_kernel`)
- [x] Full `test_conv3d.py` (excluding the long Qwen sweep): 1551 passed, 0 failures
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/conv3d-auto-blocking-l1-overflow-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/conv3d-auto-blocking-l1-overflow-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/conv3d-auto-blocking-l1-overflow-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/conv3d-auto-blocking-l1-overflow-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/conv3d-auto-blocking-l1-overflow-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/conv3d-auto-blocking-l1-overflow-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/conv3d-auto-blocking-l1-overflow-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/conv3d-auto-blocking-l1-overflow-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/conv3d-auto-blocking-l1-overflow-v2)