### PR TITLE
[skip ci] Move some galaxy models tests to run on TYO2 instead of AUS2

### DIFF
--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -51,6 +51,14 @@ skus:
       - topology-6u
       - in-service
 
+  # Temporary SKU separating UF machines
+  wh_galaxy_perf_uf:
+    runs_on:
+      - arch-wormhole_b0
+      - pipeline-perf-uf
+      - topology-6u
+      - in-service
+
   wh_galaxy_release:
     runs_on:
       - arch-wormhole_b0

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -73,6 +73,7 @@ ttnn:
     bh_p150b_civ2: 545
   unit:
     wh_llmbox: 50
+    wh_galaxy: 35
   e2e:
     wh_llmbox: 90
     wh_galaxy: 70
@@ -89,6 +90,9 @@ shield:
 scaleout:
   unit:
     wh_llmbox: 60
+    wh_galaxy: 25
+  stress:
+    wh_galaxy_perf: 120
   integration:
     wh_llmbox: 40
   health:
@@ -133,6 +137,8 @@ llk:
 models:
   sanity:
     wh_galaxy_perf: 10
+  stress:
+    wh_galaxy_perf: 500
   e2e:
     wh_llmbox: 198
     wh_llmbox_perf: 312

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -157,6 +157,8 @@ models:
     wh_llmbox_perf: 685
     wh_galaxy: 280
     wh_galaxy_perf: 150
+    # UF Galaxy perf pool (see sku_config wh_galaxy_perf_uf)
+    wh_galaxy_perf_uf: 75
   device_perf:
     wh_n150: 10
     bh_p150: 10
@@ -167,6 +169,7 @@ models:
     wh_llmbox_perf_release: 1090
     wh_galaxy: 0
     wh_galaxy_perf: 150
+    wh_galaxy_perf_uf: 45
     wh_galaxy_release: 345
     bh_galaxy: 30
     wh_n150: 500

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -191,3 +191,7 @@ models:
     wh_n150: 10
     wh_llmbox_perf: 30
     wh_galaxy: 30
+
+umd:
+  unit:
+    wh_galaxy: 35

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -194,4 +194,4 @@ models:
 
 umd:
   unit:
-    wh_galaxy: 35
+    wh_galaxy_perf_uf: 35

--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -90,7 +90,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ (matrix.test-group.sku == 'wh_galaxy_perf' || matrix.test-group.sku == 'wh_galaxy_perf_uf' || matrix.test-group.sku == 'bh_galaxy_perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
+        - ${{ contains(matrix.test-group.sku, 'perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -90,7 +90,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ contains(matrix.test-group.sku, 'perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
+        - ${{ contains(matrix.test-group.sku, 'perf') && (inputs.mlperf-read-only && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/mnt/MLPerf:/mnt/MLPerf') || '/donotmount:/donotmount:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -90,7 +90,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf${{ inputs.mlperf-read-only && ':ro' || ':rw' }}
+        - ${{( matrix.test-group.sku == 'wh_galaxy_perf' || matrix.test-group.sku == 'bh_galaxy_perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -90,7 +90,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{( matrix.test-group.sku == 'wh_galaxy_perf' || matrix.test-group.sku == 'bh_galaxy_perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
+        - ${{ (matrix.test-group.sku == 'wh_galaxy_perf' || matrix.test-group.sku == 'wh_galaxy_perf_uf' || matrix.test-group.sku == 'bh_galaxy_perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/galaxy-integration-tests-impl.yaml
+++ b/.github/workflows/galaxy-integration-tests-impl.yaml
@@ -91,7 +91,7 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         # TG integration scripts use /mnt/MLPerf (HF) on functional and perf Galaxy SKUs.
-        - ${{ (matrix.test-group.sku == 'wh_galaxy' || matrix.test-group.sku == 'bh_galaxy' || matrix.test-group.sku == 'wh_galaxy_perf' || matrix.test-group.sku == 'wh_galaxy_perf_uf' || matrix.test-group.sku == 'bh_galaxy_perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
+        - ${{ contains(matrix.test-group.sku, 'perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/galaxy-integration-tests-impl.yaml
+++ b/.github/workflows/galaxy-integration-tests-impl.yaml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
       enabled-skus:
-        required: true
+        required: false
         type: string
       model:
         required: false
@@ -51,7 +51,7 @@ jobs:
         run: |
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
-            "${{ inputs.enabled-skus }}" \
+            ALL_SKUS_IN_TESTS \
             ./.github/sku_config.yaml
       - name: Apply model filter
         id: apply-model-filter
@@ -90,7 +90,8 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{( matrix.test-group.sku == 'wh_galaxy_perf' || matrix.test-group.sku == 'bh_galaxy_perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
+        # TG integration scripts use /mnt/MLPerf (HF) on functional and perf Galaxy SKUs.
+        - ${{ (matrix.test-group.sku == 'wh_galaxy' || matrix.test-group.sku == 'bh_galaxy' || matrix.test-group.sku == 'wh_galaxy_perf' || matrix.test-group.sku == 'wh_galaxy_perf_uf' || matrix.test-group.sku == 'bh_galaxy_perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/galaxy-integration-tests-impl.yaml
+++ b/.github/workflows/galaxy-integration-tests-impl.yaml
@@ -90,7 +90,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:ro
+        - ${{( matrix.test-group.sku == 'wh_galaxy_perf' || matrix.test-group.sku == 'bh_galaxy_perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/galaxy-integration-tests.yaml
+++ b/.github/workflows/galaxy-integration-tests.yaml
@@ -64,5 +64,4 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: wh_galaxy
       model: ${{ inputs.model || 'all' }}

--- a/.github/workflows/galaxy-perf-tests-impl.yaml
+++ b/.github/workflows/galaxy-perf-tests-impl.yaml
@@ -91,7 +91,6 @@ jobs:
       - name: Enable performance mode
         run: |
           sudo cpupower frequency-set -g performance
-      - uses: ./.github/actions/ensure-active-weka-mount
       - name: ⬇️ Download Build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         timeout-minutes: 10

--- a/.github/workflows/galaxy-perf-tests-impl.yaml
+++ b/.github/workflows/galaxy-perf-tests-impl.yaml
@@ -116,7 +116,7 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e ARCH_NAME=${{ matrix.test-group.arch }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            ${{ (matrix.test-group.sku == 'wh_galaxy_perf' || matrix.test-group.sku == 'wh_galaxy_perf_uf' || matrix.test-group.sku == 'bh_galaxy_perf') && '-v /mnt/MLPerf:/mnt/MLPerf:ro' || '-v /donotmount:/donotmount:ro' }}
+            -v ${{ contains(matrix.test-group.sku, 'perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
           install_wheel: true
           run_args: |
             ${{ matrix.test-group.cmd }}

--- a/.github/workflows/galaxy-perf-tests-impl.yaml
+++ b/.github/workflows/galaxy-perf-tests-impl.yaml
@@ -116,7 +116,7 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e ARCH_NAME=${{ matrix.test-group.arch }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            ${{ (matrix.test-group.sku == 'wh_galaxy_perf' || matrix.test-group.sku == 'bh_galaxy_perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
           install_wheel: true
           run_args: |
             ${{ matrix.test-group.cmd }}

--- a/.github/workflows/galaxy-perf-tests-impl.yaml
+++ b/.github/workflows/galaxy-perf-tests-impl.yaml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
       enabled-skus:
-        required: true
+        required: false
         type: string
       model:
         required: false
@@ -48,7 +48,7 @@ jobs:
         run: |
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
-            "${{ inputs.enabled-skus }}" \
+            ALL_SKUS_IN_TESTS \
             ./.github/sku_config.yaml
       - name: Apply model filter
         id: apply-model-filter
@@ -116,7 +116,7 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e ARCH_NAME=${{ matrix.test-group.arch }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            ${{ (matrix.test-group.sku == 'wh_galaxy_perf' || matrix.test-group.sku == 'bh_galaxy_perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
+            ${{ (matrix.test-group.sku == 'wh_galaxy_perf' || matrix.test-group.sku == 'wh_galaxy_perf_uf' || matrix.test-group.sku == 'bh_galaxy_perf') && '-v /mnt/MLPerf:/mnt/MLPerf:ro' || '-v /donotmount:/donotmount:ro' }}
           install_wheel: true
           run_args: |
             ${{ matrix.test-group.cmd }}

--- a/.github/workflows/galaxy-perf-tests.yaml
+++ b/.github/workflows/galaxy-perf-tests.yaml
@@ -67,6 +67,4 @@ jobs:
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
-      # Galaxy perf runs on Wormhole Galaxy (wh_galaxy) only.
-      enabled-skus: wh_galaxy_perf
       model: ${{ inputs.model || 'all' }}

--- a/.github/workflows/galaxy-sanity-impl.yaml
+++ b/.github/workflows/galaxy-sanity-impl.yaml
@@ -66,7 +66,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ matrix.test-group.use_mlperf_mount && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
+        - ${{ (matrix.test-group.sku == 'wh_galaxy_perf' || matrix.test-group.sku == 'bh_galaxy_perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/galaxy-sanity-impl.yaml
+++ b/.github/workflows/galaxy-sanity-impl.yaml
@@ -66,7 +66,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ (matrix.test-group.sku == 'wh_galaxy_perf' || matrix.test-group.sku == 'bh_galaxy_perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
+        - ${{ contains(matrix.test-group.sku, 'perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/galaxy-sanity.yaml
+++ b/.github/workflows/galaxy-sanity.yaml
@@ -36,8 +36,6 @@ on:
   schedule:
     # Every 2 hours (UTC)
     - cron: "0 */2 * * *"
-  push:
-    branches: ["roseli/0-refactor-galaxy-quick2"]
 
 run-name: "(Galaxy) Sanity"
 

--- a/.github/workflows/galaxy-stress-tests-impl.yaml
+++ b/.github/workflows/galaxy-stress-tests-impl.yaml
@@ -115,7 +115,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ (matrix.test-group.sku == 'wh_galaxy_perf' || matrix.test-group.sku == 'bh_galaxy_perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
+        - ${{ contains(matrix.test-group.sku, 'perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/galaxy-stress-tests-impl.yaml
+++ b/.github/workflows/galaxy-stress-tests-impl.yaml
@@ -115,7 +115,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:ro
+        - ${{ (matrix.test-group.sku == 'wh_galaxy_perf' || matrix.test-group.sku == 'bh_galaxy_perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/galaxy-stress-tests-impl.yaml
+++ b/.github/workflows/galaxy-stress-tests-impl.yaml
@@ -1,4 +1,4 @@
-name: "zzz TG Stress tests"
+name: "[internal] Galaxy stress tests impl"
 
 on:
   workflow_call:
@@ -12,88 +12,97 @@ on:
       build-artifact-name:
         required: true
         type: string
+      enabled-skus:
+        required: true
+        type: string
+      test-selection:
+        required: false
+        type: string
+        default: "all"
       extra-tag:
         required: false
         type: string
         default: "in-service"
-      topology-6u:
+      topology:
         required: false
-        type: boolean
-        default: true
+        type: string
+        default: "topology-6u"
 
 jobs:
-  galaxy-stress:
-    runs-on:
-      - ${{ inputs.extra-tag }}
-      - topology-6u
-      - arch-wormhole_b0
-      - pipeline-perf
-    container:
-      image: ${{ inputs.docker-image || 'docker-image-unresolved!'}}
-      env:
-        TT_METAL_HOME: /work
-        PYTHONPATH: /work
-        LD_LIBRARY_PATH: /work/build/lib
-        LOGURU_LEVEL: INFO
-        LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/
-      volumes:
-        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /work
-        - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: --device /dev/tenstorrent
-    defaults:
-      run:
-        shell: bash
-        working-directory: /work # https://github.com/actions/runner/issues/878
+  load-test-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.apply-runner-labels.outputs.matrix }}
+    env:
+      TESTS_YAML_PATH: ./tests/pipeline_reorg/galaxy_stress_tests.yaml
     steps:
-      - name: 🧬 Checkout Repository
+      - name: Checkout the repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
-          path: docker-job
-      - name: ⬇️  Setup Job
-        uses: ./docker-job/.github/actions/setup-job
-        timeout-minutes: 10
-        with:
-          build-artifact-name: ${{ inputs.build-artifact-name }}
-          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - name: Run stress tests
-        timeout-minutes: 360
+          sparse-checkout: |
+            .github
+            tests/pipeline_reorg
+          sparse-checkout-cone-mode: true
+      - name: Install dependencies
         run: |
-          for i in {1..5}; do
-            echo "🔁 Run #$i"
-            timeout --preserve-status 1200 pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "nd-hang-test"
-          done
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()
+          pip3 install PyYAML
+      - name: Verify test timeouts against budget
+        run: |
+          set -e
+          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
+          python3 .github/scripts/utils/verify_time_budget.py \
+            ${{ env.TESTS_YAML_PATH }} \
+            ./.github/time_budget.yaml \
+            "stress"
+      - name: Build unified test matrix based on enabled SKUs
+        id: build-matrix
+        run: |
+          python3 .github/scripts/utils/prepare_test_matrix.py \
+            ${{ env.TESTS_YAML_PATH }} \
+            "${{ inputs.enabled-skus }}" \
+            ./.github/sku_config.yaml
+      - name: Apply test selection
+        id: apply-test-selection
+        run: |
+          MATRIX='${{ steps.build-matrix.outputs.matrix }}'
+          if [ "${{ inputs.test-selection }}" = "all" ]; then
+            echo "matrix<<EOF" >> $GITHUB_OUTPUT
+            echo "$MATRIX" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            FILTERED=$(echo "$MATRIX" | jq -c --arg id "${{ inputs.test-selection }}" '[.[] | select(.id == $id)]')
+            if [ "$FILTERED" = "[]" ]; then
+              echo "::error::No tests found for test-selection '${{ inputs.test-selection }}'. Ensure id matches tests/pipeline_reorg/galaxy_stress_tests.yaml and enabled-skus includes the needed SKU."
+              exit 1
+            fi
+            echo "matrix<<EOF" >> $GITHUB_OUTPUT
+            echo "$FILTERED" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+      - name: Apply runner labels (topology / extra-tag)
+        id: apply-runner-labels
+        run: |
+          MATRIX='${{ steps.apply-test-selection.outputs.matrix }}'
+          UPDATED=$(echo "$MATRIX" | jq -c \
+            --arg tag "${{ inputs.extra-tag }}" \
+            --arg topology "${{ inputs.topology }}" \
+            'map(.runs_on |= map(
+              if . == "in-service" then $tag
+              elif startswith("topology-") then $topology
+              else . end
+            ))')
+          echo "matrix<<EOF" >> $GITHUB_OUTPUT
+          echo "$UPDATED" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
-  galaxy-long-tests:
+  galaxy-stress-tests:
+    needs: load-test-matrix
     strategy:
       fail-fast: false
       matrix:
-        test-group: [
-          {
-            name: "Galaxy Fabric Stability Tests",
-            arch: wormhole_b0,
-            cmd: TT_METAL_CLEAR_L1=1 build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_6U_galaxy.yaml,
-            timeout: 100,
-            owner_id: U08FXFFH7L0
-          }, # Abhishek Agarwal
-          {
-            name: "Llama Galaxy Long Stress Test",
-            arch: wormhole_b0,
-            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py  -k 'stress-test and not mini-stress-test'",
-            timeout: 140,
-            owner_id: U053W15B6JF
-          } # Djordje Ivanovic
-        ]
+        test-group: ${{ fromJson(needs.load-test-matrix.outputs.matrix) }}
     name: ${{ matrix.test-group.name }}
-    runs-on:
-      - ${{ inputs.extra-tag }}
-      - topology-6u
-      - arch-wormhole_b0
-      - pipeline-perf
+    runs-on: ${{ matrix.test-group.runs_on }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
@@ -101,29 +110,33 @@ jobs:
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
-        ARCH_NAME: ${{ matrix.test-group.arch }}
+        ARCH_NAME: wormhole_b0
+        LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/
       volumes:
-        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - ${{ github.workspace }}/docker-job:/work
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:
       run:
         shell: bash
-        working-directory: /work # https://github.com/actions/runner/issues/878
+        working-directory: /work
     steps:
       - name: 🧬 Checkout Repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
           path: docker-job
+      - name: Mark repository as safe directory
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: ⬇️  Setup Job
         uses: ./docker-job/.github/actions/setup-job
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - name: Run tests
+      - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           ${{ matrix.test-group.cmd }}

--- a/.github/workflows/galaxy-stress-tests.yaml
+++ b/.github/workflows/galaxy-stress-tests.yaml
@@ -43,7 +43,6 @@ on:
         required: false
         type: string
         default: "in-service"
-        description: "Runner pool tag (with topology-6u, arch-wormhole_b0, pipeline-perf)"
 
 jobs:
   build-artifact:

--- a/.github/workflows/galaxy-stress-tests.yaml
+++ b/.github/workflows/galaxy-stress-tests.yaml
@@ -29,6 +29,21 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
+      test-selection:
+        description: "Run all stress suites or one id (see tests/pipeline_reorg/galaxy_stress_tests.yaml)"
+        required: false
+        type: choice
+        default: "all"
+        options:
+          - all
+          - galaxy-llama-nd-hang-stress
+          - galaxy-fabric-stability-stress
+          - galaxy-llama-long-stress
+      extra-tag:
+        required: false
+        type: string
+        default: "in-service"
+        description: "Runner pool tag (with topology-6u, arch-wormhole_b0, pipeline-perf)"
 
 jobs:
   build-artifact:
@@ -50,3 +65,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      enabled-skus: wh_galaxy_perf
+      test-selection: ${{ github.event_name == 'workflow_dispatch' && inputs.test-selection || 'all' }}
+      extra-tag: ${{ github.event_name == 'workflow_dispatch' && inputs.extra-tag || 'in-service' }}
+      topology: topology-6u

--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -115,7 +115,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ matrix.test-group.sku == 'wh_galaxy_perf' && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
+        - ${{ (matrix.test-group.sku == 'wh_galaxy_perf' || matrix.test-group.sku == 'bh_galaxy_perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -115,7 +115,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ matrix.test-group.use_mlperf_mount == true && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
+        - ${{ matrix.test-group.sku == 'wh_galaxy_perf' && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
       enabled-skus:
-        required: true
+        required: false
         type: string
       model:
         required: false
@@ -59,7 +59,7 @@ jobs:
         run: |
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
-            "${{ inputs.enabled-skus }}" \
+            ALL_SKUS_IN_TESTS \
             ./.github/sku_config.yaml
       - name: Apply model filter
         id: apply-model-filter

--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -12,6 +12,9 @@ on:
       wheel-artifact-name:
         required: true
         type: string
+      enabled-skus:
+        required: true
+        type: string
       model:
         required: false
         type: string
@@ -26,222 +29,128 @@ on:
         default: "topology-6u"
 
 jobs:
-  galaxy-umd-tests:
-   strategy:
-     fail-fast: false
-     matrix:
-       test-group: [
-         {
-           name: "Galaxy UMD unit tests",
-           arch: wormhole_b0,
-           runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-functional"],
-           cmd: "./build/test/umd/galaxy/unit_tests_glx",
-           timeout: 10
-         },  # Bojan Roško
-         {
-           name: "UMD API tests",
-           arch: wormhole_b0,
-           runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-functional"],
-           cmd: "./build/test/umd/api/api_tests",
-           timeout: 20
-         },
-       ]
-   runs-on: ${{ matrix.test-group.runs-on }}
-   container:
-     image: ${{ inputs.docker-image }}
-     env:
-       ARCH_NAME: ${{ matrix.test-group.arch }}
-       LOGURU_LEVEL: INFO
-       LD_LIBRARY_PATH: /work/build/lib
-     volumes:
-       - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-       - /dev/hugepages-1G:/dev/hugepages-1G
-     options: "--device /dev/tenstorrent"
-   defaults:
-     run:
-       shell: bash
-       working-directory: /work # https://github.com/actions/runner/issues/878
-   steps:
-     - name: 🧬 Checkout Repository
-       uses: actions/checkout@v4
-       with:
-         submodules: recursive
-         path: docker-job
-     - name: ⬇️  Setup Job
-       uses: ./docker-job/.github/actions/setup-job
-       timeout-minutes: 10
-       with:
-         build-artifact-name: ${{ inputs.build-artifact-name }}
-
-     - name: Run UMD unit regression tests
-       timeout-minutes: ${{ matrix.test-group.timeout }}
-       run: |
-         ${{ matrix.test-group.cmd }}
-
-     - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-       if: always()
-
-  generate-matrix:
+  load-test-matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.generate.outputs.matrix }}
+      matrix: ${{ steps.apply-runner-labels.outputs.matrix }}
+    env:
+      TESTS_YAML_PATH: ./tests/pipeline_reorg/galaxy_unit_tests.yaml
     steps:
-      - name: Generate test matrix
-        id: generate
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github
+            tests/pipeline_reorg
+          sparse-checkout-cone-mode: true
+      - name: Install dependencies
         run: |
-          # Owners for the following tests:
-          # Galaxy unit tests: None, see issue #29677
-          # Fabric tests: Allan Liu
-          # Multi-Process tests: Aditya Saigal
-          # Llama3-70b unit tests: Djordje Ivanovic
-          # DRAM Prefetcher unit tests: Johanna Rock, Yu Gao
-          # Distributed ops tests: Johanna Rock
-          # GPT-OSS unit tests: Stuti Raizada
-
-          all_tests=$(jq -n '[
-            { "name": "Galaxy Fabric tests", "arch": "wormhole_b0", "model": "fabric", "timeout": 5, "owner_id": "UJ45FEC7M" },
-            { "name": "Galaxy Multi-Process tests", "arch": "wormhole_b0", "model": "multiprocess", "timeout": 15, "owner_id": "U03NG0A5ND7", "auto-triage": false },
-            # { "name": "Galaxy DRAM Prefetcher unit tests", "arch": "wormhole_b0", "model": "prefetcher", "timeout": 25, "owner_id": "U044T8U8DEF" },
-            { "name": "Galaxy distributed ops tests", "arch": "wormhole_b0", "model": "distributed-ops", "timeout": 5, "owner_id": "U044T8U8DEF" },
-            { "name": "Galaxy tttv2 tests", "arch": "wormhole_b0", "model": "tttv2", "timeout": 10, "owner_id": "U07RY6B5FLJ", "mlperf": true} # Gongyu Wang
-          ]')
-
-          # Filter matrix based on model selection
+          pip3 install PyYAML
+      - name: Verify test timeouts against budget
+        run: |
+          set -e
+          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
+          python3 .github/scripts/utils/verify_time_budget.py \
+            ${{ env.TESTS_YAML_PATH }} \
+            ./.github/time_budget.yaml \
+            "unit"
+      - name: Build unified test matrix based on enabled SKUs
+        id: build-matrix
+        run: |
+          python3 .github/scripts/utils/prepare_test_matrix.py \
+            ${{ env.TESTS_YAML_PATH }} \
+            "${{ inputs.enabled-skus }}" \
+            ./.github/sku_config.yaml
+      - name: Apply model filter
+        id: apply-model-filter
+        run: |
+          MATRIX='${{ steps.build-matrix.outputs.matrix }}'
           if [ "${{ inputs.model }}" = "all" ]; then
-            matrix="$all_tests"
+            echo "matrix<<EOF" >> $GITHUB_OUTPUT
+            echo "$MATRIX" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
           else
-            matrix=$(echo "$all_tests" | jq -c "[.[] | select(.model == \"${{ inputs.model }}\")]")
+            FILTERED=$(echo "$MATRIX" | jq -c --arg m "${{ inputs.model }}" '[.[] | select(.model == $m)]')
+            if [ "$FILTERED" = "[]" ]; then
+              echo "::error::No tests found for model '${{ inputs.model }}'. Ensure the model is defined in ${{ env.TESTS_YAML_PATH }}."
+              exit 1
+            fi
+            echo "matrix<<EOF" >> $GITHUB_OUTPUT
+            echo "$FILTERED" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
           fi
-
-          # Fail fast if the matrix is empty (invalid model selected)
-          if [ "$(echo "$matrix" | jq length)" -eq 0 ]; then
-            echo "Error: Invalid model selected: '${{ inputs.model }}'"
-            exit 1
-          fi
-          echo "matrix=$(echo "$matrix" | jq -c .)" >> $GITHUB_OUTPUT
+      - name: Apply runner labels (topology / extra-tag)
+        id: apply-runner-labels
+        run: |
+          MATRIX='${{ steps.apply-model-filter.outputs.matrix }}'
+          UPDATED=$(echo "$MATRIX" | jq -c \
+            --arg tag "${{ inputs.extra-tag }}" \
+            --arg topology "${{ inputs.topology }}" \
+            'map(.runs_on |= map(
+              if . == "in-service" then $tag
+              elif startswith("topology-") then $topology
+              else . end
+            ))')
+          echo "matrix<<EOF" >> $GITHUB_OUTPUT
+          echo "$UPDATED" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
   galaxy-unit-tests:
-    needs: generate-matrix
+    needs: load-test-matrix
     strategy:
       fail-fast: false
       matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+        test-group: ${{ fromJson(needs.load-test-matrix.outputs.matrix) }}
     name: ${{ matrix.test-group.name }}
-    runs-on:
-      - arch-wormhole_b0
-      - ${{ inputs.topology }}
-      - ${{ inputs.extra-tag }}
-      - ${{ matrix.test-group.mlperf && 'pipeline-perf' || 'pipeline-functional' }}
+    runs-on: ${{ matrix.test-group.runs_on }}
     container:
-      image: ${{ inputs.docker-image }}
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
-        ARCH_NAME: ${{ matrix.test-group.arch }}
+        ARCH_NAME: wormhole_b0
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
       volumes:
-        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - ${{ github.workspace }}/docker-job:/work
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ matrix.test-group.mlperf && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
+        - ${{ matrix.test-group.use_mlperf_mount == true && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:
         shell: bash
-        working-directory: /work # https://github.com/actions/runner/issues/878
+        working-directory: /work
     steps:
       - name: 🧬 Checkout Repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
           path: docker-job
+      - name: Mark repository as safe directory
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: ⬇️  Setup Job
         uses: ./docker-job/.github/actions/setup-job
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-          auto-triage: ${{ matrix.test-group.auto-triage != false }}
-          hang-detection-timeout: ${{ matrix.test-group.hang-detection-timeout || 5.0 }}
-
-      - name: Run fabric tests
-        if: ${{ matrix.test-group.model == 'fabric' }}
+          auto-triage: ${{ matrix.test-group.auto_triage != false }}
+          hang-detection-timeout: ${{ matrix.test-group.hang_detection_timeout || 5.0 }}
+      - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
-          mkdir -p generated/test_reports
-          TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.*TG*
-          TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
-          ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
-          ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric*MuxFixture.*"
-
-          TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.*TG*
-          TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
-          ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
-          ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric*MuxFixture.*"
-
-      - name: Run Multi-Process tests
-        if: ${{ matrix.test-group.model == 'multiprocess' }}
-        timeout-minutes: ${{ matrix.test-group.timeout }}
-        uses: ./docker-job/.github/actions/run-multi-process-tests
-      - name: Run prefetcher unit tests
-        if: ${{ matrix.test-group.model == 'prefetcher' }}
-        timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          mkdir -p generated/test_reports
-          pytest tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py --timeout 600
-
-      - name: Run distributed ops tests
-        if: ${{ matrix.test-group.model == 'distributed-ops' }}
-        timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          mkdir -p generated/test_reports
-          pytest tests/ttnn/distributed/test_distributed_layernorm_TG.py
-
-      - name: Run tttv2 module tests
-        if: ${{ matrix.test-group.model == 'tttv2' }}
-        timeout-minutes: ${{ matrix.test-group.timeout }}
-        env:
-          HF_HUB_OFFLINE: 1
-          HF_HOME: /mnt/MLPerf/huggingface
-          HF_MODEL: meta-llama/Llama-3.1-8B-Instruct
-        run: |
-          # All tests run, and this step fails if any test failed.
-          failed=0
-
-          pytest --durations-min=3.0 models/common/tests/modules/rmsnorm/test_rmsnorm_2d.py \
-            -m "not slow" \
-            --tb=short \
-            --cov=models.common.modules.rmsnorm.rmsnorm_2d \
-            --cov-report=term-missing \
-            --cov-config=models/common/tests/setup.cfg || failed=1
-
-          pytest --durations-min=3.0 models/common/tests/modules/mlp/test_mlp_2d.py \
-            -m "not slow" \
-            --tb=short \
-            --cov=models.common.modules.mlp.mlp_2d \
-            --cov-report=term-missing \
-            --cov-config=models/common/tests/setup.cfg || failed=1
-
-          pytest --durations-min=3.0 models/common/tests/test_auto_compose.py \
-            --tb=short \
-            --cov=models.common.auto_compose \
-            --cov-report=term-missing \
-            --cov-config=models/common/tests/setup.cfg || failed=1
-
-          exit $failed
-
+          ${{ matrix.test-group.cmd }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
         if: ${{ failure() }}
         with:
           test-report-path: generated/test_reports/
-
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -115,7 +115,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ (matrix.test-group.sku == 'wh_galaxy_perf' || matrix.test-group.sku == 'bh_galaxy_perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
+        - ${{ contains(matrix.test-group.sku, 'perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/galaxy-unit-tests.yaml
+++ b/.github/workflows/galaxy-unit-tests.yaml
@@ -63,6 +63,5 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      enabled-skus: wh_galaxy,wh_galaxy_perf
       model: ${{ inputs.model || 'all' }}
       topology: topology-6u

--- a/.github/workflows/galaxy-unit-tests.yaml
+++ b/.github/workflows/galaxy-unit-tests.yaml
@@ -15,6 +15,7 @@ on:
           - multiprocess
           - prefetcher
           - distributed-ops
+          - tttv2
       platform:
         required: false
         type: choice
@@ -62,5 +63,6 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enabled-skus: wh_galaxy,wh_galaxy_perf
       model: ${{ inputs.model || 'all' }}
       topology: topology-6u

--- a/.github/workflows/galaxy-unit-tests.yaml
+++ b/.github/workflows/galaxy-unit-tests.yaml
@@ -13,7 +13,7 @@ on:
           - unit
           - fabric
           - multiprocess
-          - prefetcher
+#          - prefetcher
           - distributed-ops
           - tttv2
       platform:

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -275,8 +275,6 @@ jobs:
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: wh_galaxy_perf
       model: ${{ inputs.trigger_type == 'manual' && inputs.galaxy-integration || 'all' }}
   galaxy-demo-tests:
     if: ${{ needs.determine-tests.outputs.run-demo == 'true' }}

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -264,7 +264,6 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: wh_galaxy,wh_galaxy_perf
       model: ${{ inputs.trigger_type == 'manual' && inputs.galaxy-unit || 'all' }}
       topology: 'topology-6u'
   galaxy-integration-tests:

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -275,6 +275,7 @@ jobs:
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       model: ${{ inputs.trigger_type == 'manual' && inputs.galaxy-integration || 'all' }}
   galaxy-demo-tests:
     if: ${{ needs.determine-tests.outputs.run-demo == 'true' }}

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -297,7 +297,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: wh_galaxy_perf
+      enabled-skus: wh_galaxy_perf,wh_galaxy_perf_uf
       model: ${{ inputs.trigger_type == 'manual' && inputs.galaxy-perf || 'all' }}
   galaxy-e2e-tests:
     if: ${{ needs.determine-tests.outputs.run-e2e == 'true' }}

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -264,6 +264,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      enabled-skus: wh_galaxy,wh_galaxy_perf
       model: ${{ inputs.trigger_type == 'manual' && inputs.galaxy-unit || 'all' }}
       topology: 'topology-6u'
   galaxy-integration-tests:

--- a/tests/pipeline_reorg/galaxy_demo_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_demo_tests.yaml
@@ -25,7 +25,7 @@
     pytest models/tt_dit/tests/models/sd35/test_pipeline_sd35.py -k "4x8cfg1sp0tp1" --timeout 1200
   model: sd35
   skus:
-    wh_galaxy_perf:
+    wh_galaxy_perf_uf:
       timeout: 10
   owner_id: U03FJB5TM5Y # Colman Glagovich
   team: models
@@ -36,7 +36,7 @@
     pytest models/tt_dit/tests/models/flux1/test_pipeline_flux1.py -k "4x8sp0tp1-dev" --timeout 1200
   model: flux1
   skus:
-    wh_galaxy_perf:
+    wh_galaxy_perf_uf:
       timeout: 15
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: models
@@ -80,7 +80,7 @@
     pytest models/demos/deepseek_v3/demo/test_demo.py -k "tg_stress or tg_upr8" --timeout 900
   model: deepseek_v3
   skus:
-    wh_galaxy_perf:
+    wh_galaxy_perf_uf:
       timeout: 15
   owner_id: U08H32XUS9W # Yousef Al Rawwash
   team: models

--- a/tests/pipeline_reorg/galaxy_perf_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_perf_tests.yaml
@@ -16,7 +16,7 @@
   cmd: pytest models/tt_dit/tests/models/sd35/test_performance_sd35.py -k "4x8cfg1sp0tp1" --timeout=480
   model: sd35
   skus:
-    wh_galaxy_perf:
+    wh_galaxy_perf_uf:
       timeout: 15
   owner_id: U03FJB5TM5Y # Colman Glagovich
   team: models
@@ -28,7 +28,7 @@
   cmd: HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub pytest models/tt_dit/tests/models/flux1/test_performance_flux1.py -k "wh_4x8sp0tp1" --timeout=500
   model: flux1-dev
   skus:
-    wh_galaxy_perf:
+    wh_galaxy_perf_uf:
       timeout: 15
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: models
@@ -69,7 +69,7 @@
     pytest models/tt_dit/tests/models/mochi/test_performance_mochi.py -k "4x8sp1tp0 " --timeout=1000
   model: mochi
   skus:
-    wh_galaxy_perf:
+    wh_galaxy_perf_uf:
       timeout: 20
   owner_id: U09ELB03XRU # Stephen Osborne
   team: models
@@ -83,7 +83,7 @@
     pytest models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py -k "4x8" --timeout=1000
   model: qwenimage
   skus:
-    wh_galaxy_perf:
+    wh_galaxy_perf_uf:
       timeout: 20
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: models

--- a/tests/pipeline_reorg/galaxy_sanity_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_sanity_tests.yaml
@@ -4,7 +4,6 @@
 #   name: The display name for the job in GitHub Actions.
 #   cmd: The exact command to run (env vars must be inlined).
 #   skus: A mapping of SKU names to their configuration (each SKU has timeout in minutes).
-#   use_mlperf_mount: If true, mount /mnt/MLPerf read-only; otherwise use a dummy mount (no MLPerf).
 #   owner_id: The Slack user ID to notify on failure.
 #   team: The team that owns the test.
 #   arch: Architecture string (wormhole_b0) for downstream tooling.
@@ -12,7 +11,6 @@
 # For max allowed timeout refer to .github/time_budget.yaml
 
 - name: Fabric CCL tests
-  use_mlperf_mount: false
   cmd: |
     ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tt_metal/fabric/cabling_descriptors/wh_galaxy_xy_torus.textproto --hard-fail --send-traffic
 
@@ -48,7 +46,6 @@
   arch: wormhole_b0
 
 - name: Deepseek V3 tests
-  use_mlperf_mount: true
   cmd: |
     export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked
     export DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI

--- a/tests/pipeline_reorg/galaxy_stress_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_stress_tests.yaml
@@ -1,0 +1,44 @@
+# Galaxy stress tests matrix (WH Galaxy perf runners). See galaxy-stress-tests-impl.yaml.
+
+# Keys per entry:
+#   id: Stable slug for workflow_dispatch / jq filtering.
+#   name: Job display name.
+#   cmd: Shell command(s) from TT_METAL_HOME (/work).
+#   team: Required for time_budget verification.
+#   skus: SKU -> { timeout } (minutes).
+#   owner_id: Slack owner (optional).
+
+# Max timeouts: .github/time_budget.yaml (workflow key: stress)
+
+- id: galaxy-llama-nd-hang-stress
+  name: Llama Galaxy ND hang stress (loop)
+  team: models
+  owner_id: U053W15B6JF # Djordje Ivanovic
+  cmd: |
+    for i in {1..5}; do
+      echo "🔁 Run #$i"
+      timeout --preserve-status 1200 pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "nd-hang-test"
+    done
+  skus:
+    wh_galaxy_perf:
+      timeout: 360
+
+- id: galaxy-fabric-stability-stress
+  name: Galaxy Fabric Stability Tests
+  team: scaleout
+  owner_id: U08FXFFH7L0 # Abhishek Agarwal
+  cmd: |
+    TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_6U_galaxy.yaml
+  skus:
+    wh_galaxy_perf:
+      timeout: 100
+
+- id: galaxy-llama-long-stress
+  name: Llama Galaxy Long Stress Test
+  team: models
+  owner_id: U053W15B6JF # Djordje Ivanovic
+  cmd: |
+    LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k 'stress-test and not mini-stress-test'
+  skus:
+    wh_galaxy_perf:
+      timeout: 140

--- a/tests/pipeline_reorg/galaxy_stress_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_stress_tests.yaml
@@ -38,7 +38,7 @@
   team: models
   owner_id: U053W15B6JF # Djordje Ivanovic
   cmd: |
-    LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k 'stress-test and not mini-stress-test'
+    LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "stress-test and not mini-stress-test"
   skus:
     wh_galaxy_perf:
       timeout: 140

--- a/tests/pipeline_reorg/galaxy_unit_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_unit_tests.yaml
@@ -8,7 +8,6 @@
 #   team: Required for time_budget verification.
 #   skus: SKU -> { timeout } (minutes).
 #   owner_id: Slack owner (optional).
-#   use_mlperf_mount: If true, mount /mnt/MLPerf (default false).
 #   auto_triage: Passed to setup-job (default true).
 #   hang_detection_timeout: Optional float for setup-job.
 
@@ -19,7 +18,6 @@
   model: unit
   team: runtime
   # owner: see issue #29677
-  use_mlperf_mount: false
   auto_triage: true
   cmd: ./build/test/umd/galaxy/unit_tests_glx
   skus:
@@ -30,7 +28,6 @@
   name: UMD API tests
   model: unit
   team: runtime
-  use_mlperf_mount: false
   auto_triage: true
   cmd: ./build/test/umd/api/api_tests
   skus:
@@ -42,7 +39,6 @@
   model: fabric
   team: scaleout
   owner_id: UJ45FEC7M # Allan Liu
-  use_mlperf_mount: false
   auto_triage: true
   cmd: |
     mkdir -p generated/test_reports
@@ -59,7 +55,6 @@
   model: multiprocess
   team: scaleout
   owner_id: U03NG0A5ND7 # Aditya Saigal
-  use_mlperf_mount: false
   auto_triage: false
   cmd: |
     python3 tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
@@ -79,7 +74,6 @@
   model: distributed-ops
   team: ttnn
   owner_id: U044T8U8DEF # Johanna Rock
-  use_mlperf_mount: false
   auto_triage: true
   cmd: |
     mkdir -p generated/test_reports
@@ -93,7 +87,6 @@
   model: prefetcher
   team: ttnn
   owner_id: U044T8U8DEF # Johanna Rock, Yu Gao
-  use_mlperf_mount: false
   auto_triage: true
   cmd: |
     mkdir -p generated/test_reports
@@ -107,7 +100,6 @@
   model: tttv2
   team: models
   owner_id: U07RY6B5FLJ # Gongyu Wang
-  use_mlperf_mount: true
   auto_triage: true
   cmd: |
     mkdir -p generated/test_reports

--- a/tests/pipeline_reorg/galaxy_unit_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_unit_tests.yaml
@@ -1,0 +1,138 @@
+# Galaxy unit tests matrix (WH Galaxy). See galaxy-unit-tests-impl.yaml.
+
+# Keys per entry:
+#   id: Stable slug for workflow_dispatch / tooling (optional).
+#   name: Job display name.
+#   model: Filter for workflow_dispatch / pipeline-select-galaxy (fabric, multiprocess, …).
+#   cmd: Shell command(s) to run from TT_METAL_HOME (/work).
+#   team: Required for time_budget verification.
+#   skus: SKU -> { timeout } (minutes).
+#   owner_id: Slack owner (optional).
+#   use_mlperf_mount: If true, mount /mnt/MLPerf (default false).
+#   auto_triage: Passed to setup-job (default true).
+#   hang_detection_timeout: Optional float for setup-job.
+
+# Max timeouts: .github/time_budget.yaml (workflow key: unit)
+
+- id: galaxy-umd-glx
+  name: Galaxy UMD unit tests
+  model: unit
+  team: runtime
+  # owner: see issue #29677
+  use_mlperf_mount: false
+  auto_triage: true
+  cmd: ./build/test/umd/galaxy/unit_tests_glx
+  skus:
+    wh_galaxy:
+      timeout: 10
+
+- id: galaxy-umd-api
+  name: UMD API tests
+  model: unit
+  team: runtime
+  use_mlperf_mount: false
+  auto_triage: true
+  cmd: ./build/test/umd/api/api_tests
+  skus:
+    wh_galaxy:
+      timeout: 20
+
+- id: galaxy-fabric-unit-suite
+  name: Galaxy Fabric tests
+  model: fabric
+  team: scaleout
+  owner_id: UJ45FEC7M # Allan Liu
+  use_mlperf_mount: false
+  auto_triage: true
+  cmd: |
+    mkdir -p generated/test_reports
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.*TG*
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric*MuxFixture.*"
+  skus:
+    wh_galaxy:
+      timeout: 5
+
+- id: galaxy-multiprocess
+  name: Galaxy Multi-Process tests
+  model: multiprocess
+  team: scaleout
+  owner_id: U03NG0A5ND7 # Aditya Saigal
+  use_mlperf_mount: false
+  auto_triage: false
+  cmd: |
+    python3 tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
+    tt-run --mpi-args "--allow-run-as-root" --rank-binding 4x4_multi_big_mesh_rank_binding.yaml ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_dual_big_mesh_fabric_2d_sanity.yaml
+    tt-run --rank-binding 4x4_multi_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" python3 tests/ttnn/distributed/test_multi_mesh.py
+    tt-run --rank-binding 4x4_multi_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/multi_host_socket_tests
+    tt-run --mpi-args "--allow-run-as-root" --rank-binding 4x4_multi_big_mesh_rank_binding.yaml ./build/test/tt_metal/multi_host_fabric_tests --gtest_filter="*Socket*"
+    tt-run --rank-binding 2x4_multi_mesh_cyclic_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_wh_6u_quad_2x4_acyclic.yaml
+    tt-run --rank-binding 2x4_multi_mesh_cyclic_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_wh_6u_quad_2x4_cyclic.yaml
+    tt-run --rank-binding 4x2_multi_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_multi_mesh_sanity_common.yaml
+  skus:
+    wh_galaxy:
+      timeout: 15
+
+- id: galaxy-distributed-ops
+  name: Galaxy distributed ops tests
+  model: distributed-ops
+  team: ttnn
+  owner_id: U044T8U8DEF # Johanna Rock
+  use_mlperf_mount: false
+  auto_triage: true
+  cmd: |
+    mkdir -p generated/test_reports
+    pytest tests/ttnn/distributed/test_distributed_layernorm_TG.py
+  skus:
+    wh_galaxy:
+      timeout: 5
+
+- id: galaxy-prefetcher-tg
+  name: Galaxy DRAM Prefetcher unit tests
+  model: prefetcher
+  team: ttnn
+  owner_id: U044T8U8DEF # Johanna Rock, Yu Gao
+  use_mlperf_mount: false
+  auto_triage: true
+  cmd: |
+    mkdir -p generated/test_reports
+    pytest tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py --timeout 600
+  skus:
+    wh_galaxy:
+      timeout: 25
+
+- id: galaxy-tttv2-modules
+  name: Galaxy tttv2 tests
+  model: tttv2
+  team: models
+  owner_id: U07RY6B5FLJ # Gongyu Wang
+  use_mlperf_mount: true
+  auto_triage: true
+  cmd: |
+    mkdir -p generated/test_reports
+    failed=0
+    HF_HUB_OFFLINE=1 HF_HOME=/mnt/MLPerf/huggingface HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
+      pytest --durations-min=3.0 models/common/tests/modules/rmsnorm/test_rmsnorm_2d.py \
+      -m "not slow" \
+      --tb=short \
+      --cov=models.common.modules.rmsnorm.rmsnorm_2d \
+      --cov-report=term-missing \
+      --cov-config=models/common/tests/setup.cfg || failed=1
+    HF_HUB_OFFLINE=1 HF_HOME=/mnt/MLPerf/huggingface HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
+      pytest --durations-min=3.0 models/common/tests/modules/mlp/test_mlp_2d.py \
+      -m "not slow" \
+      --tb=short \
+      --cov=models.common.modules.mlp.mlp_2d \
+      --cov-report=term-missing \
+      --cov-config=models/common/tests/setup.cfg || failed=1
+    HF_HUB_OFFLINE=1 HF_HOME=/mnt/MLPerf/huggingface HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
+      pytest --durations-min=3.0 models/common/tests/test_auto_compose.py \
+      --tb=short \
+      --cov=models.common.auto_compose \
+      --cov-report=term-missing \
+      --cov-config=models/common/tests/setup.cfg || failed=1
+    exit $failed
+  skus:
+    wh_galaxy_perf:
+      timeout: 10

--- a/tests/pipeline_reorg/galaxy_unit_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_unit_tests.yaml
@@ -34,6 +34,7 @@
     wh_galaxy_perf_uf:
       timeout: 20
 
+# Unusure why fabric test commands are duplicated, but keeping from original test matrix.
 - id: galaxy-fabric-unit-suite
   name: Galaxy Fabric tests
   model: fabric
@@ -42,6 +43,10 @@
   auto_triage: true
   cmd: |
     mkdir -p generated/test_reports
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.*TG*
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric*MuxFixture.*"
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.*TG*
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
     ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
@@ -82,18 +87,18 @@
     wh_galaxy:
       timeout: 5
 
-- id: galaxy-prefetcher-tg
-  name: Galaxy DRAM Prefetcher unit tests
-  model: prefetcher
-  team: ttnn
-  owner_id: U044T8U8DEF # Johanna Rock, Yu Gao
-  auto_triage: true
-  cmd: |
-    mkdir -p generated/test_reports
-    pytest tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py --timeout 600
-  skus:
-    wh_galaxy:
-      timeout: 25
+# - id: galaxy-prefetcher-tg
+#   name: Galaxy DRAM Prefetcher unit tests
+#   model: prefetcher
+#   team: ttnn
+#   owner_id: U044T8U8DEF # Johanna Rock, Yu Gao
+#   auto_triage: true
+#   cmd: |
+#     mkdir -p generated/test_reports
+#     pytest tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py --timeout 600
+#   skus:
+#     wh_galaxy:
+#       timeout: 25
 
 - id: galaxy-tttv2-modules
   name: Galaxy tttv2 tests

--- a/tests/pipeline_reorg/galaxy_unit_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_unit_tests.yaml
@@ -16,7 +16,7 @@
 - id: galaxy-umd-glx
   name: Galaxy UMD unit tests
   model: unit
-  team: runtime
+  team: umd
   # owner: see issue #29677
   auto_triage: true
   cmd: ./build/test/umd/galaxy/unit_tests_glx
@@ -27,7 +27,7 @@
 - id: galaxy-umd-api
   name: UMD API tests
   model: unit
-  team: runtime
+  team: umd
   auto_triage: true
   cmd: ./build/test/umd/api/api_tests
   skus:

--- a/tests/pipeline_reorg/galaxy_unit_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_unit_tests.yaml
@@ -21,7 +21,7 @@
   auto_triage: true
   cmd: ./build/test/umd/galaxy/unit_tests_glx
   skus:
-    wh_galaxy:
+    wh_galaxy_perf_uf:
       timeout: 10
 
 - id: galaxy-umd-api
@@ -31,7 +31,7 @@
   auto_triage: true
   cmd: ./build/test/umd/api/api_tests
   skus:
-    wh_galaxy:
+    wh_galaxy_perf_uf:
       timeout: 20
 
 - id: galaxy-fabric-unit-suite


### PR DESCRIPTION
### PR Category
CI maintenance

### Summary
This PR adds a `wh_galaxy_perf_uf` sku to represent UF galaxies in TYO2 colo that have access to a subset of model weights. Some tests were moved from running on AUS2 colo to TYO2 colo to reduce stress on AUS2 galaxies.

This PR also cleans up some galaxy pipelines to be in pipeline reorg format.

### Notes for reviewers
The following tests were moved from `wh_galaxy_perf` to `wh_galaxy_perf_uf`

Galaxy demo pipeline
- Galaxy Stable Diffusion 3.5 Large demo tests
- Galaxy Flux.1-dev demo tests
- Galaxy DeepSeek v3 demo tests

Galaxy perf pipeline
- Galaxy DiT SD3.5 model perf tests
- Galaxy DiT Flux.1 model perf tests
- Galaxy Mochi model perf tests
- Galaxy DiT Qwen-Image model perf tests

Galaxy unit pipeline
- Galaxy UMD unit tests
- UMD API tests

### Testing
Note any failures in below pipelines are not a result of moving tests to run in TYO2.

- [x] Galaxy choose your own https://github.com/tenstorrent/tt-metal/actions/runs/25475891206
- [x] Galaxy sanity https://github.com/tenstorrent/tt-metal/actions/runs/25475856145
- [x] Galaxy unit https://github.com/tenstorrent/tt-metal/actions/runs/25505354820
- [x] Galaxy integration https://github.com/tenstorrent/tt-metal/actions/runs/25475870998
- [x] Galaxy e2e https://github.com/tenstorrent/tt-metal/actions/runs/25475874233
- [x] Galaxy demo https://github.com/tenstorrent/tt-metal/actions/runs/25475877531
- [x] Galaxy perf https://github.com/tenstorrent/tt-metal/actions/runs/25476921579
- [x] Galaxy stress https://github.com/tenstorrent/tt-metal/actions/runs/25476203803


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=roseli/0-move-wh-galaxy-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:roseli/0-move-wh-galaxy-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=roseli/0-move-wh-galaxy-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:roseli/0-move-wh-galaxy-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=roseli/0-move-wh-galaxy-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:roseli/0-move-wh-galaxy-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=roseli/0-move-wh-galaxy-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:roseli/0-move-wh-galaxy-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=roseli/0-move-wh-galaxy-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:roseli/0-move-wh-galaxy-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=roseli/0-move-wh-galaxy-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:roseli/0-move-wh-galaxy-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=roseli/0-move-wh-galaxy-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:roseli/0-move-wh-galaxy-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=roseli/0-move-wh-galaxy-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:roseli/0-move-wh-galaxy-tests)