### PR TITLE
#43742: fix up generic reduce neg kernel cb usage

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp
@@ -4,6 +4,12 @@
 
 #include "common.hpp"
 
+#include <numeric>
+#include <tuple>
+
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/work_split.hpp>
+
 namespace ttnn::prim {
 tt::tt_metal::ReduceOpParallelizationStrategy get_parallelization_strategy(
     const tt::tt_metal::Tensor& input_tensor, tt::tt_metal::ReduceOpDim reduce_dim) {
@@ -125,4 +131,95 @@ void validate_reduce_sharded_buffer_types(
         input_mem_config.memory_layout(),
         input_mem_config.buffer_type());
 }
+
+bool h_reduce_negate_fits_in_l1(
+    const tt::tt_metal::Tensor& input_tensor, const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids) {
+    using namespace tt::tt_metal;
+
+    const auto& shape = input_tensor.padded_shape();
+    const uint32_t tile_height = input_tensor.tensor_spec().tile().get_height();
+    const uint32_t tile_width = input_tensor.tensor_spec().tile().get_width();
+    if (tile_height == 0 || tile_width == 0) {
+        return true;
+    }
+
+    const uint32_t W = shape[3];
+    const uint32_t H = shape[2];
+    const uint32_t NC = shape[1] * shape[0];
+    const uint32_t Wt = W / tile_width;
+    const uint32_t Ht = H / tile_height;
+
+    auto* device = input_tensor.device();
+    const bool use_width_sharding = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+
+    uint32_t num_cols_per_core_group_1 = 0;
+    uint32_t num_cols_per_core_group_2 = 0;
+    if (use_width_sharding) {
+        if (NC == 0 || !input_tensor.shard_spec().has_value()) {
+            return true;
+        }
+        num_cols_per_core_group_1 = NC * (input_tensor.shard_spec().value().shape[1] / tile_width);
+    } else {
+        const uint32_t num_cols = NC * Wt;
+        if (num_cols == 0) {
+            return true;
+        }
+        const auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+        if (sub_core_grids.has_value()) {
+            std::tie(
+                std::ignore,
+                std::ignore,
+                std::ignore,
+                std::ignore,
+                num_cols_per_core_group_1,
+                num_cols_per_core_group_2) = tt::tt_metal::split_work_to_cores(*sub_core_grids, num_cols);
+        } else {
+            std::tie(
+                std::ignore,
+                std::ignore,
+                std::ignore,
+                std::ignore,
+                num_cols_per_core_group_1,
+                num_cols_per_core_group_2) =
+                tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_cols);
+        }
+    }
+
+    // Match the kernel's per-core compute_Wt: width-sharded cores see shard_Wt,
+    // non-sharded cores see num_cols_per_core directly (NC=1 in the kernel).
+    const uint32_t compute_Wt_g1 =
+        use_width_sharding ? (NC == 0 ? 0 : num_cols_per_core_group_1 / NC) : num_cols_per_core_group_1;
+    const uint32_t compute_Wt_g2 = use_width_sharding ? 0 : num_cols_per_core_group_2;
+
+    uint32_t per_nc_advance;
+    if (compute_Wt_g1 == 0 && compute_Wt_g2 == 0) {
+        return true;
+    } else if (compute_Wt_g2 == 0) {
+        per_nc_advance = compute_Wt_g1;
+    } else if (compute_Wt_g1 == 0) {
+        per_nc_advance = compute_Wt_g2;
+    } else {
+        per_nc_advance = std::lcm(compute_Wt_g1, compute_Wt_g2);
+    }
+    const uint64_t negate_cb_tiles = static_cast<uint64_t>(Ht) * per_nc_advance;
+    if (negate_cb_tiles == 0) {
+        return true;
+    }
+
+    const tt::DataFormat dst_cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    const uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
+    // Two CBs (cb_acc=c_4 and cb_ineg=c_5) are each sized at negate_cb_tiles.
+    const uint64_t negate_cb_bytes = 2ull * negate_cb_tiles * dst_single_tile_size;
+
+    const auto lowest_address = device->lowest_occupied_compute_l1_address();
+    uint64_t max_l1_space = lowest_address.has_value() ? lowest_address.value() : device->l1_size_per_core();
+    const uint64_t base_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    if (max_l1_space <= base_addr) {
+        return false;
+    }
+    max_l1_space -= base_addr;
+
+    return negate_cb_bytes <= max_l1_space;
+}
+
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp
@@ -194,7 +194,8 @@ bool h_reduce_negate_fits_in_l1(
     uint32_t per_nc_advance;
     if (compute_Wt_g1 == 0 && compute_Wt_g2 == 0) {
         return true;
-    } else if (compute_Wt_g2 == 0) {
+    }
+    if (compute_Wt_g2 == 0) {
         per_nc_advance = compute_Wt_g1;
     } else if (compute_Wt_g1 == 0) {
         per_nc_advance = compute_Wt_g2;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
@@ -24,6 +24,15 @@ namespace ttnn::prim {
 tt::tt_metal::ReduceOpParallelizationStrategy get_parallelization_strategy(
     const tt::tt_metal::Tensor& input_tensors, tt::tt_metal::ReduceOpDim reduce_dim);
 
+// Returns true if the fused-negate H reduce path's CBs fit in available L1.
+// The reduce_h_neg compute kernel pushes ntiles tiles per inner-loop iteration;
+// to make the FIFO write pointer wrap cleanly across all push sizes, c_4 (acc)
+// and c_5 (ineg) are each sized at Ht * lcm(Wt_per_core_g1, Wt_per_core_g2)
+// tiles.  For wide reductions this can exceed L1, in which case callers must
+// fall back to external negation around a non-fused (regular) reduce.
+bool h_reduce_negate_fits_in_l1(
+    const tt::tt_metal::Tensor& input_tensor, const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids);
+
 // Builds a tilized TensorSpec for a reduction-style op output, given the
 // already shape-adjusted output shape and the dimension that was reduced.
 //

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -129,7 +129,11 @@ Tensor reduce(
     // reduce kernel.
     auto h_reduce_with_external_negate =
         [&](const Tensor& h_input, float h_scaler, float h_post_mul, tt::tt_metal::DataType h_out_dtype) {
-            Tensor neg_input = ttnn::neg(h_input, output_mem_config, std::nullopt, sub_core_grids);
+            // Keep neg_input in h_input's memory config (pass std::nullopt) so the
+            // pre-reduce negation stays in place; forcing output_mem_config here
+            // could trigger a reshard (DRAM↔L1, interleaved↔sharded) before the
+            // H-reduce.  Only the final neg enforces output_mem_config.
+            Tensor neg_input = ttnn::neg(h_input, std::nullopt, std::nullopt, sub_core_grids);
             Tensor h_out = ttnn::prim::reduce(
                 neg_input,
                 reduce_math,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -4,6 +4,7 @@
 
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 #include "ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp"
+#include "ttnn/operations/reduction/generic/device/common.hpp"
 
 #include <optional>
 #include <string>
@@ -122,6 +123,27 @@ Tensor reduce(
     const float reduce_scaler = use_post_mul ? 1.0f : scaler;
     const float post_mul = use_post_mul ? scaler : 1.0f;
 
+    // External-negate fallback for the H step when the fused-negate kernel's
+    // CBs (reduce_h_neg.cpp uses Ht * lcm(Wt_g1, Wt_g2) tiles for both c_4 and
+    // c_5) won't fit in L1.  Computes -reduce(MAX, H, -x) using the regular
+    // reduce kernel.
+    auto h_reduce_with_external_negate =
+        [&](const Tensor& h_input, float h_scaler, float h_post_mul, tt::tt_metal::DataType h_out_dtype) {
+            Tensor neg_input = ttnn::neg(h_input, output_mem_config, std::nullopt, sub_core_grids);
+            Tensor h_out = ttnn::prim::reduce(
+                neg_input,
+                reduce_math,
+                tt::tt_metal::ReduceOpDim::H,
+                h_scaler,
+                output_mem_config,
+                h_out_dtype,
+                config,
+                sub_core_grids,
+                /*negate=*/false,
+                /*post_mul_scaler=*/h_post_mul);
+            return ttnn::neg(h_out, output_mem_config, std::nullopt, sub_core_grids);
+        };
+
     // The single-core HW path uses REDUCE_SCALAR mode, which applies the
     // scaler twice internally (once per dimension).  The host compensates with
     // sqrt(scaler) in ReduceSingleCoreHwProgramFactory::create.
@@ -147,6 +169,10 @@ Tensor reduce(
             negate,
             /*post_mul_scaler=*/1.0f);
 
+        if (negate && !ttnn::prim::h_reduce_negate_fits_in_l1(output_tensor, sub_core_grids)) {
+            return h_reduce_with_external_negate(output_tensor, reduce_scaler, post_mul, out_final_dtype);
+        }
+
         return ttnn::prim::reduce(
             output_tensor,
             reduce_math,
@@ -159,6 +185,13 @@ Tensor reduce(
             negate,
             /*post_mul_scaler=*/post_mul);
     }
+
+    if (negate && reduce_dim == tt::tt_metal::ReduceOpDim::H &&
+        !ttnn::prim::h_reduce_negate_fits_in_l1(tilized_input, sub_core_grids)) {
+        return h_reduce_with_external_negate(
+            tilized_input, reduce_scaler, post_mul, output_dtype.value_or(input_tensor.dtype()));
+    }
+
     return ttnn::prim::reduce(
         tilized_input,
         reduce_math,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -4,6 +4,8 @@
 
 #include "reduce_op_device_operation.hpp"
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
+#include "ttnn/operations/reduction/generic/device/common.hpp"
+#include <tt-metalium/allocator.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
@@ -163,37 +165,58 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
 
     if (operation_attributes.negate) {
         // The reduce_h_neg kernel pushes ntiles tiles per inner-loop iteration
-        // via push_back(ntiles).  The CB FIFO write pointer only wraps when it
-        // exactly reaches fifo_limit, so the CB size must be a multiple of
-        // every push size that occurs.
-        //
-        // For a core with Wt_per_core columns and row_chunk == chunk_size:
-        //   - Wt_per_core >= chunk_size: push sizes are chunk_size (full
-        //     chunks) and Wt_per_core % chunk_size (partial last chunk).
-        //   - Wt_per_core < chunk_size:  the only push size is Wt_per_core
-        //     (no full-sized chunk ever occurs).
-        //
-        // Compute the LCM of only the push sizes that actually occur across
-        // both core groups to avoid unnecessarily inflating the CB allocation.
-        uint32_t negate_cb_tiles = 1;
-        auto include_push_sizes = [&](uint32_t cols_per_core) {
-            if (cols_per_core == 0) {
-                return;
-            }
-            if (cols_per_core >= chunk_size) {
-                negate_cb_tiles = std::lcm(negate_cb_tiles, chunk_size);
-                uint32_t partial = cols_per_core % chunk_size;
-                if (partial > 0) {
-                    negate_cb_tiles = std::lcm(negate_cb_tiles, partial);
-                }
-            } else {
-                negate_cb_tiles = std::lcm(negate_cb_tiles, cols_per_core);
-            }
-        };
-        include_push_sizes(num_cols_per_core_group_1);
-        if (num_cols_per_core_group_2 > 0) {
-            include_push_sizes(num_cols_per_core_group_2);
+        // via push_back(ntiles).  The CB FIFO write pointer only wraps when
+        // wr_ptr exactly reaches fifo_limit, so it is not enough for the CB
+        // size to be a multiple of each individual push size — the cumulative
+        // offset across the inner Ht loop must also wrap to 0 at the end of
+        // each nc iteration.  Per nc, the kernel advances wr_ptr by
+        // Ht * Wt_per_core regardless of how that splits into chunk_size and
+        // partial pushes, so sizing the CB at Ht * Wt_per_core makes the
+        // trajectory land on fifo_limit exactly.  For two core groups, the
+        // single-CB option uses Ht * lcm(Wt_g1, Wt_g2) so the same allocation
+        // works for both groups.
+        const uint32_t compute_Wt_g1 =
+            use_width_sharding ? (NC == 0 ? 0 : num_cols_per_core_group_1 / NC) : num_cols_per_core_group_1;
+        const uint32_t compute_Wt_g2 = use_width_sharding ? 0 : num_cols_per_core_group_2;
+        uint32_t per_nc_advance = 0;
+        if (compute_Wt_g2 == 0) {
+            per_nc_advance = compute_Wt_g1;
+        } else if (compute_Wt_g1 == 0) {
+            per_nc_advance = compute_Wt_g2;
+        } else {
+            per_nc_advance = std::lcm(compute_Wt_g1, compute_Wt_g2);
         }
+        TT_FATAL(
+            per_nc_advance > 0,
+            "Negate H reduce: per-core Wt resolved to 0 (g1={}, g2={}, NC={}, sharded={})",
+            compute_Wt_g1,
+            compute_Wt_g2,
+            NC,
+            use_width_sharding);
+        const uint32_t negate_cb_tiles = Ht * per_nc_advance;
+
+        // L1 fit check: c_4 (acc) and c_5 (ineg) are each sized at
+        // negate_cb_tiles.  If the combined allocation would not fit in the
+        // available L1 budget, the caller is expected to fall back to external
+        // negation — see ttnn::prim::h_reduce_negate_fits_in_l1 in common.cpp,
+        // which mirrors this calculation.
+        const uint64_t negate_cb_bytes = 2ull * negate_cb_tiles * dst_single_tile_size;
+        const auto lowest_address = device->lowest_occupied_compute_l1_address();
+        uint64_t max_l1_space = lowest_address.has_value() ? lowest_address.value() : device->l1_size_per_core();
+        const uint64_t base_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+        TT_FATAL(
+            max_l1_space > base_addr,
+            "Negate H reduce: L1 base allocator address {} >= lowest occupied address {}; no room for CBs",
+            base_addr,
+            max_l1_space);
+        max_l1_space -= base_addr;
+        TT_FATAL(
+            negate_cb_bytes <= max_l1_space,
+            "Negate H reduce: cb_acc + cb_ineg ({} B for {} tiles) would not fit in available L1 ({} B). "
+            "Caller must use h_reduce_negate_fits_in_l1 to choose the external-negate fallback.",
+            negate_cb_bytes,
+            negate_cb_tiles,
+            max_l1_space);
 
         uint32_t acc_cb_index = CBIndex::c_4;
         desc.cbs.push_back(CBDescriptor{

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -4,7 +4,6 @@
 
 #include "reduce_op_device_operation.hpp"
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
-#include "ttnn/operations/reduction/generic/device/common.hpp"
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -12,6 +11,7 @@
 #include <tt-metalium/program_descriptors.hpp>
 #include <bit>
 #include <cmath>
+#include <limits>
 #include <numeric>
 
 namespace ttnn::prim {
@@ -193,14 +193,17 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
             compute_Wt_g2,
             NC,
             use_width_sharding);
-        const uint32_t negate_cb_tiles = Ht * per_nc_advance;
+        // Compute in uint64_t to mirror h_reduce_negate_fits_in_l1 and avoid
+        // uint32_t overflow before the L1 fit check / CB sizing.
+        const uint64_t negate_cb_tiles = static_cast<uint64_t>(Ht) * per_nc_advance;
 
         // L1 fit check: c_4 (acc) and c_5 (ineg) are each sized at
         // negate_cb_tiles.  If the combined allocation would not fit in the
         // available L1 budget, the caller is expected to fall back to external
         // negation — see ttnn::prim::h_reduce_negate_fits_in_l1 in common.cpp,
         // which mirrors this calculation.
-        const uint64_t negate_cb_bytes = 2ull * negate_cb_tiles * dst_single_tile_size;
+        const uint64_t per_cb_bytes = negate_cb_tiles * dst_single_tile_size;
+        const uint64_t negate_cb_bytes = 2ull * per_cb_bytes;
         const auto lowest_address = device->lowest_occupied_compute_l1_address();
         uint64_t max_l1_space = lowest_address.has_value() ? lowest_address.value() : device->l1_size_per_core();
         const uint64_t base_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
@@ -217,10 +220,19 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
             negate_cb_bytes,
             negate_cb_tiles,
             max_l1_space);
+        // CBDescriptor.total_size is uint32_t; the L1 fit check above already
+        // bounds per_cb_bytes by the per-core L1 budget (well under 4 GiB),
+        // but assert the narrowing explicitly so any future budget change
+        // surfaces here instead of producing a silently-truncated CB size.
+        TT_FATAL(
+            per_cb_bytes <= std::numeric_limits<uint32_t>::max(),
+            "Negate H reduce: per-CB size {} B exceeds uint32_t total_size range",
+            per_cb_bytes);
+        const uint32_t per_cb_total_size = static_cast<uint32_t>(per_cb_bytes);
 
         uint32_t acc_cb_index = CBIndex::c_4;
         desc.cbs.push_back(CBDescriptor{
-            .total_size = negate_cb_tiles * dst_single_tile_size,
+            .total_size = per_cb_total_size,
             .core_ranges = all_cores,
             .format_descriptors = {{CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(acc_cb_index),
@@ -231,7 +243,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
 
         uint32_t ineg_cb_index = CBIndex::c_5;
         desc.cbs.push_back(CBDescriptor{
-            .total_size = negate_cb_tiles * dst_single_tile_size,
+            .total_size = per_cb_total_size,
             .core_ranges = all_cores,
             .format_descriptors = {{CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(ineg_cb_index),


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Closes #43742

The first AI fix missed some corner cases that were exposed by new tests being added. This is a new AI fix.

Tested locally that tests pass.

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-43742_red_neg)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-43742_red_neg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-43742_red_neg)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-43742_red_neg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-43742_red_neg)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-43742_red_neg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-43742_red_neg)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-43742_red_neg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-43742_red_neg)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-43742_red_neg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-43742_red_neg)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-43742_red_neg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-43742_red_neg)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-43742_red_neg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-43742_red_neg)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-43742_red_neg)