### PR TITLE
Model tracer: persist pytest args and preserve merged trace variants

### DIFF
--- a/model_tracer/GUIDE.md
+++ b/model_tracer/GUIDE.md
@@ -75,9 +75,23 @@ python tests/sweep_framework/load_ttnn_ops_data_v2.py --schema ttnn_ops_v6 load 
 On load the tool:
 - Deduplicates configs by `config_hash` (same op + args + hardware + mesh = same config)
 - Rejects duplicate uploads by `trace_uid` before any data population
-- Creates a `trace_run` row capturing `trace_uid`, hardware, and tt-metal SHA
+- Creates a `trace_run` row capturing `trace_uid`, hardware, tt-metal SHA, and `pytest_args`
 - Stores canonical counts in `trace_run_configuration_model`
 - Refreshes derived aggregates in `trace_run_config`, `ttnn_configuration_model`, and `trace_run_model`
+
+`pytest_args` is the verbatim string of CLI args passed after `--` to the tracer (e.g.
+`-k "4x8sp0tp1 and encoder_device" --tb=short`). It is captured by the tracer into
+`_trace_metadata.json`, propagated per execution into the master JSON, and persisted on
+`trace_run.pytest_args`. This lets you answer "have I traced model X with these args on
+hardware Y?" purely via SQL without re-running anything.
+
+If you're upgrading an existing `ttnn_ops_v6` deployment, apply the additive migration:
+
+```bash
+psql "$TTNN_OPS_DATABASE_URL" -f model_tracer/migrate_v6_add_pytest_args.sql
+```
+
+Pre-migration `trace_run` rows simply have `pytest_args = NULL`.
 - **Auto-appends a `draft` entry** to `model_tracer/trace_selection_registry.yaml`
 
 Example output:
@@ -474,6 +488,7 @@ The global `--schema <name>` flag can appear anywhere on the command line and ap
 | `resolve-manifest [manifest] [scope]` | Dry-run: print which trace IDs and model filters would be used |
 | `reconstruct-trace <id> [output]` | Reconstruct JSON from one specific trace_run (all models) |
 | `list-traces [filter]` | List all trace_runs in DB |
+| `list-variants <pattern>` | List every (pytest_args, hardware) combination ever traced for source_files matching the pattern |
 | `reconstruct [output] [models]` | Reconstruct from DB filtered by model patterns (legacy) |
 | `reconstruct-op <name> [output]` | Reconstruct a single operation |
 | `verify [original] [reconstructed]` | Compare two JSON files |

--- a/model_tracer/destructively_create_ttnn_ops_schema_v6.sql
+++ b/model_tracer/destructively_create_ttnn_ops_schema_v6.sql
@@ -129,13 +129,19 @@ CREATE TABLE ttnn_ops_v6.trace_run (
     tt_metal_sha    TEXT,
     traced_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     config_count    INTEGER,    -- denormalized, updated after aggregate refresh
-    notes           TEXT
+    notes           TEXT,
+    -- The pytest CLI args (everything after `--`) used for this trace
+    -- invocation. Lets us answer "have I traced model X with these args
+    -- on hardware Y?" without re-running the tracer.
+    pytest_args     TEXT
 );
 CREATE INDEX trace_run_trace_uid_idx      ON ttnn_ops_v6.trace_run(trace_uid);
 CREATE INDEX trace_run_hardware_id_idx  ON ttnn_ops_v6.trace_run(hardware_id);
 CREATE INDEX trace_run_traced_at_idx    ON ttnn_ops_v6.trace_run(traced_at DESC);
 CREATE INDEX trace_run_sha_idx          ON ttnn_ops_v6.trace_run(tt_metal_sha)
     WHERE tt_metal_sha IS NOT NULL;
+CREATE INDEX trace_run_pytest_args_idx  ON ttnn_ops_v6.trace_run(pytest_args)
+    WHERE pytest_args IS NOT NULL;
 
 -- ---------------------------------------------------------------------------
 -- 8. trace_run_configuration_model

--- a/model_tracer/generic_ops_tracer.py
+++ b/model_tracer/generic_ops_tracer.py
@@ -591,8 +591,13 @@ def _compute_config_hash(op_name, op_args, machine_info):
     return hashlib.sha256(json.dumps(normalized, sort_keys=True).encode()).hexdigest()
 
 
-def update_master_file(master_file_path, operations, test_source, trace_uid=None):
-    """Update master JSON file with operations"""
+def update_master_file(master_file_path, operations, test_source, trace_uid=None, pytest_args=None):
+    """Update master JSON file with operations.
+
+    pytest_args is recorded per execution alongside trace_uid so the loader
+    can persist it on trace_run.pytest_args. Passing None preserves existing
+    behaviour (older traces simply have pytest_args absent in the JSON).
+    """
     import hashlib
 
     # Load existing master data
@@ -668,6 +673,7 @@ def update_master_file(master_file_path, operations, test_source, trace_uid=None
                         "machine_info": machine_info,
                         "count": operation.get("execution_count", 1),
                         "trace_uid": trace_uid or operation.get("trace_uid"),
+                        "pytest_args": pytest_args,
                     }
                 ],
             }
@@ -731,7 +737,13 @@ def update_master_file(master_file_path, operations, test_source, trace_uid=None
                     matching_config.pop("machine_info", None)
                     matching_config.pop("execution_count", None)
 
-                # Check if this (source, machine_info) pair already exists
+                # Dedup key is (source, machine_info, trace_uid). Including
+                # trace_uid keeps separate pytest invocations as separate
+                # execution entries even when they share source + hardware
+                # (e.g. flux1 dev and schnell on the same Galaxy). Without
+                # trace_uid here, the second variant would overwrite the
+                # first's pytest_args/trace_uid in the master JSON and the
+                # loader would never see both runs.
                 new_source = test_source
                 new_machine_info = operation.get("machine_info")
                 new_count = operation.get("execution_count", 1)
@@ -739,34 +751,38 @@ def update_master_file(master_file_path, operations, test_source, trace_uid=None
 
                 found_execution = None
                 for execution in matching_config["executions"]:
-                    if execution["source"] == new_source:
-                        # Check if machine_info matches
-                        exec_machine = execution.get("machine_info")
-                        if exec_machine is None and new_machine_info is None:
+                    if execution["source"] != new_source:
+                        continue
+                    if execution.get("trace_uid") != new_trace_uid:
+                        continue
+                    exec_machine = execution.get("machine_info")
+                    if exec_machine is None and new_machine_info is None:
+                        found_execution = execution
+                        break
+                    if exec_machine and new_machine_info:
+                        # Deep compare machine_info (all fields must match)
+                        exec_machine_str = json.dumps(exec_machine, sort_keys=True, default=str)
+                        new_machine_str = json.dumps(new_machine_info, sort_keys=True, default=str)
+                        if exec_machine_str == new_machine_str:
                             found_execution = execution
                             break
-                        elif exec_machine and new_machine_info:
-                            # Compare complete machine_info (all fields must match)
-                            # Convert to JSON strings for deep comparison
-                            exec_machine_str = json.dumps(exec_machine, sort_keys=True, default=str)
-                            new_machine_str = json.dumps(new_machine_info, sort_keys=True, default=str)
-                            if exec_machine_str == new_machine_str:
-                                found_execution = execution
-                                break
 
                 if found_execution:
-                    # Update existing execution - take max count
+                    # Same (source, machine_info, trace_uid) — same invocation.
+                    # Take max count; pytest_args is constant for a trace_uid.
                     found_execution["count"] = max(found_execution.get("count", 1), new_count)
-                    if new_trace_uid:
-                        found_execution["trace_uid"] = new_trace_uid
+                    if pytest_args is not None:
+                        found_execution["pytest_args"] = pytest_args
                 else:
-                    # Add new execution entry
+                    # New (trace_uid, source, machine_info) tuple — append
+                    # so each invocation's provenance survives in the JSON.
                     matching_config["executions"].append(
                         {
                             "source": new_source,
                             "machine_info": new_machine_info,
                             "count": new_count,
                             "trace_uid": new_trace_uid,
+                            "pytest_args": pytest_args,
                         }
                     )
 
@@ -932,6 +948,10 @@ def run_test_with_tracing(test_path, output_dir, keep_traces=False, debug_mode=F
         "trace_uid": str(uuid.uuid4()),
         "machine_info": get_machine_info(),
         "trace_count": len(json_files),
+        # Capture the pytest CLI args (everything after `--`) so the loader
+        # can persist them on trace_run.pytest_args. This is what lets users
+        # answer "did I trace model X with these args on this hardware?".
+        "pytest_args": " ".join(extra_args) if extra_args else None,
     }
 
     # Check for HF_MODEL and LLAMA_DIR environment variables
@@ -976,6 +996,7 @@ def run_test_with_tracing(test_path, output_dir, keep_traces=False, debug_mode=F
         "trace_files": json_files,
         "trace_dir": trace_dir,
         "trace_uid": metadata["trace_uid"],
+        "pytest_args": metadata.get("pytest_args"),
         "keep_traces": keep_traces,
         "output_dir": output_dir,
         "test_stats": test_stats,
@@ -1333,6 +1354,7 @@ Examples (Import existing traces):
             excluded_operations = get_excluded_operations()
             machine_info = get_machine_info()
             trace_uid = result.get("trace_uid")
+            pytest_args = result.get("pytest_args")
 
             # Extract test source name and possibly override machine_info from metadata
             if args.load:
@@ -1363,10 +1385,13 @@ Examples (Import existing traces):
                         if "machine_info" in metadata:
                             machine_info = metadata["machine_info"]
                             trace_uid = metadata.get("trace_uid", trace_uid)
+                            pytest_args = metadata.get("pytest_args", pytest_args)
                             print(f"📋 Loaded metadata from trace directory")
                             print(f"   Original source: {metadata.get('test_source')}")
                             if metadata.get("trace_uid"):
                                 print(f"   Trace UID: {metadata.get('trace_uid')}")
+                            if metadata.get("pytest_args"):
+                                print(f"   Pytest args: {metadata.get('pytest_args')}")
                             if "machine_info" in metadata and metadata["machine_info"]:
                                 machine_desc = (
                                     metadata["machine_info"][0]
@@ -1472,10 +1497,13 @@ Examples (Import existing traces):
             else:
                 os.makedirs(args.output_dir, exist_ok=True)
                 master_file = os.path.join(args.output_dir, "ttnn_operations_master.json")
-            if trace_uid:
-                new_configs_added = update_master_file(master_file, filtered_operations_unique, test_source, trace_uid)
-            else:
-                new_configs_added = update_master_file(master_file, filtered_operations_unique, test_source)
+            new_configs_added = update_master_file(
+                master_file,
+                filtered_operations_unique,
+                test_source,
+                trace_uid=trace_uid,
+                pytest_args=pytest_args,
+            )
 
             print(f"📝 Added {new_configs_added} new unique configurations to {master_file}")
             print(f"   Source: {test_source}")

--- a/model_tracer/migrate_v6_add_pytest_args.sql
+++ b/model_tracer/migrate_v6_add_pytest_args.sql
@@ -1,0 +1,18 @@
+-- Migration: add pytest_args column to ttnn_ops_v6.trace_run
+--
+-- Why: lets us answer "have I traced model X with these pytest args on
+--      hardware Y?" without re-running the tracer. pytest_args is the
+--      string of CLI flags passed after `--` to generic_ops_tracer.py,
+--      e.g. `-k "4x8sp0tp1 and encoder_device" --tb=short`.
+--
+-- Safe to run on existing deployments: the column is nullable, so all
+-- pre-migration trace_run rows simply have pytest_args = NULL.
+--
+-- Idempotent: ALTER ... ADD COLUMN IF NOT EXISTS / CREATE INDEX IF NOT EXISTS.
+
+ALTER TABLE ttnn_ops_v6.trace_run
+    ADD COLUMN IF NOT EXISTS pytest_args TEXT;
+
+CREATE INDEX IF NOT EXISTS trace_run_pytest_args_idx
+    ON ttnn_ops_v6.trace_run(pytest_args)
+    WHERE pytest_args IS NOT NULL;

--- a/tests/sweep_framework/load_ttnn_ops_data_v2.py
+++ b/tests/sweep_framework/load_ttnn_ops_data_v2.py
@@ -112,6 +112,12 @@ def _append_registry_entries(entries, path):
             notes_escaped = notes.replace("'", "''")
             f.write(f"    loaded_at: '{loaded_at_escaped}'\n")
             f.write(f"    notes: '{notes_escaped}'\n")
+            pytest_args = entry.get("pytest_args")
+            if pytest_args:
+                pytest_args_escaped = str(pytest_args).replace("'", "''")
+                f.write(f"    pytest_args: '{pytest_args_escaped}'\n")
+            else:
+                f.write("    pytest_args: null\n")
 
 
 DEFAULT_SCHEMA = "ttnn_ops_v6"
@@ -459,17 +465,25 @@ def parse_mesh_from_machine_info(machine_info, arguments=None):
     return mesh_shape, device_count, placement_type, shard_dim, distribution_shape
 
 
-def get_or_create_trace_run(cur, trace_run_cache, trace_uid, hardware_id, tt_metal_sha=None, schema=DEFAULT_SCHEMA):
-    """Create and cache a trace_run for a unique trace_uid."""
+def get_or_create_trace_run(
+    cur, trace_run_cache, trace_uid, hardware_id, tt_metal_sha=None, pytest_args=None, schema=DEFAULT_SCHEMA
+):
+    """Create and cache a trace_run for a unique trace_uid.
+
+    pytest_args is the verbatim CLI args (everything after `--`) used to
+    invoke generic_ops_tracer.py for this trace. Stored on trace_run so we
+    can answer "have I traced model X with these args on hardware Y?"
+    purely via SQL.
+    """
     _validate_schema(schema)
     if trace_uid not in trace_run_cache:
         cur.execute(
             f"""
-            INSERT INTO {schema}.trace_run (trace_uid, hardware_id, tt_metal_sha)
-            VALUES (%s, %s, %s)
+            INSERT INTO {schema}.trace_run (trace_uid, hardware_id, tt_metal_sha, pytest_args)
+            VALUES (%s, %s, %s, %s)
             RETURNING trace_run_id
             """,
-            (trace_uid, hardware_id, tt_metal_sha),
+            (trace_uid, hardware_id, tt_metal_sha, pytest_args),
         )
         trace_run_cache[trace_uid] = cur.fetchone()[0]
 
@@ -707,6 +721,10 @@ def load_data(json_path=None, tt_metal_sha=None, dry_run=False, schema=DEFAULT_S
                 machine_info = normalize_machine_info(execution.get("machine_info", {}), arguments=arguments)
                 execution_count = execution.get("count", 1)
                 trace_uid = execution.get("trace_uid", default_trace_uid)
+                # pytest_args is per-invocation (1:1 with trace_uid). Older
+                # JSONs won't have this field; treat absence as None so
+                # trace_run.pytest_args stays NULL for legacy data.
+                pytest_args = execution.get("pytest_args")
 
                 # Validate required fields
                 missing = []
@@ -800,6 +818,7 @@ def load_data(json_path=None, tt_metal_sha=None, dry_run=False, schema=DEFAULT_S
                             trace_uid,
                             hardware_id,
                             tt_metal_sha,
+                            pytest_args=pytest_args,
                             schema=schema,
                         )
                         trace_run_ids_touched.add(trace_run_id)
@@ -894,14 +913,15 @@ def _append_manifest_drafts(trace_run_cache, schema=DEFAULT_SCHEMA):
         trace_details_map = {}  # trace_run_id -> (hardware_id, sha, trace_uid)
         for trace_run_id in trace_run_cache.values():
             cur.execute(
-                f"SELECT hardware_id, tt_metal_sha, trace_uid FROM {schema}.trace_run WHERE trace_run_id = %s",
+                f"SELECT hardware_id, tt_metal_sha, trace_uid, pytest_args"
+                f" FROM {schema}.trace_run WHERE trace_run_id = %s",
                 (trace_run_id,),
             )
             tr_row = cur.fetchone()
             if not tr_row:
                 continue
-            hardware_id, sha, trace_uid = tr_row
-            trace_details_map[trace_run_id] = (hardware_id, sha, trace_uid)
+            hardware_id, sha, trace_uid, pytest_args = tr_row
+            trace_details_map[trace_run_id] = (hardware_id, sha, trace_uid, pytest_args)
             if hardware_id and hardware_id not in hw_map:
                 cur.execute(
                     f"SELECT board_type, device_series, card_count FROM {schema}.ttnn_hardware WHERE ttnn_hardware_id = %s",
@@ -935,7 +955,7 @@ def _append_manifest_drafts(trace_run_cache, schema=DEFAULT_SCHEMA):
         tr_row = trace_details_map.get(trace_run_id)
         if not tr_row:
             continue
-        hardware_id, sha, trace_uid = tr_row
+        hardware_id, sha, trace_uid, pytest_args = tr_row
         if trace_uid and trace_uid in existing_trace_uids:
             continue
         if not trace_uid and trace_run_id in existing_ids:
@@ -963,6 +983,7 @@ def _append_manifest_drafts(trace_run_cache, schema=DEFAULT_SCHEMA):
             "config_count": None,  # updated after commit
             "loaded_at": str(date.today()),
             "notes": "",
+            "pytest_args": pytest_args,
         }
         data["registry"].append(entry)
         existing_ids.add(trace_run_id)
@@ -1032,7 +1053,13 @@ def _machine_info_key(machine_info):
 
 
 def _merge_execution_lists(existing_executions, incoming_executions):
-    """Merge execution buckets by (source, machine_info), summing counts and provenance."""
+    """Merge execution buckets by (source, machine_info), summing counts and provenance.
+
+    pytest_args is per-trace, so when multiple traces collapse into one bucket
+    here we accumulate them into pytest_args_seen (a sorted, deduplicated list).
+    Single-string pytest_args from individual reconstructions also fold into
+    that list so callers always see a uniform shape across merged outputs.
+    """
     merged = {}
     for execution in list(existing_executions or []) + list(incoming_executions or []):
         source = execution.get("source")
@@ -1044,11 +1071,20 @@ def _merge_execution_lists(existing_executions, incoming_executions):
                 "machine_info": machine_info,
                 "count": 0,
                 "trace_run_ids": [],
+                "pytest_args_seen": [],
             }
         merged[key]["count"] += execution.get("count", 0)
         merged[key]["trace_run_ids"] = _merge_trace_run_ids(
             merged[key]["trace_run_ids"], execution.get("trace_run_ids")
         )
+
+        incoming_pytest_args = []
+        if execution.get("pytest_args"):
+            incoming_pytest_args.append(execution["pytest_args"])
+        if execution.get("pytest_args_seen"):
+            incoming_pytest_args.extend(execution["pytest_args_seen"])
+        if incoming_pytest_args:
+            merged[key]["pytest_args_seen"] = sorted(set(merged[key]["pytest_args_seen"]) | set(incoming_pytest_args))
     return list(merged.values())
 
 
@@ -1193,9 +1229,11 @@ def reconstruct_from_db(output_path=None, schema=DEFAULT_SCHEMA, model_filter=No
                     m.source_file,
                     m.hf_model_identifier,
                     SUM(trcm.execution_count) AS execution_count,
-                    ARRAY_AGG(DISTINCT trcm.trace_run_id ORDER BY trcm.trace_run_id) AS trace_run_ids
+                    ARRAY_AGG(DISTINCT trcm.trace_run_id ORDER BY trcm.trace_run_id) AS trace_run_ids,
+                    ARRAY_REMOVE(ARRAY_AGG(DISTINCT tr.pytest_args), NULL) AS pytest_args_seen
                 FROM {schema}.trace_run_configuration_model trcm
                 JOIN {schema}.ttnn_model m ON m.ttnn_model_id = trcm.model_id
+                JOIN {schema}.trace_run tr ON tr.trace_run_id = trcm.trace_run_id
                 WHERE trcm.configuration_id = %s
                 {source_filter_clause}
                 GROUP BY m.source_file, m.hf_model_identifier
@@ -1223,7 +1261,7 @@ def reconstruct_from_db(output_path=None, schema=DEFAULT_SCHEMA, model_filter=No
             config_dict["config_hash"] = config_hash
 
             executions = []
-            for source_file, hf_model, exec_count, trace_run_ids in source_rows:
+            for source_file, hf_model, exec_count, trace_run_ids, pytest_args_seen in source_rows:
                 source_str = format_source(source_file, hf_model)
                 if not source_str:
                     continue
@@ -1233,6 +1271,11 @@ def reconstruct_from_db(output_path=None, schema=DEFAULT_SCHEMA, model_filter=No
                     "machine_info": {},
                     "count": exec_count,
                     "trace_run_ids": list(trace_run_ids or []),
+                    # Aggregated view: a (config, model) pair may have been
+                    # produced under several pytest_args variants. Surface
+                    # them all for inspection. For a lossless single-trace
+                    # round-trip use reconstruct_from_trace_run instead.
+                    "pytest_args_seen": list(pytest_args_seen or []),
                 }
 
                 if board_type:
@@ -1299,7 +1342,8 @@ def reconstruct_from_trace_run(trace_run_id, output_path=None, schema=DEFAULT_SC
         SELECT
             tr.trace_run_id,
             h.board_type, h.device_series, h.card_count,
-            tr.tt_metal_sha, tr.traced_at, tr.config_count, tr.notes
+            tr.tt_metal_sha, tr.traced_at, tr.config_count, tr.notes,
+            tr.pytest_args
         FROM {schema}.trace_run tr
         JOIN {schema}.ttnn_hardware h ON h.ttnn_hardware_id = tr.hardware_id
         WHERE tr.trace_run_id = %s
@@ -1312,7 +1356,7 @@ def reconstruct_from_trace_run(trace_run_id, output_path=None, schema=DEFAULT_SC
         conn.close()
         return None
 
-    (_, board_type, device_series, card_count, tt_metal_sha, traced_at, _, _) = tr_row
+    (_, board_type, device_series, card_count, tt_metal_sha, traced_at, _, _, trace_pytest_args) = tr_row
 
     # Fetch all models for this trace; then apply model_names filter if specified.
     cur.execute(
@@ -1433,6 +1477,7 @@ def reconstruct_from_trace_run(trace_run_id, output_path=None, schema=DEFAULT_SC
                 "machine_info": exec_machine_info,
                 "count": execution_count,
                 "trace_run_ids": [trace_run_id],
+                "pytest_args": trace_pytest_args,
             }
         )
 
@@ -1452,6 +1497,7 @@ def reconstruct_from_trace_run(trace_run_id, output_path=None, schema=DEFAULT_SC
         "card_count": card_count,
         "tt_metal_sha": tt_metal_sha,
         "traced_at": str(traced_at) if traced_at else None,
+        "pytest_args": trace_pytest_args,
     }
 
     print(f"Reconstructed {len(result['operations'])} operations, {total_configs} configurations")
@@ -1462,6 +1508,71 @@ def reconstruct_from_trace_run(trace_run_id, output_path=None, schema=DEFAULT_SC
         print(f"Saved to {output_path}")
 
     return result
+
+
+def list_variants(model_pattern, schema=DEFAULT_SCHEMA):
+    """List every (model, pytest_args, hardware) combination traced for a model.
+
+    Answers "did I trace model X with these pytest args on this hardware?".
+    Each row is one trace_run, so repeated runs of the same variant appear
+    as separate rows (with different traced_at timestamps).
+
+    Args:
+        model_pattern: ILIKE pattern matched against ttnn_model.source_file,
+            e.g. "%flux1%". The leading/trailing wildcards are added if absent.
+        schema: Database schema to query (default: DEFAULT_SCHEMA).
+    """
+    _validate_schema(schema)
+    if not model_pattern:
+        print("Error: provide a source_file pattern (e.g. 'flux1' or '%flux1%')")
+        return []
+
+    if "%" not in model_pattern:
+        model_pattern = f"%{model_pattern}%"
+
+    conn = psycopg2.connect(NEON_URL)
+    cur = conn.cursor()
+    cur.execute(
+        f"""
+        SELECT
+            m.source_file,
+            COALESCE(m.hf_model_identifier, '') AS hf_model,
+            COALESCE(tr.pytest_args, '') AS pytest_args,
+            h.board_type,
+            h.device_series,
+            h.card_count,
+            tr.trace_uid,
+            tr.trace_run_id,
+            tr.traced_at,
+            tr.config_count
+        FROM {schema}.trace_run tr
+        JOIN {schema}.trace_run_model trm ON trm.trace_run_id = tr.trace_run_id
+        JOIN {schema}.ttnn_model m ON m.ttnn_model_id = trm.model_id
+        JOIN {schema}.ttnn_hardware h ON h.ttnn_hardware_id = tr.hardware_id
+        WHERE m.source_file ILIKE %s
+        ORDER BY m.source_file, tr.pytest_args NULLS FIRST, h.device_series, tr.traced_at DESC
+        """,
+        (model_pattern,),
+    )
+    rows = cur.fetchall()
+    conn.close()
+
+    if not rows:
+        print(f"No traces match source_file ILIKE {model_pattern!r}")
+        return []
+
+    print(f"\nVariants matching {model_pattern!r}:")
+    print(f"{'trace_id':>8}  {'hardware':22}  {'configs':>7}  {'traced_at':20}  source_file / pytest_args")
+    print("-" * 140)
+    for sf, hf, pa, board, ds, cc, _uid, tr_id, traced_at, cfg_count in rows:
+        hw = f"{ds} ({cc}x)"
+        traced = str(traced_at)[:19] if traced_at else "-"
+        label = sf if not hf else f"{sf} [HF_MODEL:{hf}]"
+        pa_disp = pa if pa else "(no pytest_args recorded)"
+        print(f"{tr_id:>8}  {hw:22}  {cfg_count or 0:>7}  {traced:20}  {label}")
+        print(f"{'':>8}  {'':22}  {'':>7}  {'':20}    args: {pa_disp}")
+
+    return rows
 
 
 def list_trace_runs(model_filter=None, schema=DEFAULT_SCHEMA):
@@ -1872,9 +1983,11 @@ def reconstruct_single_operation(operation_name, output_path=None, schema=DEFAUL
                 m.source_file,
                 m.hf_model_identifier,
                 SUM(trcm.execution_count) AS execution_count,
-                ARRAY_AGG(DISTINCT trcm.trace_run_id ORDER BY trcm.trace_run_id) AS trace_run_ids
+                ARRAY_AGG(DISTINCT trcm.trace_run_id ORDER BY trcm.trace_run_id) AS trace_run_ids,
+                ARRAY_REMOVE(ARRAY_AGG(DISTINCT tr.pytest_args), NULL) AS pytest_args_seen
             FROM {schema}.trace_run_configuration_model trcm
             JOIN {schema}.ttnn_model m ON m.ttnn_model_id = trcm.model_id
+            JOIN {schema}.trace_run tr ON tr.trace_run_id = trcm.trace_run_id
             WHERE trcm.configuration_id = %s
             GROUP BY m.source_file, m.hf_model_identifier
             ORDER BY m.source_file, m.hf_model_identifier
@@ -1899,7 +2012,7 @@ def reconstruct_single_operation(operation_name, output_path=None, schema=DEFAUL
         config_dict["config_hash"] = config_hash
 
         executions = []
-        for source_file, hf_model, exec_count, trace_run_ids in source_rows:
+        for source_file, hf_model, exec_count, trace_run_ids, pytest_args_seen in source_rows:
             source_str = format_source(source_file, hf_model)
             if not source_str:
                 continue
@@ -1908,6 +2021,7 @@ def reconstruct_single_operation(operation_name, output_path=None, schema=DEFAUL
                 "machine_info": {},
                 "count": exec_count,
                 "trace_run_ids": list(trace_run_ids or []),
+                "pytest_args_seen": list(pytest_args_seen or []),
             }
             if board_type:
                 execution["machine_info"]["board_type"] = board_type
@@ -2355,6 +2469,15 @@ if __name__ == "__main__":
         elif cmd == "list-traces":
             model_filter = sys.argv[2].split(",") if len(sys.argv) > 2 else None
             list_trace_runs(model_filter, schema=_schema)
+        elif cmd == "list-variants":
+            if len(sys.argv) < 3:
+                print(
+                    "Usage: python load_ttnn_ops_data_v2.py list-variants <source_file_pattern> [--schema S]\n"
+                    "  Lists every (model, pytest_args, hardware) combination ever traced\n"
+                    "  for source_files matching the ILIKE pattern (e.g. 'flux1' or '%%flux1%%')."
+                )
+                sys.exit(1)
+            list_variants(sys.argv[2], schema=_schema)
         elif cmd == "reconstruct-manifest":
             _args = sys.argv[2:]
             # Extract --models-filter if present.
@@ -2466,6 +2589,9 @@ if __name__ == "__main__":
                 "  python load_ttnn_ops_data_v2.py resolve-manifest [manifest] [scope]               # Show resolved trace IDs"
             )
             print("  python load_ttnn_ops_data_v2.py list-traces [model_filter]                   # List trace runs")
+            print(
+                "  python load_ttnn_ops_data_v2.py list-variants <pattern>                     # List traced (args, hw) variants per model"
+            )
             print(
                 "  python load_ttnn_ops_data_v2.py reconstruct-op <name> [output.json]          # Reconstruct single op"
             )

--- a/tests/sweep_framework/load_ttnn_ops_data_v2.py
+++ b/tests/sweep_framework/load_ttnn_ops_data_v2.py
@@ -18,6 +18,7 @@ from datetime import date
 from pathlib import Path
 
 import psycopg2
+from psycopg2 import sql
 
 try:
     import yaml
@@ -477,12 +478,15 @@ def get_or_create_trace_run(
     """
     _validate_schema(schema)
     if trace_uid not in trace_run_cache:
+        trace_run_table = sql.Identifier(schema, "trace_run")
         cur.execute(
-            f"""
-            INSERT INTO {schema}.trace_run (trace_uid, hardware_id, tt_metal_sha, pytest_args)
+            sql.SQL(
+                """
+            INSERT INTO {} (trace_uid, hardware_id, tt_metal_sha, pytest_args)
             VALUES (%s, %s, %s, %s)
             RETURNING trace_run_id
-            """,
+            """
+            ).format(trace_run_table),
             (trace_uid, hardware_id, tt_metal_sha, pytest_args),
         )
         trace_run_cache[trace_uid] = cur.fetchone()[0]

--- a/tests/sweep_framework/test_load_ttnn_ops_data_v2_functional.py
+++ b/tests/sweep_framework/test_load_ttnn_ops_data_v2_functional.py
@@ -1020,7 +1020,7 @@ class TestLoadDataWithMockedDB:
     def test_emit_id_file_writes_new_trace_run_id(self, mock_get_trace_run, mock_drafts, mock_pg, tmp_path):
         """--emit-id-file writes the new trace_run_id so CI can pin validation."""
 
-        def fake_trace_run(cur, cache, trace_uid, hardware_id, tt_metal_sha=None, schema=None):
+        def fake_trace_run(cur, cache, trace_uid, hardware_id, tt_metal_sha=None, pytest_args=None, schema=None):
             cache[trace_uid] = 77
             return 77
 
@@ -1046,7 +1046,7 @@ class TestLoadDataWithMockedDB:
     def test_emit_id_file_not_written_on_dry_run(self, mock_get_trace_run, mock_pg, tmp_path):
         """Dry run must never produce an ID file — the trace_run doesn't exist."""
 
-        def fake_trace_run(cur, cache, trace_uid, hardware_id, tt_metal_sha=None, schema=None):
+        def fake_trace_run(cur, cache, trace_uid, hardware_id, tt_metal_sha=None, pytest_args=None, schema=None):
             cache[trace_uid] = 77
             return 77
 
@@ -1324,7 +1324,7 @@ class TestReconstructFromTraceRunFunctional:
         mock_conn, mock_cur = _mock_db_for_reconstruct(
             mock_pg,
             {
-                "tr_meta": (538, "Wormhole", "n300", 1, None, "2026-03-21", 7000, ""),
+                "tr_meta": (538, "Wormhole", "n300", 1, None, "2026-03-21", 7000, "", None),
                 "trace_models": [
                     (1, "models/demos/audio/whisper/demo/demo.py", None, "whisper"),
                     (
@@ -1395,7 +1395,7 @@ class TestReconstructFromTraceRunFunctional:
         mock_conn, mock_cur = _mock_db_for_reconstruct(
             mock_pg,
             {
-                "tr_meta": (538, "Wormhole", "n300", 1, None, "2026-03-21", 7000, ""),
+                "tr_meta": (538, "Wormhole", "n300", 1, None, "2026-03-21", 7000, "", None),
                 "trace_models": [
                     (1, "models/demos/audio/whisper/demo/demo.py", None, "whisper"),
                     (2, "path/llama.py", "meta-llama/Llama-3.2-1B", "llama-3.2-1b"),
@@ -1428,7 +1428,7 @@ class TestReconstructFromTraceRunFunctional:
         mock_conn, mock_cur = _mock_db_for_reconstruct(
             mock_pg,
             {
-                "tr_meta": (538, "Wormhole", "n300", 1, None, "2026-03-21", 7000, ""),
+                "tr_meta": (538, "Wormhole", "n300", 1, None, "2026-03-21", 7000, "", None),
                 "trace_models": [
                     (1, "models/demos/audio/whisper/demo/demo.py", None, "whisper"),
                 ],
@@ -1445,7 +1445,7 @@ class TestReconstructFromTraceRunFunctional:
         mock_conn, mock_cur = _mock_db_for_reconstruct(
             mock_pg,
             {
-                "tr_meta": (35, "Wormhole", "tt-galaxy-wh", 32, "sha", "2026-03-21", 323, ""),
+                "tr_meta": (35, "Wormhole", "tt-galaxy-wh", 32, "sha", "2026-03-21", 323, "", None),
                 "trace_models": [
                     (1, "models/demos/deepseek_v3/demo/demo.py", None, "deepseek_v3"),
                 ],


### PR DESCRIPTION
### PR Category
Feature, Bug fix

### Summary
This PR records the pytest CLI arguments used for each traced invocation and carries that provenance all the way into the sweep DB. It enables queries like: *did we trace model X with args Y on hardware Z?*

It also fixes a merge-loss issue in `generic_ops_tracer.py` when multiple runs were appended into one master JSON. Execution entries are now deduplicated by `(source, machine_info, trace_uid)` so separate runs (for example Flux dev vs schnell on the same hardware) keep separate provenance instead of overwriting each other.

### What changed
- Add `trace_run.pytest_args` (schema v6 DDL + additive migration SQL for existing DBs).
- Capture args after `--` in tracer metadata and store them in per-execution JSON.
- Persist execution `pytest_args` during `load_ttnn_ops_data_v2.py load`.
- Add `list-variants <pattern>` CLI to list `(model, pytest_args, hardware)` combinations.
- Include `pytest_args` in manifest draft registry entries.
- Include pytest-args provenance in reconstruction outputs:
  - `reconstruct_from_trace_run`: `metadata.pytest_args` + per-execution `pytest_args`
  - aggregate reconstruction paths: `pytest_args_seen`
- Update docs in `model_tracer/GUIDE.md`.

### Notes for reviewers
- `trace_run` semantics remain one row per tracer invocation (`trace_uid`).
- A single load can create multiple `trace_run` rows when a master JSON contains multiple trace_uids.
- Existing rows are backward compatible (`pytest_args = NULL` for historical traces).

### Test plan
- Ran functional sweep loader tests locally (`test_load_ttnn_ops_data_v2_functional.py`); the known pre-existing failures remain unchanged.
- Manually traced Flux variants, loaded traces, and verified `pytest_args` retrieval via DB queries and `list-variants` output.
- Verified reconstruction includes pytest-args provenance fields.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=stevendae/trace_all_models)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:stevendae/trace_all_models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=stevendae/trace_all_models)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:stevendae/trace_all_models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=stevendae/trace_all_models)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:stevendae/trace_all_models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=stevendae/trace_all_models)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:stevendae/trace_all_models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=stevendae/trace_all_models)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:stevendae/trace_all_models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=stevendae/trace_all_models)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:stevendae/trace_all_models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=stevendae/trace_all_models)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:stevendae/trace_all_models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=stevendae/trace_all_models)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:stevendae/trace_all_models)