### PR TITLE
cherry-pick pack_untilize bug

### DIFF
--- a/tt_metal/hw/inc/api/compute/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/pack_untilize.h
@@ -149,7 +149,7 @@ ALWI void pack_untilize_block(uint32_t icb, uint32_t block_rt_dim, uint32_t ocb,
         for (uint32_t c = 0; c < block_ct_dim; ++c) {
             UNPACK(
                 (llk_unpack_A<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(icb, c)));
-            MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(c)));
+            MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(c, icb)));
         }
 
         MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary
pack_untilize call to math datacopy API does not pass down the CB id, which means it defaults to CB id 0
This is fixed in tt-metal main, this is just to provide a patch.