### PR TITLE
generic_op: add create_descriptor entry point for mesh sub-programs

### DIFF
--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.cpp
@@ -13,6 +13,19 @@ namespace ttnn::operations::generic {
 
 using namespace tt::tt_metal;
 
+tt::tt_metal::ProgramDescriptor GenericOpDeviceOperation::create_descriptor(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& /*tensor_args*/,
+    tensor_return_value_t& /*tensor_return_value*/,
+    const tt::tt_metal::distributed::MeshCoordinateRange& mesh_coord_range) {
+    for (const auto& [range, program_descriptor] : operation_attributes.mesh_programs) {
+        if (range == mesh_coord_range) {
+            return program_descriptor;
+        }
+    }
+    TT_FATAL(false, "MeshCoordinateRange {} not found in operation_attributes.mesh_programs", mesh_coord_range);
+}
+
 void verify_no_duplicate_mesh_coord_ranges(
     const tt::tt_metal::experimental::MeshProgramDescriptor::MeshPrograms& mesh_programs) {
     std::unordered_set<ttnn::MeshCoordinateRange> seen;

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
@@ -22,6 +22,15 @@ struct GenericOpDeviceOperation {
     using tensor_return_value_t = generic::tensor_return_value_t;
     using program_factory_t = std::variant<program::GenericMeshProgramFactory>;
 
+    /// Returns the `ProgramDescriptor` for one mesh sub-program from `mesh_programs`.
+    /// `tensor_args` / `tensor_return_value` are included for API parity with other device ops; the generic op takes
+    /// descriptors from attributes (PyKernel / user-built), not from tensors.
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value,
+        const tt::tt_metal::distributed::MeshCoordinateRange& mesh_coord_range);
+
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static void validate_inputs(const operation_attributes_t& attributes, const tensor_args_t& tensor_args);

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/global_circular_buffer.hpp>
 
 #include "generic_op_program_factory.hpp"
+#include "generic_op_device_operation.hpp"
 
 namespace ttnn::operations::generic::program {
 using namespace tt::tt_metal;
@@ -21,8 +22,10 @@ GenericMeshProgramFactory::cached_mesh_workload_t GenericMeshProgramFactory::cre
     tt::tt_metal::distributed::MeshWorkload mesh_workload;
     std::unordered_map<ttnn::MeshCoordinateRange, mesh_shared_variables_t> mesh_shared_variables;
 
-    for (const auto& [mesh_coord_range, program_descriptor] : operation_attributes.mesh_programs) {
-        auto cached_program = create_at(program_descriptor, tensor_args, tensor_return_value);
+    for (const auto& [mesh_coord_range, _] : operation_attributes.mesh_programs) {
+        const tt::tt_metal::ProgramDescriptor program_desc = GenericOpDeviceOperation::create_descriptor(
+            operation_attributes, tensor_args, tensor_return_value, mesh_coord_range);
+        auto cached_program = create_at(program_desc, tensor_args, tensor_return_value);
         mesh_workload.add_program(mesh_coord_range, std::move(cached_program.program));
         mesh_shared_variables[mesh_coord_range] = mesh_shared_variables_t{std::move(cached_program.shared_variables)};
     }


### PR DESCRIPTION
Add GenericOpDeviceOperation::create_descriptor(operation_attributes, tensor_args, tensor_return_value, mesh_coord_range) to select the ProgramDescriptor for a given MeshCoordinateRange from MeshProgramDescriptor::mesh_programs. Wire GenericMeshProgramFactory::create_mesh_workload to resolve each range via create_descriptor before building the cached Program (create_at). Tensor args are unused today but kept for parity with other device_operation create_descriptor signatures. Note: generic_op remains on GenericMeshProgramFactory (mesh workload path); a single 3-arg create_descriptor cannot represent multiple per-range descriptors without framework support.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-2)