### PR TITLE
Handle missing imageio-ffmpeg package in Wan tests

### DIFF
--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -317,8 +317,11 @@ def test_pipeline_performance(
     if not is_ci_env:
         if int(ttnn.distributed_context_get_rank()) == 0:
             output_path = f"wan_output_video_{model_type}{'_traced' if traced else ''}.mp4"
-            export_to_video(frames, output_path, fps=16)
-            print(f"✓ Saved video to: {output_path}")
+            try:
+                export_to_video(frames, output_path, fps=16)
+                print(f"✓ Saved video to: {output_path}")
+            except ImportError:
+                print("Could not export video - imageio_ffmpeg not available")
         else:
             print(f"Skipping video export on rank {ttnn.distributed_context_get_rank()}")
 

--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
@@ -127,10 +127,13 @@ def test_pipeline_inference(
         frames = frames[0]
         output_filename = f"wan_t2v_{width}x{height}_{number}.mp4"
         if int(ttnn.distributed_context_get_rank()) == 0:
-            from models.tt_dit.utils.video import export_to_video
+            try:
+                from models.tt_dit.utils.video import export_to_video
 
-            export_to_video(frames, output_filename, fps=16)
-            logger.info(f"Saved video to: {output_filename}")
+                export_to_video(frames, output_filename, fps=16)
+                logger.info(f"Saved video to: {output_filename}")
+            except ImportError:
+                logger.info("Could not export video - imageio_ffmpeg not available")
         else:
             logger.info(f"Skipping video export on rank {ttnn.distributed_context_get_rank()}")
 

--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_wan_i2v.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_wan_i2v.py
@@ -129,10 +129,13 @@ def test_pipeline_inference(
         # Remove batch dimension
         frames = frames[0]
         output_filename = f"wan_i2v_{width}x{height}_{number}.mp4"
-        from models.tt_dit.utils.video import export_to_video
+        try:
+            from models.tt_dit.utils.video import export_to_video
 
-        export_to_video(frames, output_filename, fps=16)
-        logger.info(f"Saved video to: {output_filename}")
+            export_to_video(frames, output_filename, fps=16)
+            logger.info(f"Saved video to: {output_filename}")
+        except ImportError:
+            logger.info("Could not export video - imageio_ffmpeg not available")
 
     if no_prompt:
         run(prompt=prompt, number=0, seed=42)

--- a/models/tt_dit/tests/models/wan2_2/test_stability_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_stability_wan.py
@@ -127,9 +127,12 @@ def test_stability(
                 "wan_outputs",
                 f"wan_stability_prompt_{prompt_idx}_iter{iteration}.mp4",
             )
-            from models.tt_dit.utils.video import export_to_video
+            try:
+                from models.tt_dit.utils.video import export_to_video
 
-            export_to_video(frames_to_save, out_path, fps=16)
-            print(f"✓ Saved video to: {out_path}")
+                export_to_video(frames_to_save, out_path, fps=16)
+                print(f"✓ Saved video to: {out_path}")
+            except ImportError:
+                print("Could not export video - imageio_ffmpeg not available")
 
             iteration += 1


### PR DESCRIPTION
### PR Category
Handle missing `imageio-ffmpeg` package in Wan tests, ticket [43720](https://github.com/tenstorrent/tt-metal/issues/43720).

### Summary
Adds a try/except around the `export_to_video` call to catch import errors when `imageio-ffmpeg` is missing.

- [x] [Wan Galaxy demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/25453723306/job/74678740071)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sosborne/handle-imageio-missing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sosborne/handle-imageio-missing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sosborne/handle-imageio-missing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sosborne/handle-imageio-missing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sosborne/handle-imageio-missing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sosborne/handle-imageio-missing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sosborne/handle-imageio-missing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sosborne/handle-imageio-missing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sosborne/handle-imageio-missing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sosborne/handle-imageio-missing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sosborne/handle-imageio-missing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sosborne/handle-imageio-missing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sosborne/handle-imageio-missing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sosborne/handle-imageio-missing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sosborne/handle-imageio-missing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sosborne/handle-imageio-missing)