### PR TITLE
[skip ci] Update GLX health tests in upstream tests

### DIFF
--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -168,9 +168,6 @@ test_suite_wh_6u_metal_unit_tests() {
 test_suite_wh_6u_metal_torus_xy_health_check_tests() {
     echo "[upstream-tests] Checking for XY Torus topology on WH 6U"
     ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tt_metal/fabric/cabling_descriptors/wh_galaxy_xy_torus.textproto --hard-fail --send-traffic
-}
-
-test_suite_wh_6u_metal_qsfp_links_health_check_tests() {
     echo "[upstream-tests] Checking QSFP links on WH 6U (Only works on XY (2D) Torus systems. Check https://github.com/tenstorrent/tt-metal/issues/30415 for updates)"
     ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_6U_galaxy.yaml
 }
@@ -237,6 +234,12 @@ UnitMeshCQSingleCardBufferFixture.ShardedBufferLargeDRAMReadWrites:\
 UnitMeshCQSingleCardFixture.TensixTestSubDeviceAllocations:\
 UnitMeshMultiCQMultiDeviceEventFixture.*:\
 UnitMeshCQSingleCardFixture.TensixTestReadWriteMultipleCoresL1"
+}
+
+test_suite_bh_6u_metal_torus_xy_health_check_tests() {
+    echo "[upstream-tests] Checking for XY Torus topology on BH 6U Galaxy"
+    ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tools/tests/scaleout/cabling_descriptors/bh_galaxy_xy_torus.textproto --hard-fail --send-traffic --num-iterations 1
+    ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_short_running.yaml
 }
 
 test_suite_bh_glx_python_unit_tests() {

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -168,7 +168,6 @@ test_suite_wh_6u_metal_unit_tests() {
 test_suite_wh_6u_metal_torus_xy_health_check_tests() {
     echo "[upstream-tests] Checking for XY Torus topology on WH 6U"
     ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tt_metal/fabric/cabling_descriptors/wh_galaxy_xy_torus.textproto --hard-fail --send-traffic
-    echo "[upstream-tests] Checking QSFP links on WH 6U (Only works on XY (2D) Torus systems. Check https://github.com/tenstorrent/tt-metal/issues/30415 for updates)"
     ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_6U_galaxy.yaml
 }
 
@@ -205,7 +204,7 @@ test_suite_bh_ttnn_stress_tests() {
     pytest tests/ttnn/stress_tests/
 }
 
-test_suite_bh_glx_metal_unit_tests() {
+test_suite_bh_6u_metal_unit_tests() {
     echo "[upstream-tests] running BH GLX upstream metal unit tests"
 
     # BH Galaxy XY (2D) Torus System Validation (no fabric, simply validate that expected links are discovered and healthy)
@@ -242,13 +241,13 @@ test_suite_bh_6u_metal_torus_xy_health_check_tests() {
     ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_short_running.yaml
 }
 
-test_suite_bh_glx_python_unit_tests() {
+test_suite_bh_6u_python_unit_tests() {
     echo "[upstream-tests] running BH GLX upstream python unit tests"
     # CCL / Ops
     pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_galaxy_torus.py
 }
 
-test_suite_bh_glx_llama_demo_tests() {
+test_suite_bh_6u_llama_demo_tests() {
     echo "[upstream-tests] running BH GLX upstream Llama demo tests with weights"
 
     verify_llama_dir_
@@ -256,7 +255,7 @@ test_suite_bh_glx_llama_demo_tests() {
     pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel 32 --timeout 1200
 }
 
-test_suite_bh_glx_torus_xyz_health_check_tests() {
+test_suite_bh_6u_torus_xyz_health_check_tests() {
     echo "[upstream-tests] Checking for XY Torus + Z links topology on BH 6U Galaxy"
     # Fabric
     # This test is to be run on systems that have the XY Torus links setup, along with Z connections between adjacent trays.
@@ -314,16 +313,16 @@ hw_topology_test_suites["wh_6u"]="
 test_suite_wh_6u_llama_demo_tests
 test_suite_wh_6u_metal_torus_xy_health_check_tests
 test_suite_wh_6u_model_unit_tests
-test_suite_wh_6u_metal_unit_tests
-test_suite_wh_6u_metal_qsfp_links_health_check_tests"
+test_suite_wh_6u_metal_unit_tests"
 
 hw_topology_test_suites["blackhole_ttnn_stress_tests"]="
 test_suite_bh_ttnn_stress_tests"
 
 hw_topology_test_suites["blackhole_glx"]="
-test_suite_bh_glx_metal_unit_tests
-test_suite_bh_glx_python_unit_tests
-test_suite_bh_glx_llama_demo_tests"
+test_suite_bh_6u_metal_unit_tests
+test_suite_bh_6u_python_unit_tests
+test_suite_bh_6u_llama_demo_tests
+test_suite_bh_6u_metal_torus_xy_health_check_tests"
 
 # Function to display help
 show_help() {

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -320,9 +320,9 @@ test_suite_bh_ttnn_stress_tests"
 
 hw_topology_test_suites["blackhole_glx"]="
 test_suite_bh_6u_metal_unit_tests
+test_suite_bh_6u_metal_torus_xy_health_check_tests
 test_suite_bh_6u_python_unit_tests
-test_suite_bh_6u_llama_demo_tests
-test_suite_bh_6u_metal_torus_xy_health_check_tests"
+test_suite_bh_6u_llama_demo_tests"
 
 # Function to display help
 show_help() {


### PR DESCRIPTION
### PR Category
Added more GLX health checks for BH GLXs in Upstream tests. Gathered the WH GLX health tests so its under one command.

### Summary
test_suite_bh_glx_metal_unit_tests() can take ~40 mins, the new `test_suite_bh_6u_metal_torus_xy_health_check_tests()` reduces it to ~15 mins and checks to see if the galaxy has healthy QSFP and performs additional routing checks, same to the ones ran in Galaxy Health workflow. Will help ensure BH GLX is healthy for basic health checkups in a faster manner. 

For WH GLX health tests, it made sense to have the two XY Torus tests under the same test suite

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=slee/updateglxupstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:slee/updateglxupstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=slee/updateglxupstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:slee/updateglxupstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=slee/updateglxupstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:slee/updateglxupstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=slee/updateglxupstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:slee/updateglxupstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=slee/updateglxupstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:slee/updateglxupstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=slee/updateglxupstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:slee/updateglxupstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=slee/updateglxupstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:slee/updateglxupstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=slee/updateglxupstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:slee/updateglxupstream)