### PR TITLE
fix linear biased with batched enabled CI failure

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -1321,45 +1321,42 @@ def test_linear_fused_non_broadcast_bias_width_sharded_in0_in1(device, m, k, n):
         ((1, 2, 16, 64), (1, 2, 64, 64), (1, 2, 16, 64)),
     ],
 )
-def test_linear_with_batched(a_shape, b_shape, bias_shape):
-    device = ttnn.open_device(device_id=0)
+def test_linear_with_batched(device, a_shape, b_shape, bias_shape):
+    torch.manual_seed(0)
 
-    try:
-        torch.manual_seed(0)
+    # Create inputs
+    tensor_a_torch = torch.randn(a_shape)
+    tensor_b_torch = torch.randn(b_shape)
+    bias_torch = torch.randn(bias_shape)
 
-        # Create inputs
-        tensor_a_torch = torch.randn(a_shape)
-        tensor_b_torch = torch.randn(b_shape)
-        bias_torch = torch.randn(bias_shape)
+    # PyTorch reference
+    result_torch = torch.matmul(tensor_a_torch, tensor_b_torch) + bias_torch
 
-        # PyTorch reference
-        result_torch = torch.matmul(tensor_a_torch, tensor_b_torch) + bias_torch
+    # TTNN tensors
+    tensor_a_ttnn = ttnn.from_torch(tensor_a_torch, device=device)
+    tensor_b_ttnn = ttnn.from_torch(tensor_b_torch, device=device)
+    bias_ttnn = ttnn.from_torch(bias_torch, device=device)
 
-        # TTNN tensors
-        tensor_a_ttnn = ttnn.from_torch(tensor_a_torch, device=device)
-        tensor_b_ttnn = ttnn.from_torch(tensor_b_torch, device=device)
-        bias_ttnn = ttnn.from_torch(bias_torch, device=device)
+    # Convert to TILE layout
+    tensor_a_ttnn = ttnn.to_layout(tensor_a_ttnn, ttnn.Layout.TILE)
+    tensor_b_ttnn = ttnn.to_layout(tensor_b_ttnn, ttnn.Layout.TILE)
+    bias_ttnn = ttnn.to_layout(bias_ttnn, ttnn.Layout.TILE)
 
-        # Convert to TILE layout
-        tensor_a_ttnn = ttnn.to_layout(tensor_a_ttnn, ttnn.Layout.TILE)
-        tensor_b_ttnn = ttnn.to_layout(tensor_b_ttnn, ttnn.Layout.TILE)
-        bias_ttnn = ttnn.to_layout(bias_ttnn, ttnn.Layout.TILE)
+    # Run TTNN
+    result_ttnn = ttnn.linear(
+        tensor_a_ttnn,
+        tensor_b_ttnn,
+        bias=bias_ttnn,
+    )
 
-        # Run TTNN
-        result_ttnn = ttnn.linear(
-            tensor_a_ttnn,
-            tensor_b_ttnn,
-            bias=bias_ttnn,
-        )
+    result_ttnn_torch = ttnn.to_torch(ttnn.from_device(result_ttnn))
 
-        result_ttnn_torch = ttnn.to_torch(result_ttnn)
-        assert_numeric_metrics(
-            result_torch,
-            result_ttnn_torch,
-            atol=0.1,
-            rtol=0.1,
-            frobenius_threshold=0.002,
-            pcc_threshold=0.99,
-        )
-    finally:
-        ttnn.close_device(device)
+    # test for equivalance
+    assert_numeric_metrics(
+        result_torch,
+        result_ttnn_torch,
+        atol=0.1,
+        rtol=0.1,
+        frobenius_threshold=0.002,
+        pcc_threshold=0.99,
+    )


### PR DESCRIPTION
### Ticket: #43771

### Problem description
CI was failing for `tests/ttnn/unit_tests/operations/matmul/test_linear.py::test_linear_with_batched`  because the test bypassed the pytest device fixture and hardcoded ttnn.open_device(device_id=0), which conflicts with the runner-assigned device managed by the framework.

### What's changed
Switched test_linear_with_batched to consume the device pytest fixture and removed the manual ttnn.open_device / ttnn.close_device and try/finally block.
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._


- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/linear_bias_batch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/linear_bias_batch_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/linear_bias_batch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/linear_bias_batch_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/linear_bias_batch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/linear_bias_batch_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/linear_bias_batch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/linear_bias_batch_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/linear_bias_batch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/linear_bias_batch_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/linear_bias_batch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/linear_bias_batch_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/linear_bias_batch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/linear_bias_batch_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/linear_bias_batch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/linear_bias_batch_fix)