### PR TITLE
Fix fast_device_to_host for non-tile-aligned latents in I2V encoder

### DIFF
--- a/models/tt_dit/utils/tensor.py
+++ b/models/tt_dit/utils/tensor.py
@@ -511,12 +511,24 @@ def fast_device_to_host(
                 use_hyperparams=True,
                 use_persistent_buffer=True,
             )
+
             n_hosts = int(ttnn.distributed_context_get_size())
             if n_hosts > 1:
+                # mesh_partition's internal slice asserts per-chip W is
+                # tile-aligned in TILE layout. Predict the per-chip shape
+                # after the upcoming repeat (× n_hosts on inter_dim) and
+                # mesh_partition (÷ inter_axis_size on inter_dim), then drop
+                # to ROW_MAJOR if W won't be tile-aligned.
+                post_shape = list(gathered_tensor.shape)
+                post_shape[inter_dim] = post_shape[inter_dim] * n_hosts // mesh_shape[inter_host_axis]
+                if post_shape[-1] % ttnn.TILE_SIZE != 0:
+                    gathered_tensor = ttnn.to_layout(gathered_tensor, ttnn.ROW_MAJOR_LAYOUT)
+
                 repeat_dims = [1] * len(gathered_tensor.shape)
                 repeat_dims[inter_dim] = n_hosts
                 gathered_tensor = ttnn.repeat(gathered_tensor, repeat_dims)
                 gathered_tensor = ttnn.mesh_partition(gathered_tensor, dim=inter_dim, cluster_axis=inter_host_axis)
+
             if pre_transfer_fn is not None:
                 gathered_tensor = pre_transfer_fn(gathered_tensor)
             else:


### PR DESCRIPTION
## Summary

After all_gather (TILE), multi-host code runs repeat then mesh_partition. In TILE layout, mesh_partition expects per-chip width to be tile-aligned; the I2V encoder’s per-chip W after partition is not (e.g. 5 on 4×32, 20 on 4×8). Fix: before repeat/mesh_partition, compute the post-partition size on the concat dimension (post_shape[inter_dim] * n_hosts // mesh_shape[inter_host_axis]); if post_shape[-1] is not a multiple of 32, convert to ROW_MAJOR. Decoder latents keep tile-aligned per-chip W (40 / 160), so they stay in TILE through repeat/mesh_partition and then follow the existing pre_transfer_fn or to_layout(ROW_MAJOR) pat

## Test plan

- [ ] `test_pipeline_wan_i2v` end-to-end on BH Galaxy 4x8 and 4x32
- [ ] `tests/unit/test_fast_device_to_host.py` (existing correctness + perf tests)
- [ ] `test_pipeline_wan` (T2V decoder path unaffected)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kevinmi/wan22-i2v-quad-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kevinmi/wan22-i2v-quad-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kevinmi/wan22-i2v-quad-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kevinmi/wan22-i2v-quad-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kevinmi/wan22-i2v-quad-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kevinmi/wan22-i2v-quad-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kevinmi/wan22-i2v-quad-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kevinmi/wan22-i2v-quad-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kevinmi/wan22-i2v-quad-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kevinmi/wan22-i2v-quad-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kevinmi/wan22-i2v-quad-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kevinmi/wan22-i2v-quad-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kevinmi/wan22-i2v-quad-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kevinmi/wan22-i2v-quad-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kevinmi/wan22-i2v-quad-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kevinmi/wan22-i2v-quad-support)