### PR TITLE
Remove unused LLK math parameters

### DIFF
--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
@@ -47,16 +47,6 @@ inline void llk_math_pack_sync_init() {
     _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
-template <bool mail2math = true, bool mail2pack = true>
-inline void llk_math_get_tile(std::uint32_t operand, std::uint32_t tile_index, std::uint32_t* p_tile) {
-    _llk_math_get_tile_<mail2math, mail2pack>(tile_index, p_tile);
-}
-
-template <bool mail2math = true, bool mail2pack = true>
-inline void llk_math_release_tile(std::uint32_t operand) {
-    _llk_math_release_tile_<mail2math, mail2pack>();
-}
-
 inline void llk_math_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _llk_math_debug_dump_(data, byte_size); }
 
 inline void llk_math_debug_dump_seek(std::uint8_t offset) { _llk_math_debug_dump_seek_(offset); }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_mul_reduce_scalar.h
@@ -79,7 +79,7 @@ inline void execute_high_fidelity_gapool()
  * @param idst Destination tile index (0-7)
  */
 template <EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void _llk_math_mul_reduce_scalar_move_dest_to_src_(std::uint32_t idst = 0)
+inline void _llk_math_mul_reduce_scalar_move_dest_to_src_([[maybe_unused]] std::uint32_t idst = 0)
 {
     if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA)
     {

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -116,28 +116,6 @@ inline void _llk_math_pack_sync_init_()
     }
 }
 
-template <bool mail2math = true, bool mail2pack = true>
-inline void _llk_math_get_tile_(std::uint32_t tile_index, std::uint32_t* p_tile)
-{
-    if constexpr (mail2math)
-    {
-        *p_tile = mailbox_read(ThreadId::UnpackThreadId);
-    }
-    else
-    {
-        *p_tile = 0x0;
-    }
-}
-
-template <bool mail2math = true, bool mail2pack = true>
-inline void _llk_math_release_tile_()
-{
-    if constexpr (mail2math)
-    {
-        semaphore_get(semaphore::UNPACK_OPERAND_SYNC);
-    }
-}
-
 inline void _llk_math_debug_dump_(std::uint8_t* data, std::uint32_t byte_size)
 {
     debug_dump(data, byte_size);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
@@ -457,7 +457,6 @@ inline void _llk_math_eltwise_binary_with_dest_reuse_(const ckernel::TensorShape
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     LLK_ASSERT(math_fidelity == MathFidelity::LoFi || eltwise_binary_type == ELWMUL, "Math fidelity larger than LoFi only works with Eltwise multiply");
-    [[maybe_unused]] constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
 
     // Dest counter always jumps by 32x32 tile spacing regardless of actual tile size
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -101,31 +101,6 @@ inline void _llk_math_pack_sync_init_()
     }
 }
 
-template <bool mail2math = true, bool mail2pack = true>
-inline void _llk_math_get_tile_(std::uint32_t tile_index, std::uint32_t* p_tile)
-{
-    constexpr std::uint32_t wait_sem = (mail2math && mail2pack) ? (2) : (1);
-    while (semaphore_read(semaphore::UNPACK_OPERAND_SYNC) < wait_sem)
-        ;
-    if constexpr (mail2math)
-    {
-        *p_tile = mailbox_read(ThreadId::UnpackThreadId);
-    }
-    else
-    {
-        *p_tile = 0x0;
-    }
-}
-
-template <bool mail2math = true, bool mail2pack = true>
-inline void _llk_math_release_tile_()
-{
-    if constexpr (mail2math)
-    {
-        semaphore_get(semaphore::UNPACK_OPERAND_SYNC);
-    }
-}
-
 inline void _llk_math_debug_dump_(std::uint8_t* data, std::uint32_t byte_size)
 {
     debug_dump(data, byte_size);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
@@ -82,7 +82,6 @@ inline void eltwise_binary_configure_mop_standard(const std::uint32_t acc_to_des
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     const std::uint32_t num_faces           = tensor_shape.total_num_faces();
     const std::uint32_t num_faces_c_dim     = tensor_shape.num_faces_c_dim;
-    [[maybe_unused]] const bool narrow_tile = tensor_shape.num_faces_c_dim < tensor_shape.num_faces_r_dim;
     constexpr bool high_fidelity            = is_high_fidelity(math_fidelity);
     constexpr std::uint8_t addr_mod         = ADDR_MOD_0;
 
@@ -457,7 +456,6 @@ inline void _llk_math_eltwise_binary_with_dest_reuse_(const ckernel::TensorShape
     const std::uint32_t num_faces_r_dim = tensor_shape.num_faces_r_dim;
     const std::uint32_t num_faces_c_dim = tensor_shape.num_faces_c_dim;
     LLK_ASSERT(math_fidelity == MathFidelity::LoFi || eltwise_binary_type == ELWMUL, "Math fidelity larger than LoFi only works with Eltwise multiply");
-    [[maybe_unused]] constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
 
     // Dest counter always jumps by 32x32 tile spacing regardless of actual tile size
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);


### PR DESCRIPTION
### Summary
Remove unused LLK math helper parameters and dead tile get/release wrappers from Blackhole and Wormhole LLK math paths.

### Notes for reviewers
This is the math-only remainder split from `ndivnic/optimize_out_LLK_unused_params`; unpack tilize changes are in #43780. Local validation was limited to lint/diff checks and pre-commit hooks; full LLK test suites were not run.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/llk-unused-params-math)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/llk-unused-params-math)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/llk-unused-params-math)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/llk-unused-params-math)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/llk-unused-params-math)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/llk-unused-params-math)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/llk-unused-params-math)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/llk-unused-params-math)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/llk-unused-params-math)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/llk-unused-params-math)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/llk-unused-params-math)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/llk-unused-params-math)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/llk-unused-params-math)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/llk-unused-params-math)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/llk-unused-params-math)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/llk-unused-params-math)