### PR TITLE
Backport DeepSeek V3 no-cache fixes to ds-rc1

### DIFF
--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -94,7 +94,7 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
         ARCH_NAME: ${{ matrix.test-group.arch }}
-        DEEPSEEK_V3_HF_MODEL: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized
+        DEEPSEEK_V3_HF_MODEL: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked
         DEEPSEEK_V3_CACHE: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI
         MESH_DEVICE: TG
         # Required for BenchmarkData to save to Superset
@@ -124,7 +124,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - name: Prepare custom weights cache directory
+      - name: Prepare custom DeepSeek cache directory
         if: ${{ inputs.recreate_weights_cache == 'Yes' }}
         env:
           INPUT_CACHE_DIR: ${{ inputs.new_cache_dir }}
@@ -154,6 +154,8 @@ jobs:
           echo "Copying test_io_cache from CI directory..."
           rm -rf "${NEW_DIR}/test_io_cache"
           cp -r "${CACHE_BASE}/CI/test_io_cache" "${NEW_DIR}/test_io_cache"
+          echo "Clearing tests_cache so this workflow regenerates it in the current DeepSeek cache format..."
+          rm -rf "${NEW_DIR}/tests_cache"
           chmod -R a+rwX "${NEW_DIR}"
           echo "DEEPSEEK_V3_CACHE=${NEW_DIR}" >> $GITHUB_ENV
       - name: Run DeepSeek unit tests
@@ -162,11 +164,6 @@ jobs:
         run: |
           uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
           pytest models/demos/deepseek_v3/tests/unit --timeout 60 --durations=0
-      - name: Validate weight cache
-        if: ${{ matrix.test-group.test-type == 'module' || matrix.test-group.test-type == 'final-op-unit' }}
-        timeout-minutes: 10
-        run: |
-          python3 models/demos/deepseek_v3/scripts/validate_weight_cache.py --root "$DEEPSEEK_V3_CACHE/tests_cache" || true
       - name: Run DeepSeek module tests
         if: ${{ matrix.test-group.test-type == 'module' }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
@@ -206,6 +203,18 @@ jobs:
           echo "=============================================="
           echo "All device perf tests completed!"
           echo "=============================================="
+      - name: Validate regenerated DeepSeek cache directory
+        # The shared CI cache root is still on the legacy format. Only validate
+        # branch-created/recreated cache directories that this workflow owns,
+        # after the current job has had a chance to regenerate tests_cache.
+        if: ${{ inputs.recreate_weights_cache == 'Yes' && (matrix.test-group.test-type == 'module' || matrix.test-group.test-type == 'final-op-unit') }}
+        timeout-minutes: 10
+        run: |
+          if [[ -d "$DEEPSEEK_V3_CACHE/tests_cache" ]]; then
+            python3 models/demos/deepseek_v3/scripts/validate_weight_cache.py --root "$DEEPSEEK_V3_CACHE/tests_cache"
+          else
+            echo "No DeepSeek tests_cache present under $DEEPSEEK_V3_CACHE after regeneration; skipping cache validation."
+          fi
       - name: Run DeepSeek long seq len module tests
         if: ${{ matrix.test-group.test-type == 'long-seq-module' }}
         timeout-minutes: ${{ matrix.test-group.timeout }}

--- a/.github/workflows/galaxy-deepseek-tests.yaml
+++ b/.github/workflows/galaxy-deepseek-tests.yaml
@@ -94,7 +94,7 @@ jobs:
         LOGURU_LEVEL: INFO
         ARCH_NAME: wormhole_b0
         MESH_DEVICE: T3K
-        DEEPSEEK_V3_HF_MODEL: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
+        DEEPSEEK_V3_HF_MODEL: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked
         DEEPSEEK_V3_CACHE: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI
       volumes:
         - ${{ github.workspace }}/docker-job:/work
@@ -159,7 +159,7 @@ jobs:
         LOGURU_LEVEL: INFO
         ARCH_NAME: wormhole_b0
         MESH_DEVICE: TG
-        DEEPSEEK_V3_HF_MODEL: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized
+        DEEPSEEK_V3_HF_MODEL: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked
         DEEPSEEK_V3_CACHE: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI
       volumes:
         - ${{ github.workspace }}/docker-job:/work

--- a/models/demos/deepseek_v3/README.md
+++ b/models/demos/deepseek_v3/README.md
@@ -13,6 +13,18 @@ This demo targets the [deepseek-ai/DeepSeek-R1-0528](https://huggingface.co/deep
 - Cloned [tt-metal repository](https://github.com/tenstorrent/tt-metal) for source code
 - Installed: [TT-Metalium™ / TT-NN™](https://github.com/tenstorrent/tt-metal/blob/main/INSTALLING.md)
 
+## Preferred Checkpoint Format
+
+The recommended DeepSeek-V3 runtime path is:
+- export a stacked dequantized checkpoint with `models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py`
+- point `DEEPSEEK_V3_HF_MODEL` or `--model-path` at the resulting `*-dequantized-stacked` directory
+- run without an on-disk TT weight cache
+
+`--cache-dir` and `DEEPSEEK_V3_CACHE` remain available for reference/test caches, but DeepSeek weights are converted
+directly in memory on this path. If you explicitly want to consume a prebuilt legacy TT weight cache
+(for example BSPM output), pass `--use-weight-cache --cache-dir <cache-root>`. Legacy caches generated before the
+current DeepSeek SavedWeight metadata/versioning must be regenerated first; older-format and unversioned caches are rejected.
+
 ## Running on Multi-Host Galaxy (2x or 4x)
 
 DeepSeek-V3 requires a multi-host Galaxy setup. Use the `launch_multihost_galaxy.py` script to run commands across all hosts:
@@ -29,7 +41,6 @@ DeepSeek-V3 requires a multi-host Galaxy setup. Use the `launch_multihost_galaxy
 # Run the demo
 ./models/demos/deepseek_v3/scripts/launch_multihost_galaxy.py 2x -- python models/demos/deepseek_v3/demo/demo.py \
   --model-path \$DEEPSEEK_V3_HF_MODEL \
-  --cache-dir \$DEEPSEEK_V3_CACHE \
   "Your prompt here!"
 
 # Dry run (print command without executing)
@@ -42,8 +53,10 @@ The script automatically:
 - Detects the current hostname and selects the appropriate cluster configuration
 - Sources the Python virtual environment (`python_env/bin/activate`)
 - Sets `MESH_DEVICE` environment variable (`DUAL` for 2x, `QUAD` for 4x)
-- Exports required environment variables (`DEEPSEEK_V3_HF_MODEL`, `DEEPSEEK_V3_CACHE`)
-- Wraps your command with `tt-run` and MPI for multi-host execution
+- Exports `DEEPSEEK_V3_HF_MODEL` and `DEEPSEEK_V3_CACHE`
+- Defaults `DEEPSEEK_V3_HF_MODEL` to the stacked dequantized checkpoint path
+- Leaves `DEEPSEEK_V3_CACHE` available for reference/test caches; DeepSeek weights do not use it as an on-disk TT weight cache
+- Wraps your command with **`tt-run`** (MPI) for multi-host execution; see [tt-run README](../../../ttnn/ttnn/distributed/README_ttrun.md) for **auto allocation** (`--mesh-graph-descriptor`, `--hosts`) vs **legacy** (`--rank-binding`, rankfile)
 
 ### Special Commands
 
@@ -76,8 +89,7 @@ MESH_DEVICE=TG python models/demos/deepseek_v3/demo/demo.py \
              --prompts-file models/demos/deepseek_v3/demo/test_prompts.json \
              --output-path deepseek_tt_out_batch_4.json \
              --max-new-tokens 128 \
-             --model-path $DEEPSEEK_V3_HF_MODEL \
-             --cache-dir $DEEPSEEK_V3_CACHE
+             --model-path $DEEPSEEK_V3_HF_MODEL
 ```
 
 This is useful for development and testing when multi-host resources are not available.
@@ -91,14 +103,12 @@ Running the demo on Galaxy (2x or 4x):
 # On 2x Galaxy
 ./models/demos/deepseek_v3/scripts/launch_multihost_galaxy.py 2x -- python models/demos/deepseek_v3/demo/demo.py \
   --model-path \$DEEPSEEK_V3_HF_MODEL \
-  --cache-dir \$DEEPSEEK_V3_CACHE \
   --early_print_first_user \
   "Write a haiku about autumnal days by the sea"
 
 # On 4x Galaxy
 ./models/demos/deepseek_v3/scripts/launch_multihost_galaxy.py 4x -- python models/demos/deepseek_v3/demo/demo.py \
   --model-path \$DEEPSEEK_V3_HF_MODEL \
-  --cache-dir \$DEEPSEEK_V3_CACHE \
   --early_print_first_user \
   "Write a haiku about autumnal days by the sea"
 ```
@@ -108,7 +118,6 @@ The `launch_multihost_galaxy` script automatically sets `DEEPSEEK_V3_HF_MODEL` a
 ```bash
 ./models/demos/deepseek_v3/scripts/launch_multihost_galaxy.py 2x -- python models/demos/deepseek_v3/demo/demo.py \
   --model-path \$DEEPSEEK_V3_HF_MODEL \
-  --cache-dir \$DEEPSEEK_V3_CACHE \
   --early_print_first_user \
   "Write a haiku about autumnal days by the sea"
 ```
@@ -120,7 +129,8 @@ The `launch_multihost_galaxy` script automatically sets `DEEPSEEK_V3_HF_MODEL` a
 - `--num-prompts N`: Limit the number of prompts loaded from `--prompts-file`.
 - `--output-path FILE`: Save generations/statistics to JSON when using `--prompts-file`. Defaults to `<prompts-file-stem>_output.json`.
 - `--model-path PATH`: Local HF model directory. Defaults to `$DEEPSEEK_V3_HF_MODEL` or `models/demos/deepseek_v3/reference`.
-- `--cache-dir PATH`: Directory for converted TTNN weights/cache. Defaults to `$DEEPSEEK_V3_CACHE` or `generated/deepseek_v3`.
+- `--cache-dir PATH`: Optional directory for reference/test caches. Defaults to `$DEEPSEEK_V3_CACHE` when set. Also used as the legacy TT weight-cache root when `--use-weight-cache` is enabled.
+- `--use-weight-cache`: Load a prebuilt current-format legacy TT weight cache from `--cache-dir` instead of converting weights in memory. Use this for workflows such as BSPM-generated caches. Caches generated before the current DeepSeek SavedWeight metadata/versioning must be regenerated first.
 - `--max-new-tokens N`: Number of tokens to generate (default: 32).
 - `--stop-at-eos`: Stop recording output tokens once EOS is generated. This is the default.
 - `--no-stop-at-eos`: Always record `max-new-tokens`, even after EOS. Use this for fixed-length stress or perf runs.
@@ -178,6 +188,15 @@ run_demo(None, random_weights=True)
 
 # Fixed-length generation even after EOS
 run_demo(["Write a haiku about hardware"], model_path="/abs/path/to/deepseek-v3", stop_at_eos=False)
+
+# Consume a prebuilt BSPM / legacy TT weight cache
+# Regenerate the cache first if it predates the current DeepSeek SavedWeight metadata/versioning.
+run_demo(
+    ["Write a haiku about hardware"],
+    model_path="/abs/path/to/deepseek-v3-dequantized-stacked",
+    cache_dir="/abs/path/to/bspm_cache",
+    use_weight_cache=True,
+)
 ```
 
 ### Performance metrics
@@ -214,25 +233,25 @@ Notes:
 
 If you are not running on Tenstorrent internal infrastructure, you need to set the following environment variables:
 
-- `DEEPSEEK_V3_HF_MODEL`: Path to a directory containing the DeepSeek-V3 Hugging Face model weights. Defaults to `models/demos/deepseek_v3/reference`. Download the model from Hugging Face set this to the model directory.
-- `DEEPSEEK_V3_CACHE`: Path to a directory where cached data such as converted weights and test inputs/outputs will be stored.
+- `DEEPSEEK_V3_HF_MODEL`: Path to a directory containing the DeepSeek-V3 Hugging Face model weights. Defaults to `models/demos/deepseek_v3/reference`. In practice this should normally point at a `*-dequantized-stacked` checkpoint created by `models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py`.
+- `DEEPSEEK_V3_CACHE`: Path to a directory where reference outputs, test inputs/outputs, and similar artifacts can be stored. This is no longer a TT weight cache for the DeepSeek-V3 runtime.
 
 These variables are used in scripts for generating test data and running tests.
 
 This codebase separates model execution into three distinct stages, each of which can be run independently:
-1. Convert PyTorch weights to TTNN tensor files and generate the WeightConfig
+1. Convert PyTorch weights to TTNN tensors and generate the WeightConfig
 2. Generate ModelConfigs for prefill and decode modes
-3. Load TTNN tensor files using WeightConfig, create a shared state using create_state, merge them with ModelPrefillConfig and ModelDecodeConfig to create a RunPrefillConfig and RunDecodeConfig, and execute the model with either of the model configs
+3. Merge the converted weights with model state/config to create a RunPrefillConfig or RunDecodeConfig and execute the model
 
 The modules are not instantiated directly, but rather used as a namespace for the methods that define the model's behavior in prefill and decode. This is to make it easy to separate the stateful and stateless parts of the model, and allow for easy re-use of the methods.
 
 ### Weight Configuration
-Generated by static method `convert_weights` on each module class. Returns a dict mapping operation names to their TTNN weight file paths:
+Generated by static method `convert_weights` on each module class. For the DeepSeek-V3 runtime these weights are typically materialized directly as TTNN tensors in memory rather than written to an on-disk TT cache.
 ```python
 {
-    "w1": "/path/to/weights/w1.input_tensor_b",
-    "w2": "/path/to/weights/w2.input_tensor_b",
-    "w3": "/path/to/weights/w3.input_tensor_b"
+    "w1": <ttnn.Tensor>,
+    "w2": <ttnn.Tensor>,
+    "w3": <ttnn.Tensor>,
 }
 ```
 
@@ -263,7 +282,7 @@ Generated by static methods `prefill_model_config` and `decode_model_config` on 
 
 ### Example Usage
 ```python
-# Stage 1: Convert weights and get weight_config (saves to disk in standard format)
+# Stage 1: Convert weights and get weight_config (DeepSeek-V3 runtime keeps these in memory)
 weight_config = MLP.convert_weights(hf_config, torch_state_dict, Path("weights/mlp"), mesh_device)
 
 # Stage 2: Generate operator configs (returns nested dicts with TTNN objects)

--- a/models/demos/deepseek_v3/conftest.py
+++ b/models/demos/deepseek_v3/conftest.py
@@ -239,8 +239,17 @@ def set_deterministic_env():
     Fixture to set seeds and enable deterministic algorithms for DeepSeek tests.
     This ensures reproducible results across test runs.
     """
-    torch.manual_seed(5)
-    torch.use_deterministic_algorithms(True)
+    previous_deterministic_algorithms = torch.are_deterministic_algorithms_enabled()
+    previous_fill_uninitialized_memory = torch.utils.deterministic.fill_uninitialized_memory
+    try:
+        torch.manual_seed(5)
+        torch.use_deterministic_algorithms(True)
+        # DeepSeek reference tensors are too large for PyTorch's deterministic debug fill.
+        torch.utils.deterministic.fill_uninitialized_memory = False
+        yield
+    finally:
+        torch.use_deterministic_algorithms(previous_deterministic_algorithms)
+        torch.utils.deterministic.fill_uninitialized_memory = previous_fill_uninitialized_memory
 
 
 @pytest.fixture(scope="session")

--- a/models/demos/deepseek_v3/demo/README.md
+++ b/models/demos/deepseek_v3/demo/README.md
@@ -21,35 +21,49 @@ Tokenizer (full‑model mode): expect one of `tokenizer.model`, `tokenizer.json`
 ### 1) Full model with local safetensors
 Use this when you have a local DeepSeek‑V3 model (config, tokenizer, and `.safetensors`).
 
-If you only have the original fp8 Hugging Face checkpoint, export a bf16 checkpoint first:
+The recommended path is a pre-exported stacked dequantized checkpoint. If you only have the
+original fp8 Hugging Face checkpoint, export one first:
 
 ```bash
 python models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py \
-  /proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528 \
-  --output-model-path /proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528-dequantized
+  /proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528
 ```
+
+By default this writes `/proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked`.
+Use `--no-stack-experts` only if you explicitly need the legacy non-stacked checkpoint format.
 
 ```bash
 # Point to a local HF model directory (contains tokenizer + .safetensors)
-export DEEPSEEK_V3_HF_MODEL=/proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528-dequantized
-# Where to store converted TTNN weights
-export DEEPSEEK_V3_CACHE=/proj_sw/user_dev/deepseek_ttnn_cache_all_61_layers
+export DEEPSEEK_V3_HF_MODEL=/proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked
 # What system type are we running on? (Can be TG, DUAL, QUAD)
 export MESH_DEVICE=DUAL
 
 python models/demos/deepseek_v3/demo/demo.py \
   "Explain quantum tunneling in one paragraph." \
   --model-path $DEEPSEEK_V3_HF_MODEL \
-  --cache-dir $DEEPSEEK_V3_CACHE \
   --max-new-tokens 64
 ```
+
+If you want a stable location for reference/test caches, optionally set `DEEPSEEK_V3_CACHE`
+or pass `--cache-dir`. DeepSeek TT weights are not cached on disk in this path.
+
+If you explicitly need to consume a prebuilt legacy TT weight cache, such as BSPM output, keep
+`--model-path` pointed at the stacked checkpoint and add:
+
+```bash
+  --cache-dir /path/to/legacy_weight_cache \
+  --use-weight-cache
+```
+
+Caches generated before the current DeepSeek SavedWeight metadata/versioning must be regenerated first; the runtime
+rejects older-format and unversioned caches.
 
 ### 2) Single‑layer with random weights (fast)
 Runs a minimal single‑layer pipeline with randomly initialized weights. This does not require `.safetensors`, and the tokenizer is optional. If no tokenizer is found, the demo synthesizes simple token IDs. The prompt is not used in this mode, so you don’t need to provide one.
 
 ```bash
 # Point to a local HF model directory (contains tokenizer + .safetensors)
-export DEEPSEEK_V3_HF_MODEL=/proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528-dequantized
+export DEEPSEEK_V3_HF_MODEL=/proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked
 # What system type are we running on? (Can be TG, DUAL, QUAD)
 export MESH_DEVICE=DUAL
 
@@ -57,7 +71,6 @@ export MESH_DEVICE=DUAL
 python models/demos/deepseek_v3/demo/demo.py \
   --random-weights --single-layer mlp \
   --model-path $DEEPSEEK_V3_HF_MODEL \
-  --cache-dir $DEEPSEEK_V3_CACHE \
   --max-new-tokens 16
 ```
 
@@ -80,7 +93,8 @@ usage: DeepSeek-V3 Demo on TT-NN [-h] [--model-path PATH] [--max-new-tokens N]
 - `--max-new-tokens N`: Number of tokens to generate (default: 32). Greedy decoding only.
 - `--stop-at-eos`: Stop recording output tokens once EOS is generated. This is the default.
 - `--no-stop-at-eos`: Always record `max-new-tokens`, even after EOS.
-- `--cache-dir PATH`: Where to store converted TTNN weights and caches.
+- `--cache-dir PATH`: Optional directory for reference/test caches. Also used as the legacy TT weight-cache root when `--use-weight-cache` is set.
+- `--use-weight-cache`: Load a prebuilt current-format legacy TT weight cache from `--cache-dir` instead of converting DeepSeek weights in memory. Older-format and unversioned caches must be regenerated first.
 - `--random-weights`: Use randomly initialized weights derived from the HF config (no safetensors).
 - `--single-layer {mlp,moe}`: With `--random-weights`, request a single‑layer run. `mlp` is supported; `moe` is not.
 
@@ -100,8 +114,14 @@ usage: DeepSeek-V3 Demo on TT-NN [-h] [--model-path PATH] [--max-new-tokens N]
   such as `tokenizer.model` or `tokenizer.json`.
 - "No .safetensors files found": You are in full‑model mode. Either provide a directory with safetensors or use
   `--random-weights --single-layer mlp` for a quick run without weights.
+- "Stacked expert tensors were not found": You pointed at a legacy `*-dequantized` checkpoint. Regenerate the checkpoint
+  with `python models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py <source-model-path>` and use the resulting
+  `*-dequantized-stacked` directory for the fastest startup path.
 - "--single-layer=moe not supported": Only `mlp` is supported in the single‑layer random‑weights demo.
 
 ## Notes
-- Converted weights are cached under `--cache-dir/weights` to speed up subsequent runs.
+- The recommended reusable artifact is the stacked dequantized checkpoint directory itself, not a generated TT weight cache.
+- `--cache-dir` remains useful for reference outputs and other test/demo artifacts if you want them outside the model directory.
+- If you explicitly need a legacy TT weight cache, pass both `--cache-dir` and `--use-weight-cache`.
+- Caches generated before the current DeepSeek SavedWeight metadata/versioning are no longer accepted; regenerate them before reuse.
 - This script focuses on decode and greedy sampling for simplicity; stopping at EOS is exposed and enabled by default, while temperature/top‑k/p are not.

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -105,7 +105,9 @@ def _resolve_tt_metal_commit() -> str:
 
 
 def _is_primary_artifact_writer() -> bool:
-    for rank_env in ("TT_MESH_HOST_RANK", "OMPI_COMM_WORLD_RANK", "PMI_RANK", "RANK"):
+    # Prefer global launcher ranks when available; TT_MESH_HOST_RANK is mesh-local
+    # and can repeat across submeshes in a multi-mesh launch.
+    for rank_env in ("OMPI_COMM_WORLD_RANK", "PMI_RANK", "RANK", "TT_MESH_HOST_RANK"):
         rank_value = os.getenv(rank_env)
         if rank_value is None:
             continue
@@ -236,7 +238,18 @@ def create_parser() -> argparse.ArgumentParser:
         default=DEFAULT_SAMPLING_TOP_P,
         help=f"Top-p value for sampling (default: {DEFAULT_SAMPLING_TOP_P}).",
     )
-    p.add_argument("--cache-dir", type=str, required=True)
+    p.add_argument(
+        "--cache-dir",
+        type=str,
+        default=None,
+        help="Optional reference/test cache directory. Also used as the legacy TT weight-cache root when --use-weight-cache is set.",
+    )
+    p.add_argument(
+        "--use-weight-cache",
+        action="store_true",
+        default=False,
+        help="Load a prebuilt current-format legacy TT weight cache from --cache-dir instead of converting DeepSeek weights in memory. Older-format and unversioned caches must be regenerated first.",
+    )
     # Random-weights mode options (reuse Model1D pipeline; single dense layer only)
     p.add_argument(
         "--random-weights", action="store_true", help="Use randomly initialized weights instead of loading safetensors"
@@ -329,7 +342,7 @@ def create_parser() -> argparse.ArgumentParser:
         dest="force_recalculate",
         action="store_true",
         default=False,
-        help="Force regeneration of cached TTNN weight files and config.",
+        help="Legacy compatibility flag. The stacked DeepSeek path converts weights directly in memory, so this is ignored there.",
     )
     p.add_argument(
         "--stop-at-eos",
@@ -455,6 +468,7 @@ def run_demo(
     max_seq_len: int = DEFAULT_MAX_SEQ_LEN,
     max_users_per_row: int = USERS_PER_ROW,
     cache_dir: str | Path | None = None,
+    use_weight_cache: bool = False,
     random_weights: bool = False,
     single_layer: str | None = None,
     override_num_layers: int | None = None,
@@ -488,9 +502,12 @@ def run_demo(
         raise SystemExit("Missing model path. Provide --model-path.")
     model_path = Path(model_path)
 
-    if cache_dir is None:
-        raise SystemExit("Missing cache directory. Provide --cache-dir.")
-    cache_dir = Path(cache_dir)
+    cache_dir = None if cache_dir is None else Path(cache_dir)
+
+    if use_weight_cache and cache_dir is None:
+        raise SystemExit("--use-weight-cache requires --cache-dir pointing at the legacy TT weight-cache root.")
+    if use_weight_cache and force_recalculate:
+        raise SystemExit("--use-weight-cache cannot be combined with --force-recalculate.")
 
     if sampling_temperature < 0:
         raise SystemExit("--sampling-temperature must be >= 0 (use 0 for greedy decoding).")
@@ -597,29 +614,35 @@ def run_demo(
 
             token_acc = TokenAccuracy(str(reference_file), prompt_len=tf_prompt_len)
         if generator == "bp":
-            gen = DeepseekGeneratorDP(
-                mesh_device=mesh_device,
-                model_path=model_path,
-                cache_dir=cache_dir,
-                tokenizer=tokenizer,
-                random_weights=bool(random_weights),
-                dense_layers=(1 if random_weights and single_layer else None),
-                override_num_layers=(
-                    override_num_layers if override_num_layers is not None else (1 if random_weights else None)
-                ),
-                single_layer=(single_layer if random_weights else None),
-                enable_trace=enable_trace,
-                enable_mem_profile=enable_mem_profile,
-                signpost=signpost,
-                max_seq_len=max_seq_len,
-                prefill_max_tokens=prefill_max_tokens,
-                force_recalculate=force_recalculate,
-                profile_decode=profile_decode,
-                sample_on_device=sample_on_device,
-                enable_mtp=enable_mtp,
-                batch_size_per_row=max_users_per_row,
-                sampling_params=sampling_params,
-            )
+            try:
+                gen = DeepseekGeneratorDP(
+                    mesh_device=mesh_device,
+                    model_path=model_path,
+                    cache_dir=cache_dir,
+                    use_weight_cache=use_weight_cache,
+                    tokenizer=tokenizer,
+                    random_weights=bool(random_weights),
+                    dense_layers=(1 if random_weights and single_layer else None),
+                    override_num_layers=(
+                        override_num_layers if override_num_layers is not None else (1 if random_weights else None)
+                    ),
+                    single_layer=(single_layer if random_weights else None),
+                    enable_trace=enable_trace,
+                    enable_mem_profile=enable_mem_profile,
+                    signpost=signpost,
+                    max_seq_len=max_seq_len,
+                    prefill_max_tokens=prefill_max_tokens,
+                    force_recalculate=force_recalculate,
+                    profile_decode=profile_decode,
+                    sample_on_device=sample_on_device,
+                    enable_mtp=enable_mtp,
+                    batch_size_per_row=max_users_per_row,
+                    sampling_params=sampling_params,
+                )
+            except (FileNotFoundError, ValueError) as e:
+                if use_weight_cache:
+                    raise SystemExit(str(e)) from e
+                raise
         else:
             raise ValueError(f"Unsupported generator: {generator}")
         # Build the prompt list
@@ -846,6 +869,7 @@ def main() -> None:
         max_seq_len=args.max_seq_len,
         max_users_per_row=args.max_users_per_row,
         cache_dir=args.cache_dir,
+        use_weight_cache=bool(args.use_weight_cache),
         random_weights=bool(args.random_weights),
         single_layer=args.single_layer,
         override_num_layers=args.override_num_layers,

--- a/models/demos/deepseek_v3/demo/generate_teacher_forced_file.py
+++ b/models/demos/deepseek_v3/demo/generate_teacher_forced_file.py
@@ -34,7 +34,7 @@ from models.demos.deepseek_v3.utils.hf_model_utils import (
 MODEL_PATH = Path(
     os.getenv(
         "DEEPSEEK_V3_HF_MODEL",
-        "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized",
+        "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked",
     )
 )
 

--- a/models/demos/deepseek_v3/demo/inspect_reference_file.py
+++ b/models/demos/deepseek_v3/demo/inspect_reference_file.py
@@ -19,7 +19,7 @@ try:
     MODEL_PATH = Path(
         os.getenv(
             "DEEPSEEK_V3_HF_MODEL",
-            "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized",
+            "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked",
         )
     )
     tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH, trust_remote_code=True)

--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -13,7 +13,7 @@ from models.demos.deepseek_v3.demo.demo import load_prompts_from_json, run_demo
 from models.demos.deepseek_v3.utils.test_utils import system_name_to_mesh_shape
 
 MODEL_PATH = Path(
-    os.getenv("DEEPSEEK_V3_HF_MODEL", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized")
+    os.getenv("DEEPSEEK_V3_HF_MODEL", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked")
 )
 CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI"))
 

--- a/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
+++ b/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
@@ -22,7 +22,7 @@ from models.demos.deepseek_v3.utils.test_utils import system_name_to_mesh_shape
 MODEL_PATH = Path(
     os.getenv(
         "DEEPSEEK_V3_HF_MODEL",
-        "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized",
+        "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked",
     )
 )
 CACHE_DIR = Path(

--- a/models/demos/deepseek_v3/demo/test_eval_support.py
+++ b/models/demos/deepseek_v3/demo/test_eval_support.py
@@ -3,6 +3,8 @@
 
 import inspect
 import json
+import sys
+from pathlib import Path
 
 import pytest
 
@@ -28,6 +30,9 @@ class _FakeGenerator:
     def __init__(self, **kwargs):
         self.init_kwargs = kwargs
         self.tokenizer = kwargs["tokenizer"]
+        self.enable_mtp = kwargs.get("enable_mtp", False)
+        mesh_rows = getattr(kwargs.get("mesh_device"), "shape", (1, 1))[0]
+        self.batch_size = kwargs.get("batch_size_per_row", 1) * mesh_rows
         self.generate_kwargs = None
 
     def generate(self, prompts, **kwargs):
@@ -35,7 +40,7 @@ class _FakeGenerator:
         on_user_finished = kwargs["on_user_finished"]
         if on_user_finished is not None:
             on_user_finished(0, [11, 12])
-        return [[11, 12], [21, 22, 23]], {"decode_t/s": 1.0}
+        return [[11, 12], [21, 22, 23]], {"decode_t/s": 1.0}, {"sampling": {}}
 
     def cleanup_all(self):
         return None
@@ -44,6 +49,7 @@ class _FakeGenerator:
 def test_create_parser_stop_at_eos_flag():
     args = demo_module.create_parser().parse_args(["--model-path", "/tmp/model", "--cache-dir", "/tmp/cache"])
     assert args.stop_at_eos is True
+    assert args.use_weight_cache is False
 
     args = demo_module.create_parser().parse_args(
         ["--model-path", "/tmp/model", "--cache-dir", "/tmp/cache", "--stop-at-eos"]
@@ -54,6 +60,11 @@ def test_create_parser_stop_at_eos_flag():
         ["--model-path", "/tmp/model", "--cache-dir", "/tmp/cache", "--no-stop-at-eos"]
     )
     assert args.stop_at_eos is False
+
+    args = demo_module.create_parser().parse_args(
+        ["--model-path", "/tmp/model", "--cache-dir", "/tmp/cache", "--use-weight-cache"]
+    )
+    assert args.use_weight_cache is True
 
 
 def test_stop_at_eos_signature_defaults():
@@ -71,7 +82,15 @@ def _patch_demo_runtime(monkeypatch, fake_generator, *, mesh_shape=(1, 1)):
     monkeypatch.setattr(demo_module.ttnn, "open_mesh_device", lambda *args, **kwargs: _FakeMeshDevice(shape=mesh_shape))
     monkeypatch.setattr(demo_module.ttnn, "synchronize_device", lambda *args, **kwargs: None)
     monkeypatch.setattr(demo_module.ttnn, "close_mesh_device", lambda *args, **kwargs: None)
-    monkeypatch.setattr(demo_module, "DeepseekGeneratorDP", lambda **kwargs: fake_generator)
+
+    def _construct_fake_generator(**kwargs):
+        fake_generator.init_kwargs = kwargs
+        fake_generator.tokenizer = kwargs["tokenizer"]
+        fake_generator.enable_mtp = kwargs.get("enable_mtp", False)
+        fake_generator.batch_size = kwargs["batch_size_per_row"] * kwargs["mesh_device"].shape[0]
+        return fake_generator
+
+    monkeypatch.setattr(demo_module, "DeepseekGeneratorDP", _construct_fake_generator)
 
 
 @pytest.mark.parametrize("stop_at_eos", [True, False], ids=["stop_at_eos", "no_stop_at_eos"])
@@ -115,6 +134,67 @@ def test_run_demo_defaults_to_stop_at_eos(monkeypatch, tmp_path):
     assert fake_generator.generate_kwargs["stop_at_eos"] is True
 
 
+def test_is_primary_artifact_writer_accepts_common_rank_envs(monkeypatch):
+    monkeypatch.delenv("TT_MESH_HOST_RANK", raising=False)
+    monkeypatch.setenv("OMPI_COMM_WORLD_RANK", "0")
+
+    assert demo_module._is_primary_artifact_writer() is True
+
+    monkeypatch.setenv("OMPI_COMM_WORLD_RANK", "1")
+    assert demo_module._is_primary_artifact_writer() is False
+
+
+def test_is_primary_artifact_writer_prefers_global_rank_over_mesh_local_rank(monkeypatch):
+    monkeypatch.setenv("TT_MESH_HOST_RANK", "0")
+    monkeypatch.setenv("OMPI_COMM_WORLD_RANK", "1")
+
+    assert demo_module._is_primary_artifact_writer() is False
+
+
+def test_main_uses_primary_artifact_writer_for_json_output(monkeypatch, tmp_path):
+    prompts_file = tmp_path / "prompts.json"
+    prompts_file.write_text(json.dumps([{"prompt": "prompt-0"}]), encoding="utf-8")
+
+    writes: list[tuple[Path, dict, str]] = []
+
+    monkeypatch.setattr(
+        demo_module,
+        "run_demo",
+        lambda *args, **kwargs: {"generations": [{"text": "11 12"}], "statistics": {}, "model_params": {}},
+    )
+    monkeypatch.setattr(
+        demo_module,
+        "_write_json_output",
+        lambda path, payload, label: writes.append((Path(path), payload, label)),
+    )
+    monkeypatch.setattr(demo_module, "_is_primary_artifact_writer", lambda: False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["demo.py", "--prompts-file", str(prompts_file), "--model-path", str(tmp_path / "model")],
+    )
+
+    demo_module.main()
+
+    assert writes == []
+
+    monkeypatch.setattr(demo_module, "_is_primary_artifact_writer", lambda: True)
+    demo_module.main()
+
+    assert writes == [
+        (
+            prompts_file.parent / f"{prompts_file.stem}_output.json",
+            {
+                "prompts": ["prompt-0"],
+                "generations": [{"index": 1, "prompt": "prompt-0", "text": "11 12"}],
+                "statistics": {},
+                "model_params": {},
+            },
+            "Results",
+        )
+    ]
+
+
 def test_run_demo_sizes_sampling_params_from_max_users_per_row(monkeypatch, tmp_path):
     fake_generator = _FakeGenerator(tokenizer=_FakeTokenizer())
 
@@ -132,6 +212,30 @@ def test_run_demo_sizes_sampling_params_from_max_users_per_row(monkeypatch, tmp_
     assert len(sampling_params.temperature) == expected_batch
     assert len(sampling_params.top_p) == expected_batch
     assert len(sampling_params.top_k) == expected_batch
+
+
+def test_run_demo_passes_use_weight_cache_to_generator(monkeypatch, tmp_path):
+    fake_generator = _FakeGenerator(tokenizer=_FakeTokenizer())
+
+    _patch_demo_runtime(monkeypatch, fake_generator)
+
+    demo_module.run_demo(
+        prompts=["prompt-0"],
+        model_path=tmp_path / "model",
+        cache_dir=tmp_path / "cache",
+        use_weight_cache=True,
+    )
+
+    assert fake_generator.init_kwargs["use_weight_cache"] is True
+
+
+def test_run_demo_rejects_use_weight_cache_without_cache_dir(tmp_path):
+    with pytest.raises(SystemExit, match="--use-weight-cache requires --cache-dir"):
+        demo_module.run_demo(
+            prompts=["prompt-0"],
+            model_path=tmp_path / "model",
+            use_weight_cache=True,
+        )
 
 
 def test_lmeval_helpers():

--- a/models/demos/deepseek_v3/reference/modeling_deepseek.py
+++ b/models/demos/deepseek_v3/reference/modeling_deepseek.py
@@ -400,6 +400,8 @@ class MoEGate(nn.Module):
         import torch.nn.init as init
 
         init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        if self.topk_method == "noaux_tc":
+            init.zeros_(self.e_score_correction_bias)
 
     def grouped_gate_golden(
         self, scores, bias, route_scale, epsilon, n_groups, summed_experts_per_group, topk_groups, n_activated_experts

--- a/models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py
+++ b/models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py
@@ -14,7 +14,11 @@ the exported checkpoint can be loaded by the dequantized-only DeepSeek runtime.
 import argparse
 from pathlib import Path
 
-from models.demos.deepseek_v3.utils.hf_model_utils import default_dequantized_model_path, save_dequantized_hf_checkpoint
+from models.demos.deepseek_v3.utils.hf_model_utils import (
+    default_dequantized_model_path,
+    default_stacked_dequantized_model_path,
+    save_dequantized_hf_checkpoint,
+)
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -24,23 +28,40 @@ def create_parser() -> argparse.ArgumentParser:
         "--output-model-path",
         type=Path,
         default=None,
-        help="Output directory for the dequantized checkpoint. Defaults to '<source>-dequantized'.",
+        help="Output directory for the dequantized checkpoint. Defaults to '<source>-dequantized-stacked'.",
     )
+    parser.set_defaults(stack_experts=True)
     parser.add_argument(
         "--force",
         action="store_true",
         help="Overwrite the output directory if it already exists.",
+    )
+    parser.add_argument(
+        "--stack-experts",
+        action="store_true",
+        help="Export per-layer stacked expert tensors under 'experts_stacked.*.weight' and omit per-expert tensors. This is the default.",
+    )
+    parser.add_argument(
+        "--no-stack-experts",
+        dest="stack_experts",
+        action="store_false",
+        help="Export the legacy non-stacked dequantized checkpoint format.",
     )
     return parser
 
 
 def main() -> None:
     args = create_parser().parse_args()
-    output_model_path = args.output_model_path or default_dequantized_model_path(args.source_model_path)
+    output_model_path = args.output_model_path or (
+        default_stacked_dequantized_model_path(args.source_model_path)
+        if args.stack_experts
+        else default_dequantized_model_path(args.source_model_path)
+    )
     saved_path = save_dequantized_hf_checkpoint(
         args.source_model_path,
         output_model_path=output_model_path,
         overwrite=args.force,
+        stack_experts=args.stack_experts,
     )
     print(f"Saved dequantized checkpoint to {saved_path}")
 

--- a/models/demos/deepseek_v3/scripts/launch_multihost_galaxy.py
+++ b/models/demos/deepseek_v3/scripts/launch_multihost_galaxy.py
@@ -62,7 +62,7 @@ COMMAND_ALIASES: dict[str, str] = {"reset": "tt-smi -glx_reset --snapshot_no_tty
 
 # Common environment variables for all hosts
 COMMON_ENV: tuple[tuple[str, str], ...] = (
-    ("DEEPSEEK_V3_HF_MODEL", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized"),
+    ("DEEPSEEK_V3_HF_MODEL", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked"),
     ("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/dev"),
 )
 

--- a/models/demos/deepseek_v3/scripts/validate_weight_cache.py
+++ b/models/demos/deepseek_v3/scripts/validate_weight_cache.py
@@ -14,7 +14,9 @@ from models.demos.deepseek_v3.utils.weight_config import (
     WeightConfigEncoder,
     locked_file,
     try_decode_saved_weight,
+    unwrap_weight_cache_payload,
     validate_weight_config_paths,
+    wrap_weight_cache_payload,
 )
 
 # Regex patterns for cache directory structure
@@ -219,7 +221,12 @@ def validate_cache_directory(cache_dir: Path, verbose: bool = False) -> dict[str
     # Load and decode config (with shared lock to prevent reading during writes)
     try:
         with locked_file(config_path, "r", exclusive=False) as f:
-            weight_config = json.load(f, object_hook=try_decode_saved_weight)
+            serialized_config = json.load(f, object_hook=try_decode_saved_weight)
+        weight_config = unwrap_weight_cache_payload(
+            serialized_config,
+            require_current_format=True,
+            config_path=config_path,
+        )
     except Exception as e:
         result["errors"].append(f"Failed to load config.json: {e}")
         return result
@@ -333,7 +340,12 @@ def repair_cache_directory(cache_dir: Path, verbose: bool = False) -> dict[str, 
     # Load and decode config (with exclusive lock for write)
     try:
         with locked_file(config_path, "r", exclusive=False) as f:
-            weight_config = json.load(f, object_hook=try_decode_saved_weight)
+            serialized_config = json.load(f, object_hook=try_decode_saved_weight)
+        weight_config = unwrap_weight_cache_payload(
+            serialized_config,
+            require_current_format=True,
+            config_path=config_path,
+        )
     except Exception as e:
         result["errors"].append(f"Failed to load config.json: {e}")
         return result
@@ -346,7 +358,7 @@ def repair_cache_directory(cache_dir: Path, verbose: bool = False) -> dict[str, 
         if num_repaired > 0:
             # Write repaired config back to disk (with exclusive lock)
             with locked_file(config_path, "w", exclusive=True) as f:
-                json.dump(repaired_config, f, cls=WeightConfigEncoder, indent=2)
+                json.dump(wrap_weight_cache_payload(repaired_config), f, cls=WeightConfigEncoder, indent=2)
             result["repaired"] = True
             if verbose:
                 print(f"Repaired {num_repaired} absolute path(s) in {cache_dir}")
@@ -527,7 +539,12 @@ def print_summary(stats: dict[str, Any]) -> None:
 
 def main():
     """Main entry point with argparse."""
-    parser = argparse.ArgumentParser(description="Validate weight cache directories and print a comprehensive summary.")
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate current-format DeepSeek legacy weight cache directories and print a comprehensive summary. "
+            "Caches generated before the current SavedWeight metadata/versioning must be regenerated first."
+        )
+    )
 
     # Create mutually exclusive group for cache discovery methods
     discovery_group = parser.add_mutually_exclusive_group()
@@ -552,7 +569,7 @@ def main():
     parser.add_argument(
         "--repair-absolute-paths",
         action="store_true",
-        help="Repair absolute paths by converting them to relative paths in config.json files",
+        help="Repair absolute paths by converting them to relative paths in current-format config.json files",
     )
 
     args = parser.parse_args()

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/AGENTS_GUIDE_ADD_TEST.md
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/AGENTS_GUIDE_ADD_TEST.md
@@ -9,7 +9,7 @@ Before you start, please read the example test in models/demos/deepseek_v3/tests
 Example test command for test_mla.py:
 ```
 source ../setup_metal.sh
-export DEEPSEEK_V3_HF_MODEL="/proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528-dequantized/" && export DEEPSEEK_V3_CACHE="/proj_sw/user_dev/deepseek-v3-cache2" && export TT_METAL_RUNTIME_ROOT=/proj_sw/user_dev/jrock/tt-metal && export MESH_DEVICE=TG && pytest /proj_sw/user_dev/jrock/tt-metal/models/demos/deepseek_v3/tests/test_mla.py::test_forward_pass -k "decode" 2>&1 | tee /proj_sw/user_dev/jrock/tt-metal/logs/ds_mla_$(date +%Y%m%d_%H%M%S).log
+export DEEPSEEK_V3_HF_MODEL="/proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked/" && export DEEPSEEK_V3_CACHE="/proj_sw/user_dev/deepseek-v3-cache2" && export TT_METAL_RUNTIME_ROOT=/proj_sw/user_dev/jrock/tt-metal && export MESH_DEVICE=TG && pytest /proj_sw/user_dev/jrock/tt-metal/models/demos/deepseek_v3/tests/test_mla.py::test_forward_pass -k "decode" 2>&1 | tee /proj_sw/user_dev/jrock/tt-metal/logs/ds_mla_$(date +%Y%m%d_%H%M%S).log
 ```
 
 Follow these steps to add a new fused op unit test:

--- a/models/demos/deepseek_v3/tests/test_dequantize.py
+++ b/models/demos/deepseek_v3/tests/test_dequantize.py
@@ -4,13 +4,18 @@
 
 import json
 import os
+import re
 from pathlib import Path
 from typing import Sequence
 
 import pytest
 import torch
 
-from models.demos.deepseek_v3.utils.hf_model_utils import load_weight_from_weights_dict
+from models.demos.deepseek_v3.utils.hf_model_utils import (
+    DEQUANTIZED_CHECKPOINT_SUFFIX,
+    STACKED_DEQUANTIZED_CHECKPOINT_SUFFIX,
+    load_weight_from_weights_dict,
+)
 from models.demos.deepseek_v3.utils.test_utils import load_state_dict
 
 REFERENCE_WEIGHT_KEYS = [
@@ -37,6 +42,9 @@ FULL_DEQUANT_COMPARE_TIMEOUT_SECONDS = 7200
 PRINT_TENSORS_ENV_VAR = "DEEPSEEK_V3_DEQUANT_PRINT_TENSORS"
 MAX_DIFF_INDICES_TO_PRINT = 20
 MAX_TENSOR_ELEMENTS_TO_PRINT = 100
+STACKED_EXPERT_WEIGHT_RE = re.compile(
+    r"^model\.layers\.(?P<layer>\d+)\.mlp\.experts\.(?P<expert>\d+)\.(?P<projection>gate_proj|down_proj|up_proj)\.weight$"
+)
 
 
 def _dequantize_reference_tensor(
@@ -130,6 +138,20 @@ def _print_tensor_comparison(
     print("---\n")
 
 
+def _expected_dequantized_weight_keys(orig_weight_keys: set[str], deq_keys: set[str]) -> set[str]:
+    if not any(".experts_stacked." in key for key in deq_keys):
+        return orig_weight_keys
+
+    expected_keys: set[str] = set()
+    for key in orig_weight_keys:
+        match = STACKED_EXPERT_WEIGHT_RE.match(key)
+        if match is None:
+            expected_keys.add(key)
+            continue
+        expected_keys.add(f"model.layers.{match.group('layer')}.mlp.experts_stacked.{match.group('projection')}.weight")
+    return expected_keys
+
+
 def _resolve_quantized_model_path(model_path: Path) -> Path | None:
     explicit_path = os.getenv(QUANTIZED_MODEL_PATH_ENV_VAR)
     if explicit_path:
@@ -137,8 +159,12 @@ def _resolve_quantized_model_path(model_path: Path) -> Path | None:
         return candidate if candidate.is_dir() else None
 
     model_path = Path(model_path).resolve()
-    if model_path.name.endswith("-dequantized"):
-        candidate = model_path.with_name(model_path.name.removesuffix("-dequantized"))
+    if model_path.name.endswith(STACKED_DEQUANTIZED_CHECKPOINT_SUFFIX):
+        candidate = model_path.with_name(model_path.name.removesuffix(STACKED_DEQUANTIZED_CHECKPOINT_SUFFIX))
+        return candidate if candidate.is_dir() else None
+
+    if model_path.name.endswith(DEQUANTIZED_CHECKPOINT_SUFFIX):
+        candidate = model_path.with_name(model_path.name.removesuffix(DEQUANTIZED_CHECKPOINT_SUFFIX))
         return candidate if candidate.is_dir() else None
 
     return None
@@ -268,7 +294,7 @@ def test_dequantized_checkpoint_has_all_original_weights(model_path):
     if quantized_model_path is None:
         pytest.skip(
             f"Could not resolve the original quantized checkpoint. Set {QUANTIZED_MODEL_PATH_ENV_VAR} "
-            "or run with DEEPSEEK_V3_HF_MODEL pointing at a '-dequantized' checkpoint."
+            "or run with DEEPSEEK_V3_HF_MODEL pointing at a '-dequantized-stacked' checkpoint."
         )
 
     deq_path = Path(model_path).resolve()
@@ -283,8 +309,13 @@ def test_dequantized_checkpoint_has_all_original_weights(model_path):
     orig_keys = set(orig_index["weight_map"].keys())
     deq_keys = set(deq_index["weight_map"].keys())
 
-    # Expected in dequantized = all original keys except _scale_inv (folded into weight)
-    orig_weight_keys = {k for k in orig_keys if not k.endswith("_scale_inv")}
+    # Expected in dequantized = all original keys except _scale_inv (folded into weight).
+    # Stacked exports intentionally replace per-expert MoE tensors with one
+    # `experts_stacked.<projection>.weight` tensor per layer/projection.
+    orig_weight_keys = _expected_dequantized_weight_keys(
+        {k for k in orig_keys if not k.endswith("_scale_inv")},
+        deq_keys,
+    )
 
     missing = orig_weight_keys - deq_keys
     extra = deq_keys - orig_weight_keys
@@ -305,7 +336,7 @@ def test_saved_dequantized_reference_weights_match_old_pipeline(model_path, hf_c
     if quantized_model_path is None:
         pytest.skip(
             f"Could not resolve the original quantized checkpoint. Set {QUANTIZED_MODEL_PATH_ENV_VAR} "
-            "or run with DEEPSEEK_V3_HF_MODEL pointing at a '-dequantized' checkpoint."
+            "or run with DEEPSEEK_V3_HF_MODEL pointing at a '-dequantized-stacked' checkpoint."
         )
 
     quantized_state_dict = load_state_dict(quantized_model_path, "")
@@ -331,7 +362,7 @@ def test_all_saved_dequantized_weights_match_old_pipeline(model_path, hf_config,
     if quantized_model_path is None:
         pytest.skip(
             f"Could not resolve the original quantized checkpoint. Set {QUANTIZED_MODEL_PATH_ENV_VAR} "
-            "or run with DEEPSEEK_V3_HF_MODEL pointing at a '-dequantized' checkpoint."
+            "or run with DEEPSEEK_V3_HF_MODEL pointing at a '-dequantized-stacked' checkpoint."
         )
 
     quantized_state_dict = load_state_dict(quantized_model_path, "")

--- a/models/demos/deepseek_v3/tests/test_generator_vllm.py
+++ b/models/demos/deepseek_v3/tests/test_generator_vllm.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from models.demos.deepseek_v3.tt import generator_vllm as generator_vllm_module
+
+pytestmark = pytest.mark.t3k_compat
+
+
+def test_initialize_vllm_model_passes_cache_dir_without_enabling_weight_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    captured: dict[str, object] = {}
+
+    def fake_init(self, *args, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setenv("DEEPSEEK_V3_HF_MODEL", str(tmp_path / "model"))
+    monkeypatch.setenv("DEEPSEEK_V3_CACHE", str(tmp_path / "cache"))
+    monkeypatch.setattr(generator_vllm_module, "load_tokenizer", lambda model_path: object())
+    monkeypatch.setattr(generator_vllm_module.DeepseekV3ForCausalLM, "__init__", fake_init)
+
+    generator_vllm_module.DeepseekV3ForCausalLM.initialize_vllm_model(
+        hf_config=object(),
+        mesh_device=object(),
+        max_batch_size=1,
+        max_seq_len=128,
+    )
+
+    assert captured["model_path"] == Path(tmp_path / "model")
+    assert captured["cache_dir"] == Path(tmp_path / "cache")
+    assert "use_weight_cache" not in captured

--- a/models/demos/deepseek_v3/tests/test_get_weight_config.py
+++ b/models/demos/deepseek_v3/tests/test_get_weight_config.py
@@ -5,22 +5,31 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
 from pathlib import Path
+from types import SimpleNamespace
 
+import numpy as np
 import pytest
+import safetensors.torch
 import torch
 from transformers.configuration_utils import PretrainedConfig
 
+import models.demos.deepseek_v3.utils.config_helpers as config_helpers_module
+import models.demos.deepseek_v3.utils.test_utils as test_utils_module
+import models.demos.deepseek_v3.utils.weight_config as weight_config_module
 import ttnn
+from models.demos.deepseek_v3.scripts.validate_weight_cache import repair_cache_directory, validate_cache_directory
 from models.demos.deepseek_v3.utils.config_dataclass import SavedWeight
-from models.demos.deepseek_v3.utils.config_helpers import TENSOR_CACHE_EXTENSION
+from models.demos.deepseek_v3.utils.config_helpers import TENSOR_CACHE_EXTENSION, sub_state_dict
 from models.demos.deepseek_v3.utils.weight_config import (
-    WeightConfigEncoder,
+    InvalidWeightCacheError,
     get_weight_config,
     normalize_weight_config_paths,
     validate_weight_config_paths,
+    wrap_weight_cache_payload,
 )
 
 pytestmark = pytest.mark.t3k_compat
@@ -28,8 +37,10 @@ pytestmark = pytest.mark.t3k_compat
 
 @dataclass(frozen=True)
 class _FakeMeshDevice:
-    # `get_weight_config()` only uses `.shape` for path construction and passes the object through.
     shape: tuple[int, int]
+
+    def get_num_devices(self) -> int:
+        return self.shape[0] * self.shape[1]
 
 
 def _make_hf_config(num_hidden_layers: int = 2) -> PretrainedConfig:
@@ -38,23 +49,26 @@ def _make_hf_config(num_hidden_layers: int = 2) -> PretrainedConfig:
     return hf_config
 
 
-def test_get_weight_config_cache_hit_skips_convert(tmp_path: Path) -> None:
+def _write_index(model_dir: Path, weight_map: dict[str, str]) -> None:
+    (model_dir / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": weight_map}),
+        encoding="utf-8",
+    )
+
+
+def test_get_weight_config_direct_path_runs_convert_on_every_call(tmp_path: Path) -> None:
     call_count = {"n": 0}
 
     class FakeModule:
         @staticmethod
-        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
+        def convert_weights(hf_config, state_dicts, output_path: Path, mesh_device):
             call_count["n"] += 1
-            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
-            rel_path = Path("weights") / f"w0{TENSOR_CACHE_EXTENSION}"
-            (weight_cache_path / rel_path).write_bytes(b"unit-test")
-            return {"w0": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
+            return {"w0": {"call": call_count["n"], "output_path": str(output_path)}}
 
     mesh_device = _FakeMeshDevice(shape=(4, 8))
     hf_config = _make_hf_config(num_hidden_layers=3)
     base_cache = tmp_path / "weight_cache"
 
-    # First call: cache miss -> convert_weights is invoked and config.json is written.
     cfg0 = get_weight_config(
         ModuleClass=FakeModule,
         hf_config=hf_config,
@@ -63,13 +77,6 @@ def test_get_weight_config_cache_hit_skips_convert(tmp_path: Path) -> None:
         mesh_device=mesh_device,
         force_recalculate=False,
     )
-    assert call_count["n"] == 1
-    assert isinstance(cfg0, dict) and "w0" in cfg0
-    assert isinstance(cfg0["w0"], SavedWeight)
-    assert cfg0["w0"].path.is_absolute()
-    assert cfg0["w0"].path.exists()
-
-    # Second call: cache hit -> convert_weights is skipped.
     cfg1 = get_weight_config(
         ModuleClass=FakeModule,
         hf_config=hf_config,
@@ -78,282 +85,914 @@ def test_get_weight_config_cache_hit_skips_convert(tmp_path: Path) -> None:
         mesh_device=mesh_device,
         force_recalculate=False,
     )
-    assert call_count["n"] == 1
-    assert isinstance(cfg1["w0"], SavedWeight)
-    assert cfg1["w0"].path.is_absolute()
-    assert cfg1["w0"].path.exists()
 
-
-def test_get_weight_config_force_recalculate_bypasses_cache(tmp_path: Path) -> None:
-    call_count = {"n": 0}
-
-    class FakeModule:
-        @staticmethod
-        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
-            call_count["n"] += 1
-            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
-            rel_path = Path("weights") / f"w{call_count['n']}{TENSOR_CACHE_EXTENSION}"
-            (weight_cache_path / rel_path).write_bytes(f"unit-test-{call_count['n']}".encode("utf-8"))
-            return {f"w{call_count['n']}": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
-
-    mesh_device = _FakeMeshDevice(shape=(1, 2))
-    hf_config = _make_hf_config(num_hidden_layers=1)
-    base_cache = tmp_path / "weight_cache"
-
-    cfg0 = get_weight_config(
-        ModuleClass=FakeModule,
-        hf_config=hf_config,
-        state_dicts=({"dummy": torch.empty(1)},),
-        weight_cache_path=base_cache,
-        mesh_device=mesh_device,
-        force_recalculate=False,
-    )
-    assert call_count["n"] == 1
-
-    cfg1 = get_weight_config(
-        ModuleClass=FakeModule,
-        hf_config=hf_config,
-        state_dicts=({"dummy": torch.empty(1)},),
-        weight_cache_path=base_cache,
-        mesh_device=mesh_device,
-        force_recalculate=True,
-    )
+    compatibility_output_path = base_cache / "3_layers" / "mesh_4x8"
     assert call_count["n"] == 2
+    assert cfg0["w0"]["call"] == 1
+    assert cfg1["w0"]["call"] == 2
+    assert not (compatibility_output_path / "config.json").exists()
 
-    # When force_recalculate=True, we should get the newly produced config/weight path.
-    assert cfg0 != cfg1
 
+def test_get_weight_config_direct_path_handles_bspm_wrapped_stacked_lazy_state_dict(tmp_path: Path) -> None:
+    from models.demos.deepseek_v3.scripts.convert_bspm_weights import _BsprnStateDict
+    from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
 
-def test_get_weight_config_cache_miss_when_config_missing(tmp_path: Path) -> None:
-    """Test that cache miss occurs when config.json doesn't exist."""
-    call_count = {"n": 0}
+    model_dir = tmp_path / "model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+    shard = model_dir / "model-00001-of-00001.safetensors"
+    tensors = {
+        f"model.layers.3.mlp.experts_stacked.{proj_name}.weight": (
+            torch.arange(2 * 32 * 32, dtype=torch.float32).reshape(2, 32, 32) + offset
+        ).to(torch.bfloat16)
+        for offset, proj_name in enumerate(("gate_proj", "down_proj", "up_proj"), start=1)
+    }
+    safetensors.torch.save_file(tensors, str(shard))
+    _write_index(model_dir, {key: shard.name for key in tensors})
+
+    wrapped_state_dict = _BsprnStateDict(
+        LazyStateDict(model_dir),
+        SimpleNamespace(first_k_dense_replace=3, n_routed_experts=2),
+        tmp_path / "results",
+        "unused",
+        "B",
+        3.5,
+        _codes_cache={3: np.array([[[0], [1], [1]], [[1], [1], [1]]], dtype=np.int32)},
+        _load_bspm=lambda _path, expected_n_experts=None: {"codes": np.zeros((2, 3, 1), dtype=np.int32)},
+        _qdq=lambda tensor, mant_bits: tensor + mant_bits,
+        _require_complete=True,
+    )
 
     class FakeModule:
         @staticmethod
-        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
-            call_count["n"] += 1
-            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
-            rel_path = Path("weights") / f"w{TENSOR_CACHE_EXTENSION}"
-            (weight_cache_path / rel_path).write_bytes(b"unit-test")
-            return {"w": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
+        def convert_weights(hf_config, state_dicts, output_path: Path, mesh_device):
+            mlp_state = sub_state_dict(state_dicts[0], "model.layers.3.mlp.")
+            stacked_view = mlp_state.view_with_prefix("experts_stacked.")
+            gate_weight = stacked_view["gate_proj.weight"]
+            assert torch.equal(gate_weight[0], tensors["model.layers.3.mlp.experts_stacked.gate_proj.weight"][0] + 7)
+            assert torch.equal(gate_weight[1], tensors["model.layers.3.mlp.experts_stacked.gate_proj.weight"][1])
+            return {"ok": True}
 
-    mesh_device = _FakeMeshDevice(shape=(2, 4))
-    hf_config = _make_hf_config(num_hidden_layers=5)
-    base_cache = tmp_path / "weight_cache"
+    cfg = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=_make_hf_config(num_hidden_layers=5),
+        state_dicts=(wrapped_state_dict,),
+        weight_cache_path=tmp_path / "weight_cache",
+        mesh_device=_FakeMeshDevice(shape=(1, 1)),
+    )
 
-    # No cache exists, should call convert_weights
+    assert cfg == {"ok": True}
+
+
+def test_get_weight_config_path_construction_for_direct_weights(tmp_path: Path) -> None:
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, output_path: Path, mesh_device):
+            assert output_path == tmp_path / "weight_cache" / "5_layers" / "mesh_2x4"
+            return {"ok": True}
+
+    cfg = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=_make_hf_config(num_hidden_layers=5),
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=tmp_path / "weight_cache",
+        mesh_device=_FakeMeshDevice(shape=(2, 4)),
+    )
+
+    assert cfg == {"ok": True}
+
+
+def test_get_weight_config_allows_missing_weight_cache_path_for_direct_weights() -> None:
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, output_path: Path, mesh_device):
+            assert output_path == Path("generated/deepseek_v3") / "2_layers" / "mesh_1x1"
+            return {"ok": True}
+
+    cfg = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=_make_hf_config(),
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=None,
+        mesh_device=_FakeMeshDevice(shape=(1, 1)),
+    )
+
+    assert cfg == {"ok": True}
+
+
+def test_get_weight_config_emit_weight_cache_force_recalculate_clears_existing_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    emitted_weight_config = {"w0": "direct"}
+    seen: dict[str, object] = {}
+
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, output_path: Path, mesh_device):
+            return emitted_weight_config
+
+    output_path = tmp_path / "weight_cache" / "3_layers" / "mesh_4x8"
+    stale_file = output_path / "stale" / f"leftover{TENSOR_CACHE_EXTENSION}"
+    stale_file.parent.mkdir(parents=True, exist_ok=True)
+    stale_file.write_bytes(b"stale")
+
+    def fake_save_weight_config(root_path: Path, weight_config):
+        assert not stale_file.exists()
+        seen["root_path"] = root_path
+        seen["weight_config"] = weight_config
+        return {"saved": True}
+
+    def fake_deallocate_weight_config_tensors(weight_config):
+        seen["deallocated"] = weight_config
+
+    monkeypatch.setattr(weight_config_module, "save_weight_config", fake_save_weight_config)
+    monkeypatch.setattr(weight_config_module, "deallocate_weight_config_tensors", fake_deallocate_weight_config_tensors)
+
+    cfg = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=_make_hf_config(num_hidden_layers=3),
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=tmp_path / "weight_cache",
+        mesh_device=_FakeMeshDevice(shape=(4, 8)),
+        force_recalculate=True,
+        emit_weight_cache=True,
+    )
+
+    assert cfg == {"saved": True}
+    assert seen["root_path"] == output_path
+    assert seen["weight_config"] is emitted_weight_config
+    assert seen["deallocated"] is emitted_weight_config
+
+
+def test_get_weight_config_emit_weight_cache_streams_saved_weights_from_shard_and_save(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class _FakeTTTensor:
+        def __init__(self, memory_config):
+            self._memory_config = memory_config
+
+        def memory_config(self):
+            return self._memory_config
+
+    dumped_paths: list[Path] = []
+    deallocated_tensors: list[object] = []
+
+    def fake_shard_device_impl(**kwargs):
+        return _FakeTTTensor(kwargs["memory_config"])
+
+    def fake_dump_tensor(path: Path, tensor):
+        dumped_paths.append(Path(path))
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        Path(path).write_bytes(b"unit-test")
+
+    def fake_deallocate(tensor):
+        deallocated_tensors.append(tensor)
+
+    monkeypatch.setattr(config_helpers_module, "_shard_device_impl", fake_shard_device_impl)
+    monkeypatch.setattr(config_helpers_module.ttnn, "dump_tensor", fake_dump_tensor)
+    monkeypatch.setattr(config_helpers_module.ttnn, "deallocate", fake_deallocate)
+
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, output_path: Path, mesh_device):
+            return {
+                "w": config_helpers_module.shard_and_save(
+                    output_path / "weights" / "w",
+                    torch.ones((1, 1, 32, 32), dtype=torch.bfloat16),
+                    shard_dims=(None, None),
+                    mesh_device=mesh_device,
+                    dtype=ttnn.bfloat16,
+                    layout=ttnn.TILE_LAYOUT,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                )
+            }
+
+    cfg = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=_make_hf_config(num_hidden_layers=3),
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=tmp_path / "weight_cache",
+        mesh_device=_FakeMeshDevice(shape=(4, 8)),
+        force_recalculate=True,
+        emit_weight_cache=True,
+    )
+
+    output_path = tmp_path / "weight_cache" / "3_layers" / "mesh_4x8"
+    config_payload = json.loads((output_path / "config.json").read_text(encoding="utf-8"))
+
+    assert dumped_paths == [output_path / "weights" / f"w{TENSOR_CACHE_EXTENSION}"]
+    assert len(deallocated_tensors) == 1
+    assert weight_config_module.WEIGHT_CACHE_METADATA_KEY in config_payload
+    assert isinstance(cfg["w"], SavedWeight)
+    assert cfg["w"].path == output_path / "weights" / f"w{TENSOR_CACHE_EXTENSION}"
+
+
+def test_get_weight_config_loads_legacy_cache_when_requested(tmp_path: Path) -> None:
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, output_path: Path, mesh_device):
+            raise AssertionError("convert_weights should not be called when use_weight_cache=True")
+
+    mesh_device = _FakeMeshDevice(shape=(4, 8))
+    hf_config = _make_hf_config(num_hidden_layers=3)
+    cache_root = tmp_path / "weight_cache"
+    output_path = cache_root / "3_layers" / "mesh_4x8"
+    weight_path = output_path / "weights" / f"w{TENSOR_CACHE_EXTENSION}"
+    weight_path.parent.mkdir(parents=True, exist_ok=True)
+    weight_path.write_bytes(b"unit-test")
+    (output_path / "config.json").write_text(
+        json.dumps(
+            wrap_weight_cache_payload(
+                {
+                    "w": {
+                        "path": f"weights/w{TENSOR_CACHE_EXTENSION}",
+                        "memory_config": json.loads(ttnn.DRAM_MEMORY_CONFIG.to_json()),
+                    }
+                }
+            )
+        ),
+        encoding="utf-8",
+    )
+
     cfg = get_weight_config(
         ModuleClass=FakeModule,
         hf_config=hf_config,
-        state_dicts=({"dummy": torch.empty(1)},),
-        weight_cache_path=base_cache,
+        state_dicts=None,
+        weight_cache_path=cache_root,
         mesh_device=mesh_device,
-        force_recalculate=False,
+        use_weight_cache=True,
     )
-    assert call_count["n"] == 1
+
+    assert isinstance(cfg["w"], SavedWeight)
+    assert cfg["w"].path == weight_path
+
+
+def test_get_weight_config_use_weight_cache_requires_existing_cache(tmp_path: Path) -> None:
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, output_path: Path, mesh_device):
+            raise AssertionError("convert_weights should not be called when use_weight_cache=True")
+
+    with pytest.raises(FileNotFoundError, match="Requested DeepSeek weight cache"):
+        get_weight_config(
+            ModuleClass=FakeModule,
+            hf_config=_make_hf_config(num_hidden_layers=3),
+            state_dicts=None,
+            weight_cache_path=tmp_path / "weight_cache",
+            mesh_device=_FakeMeshDevice(shape=(4, 8)),
+            use_weight_cache=True,
+        )
+
+
+def test_get_weight_config_use_weight_cache_rejects_invalid_cache(tmp_path: Path) -> None:
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, output_path: Path, mesh_device):
+            raise AssertionError("convert_weights should not be called when use_weight_cache=True")
+
+    cache_root = tmp_path / "weight_cache"
+    output_path = cache_root / "3_layers" / "mesh_4x8"
+    output_path.mkdir(parents=True)
+    (output_path / "config.json").write_text(
+        json.dumps(
+            wrap_weight_cache_payload(
+                {
+                    "w": {
+                        "path": f"weights/missing{TENSOR_CACHE_EXTENSION}",
+                        "memory_config": json.loads(ttnn.DRAM_MEMORY_CONFIG.to_json()),
+                    }
+                }
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(InvalidWeightCacheError, match="Requested DeepSeek weight cache was invalid"):
+        get_weight_config(
+            ModuleClass=FakeModule,
+            hf_config=_make_hf_config(num_hidden_layers=3),
+            state_dicts=None,
+            weight_cache_path=cache_root,
+            mesh_device=_FakeMeshDevice(shape=(4, 8)),
+            use_weight_cache=True,
+        )
+
+
+def test_get_weight_config_use_weight_cache_rejects_unversioned_legacy_cache(tmp_path: Path) -> None:
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, output_path: Path, mesh_device):
+            raise AssertionError("convert_weights should not be called when use_weight_cache=True")
+
+    cache_root = tmp_path / "weight_cache"
+    output_path = cache_root / "3_layers" / "mesh_4x8"
+    weight_path = output_path / "weights" / f"w{TENSOR_CACHE_EXTENSION}"
+    weight_path.parent.mkdir(parents=True, exist_ok=True)
+    weight_path.write_bytes(b"unit-test")
+    (output_path / "config.json").write_text(
+        json.dumps(
+            {
+                "w": {
+                    "path": f"weights/w{TENSOR_CACHE_EXTENSION}",
+                    "memory_config": json.loads(ttnn.DRAM_MEMORY_CONFIG.to_json()),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(InvalidWeightCacheError, match="missing deepseek_weight_cache_metadata"):
+        get_weight_config(
+            ModuleClass=FakeModule,
+            hf_config=_make_hf_config(num_hidden_layers=3),
+            state_dicts=None,
+            weight_cache_path=cache_root,
+            mesh_device=_FakeMeshDevice(shape=(4, 8)),
+            use_weight_cache=True,
+        )
+
+
+def test_get_weight_config_use_weight_cache_rejects_outdated_wrapped_cache_version(tmp_path: Path) -> None:
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, output_path: Path, mesh_device):
+            raise AssertionError("convert_weights should not be called when use_weight_cache=True")
+
+    cache_root = tmp_path / "weight_cache"
+    output_path = cache_root / "3_layers" / "mesh_4x8"
+    weight_path = output_path / "weights" / f"w{TENSOR_CACHE_EXTENSION}"
+    weight_path.parent.mkdir(parents=True, exist_ok=True)
+    weight_path.write_bytes(b"unit-test")
+    (output_path / "config.json").write_text(
+        json.dumps(
+            {
+                weight_config_module.WEIGHT_CACHE_METADATA_KEY: {
+                    weight_config_module.WEIGHT_CACHE_VERSION_KEY: weight_config_module.WEIGHT_CACHE_FORMAT_VERSION - 1,
+                },
+                weight_config_module.WEIGHT_CACHE_PAYLOAD_KEY: {
+                    "w": {
+                        "path": f"weights/w{TENSOR_CACHE_EXTENSION}",
+                        "memory_config": json.loads(ttnn.DRAM_MEMORY_CONFIG.to_json()),
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(InvalidWeightCacheError, match="unsupported format version"):
+        get_weight_config(
+            ModuleClass=FakeModule,
+            hf_config=_make_hf_config(num_hidden_layers=3),
+            state_dicts=None,
+            weight_cache_path=cache_root,
+            mesh_device=_FakeMeshDevice(shape=(4, 8)),
+            use_weight_cache=True,
+        )
+
+
+def test_validate_weight_cache_directory_rejects_unversioned_legacy_cache(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "weight_cache" / "3_layers" / "mesh_4x8"
+    weight_path = cache_dir / "weights" / f"w{TENSOR_CACHE_EXTENSION}"
+    weight_path.parent.mkdir(parents=True, exist_ok=True)
+    weight_path.write_bytes(b"unit-test")
+    (cache_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "w": {
+                    "path": f"weights/w{TENSOR_CACHE_EXTENSION}",
+                    "memory_config": json.loads(ttnn.DRAM_MEMORY_CONFIG.to_json()),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = validate_cache_directory(cache_dir)
+
+    assert result["valid"] is False
+    assert any("missing deepseek_weight_cache_metadata" in error for error in result["errors"])
+
+
+def test_repair_weight_cache_directory_rejects_unversioned_legacy_cache(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "weight_cache" / "3_layers" / "mesh_4x8"
+    weight_path = cache_dir / "weights" / f"w{TENSOR_CACHE_EXTENSION}"
+    weight_path.parent.mkdir(parents=True, exist_ok=True)
+    weight_path.write_bytes(b"unit-test")
+    (cache_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "w": {
+                    "path": f"weights/w{TENSOR_CACHE_EXTENSION}",
+                    "memory_config": json.loads(ttnn.DRAM_MEMORY_CONFIG.to_json()),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = repair_cache_directory(cache_dir)
+
+    assert result["repaired"] is False
+    assert any("missing deepseek_weight_cache_metadata" in error for error in result["errors"])
+
+
+def test_get_weight_config_legacy_saved_weights_are_validated_and_normalized(tmp_path: Path) -> None:
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, output_path: Path, mesh_device):
+            rel_path = Path("weights") / f"w{TENSOR_CACHE_EXTENSION}"
+            (output_path / rel_path).parent.mkdir(parents=True, exist_ok=True)
+            (output_path / rel_path).write_bytes(b"unit-test")
+            return {"w": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
+
+    cfg = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=_make_hf_config(num_hidden_layers=61),
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=tmp_path / "weight_cache",
+        mesh_device=_FakeMeshDevice(shape=(8, 8)),
+        cache_subdir_name="61_layers_mtp",
+    )
+
+    assert isinstance(cfg["w"], SavedWeight)
     assert cfg["w"].path.is_absolute()
     assert cfg["w"].path.exists()
 
 
-def test_get_weight_config_cache_invalidation_missing_weight_file(tmp_path: Path) -> None:
-    """Test that cache is invalidated when weight file is missing."""
-    call_count = {"n": 0}
-
+def test_get_weight_config_emit_weight_cache_writes_manifest_for_saved_weights(tmp_path: Path) -> None:
     class FakeModule:
         @staticmethod
-        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
-            call_count["n"] += 1
-            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
+        def convert_weights(hf_config, state_dicts, output_path: Path, mesh_device):
             rel_path = Path("weights") / f"w{TENSOR_CACHE_EXTENSION}"
-            (weight_cache_path / rel_path).write_bytes(b"unit-test")
+            (output_path / rel_path).parent.mkdir(parents=True, exist_ok=True)
+            (output_path / rel_path).write_bytes(b"unit-test")
             return {"w": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
 
-    mesh_device = _FakeMeshDevice(shape=(1, 1))
-    hf_config = _make_hf_config(num_hidden_layers=1)
-    base_cache = tmp_path / "weight_cache"
-
-    # First call: create cache
-    cfg0 = get_weight_config(
+    output_cfg = get_weight_config(
         ModuleClass=FakeModule,
-        hf_config=hf_config,
+        hf_config=_make_hf_config(num_hidden_layers=3),
         state_dicts=({"dummy": torch.empty(1)},),
-        weight_cache_path=base_cache,
-        mesh_device=mesh_device,
-        force_recalculate=False,
+        weight_cache_path=tmp_path / "weight_cache",
+        mesh_device=_FakeMeshDevice(shape=(4, 8)),
+        force_recalculate=True,
+        emit_weight_cache=True,
     )
-    assert call_count["n"] == 1
 
-    # Delete the weight file but keep config.json
-    # config.json has relative paths, so we should resolve them relative to weight_cache_path
-    # This simulates what validate_weight_config_paths does
-    weight_cache_path = (
-        base_cache / f"{hf_config.num_hidden_layers}_layers" / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
-    )
-    config_path = weight_cache_path / "config.json"
+    output_path = tmp_path / "weight_cache" / "3_layers" / "mesh_4x8"
+    config_payload = json.loads((output_path / "config.json").read_text(encoding="utf-8"))
 
-    # Read the config.json to get the relative path (as it's actually stored)
-    with config_path.open() as f:
-        saved_config = json.load(f)
-    rel_path_str = saved_config["w"]["path"]
-    assert not Path(rel_path_str).is_absolute(), "Config should store relative paths"
-
-    # Resolve relative path to get the actual file location
-    weight_file = weight_cache_path / rel_path_str
-    assert weight_file.exists(), f"Weight file should exist: {weight_file}"
-    weight_file.unlink()
-    assert not weight_file.exists()
-
-    # Second call: cache validation should fail, triggering recalculation
-    cfg1 = get_weight_config(
-        ModuleClass=FakeModule,
-        hf_config=hf_config,
-        state_dicts=({"dummy": torch.empty(1)},),
-        weight_cache_path=base_cache,
-        mesh_device=mesh_device,
-        force_recalculate=False,
-    )
-    assert call_count["n"] == 2
-    assert cfg1["w"].path.exists()
-
-
-def test_get_weight_config_cache_invalidation_wrong_suffix(tmp_path: Path) -> None:
-    """Test that cache is invalidated when weight file has wrong suffix."""
-    call_count = {"n": 0}
-
-    class FakeModule:
-        @staticmethod
-        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
-            call_count["n"] += 1
-            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
-            rel_path = Path("weights") / f"w{TENSOR_CACHE_EXTENSION}"
-            (weight_cache_path / rel_path).write_bytes(b"unit-test")
-            return {"w": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
-
-    mesh_device = _FakeMeshDevice(shape=(2, 2))
-    hf_config = _make_hf_config(num_hidden_layers=2)
-    base_cache = tmp_path / "weight_cache"
-
-    # First call: create cache
-    cfg0 = get_weight_config(
-        ModuleClass=FakeModule,
-        hf_config=hf_config,
-        state_dicts=({"dummy": torch.empty(1)},),
-        weight_cache_path=base_cache,
-        mesh_device=mesh_device,
-        force_recalculate=False,
-    )
-    assert call_count["n"] == 1
-
-    # Corrupt config.json to have wrong suffix
-    # Create a SavedWeight with wrong suffix - this will fail validation
-    weight_cache_path = (
-        base_cache / f"{hf_config.num_hidden_layers}_layers" / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
-    )
-    config_path = weight_cache_path / "config.json"
-    bad_weight = SavedWeight(path=Path("weights/w.bad"), memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    bad_config = {"w": bad_weight}
-    with config_path.open("w") as f:
-        json.dump(bad_config, f, cls=WeightConfigEncoder)
-
-    # Second call: cache validation should fail, triggering recalculation
-    cfg1 = get_weight_config(
-        ModuleClass=FakeModule,
-        hf_config=hf_config,
-        state_dicts=({"dummy": torch.empty(1)},),
-        weight_cache_path=base_cache,
-        mesh_device=mesh_device,
-        force_recalculate=False,
-    )
-    assert call_count["n"] == 2
-
-
-def test_get_weight_config_path_construction(tmp_path: Path) -> None:
-    """Test that weight_cache_path is correctly constructed with layers and mesh shape."""
-
-    class FakeModule:
-        @staticmethod
-        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
-            # Verify the path structure
-            expected_suffix = f"{hf_config.num_hidden_layers}_layers/mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
-            assert str(weight_cache_path).endswith(expected_suffix)
-            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
-            rel_path = Path("weights") / f"w{TENSOR_CACHE_EXTENSION}"
-            (weight_cache_path / rel_path).write_bytes(b"unit-test")
-            return {"w": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
-
-    mesh_device = _FakeMeshDevice(shape=(8, 16))
-    hf_config = _make_hf_config(num_hidden_layers=12)
-    base_cache = tmp_path / "weight_cache"
-
-    cfg = get_weight_config(
-        ModuleClass=FakeModule,
-        hf_config=hf_config,
-        state_dicts=({"dummy": torch.empty(1)},),
-        weight_cache_path=base_cache,
-        mesh_device=mesh_device,
-        force_recalculate=False,
-    )
-    assert cfg["w"].path.is_absolute()
+    assert weight_config_module.WEIGHT_CACHE_METADATA_KEY in config_payload
+    assert isinstance(output_cfg["w"], SavedWeight)
+    assert output_cfg["w"].path == output_path / "weights" / f"w{TENSOR_CACHE_EXTENSION}"
 
 
 def test_get_weight_config_rejects_absolute_paths_from_module(tmp_path: Path) -> None:
-    """Test that get_weight_config rejects absolute paths returned by ModuleClass.convert_weights."""
-
     class FakeModule:
         @staticmethod
-        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
-            # Return an absolute path (incorrect behavior)
-            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
-            abs_path = weight_cache_path / "weights" / f"w{TENSOR_CACHE_EXTENSION}"
+        def convert_weights(hf_config, state_dicts, output_path: Path, mesh_device):
+            abs_path = output_path / "weights" / f"w{TENSOR_CACHE_EXTENSION}"
+            abs_path.parent.mkdir(parents=True, exist_ok=True)
             abs_path.write_bytes(b"unit-test")
-            # Return absolute path instead of relative
             return {"w": SavedWeight(path=abs_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
 
-    mesh_device = _FakeMeshDevice(shape=(2, 2))
-    hf_config = _make_hf_config(num_hidden_layers=2)
-    base_cache = tmp_path / "weight_cache"
-
-    # get_weight_config should raise ValueError when convert_weights returns absolute paths
-    with pytest.raises(ValueError, match="absolute path.*Only relative paths are allowed"):
+    with pytest.raises(ValueError, match="absolute path"):
         get_weight_config(
             ModuleClass=FakeModule,
-            hf_config=hf_config,
+            hf_config=_make_hf_config(num_hidden_layers=3),
             state_dicts=({"dummy": torch.empty(1)},),
-            weight_cache_path=base_cache,
-            mesh_device=mesh_device,
+            weight_cache_path=tmp_path / "weight_cache",
+            mesh_device=_FakeMeshDevice(shape=(4, 8)),
+        )
+
+
+def test_get_weight_config_with_relative_base_cache_path_resolves_output_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, output_path: Path, mesh_device):
+            assert output_path.is_absolute()
+            rel_path = Path("weights") / f"w{TENSOR_CACHE_EXTENSION}"
+            (output_path / rel_path).parent.mkdir(parents=True, exist_ok=True)
+            (output_path / rel_path).write_bytes(b"unit-test")
+            return {"w": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
+
+    monkeypatch.chdir(tmp_path)
+
+    cfg = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=_make_hf_config(num_hidden_layers=61),
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=Path("relative_weight_cache"),
+        mesh_device=_FakeMeshDevice(shape=(4, 8)),
+    )
+
+    assert cfg["w"].path.is_absolute()
+    assert cfg["w"].path.exists()
+
+
+def test_get_test_weight_config_defaults_to_direct_conversion(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[dict[str, object]] = []
+    direct_config = {"direct": True}
+
+    def fake_get_weight_config(
+        ModuleClass,
+        hf_config,
+        state_dicts,
+        weight_cache_path: Path,
+        mesh_device,
+        force_recalculate=False,
+    ):
+        calls.append(
+            {
+                "weight_cache_path": weight_cache_path,
+                "force_recalculate": force_recalculate,
+            }
+        )
+        return direct_config
+
+    monkeypatch.setattr(test_utils_module, "get_weight_config", fake_get_weight_config)
+
+    cfg = test_utils_module.get_test_weight_config(
+        ModuleClass=type("FakeModule", (), {}),
+        hf_config=_make_hf_config(num_hidden_layers=3),
+        state_dicts=({"dummy": torch.empty(1)},),
+        cache_path=tmp_path / "weight_cache",
+        mesh_device=_FakeMeshDevice(shape=(4, 8)),
+        force_recalculate=False,
+        test_name="test_bspm_demo",
+        layer_id="uniform_5layers",
+    )
+
+    assert cfg is direct_config
+    expected_path = tmp_path / "weight_cache" / "tests_cache" / "test_bspm_demo/FakeModule/real/uniform_5layers"
+    assert calls == [
+        {
+            "weight_cache_path": expected_path,
+            "force_recalculate": False,
+        }
+    ]
+
+
+def test_shard_device_impl_uses_replicate_mapper_for_fully_replicated_weights(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeTTTensor:
+        def __init__(self, shape, dtype, layout, memory_config):
+            self.shape = tuple(shape)
+            self.dtype = dtype
+            self.layout = layout
+            self._memory_config = memory_config
+
+        def memory_config(self):
+            return self._memory_config
+
+        def reshape(self, new_shape):
+            self.shape = tuple(new_shape)
+            return self
+
+    def fake_replicate(mesh_device):
+        return ("replicate", mesh_device.shape)
+
+    def fake_shard_1d(mesh_device, dim):
+        return ("shard_1d", mesh_device.shape, dim)
+
+    def fake_shard_2d(mesh_device, *, mesh_shape, dims):
+        return ("shard_2d", mesh_shape, dims)
+
+    def fake_from_torch(tensor, **kwargs):
+        captured["mesh_mapper"] = kwargs["mesh_mapper"]
+        return _FakeTTTensor(tensor.shape, kwargs["dtype"], kwargs["layout"], kwargs["memory_config"])
+
+    monkeypatch.setattr(config_helpers_module.ttnn, "ReplicateTensorToMesh", fake_replicate)
+    monkeypatch.setattr(config_helpers_module.ttnn, "ShardTensorToMesh", fake_shard_1d)
+    monkeypatch.setattr(config_helpers_module.ttnn, "ShardTensor2dMesh", fake_shard_2d)
+    monkeypatch.setattr(config_helpers_module.ttnn, "from_torch", fake_from_torch)
+
+    result = config_helpers_module._shard_device_impl(
+        path=tmp_path / "replicated_weight",
+        tensor=torch.randn(1, 1, 32, 32, dtype=torch.bfloat16),
+        shard_dims=(None, None),
+        mesh_device=_FakeMeshDevice(shape=(4, 8)),
+        remove_dims=(False, False),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    assert captured["mesh_mapper"] == ("replicate", (4, 8))
+    assert result.shape == (1, 1, 32, 32)
+
+
+def test_get_test_weight_config_includes_cache_identity_in_cache_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[dict[str, object]] = []
+    direct_config = {"direct": True}
+
+    def fake_get_weight_config(
+        ModuleClass,
+        hf_config,
+        state_dicts,
+        weight_cache_path: Path,
+        mesh_device,
+        force_recalculate=False,
+    ):
+        calls.append(
+            {
+                "weight_cache_path": weight_cache_path,
+                "force_recalculate": force_recalculate,
+            }
+        )
+        return direct_config
+
+    monkeypatch.setattr(test_utils_module, "get_weight_config", fake_get_weight_config)
+
+    cfg = test_utils_module.get_test_weight_config(
+        ModuleClass=type("FakeModule", (), {}),
+        hf_config=_make_hf_config(num_hidden_layers=3),
+        state_dicts=({"dummy": torch.empty(1)},),
+        cache_path=tmp_path / "weight_cache",
+        mesh_device=_FakeMeshDevice(shape=(4, 8)),
+        force_recalculate=False,
+        test_name="test_bspm_demo",
+        layer_id="uniform_5layers",
+        cache_identity=Path("/tmp/stacked cache/dequantized"),
+    )
+
+    assert cfg is direct_config
+    cache_identity_digest = hashlib.sha256(b"/tmp/stacked cache/dequantized").hexdigest()[:16]
+    expected_path = (
+        tmp_path
+        / "weight_cache"
+        / "tests_cache"
+        / f"test_bspm_demo/FakeModule/real/uniform_5layers/__tmp__stacked_cache__dequantized__{cache_identity_digest}"
+    )
+    assert calls == [
+        {
+            "weight_cache_path": expected_path,
+            "force_recalculate": False,
+        }
+    ]
+
+
+def test_get_test_weight_config_cache_identity_uses_digest_to_avoid_collisions(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[Path] = []
+
+    def fake_get_weight_config(
+        ModuleClass,
+        hf_config,
+        state_dicts,
+        weight_cache_path: Path,
+        mesh_device,
+        force_recalculate=False,
+    ):
+        calls.append(weight_cache_path)
+        return {"direct": True}
+
+    monkeypatch.setattr(test_utils_module, "get_weight_config", fake_get_weight_config)
+
+    kwargs = dict(
+        ModuleClass=type("FakeModule", (), {}),
+        hf_config=_make_hf_config(num_hidden_layers=3),
+        state_dicts=({"dummy": torch.empty(1)},),
+        cache_path=tmp_path / "weight_cache",
+        mesh_device=_FakeMeshDevice(shape=(4, 8)),
+        force_recalculate=False,
+        test_name="test_bspm_demo",
+        layer_id="uniform_5layers",
+    )
+    test_utils_module.get_test_weight_config(cache_identity=Path("/tmp/stacked cache/dequantized"), **kwargs)
+    test_utils_module.get_test_weight_config(cache_identity=Path("/tmp/stacked_cache/dequantized"), **kwargs)
+
+    assert len(calls) == 2
+    assert calls[0] != calls[1]
+    assert calls[0].name.startswith("__tmp__stacked_cache__dequantized__")
+    assert calls[1].name.startswith("__tmp__stacked_cache__dequantized__")
+
+
+def test_get_test_weight_config_prefers_legacy_cache_load(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[dict[str, object]] = []
+    loaded_config = {"loaded": True}
+
+    def fake_get_weight_config(
+        *,
+        weight_cache_path: Path,
+        force_recalculate=False,
+        emit_weight_cache=False,
+        use_weight_cache=False,
+        **kwargs,
+    ):
+        calls.append(
+            {
+                "weight_cache_path": weight_cache_path,
+                "force_recalculate": force_recalculate,
+                "emit_weight_cache": emit_weight_cache,
+                "use_weight_cache": use_weight_cache,
+            }
+        )
+        return loaded_config
+
+    monkeypatch.setattr(test_utils_module, "get_weight_config", fake_get_weight_config)
+
+    cfg = test_utils_module.get_test_weight_config(
+        ModuleClass=type("FakeModule", (), {}),
+        hf_config=_make_hf_config(num_hidden_layers=3),
+        state_dicts=({"dummy": torch.empty(1)},),
+        cache_path=tmp_path / "weight_cache",
+        mesh_device=_FakeMeshDevice(shape=(4, 8)),
+        force_recalculate=False,
+        test_name="test_bspm_demo",
+        layer_id="uniform_5layers",
+        prefer_legacy_weight_cache=True,
+    )
+
+    expected_path = tmp_path / "weight_cache" / "tests_cache" / "test_bspm_demo/FakeModule/real/uniform_5layers"
+    assert cfg is loaded_config
+    assert calls == [
+        {
+            "weight_cache_path": expected_path,
+            "force_recalculate": False,
+            "emit_weight_cache": False,
+            "use_weight_cache": True,
+        },
+    ]
+
+
+def test_get_test_weight_config_rebuilds_legacy_cache_on_cache_miss(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[dict[str, object]] = []
+    emitted_config = {"emitted": True}
+
+    def fake_get_weight_config(
+        *,
+        weight_cache_path: Path,
+        force_recalculate=False,
+        emit_weight_cache=False,
+        use_weight_cache=False,
+        **kwargs,
+    ):
+        calls.append(
+            {
+                "weight_cache_path": weight_cache_path,
+                "force_recalculate": force_recalculate,
+                "emit_weight_cache": emit_weight_cache,
+                "use_weight_cache": use_weight_cache,
+            }
+        )
+        if use_weight_cache:
+            raise FileNotFoundError("Requested DeepSeek weight cache was not found")
+        return emitted_config
+
+    monkeypatch.setattr(test_utils_module, "get_weight_config", fake_get_weight_config)
+
+    cfg = test_utils_module.get_test_weight_config(
+        ModuleClass=type("FakeModule", (), {}),
+        hf_config=_make_hf_config(num_hidden_layers=3),
+        state_dicts=({"dummy": torch.empty(1)},),
+        cache_path=tmp_path / "weight_cache",
+        mesh_device=_FakeMeshDevice(shape=(4, 8)),
+        force_recalculate=False,
+        test_name="test_bspm_demo",
+        layer_id="uniform_5layers",
+        prefer_legacy_weight_cache=True,
+    )
+
+    expected_path = tmp_path / "weight_cache" / "tests_cache" / "test_bspm_demo/FakeModule/real/uniform_5layers"
+    assert cfg is emitted_config
+    assert calls == [
+        {
+            "weight_cache_path": expected_path,
+            "force_recalculate": False,
+            "emit_weight_cache": False,
+            "use_weight_cache": True,
+        },
+        {
+            "weight_cache_path": expected_path,
+            "force_recalculate": False,
+            "emit_weight_cache": True,
+            "use_weight_cache": False,
+        },
+    ]
+
+
+def test_get_test_weight_config_propagates_invalid_legacy_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_get_weight_config(
+        *,
+        weight_cache_path: Path,
+        force_recalculate=False,
+        emit_weight_cache=False,
+        use_weight_cache=False,
+        **kwargs,
+    ):
+        calls.append(
+            {
+                "weight_cache_path": weight_cache_path,
+                "force_recalculate": force_recalculate,
+                "emit_weight_cache": emit_weight_cache,
+                "use_weight_cache": use_weight_cache,
+            }
+        )
+        if use_weight_cache:
+            raise InvalidWeightCacheError("Requested DeepSeek weight cache was invalid")
+        raise AssertionError("Invalid legacy cache should not trigger regeneration")
+
+    monkeypatch.setattr(test_utils_module, "get_weight_config", fake_get_weight_config)
+
+    with pytest.raises(InvalidWeightCacheError, match="Requested DeepSeek weight cache was invalid"):
+        test_utils_module.get_test_weight_config(
+            ModuleClass=type("FakeModule", (), {}),
+            hf_config=_make_hf_config(num_hidden_layers=3),
+            state_dicts=({"dummy": torch.empty(1)},),
+            cache_path=tmp_path / "weight_cache",
+            mesh_device=_FakeMeshDevice(shape=(4, 8)),
             force_recalculate=False,
+            test_name="test_bspm_demo",
+            layer_id="uniform_5layers",
+            prefer_legacy_weight_cache=True,
         )
 
+    expected_path = tmp_path / "weight_cache" / "tests_cache" / "test_bspm_demo/FakeModule/real/uniform_5layers"
+    assert calls == [
+        {
+            "weight_cache_path": expected_path,
+            "force_recalculate": False,
+            "emit_weight_cache": False,
+            "use_weight_cache": True,
+        }
+    ]
 
-def test_get_weight_config_error_missing_weight_cache_path() -> None:
-    """Test that ValueError is raised when weight_cache_path is None."""
-    mesh_device = _FakeMeshDevice(shape=(1, 1))
-    hf_config = _make_hf_config()
 
-    with pytest.raises(ValueError, match="weight_cache_path must be provided"):
-        get_weight_config(
-            ModuleClass=None,  # Won't get this far
-            hf_config=hf_config,
-            weight_cache_path=None,
-            mesh_device=mesh_device,
+def test_get_test_weight_config_force_recalculate_rebuilds_legacy_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[dict[str, object]] = []
+    emitted_config = {"emitted": True}
+
+    def fake_get_weight_config(
+        *,
+        weight_cache_path: Path,
+        force_recalculate=False,
+        emit_weight_cache=False,
+        use_weight_cache=False,
+        **kwargs,
+    ):
+        calls.append(
+            {
+                "weight_cache_path": weight_cache_path,
+                "force_recalculate": force_recalculate,
+                "emit_weight_cache": emit_weight_cache,
+                "use_weight_cache": use_weight_cache,
+            }
         )
+        return emitted_config
+
+    monkeypatch.setattr(test_utils_module, "get_weight_config", fake_get_weight_config)
+
+    cfg = test_utils_module.get_test_weight_config(
+        ModuleClass=type("FakeModule", (), {}),
+        hf_config=_make_hf_config(num_hidden_layers=3),
+        state_dicts=({"dummy": torch.empty(1)},),
+        cache_path=tmp_path / "weight_cache",
+        mesh_device=_FakeMeshDevice(shape=(4, 8)),
+        force_recalculate=True,
+        test_name="test_bspm_demo",
+        layer_id="uniform_5layers",
+        prefer_legacy_weight_cache=True,
+    )
+
+    assert cfg is emitted_config
+    expected_path = tmp_path / "weight_cache" / "tests_cache" / "test_bspm_demo/FakeModule/real/uniform_5layers"
+    assert calls == [
+        {
+            "weight_cache_path": expected_path,
+            "force_recalculate": True,
+            "emit_weight_cache": True,
+            "use_weight_cache": False,
+        }
+    ]
 
 
 def test_get_weight_config_error_missing_mesh_device() -> None:
-    """Test that ValueError is raised when mesh_device is None."""
-    hf_config = _make_hf_config()
-
     with pytest.raises(ValueError, match="mesh_device must be provided"):
         get_weight_config(
-            ModuleClass=None,  # Won't get this far
-            hf_config=hf_config,
+            ModuleClass=None,
+            hf_config=_make_hf_config(),
             weight_cache_path=Path("/tmp"),
             mesh_device=None,
         )
 
 
 def test_validate_weight_config_paths_success(tmp_path: Path) -> None:
-    """Test successful validation of weight config paths."""
     root_path = tmp_path / "weights"
     root_path.mkdir(parents=True)
 
@@ -367,12 +1006,10 @@ def test_validate_weight_config_paths_success(tmp_path: Path) -> None:
         "layer2": SavedWeight(path=Path(f"w2{TENSOR_CACHE_EXTENSION}"), memory_config=ttnn.DRAM_MEMORY_CONFIG),
     }
 
-    # Should not raise - both paths are relative
     validate_weight_config_paths(root_path, weight_config)
 
 
 def test_validate_weight_config_paths_missing_file(tmp_path: Path) -> None:
-    """Test validation raises ValueError when weight file is missing."""
     root_path = tmp_path / "weights"
     root_path.mkdir(parents=True)
 
@@ -385,7 +1022,6 @@ def test_validate_weight_config_paths_missing_file(tmp_path: Path) -> None:
 
 
 def test_validate_weight_config_paths_wrong_suffix(tmp_path: Path) -> None:
-    """Test validation raises ValueError when weight file has wrong suffix."""
     root_path = tmp_path / "weights"
     root_path.mkdir(parents=True)
 
@@ -401,7 +1037,6 @@ def test_validate_weight_config_paths_wrong_suffix(tmp_path: Path) -> None:
 
 
 def test_validate_weight_config_paths_rejects_absolute_paths(tmp_path: Path) -> None:
-    """Test validation raises ValueError when SavedWeight has absolute path."""
     root_path = tmp_path / "weights"
     root_path.mkdir(parents=True)
 
@@ -413,12 +1048,11 @@ def test_validate_weight_config_paths_rejects_absolute_paths(tmp_path: Path) -> 
         "layer1": SavedWeight(path=abs_path, memory_config=ttnn.DRAM_MEMORY_CONFIG),
     }
 
-    with pytest.raises(ValueError, match="absolute path.*Only relative paths are allowed"):
+    with pytest.raises(ValueError, match="absolute path"):
         validate_weight_config_paths(root_path, weight_config)
 
 
 def test_validate_weight_config_paths_nested_structures(tmp_path: Path) -> None:
-    """Test validation works with nested dicts, lists, and tuples."""
     root_path = tmp_path / "weights"
     root_path.mkdir(parents=True)
 
@@ -437,22 +1071,19 @@ def test_validate_weight_config_paths_nested_structures(tmp_path: Path) -> None:
             SavedWeight(path=Path(f"w2{TENSOR_CACHE_EXTENSION}"), memory_config=ttnn.DRAM_MEMORY_CONFIG),
         ],
         "tuple_nested": (SavedWeight(path=Path(f"w3{TENSOR_CACHE_EXTENSION}"), memory_config=ttnn.DRAM_MEMORY_CONFIG),),
-        "none_value": None,
     }
 
-    # Should not raise
     validate_weight_config_paths(root_path, weight_config)
 
 
 def test_validate_weight_config_paths_error_path_prefix(tmp_path: Path) -> None:
-    """Test that error messages include path prefix for nested structures."""
     root_path = tmp_path / "weights"
     root_path.mkdir(parents=True)
 
     weight_config = {
         "outer": {
             "inner": SavedWeight(path=Path(f"missing{TENSOR_CACHE_EXTENSION}"), memory_config=ttnn.DRAM_MEMORY_CONFIG),
-        },
+        }
     }
 
     with pytest.raises(ValueError, match="outer.inner"):
@@ -460,10 +1091,7 @@ def test_validate_weight_config_paths_error_path_prefix(tmp_path: Path) -> None:
 
 
 def test_normalize_weight_config_paths_relative_paths(tmp_path: Path) -> None:
-    """Test normalization converts relative paths to absolute."""
     root_path = tmp_path / "weights"
-    root_path.mkdir(parents=True)
-
     rel_path = Path(f"w{TENSOR_CACHE_EXTENSION}")
     weight_config = {
         "w": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG),
@@ -471,36 +1099,23 @@ def test_normalize_weight_config_paths_relative_paths(tmp_path: Path) -> None:
 
     normalized = normalize_weight_config_paths(root_path, weight_config)
 
-    assert normalized["w"].path.is_absolute()
     assert normalized["w"].path == root_path / rel_path
-    # Original should be unchanged (no mutation)
-    assert not weight_config["w"].path.is_absolute()
+    assert normalized["w"].memory_config == ttnn.DRAM_MEMORY_CONFIG
 
 
 def test_normalize_weight_config_paths_absolute_paths(tmp_path: Path) -> None:
-    """Test normalization preserves absolute paths."""
-    root_path = tmp_path / "weights"
-    root_path.mkdir(parents=True)
-
     abs_path = tmp_path / "other" / f"w{TENSOR_CACHE_EXTENSION}"
-    abs_path.parent.mkdir(parents=True)
-    abs_path.write_bytes(b"test")
-
     weight_config = {
         "w": SavedWeight(path=abs_path, memory_config=ttnn.DRAM_MEMORY_CONFIG),
     }
 
-    normalized = normalize_weight_config_paths(root_path, weight_config)
+    normalized = normalize_weight_config_paths(tmp_path / "weights", weight_config)
 
-    assert normalized["w"].path.is_absolute()
     assert normalized["w"].path == abs_path
 
 
 def test_normalize_weight_config_paths_nested_structures(tmp_path: Path) -> None:
-    """Test normalization works with nested dicts, lists, and tuples."""
     root_path = tmp_path / "weights"
-    root_path.mkdir(parents=True)
-
     rel_path = Path(f"w{TENSOR_CACHE_EXTENSION}")
     weight_config = {
         "dict_nested": {
@@ -510,128 +1125,10 @@ def test_normalize_weight_config_paths_nested_structures(tmp_path: Path) -> None
             SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG),
         ],
         "tuple_nested": (SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG),),
-        "none_value": None,
     }
 
     normalized = normalize_weight_config_paths(root_path, weight_config)
 
-    assert normalized["dict_nested"]["w"].path.is_absolute()
-    assert normalized["list_nested"][0].path.is_absolute()
-    assert normalized["tuple_nested"][0].path.is_absolute()
-    assert normalized["none_value"] is None
-    # Verify tuple type is preserved
-    assert isinstance(normalized["tuple_nested"], tuple)
-    assert isinstance(normalized["list_nested"], list)
-
-
-def test_get_weight_config_returns_normalized_paths(tmp_path: Path) -> None:
-    """Test that get_weight_config returns config with absolute paths even though config.json has relative."""
-
-    class FakeModule:
-        @staticmethod
-        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
-            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
-            rel_path = Path("weights") / f"w{TENSOR_CACHE_EXTENSION}"
-            (weight_cache_path / rel_path).write_bytes(b"unit-test")
-            return {"w": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
-
-    mesh_device = _FakeMeshDevice(shape=(1, 1))
-    hf_config = _make_hf_config(num_hidden_layers=1)
-    base_cache = tmp_path / "weight_cache"
-
-    cfg = get_weight_config(
-        ModuleClass=FakeModule,
-        hf_config=hf_config,
-        state_dicts=({"dummy": torch.empty(1)},),
-        weight_cache_path=base_cache,
-        mesh_device=mesh_device,
-        force_recalculate=False,
-    )
-
-    # Returned config should have absolute paths
-    assert cfg["w"].path.is_absolute()
-
-    # But config.json should have relative paths (check by reading it)
-    weight_cache_path = (
-        base_cache / f"{hf_config.num_hidden_layers}_layers" / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
-    )
-    config_path = weight_cache_path / "config.json"
-    with config_path.open() as f:
-        saved_config = json.load(f)
-    # The saved path should be relative (as a string)
-    assert "weights" in saved_config["w"]["path"]
-    assert not Path(saved_config["w"]["path"]).is_absolute()
-
-
-def test_get_weight_config_with_relative_base_cache_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Test that relative cache roots are normalized and still persist relative SavedWeight paths."""
-
-    class FakeModule:
-        @staticmethod
-        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
-            assert weight_cache_path.is_absolute()
-            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
-            rel_path = Path("weights") / f"w{TENSOR_CACHE_EXTENSION}"
-            (weight_cache_path / rel_path).write_bytes(b"unit-test")
-            return {"w": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
-
-    monkeypatch.chdir(tmp_path)
-
-    mesh_device = _FakeMeshDevice(shape=(4, 8))
-    hf_config = _make_hf_config(num_hidden_layers=61)
-    base_cache = Path("relative_weight_cache")
-
-    cfg = get_weight_config(
-        ModuleClass=FakeModule,
-        hf_config=hf_config,
-        state_dicts=({"dummy": torch.empty(1)},),
-        weight_cache_path=base_cache,
-        mesh_device=mesh_device,
-        force_recalculate=False,
-    )
-
-    assert cfg["w"].path.is_absolute()
-    assert cfg["w"].path.exists()
-
-    config_path = (
-        tmp_path
-        / base_cache
-        / f"{hf_config.num_hidden_layers}_layers"
-        / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
-        / "config.json"
-    )
-    with config_path.open() as f:
-        saved_config = json.load(f)
-
-    saved_path = Path(saved_config["w"]["path"])
-    assert saved_path == Path("weights") / f"w{TENSOR_CACHE_EXTENSION}"
-
-
-def test_get_weight_config_with_custom_cache_subdir_name(tmp_path: Path) -> None:
-    class FakeModule:
-        @staticmethod
-        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
-            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
-            rel_path = Path("weights") / f"w{TENSOR_CACHE_EXTENSION}"
-            (weight_cache_path / rel_path).write_bytes(b"unit-test")
-            return {"w": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
-
-    mesh_device = _FakeMeshDevice(shape=(8, 8))
-    hf_config = _make_hf_config(num_hidden_layers=61)
-    base_cache = tmp_path / "weight_cache"
-
-    cfg = get_weight_config(
-        ModuleClass=FakeModule,
-        hf_config=hf_config,
-        state_dicts=({"dummy": torch.empty(1)},),
-        weight_cache_path=base_cache,
-        mesh_device=mesh_device,
-        force_recalculate=False,
-        cache_subdir_name="61_layers_mtp",
-    )
-
-    assert cfg["w"].path.is_absolute()
-    assert cfg["w"].path.exists()
-    assert (
-        base_cache / "61_layers_mtp" / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}" / "config.json"
-    ).exists()
+    assert normalized["dict_nested"]["w"].path == root_path / rel_path
+    assert normalized["list_nested"][0].path == root_path / rel_path
+    assert normalized["tuple_nested"][0].path == root_path / rel_path

--- a/models/demos/deepseek_v3/tests/test_hf_model_utils.py
+++ b/models/demos/deepseek_v3/tests/test_hf_model_utils.py
@@ -504,7 +504,7 @@ def test_unload_weight_from_lazy_state_dict_evicts_stacked_alias_cache(tmp_path:
 
     load_weight(expert_key, target_tensor)
     assert expert_key in state_dict._cache
-    assert stacked_key in state_dict._cache
+    assert stacked_key not in state_dict._cache
 
     unload_weight(expert_key, target_tensor)
     assert target_tensor.numel() == 0

--- a/models/demos/deepseek_v3/tests/test_hf_model_utils.py
+++ b/models/demos/deepseek_v3/tests/test_hf_model_utils.py
@@ -13,6 +13,7 @@ import safetensors.torch
 import torch
 
 from models.demos.deepseek_v3.utils.hf_model_utils import (
+    default_stacked_dequantized_model_path,
     index_model_weights,
     load_weight_from_weights_dict,
     materialize_model_weights,
@@ -109,7 +110,7 @@ def test_save_dequantized_hf_checkpoint_exports_bf16_weights(tmp_path: Path):
     output_dir = tmp_path / "deepseek-source-dequantized"
     quantized_weight, inverse_scale, plain_weight, integer_weight = _create_quantized_checkpoint(source_dir)
 
-    saved_path = save_dequantized_hf_checkpoint(source_dir, output_model_path=output_dir)
+    saved_path = save_dequantized_hf_checkpoint(source_dir, output_model_path=output_dir, stack_experts=False)
 
     assert saved_path == output_dir.resolve()
     assert (output_dir / "config.json").is_file()
@@ -131,6 +132,237 @@ def test_save_dequantized_hf_checkpoint_exports_bf16_weights(tmp_path: Path):
         assert torch.equal(state_dict["w_int"], integer_weight)
     finally:
         state_dict.close()
+
+
+def test_save_dequantized_hf_checkpoint_can_export_legacy_format_with_moe_metadata(tmp_path: Path):
+    source_dir = tmp_path / "deepseek-source"
+    output_dir = tmp_path / "deepseek-source-dequantized"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "quantization_config": {"weight_block_size": [2, 2]},
+                "n_routed_experts": 2,
+                "first_k_dense_replace": 0,
+                "num_hidden_layers": 1,
+            }
+        )
+    )
+
+    shard = source_dir / "model-00001-of-00001.safetensors"
+    expert_tensors = {
+        "model.layers.0.mlp.experts.0.gate_proj.weight": torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32),
+        "model.layers.0.mlp.experts.1.gate_proj.weight": torch.tensor([[5.0, 6.0], [7.0, 8.0]], dtype=torch.float32),
+        "model.layers.0.mlp.experts.0.down_proj.weight": torch.tensor([[9.0, 10.0], [11.0, 12.0]], dtype=torch.float32),
+        "model.layers.0.mlp.experts.1.down_proj.weight": torch.tensor(
+            [[13.0, 14.0], [15.0, 16.0]], dtype=torch.float32
+        ),
+        "model.layers.0.mlp.experts.0.up_proj.weight": torch.tensor([[17.0, 18.0], [19.0, 20.0]], dtype=torch.float32),
+        "model.layers.0.mlp.experts.1.up_proj.weight": torch.tensor([[21.0, 22.0], [23.0, 24.0]], dtype=torch.float32),
+    }
+    safetensors.torch.save_file(expert_tensors, str(shard))
+    _write_index(source_dir, {key: shard.name for key in expert_tensors})
+
+    saved_path = save_dequantized_hf_checkpoint(source_dir, output_model_path=output_dir, stack_experts=False)
+
+    assert saved_path == output_dir.resolve()
+    output_index = json.loads((output_dir / "model.safetensors.index.json").read_text())
+    assert set(output_index["weight_map"]) == set(expert_tensors)
+    assert not any("experts_stacked" in key for key in output_index["weight_map"])
+
+
+def test_save_dequantized_hf_checkpoint_defaults_to_stacked_export(tmp_path: Path):
+    source_dir = tmp_path / "deepseek-source"
+    output_dir = default_stacked_dequantized_model_path(source_dir)
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "config.json").write_text(json.dumps({"quantization_config": {"weight_block_size": [2, 2]}}))
+
+    shard = source_dir / "model-00001-of-00001.safetensors"
+    expert_tensors = {
+        "model.layers.0.mlp.experts.0.gate_proj.weight": torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32),
+        "model.layers.0.mlp.experts.1.gate_proj.weight": torch.tensor([[5.0, 6.0], [7.0, 8.0]], dtype=torch.float32),
+    }
+    safetensors.torch.save_file(expert_tensors, str(shard))
+    _write_index(source_dir, {key: shard.name for key in expert_tensors})
+
+    saved_path = save_dequantized_hf_checkpoint(source_dir)
+
+    assert saved_path == output_dir.resolve()
+    output_index = json.loads((output_dir / "model.safetensors.index.json").read_text())
+    assert "model.layers.0.mlp.experts_stacked.gate_proj.weight" in output_index["weight_map"]
+    assert "model.layers.0.mlp.experts.0.gate_proj.weight" not in output_index["weight_map"]
+
+
+def test_save_dequantized_hf_checkpoint_can_stack_experts(tmp_path: Path):
+    source_dir = tmp_path / "deepseek-source"
+    output_dir = default_stacked_dequantized_model_path(source_dir)
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "config.json").write_text(json.dumps({"quantization_config": {"weight_block_size": [2, 2]}}))
+
+    shard = source_dir / "model-00001-of-00001.safetensors"
+    expert_tensors = {
+        "model.layers.0.mlp.experts.0.gate_proj.weight": torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32),
+        "model.layers.0.mlp.experts.1.gate_proj.weight": torch.tensor([[5.0, 6.0], [7.0, 8.0]], dtype=torch.float32),
+        "model.layers.0.mlp.experts.0.down_proj.weight": torch.tensor([[9.0, 10.0], [11.0, 12.0]], dtype=torch.float32),
+        "model.layers.0.mlp.experts.1.down_proj.weight": torch.tensor(
+            [[13.0, 14.0], [15.0, 16.0]], dtype=torch.float32
+        ),
+        "model.layers.0.mlp.experts.0.up_proj.weight": torch.tensor([[17.0, 18.0], [19.0, 20.0]], dtype=torch.float32),
+        "model.layers.0.mlp.experts.1.up_proj.weight": torch.tensor([[21.0, 22.0], [23.0, 24.0]], dtype=torch.float32),
+        "lm_head.weight": torch.tensor([[0.5, -0.5]], dtype=torch.float32),
+    }
+    safetensors.torch.save_file(expert_tensors, str(shard))
+    _write_index(source_dir, {key: shard.name for key in expert_tensors})
+
+    saved_path = save_dequantized_hf_checkpoint(source_dir, output_model_path=output_dir, stack_experts=True)
+
+    assert saved_path == output_dir.resolve()
+    output_index = json.loads((output_dir / "model.safetensors.index.json").read_text())
+    assert "model.layers.0.mlp.experts.0.gate_proj.weight" not in output_index["weight_map"]
+    assert "model.layers.0.mlp.experts_stacked.gate_proj.weight" in output_index["weight_map"]
+    assert output_index["weight_map"]["model.layers.0.mlp.experts_stacked.gate_proj.weight"].startswith(
+        "stacked-experts-layer-"
+    )
+
+    state_dict = load_state_dict(output_dir, "")
+    try:
+        stacked_view = state_dict.view_with_prefix("model.layers.0.mlp.experts_stacked.")
+        assert "model.layers.0.mlp.experts_stacked.gate_proj.weight" not in state_dict
+        assert "gate_proj.weight" in stacked_view
+        stacked_gate = stacked_view["gate_proj.weight"]
+        expected_gate = torch.stack(
+            [
+                expert_tensors["model.layers.0.mlp.experts.0.gate_proj.weight"].to(torch.bfloat16),
+                expert_tensors["model.layers.0.mlp.experts.1.gate_proj.weight"].to(torch.bfloat16),
+            ]
+        )
+        assert stacked_gate.dtype == torch.bfloat16
+        assert torch.equal(stacked_gate, expected_gate)
+        assert "model.layers.0.mlp.experts.0.gate_proj.weight" in state_dict
+        assert torch.equal(
+            state_dict["model.layers.0.mlp.experts.0.gate_proj.weight"],
+            expert_tensors["model.layers.0.mlp.experts.0.gate_proj.weight"].to(torch.bfloat16),
+        )
+        assert torch.equal(state_dict["lm_head.weight"], expert_tensors["lm_head.weight"].to(torch.bfloat16))
+    finally:
+        state_dict.close()
+
+
+def test_save_dequantized_hf_checkpoint_rewrites_dequantized_shards_when_stacking_experts(tmp_path: Path):
+    source_dir = tmp_path / "deepseek-source"
+    output_dir = default_stacked_dequantized_model_path(source_dir)
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "config.json").write_text(json.dumps({"quantization_config": {"weight_block_size": [2, 2]}}))
+
+    shard = source_dir / "model-00001-of-00001.safetensors"
+    expert_tensors = {
+        "model.layers.0.mlp.experts.0.gate_proj.weight": torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.bfloat16),
+        "model.layers.0.mlp.experts.1.gate_proj.weight": torch.tensor([[5.0, 6.0], [7.0, 8.0]], dtype=torch.bfloat16),
+        "lm_head.weight": torch.tensor([[0.5, -0.5]], dtype=torch.bfloat16),
+    }
+    safetensors.torch.save_file(expert_tensors, str(shard))
+    _write_index(source_dir, {key: shard.name for key in expert_tensors})
+
+    save_dequantized_hf_checkpoint(source_dir, output_model_path=output_dir, stack_experts=True)
+
+    rewritten_shard = safetensors.torch.load_file(str(output_dir / shard.name))
+    assert set(rewritten_shard) == {"lm_head.weight"}
+
+    stacked_shard = safetensors.torch.load_file(str(output_dir / "stacked-experts-layer-00000.safetensors"))
+    assert set(stacked_shard) == {"model.layers.0.mlp.experts_stacked.gate_proj.weight"}
+    assert torch.equal(
+        stacked_shard["model.layers.0.mlp.experts_stacked.gate_proj.weight"],
+        torch.stack(
+            [
+                expert_tensors["model.layers.0.mlp.experts.0.gate_proj.weight"],
+                expert_tensors["model.layers.0.mlp.experts.1.gate_proj.weight"],
+            ]
+        ),
+    )
+
+
+def test_save_dequantized_hf_checkpoint_rejects_incomplete_stacked_expert_groups(tmp_path: Path):
+    source_dir = tmp_path / "deepseek-source"
+    output_dir = default_stacked_dequantized_model_path(source_dir)
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "config.json").write_text(
+        json.dumps({"quantization_config": {"weight_block_size": [2, 2]}, "n_routed_experts": 2})
+    )
+
+    shard = source_dir / "model-00001-of-00001.safetensors"
+    expert_tensors = {
+        "model.layers.0.mlp.experts.0.gate_proj.weight": torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32),
+    }
+    safetensors.torch.save_file(expert_tensors, str(shard))
+    _write_index(source_dir, {key: shard.name for key in expert_tensors})
+
+    with pytest.raises(ValueError, match="do not match n_routed_experts=2"):
+        save_dequantized_hf_checkpoint(source_dir, output_model_path=output_dir, stack_experts=True)
+
+
+def test_save_dequantized_hf_checkpoint_rejects_missing_required_moe_projection_groups(tmp_path: Path):
+    source_dir = tmp_path / "deepseek-source"
+    output_dir = default_stacked_dequantized_model_path(source_dir)
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "quantization_config": {"weight_block_size": [2, 2]},
+                "n_routed_experts": 2,
+                "first_k_dense_replace": 0,
+                "num_hidden_layers": 2,
+            }
+        )
+    )
+
+    shard = source_dir / "model-00001-of-00001.safetensors"
+    expert_tensors = {
+        "model.layers.0.mlp.experts.0.gate_proj.weight": torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32),
+        "model.layers.0.mlp.experts.1.gate_proj.weight": torch.tensor([[5.0, 6.0], [7.0, 8.0]], dtype=torch.float32),
+        "model.layers.0.mlp.experts.0.down_proj.weight": torch.tensor([[9.0, 10.0], [11.0, 12.0]], dtype=torch.float32),
+        "model.layers.0.mlp.experts.1.down_proj.weight": torch.tensor(
+            [[13.0, 14.0], [15.0, 16.0]], dtype=torch.float32
+        ),
+        "model.layers.0.mlp.experts.0.up_proj.weight": torch.tensor([[17.0, 18.0], [19.0, 20.0]], dtype=torch.float32),
+        "model.layers.0.mlp.experts.1.up_proj.weight": torch.tensor([[21.0, 22.0], [23.0, 24.0]], dtype=torch.float32),
+    }
+    safetensors.torch.save_file(expert_tensors, str(shard))
+    _write_index(source_dir, {key: shard.name for key in expert_tensors})
+
+    with pytest.raises(ValueError, match="missing required expert projections"):
+        save_dequantized_hf_checkpoint(source_dir, output_model_path=output_dir, stack_experts=True)
+
+
+def test_materialize_model_weights_respects_index_for_stacked_exports(tmp_path: Path):
+    source_dir = tmp_path / "deepseek-source"
+    output_dir = default_stacked_dequantized_model_path(source_dir)
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "config.json").write_text(json.dumps({"quantization_config": {"weight_block_size": [2, 2]}}))
+
+    shard = source_dir / "model-00001-of-00001.safetensors"
+    expert_tensors = {
+        "model.layers.0.mlp.experts.0.gate_proj.weight": torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.bfloat16),
+        "model.layers.0.mlp.experts.1.gate_proj.weight": torch.tensor([[5.0, 6.0], [7.0, 8.0]], dtype=torch.bfloat16),
+        "lm_head.weight": torch.tensor([[0.5, -0.5]], dtype=torch.bfloat16),
+    }
+    safetensors.torch.save_file(expert_tensors, str(shard))
+    _write_index(source_dir, {key: shard.name for key in expert_tensors})
+
+    save_dequantized_hf_checkpoint(source_dir, output_model_path=output_dir, stack_experts=True)
+    state_dict = materialize_model_weights(output_dir)
+
+    assert "model.layers.0.mlp.experts.0.gate_proj.weight" not in state_dict
+    assert "model.layers.0.mlp.experts.1.gate_proj.weight" not in state_dict
+    assert "model.layers.0.mlp.experts_stacked.gate_proj.weight" in state_dict
+    assert torch.equal(
+        state_dict["model.layers.0.mlp.experts_stacked.gate_proj.weight"],
+        torch.stack(
+            [
+                expert_tensors["model.layers.0.mlp.experts.0.gate_proj.weight"],
+                expert_tensors["model.layers.0.mlp.experts.1.gate_proj.weight"],
+            ]
+        ),
+    )
 
 
 def test_dequantize_state_dict_compat_shim_handles_quantized_inputs():
@@ -250,3 +482,71 @@ def test_unload_weight_from_lazy_state_dict_evicts_cache(tmp_path: Path):
     unload_weight("lm_head.weight", target_tensor)
     assert target_tensor.numel() == 0
     assert "lm_head.weight" not in state_dict._cache
+
+
+def test_unload_weight_from_lazy_state_dict_evicts_stacked_alias_cache(tmp_path: Path):
+    model_dir = tmp_path / "deepseek-lazy-stacked-unload"
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    shard = model_dir / "model-00001-of-00001.safetensors"
+    stacked_key = "model.layers.3.mlp.experts_stacked.gate_proj.weight"
+    stacked_weight = torch.arange(24, dtype=torch.bfloat16).reshape(3, 2, 4)
+    safetensors.torch.save_file({stacked_key: stacked_weight}, str(shard))
+    _write_index(model_dir, {stacked_key: shard.name})
+
+    state_dict = index_model_weights(model_dir)
+    assert isinstance(state_dict, LazyStateDict)
+
+    expert_key = "model.layers.3.mlp.experts.1.gate_proj.weight"
+    load_weight = load_weight_from_weights_dict(state_dict)
+    unload_weight = unload_weight_from_weights_dict(state_dict)
+    target_tensor = torch.empty_like(stacked_weight[1])
+
+    load_weight(expert_key, target_tensor)
+    assert expert_key in state_dict._cache
+    assert stacked_key in state_dict._cache
+
+    unload_weight(expert_key, target_tensor)
+    assert target_tensor.numel() == 0
+    assert expert_key not in state_dict._cache
+    assert stacked_key not in state_dict._cache
+
+
+def test_materialized_stacked_checkpoint_load_hooks_resolve_expert_aliases(tmp_path: Path):
+    model_dir = tmp_path / "deepseek-eager-stacked-hooks"
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    shard = model_dir / "model-00001-of-00001.safetensors"
+    stacked_key = "model.layers.3.mlp.experts_stacked.gate_proj.weight"
+    stacked_weight = torch.arange(24, dtype=torch.bfloat16).reshape(3, 2, 4)
+    safetensors.torch.save_file({stacked_key: stacked_weight}, str(shard))
+    _write_index(model_dir, {stacked_key: shard.name})
+
+    state_dict = materialize_model_weights(model_dir)
+    expert_key = "model.layers.3.mlp.experts.1.gate_proj.weight"
+    load_weight = load_weight_from_weights_dict(state_dict)
+    unload_weight = unload_weight_from_weights_dict(state_dict)
+    target_tensor = torch.empty_like(stacked_weight[1])
+
+    load_weight(expert_key, target_tensor)
+    assert torch.equal(target_tensor, stacked_weight[1])
+
+    unload_weight(expert_key, target_tensor)
+    assert target_tensor.numel() == 0
+
+
+def test_load_weight_from_weights_dict_rejects_mixed_expert_checkpoint():
+    expert_key = "model.layers.3.mlp.experts.1.gate_proj.weight"
+    stacked_key = "model.layers.3.mlp.experts_stacked.gate_proj.weight"
+    weights_dict = {
+        expert_key: torch.ones((2, 4), dtype=torch.bfloat16),
+        stacked_key: torch.ones((3, 2, 4), dtype=torch.bfloat16),
+    }
+
+    load_weight = load_weight_from_weights_dict(weights_dict)
+    unload_weight = unload_weight_from_weights_dict(weights_dict)
+
+    with pytest.raises(RuntimeError, match="mixes legacy expert tensor"):
+        load_weight(expert_key, torch.empty((2, 4), dtype=torch.bfloat16))
+    with pytest.raises(RuntimeError, match="mixes legacy expert tensor"):
+        unload_weight(expert_key, torch.empty((2, 4), dtype=torch.bfloat16))

--- a/models/demos/deepseek_v3/tests/test_lazy_state_dict.py
+++ b/models/demos/deepseek_v3/tests/test_lazy_state_dict.py
@@ -466,6 +466,29 @@ def test_stacked_expert_alias_contains_rejects_out_of_range_experts(tmp_path: Pa
         _ = state[missing_expert_key]
 
 
+def test_stacked_expert_alias_cached_access_respects_num_layers_filter(tmp_path: Path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    shard = model_dir / "model-00001-of-00001.safetensors"
+    stacked_key = "model.layers.3.mlp.experts_stacked.gate_proj.weight"
+    stacked_tensor = torch.arange(24, dtype=torch.bfloat16).reshape(3, 2, 4)
+    safetensors.torch.save_file({stacked_key: stacked_tensor}, str(shard))
+    _write_index(model_dir, {stacked_key: shard.name})
+
+    state = load_state_dict(model_dir, "")
+    expert_key = "model.layers.3.mlp.experts.1.gate_proj.weight"
+
+    assert torch.equal(state[expert_key], stacked_tensor[1])
+    assert expert_key in state._cache
+
+    limited = state.view_with_prefix("", num_layers=2)
+
+    assert expert_key not in limited
+    with pytest.raises(KeyError):
+        _ = limited[expert_key]
+
+
 def test_lazy_state_dict_rejects_mixed_expert_checkpoint(tmp_path: Path):
     model_dir = tmp_path / "model"
     model_dir.mkdir(parents=True, exist_ok=True)
@@ -549,8 +572,8 @@ def test_evict_alias_releases_unpinned_stacked_tensor(tmp_path: Path):
     expert_key = "model.layers.3.mlp.experts.1.gate_proj.weight"
 
     assert torch.equal(state[expert_key], stacked_tensor[1])
-    assert stacked_key in state._cache
     assert expert_key in state._cache
+    assert stacked_key not in state._cache
 
     state.evict(expert_key)
 

--- a/models/demos/deepseek_v3/tests/test_lazy_state_dict.py
+++ b/models/demos/deepseek_v3/tests/test_lazy_state_dict.py
@@ -426,3 +426,153 @@ def test_view_override_parent_layer_filter(tmp_path: Path):
     assert "0.k" in loose_keys
     assert "1.k" in loose_keys
     assert "3.k" in loose_keys
+
+
+def test_stacked_expert_alias_resolves_per_expert_keys(tmp_path: Path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    shard = model_dir / "model-00001-of-00001.safetensors"
+    stacked_key = "model.layers.3.mlp.experts_stacked.gate_proj.weight"
+    stacked_tensor = torch.arange(24, dtype=torch.bfloat16).reshape(3, 2, 4)
+    safetensors.torch.save_file({stacked_key: stacked_tensor}, str(shard))
+    _write_index(model_dir, {stacked_key: shard.name})
+
+    state = load_state_dict(model_dir, "")
+    expert_key = "model.layers.3.mlp.experts.1.gate_proj.weight"
+    assert expert_key in state
+    assert torch.equal(state[expert_key], stacked_tensor[1])
+
+    sub = sub_state_dict(state, "model.layers.3.mlp.")
+    sub_expert_key = "experts.2.gate_proj.weight"
+    assert sub_expert_key in sub
+    assert torch.equal(sub[sub_expert_key], stacked_tensor[2])
+
+
+def test_stacked_expert_alias_contains_rejects_out_of_range_experts(tmp_path: Path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    shard = model_dir / "model-00001-of-00001.safetensors"
+    stacked_key = "model.layers.3.mlp.experts_stacked.gate_proj.weight"
+    stacked_tensor = torch.arange(24, dtype=torch.bfloat16).reshape(3, 2, 4)
+    safetensors.torch.save_file({stacked_key: stacked_tensor}, str(shard))
+    _write_index(model_dir, {stacked_key: shard.name})
+
+    state = load_state_dict(model_dir, "")
+    missing_expert_key = "model.layers.3.mlp.experts.3.gate_proj.weight"
+    assert missing_expert_key not in state
+    with pytest.raises(KeyError):
+        _ = state[missing_expert_key]
+
+
+def test_lazy_state_dict_rejects_mixed_expert_checkpoint(tmp_path: Path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    shard = model_dir / "model-00001-of-00001.safetensors"
+    tensors = {
+        "model.layers.3.mlp.experts_stacked.gate_proj.weight": torch.arange(24, dtype=torch.bfloat16).reshape(3, 2, 4),
+        "model.layers.3.mlp.experts.0.gate_proj.weight": torch.ones((2, 4), dtype=torch.bfloat16),
+    }
+    safetensors.torch.save_file(tensors, str(shard))
+    _write_index(model_dir, {key: shard.name for key in tensors})
+
+    with pytest.raises(ValueError, match="mixes legacy per-expert and stacked expert tensors"):
+        load_state_dict(model_dir, "")
+
+
+def test_stacked_expert_iteration_exposes_logical_aliases(tmp_path: Path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    shard = model_dir / "model-00001-of-00001.safetensors"
+    stacked_key = "model.layers.3.mlp.experts_stacked.gate_proj.weight"
+    stacked_tensor = torch.arange(24, dtype=torch.bfloat16).reshape(3, 2, 4)
+    safetensors.torch.save_file({stacked_key: stacked_tensor}, str(shard))
+    _write_index(model_dir, {stacked_key: shard.name})
+
+    state = load_state_dict(model_dir, "")
+    sub = sub_state_dict(state, "model.layers.3.mlp.")
+
+    materialized = dict(sub.items())
+    stacked_view = sub_state_dict(state, "model.layers.3.mlp.experts_stacked.")
+
+    assert "experts_stacked.gate_proj.weight" not in materialized
+    assert "experts_stacked.gate_proj.weight" not in sub
+    with pytest.raises(KeyError):
+        _ = sub["experts_stacked.gate_proj.weight"]
+    assert "experts.0.gate_proj.weight" in materialized
+    assert "experts.1.gate_proj.weight" in materialized
+    assert "experts.2.gate_proj.weight" in materialized
+    assert torch.equal(materialized["experts.1.gate_proj.weight"], stacked_tensor[1])
+    assert torch.equal(stacked_view["gate_proj.weight"], stacked_tensor)
+
+
+def test_evict_keeps_explicitly_cached_stacked_tensor(tmp_path: Path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    shard = model_dir / "model-00001-of-00001.safetensors"
+    stacked_key = "model.layers.3.mlp.experts_stacked.gate_proj.weight"
+    stacked_tensor = torch.arange(24, dtype=torch.bfloat16).reshape(3, 2, 4)
+    safetensors.torch.save_file({stacked_key: stacked_tensor}, str(shard))
+    _write_index(model_dir, {stacked_key: shard.name})
+
+    state = load_state_dict(model_dir, "")
+    expert_key = "model.layers.3.mlp.experts.1.gate_proj.weight"
+    stacked_view = sub_state_dict(state, "model.layers.3.mlp.experts_stacked.")
+
+    assert torch.equal(stacked_view["gate_proj.weight"], stacked_tensor)
+    assert torch.equal(state[expert_key], stacked_tensor[1])
+    assert stacked_key in state._cache
+    assert expert_key in state._cache
+
+    state.evict(expert_key)
+
+    assert stacked_key in state._cache
+    assert expert_key not in state._cache
+    assert torch.equal(stacked_view["gate_proj.weight"], stacked_tensor)
+
+
+def test_evict_alias_releases_unpinned_stacked_tensor(tmp_path: Path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    shard = model_dir / "model-00001-of-00001.safetensors"
+    stacked_key = "model.layers.3.mlp.experts_stacked.gate_proj.weight"
+    stacked_tensor = torch.arange(24, dtype=torch.bfloat16).reshape(3, 2, 4)
+    safetensors.torch.save_file({stacked_key: stacked_tensor}, str(shard))
+    _write_index(model_dir, {stacked_key: shard.name})
+
+    state = load_state_dict(model_dir, "")
+    expert_key = "model.layers.3.mlp.experts.1.gate_proj.weight"
+
+    assert torch.equal(state[expert_key], stacked_tensor[1])
+    assert stacked_key in state._cache
+    assert expert_key in state._cache
+
+    state.evict(expert_key)
+
+    assert stacked_key not in state._cache
+    assert expert_key not in state._cache
+
+
+def test_stacked_only_subview_iterates_stacked_keys(tmp_path: Path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    shard = model_dir / "model-00001-of-00001.safetensors"
+    stacked_key = "model.layers.3.mlp.experts_stacked.gate_proj.weight"
+    stacked_tensor = torch.arange(24, dtype=torch.bfloat16).reshape(3, 2, 4)
+    safetensors.torch.save_file({stacked_key: stacked_tensor}, str(shard))
+    _write_index(model_dir, {stacked_key: shard.name})
+
+    state = load_state_dict(model_dir, "")
+    stacked_view = sub_state_dict(state, "model.layers.3.mlp.experts_stacked.")
+
+    materialized = dict(stacked_view.items())
+
+    assert list(materialized.keys()) == ["gate_proj.weight"]
+    assert len(stacked_view) == 1
+    assert torch.equal(materialized["gate_proj.weight"], stacked_tensor)

--- a/models/demos/deepseek_v3/tests/test_mlp.py
+++ b/models/demos/deepseek_v3/tests/test_mlp.py
@@ -102,11 +102,14 @@ def run_weight_conversion_test(MLPClass, hf_config, state_dict, tmp_path, refere
     # assert Path(weight_config["w2"]["input_tensor_b"]).exists()
     # assert Path(weight_config["w3"]["input_tensor_b"]).exists()
 
-    # Make the path absolute - this is required since load_weight expects an absolute path
-    weight_config["w1"]["input_tensor_b"].path = tmp_path / weight_config["w1"]["input_tensor_b"].path
-
     # Load and verify a weight
-    w1_ttnn = load_weight(weight_config["w1"]["input_tensor_b"], device=mesh_device)
+    w1_weight = weight_config["w1"]["input_tensor_b"]
+    if isinstance(w1_weight, ttnn.Tensor):
+        w1_ttnn = w1_weight
+    else:
+        # Legacy SavedWeight path retained for backward compatibility.
+        w1_weight.path = tmp_path / w1_weight.path
+        w1_ttnn = load_weight(w1_weight, device=mesh_device)
     w1_ttnn = ttnn.unsqueeze(w1_ttnn, 0)  # Unsqueeze to collect shards on a separate dim
     w1_torch = ttnn.to_torch(
         w1_ttnn,

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -33,10 +33,8 @@ from models.demos.deepseek_v3.utils.test_utils import (
 )
 
 
-@pytest.fixture
-def reference_model(hf_config):
+def build_reference_model(hf_config):
     """Build the routed-experts-only MoE reference used by the TT MoE test."""
-    torch.use_deterministic_algorithms(True)
     moe_config = deepcopy(hf_config)
     moe_config.n_shared_experts = None
     return DeepseekV3MoE(moe_config).eval()
@@ -107,7 +105,6 @@ def run_test_forward_pass_moe(
     mode,
     num_tokens,
     batch_size_per_row,
-    reference_model,
     hf_config,
     request,
     cache_path,
@@ -119,7 +116,7 @@ def run_test_forward_pass_moe(
     """Test forward pass against reference model."""
 
     moe_cls = _moe_cls(mesh_device, device_params["fabric_config"])
-
+    reference_model = build_reference_model(hf_config)
     module_path = "model.layers.3.mlp"
     checkpoint_state_dict = request.getfixturevalue("state_dict")
     state_dict, torch_input, reference_output = generate_reference_io(
@@ -205,7 +202,6 @@ def test_forward_pass(
     batch_size_per_row,
     seq_len,
     set_deterministic_env,
-    reference_model,
     hf_config,
     request,
     cache_path,
@@ -217,7 +213,6 @@ def test_forward_pass(
         mode=mode,
         num_tokens=batch_size_per_row * mesh_device.shape[0] if mode == "decode" else seq_len,
         batch_size_per_row=batch_size_per_row,
-        reference_model=reference_model,
         hf_config=hf_config,
         request=request,
         cache_path=cache_path,
@@ -239,7 +234,6 @@ def test_forward_pass(
 def test_mode_decode_forward_pass_batch_8_users_per_row(
     device_params,
     set_deterministic_env,
-    reference_model,
     hf_config,
     request,
     cache_path,
@@ -251,7 +245,6 @@ def test_mode_decode_forward_pass_batch_8_users_per_row(
         mode="decode",
         num_tokens=8 * mesh_device.shape[0],
         batch_size_per_row=8,
-        reference_model=reference_model,
         hf_config=hf_config,
         request=request,
         cache_path=cache_path,

--- a/models/demos/deepseek_v3/tests/test_moe_experts.py
+++ b/models/demos/deepseek_v3/tests/test_moe_experts.py
@@ -4,6 +4,7 @@
 
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -115,16 +116,17 @@ def test_forward_pass(
     torch_input = torch.randn(1, 1, num_tokens, hf_config.hidden_size, dtype=torch.bfloat16)
 
     if weight_type == "random":
-        state_dict = reference_model.state_dict()
+        tt_state_dict = reference_model.state_dict()
     else:
         assert weight_type == "real"
-        state_dict = create_combined_state_dict(module_path, model_path, state_dict)
-        reference_model.load_state_dict(state_dict)
+        reference_state_dict = create_combined_state_dict(module_path, model_path, state_dict)
+        tt_state_dict = sub_state_dict(state_dict, ".".join(module_path.split(".")[:-2]) + ".")
+        reference_model.load_state_dict(reference_state_dict)
 
     weight_config = get_test_weight_config(
         TTExperts,
         hf_config,
-        (state_dict,),
+        (tt_state_dict,),
         cache_path,
         mesh_device,
         force_recalculate_weight_config,
@@ -203,6 +205,48 @@ def test_forward_pass(
     ttnn.deallocate(tt_output)
 
     assert passed, f"PCC check failed! Min PCC: {min_pcc:.6f} < 0.98"
+
+
+def test_convert_weights_rejects_partial_stacked_expert_checkpoint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    class _FakeMeshDevice:
+        shape = (1, 1)
+
+        def get_num_devices(self) -> int:
+            return 1
+
+    class _ViewableStateDict(dict):
+        def view_with_prefix(self, prefix: str, num_layers: int | None = None):
+            return {k[len(prefix) :]: v for k, v in self.items() if k.startswith(prefix)}
+
+    state_dict = _ViewableStateDict(
+        {
+            "experts_stacked.gate_proj.weight": torch.arange(12, dtype=torch.bfloat16).reshape(2, 2, 3),
+            "experts.0.gate_proj.weight": torch.ones((2, 3), dtype=torch.bfloat16),
+            "experts.1.gate_proj.weight": torch.full((2, 3), 2.0, dtype=torch.bfloat16),
+            "experts.0.down_proj.weight": torch.ones((2, 3), dtype=torch.bfloat16),
+            "experts.1.down_proj.weight": torch.full((2, 3), 2.0, dtype=torch.bfloat16),
+            "experts.0.up_proj.weight": torch.ones((2, 3), dtype=torch.bfloat16),
+            "experts.1.up_proj.weight": torch.full((2, 3), 2.0, dtype=torch.bfloat16),
+        }
+    )
+
+    monkeypatch.setattr(
+        "models.demos.deepseek_v3.tt.experts.get_dequantized_tensor",
+        lambda state_dict, key, dtype=None: state_dict[key],
+    )
+    monkeypatch.setattr(
+        "models.demos.deepseek_v3.tt.experts.shard_and_save",
+        lambda path, tensor, *args, **kwargs: tensor,
+    )
+    monkeypatch.setattr(TTExperts, "_warned_legacy_expert_checkpoint", False)
+
+    with pytest.raises(ValueError, match="mixes stacked and legacy expert weights"):
+        TTExperts.convert_weights(
+            SimpleNamespace(n_routed_experts=2),
+            (state_dict,),
+            tmp_path,
+            _FakeMeshDevice(),
+        )
 
 
 if __name__ == "__main__":

--- a/models/demos/deepseek_v3/tests/test_moe_experts.py
+++ b/models/demos/deepseek_v3/tests/test_moe_experts.py
@@ -59,14 +59,44 @@ def create_combined_state_dict(module_path: str, model_path: Path, state_dict: d
     """
     parts = module_path.split(".")
     base_path = ".".join(parts[:-1])
+    container_name = base_path.split(".")[-1]
     s, e = module_path.split(".")[-1].split("-")
     s, e = int(s), int(e)
+    stacked_prefix = ".".join(parts[:-2] + ["experts_stacked"]) + "."
+    stacked_state_dict = sub_state_dict(state_dict, stacked_prefix)
+    stacked_projection_names = ("gate_proj.weight", "down_proj.weight", "up_proj.weight")
+    present_stacked_projection_names = tuple(name for name in stacked_projection_names if name in stacked_state_dict)
+
     out_state_dict = {}
+    if present_stacked_projection_names:
+        if present_stacked_projection_names != stacked_projection_names:
+            missing_projection_names = sorted(set(stacked_projection_names) - set(present_stacked_projection_names))
+            raise ValueError(
+                "Checkpoint mixes stacked and legacy expert weights in reference model setup: "
+                f"missing stacked projections {missing_projection_names} under '{stacked_prefix}'"
+            )
+
+        for projection_name in stacked_projection_names:
+            stacked_weight = stacked_state_dict[projection_name]
+            if stacked_weight.ndim != 3:
+                raise ValueError(
+                    f"Expected stacked expert weight '{stacked_prefix}{projection_name}' to have rank 3, "
+                    f"got {stacked_weight.ndim}"
+                )
+            if stacked_weight.shape[0] <= e:
+                raise ValueError(
+                    f"Expected stacked expert weight '{stacked_prefix}{projection_name}' to contain expert {e}, "
+                    f"got {stacked_weight.shape[0]} experts"
+                )
+            for expert_idx in range(s, e + 1):
+                out_state_dict[f"{container_name}.{expert_idx}.{projection_name}"] = stacked_weight[expert_idx]
+        return out_state_dict
+
     for i in range(s, e + 1):
         module_path_i = f"{base_path}.{i}"
         state_dict_i = sub_state_dict(state_dict, module_path_i + ".")
         for k, v in state_dict_i.items():
-            k_ = f"{base_path.split('.')[-1]}.{i}.{k}"
+            k_ = f"{container_name}.{i}.{k}"
             out_state_dict[k_] = v
 
     return out_state_dict
@@ -161,7 +191,8 @@ def test_forward_pass(
 
     from models.common.utility_functions import comp_pcc
 
-    min_pcc = 0.98
+    required_pcc = 0.975  # slightly lower after moving to quantize-then-transpose
+    min_pcc = float("inf")
     passed = True
 
     for chunk_idx in range(num_chunks):
@@ -191,7 +222,7 @@ def test_forward_pass(
         if chunk_ref_output.shape != tt_output_chunk_torch.shape:
             chunk_ref_output = chunk_ref_output.unsqueeze(0)
 
-        chunk_passed, chunk_pcc = comp_pcc(tt_output_chunk_torch, chunk_ref_output, pcc=0.98)
+        chunk_passed, chunk_pcc = comp_pcc(tt_output_chunk_torch, chunk_ref_output, pcc=required_pcc)
 
         min_pcc = min(min_pcc, chunk_pcc)
         if not chunk_passed:
@@ -204,7 +235,7 @@ def test_forward_pass(
     ttnn.deallocate(tt_input)
     ttnn.deallocate(tt_output)
 
-    assert passed, f"PCC check failed! Min PCC: {min_pcc:.6f} < 0.98"
+    assert passed, f"PCC check failed! Min PCC: {min_pcc:.6f} < {required_pcc}"
 
 
 def test_convert_weights_rejects_partial_stacked_expert_checkpoint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
@@ -247,6 +278,49 @@ def test_convert_weights_rejects_partial_stacked_expert_checkpoint(monkeypatch: 
             tmp_path,
             _FakeMeshDevice(),
         )
+
+
+def test_create_combined_state_dict_uses_stacked_expert_weights():
+    class _ViewableStateDict(dict):
+        def view_with_prefix(self, prefix: str, num_layers: int | None = None):
+            return {k[len(prefix) :]: v for k, v in self.items() if k.startswith(prefix)}
+
+    state_dict = _ViewableStateDict(
+        {
+            "model.layers.3.mlp.experts_stacked.gate_proj.weight": torch.arange(24, dtype=torch.bfloat16).reshape(
+                3, 2, 4
+            ),
+            "model.layers.3.mlp.experts_stacked.down_proj.weight": torch.arange(24, 48, dtype=torch.bfloat16).reshape(
+                3, 2, 4
+            ),
+            "model.layers.3.mlp.experts_stacked.up_proj.weight": torch.arange(48, 72, dtype=torch.bfloat16).reshape(
+                3, 2, 4
+            ),
+        }
+    )
+
+    combined_state_dict = create_combined_state_dict("model.layers.3.mlp.experts.1-2", Path("."), state_dict)
+
+    assert set(combined_state_dict) == {
+        "experts.1.gate_proj.weight",
+        "experts.1.down_proj.weight",
+        "experts.1.up_proj.weight",
+        "experts.2.gate_proj.weight",
+        "experts.2.down_proj.weight",
+        "experts.2.up_proj.weight",
+    }
+    assert torch.equal(
+        combined_state_dict["experts.1.gate_proj.weight"],
+        state_dict["model.layers.3.mlp.experts_stacked.gate_proj.weight"][1],
+    )
+    assert torch.equal(
+        combined_state_dict["experts.2.down_proj.weight"],
+        state_dict["model.layers.3.mlp.experts_stacked.down_proj.weight"][2],
+    )
+    assert torch.equal(
+        combined_state_dict["experts.2.up_proj.weight"],
+        state_dict["model.layers.3.mlp.experts_stacked.up_proj.weight"][2],
+    )
 
 
 if __name__ == "__main__":

--- a/models/demos/deepseek_v3/tests/test_moe_gate.py
+++ b/models/demos/deepseek_v3/tests/test_moe_gate.py
@@ -4,6 +4,7 @@
 
 import math
 import os
+import types
 
 import pytest
 import torch
@@ -203,6 +204,41 @@ def test_forward_pass(
     ), f"TopK experts weights output does not meet PCC requirement {topk_weights_pcc_required}: {pcc_message}"
 
     assert accuracy >= topk_indices_accuracy_required, f"TopK experts indices output does not match: {accuracy}"
+
+
+def test_linear_fallback_op_uses_hf_oriented_gate_weights(monkeypatch: pytest.MonkeyPatch):
+    class _FakeTTTensor:
+        def __init__(self, payload: torch.Tensor):
+            self.payload = payload
+            self.shape = tuple(payload.shape)
+
+    torch_input_payload = torch.tensor([[[1.0, 2.0], [3.0, 4.0]]], dtype=torch.bfloat16)
+    torch_weight_payload = torch.tensor([[[[5.0, 6.0], [7.0, 8.0], [9.0, 10.0]]]], dtype=torch.bfloat16)
+    captured: dict[str, torch.Tensor] = {}
+
+    monkeypatch.setattr(ttnn, "ConcatMesh2dToTensor", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ttnn, "ShardTensor2dMesh", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ttnn, "to_torch", lambda tensor, **kwargs: tensor.payload)
+
+    def fake_from_torch(tensor, **kwargs):
+        captured["output"] = tensor
+        return _FakeTTTensor(tensor)
+
+    monkeypatch.setattr(ttnn, "from_torch", fake_from_torch)
+
+    mesh_device = types.SimpleNamespace(shape=(1, 1))
+    output = MoEGate.linear_fallback_op(
+        _FakeTTTensor(torch_input_payload),
+        _FakeTTTensor(torch_weight_payload),
+        mesh_device=mesh_device,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        transpose_b=True,
+    )
+
+    expected = torch.nn.functional.linear(torch_input_payload[0], torch_weight_payload[0, 0]).unsqueeze(0).unsqueeze(0)
+    assert torch.equal(captured["output"], expected)
+    assert output.shape == tuple(expected.shape)
 
 
 if __name__ == "__main__":

--- a/models/demos/deepseek_v3/tt/experts.py
+++ b/models/demos/deepseek_v3/tt/experts.py
@@ -42,6 +42,7 @@ class Experts(AbstractModule):
     """Experts layer for Mixture-of-Experts (MoE) module."""
 
     WEIGHT_TORCH_DTYPE = torch.bfloat16
+    _warned_legacy_expert_checkpoint = False
 
     @classmethod
     def _get_num_experts_per_device(cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device) -> int:
@@ -64,12 +65,55 @@ class Experts(AbstractModule):
     def _load_expert_weight(
         cls, state_dict: dict[str, torch.Tensor], hf_name: str, n_routed_experts: int
     ) -> torch.Tensor:
+        view_with_prefix = getattr(state_dict, "view_with_prefix", None)
+        stacked_state_dict = view_with_prefix("experts_stacked.") if callable(view_with_prefix) else state_dict
+        stacked_lookup_names = {f"{name}.weight" for name in ("gate_proj", "down_proj", "up_proj")}
+        if not callable(view_with_prefix):
+            stacked_lookup_names = {f"experts_stacked.{name}" for name in stacked_lookup_names}
+        present_stacked_lookup_names = {name for name in stacked_lookup_names if name in stacked_state_dict}
+
+        stacked_weight_name = f"experts_stacked.{hf_name}.weight"
+        stacked_lookup_name = f"{hf_name}.weight" if callable(view_with_prefix) else stacked_weight_name
+        if stacked_lookup_name in stacked_state_dict:
+            stacked_weight = get_dequantized_tensor(
+                stacked_state_dict, stacked_lookup_name, dtype=cls.WEIGHT_TORCH_DTYPE
+            )
+            if stacked_weight.ndim != 3:
+                raise ValueError(
+                    f"Expected stacked expert weight '{stacked_weight_name}' to have rank 3, got {stacked_weight.ndim}"
+                )
+            if stacked_weight.shape[0] != n_routed_experts:
+                raise ValueError(
+                    f"Expected stacked expert weight '{stacked_weight_name}' to contain "
+                    f"{n_routed_experts} experts, got {stacked_weight.shape[0]}"
+                )
+            return stacked_weight.contiguous()
+
+        if present_stacked_lookup_names:
+            raise ValueError(
+                f"Checkpoint mixes stacked and legacy expert weights: missing '{stacked_weight_name}' while "
+                "other stacked expert tensors are present. Regenerate the stacked checkpoint so all expert "
+                "projections are exported together."
+            )
+
+        if not cls._warned_legacy_expert_checkpoint:
+            logger.warning(
+                "Stacked expert tensors were not found in the DeepSeek checkpoint. "
+                "Falling back to the slower legacy per-expert compatibility path. "
+                "Generate a stacked checkpoint with "
+                "`python models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py "
+                "<source-model-path> --stack-experts` "
+                "and point `DEEPSEEK_V3_HF_MODEL` or `--model-path` at the resulting "
+                "`*-dequantized-stacked` directory."
+            )
+            cls._warned_legacy_expert_checkpoint = True
+
         weight_name = f"{hf_name}.weight"
         expert_weights: list[torch.Tensor] = []
         for expert_id in range(n_routed_experts):
             full_weight_name = f"experts.{expert_id}.{weight_name}"
             expert_weights.append(get_dequantized_tensor(state_dict, full_weight_name, dtype=cls.WEIGHT_TORCH_DTYPE))
-        return torch.stack(expert_weights)
+        return torch.stack(expert_weights).contiguous()
 
     @classmethod
     def _convert_weights_default(
@@ -90,9 +134,7 @@ class Experts(AbstractModule):
             ttnn_name: {
                 "input_tensor_b": shard_and_save(
                     output_path / f"{ttnn_name}.input_tensor_b",
-                    cls._load_expert_weight(state_dict, hf_name, hf_config.n_routed_experts)
-                    .unsqueeze(0)
-                    .transpose(-1, -2),
+                    cls._load_expert_weight(state_dict, hf_name, hf_config.n_routed_experts).unsqueeze(0).contiguous(),
                     shard_dims=(1, 1),
                     mesh_device=mesh_device,
                     dtype=ttnn.bfloat8_b if hf_name == "down_proj" else ttnn.bfloat4_b,
@@ -239,16 +281,19 @@ class Experts(AbstractModule):
         else:
             config["w1_experts"] = LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                transpose_b=True,
                 memory_config=output_memory_config,
                 compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
             )
             config["w2_experts"] = LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                transpose_b=True,
                 memory_config=output_memory_config,
                 compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
             )
             config["w3_experts"] = LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                transpose_b=True,
                 memory_config=output_memory_config,
                 compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
             )

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -42,7 +42,7 @@ from models.demos.deepseek_v3.utils.config_helpers import (
     make_deepseek_sampling_args,
 )
 from models.demos.deepseek_v3.utils.debug_utils import dump_ttnn_meminfo
-from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.demos.deepseek_v3.utils.run_config import create_run_config, deallocate_weight_config_tensors
 from models.demos.deepseek_v3.utils.weight_config import get_weight_config
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
@@ -161,6 +161,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         mesh_device: ttnn.MeshDevice | None = None,
         model_path: str | Path | None = None,
         cache_dir: str | Path | None = None,
+        use_weight_cache: bool = False,
         batch_size_per_row: int = USERS_PER_ROW,
         tokenizer=None,
         random_weights: bool = False,
@@ -183,6 +184,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         self.mesh_device = mesh_device
         self.model_path = str(model_path)
         self.cache_dir = cache_dir
+        self.use_weight_cache = bool(use_weight_cache)
 
         # Load HF config + tokenizer
         self.hf_config = (
@@ -519,8 +521,15 @@ class DeepseekGenerator(WarmupForwardMixin):
             dump_ttnn_meminfo(self.mesh_device, header=header)
 
     def _prepare_weight_configs(self, cache_dir: str | Path | None) -> None:
-        weight_cache_base = Path(cache_dir) if cache_dir is not None else Path("generated/deepseek_v3")
-        weight_cache_base.mkdir(parents=True, exist_ok=True)
+        weight_cache_base = Path(cache_dir) if cache_dir is not None else None
+        if self.use_weight_cache:
+            if weight_cache_base is None:
+                raise ValueError("cache_dir must be provided when use_weight_cache=True")
+            logger.info(f"Loading DeepSeek weights from legacy weight cache at '{weight_cache_base}'.")
+        elif weight_cache_base is not None:
+            logger.info(
+                f"DeepSeek weight cache directory '{weight_cache_base}' is ignored; weights are converted directly in memory."
+            )
 
         cache_subdir_name = f"{self.hf_config.num_hidden_layers}_layers"
         if self.enable_mtp:
@@ -536,6 +545,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             model_path=self.model_path,
             single_layer=self.single_layer,
             cache_subdir_name=cache_subdir_name,
+            use_weight_cache=self.use_weight_cache,
         )
 
     def _assert_mtp_available(self) -> None:
@@ -826,6 +836,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             if self.model_decode_cfg is not None:
                 del self.model_decode_cfg
             if self.model_weight_config is not None:
+                deallocate_weight_config_tensors(self.model_weight_config)
                 del self.model_weight_config
 
         except Exception as e:

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -57,18 +57,13 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
                 "DEEPSEEK_V3_HF_MODEL is not set. Set the environment variable or initialize via the demo "
                 "entrypoint with an explicit --model-path."
             )
-        if not cache_dir:
-            raise ValueError(
-                "DEEPSEEK_V3_CACHE is not set. Set the environment variable or initialize via the demo "
-                "entrypoint with an explicit --cache-dir."
-            )
         tokenizer = load_tokenizer(model_path)
 
         model = cls(
             hf_config=hf_config,
             mesh_device=mesh_device,
             model_path=Path(model_path),
-            cache_dir=Path(cache_dir),
+            cache_dir=Path(cache_dir) if cache_dir else None,
             tokenizer=tokenizer,
             max_seq_len=max_seq_len,
             vllm_context=True,

--- a/models/demos/deepseek_v3/tt/lm_head1d.py
+++ b/models/demos/deepseek_v3/tt/lm_head1d.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import math
 from pathlib import Path
 
 import torch
@@ -63,17 +64,15 @@ class LMHead1D(AbstractModule):
 
         hidden_dim, vocab_size = cls._get_model_dims_from_cfg(hf_config)
 
-        weight_tensor = get_dequantized_tensor(state_dict, "weight").permute(
-            1, 0
-        )  # In torch the weights are in (out_features, in_features) format
-        assert weight_tensor.shape == (hidden_dim, vocab_size)
+        weight_tensor = get_dequantized_tensor(state_dict, "weight").unsqueeze(0).unsqueeze(0).contiguous()
+        assert weight_tensor.shape == (1, 1, vocab_size, hidden_dim)
 
         return {
             "linear": {
                 "input_tensor_b": shard_and_save(
                     output_path / "linear.input_tensor_b",
                     weight_tensor,
-                    shard_dims=(None, -1),
+                    shard_dims=(None, -2),
                     mesh_device=mesh_device,
                     dtype=ttnn.bfloat8_b,
                     layout=ttnn.TILE_LAYOUT,
@@ -83,14 +82,79 @@ class LMHead1D(AbstractModule):
         }
 
     @classmethod
-    def decode_model_config(cls, mesh_device: ttnn.Device) -> ModelDecodeConfig:
-        """Generate model configuration for this module."""
+    def decode_model_config(cls, hf_config: PretrainedConfig, mesh_device: ttnn.MeshDevice) -> ModelDecodeConfig:
+        """Generate model configuration for this module.
+
+        Args:
+            hf_config: HuggingFace model configuration.
+            mesh_device: Mesh device whose column count (`shape[1]`) defines tensor-parallel
+                vocab sharding for the LM head program config.
+        """
+        hidden_dim, vocab_size = cls._get_model_dims_from_cfg(hf_config)
+        tile_size = 32
+        mesh_cols = mesh_device.shape[1]
+        if vocab_size % mesh_cols != 0:
+            raise ValueError(
+                f"LMHead1D.decode_model_config requires vocab_size ({vocab_size}) to be divisible by "
+                f"mesh_device.shape[1] ({mesh_cols})."
+            )
+        if hidden_dim % tile_size != 0:
+            raise ValueError(
+                f"LMHead1D.decode_model_config requires hidden_dim ({hidden_dim}) to be a multiple of "
+                f"tile_size ({tile_size})."
+            )
+        n_per_device = vocab_size // mesh_cols
+        if n_per_device % tile_size != 0:
+            raise ValueError(
+                f"LMHead1D.decode_model_config requires per-device vocab shard size ({n_per_device}) to be "
+                f"a multiple of tile_size ({tile_size}). Computed from vocab_size ({vocab_size}) and "
+                f"mesh_device.shape[1] ({mesh_cols})."
+            )
+        K_tiles = hidden_dim // tile_size
+        N_tiles = n_per_device // tile_size
+        if N_tiles == 0:
+            raise ValueError(
+                "LMHead1D.decode_model_config requires N_tiles >= 1 (per-device vocab must span at least "
+                f"one tile in N); got N_tiles=0 from n_per_device={n_per_device}, tile_size={tile_size}."
+            )
+
+        grid_size = mesh_device.compute_with_storage_grid_size()
+        num_cores = grid_size.x * grid_size.y
+        per_core_N = math.ceil(N_tiles / num_cores)
+        if per_core_N == 0:
+            raise ValueError(
+                "LMHead1D.decode_model_config requires per_core_N >= 1 for matmul subblocking; "
+                f"got per_core_N=0 (N_tiles={N_tiles}, num_cores={num_cores})."
+            )
+
+        in0_block_w = 32
+        while K_tiles % in0_block_w != 0:
+            in0_block_w //= 2
+
+        out_subblock_w = min(per_core_N, 4)
+        while out_subblock_w > 1 and per_core_N % out_subblock_w != 0:
+            out_subblock_w -= 1
+
+        program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(grid_size.x, grid_size.y),
+            in0_block_w=in0_block_w,
+            out_subblock_h=1,
+            out_subblock_w=out_subblock_w,
+            per_core_M=1,
+            per_core_N=per_core_N,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=True,
+        )
+
         # Construct the config
         return {
             "linear": LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                transpose_b=True,
                 memory_config=ttnn.L1_MEMORY_CONFIG,
                 compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
+                program_config=program_config,
             ),
             "all_gather": AllGatherAsyncConfig(
                 mesh_device=mesh_device,
@@ -103,12 +167,13 @@ class LMHead1D(AbstractModule):
         }
 
     @classmethod
-    def prefill_model_config(cls, mesh_device: ttnn.Device) -> ModelPrefillConfig:
+    def prefill_model_config(cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device) -> ModelPrefillConfig:
         """Generate model configuration for this module."""
         # Construct the config
         return {
             "linear": LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                transpose_b=True,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
             ),

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -27,7 +27,6 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     MeshDeviceStub,
     PermuteConfig,
     ReshardConfig,
-    SavedWeight,
     SliceConfig,
 )
 from models.demos.deepseek_v3.utils.config_helpers import K_CHUNK_SIZE, Q_CHUNK_SIZE
@@ -353,9 +352,8 @@ class MLA1D(AbstractModule):
             shape=(num_heads * (qk_nope_head_dim + v_head_dim), kv_lora_rank),
         ).reshape(num_shards, num_heads, qk_nope_head_dim + v_head_dim, kv_lora_rank)
 
-        torch_weights_k = torch_weights[..., :qk_nope_head_dim, :].transpose(
-            -2, -1
-        )  # [num_shards, num_heads, kv_lora_rank, qk_nope_head_dim]
+        torch_weights_k = torch_weights[..., :qk_nope_head_dim, :].transpose(-2, -1).contiguous()
+        # [num_shards, num_heads, kv_lora_rank, qk_nope_head_dim]
         torch_weights_v = torch_weights[..., qk_nope_head_dim:, :]  # [num_shards, num_heads, v_head_dim, kv_lora_rank]
 
         # Create DRAM HEIGHT sharded memory config for wkv_b1 (batch sharding)
@@ -432,7 +430,7 @@ class MLA1D(AbstractModule):
         mesh_device: ttnn.MeshDevice,
         memory_config: ttnn.MemoryConfig,
         padding_needed: tuple[int, int, int] = (0, 0, 0),
-    ) -> SavedWeight:
+    ) -> ttnn.Tensor:
         return shard_and_save(
             path,
             torch_metaweight.transpose(-2, -1),

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -433,7 +433,7 @@ class MLA1D(AbstractModule):
     ) -> ttnn.Tensor:
         return shard_and_save(
             path,
-            torch_metaweight.transpose(-2, -1),
+            torch_metaweight.transpose(-2, -1).contiguous(),
             shard_dims=dims,
             mesh_device=mesh_device,
             dtype=ttnn.bfloat8_b,

--- a/models/demos/deepseek_v3/tt/mla/mla2d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla2d.py
@@ -16,7 +16,6 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     KvCacheConfig,
     MeshDeviceStub,
     ReduceScatterAsyncMinimalConfig,
-    SavedWeight,
 )
 from models.demos.deepseek_v3.utils.run_config import (
     MESH_DEVICE_STATE_DICT_KEY,
@@ -59,10 +58,14 @@ class MLA2D(MLA1D):
         mesh_device: ttnn.MeshDevice,
         memory_config: ttnn.MemoryConfig,
         padding_needed: tuple[int, int, int] = (0, 0, 0),
-    ) -> SavedWeight:
+    ) -> ttnn.Tensor:
         if dims[0] is not None:
             slices = torch.split(torch_metaweight, 1, dim=dims[0])
-            assert all(torch.allclose(s1, s2) for s1, s2 in zip(slices[:-1], slices[1:]))
+            # Debugging-only invariant check:
+            # the stacked MLA row slices are expected to be identical because MLA2D
+            # fans a single state dict out across mesh rows before conversion.
+            # Leave the expensive torch.allclose validation disabled in the hot path.
+            # assert all(torch.allclose(s1, s2) for s1, s2 in zip(slices[:-1], slices[1:]))
             torch_metaweight = slices[0]
             dims = (None, dims[1])
         return super()._convert_weight(path, torch_metaweight, dims, mesh_device, memory_config, padding_needed)

--- a/models/demos/deepseek_v3/tt/mlp/mlp.py
+++ b/models/demos/deepseek_v3/tt/mlp/mlp.py
@@ -19,7 +19,6 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     MulConfig,
     OpConfigBase,
     ReduceScatterAsyncMinimalConfig,
-    SavedWeight,
 )
 from models.demos.deepseek_v3.utils.config_helpers import (
     COMPUTE_KERNEL_CONFIG_HIFI2,
@@ -99,7 +98,7 @@ class MLP(AbstractModule):
         torch_metaweight_tensor: torch.Tensor,
         mesh_device: ttnn.Device,
         is_w2: bool,
-    ) -> SavedWeight:
+    ) -> ttnn.Tensor:
         """
         Convert a normal (non-quantized) weight tensor to a format suitable for TTNN.
 

--- a/models/demos/deepseek_v3/tt/mlp/mlp.py
+++ b/models/demos/deepseek_v3/tt/mlp/mlp.py
@@ -111,7 +111,7 @@ class MLP(AbstractModule):
         """
         torch_metaweight_tensor = torch_metaweight_tensor.transpose(
             2, 1
-        )  # In torch the weights are in (out_features, in_features) format
+        ).contiguous()  # In torch the weights are in (out_features, in_features) format
 
         # Calculate the expected weight dimensions
         num_shards, per_device_in_features, per_device_out_features = torch_metaweight_tensor.shape

--- a/models/demos/deepseek_v3/tt/model/row_batched_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_batched_model.py
@@ -130,7 +130,7 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
                 )
             ],
             "norm": DistributedRMSNorm.prefill_model_config(hf_config, mesh_device),
-            "lm_head": LMHead1D.prefill_model_config(mesh_device),
+            "lm_head": LMHead1D.prefill_model_config(hf_config, mesh_device),
         }
         if cls._has_mtp_layer(hf_config):
             model_cfg["mtp"] = MTP2D.prefill_model_config(
@@ -174,7 +174,7 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
             ],
             "norm_reshard": ReshardConfig(memory_config=norm_config["input_memory_config"]),
             "norm": norm_config,
-            "lm_head": LMHead1D.decode_model_config(mesh_device),
+            "lm_head": LMHead1D.decode_model_config(hf_config, mesh_device),
         }
         if cls._has_mtp_layer(hf_config):
             model_cfg["mtp"] = MTP2D.decode_model_config(

--- a/models/demos/deepseek_v3/tt/moe_gate.py
+++ b/models/demos/deepseek_v3/tt/moe_gate.py
@@ -74,7 +74,7 @@ class MoEGate(AbstractModule):
             "gate_proj": {
                 "input_tensor_b": shard_and_save(
                     output_path / f"gate_proj.input_tensor_b",
-                    gate_weight.T.unsqueeze(0).unsqueeze(0),
+                    gate_weight.unsqueeze(0).unsqueeze(0).contiguous(),
                     shard_dims=(None, None),
                     mesh_device=mesh_device,
                     dtype=ttnn.bfloat16,
@@ -244,6 +244,7 @@ class MoEGate(AbstractModule):
             return {
                 "gate_proj": LinearConfig(
                     input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                    transpose_b=True,
                     memory_config=memory_config,
                     program_config=ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                         compute_with_storage_grid_size=mesh_device.compute_with_storage_grid_size(),
@@ -285,6 +286,7 @@ class MoEGate(AbstractModule):
             return {
                 "gate_proj": LinearConfig(
                     input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                    transpose_b=True,
                     memory_config=memory_config,
                     compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
                 ),
@@ -473,6 +475,7 @@ class MoEGate(AbstractModule):
         mesh_device: ttnn.Device,
         dtype: ttnn.DataType,
         memory_config: ttnn.MemoryConfig,
+        transpose_b: bool = False,
         compute_kernel_config=None,
     ) -> ttnn.Tensor:
         """Linear fallback operation using torch.nn.functional.linear"""
@@ -490,7 +493,7 @@ class MoEGate(AbstractModule):
         )[0][0]
 
         torch_input_2d = torch_input.squeeze(0).squeeze(0)  # [seq_len, hidden_dim]
-        torch_weight_2d = torch_weight.T  # [output_dim, hidden_dim]
+        torch_weight_2d = torch_weight if transpose_b else torch_weight.T
 
         # use torch linear: input @ weight.T
         torch_output = torch.nn.functional.linear(torch_input_2d, torch_weight_2d)

--- a/models/demos/deepseek_v3/tt/mtp.py
+++ b/models/demos/deepseek_v3/tt/mtp.py
@@ -61,9 +61,9 @@ class MTP2D(AbstractModule):
         assert len(state_dicts) == 1 and state_dicts[0] is not None
         (state_dict,) = state_dicts
 
-        eh_proj_weight = state_dict["eh_proj.weight"].permute(1, 0)
-        assert eh_proj_weight.shape[0] == 2 * hf_config.hidden_size
-        assert eh_proj_weight.shape[1] == hf_config.hidden_size
+        eh_proj_weight = state_dict["eh_proj.weight"].unsqueeze(0).unsqueeze(0).contiguous()
+        assert eh_proj_weight.shape[2] == hf_config.hidden_size
+        assert eh_proj_weight.shape[3] == 2 * hf_config.hidden_size
 
         embedding_weight_cfg = (
             reuse_embedding_weight_cfg
@@ -106,7 +106,7 @@ class MTP2D(AbstractModule):
                         output_path / "eh_proj.linear.input_tensor_b",
                         eh_proj_weight,
                         # Shard output features across mesh columns to match decoder decode sharding.
-                        shard_dims=(None, -1),
+                        shard_dims=(None, -2),
                         mesh_device=mesh_device,
                         dtype=cls.WEIGHT_DTYPE,
                         layout=ttnn.TILE_LAYOUT,
@@ -143,7 +143,7 @@ class MTP2D(AbstractModule):
             batch_size_per_row=batch_size_per_row,
         )
         head_norm_cfg = DistributedRMSNorm.prefill_model_config(hf_config, mesh_device)
-        head_cfg = LMHead1D.prefill_model_config(mesh_device)
+        head_cfg = LMHead1D.prefill_model_config(hf_config, mesh_device)
         return {
             "embedding": Embedding2D.prefill_model_config(hf_config, mesh_device),
             "hidden_norm_reshard": ReshardConfig(memory_config=hidden_norm_cfg["input_memory_config"]),
@@ -160,6 +160,7 @@ class MTP2D(AbstractModule):
             "eh_proj": {
                 "linear": LinearConfig(
                     input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                    transpose_b=True,
                     memory_config=ttnn.DRAM_MEMORY_CONFIG,
                     compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
                 ),
@@ -199,7 +200,7 @@ class MTP2D(AbstractModule):
         head_norm_cfg = DistributedRMSNorm.decode_model_config(
             hf_config, mesh_device, batch_size_per_row=batch_size_per_row
         )
-        head_cfg = LMHead1D.decode_model_config(mesh_device)
+        head_cfg = LMHead1D.decode_model_config(hf_config, mesh_device)
         # Decode is single-token, so keep the MTP-specific intermediate tensors in L1.
         decode_memory_config = ttnn.L1_MEMORY_CONFIG
         return {
@@ -218,6 +219,7 @@ class MTP2D(AbstractModule):
             "eh_proj": {
                 "linear": LinearConfig(
                     input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                    transpose_b=True,
                     memory_config=decode_memory_config,
                     compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
                 ),

--- a/models/demos/deepseek_v3/utils/abstract_module.py
+++ b/models/demos/deepseek_v3/utils/abstract_module.py
@@ -33,7 +33,7 @@ class AbstractModule(ABC):
     - `forward_decode` - defines the decode-variant forward pass for the module.
     - `prefill_model_config` - generates the model configuration for prefill mode.
     - `decode_model_config` - generates the model configuration for decode mode.
-    - `convert_weights` - converts PyTorch weights to TTNN format and saves them to the specified path.
+    - `convert_weights` - converts PyTorch weights to TTNN format.
       The weights are in a form of a list of PyTorch state dictionaries. For submodules that can act as a collection
       of layers, for example MLP, the length of the list is expected to be the same as the dimension 0 of the mesh device.
       Use `{get_state_dicts.__module__}` for a convenient way to concatenate the weights from the state dictionaries into
@@ -41,8 +41,8 @@ class AbstractModule(ABC):
     - `create_state` (optional) - creates a new state for the module, which is used to store persistent model state.
 
     Typical usage by a caller would be:
-    1. (one-off) use `convert_weights` to convert PyTorch weights to TTNN format and save them to disk.
-       This returns a `WeightConfig` that contains the paths to the saved weights.
+    1. (one-off/runtime) use `convert_weights` to convert PyTorch weights to TTNN tensors.
+       This returns a `WeightConfig` that contains the converted weights.
     2. (one-off/runtime) call `prefill_model_config` and `decode_model_config` to generate static model configs.
     3. (runtime) call `create_state` to create a new state for the module.
     4. (runtime) create `RunPrefillConfig` for prefill and `RunDecodeConfig` for decode using the `run_config` method.
@@ -68,9 +68,9 @@ class AbstractModule(ABC):
     the field keys (or the dataclass field names). If there is no corresponding key in any of the configurations,
     or if one of the values is `None`, the value from the other configurations is used.
 
-    A special case during the creation of the run config is when loading the weights. If a `FromWeightConfig`
-    is found in a model config, along with a corresponding tensor path in the `WeightConfig`, said weight tensor
-    is loaded to a `ttnn.Tensor` on the device specified by the `mesh_device` argument to the `run_config` method.
+    A special case during the creation of the run config is when resolving the weights. If a `FromWeightConfig`
+    is found in a model config, along with a corresponding converted tensor in the `WeightConfig`, said tensor
+    is threaded into the run config directly. Legacy `SavedWeight` entries are still loaded on demand.
 
     Another special case is when a `MeshDeviceStub` is found in a model config. In this case, it is replaced with the
     `mesh_device` argument passed to the `run_config` method. An additional check is performed to ensure that the shape
@@ -162,18 +162,18 @@ class AbstractModule(ABC):
     ) -> WeightConfig:
         """Convert PyTorch weights to TTNN format for 1D tensor parallelism.
         Subclasses must implement this method to convert a tuple of PyTorch state dicts to a TTNN-compatible format and
-        return a (nested) dictionary of paths created from the `ttnn.Tensor`s saved using `save_and_get_path`.
+        return a (nested) dictionary of converted `ttnn.Tensor`s.
 
         Args:
             hf_config: HuggingFace model configuration object
             state_dicts: Tuple of PyTorch state dicts for the layers of this submodule. This is assumed to have
                          the same length as the dimension 0 of the mesh device. If there is a None instead of a dict,
                          this is supposed to be filled with padding.
-            output_path: Path to save converted weights
+            output_path: Compatibility path for conversion outputs. DeepSeek V3 no longer persists weights here.
             mesh_device: TTNN mesh device
 
         Returns:
-            Dict mapping operation keyword tensor arguments to their save paths
+            Dict mapping operation keyword tensor arguments to their converted tensors
         """
         raise NotImplementedError(f"Subclasses of {AbstractModule.__name__} must implement the convert_weights method")
 

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -58,7 +58,7 @@ class DeepseekSamplingArgs:
 
 
 ConfigDevice = ttnn.MeshDevice | MeshDeviceStub
-ConfigWeight = ttnn.Tensor | FromWeightConfig
+ConfigWeight = ttnn.Tensor | SavedWeight | FromWeightConfig
 
 
 @dataclass
@@ -88,6 +88,7 @@ class LinearConfig(OpConfigBase):
     """Common parameters for a ttnn.linear op, weights are in input_tensor_b"""
 
     input_tensor_b: ConfigWeight
+    transpose_b: bool = False
     memory_config: ttnn.MemoryConfig | None = None
     compute_kernel_config: ttnn.DeviceComputeKernelConfig | None = None
     program_config: ProgramConfig | None = None

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -2,20 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools
-import json
 import math
 import os
+from contextlib import contextmanager
 from itertools import takewhile
 from pathlib import Path
 from types import NoneType
-from typing import Any, Sequence
+from typing import Any, Mapping, Sequence
 
 import torch
-from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3.utils.config_dataclass import DeepseekSamplingArgs, SavedWeight
-from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
+from models.demos.deepseek_v3.utils.config_dataclass import ConfigWeight, DeepseekSamplingArgs, SavedWeight
 
 # Constants
 NORM_CATEGORIES = {"attention_norm", "mlp_norm", "q_norm", "k_norm"}
@@ -68,6 +66,20 @@ DEFAULT_SAMPLING_TOP_P = 0.95
 # So, using 32 as default value for top-k when sampling on device. If top-k = 0 is needed, then
 # do sampling on host.
 DEFAULT_SAMPLING_TOP_K = 32
+
+_LEGACY_SAVED_WEIGHT_EMISSION_DEPTH = 0
+
+
+@contextmanager
+def emit_legacy_saved_weights():
+    """Temporarily make ``shard_and_save()`` dump tensors to disk and return ``SavedWeight`` records."""
+
+    global _LEGACY_SAVED_WEIGHT_EMISSION_DEPTH
+    _LEGACY_SAVED_WEIGHT_EMISSION_DEPTH += 1
+    try:
+        yield
+    finally:
+        _LEGACY_SAVED_WEIGHT_EMISSION_DEPTH -= 1
 
 
 def align_up(value: int, align_value: int) -> int:
@@ -661,11 +673,11 @@ def get_state_dicts(
     return torch.stack(tensors, dim=concat_dim)
 
 
-def sub_state_dict(state_dict: dict[str, torch.Tensor], prefix: str, num_layers: int | None = None):
+def sub_state_dict(state_dict: Mapping[str, torch.Tensor], prefix: str, num_layers: int | None = None):
     """Get a subset of the state dict with a given prefix."""
-    # Preserve laziness when applicable by returning a LazyStateDict view.
-    if isinstance(state_dict, LazyStateDict):
-        return state_dict.view_with_prefix(prefix, num_layers)
+    view_with_prefix = getattr(state_dict, "view_with_prefix", None)
+    if callable(view_with_prefix):
+        return view_with_prefix(prefix, num_layers)
     if num_layers is None:
         return {k[len(prefix) :]: v for k, v in state_dict.items() if k.startswith(prefix)}
     else:
@@ -687,68 +699,10 @@ def sub_state_dicts(
 
 TENSOR_CACHE_EXTENSION = ".tensorbin"
 
-# Cache specs dumping for conversion optimization
-_CACHE_SPECS_DUMP_ENV_VAR = "DEEPSEEK_V3_CACHE_SPECS_JSONL"
-_CACHE_SPECS_DUMP_ENV_VAR_LEGACY = "DEEPSEEK_V3_DUMP_CACHE_SPECS"
-
-
-def _enum_name_or_str(obj: Any) -> str | None:
-    """Get the name of an enum or return the string representation."""
-    if obj is None:
-        return None
-    if hasattr(obj, "name"):
-        return obj.name
-    return str(obj)
-
-
-def _memory_config_to_dict(memory_config: ttnn.MemoryConfig | None) -> dict[str, Any] | None:
-    """Convert a MemoryConfig to a dictionary for JSON serialization."""
-    if memory_config is None:
-        return None
-    # Use the built-in to_json() method for proper serialization, then parse it
-    # This handles CoreRangeSet and other complex types correctly
-    try:
-        return json.loads(memory_config.to_json())
-    except (AttributeError, TypeError):
-        # Fallback to manual conversion if to_json() is not available
-        # This handles the case where grid might be a CoreRangeSet
-        grid_dict = None
-        if memory_config.shard_spec is not None and memory_config.shard_spec.grid is not None:
-            grid = memory_config.shard_spec.grid
-            # Handle CoreRangeSet - convert to list of ranges
-            if hasattr(grid, "__iter__"):
-                # It's a CoreRangeSet (iterable of CoreRange objects)
-                grid_dict = [
-                    {
-                        "start": (core_range.start.x, core_range.start.y),
-                        "end": (core_range.end.x, core_range.end.y),
-                    }
-                    for core_range in grid
-                ]
-            elif hasattr(grid, "start") and hasattr(grid, "end"):
-                # It's a single CoreRange
-                grid_dict = {
-                    "start": (grid.start.x, grid.start.y),
-                    "end": (grid.end.x, grid.end.y),
-                }
-
-        return {
-            "memory_layout": _enum_name_or_str(memory_config.memory_layout),
-            "buffer_type": _enum_name_or_str(memory_config.buffer_type),
-            "shard_spec": (
-                {
-                    "grid": grid_dict,
-                    "shape": list(memory_config.shard_spec.shape) if memory_config.shard_spec.shape else None,
-                    "orientation": _enum_name_or_str(memory_config.shard_spec.orientation),
-                }
-                if memory_config.shard_spec is not None
-                else None
-            ),
-        }
-
 
 def _get_relative_cache_path(path: Path) -> str | None:
     """Extract the cache-relative path after the ``mesh_<rows>x<cols>`` directory."""
+
     path_str = str(path)
     mesh_idx = path_str.find("mesh_")
     if mesh_idx == -1:
@@ -757,44 +711,6 @@ def _get_relative_cache_path(path: Path) -> str | None:
     if len(parts) < 2:
         return None if path.is_absolute() else path_str
     return parts[1]
-
-
-def _append_cache_specs_record(record: dict[str, Any]) -> None:
-    """Append a cache specs record to the JSONL file specified by the environment variable."""
-    dump_path_str = os.getenv(_CACHE_SPECS_DUMP_ENV_VAR) or os.getenv(_CACHE_SPECS_DUMP_ENV_VAR_LEGACY)
-    if not dump_path_str:
-        return
-
-    dump_path = Path(dump_path_str)
-    try:
-        dump_path.parent.mkdir(parents=True, exist_ok=True)
-        data = (json.dumps(record, sort_keys=True) + "\n").encode("utf-8")
-        fd = os.open(dump_path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o644)
-        try:
-            fcntl_module = None
-            try:
-                import fcntl as fcntl_module
-            except Exception:
-                fcntl_module = None
-            if fcntl_module is not None:
-                try:
-                    fcntl_module.flock(fd, fcntl_module.LOCK_EX)
-                except Exception as e:
-                    # Best-effort locking: ignore failures but log for diagnostics.
-                    logger.debug(f"Failed to acquire file lock on {dump_path}: {e}")
-            bytes_written = os.write(fd, data)
-            if bytes_written != len(data):
-                raise OSError(f"Short write while appending cache specs to {dump_path}")
-            if fcntl_module is not None:
-                try:
-                    fcntl_module.flock(fd, fcntl_module.LOCK_UN)
-                except Exception as e:
-                    # Best-effort unlocking: ignore failures but log for diagnostics.
-                    logger.debug(f"Failed to release file lock on {dump_path}: {e}")
-        finally:
-            os.close(fd)
-    except Exception as e:
-        logger.warning(f"Failed to append cache specs record to {dump_path}: {e}")
 
 
 def shard_and_save(
@@ -809,14 +725,17 @@ def shard_and_save(
     memory_config: ttnn.MemoryConfig | None = None,
     _torch_impl: bool = False,
     padding_needed: tuple[int, int, int] = (0, 0, 0),
-) -> SavedWeight:
-    """Shard a tensor and save it to a file."""
+) -> ConfigWeight:
+    """Shard a tensor and materialize it directly as a TTNN tensor."""
     assert all(isinstance(shard_dim, (int, NoneType)) for shard_dim in shard_dims)
     assert isinstance(remove_dims, bool) or all(isinstance(remove_dim, bool) for remove_dim in remove_dims)
     assert len(shard_dims) == 2, "shard_dims must be exactly 2 dimensions (can repeat)"
 
     if isinstance(remove_dims, bool):
         remove_dims = (remove_dims, remove_dims)
+
+    if not tensor.is_contiguous():
+        tensor = tensor.contiguous()
 
     assert (
         shard_dims[0] != shard_dims[1] or remove_dims[0] == remove_dims[1]
@@ -846,16 +765,6 @@ def shard_and_save(
                 not remove_dim or tensor.shape[shard_dim] == mesh_dim
             ), f"The removed dim {shard_dim} must be fully sharded"
 
-    cache_path = (
-        path if path.name.endswith(TENSOR_CACHE_EXTENSION) else path.with_name(f"{path.name}{TENSOR_CACHE_EXTENSION}")
-    )
-    if cache_path.exists():
-        logger.info(f"Cache file already exists, skipping shard_and_save: {cache_path}")
-        relative_cache_path = _get_relative_cache_path(cache_path)
-        if relative_cache_path is None:
-            raise ValueError(f"Expected path under a 'mesh_<rows>x<cols>' cache directory: {cache_path}")
-        return SavedWeight(Path(relative_cache_path), memory_config)
-
     if _torch_impl:
         ttnn_tensor = _shard_torch_impl(
             path=path,
@@ -880,50 +789,26 @@ def shard_and_save(
             padding_needed=padding_needed,
         )
 
-    if not path.name.endswith(TENSOR_CACHE_EXTENSION):
-        path = path.with_name(f"{path.name}{TENSOR_CACHE_EXTENSION}")
+    if _LEGACY_SAVED_WEIGHT_EMISSION_DEPTH > 0:
+        cache_path = (
+            path
+            if path.name.endswith(TENSOR_CACHE_EXTENSION)
+            else path.with_name(f"{path.name}{TENSOR_CACHE_EXTENSION}")
+        )
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        relative_cache_path = _get_relative_cache_path(cache_path)
+        if relative_cache_path is None:
+            raise ValueError(f"Expected path under a 'mesh_<rows>x<cols>' cache directory: {cache_path}")
+        try:
+            ttnn.dump_tensor(cache_path, ttnn_tensor)
+            return SavedWeight(Path(relative_cache_path), ttnn_tensor.memory_config())
+        finally:
+            try:
+                ttnn.deallocate(ttnn_tensor)
+            except Exception:
+                pass
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-
-    record = {
-        "event": "deepseek_v3.cache_tensor_spec",
-        "pid": os.getpid(),
-        "cache_file_path": str(path),
-        "cache_file_relpath": _get_relative_cache_path(path),
-        "torch_shape": list(tensor.shape),
-        "torch_dtype": str(tensor.dtype),
-        "requested_dtype": _enum_name_or_str(dtype),
-        "requested_layout": _enum_name_or_str(layout),
-        "requested_memory_config": _memory_config_to_dict(memory_config),
-        "shard_dims": list(shard_dims),
-        "remove_dims": list(remove_dims),
-        "mesh_shape": list(mesh_device.shape),
-        "mesh_num_devices": mesh_device.get_num_devices(),
-        "dtype_is_tilized": dtype in {ttnn.bfloat4_b, ttnn.bfloat8_b},
-        "shard_device_impl_uses_dram_interleaved_workaround": memory_config == ttnn.DRAM_MEMORY_CONFIG,
-        "torch_impl": _torch_impl,
-        "status": "ok",
-        "result_shape": list(ttnn_tensor.shape),
-        "result_dtype": _enum_name_or_str(ttnn_tensor.dtype),
-        "result_layout": _enum_name_or_str(ttnn_tensor.layout),
-        "result_memory_config": _memory_config_to_dict(ttnn_tensor.memory_config()),
-    }
-    try:
-        ttnn.dump_tensor(path, ttnn_tensor)
-    except Exception as e:
-        record["status"] = f"error({type(e).__name__}: {e})"
-        _append_cache_specs_record(record)
-        raise
-    else:
-        _append_cache_specs_record(record)
-
-    # Always convert cache-root-prefixed paths to relative paths for portability.
-    relative_cache_path = _get_relative_cache_path(path)
-    if relative_cache_path is None:
-        raise ValueError(f"Expected path under a 'mesh_<rows>x<cols>' cache directory: {path}")
-    path = Path(relative_cache_path)
-
-    return SavedWeight(path, memory_config)
+    return ttnn_tensor
 
 
 def _shard_device_impl(
@@ -937,7 +822,7 @@ def _shard_device_impl(
     layout: ttnn.Layout | None,
     memory_config: ttnn.MemoryConfig | None,
     padding_needed: tuple[int, int, int] = (0, 0, 0),
-) -> SavedWeight:
+) -> ttnn.Tensor:
     assert layout in {
         None,
         ttnn.ROW_MAJOR_LAYOUT,
@@ -1220,7 +1105,7 @@ def _shard_torch_impl(
     dtype: ttnn.DataType | None = None,
     layout: ttnn.Layout | None = None,
     memory_config: ttnn.MemoryConfig | None = None,
-) -> SavedWeight:
+) -> ttnn.Tensor:
     if shard_dims[0] == shard_dims[1]:
         assert remove_dims[0] == remove_dims[1], "If sharding a single dim, both remove_dim values must be the same"
         remove_dims = (remove_dims[0],)

--- a/models/demos/deepseek_v3/utils/hf_model_utils.py
+++ b/models/demos/deepseek_v3/utils/hf_model_utils.py
@@ -5,6 +5,7 @@ import concurrent.futures
 import gc
 import json
 import os
+import re
 import shutil
 from collections.abc import Mapping
 from glob import glob
@@ -24,10 +25,18 @@ from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3ForCa
 
 MODEL_INDEX_FILENAME = "model.safetensors.index.json"
 DEQUANTIZED_CHECKPOINT_SUFFIX = "-dequantized"
+STACKED_DEQUANTIZED_CHECKPOINT_SUFFIX = f"{DEQUANTIZED_CHECKPOINT_SUFFIX}-stacked"
 DEQUANTIZED_CHECKPOINT_SCRIPT = "models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py"
 DEQUANTIZED_CHECKPOINT_ERROR_GUIDANCE = (
     "Pass a dequantized HF checkpoint. "
     f"Use `{DEQUANTIZED_CHECKPOINT_SCRIPT}` to generate one from the original HF weights."
+)
+STACKED_EXPERT_WEIGHT_PATTERN = re.compile(
+    r"^model\.layers\.(?P<layer>\d+)\.mlp\.experts\.(?P<expert>\d+)\.(?P<projection>gate_proj|down_proj|up_proj)\.weight$"
+)
+STACKED_EXPERT_ALIAS_PATTERN = STACKED_EXPERT_WEIGHT_PATTERN
+STACKED_EXPERT_TENSOR_PATTERN = re.compile(
+    r"^model\.layers\.(?P<layer>\d+)\.mlp\.experts_stacked\.(?P<projection>gate_proj|down_proj|up_proj)\.weight$"
 )
 
 
@@ -57,22 +66,57 @@ def index_model_weights(model_path: str | Path) -> Mapping[str, torch.Tensor]:
     return LazyStateDict(Path(model_path))
 
 
+def _validate_no_mixed_expert_weight_layouts(weight_map: Mapping[str, str], model_path: Path) -> None:
+    has_legacy_expert_weights = any(STACKED_EXPERT_WEIGHT_PATTERN.match(key) for key in weight_map)
+    has_stacked_expert_weights = any(STACKED_EXPERT_TENSOR_PATTERN.match(key) for key in weight_map)
+    if has_legacy_expert_weights and has_stacked_expert_weights:
+        raise ValueError(
+            f"Checkpoint at {model_path} mixes legacy per-expert and stacked expert tensors. "
+            "Use either a fully legacy dequantized checkpoint or a fully stacked dequantized checkpoint, "
+            "not both."
+        )
+
+
 def materialize_model_weights(
     model_path: str | Path, thread_pool_executor: concurrent.futures.ThreadPoolExecutor | None = None
 ) -> dict[str, torch.Tensor]:
-    safetensors_filepaths = sorted(glob(f"{model_path}/*.safetensors"))
     weights_dict = {}
-    iterable = (
-        map(lambda safetensor_filepath: weights_dict.update(load_file(safetensor_filepath)), safetensors_filepaths)
-        if thread_pool_executor is None
-        else thread_pool_executor.map(
-            lambda safetensor_filepath: weights_dict.update(load_file(safetensor_filepath)), safetensors_filepaths
+    model_path = Path(model_path)
+    index_path = model_path / MODEL_INDEX_FILENAME
+
+    if index_path.is_file():
+        weight_map, _ = _load_model_weight_map(model_path)
+        shard_to_keys: dict[str, list[str]] = {}
+        for key, shard_name in weight_map.items():
+            shard_to_keys.setdefault(shard_name, []).append(key)
+
+        def load_indexed_shard(shard_name: str) -> None:
+            with safe_open(model_path / shard_name, framework="pt", device="cpu") as handle:
+                for key in shard_to_keys[shard_name]:
+                    weights_dict[key] = handle.get_tensor(key)
+
+        shard_names = sorted(shard_to_keys)
+        iterable = (
+            map(load_indexed_shard, shard_names)
+            if thread_pool_executor is None
+            else thread_pool_executor.map(load_indexed_shard, shard_names)
         )
-    )
+        total_shards = len(shard_names)
+    else:
+        safetensors_filepaths = sorted(glob(f"{model_path}/*.safetensors"))
+        iterable = (
+            map(lambda safetensor_filepath: weights_dict.update(load_file(safetensor_filepath)), safetensors_filepaths)
+            if thread_pool_executor is None
+            else thread_pool_executor.map(
+                lambda safetensor_filepath: weights_dict.update(load_file(safetensor_filepath)), safetensors_filepaths
+            )
+        )
+        total_shards = len(safetensors_filepaths)
+
     list(
         tqdm(
             iterable,
-            total=len(safetensors_filepaths),
+            total=total_shards,
             desc="Loading weights",
         )
     )
@@ -86,6 +130,15 @@ def default_dequantized_model_path(model_path: str | Path) -> Path:
     if model_path.name.endswith(DEQUANTIZED_CHECKPOINT_SUFFIX):
         return model_path
     return model_path.with_name(f"{model_path.name}{DEQUANTIZED_CHECKPOINT_SUFFIX}")
+
+
+def default_stacked_dequantized_model_path(model_path: str | Path) -> Path:
+    model_path = Path(model_path)
+    if model_path.name.endswith(STACKED_DEQUANTIZED_CHECKPOINT_SUFFIX):
+        return model_path
+    if model_path.name.endswith(DEQUANTIZED_CHECKPOINT_SUFFIX):
+        return model_path.with_name(f"{model_path.name}-stacked")
+    return model_path.with_name(f"{model_path.name}{STACKED_DEQUANTIZED_CHECKPOINT_SUFFIX}")
 
 
 def _get_weight_block_shape_from_quant_config(quantization_config: Any) -> tuple[int, ...]:
@@ -114,6 +167,17 @@ def get_weight_block_shape_from_model_path(model_path: str | Path) -> tuple[int,
     with config_path.open("r", encoding="utf-8") as handle:
         config_obj = json.load(handle)
     return _get_weight_block_shape_from_quant_config(config_obj.get("quantization_config"))
+
+
+def _load_model_config_json(model_path: str | Path) -> dict[str, Any]:
+    config_path = Path(model_path) / "config.json"
+    if not config_path.is_file():
+        raise FileNotFoundError(f"Could not find DeepSeek config at {config_path}")
+    with config_path.open("r", encoding="utf-8") as handle:
+        config_obj = json.load(handle)
+    if not isinstance(config_obj, dict):
+        raise ValueError(f"Expected JSON object in {config_path}, got {type(config_obj)}")
+    return config_obj
 
 
 def dequantize_weight_tensor(
@@ -191,7 +255,9 @@ def _load_model_weight_map(model_path: Path) -> tuple[dict[str, str], dict[str, 
     if index_path.is_file():
         with index_path.open("r", encoding="utf-8") as handle:
             index_obj = json.load(handle)
-        return dict(index_obj["weight_map"]), dict(index_obj.get("metadata", {}))
+        weight_map = dict(index_obj["weight_map"])
+        _validate_no_mixed_expert_weight_layouts(weight_map, model_path)
+        return weight_map, dict(index_obj.get("metadata", {}))
 
     weight_map: dict[str, str] = {}
     for shard_path in sorted(model_path.glob("*.safetensors")):
@@ -200,6 +266,7 @@ def _load_model_weight_map(model_path: Path) -> tuple[dict[str, str], dict[str, 
                 weight_map[key] = shard_path.name
     if not weight_map:
         raise FileNotFoundError(f"No `.safetensors` shards found in {model_path}")
+    _validate_no_mixed_expert_weight_layouts(weight_map, model_path)
     return weight_map, {}
 
 
@@ -235,16 +302,115 @@ def _close_shard_handles(file_handles: Mapping[str, Any]) -> None:
             close_fn()
 
 
+def _load_converted_tensor_from_shards(
+    model_path: Path,
+    weight_map: Mapping[str, str],
+    file_handles: dict[str, Any],
+    key: str,
+    block_shape: tuple[int, ...],
+    *,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    scale_key = f"{key}_scale_inv"
+    tensor = _load_tensor_from_shards(model_path, weight_map, file_handles, key)
+    if scale_key in weight_map:
+        return dequantize_weight_tensor(
+            tensor,
+            _load_tensor_from_shards(model_path, weight_map, file_handles, scale_key),
+            block_shape,
+            dtype=dtype,
+        )
+
+    if tensor.dtype == torch.float8_e4m3fn:
+        raise ValueError(f"Found float8 tensor '{key}' without matching inverse scale '{scale_key}'.")
+    return tensor.to(dtype).contiguous() if tensor.is_floating_point() else tensor.clone()
+
+
+def _stacked_expert_weight_name(layer_idx: int, projection: str) -> str:
+    return f"model.layers.{layer_idx}.mlp.experts_stacked.{projection}.weight"
+
+
+def _group_stacked_expert_keys(weight_map: Mapping[str, str]) -> dict[int, dict[str, list[str]]]:
+    grouped: dict[int, dict[str, list[tuple[int, str]]]] = {}
+    for key in weight_map:
+        match = STACKED_EXPERT_WEIGHT_PATTERN.match(key)
+        if match is None:
+            continue
+
+        layer_idx = int(match.group("layer"))
+        expert_idx = int(match.group("expert"))
+        projection = match.group("projection")
+        grouped.setdefault(layer_idx, {}).setdefault(projection, []).append((expert_idx, key))
+
+    normalized: dict[int, dict[str, list[str]]] = {}
+    for layer_idx, projections in grouped.items():
+        normalized[layer_idx] = {}
+        for projection, expert_entries in projections.items():
+            expert_entries.sort(key=lambda item: item[0])
+            expert_ids = [expert_idx for expert_idx, _ in expert_entries]
+            if expert_ids != list(range(len(expert_entries))):
+                raise ValueError(
+                    f"Expert weights for layer {layer_idx} projection '{projection}' are incomplete or non-contiguous: "
+                    f"{expert_ids}"
+                )
+            normalized[layer_idx][projection] = [key for _, key in expert_entries]
+    return normalized
+
+
+def _validate_stacked_expert_groups(
+    grouped_expert_keys: Mapping[int, Mapping[str, list[str]]],
+    *,
+    expected_experts: int | None,
+    first_moe_layer: int | None = None,
+    num_hidden_layers: int | None = None,
+) -> None:
+    required_projections = ("gate_proj", "down_proj", "up_proj")
+    missing_groups: list[str] = []
+    if isinstance(first_moe_layer, int) and isinstance(num_hidden_layers, int):
+        for layer_idx in range(first_moe_layer, num_hidden_layers):
+            projections = grouped_expert_keys.get(layer_idx, {})
+            for projection in required_projections:
+                if projection not in projections:
+                    missing_groups.append(f"layer {layer_idx} projection '{projection}' is missing")
+
+    if expected_experts is None and not missing_groups:
+        return
+
+    invalid_groups: list[str] = []
+    if expected_experts is not None:
+        for layer_idx, projections in grouped_expert_keys.items():
+            for projection, source_keys in projections.items():
+                if len(source_keys) != expected_experts:
+                    invalid_groups.append(
+                        f"layer {layer_idx} projection '{projection}' has {len(source_keys)}/{expected_experts} experts"
+                    )
+
+    issues: list[str] = []
+    if missing_groups:
+        sample_missing = ", ".join(missing_groups[:3])
+        extra = "" if len(missing_groups) <= 3 else f" and {len(missing_groups) - 3} more"
+        issues.append(f"missing required expert projections: {sample_missing}{extra}")
+    if invalid_groups:
+        sample_invalid = ", ".join(invalid_groups[:3])
+        extra = "" if len(invalid_groups) <= 3 else f" and {len(invalid_groups) - 3} more"
+        issues.append(f"expert counts do not match n_routed_experts={expected_experts}: {sample_invalid}{extra}")
+    if issues:
+        raise ValueError("Cannot write stacked DeepSeek checkpoint because " + ". ".join(issues) + ".")
+
+
 def save_dequantized_hf_checkpoint(
     source_model_path: str | Path,
     output_model_path: str | Path | None = None,
     *,
     overwrite: bool = False,
     dtype: torch.dtype = torch.bfloat16,
+    stack_experts: bool = True,
 ) -> Path:
     source_model_path = Path(source_model_path).resolve()
     output_model_path = (
-        default_dequantized_model_path(source_model_path)
+        default_stacked_dequantized_model_path(source_model_path)
+        if output_model_path is None and stack_experts
+        else default_dequantized_model_path(source_model_path)
         if output_model_path is None
         else Path(output_model_path).resolve()
     )
@@ -268,36 +434,40 @@ def save_dequantized_hf_checkpoint(
     output_model_path.mkdir(parents=True, exist_ok=True)
     _copy_non_weight_artifacts(source_model_path, output_model_path)
 
-    block_shape = get_weight_block_shape_from_model_path(source_model_path)
+    config_obj = _load_model_config_json(source_model_path)
+    block_shape = _get_weight_block_shape_from_quant_config(config_obj.get("quantization_config"))
     weight_map, metadata = _load_model_weight_map(source_model_path)
-    shard_to_keys: dict[str, list[str]] = {}
-    for key, shard_name in weight_map.items():
-        shard_to_keys.setdefault(shard_name, []).append(key)
+    stacked_expert_keys = _group_stacked_expert_keys(weight_map) if stack_experts else {}
+    if stack_experts:
+        _validate_stacked_expert_groups(
+            stacked_expert_keys,
+            expected_experts=config_obj.get("n_routed_experts"),
+            first_moe_layer=config_obj.get("first_k_dense_replace"),
+            num_hidden_layers=config_obj.get("num_hidden_layers"),
+        )
+    skipped_weight_keys = {
+        source_key
+        for projections in stacked_expert_keys.values()
+        for source_keys in projections.values()
+        for source_key in source_keys
+    }
 
+    shard_to_keys: dict[str, list[str]] = {}
     output_weight_map: dict[str, str] = {}
     total_size = 0
+    for key, shard_name in weight_map.items():
+        if key.endswith("_scale_inv") or key in skipped_weight_keys:
+            continue
+        shard_to_keys.setdefault(shard_name, []).append(key)
+
     file_handles: dict[str, Any] = {}
     try:
         for shard_name in sorted(shard_to_keys):
             output_tensors: dict[str, torch.Tensor] = {}
             for key in shard_to_keys[shard_name]:
-                if key.endswith("_scale_inv"):
-                    continue
-
-                scale_key = f"{key}_scale_inv"
-                tensor = _load_tensor_from_shards(source_model_path, weight_map, file_handles, key)
-                if scale_key in weight_map:
-                    output_tensor = dequantize_weight_tensor(
-                        tensor,
-                        _load_tensor_from_shards(source_model_path, weight_map, file_handles, scale_key),
-                        block_shape,
-                        dtype=dtype,
-                    )
-                else:
-                    if tensor.dtype == torch.float8_e4m3fn:
-                        raise ValueError(f"Found float8 tensor '{key}' without matching inverse scale '{scale_key}'.")
-                    output_tensor = tensor.to(dtype).contiguous() if tensor.is_floating_point() else tensor.clone()
-
+                output_tensor = _load_converted_tensor_from_shards(
+                    source_model_path, weight_map, file_handles, key, block_shape, dtype=dtype
+                )
                 output_tensors[key] = output_tensor
                 output_weight_map[key] = shard_name
                 total_size += output_tensor.numel() * output_tensor.element_size()
@@ -305,6 +475,35 @@ def save_dequantized_hf_checkpoint(
             if output_tensors:
                 logger.info(f"Saving dequantized shard {shard_name} with {len(output_tensors)} tensors")
                 save_file(output_tensors, str(output_model_path / shard_name))
+
+        if stack_experts:
+            for layer_idx in sorted(stacked_expert_keys):
+                shard_name = f"stacked-experts-layer-{layer_idx:05d}.safetensors"
+                output_tensors: dict[str, torch.Tensor] = {}
+                for projection in sorted(stacked_expert_keys[layer_idx]):
+                    source_keys = stacked_expert_keys[layer_idx][projection]
+                    output_key = _stacked_expert_weight_name(layer_idx, projection)
+                    source_tensors = [
+                        _load_converted_tensor_from_shards(
+                            source_model_path,
+                            weight_map,
+                            file_handles,
+                            source_key,
+                            block_shape,
+                            dtype=dtype,
+                        )
+                        for source_key in source_keys
+                    ]
+                    output_tensor = torch.stack(source_tensors).contiguous()
+                    output_tensors[output_key] = output_tensor
+                    output_weight_map[output_key] = shard_name
+                    total_size += output_tensor.numel() * output_tensor.element_size()
+
+                if output_tensors:
+                    logger.info(
+                        f"Saving stacked expert shard {shard_name} with {len(output_tensors)} tensors for layer {layer_idx}"
+                    )
+                    save_file(output_tensors, str(output_model_path / shard_name))
     finally:
         _close_shard_handles(file_handles)
 
@@ -340,12 +539,42 @@ def apply_with_names(
 def load_weight_from_weights_dict(
     weights_dict: Mapping[str, torch.Tensor]
 ) -> Callable[[str, torch.Tensor], torch.Tensor]:
+    def resolve_weight(name: str) -> torch.Tensor | None:
+        match = STACKED_EXPERT_ALIAS_PATTERN.match(name)
+        if match is not None:
+            stacked_name = _stacked_expert_weight_name(int(match.group("layer")), match.group("projection"))
+            if name in weights_dict and stacked_name in weights_dict:
+                raise RuntimeError(
+                    f"Checkpoint mixes legacy expert tensor '{name}' with stacked tensor '{stacked_name}'."
+                )
+            if name in weights_dict:
+                return weights_dict[name]
+            if stacked_name not in weights_dict:
+                return None
+
+            stacked_weight = weights_dict[stacked_name]
+            if stacked_weight.ndim != 3:
+                raise RuntimeError(
+                    f"Expected stacked expert tensor '{stacked_name}' to have rank 3, got {stacked_weight.ndim}"
+                )
+            expert_idx = int(match.group("expert"))
+            if expert_idx >= stacked_weight.shape[0]:
+                raise RuntimeError(
+                    f"Expected stacked expert tensor '{stacked_name}' to contain expert {expert_idx}, "
+                    f"got {stacked_weight.shape[0]} experts"
+                )
+            return stacked_weight[expert_idx]
+
+        if name in weights_dict:
+            return weights_dict[name]
+        return None
+
     @torch.no_grad()
     def load_weight(name: str, tensor: torch.Tensor) -> torch.Tensor:
         print(f"Loading weight: {name}" + " " * 50, end="\r")
-        if name not in weights_dict:
+        loaded_weight = resolve_weight(name)
+        if loaded_weight is None:
             return tensor
-        loaded_weight = weights_dict[name]
         if loaded_weight.dtype == torch.float8_e4m3fn:
             raise RuntimeError(
                 f"Expected already-dequantized bf16 weights for '{name}', but found float8 tensor. "
@@ -363,9 +592,22 @@ def load_weight_from_weights_dict(
 def unload_weight_from_weights_dict(
     weights_dict: Mapping[str, torch.Tensor],
 ) -> Callable[[str, torch.Tensor], torch.Tensor]:
+    def has_weight(name: str) -> bool:
+        match = STACKED_EXPERT_ALIAS_PATTERN.match(name)
+        if match is not None:
+            stacked_name = _stacked_expert_weight_name(int(match.group("layer")), match.group("projection"))
+            if name in weights_dict and stacked_name in weights_dict:
+                raise RuntimeError(
+                    f"Checkpoint mixes legacy expert tensor '{name}' with stacked tensor '{stacked_name}'."
+                )
+            if name in weights_dict:
+                return True
+            return stacked_name in weights_dict
+        return name in weights_dict
+
     @torch.no_grad()
     def unload_weight(name: str, tensor: torch.Tensor) -> torch.Tensor:
-        if name not in weights_dict:
+        if not has_weight(name):
             return tensor
         tensor.data = torch.empty(0, dtype=tensor.dtype)
         evict_fn = getattr(weights_dict, "evict", None)

--- a/models/demos/deepseek_v3/utils/lazy_state_dict.py
+++ b/models/demos/deepseek_v3/utils/lazy_state_dict.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Iterator, Mapping
 from pathlib import Path
 from time import perf_counter
@@ -13,6 +14,13 @@ from typing import Optional
 import torch
 from loguru import logger
 from safetensors import safe_open
+
+_STACKED_EXPERT_ALIAS_RE = re.compile(
+    r"^model\.layers\.(?P<layer>\d+)\.mlp\.experts\.(?P<expert>\d+)\.(?P<projection>gate_proj|down_proj|up_proj)\.weight$"
+)
+_STACKED_EXPERT_FULL_RE = re.compile(
+    r"^model\.layers\.(?P<layer>\d+)\.mlp\.experts_stacked\.(?P<projection>gate_proj|down_proj|up_proj)\.weight$"
+)
 
 
 class LazyStateDict(Mapping[str, torch.Tensor]):
@@ -38,6 +46,8 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
         _cache: Optional[dict[str, torch.Tensor]] = None,
         _num_layers: Optional[int] = None,
         _file_handles: Optional[dict[str, object]] = None,
+        _stacked_num_experts: Optional[dict[str, int]] = None,
+        _pinned_cache_keys: Optional[set[str]] = None,
     ):
         self._model_path = Path(model_path)
         self._base_prefix = base_prefix
@@ -54,6 +64,9 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
             except Exception as e:
                 raise ValueError(f"Failed to parse index JSON at {index_path}: {e}") from e
             self._full_to_file = dict(index_obj["weight_map"])
+            from models.demos.deepseek_v3.utils.hf_model_utils import _validate_no_mixed_expert_weight_layouts
+
+            _validate_no_mixed_expert_weight_layouts(self._full_to_file, self._model_path)
             elapsed_ms = (perf_counter() - t0) * 1e3
 
             num_keys = len(self._full_to_file)
@@ -73,6 +86,10 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
         # Cache of open safetensors handles keyed by filename to avoid repeated mmaps
         self._file_handles: dict[str, object] = {} if _file_handles is None else _file_handles
         self._cache: dict[str, torch.Tensor] = {} if _cache is None else _cache
+        self._pinned_cache_keys: set[str] = set() if _pinned_cache_keys is None else _pinned_cache_keys
+        # Cache stacked expert counts so iteration can expose logical expert aliases
+        # without materializing the full stacked tensors.
+        self._stacked_num_experts: dict[str, int] = {} if _stacked_num_experts is None else _stacked_num_experts
 
     def _get_handle(self, filename: str):
         """
@@ -94,6 +111,8 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
         """
         if self._cache:
             self._cache.clear()
+        if self._pinned_cache_keys:
+            self._pinned_cache_keys.clear()
 
     def evict(self, key: str) -> None:
         """
@@ -101,7 +120,23 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
         This is useful for dynamic weight loading flows that want per-module tensors
         to be released after a forward pass.
         """
-        self._cache.pop(self._full_key(key), None)
+        full_key = self._full_key(key)
+        self._cache.pop(full_key, None)
+        self._pinned_cache_keys.discard(full_key)
+        alias = self._resolve_stacked_expert_alias(full_key)
+        if alias is None:
+            return
+        stacked_full_key, _ = alias
+        if stacked_full_key in self._pinned_cache_keys:
+            return
+        for cached_key in self._cache:
+            if cached_key == stacked_full_key:
+                continue
+            cached_alias = self._resolve_stacked_expert_alias(cached_key)
+            if cached_alias is not None and cached_alias[0] == stacked_full_key:
+                return
+        self._cache.pop(stacked_full_key, None)
+        self._pinned_cache_keys.discard(stacked_full_key)
 
     def close(self) -> None:
         """
@@ -121,6 +156,8 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
         # Clear cached tensors and accounting to avoid stale references to mmaps
         if self._cache:
             self._cache.clear()
+        if self._pinned_cache_keys:
+            self._pinned_cache_keys.clear()
 
     def __del__(self):
         self.close()
@@ -159,10 +196,46 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
             _cache=self._cache,
             _num_layers=child_num_layers,
             _file_handles=self._file_handles,
+            _stacked_num_experts=self._stacked_num_experts,
+            _pinned_cache_keys=self._pinned_cache_keys,
         )
 
     def _full_key(self, key: str) -> str:
         return self._base_prefix + key
+
+    def _resolve_stacked_expert_alias(self, full_key: str) -> tuple[str, int] | None:
+        match = _STACKED_EXPERT_ALIAS_RE.match(full_key)
+        if match is None:
+            return None
+        stacked_full_key = f"model.layers.{match.group('layer')}.mlp.experts_stacked.{match.group('projection')}.weight"
+        if stacked_full_key not in self._full_to_file or not self._passes_layer_filter(stacked_full_key):
+            return None
+        return stacked_full_key, int(match.group("expert"))
+
+    def _exposes_physical_key(self, full_key: str) -> bool:
+        if _STACKED_EXPERT_FULL_RE.match(full_key) is None:
+            return True
+        return "experts_stacked." in self._base_prefix
+
+    def _load_tensor(self, full_key: str, *, pin_cache: bool) -> torch.Tensor:
+        if full_key in self._cache:
+            if pin_cache:
+                self._pinned_cache_keys.add(full_key)
+            return self._cache[full_key]
+        if full_key not in self._full_to_file or not self._passes_layer_filter(full_key):
+            raise KeyError(full_key)
+
+        filename = self._full_to_file[full_key]
+        filepath = self._model_path / filename
+        if not filepath.exists():
+            raise KeyError(f"Attempted to load weight {full_key} from file {filepath} but the file does not exist.")
+
+        f = self._get_handle(filename)
+        tensor = f.get_tensor(full_key)
+        self._cache[full_key] = tensor
+        if pin_cache:
+            self._pinned_cache_keys.add(full_key)
+        return tensor
 
     def _passes_layer_filter(self, full_key: str) -> bool:
         if self._num_layers is None:
@@ -172,6 +245,28 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
             return True
         layer_part = full_key[len(prefix) :].split(".", 1)[0]
         return (not layer_part.isdigit()) or (int(layer_part) < self._num_layers)
+
+    def _get_stacked_num_experts(self, stacked_full_key: str) -> int:
+        num_experts = self._stacked_num_experts.get(stacked_full_key)
+        if num_experts is None:
+            if stacked_full_key in self._cache:
+                num_experts = self._cache[stacked_full_key].shape[0]
+            else:
+                filename = self._full_to_file[stacked_full_key]
+                handle = self._get_handle(filename)
+                num_experts = handle.get_slice(stacked_full_key).get_shape()[0]
+            self._stacked_num_experts[stacked_full_key] = num_experts
+        return num_experts
+
+    def _iter_stacked_expert_aliases(self, stacked_full_key: str) -> Iterator[str]:
+        match = _STACKED_EXPERT_FULL_RE.match(stacked_full_key)
+        if match is None:
+            return
+
+        layer = match.group("layer")
+        projection = match.group("projection")
+        for expert_idx in range(self._get_stacked_num_experts(stacked_full_key)):
+            yield f"model.layers.{layer}.mlp.experts.{expert_idx}.{projection}.weight"
 
     def __getitem__(self, key: str) -> torch.Tensor:
         """
@@ -183,20 +278,30 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
         """
         full_key = self._full_key(key)
         if full_key in self._cache:
-            return self._cache[full_key]
-        if full_key not in self._full_to_file or not self._passes_layer_filter(full_key):
+            if (
+                full_key in self._full_to_file
+                and self._passes_layer_filter(full_key)
+                and self._exposes_physical_key(full_key)
+            ):
+                self._pinned_cache_keys.add(full_key)
+                return self._cache[full_key]
+        if (
+            full_key in self._full_to_file
+            and self._passes_layer_filter(full_key)
+            and self._exposes_physical_key(full_key)
+        ):
+            return self._load_tensor(full_key, pin_cache=True)
+
+        alias = self._resolve_stacked_expert_alias(full_key)
+        if alias is None:
             raise KeyError(key)
 
-        filename = self._full_to_file[full_key]
-        filepath = self._model_path / filename
-        if not filepath.exists():
-            raise KeyError(f"Attempted to load weight {full_key} from file {filepath} but the file does not exist.")
-
-        # Reuse shard-level handle to avoid creating a new mmap per tensor
-        f = self._get_handle(filename)
-        tensor = f.get_tensor(full_key)
+        stacked_full_key, expert_idx = alias
+        if expert_idx >= self._get_stacked_num_experts(stacked_full_key):
+            raise KeyError(key)
+        stacked_tensor = self._load_tensor(stacked_full_key, pin_cache=False)
+        tensor = stacked_tensor[expert_idx]
         self._cache[full_key] = tensor
-
         return tensor
 
     def __contains__(self, key: object) -> bool:
@@ -206,7 +311,17 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
         if not isinstance(key, str):
             raise TypeError(f"Key must be a string but got {type(key)}")
         full_key = self._full_key(key)
-        return full_key in self._full_to_file and self._passes_layer_filter(full_key)
+        if (
+            full_key in self._full_to_file
+            and self._passes_layer_filter(full_key)
+            and self._exposes_physical_key(full_key)
+        ):
+            return True
+        alias = self._resolve_stacked_expert_alias(full_key)
+        if alias is None:
+            return False
+        stacked_full_key, expert_idx = alias
+        return expert_idx < self._get_stacked_num_experts(stacked_full_key)
 
     def __iter__(self) -> Iterator[str]:
         """
@@ -214,11 +329,26 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
         """
         base = self._base_prefix
         for full_key in self._full_to_file.keys():
-            if not full_key.startswith(base):
-                continue
             if not self._passes_layer_filter(full_key):
                 continue
-            yield full_key[len(base) :]
+            if _STACKED_EXPERT_FULL_RE.match(full_key):
+                if "experts_stacked." in base:
+                    if full_key.startswith(base):
+                        yield full_key[len(base) :]
+                    continue
+                for alias_full_key in self._iter_stacked_expert_aliases(full_key):
+                    # Prefer the logical HF-compatible expert names when iterating.
+                    # This keeps strict reference-model load_state_dict() working.
+                    # Physical stacked tensors remain available through explicit
+                    # `experts_stacked.` subviews.
+                    if alias_full_key in self._full_to_file:
+                        continue
+                    if alias_full_key.startswith(base):
+                        yield alias_full_key[len(base) :]
+                continue
+
+            if full_key.startswith(base):
+                yield full_key[len(base) :]
 
     def __len__(self) -> int:
         """

--- a/models/demos/deepseek_v3/utils/lazy_state_dict.py
+++ b/models/demos/deepseek_v3/utils/lazy_state_dict.py
@@ -237,6 +237,20 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
             self._pinned_cache_keys.add(full_key)
         return tensor
 
+    def _load_stacked_expert_tensor(self, stacked_full_key: str, expert_idx: int) -> torch.Tensor:
+        if stacked_full_key in self._cache:
+            return self._cache[stacked_full_key][expert_idx]
+
+        filename = self._full_to_file[stacked_full_key]
+        filepath = self._model_path / filename
+        if not filepath.exists():
+            raise KeyError(
+                f"Attempted to load weight {stacked_full_key} from file {filepath} but the file does not exist."
+            )
+
+        handle = self._get_handle(filename)
+        return handle.get_slice(stacked_full_key)[expert_idx]
+
     def _passes_layer_filter(self, full_key: str) -> bool:
         if self._num_layers is None:
             return True
@@ -285,6 +299,11 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
             ):
                 self._pinned_cache_keys.add(full_key)
                 return self._cache[full_key]
+            alias = self._resolve_stacked_expert_alias(full_key)
+            if alias is not None:
+                stacked_full_key, expert_idx = alias
+                if expert_idx < self._get_stacked_num_experts(stacked_full_key):
+                    return self._cache[full_key]
         if (
             full_key in self._full_to_file
             and self._passes_layer_filter(full_key)
@@ -299,8 +318,7 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
         stacked_full_key, expert_idx = alias
         if expert_idx >= self._get_stacked_num_experts(stacked_full_key):
             raise KeyError(key)
-        stacked_tensor = self._load_tensor(stacked_full_key, pin_cache=False)
-        tensor = stacked_tensor[expert_idx]
+        tensor = self._load_stacked_expert_tensor(stacked_full_key, expert_idx)
         self._cache[full_key] = tensor
         return tensor
 

--- a/models/demos/deepseek_v3/utils/lazy_state_dict.py
+++ b/models/demos/deepseek_v3/utils/lazy_state_dict.py
@@ -185,9 +185,6 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
 
         # Inherit parent's layer filter if not explicitly overridden
         child_num_layers = self._num_layers if num_layers is None else num_layers
-        logger.debug(
-            f"LazyStateDict view created: base_prefix='{self._base_prefix}', add_prefix='{prefix}', combined='{combined_prefix}', num_layers={child_num_layers}"
-        )
 
         return LazyStateDict(
             self._model_path,

--- a/models/demos/deepseek_v3/utils/run_config.py
+++ b/models/demos/deepseek_v3/utils/run_config.py
@@ -16,10 +16,10 @@ from models.demos.deepseek_v3.utils.config_dataclass import FromWeightConfig, Me
 MESH_DEVICE_STATE_DICT_KEY = "mesh_device"
 
 WeightConfig = (
-    dict[str, "WeightConfig | SavedWeight | None"]
-    | list["WeightConfig | SavedWeight | None"]
+    dict[str, "WeightConfig | ttnn.Tensor | SavedWeight | None"]
+    | list["WeightConfig | ttnn.Tensor | SavedWeight | None"]
     | tuple[
-        "WeightConfig | SavedWeight | None", ...
+        "WeightConfig | ttnn.Tensor | SavedWeight | None", ...
     ]  # TODO: bring regular tensor saving back once Issue #26763 is resolved
 )
 
@@ -160,6 +160,8 @@ def _merge_run_config(
     if isinstance(
         model_state_config_item, FromWeightConfig
     ):  # TODO: bring regular tensor saving back once Issue #26763 is resolved
+        if isinstance(weight_config_item, ttnn.Tensor):
+            return weight_config_item
         if isinstance(weight_config_item, SavedWeight):
             # Check if we have cached weights first
             if cached_ttnn_weights is not None and weight_config_item.path in cached_ttnn_weights:
@@ -183,6 +185,10 @@ def _merge_run_config(
     # If model config doesn't need this weight (is None), but cached weight exists, ignore it
     if model_state_config_item is None and isinstance(weight_config_item, SavedWeight):
         logger.warning(f"Cached weight {weight_config_item.path} is not needed by the model config, ignoring it.")
+        return None
+
+    if model_state_config_item is None and isinstance(weight_config_item, ttnn.Tensor):
+        logger.warning("Resolved TTNN weight is not needed by the model config, ignoring it.")
         return None
 
     raise ValueError(
@@ -415,3 +421,31 @@ def load_weight(saved_weight: SavedWeight, device: ttnn.Device) -> ttnn.Tensor:
             tensor = ttnn.to_memory_config(tensor, saved_weight.memory_config)
 
     return tensor
+
+
+def iter_weight_config_tensors(weight_config_item: WeightConfig | ttnn.Tensor | SavedWeight | None):
+    if isinstance(weight_config_item, ttnn.Tensor):
+        yield weight_config_item
+        return
+
+    if isinstance(weight_config_item, dict):
+        for value in weight_config_item.values():
+            yield from iter_weight_config_tensors(value)
+        return
+
+    if isinstance(weight_config_item, (list, tuple)):
+        for value in weight_config_item:
+            yield from iter_weight_config_tensors(value)
+
+
+def deallocate_weight_config_tensors(weight_config_item: WeightConfig | ttnn.Tensor | SavedWeight | None) -> None:
+    seen_tensor_ids: set[int] = set()
+    for tensor in iter_weight_config_tensors(weight_config_item):
+        tensor_id = id(tensor)
+        if tensor_id in seen_tensor_ids:
+            continue
+        seen_tensor_ids.add(tensor_id)
+        try:
+            ttnn.deallocate(tensor)
+        except Exception as exc:
+            logger.warning(f"Failed to deallocate converted TTNN weight tensor: {exc}")

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import hashlib
 import inspect
 import itertools
 import os
@@ -620,6 +621,8 @@ def get_test_weight_config(
     test_name: str | None = None,
     real_weights: bool = True,
     layer_id: str | int | None = None,
+    prefer_legacy_weight_cache: bool = False,
+    cache_identity: str | os.PathLike[str] | None = None,
 ) -> Any:
     """Get the weight config, either by loading from cache or recalculating.
 
@@ -646,18 +649,70 @@ def get_test_weight_config(
             integer layer index, or a descriptive qualifier for random weights
             (``"kv_lora_rank"``).  ``None`` when no further distinction is
             needed.
+        prefer_legacy_weight_cache: When ``True``, prefer the historical
+            SavedWeight cache for this test case and rebuild that cache on
+            miss. Use this only for tests that intentionally compare against
+            the legacy SavedWeight emission path instead of the current direct
+            conversion path. Pair this with ``force_recalculate=True`` when a
+            test must validate the current input weights on every run.
+        cache_identity: Optional cache discriminator appended to the per-test
+            cache path. Use this when the same test/layer can legitimately run
+            against different checkpoint layouts or other distinct weight
+            sources that should not share a SavedWeight cache entry.
     """
     if test_name is not None:
         parts = [test_name, ModuleClass.__name__, "real" if real_weights else "random"]
         if layer_id is not None:
             parts.append(str(layer_id))
+        if cache_identity is not None:
+            raw_cache_identity = os.fspath(cache_identity).strip()
+            if not raw_cache_identity:
+                raise ValueError("cache_identity must be non-empty when provided")
+            normalized_cache_identity = raw_cache_identity
+            for old, new in ((os.sep, "__"), ("/", "__"), ("\\", "__"), (" ", "_"), (":", "_")):
+                normalized_cache_identity = normalized_cache_identity.replace(old, new)
+            cache_identity_digest = hashlib.sha256(raw_cache_identity.encode("utf-8")).hexdigest()[:16]
+            parts.append(f"{normalized_cache_identity}__{cache_identity_digest}")
         weight_config_id = "/".join(parts)
     else:
         weight_config_id = os.environ.get("PYTEST_CURRENT_TEST", "unknown_test")
     per_test_weight_cache_path = cache_path / "tests_cache" / weight_config_id
-    return get_weight_config(
-        ModuleClass, hf_config, state_dicts, per_test_weight_cache_path, mesh_device, force_recalculate
-    )
+
+    if not prefer_legacy_weight_cache:
+        return get_weight_config(
+            ModuleClass, hf_config, state_dicts, per_test_weight_cache_path, mesh_device, force_recalculate
+        )
+
+    if force_recalculate:
+        return get_weight_config(
+            ModuleClass=ModuleClass,
+            hf_config=hf_config,
+            state_dicts=state_dicts,
+            weight_cache_path=per_test_weight_cache_path,
+            mesh_device=mesh_device,
+            force_recalculate=True,
+            emit_weight_cache=True,
+        )
+
+    try:
+        return get_weight_config(
+            ModuleClass=ModuleClass,
+            hf_config=hf_config,
+            state_dicts=state_dicts,
+            weight_cache_path=per_test_weight_cache_path,
+            mesh_device=mesh_device,
+            use_weight_cache=True,
+        )
+    except FileNotFoundError:
+        logger.info(f"DeepSeek test weight cache miss at {per_test_weight_cache_path}; regenerating it")
+        return get_weight_config(
+            ModuleClass=ModuleClass,
+            hf_config=hf_config,
+            state_dicts=state_dicts,
+            weight_cache_path=per_test_weight_cache_path,
+            mesh_device=mesh_device,
+            emit_weight_cache=True,
+        )
 
 
 def get_rope_tensors(

--- a/models/demos/deepseek_v3/utils/weight_config.py
+++ b/models/demos/deepseek_v3/utils/weight_config.py
@@ -7,7 +7,7 @@ import fcntl
 import json
 import os
 import shutil
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from typing import Any
 
@@ -17,8 +17,18 @@ from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
 from models.demos.deepseek_v3.utils.config_dataclass import SavedWeight
-from models.demos.deepseek_v3.utils.config_helpers import TENSOR_CACHE_EXTENSION
-from models.demos.deepseek_v3.utils.run_config import WeightConfig
+from models.demos.deepseek_v3.utils.config_helpers import TENSOR_CACHE_EXTENSION, emit_legacy_saved_weights
+from models.demos.deepseek_v3.utils.run_config import WeightConfig, deallocate_weight_config_tensors
+
+
+class InvalidWeightCacheError(ValueError):
+    """Raised when a requested legacy DeepSeek weight cache exists but is invalid."""
+
+
+WEIGHT_CACHE_FORMAT_VERSION = 2
+WEIGHT_CACHE_METADATA_KEY = "deepseek_weight_cache_metadata"
+WEIGHT_CACHE_VERSION_KEY = "format_version"
+WEIGHT_CACHE_PAYLOAD_KEY = "weight_config"
 
 
 def _multihost_non_writer_should_skip_weight_file_existence_check() -> bool:
@@ -111,6 +121,43 @@ def try_decode_saved_weight(obj: dict[str, Any]) -> Any:
     return SavedWeight(path=Path(path_str), memory_config=ttnn.MemoryConfig.from_json(json.dumps(memory_config_dict)))
 
 
+def wrap_weight_cache_payload(weight_config: WeightConfig) -> dict[str, Any]:
+    return {
+        WEIGHT_CACHE_METADATA_KEY: {
+            WEIGHT_CACHE_VERSION_KEY: WEIGHT_CACHE_FORMAT_VERSION,
+        },
+        WEIGHT_CACHE_PAYLOAD_KEY: weight_config,
+    }
+
+
+def unwrap_weight_cache_payload(
+    serialized_config: Any,
+    *,
+    require_current_format: bool,
+    config_path: Path,
+) -> WeightConfig:
+    if (
+        isinstance(serialized_config, dict)
+        and WEIGHT_CACHE_METADATA_KEY in serialized_config
+        and WEIGHT_CACHE_PAYLOAD_KEY in serialized_config
+    ):
+        metadata = serialized_config[WEIGHT_CACHE_METADATA_KEY]
+        version = metadata.get(WEIGHT_CACHE_VERSION_KEY) if isinstance(metadata, dict) else None
+        if version != WEIGHT_CACHE_FORMAT_VERSION:
+            raise InvalidWeightCacheError(
+                f"Requested DeepSeek weight cache at {config_path.parent} uses unsupported format version {version!r}. "
+                f"Expected version {WEIGHT_CACHE_FORMAT_VERSION}; regenerate the cache."
+            )
+        return serialized_config[WEIGHT_CACHE_PAYLOAD_KEY]
+
+    if require_current_format:
+        raise InvalidWeightCacheError(
+            f"Requested DeepSeek weight cache at {config_path.parent} is missing {WEIGHT_CACHE_METADATA_KEY}. "
+            "It was likely generated before the current DeepSeek SavedWeight layout; regenerate the cache."
+        )
+    return serialized_config
+
+
 def _try_load_cached_config(config_path: Path, weight_cache_path: Path, force_recalculate: bool) -> WeightConfig | None:
     """
     Attempt to load weight config from cache.
@@ -122,34 +169,46 @@ def _try_load_cached_config(config_path: Path, weight_cache_path: Path, force_re
 
     Returns:
         Normalized weight config if cache hit, None if cache miss
+
+    Raises:
+        InvalidWeightCacheError: if a cache exists but its saved-weight paths are invalid.
     """
     if force_recalculate:
         logger.info("Forcing recalculating weights")
-        if weight_cache_path.exists():
-            logger.info(f"Deleting existing cache directory: {weight_cache_path}")
-            try:
-                if weight_cache_path.is_dir():
-                    shutil.rmtree(weight_cache_path)
-                else:
-                    weight_cache_path.unlink()
-            except OSError as e:
-                logger.warning(f"Failed to remove weight cache at {weight_cache_path}: {e}")
+        clear_weight_cache_path(weight_cache_path)
         return None
     if not config_path.exists():
         logger.info("Weight configuration file does not exist, forcing recalculating weights")
         return None
 
     with locked_file(config_path, "r", exclusive=False) as f:
-        weight_config = json.load(f, object_hook=try_decode_saved_weight)
+        serialized_config = json.load(f, object_hook=try_decode_saved_weight)
+
+    weight_config = unwrap_weight_cache_payload(
+        serialized_config,
+        require_current_format=True,
+        config_path=config_path,
+    )
 
     try:
         validate_weight_config_paths(weight_cache_path, weight_config)
     except ValueError as e:
-        logger.warning(f"Cache validation failed, will recalculate weights: {e}")
-        return None
+        raise InvalidWeightCacheError(f"Requested DeepSeek weight cache was invalid at {weight_cache_path}: {e}") from e
 
     logger.info(f"Using weights cached at {weight_cache_path}")
     return normalize_weight_config_paths(weight_cache_path, weight_config)
+
+
+def clear_weight_cache_path(weight_cache_path: Path) -> None:
+    if weight_cache_path.exists():
+        logger.info(f"Deleting existing cache directory: {weight_cache_path}")
+        try:
+            if weight_cache_path.is_dir():
+                shutil.rmtree(weight_cache_path)
+            else:
+                weight_cache_path.unlink()
+        except OSError as e:
+            logger.warning(f"Failed to remove weight cache at {weight_cache_path}: {e}")
 
 
 def get_weight_config(
@@ -163,46 +222,74 @@ def get_weight_config(
     model_path: str | None = None,
     single_layer: str | None = None,
     cache_subdir_name: str | None = None,
+    emit_weight_cache: bool = False,
+    use_weight_cache: bool = False,
 ):
     """
-    Get weight configuration, either from cache or by converting weights.
+    Convert HuggingFace weights directly into in-memory TTNN tensors.
 
     Args:
         ModuleClass: The module class to convert weights for
         hf_config: HuggingFace model configuration
         state_dicts: Optional pre-loaded state dicts. If None, will be loaded based on random_weights/model_path.
-        weight_cache_path: Path to cache weights
+        weight_cache_path: Optional base path used only to preserve the historical conversion subdirectory layout for
+            callers that key weight generation by this path. No on-disk weight cache is generated.
         mesh_device: TTNN mesh device
-        force_recalculate: Force recalculation even if cached weights exist
+        force_recalculate: Accepted for API compatibility. Pure in-memory conversion still runs on every call,
+            but emitted legacy caches are cleared before being regenerated.
         random_weights: If True, generate random weights from reference model
         model_path: Path to HuggingFace model directory (required if random_weights=False and state_dicts=None)
         single_layer: Optional single layer name (used for validation with random weights)
         cache_subdir_name: Optional cache subdirectory name under ``weight_cache_path``.
             Defaults to ``"{num_hidden_layers}_layers"``.
+        emit_weight_cache: If True, persist converted TTNN tensors to a legacy on-disk
+            weight cache rooted at ``weight_cache_path``. This is intended only for
+            compatibility flows such as BSPM cache export.
+        use_weight_cache: If True, require and load a legacy on-disk weight cache from
+            ``weight_cache_path`` instead of converting weights directly in memory.
 
     Returns:
         Weight configuration dictionary
     """
-    if weight_cache_path is None:
-        raise ValueError("weight_cache_path must be provided")
     if mesh_device is None:
         raise ValueError("mesh_device must be provided")
 
-    weight_cache_path = weight_cache_path.expanduser()
-    if not weight_cache_path.is_absolute():
-        weight_cache_path = weight_cache_path.resolve()
+    if emit_weight_cache and use_weight_cache:
+        raise ValueError("emit_weight_cache and use_weight_cache cannot both be True")
 
-    cache_subdir_name = cache_subdir_name or f"{hf_config.num_hidden_layers}_layers"
-    weight_cache_path = weight_cache_path / cache_subdir_name / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
-    config_path = weight_cache_path / "config.json"
+    if weight_cache_path is not None:
+        weight_cache_path = weight_cache_path.expanduser()
+        if not weight_cache_path.is_absolute():
+            weight_cache_path = weight_cache_path.resolve()
+        cache_subdir_name = cache_subdir_name or f"{hf_config.num_hidden_layers}_layers"
+        output_path = weight_cache_path / cache_subdir_name / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
+    else:
+        output_path = (
+            Path("generated/deepseek_v3")
+            / f"{hf_config.num_hidden_layers}_layers"
+            / (f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}")
+        )
 
-    # Try to load from cache
-    cached_config = _try_load_cached_config(config_path, weight_cache_path, force_recalculate)
-    if cached_config is not None:
-        return cached_config
+    if use_weight_cache:
+        if weight_cache_path is None:
+            raise ValueError("weight_cache_path must be provided when use_weight_cache=True")
+        if force_recalculate:
+            raise ValueError("force_recalculate cannot be used when use_weight_cache=True")
+        config_path = output_path / "config.json"
+        cached_weight_config = _try_load_cached_config(config_path, output_path, force_recalculate=False)
+        if cached_weight_config is None:
+            raise FileNotFoundError(
+                f"Requested DeepSeek weight cache was not found at {output_path}. "
+                "Generate the cache first or disable use_weight_cache."
+            )
+        return cached_weight_config
 
-    # Cache miss - need to convert weights
-    logger.info(f"Caching weights at {weight_cache_path}")
+    if force_recalculate:
+        if emit_weight_cache:
+            clear_weight_cache_path(output_path)
+        else:
+            logger.info("force_recalculate=True is ignored for direct in-memory DeepSeek weight conversion")
+
     if state_dicts is None:
         logger.info("State dict was not provided, preparing from random weights or model path")
         from models.demos.deepseek_v3.utils.hf_model_utils import prepare_model_state_dict
@@ -215,30 +302,131 @@ def get_weight_config(
         )
         state_dicts = (model_state,)
 
-    # Convert weights to TT tensors-on-disk and build weight_config
-    logger.info("Converting weights to TTNN SavedWeight format...")
+    if emit_weight_cache:
+        logger.info(f"Converting DeepSeek weights and streaming them to a legacy weight cache at {output_path}")
+    else:
+        logger.info("Converting DeepSeek weights directly to TTNN tensors (no on-disk weight cache)")
 
-    weight_config = ModuleClass.convert_weights(hf_config, state_dicts, weight_cache_path, mesh_device)
+    emit_context = emit_legacy_saved_weights() if emit_weight_cache else nullcontext()
+    with emit_context:
+        weight_config = ModuleClass.convert_weights(hf_config, state_dicts, output_path, mesh_device)
+    if contains_saved_weights(weight_config):
+        if weight_cache_path is None:
+            raise ValueError(
+                "weight_cache_path must be provided when convert_weights returns legacy SavedWeight entries"
+            )
+        validate_weight_config_paths(output_path, weight_config)
+        if emit_weight_cache:
+            saved_weight_config = save_weight_config(output_path, weight_config)
+            deallocate_weight_config_tensors(weight_config)
+            return saved_weight_config
+        return normalize_weight_config_paths(output_path, weight_config)
+    if emit_weight_cache:
+        if weight_cache_path is None:
+            raise ValueError("weight_cache_path must be provided when emit_weight_cache=True")
+        saved_weight_config = save_weight_config(output_path, weight_config)
+        deallocate_weight_config_tensors(weight_config)
+        return saved_weight_config
+    return weight_config
 
+
+def contains_saved_weights(weight_config: Any) -> bool:
+    if isinstance(weight_config, SavedWeight):
+        return True
+    if isinstance(weight_config, dict):
+        return any(contains_saved_weights(value) for value in weight_config.values())
+    if isinstance(weight_config, (list, tuple)):
+        return any(contains_saved_weights(value) for value in weight_config)
+    return False
+
+
+def _tensor_cache_relpath(path_components: tuple[str, ...]) -> Path:
+    if not path_components:
+        raise ValueError("Cannot persist a TTNN tensor without a path in the weight-config tree")
+    return Path(*path_components[:-1]) / f"{path_components[-1]}{TENSOR_CACHE_EXTENSION}"
+
+
+def _save_weight_config_item(
+    root_path: Path,
+    weight_config: Any,
+    *,
+    path_components: tuple[str, ...],
+    seen_tensors: dict[int, SavedWeight],
+) -> Any:
+    if isinstance(weight_config, ttnn.Tensor):
+        tensor_id = id(weight_config)
+        if tensor_id in seen_tensors:
+            cached = seen_tensors[tensor_id]
+            return SavedWeight(path=cached.path, memory_config=cached.memory_config)
+
+        rel_path = _tensor_cache_relpath(path_components)
+        abs_path = root_path / rel_path
+        abs_path.parent.mkdir(parents=True, exist_ok=True)
+        ttnn.dump_tensor(abs_path, weight_config)
+        saved_weight = SavedWeight(path=rel_path, memory_config=weight_config.memory_config())
+        seen_tensors[tensor_id] = saved_weight
+        return SavedWeight(path=rel_path, memory_config=saved_weight.memory_config)
+
+    if isinstance(weight_config, dict):
+        return {
+            key: _save_weight_config_item(
+                root_path,
+                value,
+                path_components=(*path_components, str(key)),
+                seen_tensors=seen_tensors,
+            )
+            if value is not None
+            else None
+            for key, value in weight_config.items()
+        }
+
+    if isinstance(weight_config, list):
+        return [
+            _save_weight_config_item(
+                root_path,
+                value,
+                path_components=(*path_components, str(idx)),
+                seen_tensors=seen_tensors,
+            )
+            if value is not None
+            else None
+            for idx, value in enumerate(weight_config)
+        ]
+
+    if isinstance(weight_config, tuple):
+        return tuple(
+            _save_weight_config_item(
+                root_path,
+                value,
+                path_components=(*path_components, str(idx)),
+                seen_tensors=seen_tensors,
+            )
+            if value is not None
+            else None
+            for idx, value in enumerate(weight_config)
+        )
+
+    return weight_config
+
+
+def save_weight_config(root_path: Path, weight_config: WeightConfig) -> WeightConfig:
+    """Persist a TTNN-backed weight config as a legacy ``config.json`` + ``.tensorbin`` cache."""
+    root_path.mkdir(parents=True, exist_ok=True)
+    serialized_weight_config = _save_weight_config_item(
+        root_path,
+        weight_config,
+        path_components=(),
+        seen_tensors={},
+    )
+    config_path = root_path / "config.json"
     if ttnn.using_distributed_env():
         ttnn.distributed_context_barrier()
-
-    # Validate the converted weight config
-    validate_weight_config_paths(weight_cache_path, weight_config)
-
-    # Publish config with relative paths. On multihost, only global rank 0 writes disk (same as tensor dumps);
-    # other ranks keep ``weight_config`` in memory and synchronize on a barrier before returning.
-    if not ttnn.using_distributed_env():
-        _write_weight_config_json_atomically(config_path, weight_config)
-    else:
         if int(ttnn.distributed_context_get_rank()) == 0:
-            _write_weight_config_json_atomically(config_path, weight_config)
+            _write_weight_config_json_atomically(config_path, wrap_weight_cache_payload(serialized_weight_config))
         ttnn.distributed_context_barrier()
-
-    # Return normalized config with absolute paths for runtime use
-    normalized_config = normalize_weight_config_paths(weight_cache_path, weight_config)
-    logger.info("Done converting weights to TTNN SavedWeight format")
-    return normalized_config
+    else:
+        _write_weight_config_json_atomically(config_path, wrap_weight_cache_payload(serialized_weight_config))
+    return normalize_weight_config_paths(root_path, serialized_weight_config)
 
 
 def validate_weight_config_paths(root_path: Path, weight_config: WeightConfig, path_prefix: str = "") -> None:
@@ -257,6 +445,8 @@ def validate_weight_config_paths(root_path: Path, weight_config: WeightConfig, p
         entries = weight_config.items()
     elif isinstance(weight_config, (list, tuple)):
         entries = enumerate(weight_config)
+    elif isinstance(weight_config, ttnn.Tensor):
+        return
     else:
         raise ValueError(f"Invalid weight config type: {type(weight_config)}")
 
@@ -323,6 +513,8 @@ def normalize_weight_config_paths(root_path: Path, weight_config: WeightConfig) 
         else:
             normalized_path = root_path / weight_config.path
         return SavedWeight(path=normalized_path, memory_config=weight_config.memory_config)
+    elif isinstance(weight_config, ttnn.Tensor):
+        return weight_config
     else:
         # For other types (None, primitives, etc.), return as-is
         return weight_config

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -132,20 +132,20 @@ DEVICE_PERF_EXPECTATIONS = {
         "blackhole": None,  # Only 1024x1024 tested on Blackhole
     },
     "vae_encode_1024x1024": {
-        "wormhole": 324_271_938,
-        "blackhole": 140_042_000,
+        "wormhole": 328_968_938,  # Note: this is an average value of 30 test runs due to high variability
+        "blackhole": 143_563_697,
     },
     "vae_encode_512x512": {
-        "wormhole": 83_537_085,
+        "wormhole": 85_005_572,  # Note: this is an average value of 30 test runs due to high variability
         "blackhole": None,  # Only 1024x1024 tested on Blackhole
     },
     "clip_encoder_1": {
-        "wormhole": 13_112_562,
-        "blackhole": 7_089_747,
+        "wormhole": 40_995_000,  # Note: this is an average value of 30 test runs due to high variability
+        "blackhole": 19_377_824,
     },
     "clip_encoder_2": {
-        "wormhole": 63_591_763,  # Note: this is an average value of 30 test runs due to high variability
-        "blackhole": 29_182_499,
+        "wormhole": 125_300_000,
+        "blackhole": 60_903_932,
     },
 }
 
@@ -161,7 +161,7 @@ def get_device_perf(test_id):
 
 
 @pytest.mark.parametrize(
-    "test_id, command, subdir, model_name, num_iterations, batch_size, margin, comments",
+    "test_id, command, subdir, model_name, num_iterations, batch_size, margin, comments, op_support_count",
     [
         (
             "unet_1024x1024",
@@ -172,6 +172,7 @@ def get_device_perf(test_id):
             1 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
             0.015,
             f"iterations={UNET_DEVICE_TEST_TOTAL_ITERATIONS}",
+            None,
         ),
         (
             "unet_512x512",
@@ -182,6 +183,7 @@ def get_device_perf(test_id):
             1 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
             0.015,
             f"iterations={UNET_DEVICE_TEST_TOTAL_ITERATIONS}",
+            None,
         ),
         (
             "refiner_unet_1024x1024",
@@ -192,6 +194,7 @@ def get_device_perf(test_id):
             1 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
             0.06,
             f"iterations={UNET_DEVICE_TEST_TOTAL_ITERATIONS}",
+            None,
         ),
         (
             "refiner_unet_512x512",
@@ -202,6 +205,7 @@ def get_device_perf(test_id):
             1 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
             0.06,
             f"iterations={UNET_DEVICE_TEST_TOTAL_ITERATIONS}",
+            None,
         ),
         (
             "vae_decode_1024x1024",
@@ -212,6 +216,7 @@ def get_device_perf(test_id):
             1,
             0.015,
             "",
+            None,
         ),
         (
             "vae_decode_512x512",
@@ -222,6 +227,7 @@ def get_device_perf(test_id):
             1,
             0.015,
             "",
+            None,
         ),
         (
             "vae_encode_1024x1024",
@@ -232,6 +238,7 @@ def get_device_perf(test_id):
             1,
             0.015,
             "",
+            None,
         ),
         (
             "vae_encode_512x512",
@@ -242,6 +249,7 @@ def get_device_perf(test_id):
             1,
             0.015,
             "",
+            None,
         ),
         (
             "clip_encoder_1",
@@ -252,6 +260,7 @@ def get_device_perf(test_id):
             1,
             0.015,
             "",
+            None,
         ),
         (
             "clip_encoder_2",
@@ -262,6 +271,7 @@ def get_device_perf(test_id):
             1,
             0.020,
             "",
+            5000,
         ),
     ],
     ids=[
@@ -278,7 +288,9 @@ def get_device_perf(test_id):
     ],
 )
 @pytest.mark.models_device_performance_bare_metal
-def test_sdxl_perf_device(test_id, command, subdir, model_name, num_iterations, batch_size, margin, comments):
+def test_sdxl_perf_device(
+    test_id, command, subdir, model_name, num_iterations, batch_size, margin, comments, op_support_count
+):
     expected_perf = get_device_perf(test_id)
     if expected_perf is None:
         pytest.skip(f"Test {test_id} not configured for current device")
@@ -295,4 +307,5 @@ def test_sdxl_perf_device(test_id, command, subdir, model_name, num_iterations, 
         batch_size=batch_size,
         margin=margin,
         comments=comments,
+        op_support_count=op_support_count,
     )

--- a/models/perf/device_perf_utils.py
+++ b/models/perf/device_perf_utils.py
@@ -390,6 +390,7 @@ def run_model_device_perf_test(
     batch_size: int = 1,
     margin: float = 0.015,
     comments: str = "",
+    op_support_count: int = None,
 ):
     """
     Run device performance test for a model and validate results against expected performance.
@@ -407,6 +408,7 @@ def run_model_device_perf_test(
         batch_size (int, optional): Batch size for the model. Defaults to 1.
         margin (float, optional): Acceptable performance margin as a percentage (e.g., 0.015 = 1.5%). Defaults to 0.015.
         comments (str, optional): Additional comments or settings description for the report. Defaults to "".
+        op_support_count (int, optional): Number of operations to support. Defaults to None.
 
     Raises:
         AssertionError: If the measured performance is outside the acceptable margin from expected performance.
@@ -415,7 +417,12 @@ def run_model_device_perf_test(
 
     inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
     post_processed_results = run_device_perf(
-        command, subdir=subdir, num_iterations=num_iterations, cols=cols, batch_size=batch_size
+        command,
+        subdir=subdir,
+        num_iterations=num_iterations,
+        cols=cols,
+        batch_size=batch_size,
+        op_support_count=op_support_count,
     )
     expected_perf_cols = {inference_time_key: expected_device_perf_ns_per_iteration}
     expected_results = check_device_perf(

--- a/tests/pipeline_reorg/galaxy_demo_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_demo_tests.yaml
@@ -129,7 +129,7 @@
 
 - name: Galaxy DeepSeek v3 demo tests
   cmd: |
-    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI MESH_DEVICE=TG
+    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI MESH_DEVICE=TG
     pytest models/demos/deepseek_v3/demo/test_demo.py -k "tg_stress or tg_upr8" --timeout 900
   model: deepseek_v3
   skus:

--- a/tests/pipeline_reorg/t3k_integration_tests.yaml
+++ b/tests/pipeline_reorg/t3k_integration_tests.yaml
@@ -175,7 +175,7 @@
 - name: t3k_deepseek_module_tests
   cmd: |
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528 DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI MESH_DEVICE=T3K
+    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI MESH_DEVICE=T3K
     pytest models/demos/deepseek_v3/tests -m t3k_compat --durations=0
   skus:
     wh_llmbox:

--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -21,6 +21,7 @@ wormhole_b0:
   - tests/ttnn/unit_tests/base_functionality/test_tilize_untilize_2D.py
   - tests/ttnn/unit_tests/base_functionality/test_to_layout.py
   - tests/ttnn/unit_tests/base_functionality/test_tilize_pad_cb.py
+  - tests/ttnn/unit_tests/base_functionality/test_reshape.py::test_reshape_replicated_tensor # ttnn.from_torch uses to_layout for distributed tensors
 
   # Slow tests (Tier 3-4: 5-20+ minutes, would cause CI timeouts)
   - tests/ttnn/unit_tests/operations/reduce/test_topk.py

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -281,7 +281,7 @@ resolve_deepseekv3_cache() {
 }
 
 resolve_deepseekv3_model() {
-    local default_model="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized"
+    local default_model="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked"
     local model_path="${DEEPSEEK_V3_HF_MODEL_OVERRIDE:-${DEEPSEEK_V3_HF_MODEL:-${default_model}}}"
 
     if [[ ! -d "${model_path}" ]]; then
@@ -371,7 +371,7 @@ setup_quad_galaxy_env() {
 }
 
 # Compute pytest --timeout value.
-# When DEEPSEEK_V3_CACHE_OVERRIDE is set (cache recalculation), add 6 hours.
+# When DEEPSEEK_V3_CACHE_OVERRIDE is set (custom DeepSeek cache dir), add 6 hours.
 _demo_timeout() {
     local base_timeout=$1
     local cache_extra=21600  # 6 hours
@@ -918,7 +918,7 @@ main() {
             echo "Available options: unit_tests, dual_deepseekv3_unit_tests, quad_deepseekv3_unit_tests, dual_deepseekv3_module_tests, quad_deepseekv3_module_tests, dual_teacher_forced, quad_teacher_forced, dual_demo, dual_demo_mtp, quad_demo, quad_demo_mtp, dual_demo_stress, quad_demo_stress, dual_deepseekv3_integration_tests, quad_deepseekv3_integration_tests, all_needed_local_tests, all" 1>&2
             echo "Optional second argument: UPR mode (all|32|8)" 1>&2
             echo "Optional flags: --no-torus  --model-path <path>  --cache-path <path>" 1>&2
-            echo "Example: $0 quad_demo 32 --no-torus --model-path /data/deepseek/DeepSeek-R1-0528-dequantized --cache-path /data/deepseek/DeepSeek-R1-0528-Cache/CI" 1>&2
+            echo "Example: $0 quad_demo 32 --no-torus --model-path /data/deepseek/DeepSeek-R1-0528-dequantized-stacked --cache-path /data/deepseek/DeepSeek-R1-0528-Cache/CI" 1>&2
             exit 1
             ;;
     esac

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -560,7 +560,7 @@ run_t3000_qwen3_vl_unit_tests() {
 run_t3000_deepseek_tests() {
   uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
 
-  export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized
+  export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked
   export DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI
   MESH_DEVICE=T3K pytest models/demos/deepseek_v3/tests/unit --timeout 60 --durations=0
 }

--- a/tests/ttnn/unit_tests/test_torch_conversion.py
+++ b/tests/ttnn/unit_tests/test_torch_conversion.py
@@ -941,9 +941,10 @@ def test_from_torch_row_major_sharded_non_tile_aligned_shard_shape(mesh_device, 
         ttnn.ShardSpec(core_grid, (shard_height, shard_width), ttnn.ShardOrientation.ROW_MAJOR),
     )
 
+    shard_dim = 1
     torch_tensor = torch.arange(shard_height * total_width, dtype=torch.int32).reshape(shard_height, total_width)
 
-    indices_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=1)
+    indices_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=shard_dim)
 
     ttnn_tensor = ttnn.from_torch(
         torch_tensor,
@@ -958,7 +959,8 @@ def test_from_torch_row_major_sharded_non_tile_aligned_shard_shape(mesh_device, 
     assert ttnn_tensor.layout == ttnn.ROW_MAJOR_LAYOUT
     assert ttnn_tensor.memory_config().memory_layout == ttnn.TensorMemoryLayout.WIDTH_SHARDED
 
-    result = ttnn.to_torch(ttnn_tensor)
+    indices_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=shard_dim)
+    result = ttnn.to_torch(ttnn_tensor, mesh_composer=indices_mesh_composer)
     torch.testing.assert_close(torch_tensor, result.to(torch.int32))
 
 
@@ -1072,3 +1074,145 @@ def test_from_torch_large_tensor_type_conversion_row_major_l1(device, torch_dtyp
 
     result = ttnn.to_torch(ttnn_tensor)
     assert_with_pcc(torch_tensor, result, 0.999)
+
+
+def test_from_torch_sharded_tilize_dispatch_core_overlap(device):
+    """
+    Regression test for tilize with a shard grid that extends beyond the compute
+    grid (e.g. includes dispatch cores).
+
+    Derived from test_all_gather_6u_llama (TG nightly, SDPA case) where the
+    persistent output tensor's shard grid included cores at positions overlapping
+    with dispatch cores.  The sharded tilize program factory would place compute
+    kernels on ALL shard cores, crashing with:
+
+        TT_FATAL: Illegal kernel placement for tilize, Kernels cannot be
+        placed on dispatch cores!
+
+    On WH B0 80 with fast dispatch (row mode), the compute grid is (8, 8) and
+    dispatch cores occupy y=9 (last row of the 8x10 tensix grid).  This test
+    constructs a shard grid that spans both compute cores (y=0) and a row
+    beyond the compute grid (y=grid.y) and verifies that from_torch succeeds.
+    """
+    grid = device.compute_with_storage_grid_size()
+
+    shard_height = 32
+    shard_width = 128
+
+    # Row y = grid.y is beyond the compute grid.  On most WH B0 configs this
+    # is the dispatch core row (e.g. 72-core: y=8, 80-core: y=9).
+    # The tilize fix must handle this gracefully.
+    dispatch_y = grid.y
+
+    num_cores = grid.x * 2
+    total_height = num_cores * shard_height
+    shape = (1, 1, total_height, shard_width)
+
+    core_grid = ttnn.CoreRangeSet(
+        [
+            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, 0)),
+            ttnn.CoreRange(ttnn.CoreCoord(0, dispatch_y), ttnn.CoreCoord(grid.x - 1, dispatch_y)),
+        ]
+    )
+    sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(core_grid, [shard_height, shard_width], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    torch_tensor = torch.zeros(shape, dtype=torch.bfloat16)
+
+    result = ttnn.from_torch(
+        torch_tensor,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=sharded_mem_config,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(device),
+    )
+
+    assert result.layout == ttnn.TILE_LAYOUT
+    assert result.dtype == ttnn.bfloat16
+    assert list(result.shape) == list(shape)
+
+
+@pytest.mark.parametrize(
+    "torch_dtype,ttnn_dtype,total_width,num_shards",
+    [
+        (torch.float32, ttnn.bfloat16, 14336, 28),
+    ],
+)
+def test_from_torch_width_sharded_l1_tilize_with_sub_devices(device, torch_dtype, ttnn_dtype, total_width, num_shards):
+    """
+    Regression test: from_torch with float32 → bfloat16, TILE_LAYOUT, WIDTH_SHARDED
+    L1 memory config, mesh_mapper, and sub-devices must not overflow L1 during tilize.
+
+    Derived from test_all_reduce (FF1 intermediate buffer, TG nightly):
+        from_torch(torch.zeros([8, 4, 32, 14336]), dtype=bfloat16,
+                   memory_config=WIDTH_SHARDED_L1, mesh_mapper=ShardTensor2dMesh(...))
+
+    When sub-devices are loaded, convert_python_tensor_to_tt_tensor passes a
+    sub_core_grids to to_layout → tilize. The sharded tilize program factories
+    reject sub_core_grids (tilize_device_operation.cpp can_use_sharded_optimized_factories),
+    causing a fallback to TilizeMultiCoreDefaultProgramFactory which treats the
+    entire tensor as one block on a single core. For [1,1,32,14336] bfloat16
+    this allocates ~1.84 MB of static CBs, exceeding L1 capacity (~1.50 MB on
+    Wormhole B0, ~1.57 MB on Blackhole).
+    """
+    grid = device.compute_with_storage_grid_size()
+    cols, rows = grid.x, grid.y
+
+    if cols * rows < num_shards:
+        pytest.skip(f"Device grid {cols}x{rows} has fewer cores than {num_shards} shards")
+
+    shard_width = total_width // num_shards
+    assert total_width % num_shards == 0
+    assert shard_width % ttnn.TILE_SIZE == 0
+
+    full_rows = num_shards // cols
+    remaining = num_shards % cols
+    core_ranges = []
+    if full_rows > 0:
+        core_ranges.append(ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(cols - 1, full_rows - 1)))
+    if remaining > 0:
+        core_ranges.append(ttnn.CoreRange(ttnn.CoreCoord(0, full_rows), ttnn.CoreCoord(remaining - 1, full_rows)))
+    shard_crs = ttnn.CoreRangeSet(core_ranges)
+
+    worker_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(cols - 1, rows - 1))})
+    worker_sub_device = ttnn.SubDevice([worker_crs])
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+
+    sub_device_manager = device.create_sub_device_manager([worker_sub_device], 0)
+    device.load_sub_device_manager(sub_device_manager)
+    device.set_sub_device_stall_group([worker_sub_device_id])
+
+    try:
+        shape = (1, 1, 32, total_width)
+
+        sharded_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(shard_crs, [32, shard_width], ttnn.ShardOrientation.ROW_MAJOR),
+        )
+
+        torch.manual_seed(42)
+        torch_tensor = torch.zeros(shape, dtype=torch_dtype)
+
+        ttnn_tensor = ttnn.from_torch(
+            torch_tensor,
+            dtype=ttnn_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=sharded_mem_config,
+            mesh_mapper=ReplicateTensorToMesh(device),
+        )
+
+        assert ttnn_tensor.dtype == ttnn_dtype
+        assert ttnn_tensor.layout == ttnn.TILE_LAYOUT
+        assert ttnn_tensor.memory_config().memory_layout == ttnn.TensorMemoryLayout.WIDTH_SHARDED
+
+        result = ttnn.to_torch(ttnn_tensor)
+        assert_with_pcc(torch_tensor, result, 0.999)
+    finally:
+        device.reset_sub_device_stall_group()
+        device.clear_loaded_sub_device_manager()
+        device.remove_sub_device_manager(sub_device_manager)

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp
@@ -11,7 +11,14 @@
 #include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
 
+#include <optional>
+#include <string>
+
 namespace tt::tt_metal {
+
+// Validates that the physical shard shape is aligned to tile dimensions for sharded TILE layouts.
+// Returns true if the configuration is valid, false otherwise.
+bool can_shard_align(const MemoryConfig& memory_config, const Layout& layout, const Tile& tile = Tile{});
 
 class IDevice;
 
@@ -30,8 +37,7 @@ public:
 
     // static method makes it easy to find and remove all of its usages in the codebase - that's why it is not a
     // constructor
-    [[deprecated("Use of Padded Shape is deprecated")]]
-    static TensorLayout fromPaddedShape(
+    [[deprecated("Use of Padded Shape is deprecated")]] static TensorLayout fromPaddedShape(
         DataType dtype,
         const PageConfig& page_config,
         const MemoryConfig& memory_config,
@@ -58,8 +64,10 @@ public:
 
     // This method is deprecated and should be replaced with get_strides() / get_physical_size()
     // It computes padded shape on the fly from shape and alignment
-    [[deprecated("Use of LegacyPaddedShape is deprecated. Please use get_physical_size() or get_strides() instead.")]]
-    tt::tt_metal::Shape compute_padded_shape(const tt::tt_metal::Shape& shape) const;
+    [[deprecated(
+        "Use of LegacyPaddedShape is deprecated. Please use get_physical_size() or get_strides() instead.")]] tt::
+        tt_metal::Shape
+        compute_padded_shape(const tt::tt_metal::Shape& shape) const;
 
     // Flattens input shape into height and width
     // - Height is accumulated over all dims except last

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/tensor_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/tensor_spec.hpp
@@ -9,6 +9,13 @@
 
 namespace tt::tt_metal {
 
+// Validates that a tensor's physical shape fits within the shard grid for sharded memory layouts.
+// Checks that the number of shards required along each dimension does not exceed the available
+// cores/grid size, and that non-sharded dimensions match exactly (e.g. width for height-sharded,
+// height for width-sharded). Only applies to legacy (non-nd) shard specs.
+// Returns true if valid, false otherwise.
+bool can_shape_fits_shard_grid(const TensorLayout& tensor_layout, const Shape& logical_shape);
+
 class TensorSpec final {
 public:
     TensorSpec(tt::tt_metal::Shape logical_shape, TensorLayout tensor_layout);

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -97,39 +97,41 @@ void validate_alignment(const TensorLayout& tensor_layout) {
     page_config.validate_alignment(alignment, dtype, memory_config);
 }
 
-void validate_shard_spec(const TensorLayout& tensor_layout) {
-    const auto& memory_config = tensor_layout.get_memory_config();
-    const auto& layout = tensor_layout.get_layout();
+std::optional<std::string> get_shard_align_error(
+    const MemoryConfig& memory_config, const Layout& layout, const Tile& tile) {
     if (memory_config.is_sharded() && layout == Layout::TILE) {
-        const auto& tile_shape = tensor_layout.get_tile().get_tile_shape();
+        const auto& tile_shape = tile.get_tile_shape();
         if (memory_config.shard_spec().has_value()) {
-            const auto& physical_shard_shape = tensor_layout.get_physical_shard_shape();
-            TT_FATAL(
-                (physical_shard_shape.height() % tile_shape[0] == 0 &&
-                 physical_shard_shape.width() % tile_shape[1] == 0),
-                "Physical shard shape {} must be tile {} sized!",
-                physical_shard_shape,
-                tile_shape);
+            const auto& physical_shard_shape = Shape2D(memory_config.shard_spec().value().shape);
+            if (!(physical_shard_shape.height() % tile_shape[0] == 0 &&
+                  physical_shard_shape.width() % tile_shape[1] == 0)) {
+                return fmt::format("Physical shard shape {} must be tile {} sized!", physical_shard_shape, tile_shape);
+            }
         } else {
             const auto& shard_shape = memory_config.nd_shard_spec().value().shard_shape;
-            TT_FATAL(
-                (shard_shape[-2] % tile_shape[0] == 0 && shard_shape[-1] % tile_shape[1] == 0),
-                "Physical shard shape {} must be tile {} sized!",
-                shard_shape,
-                tile_shape);
+            if (!(shard_shape[-2] % tile_shape[0] == 0 && shard_shape[-1] % tile_shape[1] == 0)) {
+                return fmt::format("Physical shard shape {} must be tile {} sized!", shard_shape, tile_shape);
+            }
         }
     }
+    return std::nullopt;
 }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
+
+bool can_shard_align(const MemoryConfig& memory_config, const Layout& layout, const Tile& tile) {
+    return !CMAKE_UNIQUE_NAMESPACE::get_shard_align_error(memory_config, layout, tile).has_value();
+}
 
 TensorLayout::TensorLayout(
     DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment) :
     dtype_(dtype), page_config_(page_config), memory_config_(memory_config), alignment_(alignment) {
     initialize_alignment();
     CMAKE_UNIQUE_NAMESPACE::validate_alignment(*this);
-    CMAKE_UNIQUE_NAMESPACE::validate_shard_spec(*this);
+
+    auto shard_align_error = CMAKE_UNIQUE_NAMESPACE::get_shard_align_error(memory_config_, get_layout(), get_tile());
+    TT_FATAL(!shard_align_error.has_value(), "{}", shard_align_error);
 }
 
 TensorLayout TensorLayout::fromPaddedShape(

--- a/tt_metal/impl/tensor/spec/tensor_spec.cpp
+++ b/tt_metal/impl/tensor/spec/tensor_spec.cpp
@@ -10,82 +10,86 @@ namespace tt::tt_metal {
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
 
-void validate_shard_spec_with_tensor_shape(const TensorSpec& tensor_spec) {
-    const auto& memory_config = tensor_spec.memory_config();
+std::optional<std::string> get_shape_fits_shard_grid_error(
+    const TensorLayout& tensor_layout, const Shape& logical_shape) {
+    const auto& memory_config = tensor_layout.get_memory_config();
     if (!memory_config.is_sharded() or !memory_config.shard_spec().has_value()) {
-        return;
+        return std::nullopt;
     }
+
     // Sharding checks use physical shape and physical shard shape
     // TODO: Review and port to use logical shapes
-    const auto& physical_shape = tensor_spec.physical_shape();
+    const auto physical_shape = tensor_layout.compute_physical_shape(logical_shape);
     const auto physical_height = physical_shape.height();
     const auto physical_width = physical_shape.width();
 
-    const auto& physical_shard_shape = tensor_spec.tensor_layout().get_physical_shard_shape();
+    const auto physical_shard_shape = tensor_layout.get_physical_shard_shape();
     const auto physical_shard_height = physical_shard_shape.height();
     const auto physical_shard_width = physical_shard_shape.width();
 
     const auto& shard_spec = memory_config.shard_spec().value();
     uint32_t num_cores = shard_spec.num_cores();
 
-    // TODO (issue #17060): Flip to TT_FATAL
     if (memory_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
-        TT_FATAL(
-            physical_width == physical_shard_width,
-            "Shard width {} must match physical width {} for height sharded",
-            physical_shard_width,
-            physical_width);
+        if (physical_width != physical_shard_width) {
+            return fmt::format(
+                "Shard width {} must match physical width {} for height sharded", physical_shard_width, physical_width);
+        }
         uint32_t num_shards = div_up(physical_height, physical_shard_height);
-        TT_FATAL(
-            num_shards <= num_cores,
-            "Number of shards along height {} must not exceed number of cores {}",
-            num_shards,
-            num_cores);
+        if (num_shards > num_cores) {
+            return fmt::format(
+                "Number of shards along height {} must not exceed number of cores {}", num_shards, num_cores);
+        }
     } else if (memory_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
-        TT_FATAL(
-            physical_height == physical_shard_height,
-            "Shard height {} must match physical height {} for width sharded",
-            physical_shard_height,
-            physical_height);
+        if (physical_height != physical_shard_height) {
+            return fmt::format(
+                "Shard height {} must match physical height {} for width sharded",
+                physical_shard_height,
+                physical_height);
+        }
         uint32_t num_shards = div_up(physical_width, physical_shard_width);
-        TT_FATAL(
-            num_shards <= num_cores,
-            "Number of shards along width {} must not exceed number of cores {}",
-            num_shards,
-            num_cores);
+        if (num_shards > num_cores) {
+            return fmt::format(
+                "Number of shards along width {} must not exceed number of cores {}", num_shards, num_cores);
+        }
     } else if (memory_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
-        TT_FATAL(
-            shard_spec.grid.ranges().size() == 1, "Shard grid must be one full rectangular grid for block sharded!");
+        if (shard_spec.grid.ranges().size() != 1) {
+            return std::string("Shard grid must be one full rectangular grid for block sharded!");
+        }
         uint32_t num_shards_along_height = div_up(physical_height, physical_shard_height);
         uint32_t num_shards_along_width = div_up(physical_width, physical_shard_width);
 
-        // Additionally check that number of cores along height and width matches shard grid
         const CoreCoord shard_grid = shard_spec.grid.bounding_box().grid_size();
         if (shard_spec.orientation == ShardOrientation::ROW_MAJOR) {
-            TT_FATAL(
-                num_shards_along_height <= shard_grid.y,
-                "Number of shards along height {} must not exceed number of rows {} for row major orientation!",
-                num_shards_along_height,
-                shard_grid.y);
-            TT_FATAL(
-                num_shards_along_width <= shard_grid.x,
-                "Number of shards along width {} must not exceed number of columns {} for row major orientation!",
-                num_shards_along_width,
-                shard_grid.x);
+            if (num_shards_along_height > shard_grid.y) {
+                return fmt::format(
+                    "Number of shards along height {} must not exceed number of rows {} for row major orientation!",
+                    num_shards_along_height,
+                    shard_grid.y);
+            }
+            if (num_shards_along_width > shard_grid.x) {
+                return fmt::format(
+                    "Number of shards along width {} must not exceed number of columns {} for row major orientation!",
+                    num_shards_along_width,
+                    shard_grid.x);
+            }
         } else {
-            TT_FATAL(
-                num_shards_along_height <= shard_grid.x,
-                "Number of shards along height {} must not exceed number of columns {} for column major "
-                "orientation!",
-                num_shards_along_height,
-                shard_grid.x);
-            TT_FATAL(
-                num_shards_along_width <= shard_grid.y,
-                "Number of shards along width {} must not exceed number of rows {} for column major orientation!",
-                num_shards_along_width,
-                shard_grid.y);
+            if (num_shards_along_height > shard_grid.x) {
+                return fmt::format(
+                    "Number of shards along height {} must not exceed number of columns {} for column major "
+                    "orientation!",
+                    num_shards_along_height,
+                    shard_grid.x);
+            }
+            if (num_shards_along_width > shard_grid.y) {
+                return fmt::format(
+                    "Number of shards along width {} must not exceed number of rows {} for column major orientation!",
+                    num_shards_along_width,
+                    shard_grid.y);
+            }
         }
     }
+    return std::nullopt;
 }
 
 void validate_dtype_and_layout(DataType dtype, Layout layout) {
@@ -124,13 +128,18 @@ void validate_dtype_and_layout(DataType dtype, Layout layout) {
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
+bool can_shape_fits_shard_grid(const TensorLayout& tensor_layout, const Shape& logical_shape) {
+    return !CMAKE_UNIQUE_NAMESPACE::get_shape_fits_shard_grid_error(tensor_layout, logical_shape).has_value();
+}
+
 TensorSpec::TensorSpec(tt::tt_metal::Shape logical_shape, TensorLayout tensor_layout) :
     logical_shape_(std::move(logical_shape)),
     tensor_layout_(std::move(tensor_layout)),
     cached_padded_shape_(tensor_layout_.compute_padded_shape(logical_shape_)),
     cached_logical_2d_shape_(tensor_layout_.compute_logical_2d_shape(logical_shape_)),
     cached_physical_shape_(tensor_layout_.compute_physical_shape(logical_shape_)) {
-    CMAKE_UNIQUE_NAMESPACE::validate_shard_spec_with_tensor_shape(*this);
+    auto shard_grid_fit_error = CMAKE_UNIQUE_NAMESPACE::get_shape_fits_shard_grid_error(tensor_layout_, logical_shape_);
+    TT_FATAL(!shard_grid_fit_error.has_value(), "{}", shard_grid_fit_error);
     CMAKE_UNIQUE_NAMESPACE::validate_dtype_and_layout(data_type(), layout());
     populate_sharding_specs();
 }

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -18,6 +18,28 @@ using namespace tt::tt_metal;
 namespace {
 auto get_datatype_tile_size(DataType dtype) { return tt::tile_size(datatype_to_dataformat_converter(dtype)); }
 
+TensorLayout compute_input_tensor_layout(
+    DataType src_dtype,
+    const ttnn::Shape& tensor_shape,
+    const MemoryConfig& memory_config,
+    const Layout& layout,
+    const std::optional<Tile>& optional_tile) {
+    auto default_tensor_layout = TensorLayout(src_dtype, PageConfig(ttnn::Layout::ROW_MAJOR), MemoryConfig{});
+
+    // Check if we can create tensor layout with the given memory config and layout.
+    if (!can_shard_align(memory_config, layout, optional_tile.value_or(Tile{}))) {
+        return default_tensor_layout;
+    }
+
+    TensorLayout src_tensor_layout = TensorLayout(src_dtype, PageConfig(ttnn::Layout::ROW_MAJOR), memory_config);
+
+    // Check if we can create tensor spec with the given tensor shape and tensor layout.
+    if (!can_shape_fits_shard_grid(src_tensor_layout, tensor_shape)) {
+        return default_tensor_layout;
+    }
+    return src_tensor_layout;
+}
+
 // Check if typecast and layout operations can be safely executed on the device
 // for particular data type.
 bool can_exec_ops_on_device(DataType type) {
@@ -42,7 +64,8 @@ bool can_construct_on_device(
     const std::optional<Tile>& optional_tile,
     bool enable_device_typecast,
     bool preserve_nan_values) {
-    bool res = device != nullptr && !device->is_remote_only() && (device->num_sub_devices() == 0) &&
+    bool res = device != nullptr && !device->is_remote_only() &&
+               (device->get_active_sub_device_manager_id() == device->get_default_sub_device_manager_id()) &&
                tensor_shape.volume() > 0 && can_exec_ops_on_device(src_dtype) && can_exec_ops_on_device(dst_dtype) &&
                enable_device_typecast &&
                // TODO: Remove preserve_nan_values check after
@@ -96,6 +119,7 @@ bool can_construct_on_single_device(
 //   target RM,   same dtype:  RM(src)  (no conversion needed)
 bool has_sufficient_device_memory(
     ttnn::distributed::MeshDevice* device,
+    const TensorLayout& src_tensor_layout,
     const ttnn::Shape& tensor_shape,
     DataType src_dtype,
     DataType dst_dtype,
@@ -114,7 +138,7 @@ bool has_sufficient_device_memory(
     auto num_banks = device->allocator()->get_num_banks(buffer_type);
     auto bank_size = device->allocator()->get_bank_size(buffer_type);
 
-    TensorSpec src_rm_spec(tensor_shape, TensorLayout(src_dtype, PageConfig(Layout::ROW_MAJOR), memory_config));
+    TensorSpec src_rm_spec(tensor_shape, src_tensor_layout);
     auto src_rm_per_bank = src_rm_spec.compute_consumed_memory_bytes_per_bank(alignment, num_banks);
 
     size_t peak_per_bank = src_rm_per_bank;
@@ -206,18 +230,28 @@ Tensor create_tt_tensor_from_host_data(
 
     using namespace tt::tt_metal;
     auto create_tensor_from_host_buffer = [&]<typename T>() -> Tensor {
-        TensorLayout src_tensor_layout(src_dtype, PageConfig(ttnn::Layout::ROW_MAJOR), memory_config);
         TensorLayout dst_tensor_layout(dst_dtype, PageConfig(layout, optional_tile), memory_config);
 
         const bool construct_on_device = can_construct_on_device(
             device, tensor_shape, src_dtype, dst_dtype, optional_tile, enable_device_typecast, preserve_nan_values);
 
         if (mesh_mapper != nullptr) {
-            const auto shard_shape = estimate_per_device_shard_shape(tensor_shape, mesh_mapper->config(), device);
-            const bool construct_on_mesh_device =
-                construct_on_device &&
-                has_sufficient_device_memory(
-                    device, shard_shape, src_dtype, dst_dtype, layout, memory_config, optional_tile);
+            const auto device_shard_shape =
+                estimate_per_device_shard_shape(tensor_shape, mesh_mapper->config(), device);
+
+            auto src_tensor_layout =
+                compute_input_tensor_layout(src_dtype, device_shard_shape, memory_config, layout, optional_tile);
+
+            const bool construct_on_mesh_device = construct_on_device && has_sufficient_device_memory(
+                                                                             device,
+                                                                             src_tensor_layout,
+                                                                             device_shard_shape,
+                                                                             src_dtype,
+                                                                             dst_dtype,
+                                                                             layout,
+                                                                             memory_config,
+                                                                             optional_tile);
+
             return ttnn::distributed::create_distributed_tensor(
                 host_buffer.view_as<T>(),
                 tensor_shape,
@@ -228,6 +262,9 @@ Tensor create_tt_tensor_from_host_data(
                 cq_id,
                 static_cast<T>(pad_value));
         }
+
+        auto src_tensor_layout =
+            compute_input_tensor_layout(src_dtype, tensor_shape, memory_config, layout, optional_tile);
 
         // TODO: #https://github.com/tenstorrent/tt-metal/issues/40850
         // For single-device tensors, we cannot enable layout/data type changes due to tt-sim CI failures
@@ -244,11 +281,11 @@ Tensor create_tt_tensor_from_host_data(
         // This requires enough memory for both input and output to coexist during tilize/typecast.
         // Example: src_dtype = FLOAT32, dst_dtype = BFLOAT16.
         // The f32 tensor does not fit in L1, but bf16 does, so the typecast is performed on the host.
-        const bool can_borrow = src_dtype == convert_to_data_type<T>() && construct_on_device &&
-                                !is_data_transformation_required &&
-                                can_construct_on_single_device(tensor_shape, src_tensor_layout, memory_config) &&
-                                has_sufficient_device_memory(
-                                    device, tensor_shape, src_dtype, dst_dtype, layout, memory_config, optional_tile);
+        const bool can_borrow =
+            src_dtype == convert_to_data_type<T>() && construct_on_device && !is_data_transformation_required &&
+            can_construct_on_single_device(tensor_shape, src_tensor_layout, memory_config) &&
+            has_sufficient_device_memory(
+                device, src_tensor_layout, tensor_shape, src_dtype, dst_dtype, layout, memory_config, optional_tile);
 
         if (can_borrow) {
             return Tensor::from_borrowed_data(host_buffer.view_as<T>(), tensor_shape, host_buffer.pin(), optional_tile);
@@ -334,7 +371,6 @@ Tensor convert_python_tensor_to_tt_tensor(
     if (dst_dtype == DataType::BFLOAT8_B || dst_dtype == DataType::BFLOAT4_B) {
         TT_FATAL(layout == Layout::TILE, "Layout must be Layout::TILE for bfloat8_b or bfloat4_b!");
     }
-
     GraphTracker::instance().track_function_start(
         "ttnn::convert_python_tensor_to_tt_tensor",
         dst_dtype,
@@ -410,12 +446,13 @@ Tensor convert_python_tensor_to_tt_tensor(
     auto set_layout = [&](Layout target) {
         if (output.layout() != target) {
             output =
-                ttnn::to_layout(output, target, std::nullopt, std::nullopt, std::nullopt, pad_value.value_or(0.0f));
+                ttnn::to_layout(output, target, std::nullopt, memory_config, std::nullopt, pad_value.value_or(0.0f));
         }
     };
 
     if (device) {
         output = output.to_device(device.value(), memory_config, cq_id);
+
         if (output.dtype() != dst_dtype) {
             // Need to perform final data conversion on device, typecast requires TILE layout.
             set_layout(Layout::TILE);

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -61,6 +61,23 @@ bool can_use_sharded_optimized_factories(
         return false;  // Sharded tilize does not support sub core grid specification
     }
 
+    // The sharded factories place kernels on every core in the shard grid.
+    // If the grid extends beyond the compute grid (e.g. includes dispatch cores),
+    // kernel placement will fail.  Fall back to the default factory which
+    // distributes work across the compute grid and accesses shards via NoC.
+    auto* device = input_tensor.device();
+    auto grid_size = device->compute_with_storage_grid_size();
+    CoreRangeSet compute_grid(CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1}));
+    const auto& shard_grid = input_tensor.shard_spec().value().grid;
+    if (!compute_grid.contains(shard_grid)) {
+        log_debug(
+            tt::LogOp,
+            "ttnn::tilize: Shard grid {} extends beyond compute grid {}x{}, falling back to default factory",
+            shard_grid.str(),
+            grid_size.x,
+            grid_size.y);
+        return false;
+    }
     return true;
 }
 }  // namespace


### PR DESCRIPTION
## Summary

Backports the DeepSeek V3 no-cache work and follow-up fixes onto `ds-rc1`.

Cherry-picks included:

- #42150: default DeepSeek V3 to stacked checkpoints and remove weight-cache generation
- #42966: fix stacked-reference setup timeout
- #43416: disable deterministic fill in DeepSeek tests
- #41726: restore the fast `ttnn.from_torch` path needed to keep direct in-memory conversion from becoming slow

## Validation

Validated on ufb4 dual host, direct SSH, branch `yieldthought/ds-rc1-deepseek-no-cache` at `0887b9cba5`:

- `./build_metal.sh` passed
- `/data/deepseek/scripts/tt-reset` passed reset/reinit/link test
- MoE decode smoke passed on both ranks: `models/demos/deepseek_v3/tests/test_moe.py::test_forward_pass[decode-32-1-device_params0]`, PCC `0.9950487198264197`, about 66-67s
- Demo profile decode passed: `models/demos/deepseek_v3/demo/test_demo.py -k profile_decode`, `1 passed, 10 deselected`, about 51-52s

Timing check: before #41726, the same demo took about 389s and MoE layer conversion was about 84-85s/layer. With #41726, MoE conversion is about 3s/layer.

Refs #43723