### PR TITLE
[ci] Fail fast in vllm-nightly when server crashes before /health

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -462,24 +462,34 @@ jobs:
           elapsed=0
           interval=20
 
-          # Read the launcher PID once; non-existent file means we never
-          # captured one and we silently skip the liveness check below
-          # rather than fail closed.
+          # Read the launcher PID once. ``read -r`` consumes only the
+          # first line, so a stray trailing line in the PID file can't
+          # turn ``$server_pid`` into a multi-token argument to
+          # ``kill -0``. A missing file or non-numeric content leaves
+          # ``$server_pid`` empty and the liveness check below silently
+          # skips rather than failing closed.
           server_pid=""
           if [ -f "${FILE_SERVER_PID}" ]; then
-            server_pid=$(cat "${FILE_SERVER_PID}")
+            read -r server_pid < "${FILE_SERVER_PID}" || server_pid=""
+          fi
+          if ! [[ "$server_pid" =~ ^[0-9]+$ ]]; then
+            server_pid=""
           fi
 
-          # vLLM writes these to the server log within seconds of an
-          # engine-core crash. Polling /health for the full server-timeout
-          # after one of these has appeared just burns CI minutes — fail
-          # fast so the rest of the matrix can move on.
-          fatal_markers=(
-            "EngineCore failed to start"
-            "EngineCore encountered a fatal error"
-            "EngineDeadError"
-            "Engine core initialization failed"
-            "Failed core proc"
+          # vLLM writes one of these to the server log within seconds of
+          # an engine-core crash. Polling /health for the full
+          # server-timeout after one has appeared just burns CI minutes —
+          # fail fast so the rest of the matrix can move on. Using a
+          # single ``grep -m1`` with multiple ``-e`` patterns gives one
+          # bounded-by-first-match file scan per poll cycle even as the
+          # log grows.
+          fatal_grep_args=(
+            -F -m1
+            -e "EngineCore failed to start"
+            -e "EngineCore encountered a fatal error"
+            -e "EngineDeadError"
+            -e "Engine core initialization failed"
+            -e "Failed core proc"
           )
 
           while [ $elapsed -lt $timeout_seconds ]; do
@@ -499,13 +509,12 @@ jobs:
             # may stay alive after engine cores crash (e.g. multiprocess
             # DP), so the log signal complements the liveness check.
             if [ -f "${FILE_SERVER_LOG}" ]; then
-              for marker in "${fatal_markers[@]}"; do
-                if grep -qF "$marker" "${FILE_SERVER_LOG}" 2>/dev/null; then
-                  echo "❌ Fatal marker '$marker' in server log [$elapsed sec]."
-                  echo "Check out the server log in a step below."
-                  exit 1
-                fi
-              done
+              fatal_match=$(grep "${fatal_grep_args[@]}" "${FILE_SERVER_LOG}" 2>/dev/null) || true
+              if [ -n "$fatal_match" ]; then
+                echo "❌ Fatal marker in server log [$elapsed sec]: $fatal_match"
+                echo "Check out the server log in a step below."
+                exit 1
+              fi
             fi
 
             sleep $interval

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -462,11 +462,52 @@ jobs:
           elapsed=0
           interval=20
 
+          # Read the launcher PID once; non-existent file means we never
+          # captured one and we silently skip the liveness check below
+          # rather than fail closed.
+          server_pid=""
+          if [ -f "${FILE_SERVER_PID}" ]; then
+            server_pid=$(cat "${FILE_SERVER_PID}")
+          fi
+
+          # vLLM writes these to the server log within seconds of an
+          # engine-core crash. Polling /health for the full server-timeout
+          # after one of these has appeared just burns CI minutes — fail
+          # fast so the rest of the matrix can move on.
+          fatal_markers=(
+            "EngineCore failed to start"
+            "EngineCore encountered a fatal error"
+            "EngineDeadError"
+            "Engine core initialization failed"
+            "Failed core proc"
+          )
+
           while [ $elapsed -lt $timeout_seconds ]; do
             if curl -sf http://localhost:8000/health; then
               echo "Server is up! 🚀 [$elapsed sec]"
               exit 0
             fi
+
+            # Fast-fail when the launcher process has already exited.
+            if [ -n "$server_pid" ] && ! kill -0 "$server_pid" 2>/dev/null; then
+              echo "❌ Server launcher (pid=$server_pid) exited before becoming ready [$elapsed sec]."
+              echo "Check out the server log in a step below."
+              exit 1
+            fi
+
+            # Fast-fail on a fatal marker in the server log. The launcher
+            # may stay alive after engine cores crash (e.g. multiprocess
+            # DP), so the log signal complements the liveness check.
+            if [ -f "${FILE_SERVER_LOG}" ]; then
+              for marker in "${fatal_markers[@]}"; do
+                if grep -qF "$marker" "${FILE_SERVER_LOG}" 2>/dev/null; then
+                  echo "❌ Fatal marker '$marker' in server log [$elapsed sec]."
+                  echo "Check out the server log in a step below."
+                  exit 1
+                fi
+              done
+            fi
+
             sleep $interval
             elapsed=$((elapsed + interval))
           done


### PR DESCRIPTION
## Summary

The wait-for-server step in `vllm-nightly-tests-impl.yaml` polls `/health` every 20s for the full `server-timeout` (10–45 minutes per matrix entry) before giving up. When the server crashes during startup the step keeps polling for the entire timeout, wasting runner time and stretching out failed nightly runs — one recent run spent ~50 min on a job that crashed within seconds.

This PR adds two cheap fast-fail signals to the existing poll loop:

- **Launcher liveness**: the PID is already saved to `FILE_SERVER_PID`; one `kill -0` per cycle catches single-process crashes.
- **Fatal markers in the server log**: vLLM writes recognisable phrases (\`EngineCore failed to start\`, \`EngineCore encountered a fatal error\`, \`EngineDeadError\`, \`Engine core initialization failed\`, \`Failed core proc\`) within seconds of any engine-core crash. \`grep -qF\` once per cycle picks those up — required for multiprocess DP, where the launcher process stays alive after the engine cores die.

Either signal exits within `interval=20s` of the failure instead of waiting the full timeout.

Healthy runs are unaffected: the new checks only fire on a known-bad signal, so the success path is byte-identical except for one \`[ -f log ]\` and one \`kill -0\` per poll cycle.

## Example

Current main failure:
<img width="1343" height="165" alt="image" src="https://github.com/user-attachments/assets/a5086c52-e380-457c-99b9-8c3c4fe38adf" />


After this fix:
<img width="1344" height="160" alt="image" src="https://github.com/user-attachments/assets/751ceaa5-0f66-40bb-8c18-734719959aaf" />


Note: I am fixing the underlying error in a separate PR #43475

## Test plan
- [x] Unit-style review of the bash logic (markers chosen from observed failure traces in run [#25453020211](https://github.com/tenstorrent/tt-metal/actions/runs/25453020211))
- [ ] Next vllm nightly run on a known-broken commit confirms the wait-for-server step fails within seconds rather than minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=handrews/vllm-nightly-fast-fail)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:handrews/vllm-nightly-fast-fail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=handrews/vllm-nightly-fast-fail)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:handrews/vllm-nightly-fast-fail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=handrews/vllm-nightly-fast-fail)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:handrews/vllm-nightly-fast-fail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=handrews/vllm-nightly-fast-fail)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:handrews/vllm-nightly-fast-fail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=handrews/vllm-nightly-fast-fail)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:handrews/vllm-nightly-fast-fail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=handrews/vllm-nightly-fast-fail)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:handrews/vllm-nightly-fast-fail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=handrews/vllm-nightly-fast-fail)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:handrews/vllm-nightly-fast-fail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=handrews/vllm-nightly-fast-fail)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:handrews/vllm-nightly-fast-fail)