### PR TITLE
[Bug Fix] Enable kernel path collection in Inspector when DEVICE_PRINT is active

### DIFF
--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -304,7 +304,9 @@ static_assert(sizeof(DevicePrintHeader) == sizeof(uint32_t));
 class DevicePrintImpl : public DPrintServer::Impl {
 public:
     DevicePrintImpl(MetalEnv& env, uint8_t num_hw_cqs, const DispatchCoreConfig& dispatch_core_config) :
-        DPrintServer::Impl(env, num_hw_cqs, dispatch_core_config) {}
+        DPrintServer::Impl(env, num_hw_cqs, dispatch_core_config) {
+        Inspector::enable_kernel_path_collection();
+    }
 
 protected:
     bool poll_one_core(ChipId device_id, const umd::CoreDescriptor& logical_core, bool new_data_this_iter) override;

--- a/tt_metal/impl/debug/inspector/data.hpp
+++ b/tt_metal/impl/debug/inspector/data.hpp
@@ -77,6 +77,10 @@ private:
     // store prefetcher core info by virtual core
     std::unordered_map<tt_cxy_pair, inspector::CoreInfo> prefetcher_core_info;
 
+    std::atomic<bool> kernel_path_collection_enabled{false};
+    std::mutex kernel_path_mutex;
+    std::unordered_map<int, std::string> kernel_id_to_path;
+
     // fw_compile_hash needs to be atomic because it is set in MetalContext::initialize()
     std::atomic<uint64_t> fw_compile_hash;
     friend class tt::tt_metal::Inspector;

--- a/tt_metal/impl/debug/inspector/inspector.cpp
+++ b/tt_metal/impl/debug/inspector/inspector.cpp
@@ -175,6 +175,10 @@ void Inspector::program_kernel_compile_finished(
         kernel_data.watcher_kernel_id = kernel->get_watcher_kernel_id();
         kernel_data.name = kernel->name();
         kernel_data.path = build_options.path;
+        if (data->kernel_path_collection_enabled) {
+            std::lock_guard<std::mutex> path_lock(data->kernel_path_mutex);
+            data->kernel_id_to_path[kernel->get_watcher_kernel_id()] = build_options.path;
+        }
         kernel_data.source = kernel->kernel_source().source_;
         data->kernel_id_to_program_id[kernel->get_watcher_kernel_id()] = program->get_id();
         data->logger.log_program_kernel_compile_finished(program_data, kernel_data);
@@ -552,6 +556,22 @@ void Inspector::set_build_env_fw_compile_hash(const uint64_t fw_compile_hash) {
     }
 }
 
+void Inspector::enable_kernel_path_collection() {
+    if (!is_enabled()) {
+        return;
+    }
+    auto* data = get_inspector_data();
+    if (!data) {
+        // Inspector failed to initialize, no need to print failure message again.
+        return;
+    }
+    try {
+        data->kernel_path_collection_enabled = true;
+    } catch (const std::exception& e) {
+        TT_INSPECTOR_LOG("Failed to enable kernel path collection: {}", e.what());
+    }
+}
+
 std::string Inspector::get_kernel_path_from_watcher_kernel_id(int watcher_kernel_id) {
     std::string elf_path;
 
@@ -564,16 +584,24 @@ std::string Inspector::get_kernel_path_from_watcher_kernel_id(int watcher_kernel
         return elf_path;
     }
     try {
-        std::lock_guard<std::mutex> lock(data->programs_mutex);
-        auto program_id_it = data->kernel_id_to_program_id.find(watcher_kernel_id);
-        if (program_id_it != data->kernel_id_to_program_id.end()) {
-            auto program_id = data->kernel_id_to_program_id.at(watcher_kernel_id);
-            auto program_data_it = data->programs_data.find(program_id);
-            if (program_data_it != data->programs_data.end()) {
-                auto& program_data = program_data_it->second;
-                auto kernel_data_it = program_data.kernels.find(watcher_kernel_id);
-                if (kernel_data_it != program_data.kernels.end()) {
-                    elf_path = kernel_data_it->second.path;
+        if (data->kernel_path_collection_enabled) {
+            std::lock_guard<std::mutex> lock(data->kernel_path_mutex);
+            auto kernel_path_it = data->kernel_id_to_path.find(watcher_kernel_id);
+            if (kernel_path_it != data->kernel_id_to_path.end()) {
+                elf_path = kernel_path_it->second;
+            }
+        } else {
+            std::lock_guard<std::mutex> lock(data->programs_mutex);
+            auto program_id_it = data->kernel_id_to_program_id.find(watcher_kernel_id);
+            if (program_id_it != data->kernel_id_to_program_id.end()) {
+                auto program_id = data->kernel_id_to_program_id.at(watcher_kernel_id);
+                auto program_data_it = data->programs_data.find(program_id);
+                if (program_data_it != data->programs_data.end()) {
+                    auto& program_data = program_data_it->second;
+                    auto kernel_data_it = program_data.kernels.find(watcher_kernel_id);
+                    if (kernel_data_it != program_data.kernels.end()) {
+                        elf_path = kernel_data_it->second.path;
+                    }
                 }
             }
         }

--- a/tt_metal/impl/debug/inspector/inspector.hpp
+++ b/tt_metal/impl/debug/inspector/inspector.hpp
@@ -100,6 +100,7 @@ public:
     // If data is available, returns ELF path. If data is not available (e.g. inspector disabled, or no kernel data for
     // the given id), returns empty string.
     static std::string get_kernel_path_from_watcher_kernel_id(int watcher_kernel_id);
+    static void enable_kernel_path_collection();
 
     static inspector::RpcServer& get_rpc_server();
 


### PR DESCRIPTION
### Summary
Kernel object lifetime can cause `DEVICE_PRINT` not to show up its print messages. If kernel object is not in Inspector, `DEVICE_PRINT` server won't know how to find kernel path. This change enables collection of kernel paths in Inspector when `DEVICE_PRINT` is enabled. This will guarantee that server knows which kernel is being addressed in downloaded buffer even if kernel object is destroyed on host (its elf file will still be inside the cache directory).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vjovanovic/device_print_kernel_paths_mapping)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/device_print_kernel_paths_mapping)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vjovanovic/device_print_kernel_paths_mapping)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vjovanovic/device_print_kernel_paths_mapping)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vjovanovic/device_print_kernel_paths_mapping)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vjovanovic/device_print_kernel_paths_mapping)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/device_print_kernel_paths_mapping)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/device_print_kernel_paths_mapping)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vjovanovic/device_print_kernel_paths_mapping)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vjovanovic/device_print_kernel_paths_mapping)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vjovanovic/device_print_kernel_paths_mapping)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/device_print_kernel_paths_mapping)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vjovanovic/device_print_kernel_paths_mapping)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/device_print_kernel_paths_mapping)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vjovanovic/device_print_kernel_paths_mapping)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/device_print_kernel_paths_mapping)