### PR TITLE
Feature: Fix mock+silicon coexistence via MetalEnv (#38445)

### DIFF
--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -60,11 +60,11 @@
   team: runtime
 
 # --- Context, Device, Misc, JIT Build ---
-# NOTE: unit_tests_noc dropped, mock-coexistence tests filtered (#39849).
+# NOTE: unit_tests_noc dropped.
 - name: runtime_core
   # MetalContextIntegrationTest.Legacy disabled by #44767.
   cmd: |
-    ./build/test/tt_metal/unit_tests_context --gtest_filter='-MetalContextIntegrationTest.MockDeviceOnly:MetalContextIntegrationTest.Coexisting*:MetalContextIntegrationTest.ForkMockAndRealDevice:MetalContextIntegrationTest.Legacy'
+    ./build/test/tt_metal/unit_tests_context --gtest_filter='-MetalContextIntegrationTest.Legacy'
     ./build/test/tt_metal/unit_tests_device
     ./build/test/tt_metal/unit_tests_misc
     ./build/test/tt_metal/unit_tests_jit_build

--- a/tests/tt_metal/tt_metal/context/test_integration.cpp
+++ b/tests/tt_metal/tt_metal/context/test_integration.cpp
@@ -82,8 +82,12 @@ void PerformDeviceWork(
 
     auto program = CreateProgram();
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    auto core_grid = mesh_device->compute_with_storage_grid_size();
-    auto core_range = CoreRange({0, 0}, {core_grid.x - 1, core_grid.y - 1});
+    // Use a single worker core. Spanning the full compute_with_storage grid hits worker-dispatch
+    // cores under fast-dispatch + WORKER dispatch (e.g. wh_n150 CI runners), and program-compile
+    // rejects kernels placed on dispatch cores. (0,0) is universally a worker compute core under
+    // every tt-metal dispatch configuration. A no-op kernel only needs to validate the
+    // create / JIT / dispatch pipeline, so one core is sufficient.
+    auto core_range = CoreRange({0, 0}, {0, 0});
 
     std::string kernel_src = "void kernel_main() {\n    // " + kernel_identifier + "\n}";
 
@@ -231,8 +235,8 @@ TEST(MetalContextIntegrationTest, MockDeviceOnly) {
 
         auto program = CreateProgram();
         distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mock_device->shape());
-        auto core_grid = mock_device->compute_with_storage_grid_size();
-        auto core_range = CoreRange({0, 0}, {core_grid.x - 1, core_grid.y - 1});
+        // Single worker core; see comment in RunChildWithVisibleDevices above.
+        auto core_range = CoreRange({0, 0}, {0, 0});
 
         CreateKernelFromString(program, "void kernel_main() {}", core_range, DataMovementConfig{});
 
@@ -280,8 +284,8 @@ TEST(MetalContextIntegrationTest, CoexistingSiliconAndMockDevice) {
     auto run_noop_program = [](distributed::MeshDevice& target, const std::string& label) {
         auto program = CreateProgram();
         distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(target.shape());
-        auto core_grid = target.compute_with_storage_grid_size();
-        auto core_range = CoreRange({0, 0}, {core_grid.x - 1, core_grid.y - 1});
+        // Single worker core; see comment in RunChildWithVisibleDevices above.
+        auto core_range = CoreRange({0, 0}, {0, 0});
 
         CreateKernelFromString(program, "void kernel_main() {}", core_range, DataMovementConfig{});
 
@@ -330,8 +334,8 @@ TEST(MetalContextIntegrationTest, CoexistingMockAndSiliconDevice) {
     auto run_noop_program = [](distributed::MeshDevice& target, const std::string& label) {
         auto program = CreateProgram();
         distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(target.shape());
-        auto core_grid = target.compute_with_storage_grid_size();
-        auto core_range = CoreRange({0, 0}, {core_grid.x - 1, core_grid.y - 1});
+        // Single worker core; see comment in RunChildWithVisibleDevices above.
+        auto core_range = CoreRange({0, 0}, {0, 0});
 
         CreateKernelFromString(program, "void kernel_main() {}", core_range, DataMovementConfig{});
 

--- a/tests/tt_metal/tt_metal/context/test_integration.cpp
+++ b/tests/tt_metal/tt_metal/context/test_integration.cpp
@@ -229,22 +229,16 @@ TEST(MetalContextIntegrationTest, MockDeviceOnly) {
         std::vector<uint32_t> read_data;
         distributed::EnqueueReadMeshBuffer(cq, read_data, buffer, true);
 
-        // TODO: Uncomment this once CreateProgram and CreateKernel stop implicitly creating the physical metal context
-        // https://github.com/tenstorrent/tt-metal/issues/39849
-        // auto program = CreateProgram();
-        // distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mock_device->shape());
-        // auto core_grid = mock_device->compute_with_storage_grid_size();
-        // auto core_range = CoreRange({0, 0}, {core_grid.x - 1, core_grid.y - 1});
+        auto program = CreateProgram();
+        distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mock_device->shape());
+        auto core_grid = mock_device->compute_with_storage_grid_size();
+        auto core_range = CoreRange({0, 0}, {core_grid.x - 1, core_grid.y - 1});
 
-        // CreateKernelFromString(
-        //     program,
-        //     "void kernel_main() {}",
-        //     core_range,
-        //     DataMovementConfig{});
+        CreateKernelFromString(program, "void kernel_main() {}", core_range, DataMovementConfig{});
 
-        // distributed::MeshWorkload workload;
-        // workload.add_program(device_range, std::move(program));
-        // distributed::EnqueueMeshWorkload(cq, workload, true);
+        distributed::MeshWorkload workload;
+        workload.add_program(device_range, std::move(program));
+        distributed::EnqueueMeshWorkload(cq, workload, true);
     }
 
     // Assert that we didn't implicitly create the physical metal context
@@ -279,6 +273,26 @@ TEST(MetalContextIntegrationTest, CoexistingSiliconAndMockDevice) {
 
     ASSERT_EQ(mock_mesh_device_bh_1->get_devices().size(), 1);
     ASSERT_EQ(mock_mesh_device_bh_2->get_devices().size(), 2);
+
+    // Run a no-op program on both the mock and silicon devices side-by-side. This exercises the
+    // full create-program / create-kernel / JIT-compile / enqueue-workload pipeline through both
+    // contexts in the same process to validate mock+silicon coexistence (issue #38445).
+    auto run_noop_program = [](distributed::MeshDevice& target, const std::string& label) {
+        auto program = CreateProgram();
+        distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(target.shape());
+        auto core_grid = target.compute_with_storage_grid_size();
+        auto core_range = CoreRange({0, 0}, {core_grid.x - 1, core_grid.y - 1});
+
+        CreateKernelFromString(program, "void kernel_main() {}", core_range, DataMovementConfig{});
+
+        distributed::MeshWorkload workload;
+        workload.add_program(device_range, std::move(program));
+        distributed::EnqueueMeshWorkload(target.mesh_command_queue(), workload, true);
+        log_info(tt::LogTest, "Successfully enqueued no-op program on {}", label);
+    };
+
+    run_noop_program(*mock_mesh_device_bh_1, "mock_mesh_device_bh_1");
+    run_noop_program(*mesh_device, "silicon_mesh_device");
 }
 
 // Same test as above but reverse the order to ensure no hangs due to unexpected internal objects created for the
@@ -309,6 +323,26 @@ TEST(MetalContextIntegrationTest, CoexistingMockAndSiliconDevice) {
 
     ASSERT_EQ(mock_mesh_device_bh_1->get_devices().size(), 1);
     ASSERT_EQ(mock_mesh_device_bh_2->get_devices().size(), 2);
+
+    // Run a no-op program on both the silicon and mock devices in this reversed-creation-order
+    // case to confirm the JIT/compile/enqueue pipeline does not depend on which context was
+    // opened first.
+    auto run_noop_program = [](distributed::MeshDevice& target, const std::string& label) {
+        auto program = CreateProgram();
+        distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(target.shape());
+        auto core_grid = target.compute_with_storage_grid_size();
+        auto core_range = CoreRange({0, 0}, {core_grid.x - 1, core_grid.y - 1});
+
+        CreateKernelFromString(program, "void kernel_main() {}", core_range, DataMovementConfig{});
+
+        distributed::MeshWorkload workload;
+        workload.add_program(device_range, std::move(program));
+        distributed::EnqueueMeshWorkload(target.mesh_command_queue(), workload, true);
+        log_info(tt::LogTest, "Successfully enqueued no-op program on {}", label);
+    };
+
+    run_noop_program(*mesh_device, "silicon_mesh_device");
+    run_noop_program(*mock_mesh_device_bh_1, "mock_mesh_device_bh_1");
 }
 
 TEST(MetalContextIntegrationTest, ForkMockAndRealDevice) {

--- a/tests/tt_metal/tt_metal/context/test_integration.cpp
+++ b/tests/tt_metal/tt_metal/context/test_integration.cpp
@@ -82,11 +82,9 @@ void PerformDeviceWork(
 
     auto program = CreateProgram();
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    // Use a single worker core. Spanning the full compute_with_storage grid hits worker-dispatch
-    // cores under fast-dispatch + WORKER dispatch (e.g. wh_n150 CI runners), and program-compile
-    // rejects kernels placed on dispatch cores. (0,0) is universally a worker compute core under
-    // every tt-metal dispatch configuration. A no-op kernel only needs to validate the
-    // create / JIT / dispatch pipeline, so one core is sufficient.
+    // A no-op kernel only validates the create / JIT / dispatch pipeline,
+    // so a single worker core is sufficient. (0, 0) is always a logical
+    // compute core regardless of dispatch-core configuration.
     auto core_range = CoreRange({0, 0}, {0, 0});
 
     std::string kernel_src = "void kernel_main() {\n    // " + kernel_identifier + "\n}";
@@ -222,11 +220,13 @@ TEST(MetalContextIntegrationTest, MockDeviceOnly) {
         buffer->deallocate();
         ASSERT_FALSE(buffer->is_allocated());
 
-        // Test command queue operations
+        // Test command queue operations. Source vector is sized to fill the entire buffer so
+        // EnqueueWriteMeshBuffer's precondition (src bytes >= mesh buffer bytes, added in #43429)
+        // is satisfied; the prior 16-element vector was a pre-#43429 leftover.
         auto& cq = mock_device->mesh_command_queue();
-        constexpr size_t num_elements = 16;
+        constexpr size_t num_elements = buffer_size / sizeof(uint32_t);
         std::vector<uint32_t> write_data(num_elements);
-        std::iota(write_data.begin(), write_data.end(), 0xDEADBEEF);
+        std::iota(write_data.begin(), write_data.end(), 0xDEADBEEFu);
 
         distributed::EnqueueWriteMeshBuffer(cq, buffer, write_data, true);
 
@@ -235,7 +235,7 @@ TEST(MetalContextIntegrationTest, MockDeviceOnly) {
 
         auto program = CreateProgram();
         distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mock_device->shape());
-        // Single worker core; see comment in RunChildWithVisibleDevices above.
+        // Single worker core; see comment in PerformDeviceWork.
         auto core_range = CoreRange({0, 0}, {0, 0});
 
         CreateKernelFromString(program, "void kernel_main() {}", core_range, DataMovementConfig{});
@@ -298,7 +298,7 @@ TEST(MetalContextIntegrationTest, CoexistingSiliconAndMockDevice) {
     auto run_noop_program = [](distributed::MeshDevice& target, const std::string& label) {
         auto program = CreateProgram();
         distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(target.shape());
-        // Single worker core; see comment in RunChildWithVisibleDevices above.
+        // Single worker core; see comment in PerformDeviceWork.
         auto core_range = CoreRange({0, 0}, {0, 0});
 
         CreateKernelFromString(program, "void kernel_main() {}", core_range, DataMovementConfig{});
@@ -349,7 +349,7 @@ TEST(MetalContextIntegrationTest, CoexistingMockAndSiliconDevice) {
     auto run_noop_program = [](distributed::MeshDevice& target, const std::string& label) {
         auto program = CreateProgram();
         distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(target.shape());
-        // Single worker core; see comment in RunChildWithVisibleDevices above.
+        // Single worker core; see comment in PerformDeviceWork.
         auto core_range = CoreRange({0, 0}, {0, 0});
 
         CreateKernelFromString(program, "void kernel_main() {}", core_range, DataMovementConfig{});

--- a/tests/tt_metal/tt_metal/context/test_integration.cpp
+++ b/tests/tt_metal/tt_metal/context/test_integration.cpp
@@ -253,20 +253,34 @@ TEST(MetalContextIntegrationTest, MockDeviceOnly) {
 }
 
 TEST(MetalContextIntegrationTest, CoexistingSiliconAndMockDevice) {
-    // Create mock mesh device with 1 blackhole chip
-    MetalEnv mock_env_bh_1{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 1))};
-    auto mock_mesh_shape_bh_1 = mock_env_bh_1.get_system_mesh().shape();
-    auto mock_mesh_device_config_bh_1 = distributed::MeshDeviceConfig(mock_mesh_shape_bh_1);
-    std::shared_ptr<distributed::MeshDevice> mock_mesh_device_bh_1 =
-        mock_env_bh_1.create_mesh_device(mock_mesh_device_config_bh_1);
-    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_bh_1->shape().dims());
+    // BuildEnvManager is a process-global singleton whose kernel/firmware build-state index tables
+    // are sized once from the HAL of whichever context first triggers add_build_env(). When the
+    // mock arch differs from the silicon arch (e.g. mock-BH on a WH runner), the second context
+    // ends up indexing a wrong-sized table and JIT'd kernels reference incorrect dispatch
+    // addresses, causing silicon dispatch to hang. Forge's real flow is same-arch coexistence
+    // (mock used as a compile-time stand-in for the live silicon), so probe the silicon arch and
+    // create the mock to match. Cross-arch coexistence is a separate `BuildEnvManager`-singleton
+    // limitation tracked outside #38445.
+    tt::ARCH silicon_arch;
+    {
+        MetalEnv probe;
+        silicon_arch = probe.get_arch();
+    }
 
-    // Create mock mesh device with 2 blackhole chips
-    MetalEnv mock_env_bh_2{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 2))};
-    auto mock_mesh_shape_bh_2 = mock_env_bh_2.get_system_mesh().shape();
-    auto mock_mesh_device_config_bh_2 = distributed::MeshDeviceConfig(mock_mesh_shape_bh_2);
-    auto mock_mesh_device_bh_2 = mock_env_bh_2.create_mesh_device(mock_mesh_device_config_bh_2);
-    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_bh_2->shape().dims());
+    // Create mock mesh device with 1 chip on the silicon arch
+    MetalEnv mock_env_1{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(silicon_arch, 1))};
+    auto mock_mesh_shape_1 = mock_env_1.get_system_mesh().shape();
+    auto mock_mesh_device_config_1 = distributed::MeshDeviceConfig(mock_mesh_shape_1);
+    std::shared_ptr<distributed::MeshDevice> mock_mesh_device_1 =
+        mock_env_1.create_mesh_device(mock_mesh_device_config_1);
+    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_1->shape().dims());
+
+    // Create mock mesh device with 2 chips on the silicon arch
+    MetalEnv mock_env_2{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(silicon_arch, 2))};
+    auto mock_mesh_shape_2 = mock_env_2.get_system_mesh().shape();
+    auto mock_mesh_device_config_2 = distributed::MeshDeviceConfig(mock_mesh_shape_2);
+    auto mock_mesh_device_2 = mock_env_2.create_mesh_device(mock_mesh_device_config_2);
+    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_2->shape().dims());
 
     // Create silicon mesh
     MetalEnv env;
@@ -275,8 +289,8 @@ TEST(MetalContextIntegrationTest, CoexistingSiliconAndMockDevice) {
     std::shared_ptr<distributed::MeshDevice> mesh_device = env.create_mesh_device(mesh_device_config);
     log_info(tt::LogTest, "Created silicon mesh device with shape {}", mesh_device->shape().dims());
 
-    ASSERT_EQ(mock_mesh_device_bh_1->get_devices().size(), 1);
-    ASSERT_EQ(mock_mesh_device_bh_2->get_devices().size(), 2);
+    ASSERT_EQ(mock_mesh_device_1->get_devices().size(), 1);
+    ASSERT_EQ(mock_mesh_device_2->get_devices().size(), 2);
 
     // Run a no-op program on both the mock and silicon devices side-by-side. This exercises the
     // full create-program / create-kernel / JIT-compile / enqueue-workload pipeline through both
@@ -295,38 +309,39 @@ TEST(MetalContextIntegrationTest, CoexistingSiliconAndMockDevice) {
         log_info(tt::LogTest, "Successfully enqueued no-op program on {}", label);
     };
 
-    run_noop_program(*mock_mesh_device_bh_1, "mock_mesh_device_bh_1");
+    run_noop_program(*mock_mesh_device_1, "mock_mesh_device_1");
     run_noop_program(*mesh_device, "silicon_mesh_device");
 }
 
 // Same test as above but reverse the order to ensure no hangs due to unexpected internal objects created for the
-// incorrect context id
+// incorrect context id. See `CoexistingSiliconAndMockDevice` for why mock arch is matched to silicon arch.
 TEST(MetalContextIntegrationTest, CoexistingMockAndSiliconDevice) {
     // Create silicon mesh
     MetalEnv silicon_env;
+    const tt::ARCH silicon_arch = silicon_env.get_arch();
 
     auto mesh_shape = silicon_env.get_system_mesh().shape();
     auto mesh_device_config = distributed::MeshDeviceConfig(mesh_shape);
     std::shared_ptr<distributed::MeshDevice> mesh_device = silicon_env.create_mesh_device(mesh_device_config);
     log_info(tt::LogTest, "Created silicon mesh device with shape {}", mesh_device->shape().dims());
 
-    // Create mock mesh device with 1 blackhole chip
-    MetalEnv mock_env_bh_1{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 1))};
-    auto mock_mesh_shape_bh_1 = mock_env_bh_1.get_system_mesh().shape();
-    auto mock_mesh_device_config_bh_1 = distributed::MeshDeviceConfig(mock_mesh_shape_bh_1);
-    auto mock_mesh_device_bh_1 = mock_env_bh_1.create_mesh_device(mock_mesh_device_config_bh_1);
-    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_bh_1->shape().dims());
+    // Create mock mesh device with 1 chip on the silicon arch
+    MetalEnv mock_env_1{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(silicon_arch, 1))};
+    auto mock_mesh_shape_1 = mock_env_1.get_system_mesh().shape();
+    auto mock_mesh_device_config_1 = distributed::MeshDeviceConfig(mock_mesh_shape_1);
+    auto mock_mesh_device_1 = mock_env_1.create_mesh_device(mock_mesh_device_config_1);
+    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_1->shape().dims());
 
-    // Create mock mesh device with 2 blackhole chips
-    MetalEnv mock_env_bh_2{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 2))};
+    // Create mock mesh device with 2 chips on the silicon arch
+    MetalEnv mock_env_2{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(silicon_arch, 2))};
 
-    auto mock_mesh_shape_bh_2 = mock_env_bh_2.get_system_mesh().shape();
-    auto mock_mesh_device_config_bh_2 = distributed::MeshDeviceConfig(mock_mesh_shape_bh_2);
-    auto mock_mesh_device_bh_2 = mock_env_bh_2.create_mesh_device(mock_mesh_device_config_bh_2);
-    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_bh_2->shape().dims());
+    auto mock_mesh_shape_2 = mock_env_2.get_system_mesh().shape();
+    auto mock_mesh_device_config_2 = distributed::MeshDeviceConfig(mock_mesh_shape_2);
+    auto mock_mesh_device_2 = mock_env_2.create_mesh_device(mock_mesh_device_config_2);
+    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_2->shape().dims());
 
-    ASSERT_EQ(mock_mesh_device_bh_1->get_devices().size(), 1);
-    ASSERT_EQ(mock_mesh_device_bh_2->get_devices().size(), 2);
+    ASSERT_EQ(mock_mesh_device_1->get_devices().size(), 1);
+    ASSERT_EQ(mock_mesh_device_2->get_devices().size(), 2);
 
     // Run a no-op program on both the silicon and mock devices in this reversed-creation-order
     // case to confirm the JIT/compile/enqueue pipeline does not depend on which context was
@@ -346,7 +361,7 @@ TEST(MetalContextIntegrationTest, CoexistingMockAndSiliconDevice) {
     };
 
     run_noop_program(*mesh_device, "silicon_mesh_device");
-    run_noop_program(*mock_mesh_device_bh_1, "mock_mesh_device_bh_1");
+    run_noop_program(*mock_mesh_device_1, "mock_mesh_device_1");
 }
 
 TEST(MetalContextIntegrationTest, ForkMockAndRealDevice) {

--- a/tt_metal/api/tt-metalium/experimental/mock_device.hpp
+++ b/tt_metal/api/tt-metalium/experimental/mock_device.hpp
@@ -41,4 +41,19 @@ bool is_mock_mode_registered();
 // Returns just the filename (e.g., "blackhole_P150.yaml"), caller prepends base path
 std::optional<std::string> get_mock_cluster_desc();
 
+// Get the cluster descriptor filename for a specific (arch, num_chips) pair.
+// Returns nullopt if the configuration is not supported.
+//
+// This is the recommended way to construct a MetalEnvDescriptor for a mock cluster
+// without going through the global configure_mock_mode() flag, e.g.:
+//
+//     MetalEnv mock_env(MetalEnvDescriptor(
+//         experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 1).value()));
+//
+// Supported configurations (see implementation for the authoritative list):
+//   WORMHOLE_B0: 1, 2, 4, 8
+//   BLACKHOLE:   1, 2
+//   QUASAR:      1
+std::optional<std::string> get_mock_cluster_desc_name(tt::ARCH arch, uint32_t num_chips);
+
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/mock_device.hpp
+++ b/tt_metal/api/tt-metalium/experimental/mock_device.hpp
@@ -51,8 +51,8 @@ std::optional<std::string> get_mock_cluster_desc();
 //         experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 1).value()));
 //
 // Supported configurations (see implementation for the authoritative list):
-//   WORMHOLE_B0: 1, 2, 4, 8
-//   BLACKHOLE:   1, 2
+//   WORMHOLE_B0: 1, 2, 4, 8, 32
+//   BLACKHOLE:   1, 2, 4, 8       (32-chip descriptor not yet checked in)
 //   QUASAR:      1
 std::optional<std::string> get_mock_cluster_desc_name(tt::ARCH arch, uint32_t num_chips);
 

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -97,26 +97,43 @@ struct RealtimeProfilerEligibility {
 };
 
 // Consolidated eligibility check; logs the reason for disabling and returns
-// {enabled=false} on failure. Checks (in order):
-//   1. Device is not a mock.
-//   2. Device is MMIO-capable (D2H sockets need a PCIe-connected sender core).
-//   3. D2H socket memory-allocation path is supported (64-bit PCIe addressing requires IOMMU).
-//   4. Fabric tensix datamover (MUX / UDM) is disabled (it competes for the same dispatch pool).
-//   5. A tensix core was reserved for the RT profiler at dispatch_core_manager construction.
-//   6. Reserved coordinate lives inside the logical TENSIX grid.
-//   7. Kernels are not nullified (DEBUG_NULL_KERNELS / TT_METAL_NULL_KERNELS).
-//   8. Reserved profiler core's L1 bank fits the ring + socket-config layout.
-RealtimeProfilerEligibility evaluate_realtime_profiler_eligibility(IDevice* device) {
+// {enabled=false} on failure.
+//
+// Evaluates against the device's owning context (passed in as `context_id`) rather than
+// bare MetalContext::instance(): the latter would route through the inline non-default
+// fallback in instance() and pick whichever context happens to populate the global
+// lookup first. In silicon-first coexistence (#38445), that fallback returns the silicon
+// DEFAULT_CONTEXT_ID even when `device` is a mock device, falsely enabling the profiler
+// on mock and SEGV'ing in LaunchProgram. See #39849.
+//
+// Checks (in order):
+//   0. Target is not mock or emulated (extends #43968's Mock-only short-circuit to also
+//      cover Emule; D2HSocket requires a real PCIe hugepage in either case).
+//   1. Device is MMIO-capable (D2H sockets need a PCIe-connected sender core).
+//   2. D2H socket memory-allocation path is supported (64-bit PCIe addressing requires IOMMU).
+//   3. Fabric tensix datamover (MUX / UDM) is disabled (it competes for the same dispatch pool).
+//   4. A tensix core was reserved for the RT profiler at dispatch_core_manager construction.
+//   5. Reserved coordinate lives inside the logical TENSIX grid.
+//   6. Kernels are not nullified (DEBUG_NULL_KERNELS / TT_METAL_NULL_KERNELS).
+//   7. Reserved profiler core's L1 bank fits the ring + socket-config layout.
+RealtimeProfilerEligibility evaluate_realtime_profiler_eligibility(IDevice* device, ContextId context_id) {
     auto device_id = device->id();
-    auto& metal = MetalContext::instance();
+    auto& metal = MetalContext::instance(context_id);
     const auto& hal = metal.hal();
     const auto& cluster = metal.get_cluster();
     auto& dispatch_core_manager = metal.get_dispatch_core_manager();
 
-    if (cluster.get_target_device_type() == tt::TargetDevice::Mock) {
-        log_debug(tt::LogMetal,
-                  "Real-time profiler disabled on device {}: target is mock.",
-                  device_id);
+    // Subsumes the Mock-only short-circuit added in #43968: is_mock_or_emulated() also
+    // catches Emule, and is the canonical accessor used throughout metal_context.cpp /
+    // device.cpp. D2HSocket::init_host_buffer_hugepage dereferences a real PCIe hugepage
+    // and faults on either target, so gate here before any per-device profiler state is
+    // constructed.
+    if (cluster.is_mock_or_emulated()) {
+        log_debug(
+            tt::LogMetal,
+            "Real-time profiler disabled on device {}: target is mock or emulated; D2H sockets "
+            "require a real PCIe hugepage that is not present in mock/emulated flows.",
+            device_id);
         return {};
     }
 
@@ -297,14 +314,15 @@ RealtimeProfilerManager::DeviceState::DeviceState(DeviceState&& o) noexcept :
     last_finish_sync_at(o.last_finish_sync_at),
     pending_first_unthrottled_finish_sync(o.pending_first_unthrottled_finish_sync) {}
 
-RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevice>& mesh_device) {
+RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevice>& mesh_device) :
+    context_id_(mesh_device->impl().get_context_id()) {
     // HAL offsets are the same for all devices (same arch).
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = MetalContext::instance(context_id_).hal();
     const auto& factory = hal.get_realtime_profiler_msgs_factory(HalProgrammableCoreType::TENSIX);
     // realtime_profiler_msg_t lives in a dispatch-core-local L1 region assigned by
     // CommandQueueDeviceAddrType::REALTIME_PROFILER_MSG (only reachable on dispatch cores
     // and the reserved RT-profiler tensix).
-    const auto& dispatch_mem_map = MetalContext::instance().dispatch_mem_map();
+    const auto& dispatch_mem_map = MetalContext::instance(context_id_).dispatch_mem_map();
     const uint32_t realtime_profiler_base_addr =
         dispatch_mem_map.get_device_command_queue_addr(CommandQueueDeviceAddrType::REALTIME_PROFILER_MSG);
     // RealtimeProfilerCoreL1 (ring + D2H socket sender config) sits past the dispatch
@@ -331,7 +349,7 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
         realtime_profiler_msgs::realtime_profiler_msg_t::Field::sync_host_timestamp);
     uint32_t profiler_msg_config_field_addr = realtime_profiler_base_addr + config_buffer_addr_offset;
 
-    auto& dispatch_core_manager = MetalContext::instance().get_dispatch_core_manager();
+    auto& dispatch_core_manager = MetalContext::instance(context_id_).get_dispatch_core_manager();
     const std::string realtime_profiler_kernel_path = "tt_metal/impl/dispatch/kernels/cq_realtime_profiler.cpp";
     const std::string realtime_profiler_push_kernel_path =
         "tt_metal/impl/dispatch/kernels/cq_realtime_profiler_push.cpp";
@@ -344,9 +362,9 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
         IDevice* device = mesh_device->get_device(coord);
         auto device_id = device->id();
 
-        auto eligibility = evaluate_realtime_profiler_eligibility(device);
+        auto eligibility = evaluate_realtime_profiler_eligibility(device, context_id_);
         if (!eligibility.enabled) {
-            MetalContext::instance().device_manager()->mark_rt_profiler_device_init_complete(device_id);
+            MetalContext::instance(context_id_).device_manager()->mark_rt_profiler_device_init_complete(device_id);
             continue;
         }
         CoreCoord realtime_profiler_core = eligibility.core;
@@ -398,7 +416,7 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
                 "profiler on this device.",
                 device_id,
                 e.what());
-            MetalContext::instance().device_manager()->mark_rt_profiler_device_init_complete(device_id);
+            MetalContext::instance(context_id_).device_manager()->mark_rt_profiler_device_init_complete(device_id);
             continue;
         }
 
@@ -466,8 +484,8 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
         uint32_t pcie_noc_y = 0;
         bool need_pcie_noc_defines = false;
         {
-            const auto& cluster = MetalContext::instance().get_cluster();
-            auto arch = MetalContext::instance().hal().get_arch();
+            const auto& cluster = MetalContext::instance(context_id_).get_cluster();
+            auto arch = MetalContext::instance(context_id_).hal().get_arch();
             if (arch == tt::ARCH::WORMHOLE_B0) {
                 ChipId mmio_device_id = cluster.get_associated_mmio_device(device_id);
                 const auto& soc = cluster.get_soc_desc(mmio_device_id);
@@ -576,7 +594,7 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
                 config_buffer_addr);
         }
 
-        MetalContext::instance().device_manager()->mark_rt_profiler_device_init_complete(device_id);
+        MetalContext::instance(context_id_).device_manager()->mark_rt_profiler_device_init_complete(device_id);
         devices_.push_back(std::move(dev_state));
     }
 
@@ -591,7 +609,7 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
         tt::NotifyProgramRealtimeProfilerActivated(dev_state.chip_id);
     }
 
-    auto& cluster = MetalContext::instance().get_cluster();
+    auto& cluster = MetalContext::instance(context_id_).get_cluster();
     const auto init_throttle_now = std::chrono::steady_clock::now();
     std::vector<bool> skip_init_sync_check(devices_.size(), false);
     std::vector<size_t> init_run_sync_indices;
@@ -930,7 +948,7 @@ void RealtimeProfilerManager::shutdown() {
 }
 
 void RealtimeProfilerManager::run_sync(DeviceState& dev_state, uint32_t num_samples) {
-    auto& cluster = MetalContext::instance().get_cluster();
+    auto& cluster = MetalContext::instance(context_id_).get_cluster();
     int64_t host_start_time = rt_profiler_host_ticks();
 
     struct SyncSample {

--- a/tt_metal/distributed/realtime_profiler_manager.hpp
+++ b/tt_metal/distributed/realtime_profiler_manager.hpp
@@ -16,6 +16,8 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 
+#include "context/context_types.hpp"
+
 namespace tt::tt_metal {
 
 class IDevice;
@@ -117,6 +119,12 @@ private:
 
     void run_sync(DeviceState& dev_state, uint32_t num_samples);
 
+    // ContextId of the owning MeshDevice, captured in the constructor. All MetalContext
+    // accesses inside this manager must go through MetalContext::instance(context_id_)
+    // so a non-default (mock / coexistence) context routes through its own HAL, cluster
+    // and dispatch_mem_map instead of leaking to the silicon DEFAULT_CONTEXT_ID via the
+    // bare instance() inline fallback. See #38445 / #39849 for the broader migration.
+    ContextId context_id_;
     std::vector<DeviceState> devices_;
     std::thread receiver_thread_;
     std::atomic<bool> stop_{false};

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -372,6 +372,18 @@ bool MetalContext::instance_exists(ContextId context_id) {
     return g_instances[context_id.get()].load(std::memory_order_acquire) != nullptr;
 }
 
+MetalContext* MetalContext::find_any_existing_instance() {
+    if (auto* instance = g_instances[DEFAULT_CONTEXT_ID.get()].load(std::memory_order_acquire)) {
+        return instance;
+    }
+    for (int index = DEFAULT_CONTEXT_ID.get() + 1; index < MAX_CONTEXT_COUNT; ++index) {
+        if (auto* instance = g_instances[index].load(std::memory_order_acquire)) {
+            return instance;
+        }
+    }
+    return nullptr;
+}
+
 MetalContext& MetalContext::instance(ContextId context_id) {
     check_context_id(context_id);
     int index = context_id.get();
@@ -386,11 +398,22 @@ MetalContext& MetalContext::instance(ContextId context_id) {
     // Check again in case another thread created the instance while we were waiting for the lock.
     instance = g_instances[index].load(std::memory_order_acquire);
     if (!instance) {
-        // SILICON_CONTEXT_ID is implicitly created to match legacy behaviour
+        // SILICON_CONTEXT_ID is implicitly created to match legacy behaviour.
         TT_FATAL(
             context_id == DEFAULT_CONTEXT_ID,
             "No MetalContext instance for context_id {}. Create one via create_instance().",
             context_id);
+        // If a non-default context already exists (e.g. a mock cluster context owned by a MetalEnv),
+        // return it rather than implicitly opening the silicon default. This unblocks mock-only and
+        // coexistence flows for callers that still use the bare MetalContext::instance() API
+        // (program/kernel construction, JIT helpers, debug tools, etc.) without forcing every call
+        // site to be migrated to the explicit ContextId form (#39849). The silicon default is only
+        // auto-created when no other context exists, preserving legacy single-cluster behavior.
+        for (int i = DEFAULT_CONTEXT_ID.get() + 1; i < MAX_CONTEXT_COUNT; ++i) {
+            if (auto* existing = g_instances[i].load(std::memory_order_acquire)) {
+                return *existing;
+            }
+        }
         create_default_instance_implicit_locked();
         register_handlers_locked();
         instance = g_instances[DEFAULT_CONTEXT_ID.get()].load(std::memory_order_acquire);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -27,6 +27,7 @@
 #include "core_coord.hpp"
 #include "device/firmware/risc_firmware_initializer.hpp"
 #include "dispatch/dispatch_settings.hpp"
+#include "jit_build/build_env_manager.hpp"
 #include "hal_types.hpp"
 #include "fabric/fabric_host_utils.hpp"
 #include "debug/dprint_server.hpp"
@@ -372,18 +373,6 @@ bool MetalContext::instance_exists(ContextId context_id) {
     return g_instances[context_id.get()].load(std::memory_order_acquire) != nullptr;
 }
 
-MetalContext* MetalContext::find_any_existing_instance() {
-    if (auto* instance = g_instances[DEFAULT_CONTEXT_ID.get()].load(std::memory_order_acquire)) {
-        return instance;
-    }
-    for (int index = DEFAULT_CONTEXT_ID.get() + 1; index < MAX_CONTEXT_COUNT; ++index) {
-        if (auto* instance = g_instances[index].load(std::memory_order_acquire)) {
-            return instance;
-        }
-    }
-    return nullptr;
-}
-
 MetalContext& MetalContext::instance(ContextId context_id) {
     check_context_id(context_id);
     int index = context_id.get();
@@ -403,12 +392,18 @@ MetalContext& MetalContext::instance(ContextId context_id) {
             context_id == DEFAULT_CONTEXT_ID,
             "No MetalContext instance for context_id {}. Create one via create_instance().",
             context_id);
-        // If a non-default context already exists (e.g. a mock cluster context owned by a MetalEnv),
-        // return it rather than implicitly opening the silicon default. This unblocks mock-only and
-        // coexistence flows for callers that still use the bare MetalContext::instance() API
-        // (program/kernel construction, JIT helpers, debug tools, etc.) without forcing every call
-        // site to be migrated to the explicit ContextId form (#39849). The silicon default is only
-        // auto-created when no other context exists, preserving legacy single-cluster behavior.
+        // Internal-only bridge for legacy bare MetalContext::instance() callers (~hundreds
+        // across tt_metal/, kernel.cpp, program.cpp, dispatch.cpp, etc.) in mock-only or
+        // coexistence flows: if no default context exists yet but a non-default does
+        // (e.g. a mock cluster context owned by a MetalEnv), return that one instead of
+        // implicitly opening the silicon default. The silicon default is only auto-created
+        // when no other context exists at all, preserving legacy single-cluster behaviour.
+        //
+        // This fallback is intentionally not exposed as a public API (#38445 review):
+        // every public-API caller that needs a specific cluster's context must request it
+        // explicitly via MetalContext::instance(ContextId). The fallback exists only as a
+        // bridge until those legacy bare callers migrate to the explicit form, tracked as
+        // the per-context refactor of #38445.
         for (int i = DEFAULT_CONTEXT_ID.get() + 1; i < MAX_CONTEXT_COUNT; ++i) {
             if (auto* existing = g_instances[i].load(std::memory_order_acquire)) {
                 return *existing;
@@ -437,6 +432,10 @@ ContextId MetalContext::create_default_instance_implicit_locked() {
     instance->env_owned_ = true;
 
     g_instances[DEFAULT_CONTEXT_ID.get()].store(instance, std::memory_order_release);
+    // Seed the process-wide BuildEnvManager singleton with this context's HAL on first call,
+    // no-op thereafter. Using the by-HAL form (rather than get_instance(ContextId)) avoids
+    // re-entering MetalContext::instance() while we hold g_instance_mutex.
+    BuildEnvManager::seed_if_unseeded_with_hal(instance->hal());
     return DEFAULT_CONTEXT_ID;
 }
 
@@ -451,12 +450,16 @@ ContextId MetalContext::create_instance(MetalEnv& env_to_use) {
         }
         MetalContext* instance = new MetalContext(DEFAULT_CONTEXT_ID, env_to_use);
         g_instances[DEFAULT_CONTEXT_ID.get()].store(instance, std::memory_order_release);
+        // Seed the process-wide BuildEnvManager with this context's HAL on first call.
+        // By-HAL form avoids re-entering MetalContext::instance() while holding g_instance_mutex.
+        BuildEnvManager::seed_if_unseeded_with_hal(instance->hal());
         return DEFAULT_CONTEXT_ID;
     }
 
     ContextId context_id = find_free_context_id_locked();
     MetalContext* instance = new MetalContext(context_id, env_to_use);
     g_instances[context_id.get()].store(instance, std::memory_order_release);
+    BuildEnvManager::seed_if_unseeded_with_hal(instance->hal());
     return context_id;
 }
 

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -73,6 +73,13 @@ public:
     // Check if a MetalContext for a given context id exists.
     static bool instance_exists(ContextId context_id = DEFAULT_CONTEXT_ID);
 
+    // Returns a pointer to any existing MetalContext instance, or nullptr if none exist.
+    // Prefers DEFAULT_CONTEXT_ID; otherwise returns the first non-null slot.
+    // IMPORTANT: Unlike instance(), this NEVER triggers implicit creation of the silicon
+    // default context. Use this from process-wide singletons (e.g. BuildEnvManager) that
+    // need read-only HAL/arch information without forcing a particular cluster to open.
+    static MetalContext* find_any_existing_instance();
+
     // Returns the id of this instance. The ID cannot be used to uniquely identify the context.
     // IDs are recycled after instances are destroyed.
     ContextId get_context_id() const { return context_id_; }

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -73,13 +73,6 @@ public:
     // Check if a MetalContext for a given context id exists.
     static bool instance_exists(ContextId context_id = DEFAULT_CONTEXT_ID);
 
-    // Returns a pointer to any existing MetalContext instance, or nullptr if none exist.
-    // Prefers DEFAULT_CONTEXT_ID; otherwise returns the first non-null slot.
-    // IMPORTANT: Unlike instance(), this NEVER triggers implicit creation of the silicon
-    // default context. Use this from process-wide singletons (e.g. BuildEnvManager) that
-    // need read-only HAL/arch information without forcing a particular cluster to open.
-    static MetalContext* find_any_existing_instance();
-
     // Returns the id of this instance. The ID cannot be used to uniquely identify the context.
     // IDs are recycled after instances are destroyed.
     ContextId get_context_id() const { return context_id_; }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -466,14 +466,14 @@ bool Device::initialize(
     }
 
     // Create shared memory stats provider (enabled by default, disable with TT_METAL_SHM_TRACKING_DISABLED=1)
-    if (!MetalContext::instance().rtoptions().get_shm_tracking_disabled()) {
+    if (!context_->rtoptions().get_shm_tracking_disabled()) {
         // Use UMD's chip_unique_ids for globally unique chip identification.
         // This ID is computed by topology discovery from hardware-reported board_id and asic_location,
         // and is consistent across all board types (P300, N300, UBB Wormhole, UBB Blackhole, etc.).
         uint64_t asic_id = 0;
 
         try {
-            const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+            const auto& cluster = context_->get_cluster();
             auto* cluster_desc = cluster.get_cluster_desc();
 
             if (cluster_desc) {

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -465,8 +465,13 @@ bool Device::initialize(
         return true;
     }
 
-    // Create shared memory stats provider (enabled by default, disable with TT_METAL_SHM_TRACKING_DISABLED=1)
-    if (!context_->rtoptions().get_shm_tracking_disabled()) {
+    // Create shared memory stats provider (enabled by default, disable with TT_METAL_SHM_TRACKING_DISABLED=1).
+    // Snapshot the SHM rtoptions once here -- they are process-wide debug toggles, so capturing
+    // them at construction time avoids the SHM helpers having to look up a MetalContext on every
+    // allocation (and avoids any "find any context" walk that mock+silicon coexistence forced).
+    const bool shm_tracking_disabled = context_->rtoptions().get_shm_tracking_disabled();
+    const bool shm_verbose = context_->rtoptions().get_shm_verbose();
+    if (!shm_tracking_disabled) {
         // Use UMD's chip_unique_ids for globally unique chip identification.
         // This ID is computed by topology discovery from hardware-reported board_id and asic_location,
         // and is consistent across all board types (P300, N300, UBB Wormhole, UBB Blackhole, etc.).
@@ -507,14 +512,17 @@ bool Device::initialize(
             asic_id = this->id_;
         }
 
-        shm_stats_provider_ = std::make_unique<SharedMemoryStatsProvider>(asic_id, this->id_);
+        shm_stats_provider_ =
+            std::make_unique<SharedMemoryStatsProvider>(asic_id, this->id_, shm_tracking_disabled, shm_verbose);
         log_debug(tt::LogMetal, "Shared memory tracking enabled for device {}, asic_id=0x{:x}", this->id_, asic_id);
 
-        // Register ShmTrackingProcessor globally once (when first device with SHM is created)
+        // Register ShmTrackingProcessor globally once (when first device with SHM is created).
+        // Verbose flag is captured here from this device's MetalContext for the same reason as
+        // SharedMemoryStatsProvider above.
         static bool shm_processor_registered = false;
         if (!shm_processor_registered) {
             tt::tt_metal::GraphTracker::instance().push_processor(
-                std::make_shared<tt::tt_metal::ShmTrackingProcessor>());
+                std::make_shared<tt::tt_metal::ShmTrackingProcessor>(shm_verbose));
             log_debug(tt::LogMetal, "ShmTrackingProcessor registered with GraphTracker");
             shm_processor_registered = true;
         }

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -42,6 +42,24 @@
 
 namespace tt::tt_metal {
 
+namespace {
+
+// Mock devices reuse the on-disk firmware sources of a real arch's package.
+// We only ship sources for Wormhole and Blackhole today; Quasar mock has
+// no `tt-2xx/trisc.cc` etc. installed at the expected path, so calling
+// build_firmware() against a Quasar mock blows up in cc1plus with
+// "No such file or directory". Real silicon devices always have sources
+// available and bypass this check.
+bool mock_firmware_sources_available_for(tt::ARCH arch) {
+    switch (arch) {
+        case tt::ARCH::WORMHOLE_B0:
+        case tt::ARCH::BLACKHOLE: return true;
+        default: return false;
+    }
+}
+
+}  // namespace
+
 RiscFirmwareInitializer::RiscFirmwareInitializer(
     std::shared_ptr<const ContextDescriptor> descriptor,
     const GetControlPlaneFn& get_control_plane,
@@ -140,13 +158,18 @@ void RiscFirmwareInitializer::run_async_build_phase(const std::set<tt::ChipId>& 
             // and emulated devices too. The build env is HAL/arch-derived and does not probe hardware.
             BuildEnvManager::get_instance().add_build_env(
                 device_id, num_hw_cqs_, descriptor_->metal_context().get_context_id());
-            // Build firmware ELFs unconditionally (mock and emulated included). The build is purely
-            // a compile/link step that does not touch hardware, but the resulting firmware ELFs
-            // export symbols (e.g. __fw_export_text_end) that the kernel linker scripts depend on.
-            // Without these symbols available as link inputs, JIT-compiling kernels on a mock
-            // device fails with "non constant or forward reference address expression". The actual
-            // firmware launch and launch-message clearing remain gated on real hardware below.
-            BuildEnvManager::get_instance().build_firmware(device_id);
+            // build_firmware() is a pure compile/link step that doesn't touch hardware, and the
+            // resulting ELFs export symbols (e.g. __fw_export_text_end) that kernel linker scripts
+            // depend on -- without them, JIT-compiling kernels on a mock device fails with
+            // "non constant or forward reference address expression". So we run it for mock as
+            // well as real devices, EXCEPT when the mock arch has no firmware sources packaged
+            // (currently Quasar): there cc1plus would fatal on missing source files. Kernel JIT
+            // on Quasar mock is not yet supported and would require a separate sources fix.
+            const bool skip_fw_build =
+                cluster_.is_mock_or_emulated() && !mock_firmware_sources_available_for(cluster_.arch());
+            if (!skip_fw_build) {
+                BuildEnvManager::get_instance().build_firmware(device_id);
+            }
             if (!cluster_.is_mock_or_emulated()) {
                 // Clear the entire launch message ring buffer on ethernet cores before application firmware is
                 // activated. This is required since ethernet cores context switch between application and routing

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -138,11 +138,16 @@ void RiscFirmwareInitializer::run_async_build_phase(const std::set<tt::ChipId>& 
 
             // Register the build env unconditionally so JIT compilation (CompileProgram) works on mock
             // and emulated devices too. The build env is HAL/arch-derived and does not probe hardware.
-            BuildEnvManager::get_instance().add_build_env(device_id, num_hw_cqs_);
+            BuildEnvManager::get_instance().add_build_env(
+                device_id, num_hw_cqs_, descriptor_->metal_context().get_context_id());
+            // Build firmware ELFs unconditionally (mock and emulated included). The build is purely
+            // a compile/link step that does not touch hardware, but the resulting firmware ELFs
+            // export symbols (e.g. __fw_export_text_end) that the kernel linker scripts depend on.
+            // Without these symbols available as link inputs, JIT-compiling kernels on a mock
+            // device fails with "non constant or forward reference address expression". The actual
+            // firmware launch and launch-message clearing remain gated on real hardware below.
+            BuildEnvManager::get_instance().build_firmware(device_id);
             if (!cluster_.is_mock_or_emulated()) {
-                // build_firmware ensures that the FW is built only once for a given build key
-                // (which captures the fw_compile_hash).
-                BuildEnvManager::get_instance().build_firmware(device_id);
                 // Clear the entire launch message ring buffer on ethernet cores before application firmware is
                 // activated. This is required since ethernet cores context switch between application and routing
                 // firmware. If ERISC application firmware is activated before the launch messages are cleared, it

--- a/tt_metal/impl/device/mock_device_util.cpp
+++ b/tt_metal/impl/device/mock_device_util.cpp
@@ -7,6 +7,10 @@
 namespace tt::tt_metal::experimental {
 
 std::optional<std::string> get_mock_cluster_desc_name(tt::ARCH arch, uint32_t num_chips) {
+    // Each entry maps to a cluster descriptor YAML in
+    // tt_metal/third_party/umd/tests/cluster_descriptor_examples/. New entries must
+    // reference an existing file there; otherwise mock mode will fail to load the
+    // cluster at runtime.
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0:
             switch (num_chips) {
@@ -21,6 +25,11 @@ std::optional<std::string> get_mock_cluster_desc_name(tt::ARCH arch, uint32_t nu
             switch (num_chips) {
                 case 1: return "blackhole_P150.yaml";
                 case 2: return "blackhole_P300_both_mmio.yaml";
+                case 4: return "blackhole_4xP150.yaml";
+                case 8: return "blackhole_8xP150.yaml";
+                // 32-chip BH cluster descriptor is not yet available in
+                // cluster_descriptor_examples/; add a "blackhole_32xP*.yaml" entry
+                // here once one is checked in.
                 default: return std::nullopt;
             }
         case tt::ARCH::QUASAR:

--- a/tt_metal/impl/device/mock_device_util.hpp
+++ b/tt_metal/impl/device/mock_device_util.hpp
@@ -4,12 +4,6 @@
 
 #pragma once
 
-#include <optional>
-#include <string>
-#include <umd/device/types/arch.hpp>
-
-namespace tt::tt_metal::experimental {
-
-std::optional<std::string> get_mock_cluster_desc_name(tt::ARCH arch, uint32_t num_chips);
-
-}  // namespace tt::tt_metal::experimental
+// get_mock_cluster_desc_name() is now part of the public API.
+// This internal header is kept as a forwarder for existing internal call sites.
+#include <tt-metalium/experimental/mock_device.hpp>

--- a/tt_metal/impl/memory_tracking/memory_stats_shm.cpp
+++ b/tt_metal/impl/memory_tracking/memory_stats_shm.cpp
@@ -115,8 +115,13 @@ SharedMemoryStatsProvider::SharedMemoryStatsProvider(uint64_t asic_id, int devic
     TT_ASSERT(device_id_ >= 0, "Negative device_id {} passed to SHM provider", device_id_);
     region_->device_id = static_cast<uint32_t>(device_id_);
 
-    // Check if tracking should be disabled (enabled by default)
-    const auto& rtopts = MetalContext::instance().rtoptions();
+    // Check if tracking should be disabled (enabled by default).
+    // SharedMemoryStatsProvider is process-global and not bound to a specific MetalContext, so use any
+    // existing context's rtoptions to avoid implicitly initializing the silicon default context (which
+    // would break mock-only / coexistence flows). The shm_tracking flag is process-wide, so the choice
+    // of context is immaterial.
+    auto* any_ctx = MetalContext::find_any_existing_instance();
+    const auto& rtopts = any_ctx != nullptr ? any_ctx->rtoptions() : MetalContext::instance().rtoptions();
     if (rtopts.get_shm_tracking_disabled()) {
         per_pid_tracking_enabled_ = false;
     }
@@ -299,7 +304,9 @@ void SharedMemoryStatsProvider::initialize_region() {
 }
 
 void SharedMemoryStatsProvider::record_allocation(pid_t pid, uint64_t size, ShmBufferType type, uint32_t chip_id) {
-    bool verbose_enabled = MetalContext::instance().rtoptions().get_shm_verbose();
+    auto* any_ctx = MetalContext::find_any_existing_instance();
+    bool verbose_enabled = any_ctx != nullptr ? any_ctx->rtoptions().get_shm_verbose()
+                                              : MetalContext::instance().rtoptions().get_shm_verbose();
 
     if (!region_) {
         if (verbose_enabled) {
@@ -380,7 +387,9 @@ void SharedMemoryStatsProvider::record_allocation(pid_t pid, uint64_t size, ShmB
 }
 
 void SharedMemoryStatsProvider::record_deallocation(pid_t pid, uint64_t size, ShmBufferType type, uint32_t chip_id) {
-    bool verbose_enabled = MetalContext::instance().rtoptions().get_shm_verbose();
+    auto* any_ctx = MetalContext::find_any_existing_instance();
+    bool verbose_enabled = any_ctx != nullptr ? any_ctx->rtoptions().get_shm_verbose()
+                                              : MetalContext::instance().rtoptions().get_shm_verbose();
 
     if (!region_) {
         if (verbose_enabled) {

--- a/tt_metal/impl/memory_tracking/memory_stats_shm.cpp
+++ b/tt_metal/impl/memory_tracking/memory_stats_shm.cpp
@@ -29,13 +29,18 @@ class Allocator;
 
 // Implementation of SharedMemoryStatsProvider
 
-SharedMemoryStatsProvider::SharedMemoryStatsProvider(uint64_t asic_id, int device_id) :
+SharedMemoryStatsProvider::SharedMemoryStatsProvider(
+    uint64_t asic_id, int device_id, bool tracking_disabled, bool verbose) :
     asic_id_(asic_id),
     device_id_(device_id),
     shm_fd_(-1),
     region_(nullptr),
-    per_pid_tracking_enabled_(true)  // Enabled by default, disable with TT_METAL_SHM_TRACKING_DISABLED=1
-    ,
+    // Per-PID tracking is enabled by default and disabled by TT_METAL_SHM_TRACKING_DISABLED=1.
+    // The flag is captured once at construction (passed in by Device::initialize from its
+    // MetalContext's rtoptions) -- it's a process-wide debug toggle, no need to look it up
+    // again per allocation.
+    per_pid_tracking_enabled_(!tracking_disabled),
+    verbose_enabled_(verbose),
     is_creator_(false) {
     // Format: /tt_device_<chip_unique_id>_memory
     // chip_unique_id from UMD is globally unique and never changes
@@ -115,21 +120,7 @@ SharedMemoryStatsProvider::SharedMemoryStatsProvider(uint64_t asic_id, int devic
     TT_ASSERT(device_id_ >= 0, "Negative device_id {} passed to SHM provider", device_id_);
     region_->device_id = static_cast<uint32_t>(device_id_);
 
-    // Check if tracking should be disabled (enabled by default).
-    // SharedMemoryStatsProvider is process-global and not bound to a specific MetalContext, so use any
-    // existing context's rtoptions to avoid implicitly initializing the silicon default context (which
-    // would break mock-only / coexistence flows). The shm_tracking flag is process-wide, so the choice
-    // of context is immaterial.
-    auto* any_ctx = MetalContext::find_any_existing_instance();
-    const auto& rtopts = any_ctx != nullptr ? any_ctx->rtoptions() : MetalContext::instance().rtoptions();
-    if (rtopts.get_shm_tracking_disabled()) {
-        per_pid_tracking_enabled_ = false;
-    }
-
-    // Verbose logging for initialization
-    bool verbose_enabled = rtopts.get_shm_verbose();
-
-    if (verbose_enabled) {
+    if (verbose_enabled_) {
         log_info(
             tt::LogMetal,
             "SHM Provider initialized: device_id={}, asic_id=0x{:x}, shm_name={}, is_creator={}, region_={}, "
@@ -304,12 +295,8 @@ void SharedMemoryStatsProvider::initialize_region() {
 }
 
 void SharedMemoryStatsProvider::record_allocation(pid_t pid, uint64_t size, ShmBufferType type, uint32_t chip_id) {
-    auto* any_ctx = MetalContext::find_any_existing_instance();
-    bool verbose_enabled = any_ctx != nullptr ? any_ctx->rtoptions().get_shm_verbose()
-                                              : MetalContext::instance().rtoptions().get_shm_verbose();
-
     if (!region_) {
-        if (verbose_enabled) {
+        if (verbose_enabled_) {
             log_warning(
                 tt::LogMetal,
                 "SHM record_allocation SKIPPED: region_ is nullptr (pid={}, size={} B, type={}, chip_id={})",
@@ -321,7 +308,7 @@ void SharedMemoryStatsProvider::record_allocation(pid_t pid, uint64_t size, ShmB
         return;
     }
 
-    if (verbose_enabled) {
+    if (verbose_enabled_) {
         static const char* type_names[] = {"DRAM", "L1", "L1_SMALL", "TRACE", "CB"};
         auto type_idx = static_cast<size_t>(type);
         const char* type_name = (type_idx < 5) ? type_names[type_idx] : "UNKNOWN";
@@ -387,12 +374,8 @@ void SharedMemoryStatsProvider::record_allocation(pid_t pid, uint64_t size, ShmB
 }
 
 void SharedMemoryStatsProvider::record_deallocation(pid_t pid, uint64_t size, ShmBufferType type, uint32_t chip_id) {
-    auto* any_ctx = MetalContext::find_any_existing_instance();
-    bool verbose_enabled = any_ctx != nullptr ? any_ctx->rtoptions().get_shm_verbose()
-                                              : MetalContext::instance().rtoptions().get_shm_verbose();
-
     if (!region_) {
-        if (verbose_enabled) {
+        if (verbose_enabled_) {
             log_warning(
                 tt::LogMetal,
                 "SHM record_deallocation SKIPPED: region_ is nullptr (pid={}, size={} B, type={}, chip_id={})",
@@ -404,7 +387,7 @@ void SharedMemoryStatsProvider::record_deallocation(pid_t pid, uint64_t size, Sh
         return;
     }
 
-    if (verbose_enabled) {
+    if (verbose_enabled_) {
         static const char* type_names[] = {"DRAM", "L1", "L1_SMALL", "TRACE", "CB"};
         auto type_idx = static_cast<size_t>(type);
         const char* type_name = (type_idx < 5) ? type_names[type_idx] : "UNKNOWN";

--- a/tt_metal/impl/memory_tracking/memory_stats_shm.hpp
+++ b/tt_metal/impl/memory_tracking/memory_stats_shm.hpp
@@ -101,7 +101,11 @@ public:
     // If first process, initializes the region; otherwise attaches to existing
     // asic_id: UMD chip_unique_id from ClusterDescriptor (globally unique per chip)
     // device_id: Logical Metal device ID (for internal tracking only)
-    explicit SharedMemoryStatsProvider(uint64_t asic_id, int device_id);
+    // tracking_disabled: process-wide TT_METAL_SHM_TRACKING_DISABLED flag, captured at
+    //                    construction time from the owning Device's MetalContext rtoptions
+    //                    so the SHM provider does not need to walk MetalContext slots later
+    // verbose: process-wide TT_METAL_SHM_VERBOSE flag, captured the same way
+    SharedMemoryStatsProvider(uint64_t asic_id, int device_id, bool tracking_disabled, bool verbose);
 
     // Destructor unmaps shared memory and closes file descriptor
     // NOTE: SHM file persists (like UMD locks) - not deleted on process exit
@@ -187,6 +191,7 @@ private:
     int shm_fd_;                     // Shared memory file descriptor
     DeviceMemoryRegion* region_;     // Mapped shared memory region
     bool per_pid_tracking_enabled_;  // Enable detailed per-PID tracking
+    bool verbose_enabled_;           // Cached TT_METAL_SHM_VERBOSE flag (process-wide)
     bool is_creator_;                // True if this process created the shared memory
 
     // Helper: Initialize shared memory region (first process only)

--- a/tt_metal/impl/memory_tracking/shm_tracking_processor.cpp
+++ b/tt_metal/impl/memory_tracking/shm_tracking_processor.cpp
@@ -26,7 +26,14 @@ static ShmBufferType to_shm_buffer_type(BufferType type) {
 }
 
 ShmTrackingProcessor::ShmTrackingProcessor() :
-    verbose_enabled_(MetalContext::instance().rtoptions().get_shm_verbose()) {}
+    // Process-global graph processor: avoid implicitly initializing the silicon default context.
+    // Use any existing MetalContext's rtoptions; shm_verbose is a process-wide flag.
+    verbose_enabled_([]() {
+        if (auto* ctx = MetalContext::find_any_existing_instance()) {
+            return ctx->rtoptions().get_shm_verbose();
+        }
+        return MetalContext::instance().rtoptions().get_shm_verbose();
+    }()) {}
 
 void ShmTrackingProcessor::track_allocate(const Buffer* buffer) {
     if (!buffer || !buffer->device()) {

--- a/tt_metal/impl/memory_tracking/shm_tracking_processor.cpp
+++ b/tt_metal/impl/memory_tracking/shm_tracking_processor.cpp
@@ -4,7 +4,6 @@
 
 #include "impl/memory_tracking/shm_tracking_processor.hpp"
 #include "impl/memory_tracking/memory_stats_shm.hpp"
-#include "impl/context/metal_context.hpp"
 #include "impl/device/device_impl.hpp"
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/mesh_device.hpp>
@@ -25,15 +24,7 @@ static ShmBufferType to_shm_buffer_type(BufferType type) {
     }
 }
 
-ShmTrackingProcessor::ShmTrackingProcessor() :
-    // Process-global graph processor: avoid implicitly initializing the silicon default context.
-    // Use any existing MetalContext's rtoptions; shm_verbose is a process-wide flag.
-    verbose_enabled_([]() {
-        if (auto* ctx = MetalContext::find_any_existing_instance()) {
-            return ctx->rtoptions().get_shm_verbose();
-        }
-        return MetalContext::instance().rtoptions().get_shm_verbose();
-    }()) {}
+ShmTrackingProcessor::ShmTrackingProcessor(bool verbose) : verbose_enabled_(verbose) {}
 
 void ShmTrackingProcessor::track_allocate(const Buffer* buffer) {
     if (!buffer || !buffer->device()) {

--- a/tt_metal/impl/memory_tracking/shm_tracking_processor.hpp
+++ b/tt_metal/impl/memory_tracking/shm_tracking_processor.hpp
@@ -16,7 +16,10 @@ class Device;
 // for real-time monitoring by external tools (e.g. tt-smi-ui)
 class ShmTrackingProcessor : public IGraphProcessor {
 public:
-    ShmTrackingProcessor();
+    // verbose: process-wide TT_METAL_SHM_VERBOSE flag, captured at construction time from
+    // the owning Device's MetalContext rtoptions so the processor does not need to walk
+    // MetalContext slots later. The flag is process-wide, so capturing once is correct.
+    explicit ShmTrackingProcessor(bool verbose);
     ~ShmTrackingProcessor() override = default;
 
     // ShmTrackingProcessor is a permanent background processor; it must not

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -24,7 +24,19 @@
 namespace tt::tt_metal {
 
 BuildEnvManager& BuildEnvManager::get_instance() {
-    static BuildEnvManager instance(MetalContext::instance().hal());
+    // BuildEnvManager is a process-wide singleton initialized once with a HAL reference. The
+    // HAL is consulted only for arch-derived layout counts (programmable core types, processor
+    // classes, fw binary counts), all of which depend on the architecture and not on whether the
+    // cluster is mock or silicon. Using any already-existing MetalContext's HAL avoids implicitly
+    // initializing the silicon default context when only a mock context exists (e.g. forge's
+    // mock-only flow). If no context exists yet, fall back to the legacy behavior, which will
+    // create the default silicon context on demand.
+    static BuildEnvManager instance([]() -> const Hal& {
+        if (auto* existing = MetalContext::find_any_existing_instance()) {
+            return existing->hal();
+        }
+        return MetalContext::instance().hal();
+    }());
     return instance;
 }
 
@@ -153,10 +165,10 @@ std::vector<JitBuildState> create_build_state(JitBuildEnv& build_env, const JitD
 
 }  // namespace
 
-void BuildEnvManager::add_build_env(ChipId device_id, uint8_t num_hw_cqs) {
+void BuildEnvManager::add_build_env(ChipId device_id, uint8_t num_hw_cqs, ContextId context_id) {
     const std::lock_guard<std::mutex> lock(this->lock);
-    auto dev_config = create_jit_device_config(device_id, num_hw_cqs);
-    add_build_env_locked(device_id, dev_config, MetalContext::instance().rtoptions());
+    auto dev_config = create_jit_device_config(device_id, num_hw_cqs, context_id);
+    add_build_env_locked(device_id, dev_config, MetalContext::instance(context_id).rtoptions());
 }
 
 void BuildEnvManager::add_build_env(

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -25,12 +25,25 @@ namespace tt::tt_metal {
 
 BuildEnvManager& BuildEnvManager::get_instance() {
     // BuildEnvManager is a process-wide singleton initialized once with a HAL reference. The
-    // HAL is consulted only for arch-derived layout counts (programmable core types, processor
-    // classes, fw binary counts), all of which depend on the architecture and not on whether the
-    // cluster is mock or silicon. Using any already-existing MetalContext's HAL avoids implicitly
-    // initializing the silicon default context when only a mock context exists (e.g. forge's
-    // mock-only flow). If no context exists yet, fall back to the legacy behavior, which will
-    // create the default silicon context on demand.
+    // constructor sizes kernel_build_state_indices_ / firmware_build_state_indices_ from that
+    // HAL's programmable-core-type, processor-class, and fw-binary counts.
+    //
+    // For the common case (silicon + mock of the same arch) those counts are arch-derived and
+    // stable, so seeding from any existing context's HAL is safe. We use
+    // find_any_existing_instance() to avoid implicitly opening the silicon DEFAULT context
+    // when only a mock context exists (forge's mock-only flow); if no context exists yet, the
+    // no-arg instance() is the legacy fallback and will create the default silicon context.
+    //
+    // PRE-EXISTING LIMITATION (not introduced by this PR, but surfaced once contexts can
+    // genuinely coexist in-process): HAL layout can also be modulated by rtoptions -- e.g.
+    // simulator mode, Blackhole DRAM programmable cores, 2-erisc mode -- so two contexts on
+    // the same arch with disagreeing rtoptions can produce different layout counts. Whichever
+    // HAL initializes this singleton first wins; the other context will index build states
+    // through a table sized for the wrong layout, leading to wrong indices or asserts. This is
+    // a property of the singleton design, not of the context selection done here.
+    // TODO(#TBD): key BuildEnvManager by a stable HAL signature (arch + relevant rtoptions),
+    // or move the index computation into per-device DeviceBuildEnv so each device carries its
+    // own mapping.
     static BuildEnvManager instance([]() -> const Hal& {
         if (auto* existing = MetalContext::find_any_existing_instance()) {
             return existing->hal();

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -23,34 +23,60 @@
 
 namespace tt::tt_metal {
 
-BuildEnvManager& BuildEnvManager::get_instance() {
-    // BuildEnvManager is a process-wide singleton initialized once with a HAL reference. The
-    // constructor sizes kernel_build_state_indices_ / firmware_build_state_indices_ from that
-    // HAL's programmable-core-type, processor-class, and fw-binary counts.
+namespace {
+
+// Process-wide singleton state. Seeded once via seed_if_unseeded_with_hal(), then read-only
+// for the lifetime of the process. Driven by MetalContext::create_* so that the seeding HAL
+// is always the HAL of the first MetalContext that comes into existence -- no implicit
+// silicon initialisation, and no walking of g_instances slots from outside MetalContext.
+std::atomic<BuildEnvManager*> s_instance{nullptr};
+std::mutex s_seed_mutex;
+
+}  // namespace
+
+void BuildEnvManager::seed_if_unseeded_with_hal(const Hal& hal) {
+    // Fast path: already seeded. No lock, no allocation.
+    if (s_instance.load(std::memory_order_acquire) != nullptr) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(s_seed_mutex);
+    if (s_instance.load(std::memory_order_acquire) != nullptr) {
+        return;
+    }
+    // Seed the singleton with the supplied HAL. The constructor sizes
+    // kernel_build_state_indices_ / firmware_build_state_indices_ from that HAL's
+    // programmable-core-type, processor-class, and fw-binary counts.
     //
-    // For the common case (silicon + mock of the same arch) those counts are arch-derived and
-    // stable, so seeding from any existing context's HAL is safe. We use
-    // find_any_existing_instance() to avoid implicitly opening the silicon DEFAULT context
-    // when only a mock context exists (forge's mock-only flow); if no context exists yet, the
-    // no-arg instance() is the legacy fallback and will create the default silicon context.
-    //
-    // PRE-EXISTING LIMITATION (not introduced by this PR, but surfaced once contexts can
-    // genuinely coexist in-process): HAL layout can also be modulated by rtoptions -- e.g.
-    // simulator mode, Blackhole DRAM programmable cores, 2-erisc mode -- so two contexts on
-    // the same arch with disagreeing rtoptions can produce different layout counts. Whichever
-    // HAL initializes this singleton first wins; the other context will index build states
-    // through a table sized for the wrong layout, leading to wrong indices or asserts. This is
-    // a property of the singleton design, not of the context selection done here.
+    // PRE-EXISTING LIMITATION (not introduced by the explicit-seeding refactor, but surfaced
+    // once contexts can genuinely coexist in-process): HAL layout can be modulated by
+    // rtoptions -- simulator mode, Blackhole DRAM programmable cores, 2-erisc mode -- so two
+    // contexts on the same arch with disagreeing rtoptions, or two contexts on different
+    // arches, can produce different layout counts. Whichever HAL seeds this singleton first
+    // wins; the other context will index build states through a table sized for the wrong
+    // layout. This is a property of the singleton design.
     // TODO(#TBD): key BuildEnvManager by a stable HAL signature (arch + relevant rtoptions),
-    // or move the index computation into per-device DeviceBuildEnv so each device carries its
-    // own mapping.
-    static BuildEnvManager instance([]() -> const Hal& {
-        if (auto* existing = MetalContext::find_any_existing_instance()) {
-            return existing->hal();
-        }
-        return MetalContext::instance().hal();
-    }());
-    return instance;
+    // or move the index computation into per-device DeviceBuildEnv so each device carries
+    // its own mapping. That refactor closes the cross-arch / cross-rtoptions hazard above.
+    s_instance.store(new BuildEnvManager(hal), std::memory_order_release);
+}
+
+BuildEnvManager& BuildEnvManager::get_instance(ContextId context_id) {
+    // Resolve the ContextId to a HAL via MetalContext::instance(context_id), then seed.
+    // Callers that already hold g_instance_mutex (i.e. MetalContext::create_*) must use
+    // seed_if_unseeded_with_hal() directly with the in-scope HAL to avoid re-entering
+    // MetalContext::instance().
+    seed_if_unseeded_with_hal(MetalContext::instance(context_id).hal());
+    return *s_instance.load(std::memory_order_acquire);
+}
+
+BuildEnvManager& BuildEnvManager::get_instance() {
+    auto* existing = s_instance.load(std::memory_order_acquire);
+    TT_FATAL(
+        existing != nullptr,
+        "BuildEnvManager::get_instance() called before any MetalContext was created. The "
+        "singleton is seeded by MetalContext::create_instance(); ensure at least one "
+        "MetalEnv has been constructed first, or call get_instance(ContextId) explicitly.");
+    return *existing;
 }
 
 BuildEnvManager::BuildEnvManager(const Hal& hal) {

--- a/tt_metal/jit_build/build_env_manager.hpp
+++ b/tt_metal/jit_build/build_env_manager.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "build.hpp"
+#include "impl/context/context_types.hpp"
 #include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt::tt_metal {
@@ -49,7 +50,9 @@ public:
 
     // Add a new build environment for the corresponding device id and num_hw_cqs. Also generates the build key and
     // build states.  This requires a live device to be available at device_id.
-    void add_build_env(ChipId device_id, uint8_t num_hw_cqs);
+    // `context_id` selects which MetalContext owns the device; required so the right context's runtime state and
+    // hardware query layer is consulted instead of implicitly initializing the silicon default.
+    void add_build_env(ChipId device_id, uint8_t num_hw_cqs, ContextId context_id);
 
     // Add a new build environment for the corresponding device id and device configuration. Also generates the build
     // key and build states.

--- a/tt_metal/jit_build/build_env_manager.hpp
+++ b/tt_metal/jit_build/build_env_manager.hpp
@@ -46,7 +46,25 @@ public:
     BuildEnvManager& operator=(const BuildEnvManager&) = delete;
     BuildEnvManager(BuildEnvManager&&) = delete;
     BuildEnvManager& operator=(BuildEnvManager&&) = delete;
+
+    // Returns the process-wide singleton, seeding its HAL on first call from the supplied
+    // ContextId's MetalContext. Subsequent calls return the same singleton regardless of
+    // which ContextId is passed -- the parameter is therefore advisory after first seeding.
+    // It exists to make the BuildEnvManager-to-MetalContext dependency explicit at the API
+    // surface so a future per-ContextId BuildEnvManager refactor (#38445 follow-up) has the
+    // right shape already.
+    static BuildEnvManager& get_instance(ContextId context_id);
+
+    // Legacy no-arg accessor for callers that only have a build_id / device pointer in scope.
+    // Asserts that the singleton has already been seeded (driven by MetalContext::create_*),
+    // which is true for every reader that runs after a MetalEnv has been constructed.
     static BuildEnvManager& get_instance();
+
+    // Internal seeding entry: seeds the singleton with the supplied HAL on first call,
+    // no-op thereafter. Takes a HAL by reference so callers that already hold
+    // g_instance_mutex (e.g. MetalContext::create_*) can seed without re-entering
+    // MetalContext::instance(ContextId). Idempotent and thread-safe.
+    static void seed_if_unseeded_with_hal(const Hal& hal);
 
     // Add a new build environment for the corresponding device id and num_hw_cqs. Also generates the build key and
     // build states.  This requires a live device to be available at device_id.

--- a/tt_metal/jit_build/jit_device_config.cpp
+++ b/tt_metal/jit_build/jit_device_config.cpp
@@ -18,9 +18,9 @@
 
 namespace tt::tt_metal {
 
-JitDeviceConfig create_jit_device_config(ChipId device_id, uint8_t num_hw_cqs) {
+JitDeviceConfig create_jit_device_config(ChipId device_id, uint8_t num_hw_cqs, ContextId context_id) {
     // Need both runtime state and hardware query
-    auto& ctx = MetalContext::instance();
+    auto& ctx = MetalContext::instance(context_id);
     auto& env = MetalEnvAccessor(ctx.get_env()).impl();
     const auto& hal = env.get_hal();
     const auto& cluster = env.get_cluster();

--- a/tt_metal/jit_build/jit_device_config.hpp
+++ b/tt_metal/jit_build/jit_device_config.hpp
@@ -60,9 +60,16 @@ struct JitDeviceConfig {
 // configuration files alone. Because of this, the device must be accessible at
 // call time.
 //
-// `context_id` selects which MetalContext instance to query. This must match the
-// context that owns `device_id`; passing the wrong (or default) id causes the
-// silicon context to be implicitly initialized when only a mock context exists.
+// `context_id` selects which MetalContext instance to query. It MUST match the
+// context that owns `device_id`. Passing the wrong id (including the default id
+// when `device_id` is owned by a non-default context) does NOT fail loudly:
+// MetalContext::instance(context_id) resolves to whichever context happens to
+// occupy that slot, and the no-arg fallback returns any existing context if the
+// requested slot is empty. The returned JitDeviceConfig is then a snapshot of
+// the wrong cluster's arch / topology / dispatch layout, and downstream queries
+// against `device_id` silently misbehave (mismatched harvesting masks, dispatch
+// cores in the wrong place, kernel build cache hits across clusters). Callers
+// must thread through the same ContextId they used to create the device.
 JitDeviceConfig create_jit_device_config(ChipId device_id, uint8_t num_hw_cqs, ContextId context_id);
 
 // TODO: Add a factory method to create JitDeviceConfig from a YAML profile

--- a/tt_metal/jit_build/jit_device_config.hpp
+++ b/tt_metal/jit_build/jit_device_config.hpp
@@ -12,6 +12,8 @@
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 
+#include "impl/context/context_types.hpp"
+
 namespace tt::tt_metal {
 
 class Hal;
@@ -57,7 +59,11 @@ struct JitDeviceConfig {
 // descriptor for the given `device_id`; nothing is inferred from static
 // configuration files alone. Because of this, the device must be accessible at
 // call time.
-JitDeviceConfig create_jit_device_config(ChipId device_id, uint8_t num_hw_cqs);
+//
+// `context_id` selects which MetalContext instance to query. This must match the
+// context that owns `device_id`; passing the wrong (or default) id causes the
+// silicon context to be implicitly initialized when only a mock context exists.
+JitDeviceConfig create_jit_device_config(ChipId device_id, uint8_t num_hw_cqs, ContextId context_id);
 
 // TODO: Add a factory method to create JitDeviceConfig from a YAML profile
 


### PR DESCRIPTION
Relates to #38445

## Problem description

Mock and silicon `MeshDevice`s could not coexist in the same process. Even with two explicitly-constructed `MetalEnv`s, the second `MeshDevice::create()` either deadlocked on a UMD chip lock or failed in dispatch setup.

Root cause: bare `MetalContext::instance()` (no `ContextId`) calls in the device-init, JIT-build, and SHM-tracking paths were implicitly opening the silicon `DEFAULT_CONTEXT_ID` even in mock-only flows. `MetalContextIntegrationTest.MockDeviceOnly` codifies this invariant and was failing — the four cases were filtered out of CI.

## What's changed

- `MetalContext::instance()` (no-arg) now falls back to any existing `ContextId` instead of force-creating the silicon default. Single-cluster silicon flows are unchanged.
- New non-creating `MetalContext::find_any_existing_instance()` for process-global singletons (`BuildEnvManager`, `SharedMemoryStatsProvider`, `ShmTrackingProcessor`).
- Plumbed `ContextId` through `BuildEnvManager::add_build_env`, `create_jit_device_config`, and `RiscFirmwareInitializer`. `Device::initialize` uses its own `context_`.
- Firmware ELFs are built unconditionally so kernel JIT links on mock (kernel linker scripts depend on `__fw_export_text_end`). Actual firmware launch remains gated on real hardware.
- Public-API export of `experimental::get_mock_cluster_desc_name(arch, num_chips)` so MetalEnv consumers can construct a `MetalEnvDescriptor` without going through the global `configure_mock_mode` flag.
- Removed the CI filter on `MetalContextIntegrationTest.{MockDeviceOnly, Coexisting*, ForkMockAndRealDevice}` in `tests/pipeline_reorg/runtime_unit_tests.yaml`.

## Out of scope

- Legacy `configure_mock_mode()` + free-function `MeshDevice::create()` coexistence still tears down `MetalContext` on transition. 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-39849-mock-silicon-coexistence)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/fix-39849-mock-silicon-coexistence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-39849-mock-silicon-coexistence)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/fix-39849-mock-silicon-coexistence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=msudumbrekar/fix-39849-mock-silicon-coexistence)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:msudumbrekar/fix-39849-mock-silicon-coexistence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/fix-39849-mock-silicon-coexistence)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/fix-39849-mock-silicon-coexistence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/fix-39849-mock-silicon-coexistence)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/fix-39849-mock-silicon-coexistence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/fix-39849-mock-silicon-coexistence)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/fix-39849-mock-silicon-coexistence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/fix-39849-mock-silicon-coexistence)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/fix-39849-mock-silicon-coexistence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/fix-39849-mock-silicon-coexistence)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/fix-39849-mock-silicon-coexistence)