### PR TITLE
[skip ci] #43748: (Tier 3) Remove falcon40b T3K perf and integration tests from scheduled pipelines

### DIFF
--- a/.github/workflows/pipeline-select-t3k.yaml
+++ b/.github/workflows/pipeline-select-t3k.yaml
@@ -75,7 +75,6 @@ on:
           - disabled
           - all
           - falcon7b
-          - falcon40b
           - resnet50
           - sentence_bert
           - stable_diffusion_35_large

--- a/.github/workflows/pipeline-select-t3k.yaml
+++ b/.github/workflows/pipeline-select-t3k.yaml
@@ -94,7 +94,6 @@ on:
           - tteager
           - ethernet
           - trace stress
-          - falcon40b
           # - llama3.2-vision #Tier 3 models
           # - n300 mesh llama3.2-vision #Tier 3 models
           # - llama3.2-90b-vision #Tier 3 model

--- a/.github/workflows/pipeline-select-t3k.yaml
+++ b/.github/workflows/pipeline-select-t3k.yaml
@@ -26,7 +26,6 @@ on:
           - t3k_ttmetal_tests
           - t3k_ttnn_tests
           - falcon7b
-          - falcon40b
           - llama3-small
           - llama3.2-11b
           - llama3.2-11b-vision
@@ -48,7 +47,6 @@ on:
           - disabled
           - all
           - falcon7b
-          - falcon40b
           - llama3
           - llama3_vision
           - llama3_90b_vision

--- a/.github/workflows/t3000-integration-tests.yaml
+++ b/.github/workflows/t3000-integration-tests.yaml
@@ -12,7 +12,6 @@ on:
           - all
           - tteager
           - trace stress
-          - falcon40b
           # - llama3.2-vision # Tier 3 models
           # - n300 mesh llama3.2-vision # Tier 3 models
           - llama3.2-90b-vision # Tier 2 model

--- a/tests/pipeline_reorg/t3k_integration_tests.yaml
+++ b/tests/pipeline_reorg/t3k_integration_tests.yaml
@@ -28,15 +28,6 @@
   team: scaleout
   model-name: trace stress
 
-- name: t3k_falcon40b_tests
-  cmd: run_t3000_falcon40b_tests
-  skus:
-    wh_llmbox:
-      timeout: 20
-  owner_id: U04S2UV6L8N # Sofija Jovic
-  team: models
-  model-name: falcon40b
-
 # - name: t3k_llama3.2-vision_tests
 #   cmd: run_t3000_llama3.2-11b-vision_freq_tests
 #   skus:

--- a/tests/pipeline_reorg/t3k_perf_tests.yaml
+++ b/tests/pipeline_reorg/t3k_perf_tests.yaml
@@ -21,16 +21,6 @@
   model-name: falcon7b
   model-type: LLM
 
-- name: t3k_LLM_falcon40b_model_perf_tests
-  cmd: run_t3000_falcon40b_tests
-  skus:
-    wh_llmbox_perf:
-      timeout: 75
-  owner_id: U053W15B6JF # Djordje Ivanovic
-  team: models
-  model-name: falcon40b
-  model-type: LLM
-
 - name: t3k_CNN_resnet50_model_perf_tests
   cmd: run_t3000_resnet50_tests
   skus:

--- a/tests/scripts/t3000/run_t3000_integration_tests.sh
+++ b/tests/scripts/t3000/run_t3000_integration_tests.sh
@@ -291,27 +291,6 @@ run_t3000_trace_stress_tests() {
   fi
 }
 
-run_t3000_falcon40b_tests() {
-  fail=0
-  # Record the start time
-  start_time=$(date +%s)
-
-  echo "LOG_METAL: Running run_t3000_falcon40b_tests"
-
-  pytest models/demos/t3000/falcon40b/tests/test_falcon_mlp.py ; fail+=$?
-  pytest models/demos/t3000/falcon40b/tests/test_falcon_attention.py --timeout=480 ; fail+=$?
-  pytest models/demos/t3000/falcon40b/tests/test_falcon_decoder.py --timeout=480 ; fail+=$?
-  pytest models/demos/t3000/falcon40b/tests/test_falcon_causallm.py --timeout=600 ; fail+=$?
-
-  # Record the end time
-  end_time=$(date +%s)
-  duration=$((end_time - start_time))
-  echo "LOG_METAL: run_t3000_falcon40b_tests $duration seconds to complete"
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
-}
-
 run_t3000_resnet_tests() {
   fail=0
   # Record the start time
@@ -430,9 +409,6 @@ run_t3000_tests() {
 
   # Run trace tests
   run_t3000_trace_stress_tests
-
-  # Run falcon40b tests
-  run_t3000_falcon40b_tests
 
   # Run llama3 small (1B, 3B, 8B, 11B) tests
   run_t3000_llama3_tests

--- a/tests/scripts/t3000/run_t3000_perf_tests.sh
+++ b/tests/scripts/t3000/run_t3000_perf_tests.sh
@@ -43,24 +43,6 @@ run_t3000_mistral7b_perf_tests() {
   fi
 }
 
-run_t3000_falcon40b_tests() {
-  # Record the start time
-  fail=0
-  start_time=$(date +%s)
-
-  echo "LOG_METAL: Running run_t3000_falcon40b_tests"
-
-  pytest models/demos/t3000/falcon40b/tests/test_perf_falcon.py -m "model_perf_t3000" --timeout=600 ; fail+=$?
-
-  # Record the end time
-  end_time=$(date +%s)
-  duration=$((end_time - start_time))
-  echo "LOG_METAL: run_t3000_falcon40b_tests $duration seconds to complete"
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
-}
-
 run_t3000_resnet50_tests() {
   # Record the start time
   fail=0


### PR DESCRIPTION
## Summary
Remove deterministically-failing **Falcon-40B T3K** jobs at the pipeline level until the underlying perf regression is addressed, and clean up the stale dropdown options that point at no-longer-existent matrix entries.

**T3K perf pipeline:**
- Remove `t3k_LLM_falcon40b_model_perf_tests` from `tests/pipeline_reorg/t3k_perf_tests.yaml` (matrix consumed by **(T3K) T3000 perf tests**).
- Remove the now-unused `run_t3000_falcon40b_tests` function from `tests/scripts/t3000/run_t3000_perf_tests.sh`.

**T3K integration pipeline:**
- Remove `t3k_falcon40b_tests` from `tests/pipeline_reorg/t3k_integration_tests.yaml` (matrix consumed by **(T3K) T3000 integration tests**).
- Remove the corresponding `run_t3000_falcon40b_tests` function and its umbrella call from `tests/scripts/t3000/run_t3000_integration_tests.sh`.
- Drop the `falcon40b` choice from the **(T3K) T3000 integration tests** workflow_dispatch dropdown.

**`pipeline-select-t3k.yaml` dropdown cleanups:**
- Drop the `falcon40b` choice from the `t3000-perf` dropdown (matrix entry just removed).
- Drop the `falcon40b` choice from the `t3000-integration` dropdown (matrix entry just removed).
- Drop the `falcon40b` choice from the `t3000-unit` dropdown — the dropdown filters `t3k_unit_tests.yaml`, which does not contain a falcon40b entry, so this was already a dead option.
- Drop the `falcon40b` choice from the `t3000-demo` dropdown — same reason against `t3k_demo_tests.yaml`.

Closes #43748.

Per the issue, the perf job has been failing the post-test inference-time threshold check across multiple decode/prefill configs (e.g. BFLOAT8_B-SHARDED decode `seq_len=1` 11.5% over, BFLOAT16-DRAM prefill `seq_len=128` 26.3% over).

## Out of scope (intentionally not touched)
Falcon-40B unit and e2e entries in `tests/pipeline_reorg/models_unit_tests.yaml` (line 404, tier 3) and `tests/pipeline_reorg/models_e2e_tests.yaml` (line 412, tier 3). Those are consumed by `models-unit-tests-impl.yaml`, `models-e2e-tests-impl.yaml`, and `all-model-tests.yaml` (Tier 3 model pipelines), are currently green for Falcon-40B, and are not implicated by #43748.
