### PR TITLE
[Bug Fix] Fix DeviceStorage's move ctor

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
@@ -132,20 +132,6 @@ TEST_F(DeviceStorageOwnershipTest, DeviceStorage_MoveDoesNotAddSharedReference) 
     EXPECT_TRUE(tensor.device_storage().is_sole_owner_of_device_memory());
 }
 
-TEST_F(DeviceStorageOwnershipTest, DeviceStorage_MovedFromIsDestroyedSafely) {
-    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
-
-    // Scope ensures moved-from DeviceStorage is destroyed before the tensor.
-    {
-        DeviceStorage original = tensor.device_storage();
-        DeviceStorage moved_into(std::move(original));
-        // original goes out of scope here — must not crash or double-free.
-        (void)moved_into;
-    }
-
-    EXPECT_TRUE(tensor.is_allocated());
-}
-
 TEST_F(DeviceStorageOwnershipTest, DeviceStorage_ViewSharesOwnership) {
     Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
     const auto& storage = tensor.device_storage();

--- a/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
@@ -19,6 +19,7 @@ using ::testing::SizeIs;
 
 using tt::tt_metal::DataType;
 using tt::tt_metal::DeviceStorage;
+using tt::tt_metal::GenericMeshDeviceFixture;
 using tt::tt_metal::Layout;
 using tt::tt_metal::MemoryConfig;
 using tt::tt_metal::MeshDevice1x2Fixture;
@@ -26,7 +27,10 @@ using tt::tt_metal::Tensor;
 using tt::tt_metal::TensorLayout;
 using tt::tt_metal::TensorSpec;
 
-using DeviceStorageOwnershipTest = MeshDevice1x2Fixture;
+// Most ownership tests only need a single device.
+using DeviceStorageOwnershipTest = GenericMeshDeviceFixture;
+// Tests that explicitly exercise multi-device behaviour (views, shards).
+using DeviceStorageMultiDeviceTest = MeshDevice1x2Fixture;
 
 TensorSpec make_test_tensor_spec() {
     return TensorSpec(ttnn::Shape{1, 1, 32, 32}, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
@@ -132,7 +136,7 @@ TEST_F(DeviceStorageOwnershipTest, DeviceStorage_MoveDoesNotAddSharedReference) 
     EXPECT_TRUE(tensor.device_storage().is_sole_owner_of_device_memory());
 }
 
-TEST_F(DeviceStorageOwnershipTest, DeviceStorage_ViewSharesOwnership) {
+TEST_F(DeviceStorageMultiDeviceTest, DeviceStorage_ViewSharesOwnership) {
     Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
     const auto& storage = tensor.device_storage();
 
@@ -149,7 +153,7 @@ TEST_F(DeviceStorageOwnershipTest, DeviceStorage_ViewSharesOwnership) {
     ASSERT_THAT(view_storage.get_coords(), SizeIs(1));
 }
 
-TEST_F(DeviceStorageOwnershipTest, DeviceStorage_ViewDeallocateAffectsOwner) {
+TEST_F(DeviceStorageMultiDeviceTest, DeviceStorage_ViewDeallocateAffectsOwner) {
     Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
     const auto& storage = tensor.device_storage();
 
@@ -162,7 +166,7 @@ TEST_F(DeviceStorageOwnershipTest, DeviceStorage_ViewDeallocateAffectsOwner) {
     EXPECT_FALSE(storage.is_allocated());
 }
 
-TEST_F(DeviceStorageOwnershipTest, DeviceStorage_OwnerDeallocateAffectsView) {
+TEST_F(DeviceStorageMultiDeviceTest, DeviceStorage_OwnerDeallocateAffectsView) {
     Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
     DeviceStorage owner_storage = tensor.device_storage();
 
@@ -242,12 +246,8 @@ TEST_F(DeviceStorageOwnershipTest, Tensor_DeallocateIsIdempotent) {
     EXPECT_NO_THROW(tensor.deallocate(/*force=*/false));
 }
 
-TEST_F(DeviceStorageOwnershipTest, Tensor_ShardsShareDeviceStorageOwnership) {
+TEST_F(DeviceStorageMultiDeviceTest, Tensor_ShardsShareDeviceStorageOwnership) {
     const auto num_devices = mesh_device_->num_devices();
-    if (num_devices < 2) {
-        GTEST_SKIP() << "Test requires at least 2 devices";
-    }
-
     Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
     auto shards = get_device_tensors(tensor);
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
@@ -82,6 +82,70 @@ TEST_F(DeviceStorageOwnershipTest, DeviceStorage_SoleOwnerRestoredAfterCopyDestr
     EXPECT_TRUE(original_storage.is_sole_owner_of_device_memory());
 }
 
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_MoveConstructorTransfersOwnership) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    DeviceStorage original = tensor.device_storage();
+    EXPECT_TRUE(original.is_allocated());
+
+    DeviceStorage moved_into(std::move(original));
+
+    // Moved-into storage has the memory; moved-from is in DeallocatedDefaultConstructed state.
+    EXPECT_TRUE(moved_into.is_allocated());
+    EXPECT_FALSE(original.is_allocated());  // NOLINT(bugprone-use-after-move)
+}
+
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_MoveAssignmentTransfersOwnership) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    DeviceStorage original = tensor.device_storage();
+    EXPECT_TRUE(original.is_allocated());
+
+    DeviceStorage moved_into;
+    moved_into = std::move(original);
+
+    // Moved-into storage has the memory; moved-from is in DeallocatedDefaultConstructed state.
+    EXPECT_TRUE(moved_into.is_allocated());
+    EXPECT_FALSE(original.is_allocated());  // NOLINT(bugprone-use-after-move)
+}
+
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_MoveDoesNotAddSharedReference) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    ASSERT_TRUE(tensor.device_storage().is_sole_owner_of_device_memory());
+
+    // Copying the storage increments the use-count — tensor is no longer sole owner.
+    {
+        DeviceStorage copy = tensor.device_storage();
+        EXPECT_FALSE(tensor.device_storage().is_sole_owner_of_device_memory());
+    }
+    // Copy destroyed — sole ownership restored.
+    EXPECT_TRUE(tensor.device_storage().is_sole_owner_of_device_memory());
+
+    // Moving the storage does NOT increment the use-count: it transfers the
+    // existing slot.  After both the moved-from (temp) and moved-into objects
+    // are destroyed, tensor is the sole owner again — proving no extra reference
+    // was added by the move.
+    {
+        DeviceStorage temp = tensor.device_storage();  // copy: use_count = 2
+        DeviceStorage moved_into(std::move(temp));     // move: use_count stays 2, temp deallocated
+        EXPECT_FALSE(temp.is_allocated());
+    }
+    // temp and moved_into both gone — sole ownership restored.
+    EXPECT_TRUE(tensor.device_storage().is_sole_owner_of_device_memory());
+}
+
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_MovedFromIsDestroyedSafely) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+
+    // Scope ensures moved-from DeviceStorage is destroyed before the tensor.
+    {
+        DeviceStorage original = tensor.device_storage();
+        DeviceStorage moved_into(std::move(original));
+        // original goes out of scope here — must not crash or double-free.
+        (void)moved_into;
+    }
+
+    EXPECT_TRUE(tensor.is_allocated());
+}
+
 TEST_F(DeviceStorageOwnershipTest, DeviceStorage_ViewSharesOwnership) {
     Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
     const auto& storage = tensor.device_storage();

--- a/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
@@ -117,7 +117,7 @@ TEST_F(DeviceStorageOwnershipTest, DeviceStorage_MoveDoesNotAddSharedReference) 
 
     // Copying the storage increments the use-count — tensor is no longer sole owner.
     {
-        DeviceStorage copy = tensor.device_storage();
+        DeviceStorage copy = tensor.device_storage();  // NOLINT(performance-unnecessary-copy-initialization)
         EXPECT_FALSE(tensor.device_storage().is_sole_owner_of_device_memory());
     }
     // Copy destroyed — sole ownership restored.
@@ -130,7 +130,7 @@ TEST_F(DeviceStorageOwnershipTest, DeviceStorage_MoveDoesNotAddSharedReference) 
     {
         DeviceStorage temp = tensor.device_storage();  // copy: use_count = 2
         DeviceStorage moved_into(std::move(temp));     // move: use_count stays 2, temp deallocated
-        EXPECT_FALSE(temp.is_allocated());
+        EXPECT_FALSE(temp.is_allocated());  // NOLINT(bugprone-use-after-move)
     }
     // temp and moved_into both gone — sole ownership restored.
     EXPECT_TRUE(tensor.device_storage().is_sole_owner_of_device_memory());

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -41,7 +41,7 @@ public:
     auto attribute_values() const { return std::forward_as_tuple(); }
 
 private:
-    HostTensor tensor;
+    std::shared_ptr<HostTensor> tensor_;
 };
 
 // DeviceStorage is a wrapper around the MeshTensor to fit the semantics of ttnn::Tensor.
@@ -79,9 +79,9 @@ struct DeviceStorage {
 
     // Creates a copy of the DeviceStorage that shares the underlying device memory
     DeviceStorage(const DeviceStorage&) = default;
-    DeviceStorage(DeviceStorage&&) noexcept = default;
+    DeviceStorage(DeviceStorage&&) noexcept;
     DeviceStorage& operator=(const DeviceStorage&) = default;
-    DeviceStorage& operator=(DeviceStorage&&) noexcept = default;
+    DeviceStorage& operator=(DeviceStorage&&) noexcept;
 
     // Creates a copy of the DeviceStorage that shares the underlying device memory,
     // but with a different set of coords.
@@ -205,6 +205,7 @@ private:
         std::vector<distributed::MeshCoordinate> coords,
         std::shared_ptr<MeshTensorHolder> root_mesh_tensor_holder);
 
+    // Invariant: should never be nullptr.
     std::shared_ptr<MeshTensorHolder> mesh_tensor_holder_;
     std::vector<distributed::MeshCoordinate> coords_;
 

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -79,8 +79,11 @@ struct DeviceStorage {
 
     // Creates a copy of the DeviceStorage that shares the underlying device memory
     DeviceStorage(const DeviceStorage&) = default;
-    DeviceStorage(DeviceStorage&&) noexcept;
     DeviceStorage& operator=(const DeviceStorage&) = default;
+
+    // Moves the ownership of the underlying device memory to the new DeviceStorage.
+    // The moved-from DeviceStorage is in a deallocated state.
+    DeviceStorage(DeviceStorage&&) noexcept;
     DeviceStorage& operator=(DeviceStorage&&) noexcept;
 
     // Creates a copy of the DeviceStorage that shares the underlying device memory,

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -41,7 +41,7 @@ public:
     auto attribute_values() const { return std::forward_as_tuple(); }
 
 private:
-    std::shared_ptr<HostTensor> tensor_;
+    HostTensor tensor;
 };
 
 // DeviceStorage is a wrapper around the MeshTensor to fit the semantics of ttnn::Tensor.

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -41,15 +41,15 @@ void validate_mesh_coordinates(
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
-HostStorage::HostStorage(HostTensor tensor) : tensor_(std::make_shared<HostTensor>(std::move(tensor))) {}
+HostStorage::HostStorage(HostTensor tensor) : tensor(std::move(tensor)) {}
 
-const DistributedHostBuffer& HostStorage::buffer() const { return tensor_->buffer(); }
+const DistributedHostBuffer& HostStorage::buffer() const { return tensor.buffer(); }
 
-const HostTensor& HostStorage::host_tensor() const { return *tensor_; }
-HostTensor& HostStorage::host_tensor() { return *tensor_; }
+const HostTensor& HostStorage::host_tensor() const { return tensor; }
+HostTensor& HostStorage::host_tensor() { return tensor; }
 
 HostStorage HostStorage::transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const {
-    return HostStorage(tensor_->transform(callable));
+    return HostStorage(tensor.transform(callable));
 }
 
 // MeshTensor lifetime holder:

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -41,15 +41,15 @@ void validate_mesh_coordinates(
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
-HostStorage::HostStorage(HostTensor tensor) : tensor(std::move(tensor)) {}
+HostStorage::HostStorage(HostTensor tensor) : tensor_(std::make_shared<HostTensor>(std::move(tensor))) {}
 
-const DistributedHostBuffer& HostStorage::buffer() const { return tensor.buffer(); }
+const DistributedHostBuffer& HostStorage::buffer() const { return tensor_->buffer(); }
 
-const HostTensor& HostStorage::host_tensor() const { return tensor; }
-HostTensor& HostStorage::host_tensor() { return tensor; }
+const HostTensor& HostStorage::host_tensor() const { return *tensor_; }
+HostTensor& HostStorage::host_tensor() { return *tensor_; }
 
 HostStorage HostStorage::transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const {
-    return HostStorage(tensor.transform(callable));
+    return HostStorage(tensor_->transform(callable));
 }
 
 // MeshTensor lifetime holder:
@@ -106,6 +106,23 @@ struct DeviceStorage::MeshTensorHolder {
 };
 
 DeviceStorage::DeviceStorage() : mesh_tensor_holder_(std::make_shared<MeshTensorHolder>()) {}
+
+DeviceStorage::DeviceStorage(DeviceStorage&& other) noexcept :
+    mesh_tensor_holder_(std::move(other.mesh_tensor_holder_)),
+    coords_(std::move(other.coords_)),
+    root_mesh_tensor_holder_(std::move(other.root_mesh_tensor_holder_)) {
+    other.mesh_tensor_holder_ = std::make_shared<MeshTensorHolder>();
+}
+
+DeviceStorage& DeviceStorage::operator=(DeviceStorage&& other) noexcept {
+    if (this != &other) {
+        mesh_tensor_holder_ = std::move(other.mesh_tensor_holder_);
+        coords_ = std::move(other.coords_);
+        root_mesh_tensor_holder_ = std::move(other.root_mesh_tensor_holder_);
+        other.mesh_tensor_holder_ = std::make_shared<MeshTensorHolder>();
+    }
+    return *this;
+}
 
 DeviceStorage::DeviceStorage(MeshTensor mesh_tensor) :
     mesh_tensor_holder_(std::make_shared<MeshTensorHolder>(std::move(mesh_tensor))),


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

`DeviceStorage`'s move ctor and assignment were implemented incorrectly, following code segfaults:

```cpp
DeviceStorage origin = get_storage();
DeviceStorage new_storage = std::move(origin);
TT_FATAL(
	!origin.is_allocated(),  // Segfaults here.
	"Expect original device storage to be deallocated"
);
```
This PR fixes this case by providing a custom move ctor & assign function

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

New unit test added.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/fix-device-storage-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/fix-device-storage-move) (perf swing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/fix-device-storage-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/fix-device-storage-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/fix-device-storage-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/fix-device-storage-move) (ImportError)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/fix-device-storage-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/fix-device-storage-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/fix-device-storage-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/fix-device-storage-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/fix-device-storage-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/fix-device-storage-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/fix-device-storage-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/fix-device-storage-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/fix-device-storage-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/fix-device-storage-move)