### PR TITLE
Remove unused LLK unpack tilize parameters

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -32,8 +32,10 @@ inline void llk_unpack_tilize_uninit(const std::uint32_t operand, const std::uin
     _llk_unpack_tilize_uninit_((uint)unpack_dst_format[operand_id], num_faces, face_r_dim);
 }
 
-inline void llk_unpack_tilize(std::uint32_t operand, std::uint32_t tile_index, std::uint32_t /* unused block_ct_dim*/) {
+inline void llk_unpack_tilize(std::uint32_t operand, std::uint32_t tile_index) {
     std::uint32_t operand_id = get_operand_id(operand);
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const bool narrow_tile = get_operand_narrow_tile(operand_id);
 
     std::uint32_t base_address =
@@ -45,9 +47,8 @@ inline void llk_unpack_tilize(std::uint32_t operand, std::uint32_t tile_index, s
         tile_index,
         unpack_src_format[operand_id],
         unpack_dst_format[operand_id],
-        0 /* unused block_ct_dim*/,
-        FACE_R_DIM /* unused face_r_dim*/,
-        4 /* unused num_faces */,
+        face_r_dim,
+        num_faces,
         narrow_tile);
     WAYPOINT("UPTD");
 }
@@ -57,7 +58,7 @@ inline void llk_unpack_tilize_block(std::uint32_t operand, std::uint32_t block_c
     // i.e. input_tile_index % block_c_tiles == 0
     input_tile_index = input_tile_index % block_c_tiles + (input_tile_index / block_c_tiles) * block_c_tiles * TILE_R_DIM;
     for (std::uint32_t tile_index = 0; tile_index < block_c_tiles; tile_index++) {
-        llk_unpack_tilize(operand, input_tile_index + tile_index, 0 /* unused block_ct_dim*/);
+        llk_unpack_tilize(operand, input_tile_index + tile_index);
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -68,8 +68,8 @@ inline void llk_unpack_tilize_block(std::uint32_t operand, std::uint32_t block_c
 
 // TODO: add support for all the template parameters
 template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false, bool zero_srcA_reduce = false>
-inline void llk_unpack_tilizeA_B_mop_config(const bool narrow_tile = false, const std::uint32_t num_faces = 4) {
-    _llk_unpack_tilizeA_B_mop_config_<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(narrow_tile, num_faces);
+inline void llk_unpack_tilizeA_B_mop_config(const std::uint32_t num_faces = 4) {
+    _llk_unpack_tilizeA_B_mop_config_<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(num_faces);
 }
 
 template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false, bool zero_srcA_reduce = false>
@@ -82,7 +82,6 @@ inline void llk_unpack_tilizeA_B_init(
     const std::uint32_t unpB_face_r_dim = FACE_R_DIM) {
 
     const std::uint32_t operandA_id = get_operand_id(operandA);
-    const bool narrow_tile = get_operand_narrow_tile(operandA_id);
 
     LLK_ASSERT_BLOCK(are_unpackers_AB_configured_correctly<UnpackerProgramType::ProgramByFace>(
         unpack_src_format[operandA_id],
@@ -97,10 +96,8 @@ inline void llk_unpack_tilizeA_B_init(
     _llk_unpack_tilizeA_B_init_<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(
         unpack_src_format[operandA_id],
         unpack_dst_format[operandA_id],
-        narrow_tile,
         ct_dim,
         num_faces,
-        unpA_face_r_dim,
         unpB_face_r_dim
     );
 }
@@ -123,7 +120,6 @@ inline void llk_unpack_tilizeA_B(
 
     const std::uint32_t base_address_a =
         get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;  // Remove header size added by descriptor
-    const bool narrow_tile = get_operand_narrow_tile(operandA_id);
 
     const std::uint32_t base_address_b =
         get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;  // Remove header size added by descriptor
@@ -145,11 +141,9 @@ inline void llk_unpack_tilizeA_B(
     _llk_unpack_tilizeA_B_<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(
         unpack_src_format[operandA_id],
         face_r_dim,
-        narrow_tile,
         base_address_a,
         address_b,
         tile_index_a,
-        tile_index_b,
         block_ct_dim,
         num_faces
     );

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -73,8 +73,8 @@ template <
     std::uint32_t reload_srcB = false,
     bool zero_srcA = false,
     bool zero_srcA_reduce = false>
-inline void llk_unpack_tilizeA_B_mop_config(const bool narrow_tile = false, const std::uint32_t num_faces = 4) {
-    _llk_unpack_tilizeA_B_mop_config_<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(narrow_tile, num_faces);
+inline void llk_unpack_tilizeA_B_mop_config(const std::uint32_t num_faces = 4) {
+    _llk_unpack_tilizeA_B_mop_config_<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(num_faces);
 }
 
 template <
@@ -155,10 +155,8 @@ inline void llk_unpack_tilizeA_B(
         base_address_a,
         address_b,
         tile_index_a,
-        tile_index_b,
         block_ct_dim,
-        num_faces
-    );
+        num_faces);
     WAYPOINT("UPTD");
 }
 

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_unpack_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_unpack_wrappers.h
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "llk_unpack_tilize.h"
+
+using ckernel::FACE_R_DIM;
+
+#ifdef ARCH_WORMHOLE
+
+inline void _llk_unpack_tilize_init_wrapper_(
+    const std::uint32_t unpack_src_format = 0,
+    const std::uint32_t unpack_dst_format = 0,
+    const std::uint32_t ct_dim            = 0,
+    const std::uint32_t face_r_dim        = FACE_R_DIM,
+    const bool narrow_tile                = false,
+    const std::uint32_t num_faces         = 4)
+{
+    (void)num_faces;
+    _llk_unpack_tilize_init_(unpack_src_format, unpack_dst_format, ct_dim, face_r_dim, narrow_tile);
+}
+
+inline void _llk_unpack_tilize_wrapper_(
+    const std::uint32_t base_address,
+    const std::uint32_t tile_index,
+    const std::uint32_t unpack_src_format = 0,
+    const std::uint32_t unpack_dst_format = 0,
+    const std::uint32_t block_ct_dim      = 0,
+    const std::uint32_t face_r_dim        = FACE_R_DIM,
+    const std::uint32_t num_faces         = 4,
+    const bool narrow_tile                = false)
+{
+    _llk_unpack_tilize_(base_address, tile_index, unpack_src_format, unpack_dst_format, block_ct_dim, face_r_dim, num_faces, narrow_tile);
+}
+
+#else // ARCH_BLACKHOLE version of the wrappers
+
+inline void _llk_unpack_tilize_init_wrapper_(
+    const std::uint32_t unpack_src_format = 0,
+    const std::uint32_t unpack_dst_format = 0,
+    const std::uint32_t ct_dim            = 0,
+    const std::uint32_t face_r_dim        = FACE_R_DIM,
+    const bool narrow_tile                = false,
+    const std::uint32_t num_faces         = 4)
+{
+    _llk_unpack_tilize_init_(unpack_src_format, unpack_dst_format, ct_dim, face_r_dim, narrow_tile, num_faces);
+}
+
+inline void _llk_unpack_tilize_wrapper_(
+    const std::uint32_t base_address,
+    const std::uint32_t tile_index,
+    const std::uint32_t unpack_src_format = 0,
+    const std::uint32_t unpack_dst_format = 0,
+    const std::uint32_t block_ct_dim      = 0,
+    const std::uint32_t face_r_dim        = FACE_R_DIM,
+    const std::uint32_t num_faces         = 4,
+    const bool narrow_tile                = false)
+{
+    (void)block_ct_dim;
+    _llk_unpack_tilize_(base_address, tile_index, unpack_src_format, unpack_dst_format, face_r_dim, num_faces, narrow_tile);
+}
+
+#endif

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_unpack_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_unpack_wrappers.h
@@ -8,17 +8,15 @@
 
 #include "llk_unpack_tilize.h"
 
-using ckernel::FACE_R_DIM;
-
 #ifdef ARCH_WORMHOLE
 
 inline void _llk_unpack_tilize_init_wrapper_(
-    const std::uint32_t unpack_src_format = 0 /* unpack_src_format */,
-    const std::uint32_t unpack_dst_format = 0 /* unpack_dst_format */,
-    const std::uint32_t ct_dim            = 0 /* ct_dim */,
-    const std::uint32_t face_r_dim        = FACE_R_DIM,
-    const bool narrow_tile                = false /* narrow_tile */,
-    const std::uint32_t num_faces         = 4 /* num_faces */)
+    const std::uint32_t unpack_src_format = 0,
+    const std::uint32_t unpack_dst_format = 0,
+    const std::uint32_t ct_dim            = 0,
+    const std::uint32_t face_r_dim        = ckernel::FACE_R_DIM,
+    const bool narrow_tile                = false,
+    const std::uint32_t num_faces         = 4)
 {
     (void)num_faces;
     _llk_unpack_tilize_init_(unpack_src_format, unpack_dst_format, ct_dim, face_r_dim, narrow_tile);
@@ -27,25 +25,25 @@ inline void _llk_unpack_tilize_init_wrapper_(
 inline void _llk_unpack_tilize_wrapper_(
     const std::uint32_t base_address,
     const std::uint32_t tile_index,
-    const std::uint32_t unpack_src_format = 0 /* unpack_src_format */,
-    const std::uint32_t unpack_dst_format = 0 /* unpack_dst_format */,
-    const std::uint32_t block_ct_dim      = 0 /* block_ct_dim */,
-    const std::uint32_t face_r_dim        = FACE_R_DIM,
-    const std::uint32_t num_faces         = 4 /* num_faces */,
-    const bool narrow_tile                = false /* narrow_tile */)
+    const std::uint32_t unpack_src_format = 0,
+    const std::uint32_t unpack_dst_format = 0,
+    const std::uint32_t block_ct_dim      = 0,
+    const std::uint32_t face_r_dim        = ckernel::FACE_R_DIM,
+    const std::uint32_t num_faces         = 4,
+    const bool narrow_tile                = false)
 {
     _llk_unpack_tilize_(base_address, tile_index, unpack_src_format, unpack_dst_format, block_ct_dim, face_r_dim, num_faces, narrow_tile);
 }
 
-#else // ARCH_BLACKHOLE version of the wrappers
+#elif defined(ARCH_BLACKHOLE)
 
 inline void _llk_unpack_tilize_init_wrapper_(
-    const std::uint32_t unpack_src_format = 0 /* unpack_src_format */,
-    const std::uint32_t unpack_dst_format = 0 /* unpack_dst_format */,
-    const std::uint32_t ct_dim            = 0 /* ct_dim */,
-    const std::uint32_t face_r_dim        = FACE_R_DIM,
-    const bool narrow_tile                = false /* narrow_tile */,
-    const std::uint32_t num_faces         = 4 /* num_faces */)
+    const std::uint32_t unpack_src_format = 0,
+    const std::uint32_t unpack_dst_format = 0,
+    const std::uint32_t ct_dim            = 0,
+    const std::uint32_t face_r_dim        = ckernel::FACE_R_DIM,
+    const bool narrow_tile                = false,
+    const std::uint32_t num_faces         = 4)
 {
     _llk_unpack_tilize_init_(unpack_src_format, unpack_dst_format, ct_dim, face_r_dim, narrow_tile, num_faces);
 }
@@ -53,15 +51,18 @@ inline void _llk_unpack_tilize_init_wrapper_(
 inline void _llk_unpack_tilize_wrapper_(
     const std::uint32_t base_address,
     const std::uint32_t tile_index,
-    const std::uint32_t unpack_src_format = 0 /* unpack_src_format */,
-    const std::uint32_t unpack_dst_format = 0 /* unpack_dst_format */,
-    const std::uint32_t block_ct_dim      = 0 /* block_ct_dim */,
-    const std::uint32_t face_r_dim        = FACE_R_DIM,
-    const std::uint32_t num_faces         = 4 /* num_faces */,
-    const bool narrow_tile                = false /* narrow_tile */)
+    const std::uint32_t unpack_src_format = 0,
+    const std::uint32_t unpack_dst_format = 0,
+    const std::uint32_t block_ct_dim      = 0,
+    const std::uint32_t face_r_dim        = ckernel::FACE_R_DIM,
+    const std::uint32_t num_faces         = 4,
+    const bool narrow_tile                = false)
 {
     (void)block_ct_dim;
     _llk_unpack_tilize_(base_address, tile_index, unpack_src_format, unpack_dst_format, face_r_dim, num_faces, narrow_tile);
 }
+
+#else
+#error "Unsupported architecture for LLK unpack tilize wrappers"
 
 #endif

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_unpack_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_unpack_wrappers.h
@@ -13,12 +13,12 @@ using ckernel::FACE_R_DIM;
 #ifdef ARCH_WORMHOLE
 
 inline void _llk_unpack_tilize_init_wrapper_(
-    const std::uint32_t unpack_src_format = 0,
-    const std::uint32_t unpack_dst_format = 0,
-    const std::uint32_t ct_dim            = 0,
+    const std::uint32_t unpack_src_format = 0 /* unpack_src_format */,
+    const std::uint32_t unpack_dst_format = 0 /* unpack_dst_format */,
+    const std::uint32_t ct_dim            = 0 /* ct_dim */,
     const std::uint32_t face_r_dim        = FACE_R_DIM,
-    const bool narrow_tile                = false,
-    const std::uint32_t num_faces         = 4)
+    const bool narrow_tile                = false /* narrow_tile */,
+    const std::uint32_t num_faces         = 4 /* num_faces */)
 {
     (void)num_faces;
     _llk_unpack_tilize_init_(unpack_src_format, unpack_dst_format, ct_dim, face_r_dim, narrow_tile);
@@ -27,12 +27,12 @@ inline void _llk_unpack_tilize_init_wrapper_(
 inline void _llk_unpack_tilize_wrapper_(
     const std::uint32_t base_address,
     const std::uint32_t tile_index,
-    const std::uint32_t unpack_src_format = 0,
-    const std::uint32_t unpack_dst_format = 0,
-    const std::uint32_t block_ct_dim      = 0,
+    const std::uint32_t unpack_src_format = 0 /* unpack_src_format */,
+    const std::uint32_t unpack_dst_format = 0 /* unpack_dst_format */,
+    const std::uint32_t block_ct_dim      = 0 /* block_ct_dim */,
     const std::uint32_t face_r_dim        = FACE_R_DIM,
-    const std::uint32_t num_faces         = 4,
-    const bool narrow_tile                = false)
+    const std::uint32_t num_faces         = 4 /* num_faces */,
+    const bool narrow_tile                = false /* narrow_tile */)
 {
     _llk_unpack_tilize_(base_address, tile_index, unpack_src_format, unpack_dst_format, block_ct_dim, face_r_dim, num_faces, narrow_tile);
 }
@@ -40,12 +40,12 @@ inline void _llk_unpack_tilize_wrapper_(
 #else // ARCH_BLACKHOLE version of the wrappers
 
 inline void _llk_unpack_tilize_init_wrapper_(
-    const std::uint32_t unpack_src_format = 0,
-    const std::uint32_t unpack_dst_format = 0,
-    const std::uint32_t ct_dim            = 0,
+    const std::uint32_t unpack_src_format = 0 /* unpack_src_format */,
+    const std::uint32_t unpack_dst_format = 0 /* unpack_dst_format */,
+    const std::uint32_t ct_dim            = 0 /* ct_dim */,
     const std::uint32_t face_r_dim        = FACE_R_DIM,
-    const bool narrow_tile                = false,
-    const std::uint32_t num_faces         = 4)
+    const bool narrow_tile                = false /* narrow_tile */,
+    const std::uint32_t num_faces         = 4 /* num_faces */)
 {
     _llk_unpack_tilize_init_(unpack_src_format, unpack_dst_format, ct_dim, face_r_dim, narrow_tile, num_faces);
 }
@@ -53,12 +53,12 @@ inline void _llk_unpack_tilize_init_wrapper_(
 inline void _llk_unpack_tilize_wrapper_(
     const std::uint32_t base_address,
     const std::uint32_t tile_index,
-    const std::uint32_t unpack_src_format = 0,
-    const std::uint32_t unpack_dst_format = 0,
-    const std::uint32_t block_ct_dim      = 0,
+    const std::uint32_t unpack_src_format = 0 /* unpack_src_format */,
+    const std::uint32_t unpack_dst_format = 0 /* unpack_dst_format */,
+    const std::uint32_t block_ct_dim      = 0 /* block_ct_dim */,
     const std::uint32_t face_r_dim        = FACE_R_DIM,
-    const std::uint32_t num_faces         = 4,
-    const bool narrow_tile                = false)
+    const std::uint32_t num_faces         = 4 /* num_faces */,
+    const bool narrow_tile                = false /* narrow_tile */)
 {
     (void)block_ct_dim;
     _llk_unpack_tilize_(base_address, tile_index, unpack_src_format, unpack_dst_format, face_r_dim, num_faces, narrow_tile);

--- a/tt_metal/tt-llk/tests/sources/ai_gen/unpack_tilize_sfpu_pack.cpp
+++ b/tt_metal/tt-llk/tests/sources/ai_gen/unpack_tilize_sfpu_pack.cpp
@@ -18,7 +18,6 @@ std::uint32_t math_sync_tile_dst_index = 0;
 
 #include "llk_lib_unpack_wrappers.h"
 #include "llk_unpack_common.h"
-#include "llk_unpack_tilize.h"
 #include "params.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
@@ -27,10 +26,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // This handles both A and B inputs which need to be tilized before binary ops
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* num_faces */, 4 /* num_faces */);
-    _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, false);
+    _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, false /* narrow_tile */);
 
     // Unpack and tilize single tile A (stored in src A register - index 0)
-    _llk_unpack_tilize_wrapper_(L1_ADDRESS(params.buffer_A[0]), 0, formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, 4, false);
+    _llk_unpack_tilize_wrapper_(
+        L1_ADDRESS(params.buffer_A[0]),
+        0 /* tile_index */,
+        formats.unpack_A_src,
+        formats.unpack_A_dst,
+        BLOCK_CT_DIM,
+        FACE_R_DIM,
+        4 /* num_faces */,
+        false /* narrow_tile */);
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/ai_gen/unpack_tilize_sfpu_pack.cpp
+++ b/tt_metal/tt-llk/tests/sources/ai_gen/unpack_tilize_sfpu_pack.cpp
@@ -29,7 +29,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_tilize_init_(formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, false);
 
     // Unpack and tilize single tile A (stored in src A register - index 0)
+#ifdef ARCH_BLACKHOLE
+    _llk_unpack_tilize_(L1_ADDRESS(params.buffer_A[0]), 0, formats.unpack_A_src, formats.unpack_A_dst, FACE_R_DIM, 4, false);
+#else
     _llk_unpack_tilize_(L1_ADDRESS(params.buffer_A[0]), 0, formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, 4, false);
+#endif
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/ai_gen/unpack_tilize_sfpu_pack.cpp
+++ b/tt_metal/tt-llk/tests/sources/ai_gen/unpack_tilize_sfpu_pack.cpp
@@ -16,6 +16,7 @@ std::uint32_t math_sync_tile_dst_index = 0;
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_lib_unpack_wrappers.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_tilize.h"
 #include "params.h"
@@ -26,14 +27,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // This handles both A and B inputs which need to be tilized before binary ops
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* num_faces */, 4 /* num_faces */);
-    _llk_unpack_tilize_init_(formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, false);
+    _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, false);
 
     // Unpack and tilize single tile A (stored in src A register - index 0)
-#ifdef ARCH_BLACKHOLE
-    _llk_unpack_tilize_(L1_ADDRESS(params.buffer_A[0]), 0, formats.unpack_A_src, formats.unpack_A_dst, FACE_R_DIM, 4, false);
-#else
-    _llk_unpack_tilize_(L1_ADDRESS(params.buffer_A[0]), 0, formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, 4, false);
-#endif
+    _llk_unpack_tilize_wrapper_(L1_ADDRESS(params.buffer_A[0]), 0, formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, 4, false);
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
@@ -20,7 +20,6 @@ std::uint32_t math_sync_tile_dst_index = 0;
 #include "llk_lib_unpack_wrappers.h"
 #include "llk_unpack_A.h"
 #include "llk_unpack_common.h"
-#include "llk_unpack_tilize.h"
 #include "params.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
@@ -47,14 +46,22 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
-        _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, false);
+        _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, false /* narrow_tile */);
 
         for (std::uint32_t i = 0; i < BLOCK_RT_DIM; i++)
         {
             const std::uint32_t read_offset = i * BLOCK_CT_DIM;
             for (std::uint32_t j = 0; j < BLOCK_CT_DIM; j++)
             {
-                _llk_unpack_tilize_wrapper_(L1_ADDRESS(params.buffer_A[read_offset]), j, formats.unpack_A_src, formats.unpack_A_dst, 0, FACE_R_DIM, 4, false);
+                _llk_unpack_tilize_wrapper_(
+                    L1_ADDRESS(params.buffer_A[read_offset]),
+                    j,
+                    formats.unpack_A_src,
+                    formats.unpack_A_dst,
+                    0 /* block_ct_dim */,
+                    FACE_R_DIM,
+                    4 /* num_faces */,
+                    false /* narrow_tile */);
             }
         }
     }

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
@@ -53,7 +53,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
             const std::uint32_t read_offset = i * BLOCK_CT_DIM;
             for (std::uint32_t j = 0; j < BLOCK_CT_DIM; j++)
             {
+#ifdef ARCH_BLACKHOLE
+                _llk_unpack_tilize_(L1_ADDRESS(params.buffer_A[read_offset]), j, formats.unpack_A_src, formats.unpack_A_dst, FACE_R_DIM, 4, false);
+#else
                 _llk_unpack_tilize_(L1_ADDRESS(params.buffer_A[read_offset]), j, formats.unpack_A_src, formats.unpack_A_dst, 0, FACE_R_DIM, 4, false);
+#endif
             }
         }
     }

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
@@ -17,6 +17,7 @@ std::uint32_t math_sync_tile_dst_index = 0;
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_lib_unpack_wrappers.h"
 #include "llk_unpack_A.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_tilize.h"
@@ -46,18 +47,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
-        _llk_unpack_tilize_init_(formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, false);
+        _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, false);
 
         for (std::uint32_t i = 0; i < BLOCK_RT_DIM; i++)
         {
             const std::uint32_t read_offset = i * BLOCK_CT_DIM;
             for (std::uint32_t j = 0; j < BLOCK_CT_DIM; j++)
             {
-#ifdef ARCH_BLACKHOLE
-                _llk_unpack_tilize_(L1_ADDRESS(params.buffer_A[read_offset]), j, formats.unpack_A_src, formats.unpack_A_dst, FACE_R_DIM, 4, false);
-#else
-                _llk_unpack_tilize_(L1_ADDRESS(params.buffer_A[read_offset]), j, formats.unpack_A_src, formats.unpack_A_dst, 0, FACE_R_DIM, 4, false);
-#endif
+                _llk_unpack_tilize_wrapper_(L1_ADDRESS(params.buffer_A[read_offset]), j, formats.unpack_A_src, formats.unpack_A_dst, 0, FACE_R_DIM, 4, false);
             }
         }
     }

--- a/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
@@ -26,6 +26,7 @@ constexpr std::uint32_t buffer_B_tilized = 0xA1000;
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_lib_unpack_wrappers.h"
 #include "llk_unpack_AB_matmul.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_tilize.h"
@@ -37,9 +38,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig(&formats_array)[2] = params.formats;
 #endif
 
-#ifndef ARCH_BLACKHOLE
     const std::uint32_t block_ct_dim = BLOCK_CT_DIM;
-#endif
 
     int run = 0; // first L1-to-L1 run, we access the first set of formats_array in our array
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
@@ -52,21 +51,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
         4 /* num_faces */,
         4 /* num_faces */);
 
-    _llk_unpack_tilize_init_(formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, 1, FACE_R_DIM, false);
-#ifdef ARCH_BLACKHOLE
-    _llk_unpack_tilize_(L1_ADDRESS(params.buffer_A[0]), 0, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, FACE_R_DIM, 4, false);
-#else
-    _llk_unpack_tilize_(
+    _llk_unpack_tilize_init_wrapper_(formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, 1, FACE_R_DIM, false);
+    _llk_unpack_tilize_wrapper_(
         L1_ADDRESS(params.buffer_A[0]), 0, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, block_ct_dim, FACE_R_DIM, 4, false);
-#endif
 
-    _llk_unpack_tilize_init_(formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, 1, FACE_R_DIM, false);
-#ifdef ARCH_BLACKHOLE
-    _llk_unpack_tilize_(L1_ADDRESS(params.buffer_B[0]), 0, formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, FACE_R_DIM, 4, false);
-#else
-    _llk_unpack_tilize_(
+    _llk_unpack_tilize_init_wrapper_(formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, 1, FACE_R_DIM, false);
+    _llk_unpack_tilize_wrapper_(
         L1_ADDRESS(params.buffer_B[0]), 0, formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, block_ct_dim, FACE_R_DIM, 4, false);
-#endif
 
     t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(
         semaphore::PACK_DONE); // Unpacker waits on signal when packer will increment semaphore to 1 (waits while semaphore == 0), utilizing SEMWAIT.

--- a/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
@@ -37,9 +37,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig(&formats_array)[2] = params.formats;
 #endif
 
-#ifdef ARCH_BLACKHOLE
-    const std::uint32_t block_ct_dim = 0;
-#else
+#ifndef ARCH_BLACKHOLE
     const std::uint32_t block_ct_dim = BLOCK_CT_DIM;
 #endif
 
@@ -55,12 +53,20 @@ void run_kernel(RUNTIME_PARAMETERS params)
         4 /* num_faces */);
 
     _llk_unpack_tilize_init_(formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, 1, FACE_R_DIM, false);
+#ifdef ARCH_BLACKHOLE
+    _llk_unpack_tilize_(L1_ADDRESS(params.buffer_A[0]), 0, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, FACE_R_DIM, 4, false);
+#else
     _llk_unpack_tilize_(
         L1_ADDRESS(params.buffer_A[0]), 0, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, block_ct_dim, FACE_R_DIM, 4, false);
+#endif
 
     _llk_unpack_tilize_init_(formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, 1, FACE_R_DIM, false);
+#ifdef ARCH_BLACKHOLE
+    _llk_unpack_tilize_(L1_ADDRESS(params.buffer_B[0]), 0, formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, FACE_R_DIM, 4, false);
+#else
     _llk_unpack_tilize_(
         L1_ADDRESS(params.buffer_B[0]), 0, formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, block_ct_dim, FACE_R_DIM, 4, false);
+#endif
 
     t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(
         semaphore::PACK_DONE); // Unpacker waits on signal when packer will increment semaphore to 1 (waits while semaphore == 0), utilizing SEMWAIT.

--- a/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
@@ -29,7 +29,6 @@ constexpr std::uint32_t buffer_B_tilized = 0xA1000;
 #include "llk_lib_unpack_wrappers.h"
 #include "llk_unpack_AB_matmul.h"
 #include "llk_unpack_common.h"
-#include "llk_unpack_tilize.h"
 #include "params.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
@@ -51,13 +50,27 @@ void run_kernel(RUNTIME_PARAMETERS params)
         4 /* num_faces */,
         4 /* num_faces */);
 
-    _llk_unpack_tilize_init_wrapper_(formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, 1, FACE_R_DIM, false);
+    _llk_unpack_tilize_init_wrapper_(formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, 1 /* ct_dim */, FACE_R_DIM, false /* narrow_tile */);
     _llk_unpack_tilize_wrapper_(
-        L1_ADDRESS(params.buffer_A[0]), 0, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, block_ct_dim, FACE_R_DIM, 4, false);
+        L1_ADDRESS(params.buffer_A[0]),
+        0 /* tile_index */,
+        formats_array[run].unpack_A_src,
+        formats_array[run].unpack_A_dst,
+        block_ct_dim,
+        FACE_R_DIM,
+        4 /* num_faces */,
+        false /* narrow_tile */);
 
-    _llk_unpack_tilize_init_wrapper_(formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, 1, FACE_R_DIM, false);
+    _llk_unpack_tilize_init_wrapper_(formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, 1 /* ct_dim */, FACE_R_DIM, false /* narrow_tile */);
     _llk_unpack_tilize_wrapper_(
-        L1_ADDRESS(params.buffer_B[0]), 0, formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, block_ct_dim, FACE_R_DIM, 4, false);
+        L1_ADDRESS(params.buffer_B[0]),
+        0 /* tile_index */,
+        formats_array[run].unpack_B_src,
+        formats_array[run].unpack_B_dst,
+        block_ct_dim,
+        FACE_R_DIM,
+        4 /* num_faces */,
+        false /* narrow_tile */);
 
     t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(
         semaphore::PACK_DONE); // Unpacker waits on signal when packer will increment semaphore to 1 (waits while semaphore == 0), utilizing SEMWAIT.

--- a/tt_metal/tt-llk/tests/sources/tilize_calculate_untilize_L1.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_calculate_untilize_L1.cpp
@@ -33,7 +33,6 @@ constexpr std::uint32_t buffer_B_tilized = 0x17000;
 #include "llk_unpack_A.h"
 #include "llk_unpack_AB.h"
 #include "llk_unpack_common.h"
-#include "llk_unpack_tilize.h"
 #include "params.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
@@ -55,13 +54,27 @@ void run_kernel(RUNTIME_PARAMETERS params)
         4 /* num_faces */,
         4 /* num_faces */);
 
-    _llk_unpack_tilize_init_wrapper_(formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, 1, FACE_R_DIM, false);
+    _llk_unpack_tilize_init_wrapper_(formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, 1 /* ct_dim */, FACE_R_DIM, false /* narrow_tile */);
     _llk_unpack_tilize_wrapper_(
-        L1_ADDRESS(params.buffer_A[0]), 0, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, block_ct_dim, FACE_R_DIM, 4, false);
+        L1_ADDRESS(params.buffer_A[0]),
+        0 /* tile_index */,
+        formats_array[run].unpack_A_src,
+        formats_array[run].unpack_A_dst,
+        block_ct_dim,
+        FACE_R_DIM,
+        4 /* num_faces */,
+        false /* narrow_tile */);
 
-    _llk_unpack_tilize_init_wrapper_(formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, 1, FACE_R_DIM, false);
+    _llk_unpack_tilize_init_wrapper_(formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, 1 /* ct_dim */, FACE_R_DIM, false /* narrow_tile */);
     _llk_unpack_tilize_wrapper_(
-        L1_ADDRESS(params.buffer_B[0]), 0, formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, block_ct_dim, FACE_R_DIM, 4, false);
+        L1_ADDRESS(params.buffer_B[0]),
+        0 /* tile_index */,
+        formats_array[run].unpack_B_src,
+        formats_array[run].unpack_B_dst,
+        block_ct_dim,
+        FACE_R_DIM,
+        4 /* num_faces */,
+        false /* narrow_tile */);
 
     /*
     In this test we fuse two LLK pipeline runs, one is to unpack untilized buffers/operands from L1 (39-45) and pack them in tilized format(130-145).

--- a/tt_metal/tt-llk/tests/sources/tilize_calculate_untilize_L1.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_calculate_untilize_L1.cpp
@@ -59,12 +59,20 @@ void run_kernel(RUNTIME_PARAMETERS params)
         4 /* num_faces */);
 
     _llk_unpack_tilize_init_(formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, 1, FACE_R_DIM, false);
+#ifdef ARCH_BLACKHOLE
+    _llk_unpack_tilize_(L1_ADDRESS(params.buffer_A[0]), 0, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, FACE_R_DIM, 4, false);
+#else
     _llk_unpack_tilize_(
         L1_ADDRESS(params.buffer_A[0]), 0, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, block_ct_dim, FACE_R_DIM, 4, false);
+#endif
 
     _llk_unpack_tilize_init_(formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, 1, FACE_R_DIM, false);
+#ifdef ARCH_BLACKHOLE
+    _llk_unpack_tilize_(L1_ADDRESS(params.buffer_B[0]), 0, formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, FACE_R_DIM, 4, false);
+#else
     _llk_unpack_tilize_(
         L1_ADDRESS(params.buffer_B[0]), 0, formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, block_ct_dim, FACE_R_DIM, 4, false);
+#endif
 
     /*
     In this test we fuse two LLK pipeline runs, one is to unpack untilized buffers/operands from L1 (39-45) and pack them in tilized format(130-145).

--- a/tt_metal/tt-llk/tests/sources/tilize_calculate_untilize_L1.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_calculate_untilize_L1.cpp
@@ -17,11 +17,6 @@ std::uint32_t math_sync_tile_dst_index = 0;
 
 using namespace ckernel;
 
-// TODO: CLEANUP
-
-constexpr std::uint32_t buffer_A_tilized = 0x16000;
-constexpr std::uint32_t buffer_B_tilized = 0x17000;
-
 // Translation of these lines:
 // const FormatConfig(&formats_array)[2] = params.formats;
 // to English:
@@ -106,7 +101,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         4 /* num_faces */,
         4 /* num_faces */);
     _llk_unpack_AB_init_<>(DEFAULT_TENSOR_SHAPE);
-    _llk_unpack_AB_<>(L1_ADDRESS(buffer_A_tilized), L1_ADDRESS(buffer_B_tilized));
+    _llk_unpack_AB_<>(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]));
 }
 
 #endif
@@ -192,11 +187,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     _llk_packer_wait_for_math_done_();
-    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, UNTILIZE>(operand_A_dst_index, L1_ADDRESS(buffer_A_tilized));
+    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, UNTILIZE>(operand_A_dst_index, L1_ADDRESS(params.buffer_A[0]));
     _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 
     _llk_packer_wait_for_math_done_();
-    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, UNTILIZE>(operand_B_dst_index, L1_ADDRESS(buffer_B_tilized));
+    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, UNTILIZE>(operand_B_dst_index, L1_ADDRESS(params.buffer_B[0]));
     _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>(); // Packer will execute _llk_pack_dest_section_done_ function which ensures the write
                                                                             // to L1 is fully is complete.
     t6_semaphore_post<>(semaphore::PACK_DONE); // The packer signals to the unpacker that it has finished writing to L1 by posting (incrementing) the semaphore.

--- a/tt_metal/tt-llk/tests/sources/tilize_calculate_untilize_L1.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_calculate_untilize_L1.cpp
@@ -29,6 +29,7 @@ constexpr std::uint32_t buffer_B_tilized = 0x17000;
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_lib_unpack_wrappers.h"
 #include "llk_unpack_A.h"
 #include "llk_unpack_AB.h"
 #include "llk_unpack_common.h"
@@ -41,11 +42,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig(&formats_array)[2] = params.formats;
 #endif
 
-#ifdef ARCH_BLACKHOLE
-    const std::uint32_t block_ct_dim = 0;
-#else
     const std::uint32_t block_ct_dim = BLOCK_CT_DIM;
-#endif
 
     int run = 0; // first L1-to-L1 run, we access the first set of formats_array in our array
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
@@ -58,21 +55,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
         4 /* num_faces */,
         4 /* num_faces */);
 
-    _llk_unpack_tilize_init_(formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, 1, FACE_R_DIM, false);
-#ifdef ARCH_BLACKHOLE
-    _llk_unpack_tilize_(L1_ADDRESS(params.buffer_A[0]), 0, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, FACE_R_DIM, 4, false);
-#else
-    _llk_unpack_tilize_(
+    _llk_unpack_tilize_init_wrapper_(formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, 1, FACE_R_DIM, false);
+    _llk_unpack_tilize_wrapper_(
         L1_ADDRESS(params.buffer_A[0]), 0, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, block_ct_dim, FACE_R_DIM, 4, false);
-#endif
 
-    _llk_unpack_tilize_init_(formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, 1, FACE_R_DIM, false);
-#ifdef ARCH_BLACKHOLE
-    _llk_unpack_tilize_(L1_ADDRESS(params.buffer_B[0]), 0, formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, FACE_R_DIM, 4, false);
-#else
-    _llk_unpack_tilize_(
+    _llk_unpack_tilize_init_wrapper_(formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, 1, FACE_R_DIM, false);
+    _llk_unpack_tilize_wrapper_(
         L1_ADDRESS(params.buffer_B[0]), 0, formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, block_ct_dim, FACE_R_DIM, 4, false);
-#endif
 
     /*
     In this test we fuse two LLK pipeline runs, one is to unpack untilized buffers/operands from L1 (39-45) and pack them in tilized format(130-145).

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_perf.cpp
@@ -76,7 +76,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 const std::uint32_t tile_row_addr = L1_ADDRESS(src + (i % 8) * 0x1000); // TODO SS<-LP use PERF_ADDRESS here
                 for (std::uint32_t j = 0; j < BLOCK_CT_DIM; j++)
                 {
+#ifdef ARCH_BLACKHOLE
+                    _llk_unpack_tilize_(tile_row_addr, j, formats.unpack_A_src, formats.unpack_A_dst, FACE_R_DIM, 4, false);
+#else
                     _llk_unpack_tilize_(tile_row_addr, j, formats.unpack_A_src, formats.unpack_A_dst, 0, FACE_R_DIM, 4, false);
+#endif
                 }
             }
         }

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_perf.cpp
@@ -30,7 +30,6 @@ static constexpr std::uint32_t MAX_TILES_DEST = is_fp32_dest_acc_en ? 4 : 8;
 
 #include "llk_lib_unpack_wrappers.h"
 #include "llk_unpack_common.h"
-#include "llk_unpack_tilize.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
@@ -59,7 +58,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             FACE_R_DIM,
             4 /* num_faces */,
             4 /* num_faces */);
-        _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, false);
+        _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, false /* narrow_tile */);
         PROFILER_SYNC();
     }
 
@@ -77,7 +76,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 const std::uint32_t tile_row_addr = L1_ADDRESS(src + (i % 8) * 0x1000); // TODO SS<-LP use PERF_ADDRESS here
                 for (std::uint32_t j = 0; j < BLOCK_CT_DIM; j++)
                 {
-                    _llk_unpack_tilize_wrapper_(tile_row_addr, j, formats.unpack_A_src, formats.unpack_A_dst, 0, FACE_R_DIM, 4, false);
+                    _llk_unpack_tilize_wrapper_(
+                        tile_row_addr,
+                        j,
+                        formats.unpack_A_src,
+                        formats.unpack_A_dst,
+                        0 /* block_ct_dim */,
+                        FACE_R_DIM,
+                        4 /* num_faces */,
+                        false /* narrow_tile */);
                 }
             }
         }

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_perf.cpp
@@ -28,6 +28,7 @@ static constexpr std::uint32_t MAX_TILES_DEST = is_fp32_dest_acc_en ? 4 : 8;
 
 #include <algorithm>
 
+#include "llk_lib_unpack_wrappers.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_tilize.h"
 
@@ -58,7 +59,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             FACE_R_DIM,
             4 /* num_faces */,
             4 /* num_faces */);
-        _llk_unpack_tilize_init_(formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, false);
+        _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, false);
         PROFILER_SYNC();
     }
 
@@ -76,11 +77,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 const std::uint32_t tile_row_addr = L1_ADDRESS(src + (i % 8) * 0x1000); // TODO SS<-LP use PERF_ADDRESS here
                 for (std::uint32_t j = 0; j < BLOCK_CT_DIM; j++)
                 {
-#ifdef ARCH_BLACKHOLE
-                    _llk_unpack_tilize_(tile_row_addr, j, formats.unpack_A_src, formats.unpack_A_dst, FACE_R_DIM, 4, false);
-#else
-                    _llk_unpack_tilize_(tile_row_addr, j, formats.unpack_A_src, formats.unpack_A_dst, 0, FACE_R_DIM, 4, false);
-#endif
+                    _llk_unpack_tilize_wrapper_(tile_row_addr, j, formats.unpack_A_src, formats.unpack_A_dst, 0, FACE_R_DIM, 4, false);
                 }
             }
         }

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
@@ -19,7 +19,6 @@ std::uint32_t math_sync_tile_dst_index = 0;
 #include "ckernel_template.h"
 #include "llk_lib_unpack_wrappers.h"
 #include "llk_unpack_common.h"
-#include "llk_unpack_tilize.h"
 #include "params.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
@@ -32,13 +31,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_configure_stoch_rnd_<STOCHASTIC_RND>();
 
     // Initialize tilize unpacker
-    _llk_unpack_tilize_init_wrapper_(
-        formats.unpack_A_src,
-        formats.unpack_A_dst,
-        params.BLOCK_CT_DIM,
-        FACE_R_DIM,
-        params.NARROW_TILE // narrow_tile disabled for now
-    );
+    _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, params.BLOCK_CT_DIM, FACE_R_DIM, params.NARROW_TILE);
 
     std::uint32_t read_offset = 0;
 
@@ -57,14 +50,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         for (std::uint32_t col = 0; col < params.BLOCK_CT_DIM; ++col)
         {
             _llk_unpack_tilize_wrapper_(
-                tile_row_addr,
-                col,
-                formats.unpack_A_src,
-                formats.unpack_A_dst,
-                block_ct_dim,
-                FACE_R_DIM,
-                num_faces,
-                false // narrow_tile disabled for now
+                tile_row_addr, col, formats.unpack_A_src, formats.unpack_A_dst, block_ct_dim, FACE_R_DIM, num_faces, false /* narrow_tile */
             );
         }
         read_offset += params.BLOCK_CT_DIM;

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
@@ -17,6 +17,7 @@ std::uint32_t math_sync_tile_dst_index = 0;
 #ifdef LLK_TRISC_UNPACK
 
 #include "ckernel_template.h"
+#include "llk_lib_unpack_wrappers.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_tilize.h"
 #include "params.h"
@@ -31,7 +32,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_configure_stoch_rnd_<STOCHASTIC_RND>();
 
     // Initialize tilize unpacker
-    _llk_unpack_tilize_init_(
+    _llk_unpack_tilize_init_wrapper_(
         formats.unpack_A_src,
         formats.unpack_A_dst,
         params.BLOCK_CT_DIM,
@@ -41,11 +42,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     std::uint32_t read_offset = 0;
 
-#ifdef ARCH_BLACKHOLE
-    const std::uint32_t block_ct_dim = 0;
-#else
     const std::uint32_t block_ct_dim = params.BLOCK_CT_DIM;
-#endif
 
 #ifdef ARCH_BLACKHOLE
     const std::uint32_t num_faces = 4;
@@ -59,18 +56,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         std::uint32_t tile_row_addr = L1_ADDRESS(params.buffer_A[read_offset]);
         for (std::uint32_t col = 0; col < params.BLOCK_CT_DIM; ++col)
         {
-#ifdef ARCH_BLACKHOLE
-            _llk_unpack_tilize_(
-                tile_row_addr,
-                col,
-                formats.unpack_A_src,
-                formats.unpack_A_dst,
-                FACE_R_DIM,
-                num_faces,
-                false // narrow_tile disabled for now
-            );
-#else
-            _llk_unpack_tilize_(
+            _llk_unpack_tilize_wrapper_(
                 tile_row_addr,
                 col,
                 formats.unpack_A_src,
@@ -80,7 +66,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 num_faces,
                 false // narrow_tile disabled for now
             );
-#endif
         }
         read_offset += params.BLOCK_CT_DIM;
     }

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
@@ -59,6 +59,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
         std::uint32_t tile_row_addr = L1_ADDRESS(params.buffer_A[read_offset]);
         for (std::uint32_t col = 0; col < params.BLOCK_CT_DIM; ++col)
         {
+#ifdef ARCH_BLACKHOLE
+            _llk_unpack_tilize_(
+                tile_row_addr,
+                col,
+                formats.unpack_A_src,
+                formats.unpack_A_dst,
+                FACE_R_DIM,
+                num_faces,
+                false // narrow_tile disabled for now
+            );
+#else
             _llk_unpack_tilize_(
                 tile_row_addr,
                 col,
@@ -69,6 +80,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 num_faces,
                 false // narrow_tile disabled for now
             );
+#endif
         }
         read_offset += params.BLOCK_CT_DIM;
     }

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_test.cpp
@@ -43,8 +43,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         for (std::uint32_t j = 0; j < params.BLOCK_CT_DIM; j++)
         {
+#ifdef ARCH_BLACKHOLE
+            _llk_unpack_tilize_(L1_ADDRESS(params.buffer_A[read_offset]), j, formats.unpack_A_src, formats.unpack_A_dst, FACE_R_DIM, num_faces, false);
+#else
             _llk_unpack_tilize_(
                 L1_ADDRESS(params.buffer_A[read_offset]), j, formats.unpack_A_src, formats.unpack_A_dst, block_ct_dim, FACE_R_DIM, num_faces, false);
+#endif
         }
         read_offset += params.BLOCK_CT_DIM;
     }

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_test.cpp
@@ -17,6 +17,7 @@ std::uint32_t math_sync_tile_dst_index = 0;
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_lib_unpack_wrappers.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_tilize.h"
 #include "params.h"
@@ -29,26 +30,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t num_faces = params.num_faces;
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, num_faces, num_faces);
-    _llk_unpack_tilize_init_(formats.unpack_A_src, formats.unpack_A_dst, params.BLOCK_CT_DIM, FACE_R_DIM, false);
+    _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, params.BLOCK_CT_DIM, FACE_R_DIM, false);
 
     std::uint32_t read_offset = 0;
 
-#ifdef ARCH_BLACKHOLE
-    const std::uint32_t block_ct_dim = 0;
-#else
     const std::uint32_t block_ct_dim = params.BLOCK_CT_DIM;
-#endif
 
     for (std::uint32_t i = 0; i < params.BLOCK_RT_DIM; i++)
     {
         for (std::uint32_t j = 0; j < params.BLOCK_CT_DIM; j++)
         {
-#ifdef ARCH_BLACKHOLE
-            _llk_unpack_tilize_(L1_ADDRESS(params.buffer_A[read_offset]), j, formats.unpack_A_src, formats.unpack_A_dst, FACE_R_DIM, num_faces, false);
-#else
-            _llk_unpack_tilize_(
+            _llk_unpack_tilize_wrapper_(
                 L1_ADDRESS(params.buffer_A[read_offset]), j, formats.unpack_A_src, formats.unpack_A_dst, block_ct_dim, FACE_R_DIM, num_faces, false);
-#endif
         }
         read_offset += params.BLOCK_CT_DIM;
     }

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_test.cpp
@@ -19,7 +19,6 @@ std::uint32_t math_sync_tile_dst_index = 0;
 
 #include "llk_lib_unpack_wrappers.h"
 #include "llk_unpack_common.h"
-#include "llk_unpack_tilize.h"
 #include "params.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
@@ -30,7 +29,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t num_faces = params.num_faces;
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, num_faces, num_faces);
-    _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, params.BLOCK_CT_DIM, FACE_R_DIM, false);
+    _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, params.BLOCK_CT_DIM, FACE_R_DIM, false /* narrow_tile */);
 
     std::uint32_t read_offset = 0;
 
@@ -41,7 +40,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         for (std::uint32_t j = 0; j < params.BLOCK_CT_DIM; j++)
         {
             _llk_unpack_tilize_wrapper_(
-                L1_ADDRESS(params.buffer_A[read_offset]), j, formats.unpack_A_src, formats.unpack_A_dst, block_ct_dim, FACE_R_DIM, num_faces, false);
+                L1_ADDRESS(params.buffer_A[read_offset]),
+                j,
+                formats.unpack_A_src,
+                formats.unpack_A_dst,
+                block_ct_dim,
+                FACE_R_DIM,
+                num_faces,
+                false /* narrow_tile */);
         }
         read_offset += params.BLOCK_CT_DIM;
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
@@ -63,7 +63,6 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces, const cker
     static constexpr std::uint32_t unpack_srcb = TT_OP_UNPACR(SrcB, 0b1, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr std::uint32_t unpack_srca_transpose =
         TT_OP_UNPACR(SrcA, 0b10 /*This is an inc of 2, which is meant to be num_faces_c_dim*/, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-    [[maybe_unused]] const std::uint32_t srca_end_op = TT_OP_SETADCZW(p_setadc::UNP_A, 0, 0, 0, 1, 0b0001);
 
     const std::uint32_t outerloop = transpose_of_faces ? num_faces_c_dim : num_faces_r_dim;
     const std::uint32_t innerloop = transpose_of_faces ? num_faces_r_dim : num_faces_c_dim;

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -18,11 +18,8 @@
 using namespace ckernel;
 using namespace ckernel::unpacker;
 
-inline void _llk_unpack_tilize_mop_config_(
-    [[maybe_unused]] const bool narrow_tile = false, const bool unpack_to_dest = false, const bool skip_bh_workaround = false)
+inline void _llk_unpack_tilize_mop_config_(const bool narrow_tile = false, const bool unpack_to_dest = false, const bool skip_bh_workaround = false)
 {
-    LLK_ASSERT(!narrow_tile, "narrow_tile: this parameter is unused");
-
     static constexpr std::uint32_t unpack_srca =
         TT_OP_UNPACR(SrcA, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr std::uint32_t unpack_srca_to_dest =
@@ -116,14 +113,12 @@ inline void _llk_unpack_tilize_init_(
 inline void _llk_unpack_tilize_(
     const std::uint32_t base_address,
     const std::uint32_t tile_index,
-    std::uint32_t unpack_src_format                 = 0,
-    std::uint32_t unpack_dst_format                 = 0,
-    [[maybe_unused]] std::uint32_t block_ct_dim     = 0,
-    [[maybe_unused]] const std::uint32_t face_r_dim = FACE_R_DIM,
-    [[maybe_unused]] const std::uint32_t num_faces  = 4,
-    const bool narrow_tile                          = false)
+    std::uint32_t unpack_src_format = 0,
+    std::uint32_t unpack_dst_format = 0,
+    const std::uint32_t face_r_dim  = FACE_R_DIM,
+    const std::uint32_t num_faces   = 4,
+    const bool narrow_tile          = false)
 {
-    LLK_ASSERT(block_ct_dim == 0, "block_ct_dim: this parameter is unused");
     LLK_ASSERT(num_faces == 2 || num_faces == 4, "num_faces must be 2 or 4 for tilize");
 
     volatile std::uint32_t tt_reg_ptr* cfg = get_cfg_pointer(); // get pointer to registers for current state ID
@@ -271,7 +266,7 @@ inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, co
 
 // TODO: add support for all the template parameters
 template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false, bool zero_srcA_reduce = false>
-inline void _llk_unpack_tilizeA_B_mop_config_(const bool narrow_tile = false, const std::uint32_t num_faces = 4)
+inline void _llk_unpack_tilizeA_B_mop_config_([[maybe_unused]] const bool narrow_tile = false, const std::uint32_t num_faces = 4)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     const std::uint32_t replay_buf_run_len  = 6;
@@ -318,9 +313,9 @@ inline void _llk_unpack_tilizeA_B_init_(
     const std::uint32_t unpack_dst_format,
     const bool narrow_tile,
     const std::uint32_t ct_dim,
-    const std::uint32_t num_faces       = 4,
-    const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
-    const std::uint32_t unpB_face_r_dim = FACE_R_DIM)
+    const std::uint32_t num_faces                        = 4,
+    [[maybe_unused]] const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
+    const std::uint32_t unpB_face_r_dim                  = FACE_R_DIM)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     // Sets the block_c_dim for unpack to use to increment the L1 address
@@ -349,11 +344,11 @@ template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero
 inline void _llk_unpack_tilizeA_B_(
     std::uint32_t unpA_src_format,
     std::uint32_t face_r_dim,
-    std::uint32_t narrow_tile,
+    [[maybe_unused]] std::uint32_t narrow_tile,
     std::uint32_t base_address_a,
     std::uint32_t address_b,
     std::uint32_t tile_index_a,
-    std::uint32_t tile_index_b,
+    [[maybe_unused]] std::uint32_t tile_index_b,
     std::uint32_t block_ct_dim,
     std::uint32_t num_faces = 4)
 {

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -266,7 +266,7 @@ inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, co
 
 // TODO: add support for all the template parameters
 template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false, bool zero_srcA_reduce = false>
-inline void _llk_unpack_tilizeA_B_mop_config_([[maybe_unused]] const bool narrow_tile = false, const std::uint32_t num_faces = 4)
+inline void _llk_unpack_tilizeA_B_mop_config_(const std::uint32_t num_faces = 4)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     const std::uint32_t replay_buf_run_len  = 6;
@@ -311,11 +311,9 @@ template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero
 inline void _llk_unpack_tilizeA_B_init_(
     const std::uint32_t unpack_src_format,
     const std::uint32_t unpack_dst_format,
-    const bool narrow_tile,
     const std::uint32_t ct_dim,
-    const std::uint32_t num_faces                        = 4,
-    [[maybe_unused]] const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
-    const std::uint32_t unpB_face_r_dim                  = FACE_R_DIM)
+    const std::uint32_t num_faces       = 4,
+    const std::uint32_t unpB_face_r_dim = FACE_R_DIM)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     // Sets the block_c_dim for unpack to use to increment the L1 address
@@ -337,18 +335,16 @@ inline void _llk_unpack_tilizeA_B_init_(
     cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_RMW>(unpA_ch1_y_stride);
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(0);
 
-    _llk_unpack_tilizeA_B_mop_config_<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(narrow_tile, num_faces);
+    _llk_unpack_tilizeA_B_mop_config_<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(num_faces);
 }
 
 template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false, bool zero_srcA_reduce = false>
 inline void _llk_unpack_tilizeA_B_(
     std::uint32_t unpA_src_format,
     std::uint32_t face_r_dim,
-    [[maybe_unused]] std::uint32_t narrow_tile,
     std::uint32_t base_address_a,
     std::uint32_t address_b,
     std::uint32_t tile_index_a,
-    [[maybe_unused]] std::uint32_t tile_index_b,
     std::uint32_t block_ct_dim,
     std::uint32_t num_faces = 4)
 {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -223,7 +223,7 @@ inline void _llk_unpack_tilize_(
  *************************************************************************/
 
 template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false, bool zero_srcA_reduce = false>
-inline void _llk_unpack_tilizeA_B_mop_config_(const bool narrow_tile = false, const std::uint32_t num_faces = 4)
+inline void _llk_unpack_tilizeA_B_mop_config_(const std::uint32_t num_faces = 4)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     static constexpr std::uint32_t unpack_srca =
@@ -312,7 +312,7 @@ inline void _llk_unpack_tilizeA_B_init_(
         THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32 - THCON_CFGREG_BASE_ADDR32,
         p_gpr_unpack::FACE_DIM_1x16); // GPR preloaded with  16 | (16 << 16)
 
-    _llk_unpack_tilizeA_B_mop_config_<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(narrow_tile, num_faces);
+    _llk_unpack_tilizeA_B_mop_config_<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(num_faces);
 }
 
 template <bool zero_srcA = false>
@@ -323,7 +323,6 @@ inline void _llk_unpack_tilizeA_B_(
     std::uint32_t base_address_a,
     std::uint32_t address_b,
     std::uint32_t tile_index_a,
-    std::uint32_t tile_index_b,
     std::uint32_t block_ct_dim,
     std::uint32_t num_faces = 4)
 {


### PR DESCRIPTION
### Summary
Remove unused LLK unpack tilize parameters from Blackhole and Wormhole paths, and update LLK tests for the architecture-specific unpack tilize signatures.

### Notes for reviewers
Focus on the LLK unpack tilize API/lib signature changes and the corresponding test call-site updates. Local validation was limited to lint/diff checks during the split; full LLK test suites were not run.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/llk-unused-params-unpack-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/llk-unused-params-unpack-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/llk-unused-params-unpack-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/llk-unused-params-unpack-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/llk-unused-params-unpack-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/llk-unused-params-unpack-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/llk-unused-params-unpack-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/llk-unused-params-unpack-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/llk-unused-params-unpack-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/llk-unused-params-unpack-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/llk-unused-params-unpack-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/llk-unused-params-unpack-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/llk-unused-params-unpack-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/llk-unused-params-unpack-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/llk-unused-params-unpack-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/llk-unused-params-unpack-tilize)