### PR TITLE
[cleanup] Remove default constructor for Metal Tensors

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -189,24 +189,24 @@ void run_single_dfb_program(
     const bool need_in_tensor = (producer_type == DFBPorCType::DM);
     const bool need_out_tensor = (consumer_type == DFBPorCType::DM);
 
-    MeshTensor in_tensor;
-    MeshTensor out_tensor;
+    std::optional<MeshTensor> in_tensor;
+    std::optional<MeshTensor> out_tensor;
     const auto tensor_spec = make_flat_dram_tensor_spec(entry_size, total_entries);
     if (need_in_tensor) {
         in_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec, TensorTopology{});
         log_info(
             tt::LogTest,
             "In Tensor:  [address: {} B, size: {} B]",
-            in_tensor.mesh_buffer().get_reference_buffer()->address(),
-            in_tensor.mesh_buffer().get_reference_buffer()->size());
+            in_tensor->mesh_buffer().get_reference_buffer()->address(),
+            in_tensor->mesh_buffer().get_reference_buffer()->size());
     }
     if (need_out_tensor) {
         out_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec, TensorTopology{});
         log_info(
             tt::LogTest,
             "Out Tensor: [address: {} B, size: {} B]",
-            out_tensor.mesh_buffer().get_reference_buffer()->address(),
-            out_tensor.mesh_buffer().get_reference_buffer()->size());
+            out_tensor->mesh_buffer().get_reference_buffer()->address(),
+            out_tensor->mesh_buffer().get_reference_buffer()->size());
     }
 
     const auto consumer_pattern = is_all ? experimental::metal2_host_api::DFBAccessPattern::ALL
@@ -336,10 +336,10 @@ void run_single_dfb_program(
 
     std::vector<experimental::metal2_host_api::TensorParameter> tensor_parameters;
     if (need_in_tensor) {
-        tensor_parameters.push_back({.unique_id = IN_TENSOR, .spec = in_tensor.tensor_spec()});
+        tensor_parameters.push_back({.unique_id = IN_TENSOR, .spec = in_tensor->tensor_spec()});
     }
     if (need_out_tensor) {
-        tensor_parameters.push_back({.unique_id = OUT_TENSOR, .spec = out_tensor.tensor_spec()});
+        tensor_parameters.push_back({.unique_id = OUT_TENSOR, .spec = out_tensor->tensor_spec()});
     }
 
     experimental::metal2_host_api::ProgramSpec spec{
@@ -375,10 +375,10 @@ void run_single_dfb_program(
     }
     run_params.kernel_run_params = {producer_params, consumer_params};
     if (need_in_tensor) {
-        run_params.tensor_args.push_back({.tensor_parameter_name = IN_TENSOR, .tensor = std::cref(in_tensor)});
+        run_params.tensor_args.push_back({.tensor_parameter_name = IN_TENSOR, .tensor = std::cref(*in_tensor)});
     }
     if (need_out_tensor) {
-        run_params.tensor_args.push_back({.tensor_parameter_name = OUT_TENSOR, .tensor = std::cref(out_tensor)});
+        run_params.tensor_args.push_back({.tensor_parameter_name = OUT_TENSOR, .tensor = std::cref(*out_tensor)});
     }
     experimental::metal2_host_api::SetProgramRunParameters(program, run_params);
 
@@ -469,12 +469,12 @@ void run_single_dfb_program(
     // so the I/O flow is inlined here to skip operations on unallocated tensors.
     const bool verify_output = (consumer_type == DFBPorCType::DM);
     if (need_in_tensor) {
-        detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), input);
+        detail::WriteToBuffer(*in_tensor->mesh_buffer().get_reference_buffer(), input);
         if (arch == ARCH::QUASAR) {
             // TODO #38042: Need to wait for data to be written, the barrier needs to be uplifted for Quasar
             std::this_thread::sleep_for(std::chrono::milliseconds(500));
             std::vector<uint32_t> rdback_dram;
-            detail::ReadFromBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), rdback_dram);
+            detail::ReadFromBuffer(*in_tensor->mesh_buffer().get_reference_buffer(), rdback_dram);
             tt_driver_atomics::mfence();
             EXPECT_EQ(rdback_dram, input);
         }
@@ -484,7 +484,7 @@ void run_single_dfb_program(
 
     if (verify_output) {
         std::vector<uint32_t> output;
-        detail::ReadFromBuffer(*out_tensor.mesh_buffer().get_reference_buffer(), output);
+        detail::ReadFromBuffer(*out_tensor->mesh_buffer().get_reference_buffer(), output);
         const std::vector<uint32_t>& expected = tensix_dm_expected ? *tensix_dm_expected : input;
         if (expected != output) {
             log_info(tt::LogTest, "Printing expected");

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
@@ -280,7 +280,7 @@ TEST(HostTensorTest, IsValuelessAfterMoveReturnsTrueAfterMoveConstruction) {
     auto tensor = create_simple_host_tensor(Shape{4, 32});
     HostTensor moved(std::move(tensor));
 
-    EXPECT_TRUE(tensor.is_valueless_after_move());
+    EXPECT_TRUE(tensor.is_valueless_after_move());  // NOLINT(bugprone-use-after-move)
     EXPECT_FALSE(moved.is_valueless_after_move());
 }
 
@@ -290,7 +290,7 @@ TEST(HostTensorTest, IsValuelessAfterMoveReturnsTrueAfterMoveAssignment) {
 
     target = std::move(source);
 
-    EXPECT_TRUE(source.is_valueless_after_move());
+    EXPECT_TRUE(source.is_valueless_after_move());  // NOLINT(bugprone-use-after-move)
     EXPECT_FALSE(target.is_valueless_after_move());
 }
 

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
@@ -43,7 +43,7 @@ HostTensor create_simple_host_tensor(const Shape& shape, DataType dtype = DataTy
 
 // Type trait tests verifying HostTensor's semantic constraints
 
-TEST(HostTensorTypeTraitsTest, IsDefaultConstructible) { EXPECT_TRUE(std::is_default_constructible_v<HostTensor>); }
+TEST(HostTensorTypeTraitsTest, IsDefaultConstructible) { EXPECT_FALSE(std::is_default_constructible_v<HostTensor>); }
 
 TEST(HostTensorTypeTraitsTest, IsDestructible) { EXPECT_TRUE(std::is_destructible_v<HostTensor>); }
 
@@ -167,20 +167,6 @@ TEST(HostTensorTest, CopyAssignment) {
     EXPECT_EQ(other.dtype(), DataType::BFLOAT16);
     // Original should still be valid
     EXPECT_EQ(tensor.logical_shape(), shape);
-}
-
-TEST(HostTensorTest, CopyConstructionFromDefaultConstructed) {
-    HostTensor default_tensor;
-    const HostTensor& copied(default_tensor);
-    (void)copied;
-    // Both should be in default-constructed state (no assertions, just shouldn't crash)
-}
-
-TEST(HostTensorTest, CopyAssignmentFromDefaultConstructed) {
-    HostTensor default_tensor;
-    [[maybe_unused]] auto tensor = create_simple_host_tensor(Shape{2, 64});
-    tensor = default_tensor;
-    // tensor should now be in default-constructed state (no assertions, just shouldn't crash)
 }
 
 TEST(HostTensorTest, TensorSpecAccess) {

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
@@ -259,5 +259,40 @@ TEST(HostTensorTest, NdShardSpecNotSet) {
     EXPECT_FALSE(tensor.nd_shard_spec().has_value());
 }
 
+TEST(HostTensorTest, IsValuelessAfterMoveReturnsFalse) {
+    // A freshly constructed tensor is not valueless.
+    auto tensor = create_simple_host_tensor(Shape{4, 32});
+    EXPECT_FALSE(tensor.is_valueless_after_move());
+
+    // Copy construction leaves neither source nor destination valueless.
+    HostTensor copy(tensor);  // NOLINT(performance-unnecessary-copy-initialization)
+    EXPECT_FALSE(tensor.is_valueless_after_move());
+    EXPECT_FALSE(copy.is_valueless_after_move());
+
+    // Copy assignment leaves neither source nor destination valueless.
+    auto target = create_simple_host_tensor(Shape{1, 8});
+    target = tensor;
+    EXPECT_FALSE(tensor.is_valueless_after_move());
+    EXPECT_FALSE(target.is_valueless_after_move());
+}
+
+TEST(HostTensorTest, IsValuelessAfterMoveReturnsTrueAfterMoveConstruction) {
+    auto tensor = create_simple_host_tensor(Shape{4, 32});
+    HostTensor moved(std::move(tensor));
+
+    EXPECT_TRUE(tensor.is_valueless_after_move());
+    EXPECT_FALSE(moved.is_valueless_after_move());
+}
+
+TEST(HostTensorTest, IsValuelessAfterMoveReturnsTrueAfterMoveAssignment) {
+    auto source = create_simple_host_tensor(Shape{4, 32});
+    auto target = create_simple_host_tensor(Shape{1, 8});
+
+    target = std::move(source);
+
+    EXPECT_TRUE(source.is_valueless_after_move());
+    EXPECT_FALSE(target.is_valueless_after_move());
+}
+
 }  // namespace
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
@@ -162,6 +162,46 @@ TEST_F(MeshTensorDeviceTest, TensorProperties) {
     EXPECT_EQ(tensor.memory_config().buffer_type(), BufferType::DRAM);
 }
 
+TEST_F(MeshTensorDeviceTest, IsValuelessAfterMoveReturnsFalse) {
+    auto page_config = PageConfig(Layout::ROW_MAJOR);
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto tensor_layout = TensorLayout(DataType::BFLOAT16, page_config, memory_config);
+    auto spec = TensorSpec(Shape{1, 32}, tensor_layout);
+
+    // A freshly constructed tensor is not valueless.
+    auto tensor = MeshTensor::allocate_on_device(*mesh_device_, spec, TensorTopology());
+    EXPECT_FALSE(tensor.is_valueless_after_move());
+}
+
+TEST_F(MeshTensorDeviceTest, IsValuelessAfterMoveReturnsTrueAfterMoveConstruction) {
+    auto page_config = PageConfig(Layout::ROW_MAJOR);
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto tensor_layout = TensorLayout(DataType::BFLOAT16, page_config, memory_config);
+    auto spec = TensorSpec(Shape{1, 32}, tensor_layout);
+
+    auto original = MeshTensor::allocate_on_device(*mesh_device_, spec, TensorTopology());
+    MeshTensor moved(std::move(original));
+
+    EXPECT_TRUE(original.is_valueless_after_move());
+    EXPECT_FALSE(moved.is_valueless_after_move());
+}
+
+TEST_F(MeshTensorDeviceTest, IsValuelessAfterMoveReturnsTrueAfterMoveAssignment) {
+    auto page_config = PageConfig(Layout::ROW_MAJOR);
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto tensor_layout = TensorLayout(DataType::BFLOAT16, page_config, memory_config);
+    auto spec1 = TensorSpec(Shape{1, 32}, tensor_layout);
+    auto spec2 = TensorSpec(Shape{2, 64}, tensor_layout);
+
+    auto source = MeshTensor::allocate_on_device(*mesh_device_, spec1, TensorTopology());
+    auto target = MeshTensor::allocate_on_device(*mesh_device_, spec2, TensorTopology());
+
+    target = std::move(source);
+
+    EXPECT_TRUE(source.is_valueless_after_move());
+    EXPECT_FALSE(target.is_valueless_after_move());
+}
+
 TEST_F(MeshTensorDeviceTest, ConstructionWithTooSmallBufferFails) {
     // Create a TensorSpec that requires multiple pages, then create a buffer
     // that's too small to hold the tensor but still valid (multiple of page_size).

--- a/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
@@ -182,8 +182,9 @@ TEST_F(MeshTensorDeviceTest, IsValuelessAfterMoveReturnsTrueAfterMoveConstructio
     auto original = MeshTensor::allocate_on_device(*mesh_device_, spec, TensorTopology());
     MeshTensor moved(std::move(original));
 
-    EXPECT_TRUE(original.is_valueless_after_move());
-    EXPECT_FALSE(moved.is_valueless_after_move());
+    // Intentional use-after-move: verifying valueless-after-move semantics.
+    EXPECT_TRUE(original.is_valueless_after_move());  // NOLINT(bugprone-use-after-move)
+    EXPECT_FALSE(moved.is_valueless_after_move());    // NOLINT(bugprone-use-after-move)
 }
 
 TEST_F(MeshTensorDeviceTest, IsValuelessAfterMoveReturnsTrueAfterMoveAssignment) {
@@ -198,8 +199,9 @@ TEST_F(MeshTensorDeviceTest, IsValuelessAfterMoveReturnsTrueAfterMoveAssignment)
 
     target = std::move(source);
 
-    EXPECT_TRUE(source.is_valueless_after_move());
-    EXPECT_FALSE(target.is_valueless_after_move());
+    // Intentional use-after-move: verifying valueless-after-move semantics.
+    EXPECT_TRUE(source.is_valueless_after_move());   // NOLINT(bugprone-use-after-move)
+    EXPECT_FALSE(target.is_valueless_after_move());  // NOLINT(bugprone-use-after-move)
 }
 
 TEST_F(MeshTensorDeviceTest, ConstructionWithTooSmallBufferFails) {

--- a/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
@@ -30,7 +30,7 @@ namespace CMAKE_UNIQUE_NAMESPACE {
 
 // Type trait tests verifying MeshTensor's semantic constraints
 
-TEST(MeshTensorTypeTraitsTest, IsDefaultConstructible) { EXPECT_TRUE(std::is_default_constructible_v<MeshTensor>); }
+TEST(MeshTensorTypeTraitsTest, IsDefaultConstructible) { EXPECT_FALSE(std::is_default_constructible_v<MeshTensor>); }
 
 TEST(MeshTensorTypeTraitsTest, IsDestructible) { EXPECT_TRUE(std::is_destructible_v<MeshTensor>); }
 
@@ -47,41 +47,6 @@ TEST(MeshTensorTypeTraitsTest, IsNothrowMoveConstructible) {
 }
 
 TEST(MeshTensorTypeTraitsTest, IsNothrowMoveAssignable) { EXPECT_TRUE(std::is_nothrow_move_assignable_v<MeshTensor>); }
-
-// Runtime tests for default construction and move semantics
-
-TEST(MeshTensorTest, DefaultConstruction) {
-    MeshTensor tensor;
-    // Default constructed tensor is in valueless state
-    // Accessing members would trigger TT_ASSERT in debug builds
-    (void)tensor;
-}
-
-TEST(MeshTensorTest, MoveConstruction) {
-    MeshTensor tensor;
-    MeshTensor moved(std::move(tensor));
-    (void)moved;
-}
-
-TEST(MeshTensorTest, MoveAssignment) {
-    MeshTensor tensor;
-    MeshTensor other;
-    other = std::move(tensor);
-    (void)other;
-}
-
-TEST(MeshTensorTest, DefaultConstructedIsNotInitialized) {
-    MeshTensor tensor;
-    EXPECT_FALSE(tensor.is_initialized());
-}
-
-TEST(MeshTensorTest, MovedFromIsNotInitialized) {
-    MeshTensor source;
-    MeshTensor dest;
-    dest = std::move(source);
-    EXPECT_FALSE(source.is_initialized());  // NOLINT(bugprone-use-after-move)
-    EXPECT_FALSE(dest.is_initialized());
-}
 
 TEST(MeshTensorTest, ConstructionWithNullMeshBufferFails) {
     auto page_config = PageConfig(Layout::ROW_MAJOR);

--- a/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
@@ -102,42 +102,6 @@ TEST_F(MeshTensorDeviceTest, ConstructionWithMeshBuffer) {
     EXPECT_EQ(tensor.logical_shape(), Shape({1, 32}));
 }
 
-TEST_F(MeshTensorDeviceTest, ConstructedWithMeshBufferIsInitialized) {
-    auto page_config = PageConfig(Layout::ROW_MAJOR);
-    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    auto tensor_layout = TensorLayout(DataType::BFLOAT16, page_config, memory_config);
-    auto spec = TensorSpec(Shape{1, 32}, tensor_layout);
-
-    auto mesh_buffer = create_mesh_buffer(*mesh_device_, spec);
-    ASSERT_NE(mesh_buffer, nullptr);
-    ASSERT_TRUE(mesh_buffer->is_allocated());
-
-    auto topology = TensorTopology();
-
-    MeshTensor tensor(mesh_buffer, std::move(spec), std::move(topology));
-
-    EXPECT_TRUE(tensor.is_initialized());
-}
-
-TEST_F(MeshTensorDeviceTest, IsNotInitializedAfterMoveFrom) {
-    auto page_config = PageConfig(Layout::ROW_MAJOR);
-    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    auto tensor_layout = TensorLayout(DataType::BFLOAT16, page_config, memory_config);
-    auto spec = TensorSpec(Shape{1, 32}, tensor_layout);
-
-    auto mesh_buffer = create_mesh_buffer(*mesh_device_, spec);
-    auto topology = TensorTopology();
-
-    MeshTensor original(mesh_buffer, std::move(spec), std::move(topology));
-
-    EXPECT_TRUE(original.is_initialized());
-
-    MeshTensor moved(std::move(original));
-
-    EXPECT_FALSE(original.is_initialized());  // NOLINT(bugprone-use-after-move)
-    EXPECT_TRUE(moved.is_initialized());
-}
-
 TEST_F(MeshTensorDeviceTest, MoveConstructionTransfersOwnership) {
     auto page_config = PageConfig(Layout::ROW_MAJOR);
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};

--- a/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
@@ -23,9 +23,11 @@ using tt::tt_metal::GenericMeshDeviceFixture;
 using tt::tt_metal::Layout;
 using tt::tt_metal::MemoryConfig;
 using tt::tt_metal::MeshDevice1x2Fixture;
+using tt::tt_metal::MeshTensor;
 using tt::tt_metal::Tensor;
 using tt::tt_metal::TensorLayout;
 using tt::tt_metal::TensorSpec;
+using tt::tt_metal::TensorTopology;
 
 // Most ownership tests only need a single device.
 using DeviceStorageOwnershipTest = GenericMeshDeviceFixture;
@@ -48,6 +50,20 @@ TEST_F(DeviceStorageOwnershipTest, DeviceStorage_DefaultConstructedState) {
 
     EXPECT_FALSE(storage.is_allocated());
     EXPECT_TRUE(storage.is_uniform_storage());
+}
+
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_ThrowsWhenConstructedFromMovedFromMeshTensor) {
+    auto source_mesh_tensor = MeshTensor::allocate_on_device(*mesh_device_, make_test_tensor_spec(), TensorTopology{});
+    MeshTensor moved_mesh_tensor(std::move(source_mesh_tensor));
+
+    EXPECT_TRUE(source_mesh_tensor.is_valueless_after_move());  // NOLINT(bugprone-use-after-move)
+    EXPECT_FALSE(moved_mesh_tensor.is_valueless_after_move());
+
+    auto construct_storage_from_moved_from = [&]() {
+        DeviceStorage storage(std::move(source_mesh_tensor));  // NOLINT(bugprone-use-after-move)
+        (void)storage;
+    };
+    EXPECT_THROW(construct_storage_from_moved_from(), std::exception);
 }
 
 TEST_F(DeviceStorageOwnershipTest, DeviceStorage_SoleOwnerAfterCreation) {

--- a/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
@@ -156,6 +156,15 @@ public:
     const TensorTopology& tensor_topology() const;
 
     /**
+     * Returns true if this HostTensor was left in a moved-from state.
+     *
+     * A HostTensor becomes valueless when it is the source of a move construction or move assignment.
+     * Unlike every other member function (except destruction and assignment), this function is safe to
+     * call on a moved-from instance; it is in fact the intended way to detect that state.
+     */
+    bool is_valueless_after_move() const;
+
+    /**
      * Returns the DistributedHostBuffer of the HostTensor.
      */
     const DistributedHostBuffer& buffer() const;

--- a/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
@@ -209,7 +209,7 @@ public:
 
 private:
     // impl_ could be a nullptr if HostTensor is in a moved-from state.
-    // Avoid using impl_ pointer directly, use the accessors instead.
+    // Avoid using impl_ pointer directly, use the impl() accessor instead.
     // Otherwise, please add manual TT_FATAL checks for nullptr.
     std::unique_ptr<HostTensorImpl> impl_;
 };

--- a/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
@@ -39,8 +39,6 @@ class HostTensorImpl;
  * MeshTensor for host <-> device communication.
  *
  * Invariants of HostTensor:
- * - Default constructed: This is a valueless state, where any access to any member function outside of assignment and
- *   move construction will be UB. This exists to allow for default constructed HostTensor. This mirrors MeshTensor.
  * - Initialized: The HostTensor holds some tensor configurations and associated HostBuffer.
  */
 class HostTensor {
@@ -49,10 +47,7 @@ public:
 
     // Special Member functions
 
-    /**
-     * Constructs a host tensor in the default constructed state, acting like a nullptr.
-     */
-    HostTensor();
+    HostTensor() = delete;
 
     /**
      * Constructs a host tensor from a distributed host buffer.
@@ -89,7 +84,7 @@ public:
      * Move constructor.
      *
      * Takes over properties of the other HostTensor.
-     * The other HostTensor becomes a default-constructed HostTensor.
+     * The other HostTensor is left in a valid but unspecified state.
      */
     HostTensor(HostTensor&& other) noexcept;
 
@@ -97,7 +92,7 @@ public:
      * Move assignment operator.
      *
      * Takes over properties of the other HostTensor.
-     * The other HostTensor becomes a default-constructed HostTensor.
+     * The other HostTensor is left in a valid but unspecified state.
      */
     HostTensor& operator=(HostTensor&& other) noexcept;
 
@@ -208,6 +203,9 @@ public:
     const HostTensorImpl& impl() const;
 
 private:
+    // impl_ could be a nullptr if HostTensor is in a moved-from state.
+    // Avoid using impl_ pointer directly, use the accessors instead.
+    // Otherwise, please add manual TT_FATAL checks for nullptr.
     std::unique_ptr<HostTensorImpl> impl_;
 };
 

--- a/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
@@ -30,16 +30,20 @@ namespace tt::tt_metal {
 class HostTensorImpl;
 
 /**
- * HostTensor represents a Tensor in host memory.
- * Unlike from MeshTensor, copying a HostTensor will perform a value-copy semantics of the underlying config and
- * HostBuffer. Note that this usually doesn't mean a deep copy of the underlying data, as the HostBuffer is usually
- * a view into a contiguous memory region.
- *
- * HostTensor has limited transformation operations supported (via tensor_apis.hpp), and is intended to be used with
- * MeshTensor for host <-> device communication.
+ * HostTensor represents a Tensor in host memory. It is intended to be used with MeshTensor for host <-> device
+ * communication, and has a limited set of transformation operations supported (via tensor_apis.hpp).
  *
  * Invariants of HostTensor:
- * - Initialized: The HostTensor holds some tensor configurations and associated HostBuffer.
+ * - The DistributedHostBuffer data is laid out in a way that conforms to the TensorSpec.
+ *
+ * Notes:
+ * - HostTensor is copyable with value semantics: TensorSpec and TensorTopology are deep-copied; the
+ *   DistributedHostBuffer follows its own copy semantics, which is typically a shallow copy (view into the
+ *   same underlying data).
+ * - Unlike MeshTensor, HostTensor does not have unique ownership semantics.
+ *
+ * Note: A moved-from HostTensor is in a valid but unspecified state. All member functions except destruction and
+ * assignment will fail on a moved-from instance.
  */
 class HostTensor {
 public:
@@ -137,30 +141,22 @@ public:
      * Converts a `Tensor` to a `std::vector<T>`.
      * Elements in the vector will be stored in row-major order. The type of the requested vector has to match that of
      * the `Tensor`; block float formats such as BFLOAT8_B and BFLOAT4_B require `T` equal `float`.
-     *
-     * pre-condition: The HostTensor must be engaged.
      */
     template <typename T>
     std::vector<T> to_vector() const;
 
     /**
      * Returns the TensorSpec of the HostTensor.
-     *
-     * pre-condition: The HostTensor must be engaged.
      */
     const TensorSpec& tensor_spec() const;
 
     /**
      * Multi-device topology configuration - tracks how tensor is distributed across mesh devices
-     *
-     * pre-condition: The HostTensor must be engaged.
      */
     const TensorTopology& tensor_topology() const;
 
     /**
      * Returns the DistributedHostBuffer of the HostTensor.
-     *
-     * pre-condition: The HostTensor must be engaged.
      */
     const DistributedHostBuffer& buffer() const;
 

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -43,8 +43,6 @@ class MeshDevice;
  *   semantics)
  *
  * Invariants of MeshTensor:
- * - Default constructed: This is a valueless state, where any access to any member function outside of assignment and
- *   move construction will be UB. This exists to allow for default constructed MeshTensor. This mirrors HostTensor.
  * - Allocated: The device memory is allocated and **solely owned** by MeshTensor, user is able to get non-null
  *   pointers to the underlying storage and associated MeshDevice. Please note that this invariant isn't guaranteed
  *   currently, see: #38375
@@ -55,10 +53,7 @@ public:
 
     // Special Member functions
 
-    /**
-     * Construct a tensor that does not own any device memory.
-     */
-    MeshTensor();
+    MeshTensor() = delete;
 
     /**
      * Allocate a MeshTensor on the given device with the given spec and topology.
@@ -89,14 +84,14 @@ public:
     /**
      * Transfer ownership of the underlying device memory to the other MeshTensor.
      *
-     * post-condition: The other MeshTensor will be in a default constructed state.
+     * post-condition: The moved-from MeshTensor is left in a valid but unspecified state.
      */
     MeshTensor(MeshTensor&& other) noexcept;
 
     /**
      * Transfer ownership of the underlying device memory to the other MeshTensor.
      *
-     * post-condition: The other MeshTensor will be in a default constructed state.
+     * post-condition: The moved-from MeshTensor is left in a valid but unspecified state.
      */
     MeshTensor& operator=(MeshTensor&& other) noexcept;
 
@@ -107,21 +102,21 @@ public:
     /**
      * Return the underlying device storage MeshBuffer.
      *
-     * pre-condition: The device tensor must not be in a default constructed state.
+     * pre-condition: The MeshTensor must be allocated (not moved-from).
      */
     const distributed::MeshBuffer& mesh_buffer() const;
 
     /**
      * Get the device the allocated device memory is on.
      *
-     * pre-condition: The device tensor must not be in a default constructed state.
+     * pre-condition: The MeshTensor must be allocated (not moved-from).
      */
     distributed::MeshDevice& device() const;
 
     // Getters:
 
     /**
-     * Returns true if MeshTensor owns device memory (not default-constructed or moved-from).
+     * Returns true if MeshTensor owns device memory (not moved-from).
      */
     bool is_initialized() const;
 
@@ -130,7 +125,7 @@ public:
     /**
      * Multi-device topology configuration - tracks how tensor is distributed across mesh devices
      *
-     * pre-condition: The device tensor must not be in a default constructed state.
+     * pre-condition: The MeshTensor must be allocated (not moved-from).
      */
     const TensorTopology& tensor_topology() const;
 
@@ -158,7 +153,7 @@ public:
     /**
      * Get the size in bytes of a single element held in the tensor.
      *
-     * pre-condition: The device tensor must not be in a default constructed state.
+     * pre-condition: The MeshTensor must be allocated (not moved-from).
      */
     std::size_t element_size() const;
 
@@ -197,9 +192,9 @@ private:
      */
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer_invariant_breaking() const;
 
-    // impl_ could be a nullptr if MeshTensor is in a default constructed state.
+    // impl_ could be a nullptr if MeshTensor is in a moved-from state.
     // Avoid using impl_ pointer directly, use the accessors instead.
-    // Otherwise, please add manual TT_ASSERT checks for nullptr.
+    // Otherwise, please add manual TT_FATAL checks for nullptr.
     std::unique_ptr<MeshTensorImpl> impl_;
 };
 

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -31,21 +31,22 @@ class MeshDevice;
  * MeshTensor is a device memory object. The user’s mental model of MeshTensor is an owning handle to
  * device-allocated memory.
  *
- * MeshTensor should have RAII semantics with unique ownership:
- * - Device memory resource lifetime == object lifetime
- *   - Device memory is allocated on construction, and released on destruction.
- *   - The programmer explicitly manages the device-allocated memory lifetime.
- *   - This can be tricky in an asynchronous runtime environment. For now, the focus is on the programmer to correctly
- *     manage MeshTensor lifetime around queue synchronization events.
- * - Movable (RAII transfer of ownership)
- * - Non-copyable
- * - No equality/inequality operator. (If we did add this, equality would mean the same underlying allocation – no value
- *   semantics)
- *
  * Invariants of MeshTensor:
- * - Allocated: The device memory is allocated and **solely owned** by MeshTensor, user is able to get non-null
- *   pointers to the underlying storage and associated MeshDevice. Please note that this invariant isn't guaranteed
- *   currently, see: #38375
+ * - MeshTensor is the sole owner of the underlying device memory.
+ * - MeshTensor object lifetime is the same as the underlying device memory lifetime. An instance of MeshTensor maps to
+ * a single allocated device memory.
+ * - The underlying device memory is always allocated, large enough to hold the tensor, and laid out in a way
+ *   that conforms to the TensorSpec (page size, buffer type, memory layout).
+ *
+ * Notes:
+ * - MeshTensor is non-copyable but movable due to the unique ownership model.
+ * - To "deallocate" a MeshTensor, simply let the MeshTensor go out of scope.
+ * - The programmer is responsible for managing MeshTensor lifetime around queue synchronization events,
+ *   which can be tricky in an asynchronous runtime environment.
+ * - There is no invariant between a MeshTensor and it's associated TensorTopology.
+ *
+ * Note: A moved-from MeshTensor is in a valid but unspecified state. All member functions except destruction and
+ * assignment will fail on a moved-from instance.
  */
 class MeshTensor {
 public:
@@ -97,19 +98,13 @@ public:
 
     // End special member functions
 
-    // Deallocation related:
-
     /**
      * Return the underlying device storage MeshBuffer.
-     *
-     * pre-condition: The MeshTensor must be allocated (not moved-from).
      */
     const distributed::MeshBuffer& mesh_buffer() const;
 
     /**
      * Get the device the allocated device memory is on.
-     *
-     * pre-condition: The MeshTensor must be allocated (not moved-from).
      */
     distributed::MeshDevice& device() const;
 
@@ -119,8 +114,6 @@ public:
 
     /**
      * Multi-device topology configuration - tracks how tensor is distributed across mesh devices
-     *
-     * pre-condition: The MeshTensor must be allocated (not moved-from).
      */
     const TensorTopology& tensor_topology() const;
 
@@ -147,16 +140,14 @@ public:
 
     /**
      * Get the size in bytes of a single element held in the tensor.
-     *
-     * pre-condition: The MeshTensor must be allocated (not moved-from).
      */
     std::size_t element_size() const;
 
     Strides strides() const;
 
-    // Update the topology of the MeshTensor post construction.
-    // TODO(river): Is this a good idea? Would a move constructor be better?
-    // Is a MeshTensor with a new tensor topology fundamentally different?
+    /**
+     * Update the topology of the MeshTensor post construction.
+     */
     void update_tensor_topology(TensorTopology tensor_topology);
 
     /**

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -188,7 +188,7 @@ private:
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer_invariant_breaking() const;
 
     // impl_ could be a nullptr if MeshTensor is in a moved-from state.
-    // Avoid using impl_ pointer directly, use the accessors instead.
+    // Avoid using impl_ pointer directly, use the impl() accessor instead.
     // Otherwise, please add manual TT_FATAL checks for nullptr.
     std::unique_ptr<MeshTensorImpl> impl_;
 };

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -117,6 +117,15 @@ public:
      */
     const TensorTopology& tensor_topology() const;
 
+    /**
+     * Returns true if this MeshTensor was left in a moved-from state.
+     *
+     * A MeshTensor becomes valueless when it is the source of a move construction or move assignment.
+     * Unlike every other member function (except destruction and assignment), this function is safe to
+     * call on a moved-from instance; it is in fact the intended way to detect that state.
+     */
+    bool is_valueless_after_move() const;
+
     // Derivables:
 
     DataType dtype() const;

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -115,11 +115,6 @@ public:
 
     // Getters:
 
-    /**
-     * Returns true if MeshTensor owns device memory (not moved-from).
-     */
-    bool is_initialized() const;
-
     const TensorSpec& tensor_spec() const;
 
     /**

--- a/tt_metal/impl/tensor/host_tensor.cpp
+++ b/tt_metal/impl/tensor/host_tensor.cpp
@@ -58,22 +58,13 @@ const HostTensorImpl& HostTensor::impl() const {
     return *impl_;
 }
 
-const TensorSpec& HostTensor::tensor_spec() const {
-    TT_FATAL(impl_ != nullptr, "HostTensor is in a moved-from state.");
-    return impl_->spec();
-}
+const TensorSpec& HostTensor::tensor_spec() const { return impl().spec(); }
 
-const TensorTopology& HostTensor::tensor_topology() const {
-    TT_FATAL(impl_ != nullptr, "HostTensor is in a moved-from state.");
-    return impl_->topology();
-}
+const TensorTopology& HostTensor::tensor_topology() const { return impl().topology(); }
 
 bool HostTensor::is_valueless_after_move() const { return impl_ == nullptr; }
 
-const DistributedHostBuffer& HostTensor::buffer() const {
-    TT_FATAL(impl_ != nullptr, "HostTensor is in a moved-from state.");
-    return impl_->buffer();
-}
+const DistributedHostBuffer& HostTensor::buffer() const { return impl().buffer(); }
 
 DataType HostTensor::dtype() const { return tensor_spec().tensor_layout().get_data_type(); }
 
@@ -118,8 +109,7 @@ HostTensor HostTensor::transform(const std::function<HostBuffer(const HostBuffer
 }
 
 void HostTensor::update_tensor_topology(TensorTopology tensor_topology) {
-    TT_FATAL(impl_ != nullptr, "HostTensor is in a moved-from state.");
-    impl_->update_topology(std::move(tensor_topology));
+    impl().update_topology(std::move(tensor_topology));
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/host_tensor.cpp
+++ b/tt_metal/impl/tensor/host_tensor.cpp
@@ -68,6 +68,8 @@ const TensorTopology& HostTensor::tensor_topology() const {
     return impl_->topology();
 }
 
+bool HostTensor::is_valueless_after_move() const { return impl_ == nullptr; }
+
 const DistributedHostBuffer& HostTensor::buffer() const {
     TT_FATAL(impl_ != nullptr, "HostTensor is in default constructed state.");
     return impl_->buffer();

--- a/tt_metal/impl/tensor/host_tensor.cpp
+++ b/tt_metal/impl/tensor/host_tensor.cpp
@@ -49,29 +49,29 @@ HostTensor& HostTensor::operator=(HostTensor&& other) noexcept {
 HostTensor::~HostTensor() = default;
 
 HostTensorImpl& HostTensor::impl() {
-    TT_FATAL(impl_ != nullptr, "HostTensor is in default constructed state.");
+    TT_FATAL(impl_ != nullptr, "HostTensor is in a moved-from state.");
     return *impl_;
 }
 
 const HostTensorImpl& HostTensor::impl() const {
-    TT_FATAL(impl_ != nullptr, "HostTensor is in default constructed state.");
+    TT_FATAL(impl_ != nullptr, "HostTensor is in a moved-from state.");
     return *impl_;
 }
 
 const TensorSpec& HostTensor::tensor_spec() const {
-    TT_FATAL(impl_ != nullptr, "HostTensor is in default constructed state.");
+    TT_FATAL(impl_ != nullptr, "HostTensor is in a moved-from state.");
     return impl_->spec();
 }
 
 const TensorTopology& HostTensor::tensor_topology() const {
-    TT_FATAL(impl_ != nullptr, "HostTensor is in default constructed state.");
+    TT_FATAL(impl_ != nullptr, "HostTensor is in a moved-from state.");
     return impl_->topology();
 }
 
 bool HostTensor::is_valueless_after_move() const { return impl_ == nullptr; }
 
 const DistributedHostBuffer& HostTensor::buffer() const {
-    TT_FATAL(impl_ != nullptr, "HostTensor is in default constructed state.");
+    TT_FATAL(impl_ != nullptr, "HostTensor is in a moved-from state.");
     return impl_->buffer();
 }
 
@@ -118,7 +118,7 @@ HostTensor HostTensor::transform(const std::function<HostBuffer(const HostBuffer
 }
 
 void HostTensor::update_tensor_topology(TensorTopology tensor_topology) {
-    TT_FATAL(impl_ != nullptr, "HostTensor is in default constructed state.");
+    TT_FATAL(impl_ != nullptr, "HostTensor is in a moved-from state.");
     impl_->update_topology(std::move(tensor_topology));
 }
 

--- a/tt_metal/impl/tensor/host_tensor.cpp
+++ b/tt_metal/impl/tensor/host_tensor.cpp
@@ -9,8 +9,6 @@
 namespace tt::tt_metal {
 
 
-HostTensor::HostTensor() = default;
-
 HostTensor::HostTensor(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology) :
     impl_(std::make_unique<HostTensorImpl>(std::move(buffer), std::move(spec), std::move(topology))) {}
 

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -36,8 +36,6 @@ std::shared_ptr<distributed::MeshBuffer> MeshTensor::mesh_buffer_invariant_break
 
 distributed::MeshDevice& MeshTensor::device() const { return *mesh_buffer().device(); }
 
-bool MeshTensor::is_initialized() const { return impl_ != nullptr; }
-
 const TensorSpec& MeshTensor::tensor_spec() const { return impl().spec(); }
 
 const TensorTopology& MeshTensor::tensor_topology() const { return impl().topology(); }

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -19,12 +19,12 @@ MeshTensor::MeshTensor(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, Ten
 MeshTensor::~MeshTensor() = default;
 
 MeshTensorImpl& MeshTensor::impl() {
-    TT_FATAL(impl_ != nullptr, "MeshTensor is in default constructed state.");
+    TT_FATAL(impl_ != nullptr, "MeshTensor is in a moved-from state.");
     return *impl_;
 }
 
 const MeshTensorImpl& MeshTensor::impl() const {
-    TT_FATAL(impl_ != nullptr, "MeshTensor is in default constructed state.");
+    TT_FATAL(impl_ != nullptr, "MeshTensor is in a moved-from state.");
     return *impl_;
 }
 

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -40,6 +40,8 @@ const TensorSpec& MeshTensor::tensor_spec() const { return impl().spec(); }
 
 const TensorTopology& MeshTensor::tensor_topology() const { return impl().topology(); }
 
+bool MeshTensor::is_valueless_after_move() const { return impl_ == nullptr; }
+
 DeviceAddr MeshTensor::address() const { return mesh_buffer().address(); }
 
 DataType MeshTensor::dtype() const { return tensor_spec().data_type(); }

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -9,8 +9,6 @@
 
 namespace tt::tt_metal {
 
-MeshTensor::MeshTensor() = default;
-
 MeshTensor::MeshTensor(MeshTensor&& other) noexcept = default;
 
 MeshTensor& MeshTensor::operator=(MeshTensor&& other) noexcept = default;

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -79,11 +79,7 @@ struct DeviceStorage::MeshTensorHolder {
     States state_;
 
     MeshTensorHolder() : state_(DeallocatedDefaultConstructed{}) {}
-    MeshTensorHolder(MeshTensor mesh_tensor) : state_(Allocated{std::move(mesh_tensor)}) {
-        TT_FATAL(
-            std::get<Allocated>(state_).mesh_tensor_.is_initialized(),
-            "MeshTensor must not be in default constructed state.");
-    }
+    MeshTensorHolder(MeshTensor mesh_tensor) : state_(Allocated{std::move(mesh_tensor)}) {}
 
     bool is_allocated() const { return std::holds_alternative<Allocated>(state_); }
 

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -79,7 +79,10 @@ struct DeviceStorage::MeshTensorHolder {
     States state_;
 
     MeshTensorHolder() : state_(DeallocatedDefaultConstructed{}) {}
-    MeshTensorHolder(MeshTensor mesh_tensor) : state_(Allocated{std::move(mesh_tensor)}) {}
+    MeshTensorHolder(MeshTensor mesh_tensor) {
+        TT_FATAL(!mesh_tensor.is_valueless_after_move(), "MeshTensor must not be in a moved-from state.");
+        state_ = Allocated{std::move(mesh_tensor)};
+    }
 
     bool is_allocated() const { return std::holds_alternative<Allocated>(state_); }
 


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

This PR removes the default constructor of Metal Tensors and removes methods to query if the MeshTensor was default initialized. 

### Rational for removal

#### Surrounding infrastructure generally does not provide a default constructor

| struct | default constructible |
| --- | --- |
DistributedHostBuffer | ❌
TensorSpec | ❌
TensorTopology | ✅
MeshBuffer | ❌
Buffer | ❌
MeshDevice | ❌

#### A default constructor forces an extra state Metal Tensor can be in that holds completely different invariant

An "initialized"/"allocated" MeshTensor provides a set of invariant that is core to what a Metal Tensor is.
For example, for both `Host` and `Mesh` Tensor, they guarantee that the underlying storage container is big enough to store anything described in `TensorSpec`.

Default construction introduces a new state the object can be in that inherently does not these invariants, users have to keep checking if the object is in default constructed state to get the desired set of invariant Metal Tensor is trying to provide.

#### Default constructed metal tensor acting like a nullptr maybe "surprising"

Current default constructed metal tensor act like a handle, where a default constructed object has the semantic meaning as a nullptr (only assignable, calls to all member functions fails).
However, intuitively, "Tensor" suggest a storage data structure (like a `std::vector`), where some basic access can return an "empty" value (e.g. size() returns 0), erroring out maybe a surprise to the API user.
There's no appropriate default value to provide to a default constructed Metal Tensor, the `TensorSpec` is not default constructible, and it's associated memory config inherently describe a chunk of memory with device information.

### Moved-from state

The moved-from state of Metal Tensor is not affected.
Though it is now put as a side note instead of being listed as an official state within the invariant of the object.

There will be no function to detect if Metal Tensor is in a moved-from state, this is okay as:
- This is not a state the developer should be using/ actively checking.
- Most static analyzers and compilers warns about using moved-from objects.

### Data movement examples

In the original design doc, the default constructibility is used in data movements, specifically:

```cpp
// ht is a HostTensor
// Allocate device Tensor
DeviceTensor  dt(spec, device);  
// H2D transfer 
cq.transferToDeviceAsync(dt, ht);
```

The becomes:

```cpp
// ht is a HostTensor
// Allocate device Tensor
MeshTensor mt = MeshTensor::allocate_on_device(device, spec, topology);
// H2D transfer 
cq.enqueueWriteTensor(ht, mt);
```

Or,

```cpp
// ht is a HostTensor
// H2D transfer
MeshTensor mt = cq.enqueueWriteTensor(ht, device); // does allocation
```

Which I argue is a cleaner syntax too?

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Also cleaned up the docs.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/metal-tensor-non-default-const)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/metal-tensor-non-default-const)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/metal-tensor-non-default-const)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/metal-tensor-non-default-const)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/metal-tensor-non-default-const)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/metal-tensor-non-default-const)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/metal-tensor-non-default-const)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/metal-tensor-non-default-const)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/metal-tensor-non-default-const)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/metal-tensor-non-default-const)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/metal-tensor-non-default-const)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/metal-tensor-non-default-const)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/metal-tensor-non-default-const)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/metal-tensor-non-default-const)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/metal-tensor-non-default-const)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/metal-tensor-non-default-const)