### PR TITLE
Migrate generic_op mesh factory to ProgramDescriptor factory adapter

### DIFF
--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
@@ -20,7 +20,7 @@ struct GenericOpDeviceOperation {
     using tensor_args_t = generic::tensor_args_t;
     using spec_return_value_t = generic::spec_return_value_t;
     using tensor_return_value_t = generic::tensor_return_value_t;
-    using program_factory_t = std::variant<program::GenericMeshProgramFactory>;
+    using program_factory_t = std::variant<program::GenericMeshDescriptorFactory>;
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
@@ -2,138 +2,37 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/circular_buffer_config.hpp>
-#include <tt-metalium/program.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/global_circular_buffer.hpp>
-
 #include "generic_op_program_factory.hpp"
 
+#include <tt_stl/assert.hpp>
+
 namespace ttnn::operations::generic::program {
+
 using namespace tt::tt_metal;
-using namespace tt::tt_metal::experimental;
 
-GenericMeshProgramFactory::cached_mesh_workload_t GenericMeshProgramFactory::create_mesh_workload(
-    const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& /*tensor_coords*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload mesh_workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, mesh_shared_variables_t> mesh_shared_variables;
-
-    for (const auto& [mesh_coord_range, program_descriptor] : operation_attributes.mesh_programs) {
-        auto cached_program = create_at(program_descriptor, tensor_args, tensor_return_value);
-        mesh_workload.add_program(mesh_coord_range, std::move(cached_program.program));
-        mesh_shared_variables[mesh_coord_range] = mesh_shared_variables_t{std::move(cached_program.shared_variables)};
-    }
-
-    return cached_mesh_workload_t{std::move(mesh_workload), std::move(mesh_shared_variables)};
-}
-
-GenericMeshProgramFactory::cached_program_t GenericMeshProgramFactory::create_at(
-    const tt::tt_metal::ProgramDescriptor& program_descriptor,
-    const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& /*tensor_return_value*/) {
-    Program program{program_descriptor};
-    shared_variables_t shared_vars;
-
-    auto cbs = program.circular_buffers();
-    shared_vars.cb_handles.reserve(cbs.size());
-    for (const auto& cb : cbs) {
-        shared_vars.cb_handles.push_back(static_cast<tt::tt_metal::CBHandle>(cb->id()));
-    }
-    shared_vars.num_kernel_handles = program_descriptor.kernels.size();
-
-    return {std::move(program), std::move(shared_vars)};
-}
-
-void override_program_runtime_arguments(
-    Program& program,
-    GenericMeshProgramFactory::shared_variables_t& shared_vars,
-    const ProgramDescriptor& program_descriptor) {
-    // Update kernel runtime args.
-    TT_ASSERT(
-        shared_vars.num_kernel_handles == program_descriptor.kernels.size(),
-        "Number of kernel handles mismatch: cached {} vs new program {}",
-        shared_vars.num_kernel_handles,
-        program_descriptor.kernels.size());
-    for (size_t kernel_handle = 0; kernel_handle < shared_vars.num_kernel_handles; ++kernel_handle) {
-        const auto& kernel_desc = program_descriptor.kernels[kernel_handle];
-
-        for (const auto& [core_coord, runtime_arg] : kernel_desc.runtime_args) {
-            if (!runtime_arg.empty()) {
-                auto& cached_runtime_args = GetRuntimeArgs(program, kernel_handle, core_coord);
-                TT_FATAL(
-                    cached_runtime_args.size() == runtime_arg.size(),
-                    "Runtime args size mismatch: cached {} vs new {}",
-                    cached_runtime_args.size(),
-                    runtime_arg.size());
-                std::copy(runtime_arg.begin(), runtime_arg.end(), cached_runtime_args.data());
-            }
-        }
-        if (!kernel_desc.common_runtime_args.empty()) {
-            auto& cached_common_runtime_args = GetCommonRuntimeArgs(program, kernel_handle);
-            TT_FATAL(
-                cached_common_runtime_args.size() == kernel_desc.common_runtime_args.size(),
-                "Common runtime args size mismatch: cached {} vs new {}",
-                cached_common_runtime_args.size(),
-                kernel_desc.common_runtime_args.size());
-            std::copy(
-                kernel_desc.common_runtime_args.begin(),
-                kernel_desc.common_runtime_args.end(),
-                cached_common_runtime_args.data());
-        }
-    }
-
-    // Update circular buffer config.
-    for (size_t cb_idx = 0; cb_idx < program_descriptor.cbs.size(); ++cb_idx) {
-        const auto& cb_desc = program_descriptor.cbs[cb_idx];
-        auto cb_handle = shared_vars.cb_handles[cb_idx];
-        const CircularBufferConfig& cb_config = GetCircularBufferConfig(program, cb_handle);
-
-        if (cb_config.total_size() != cb_desc.total_size) {
-            UpdateCircularBufferTotalSize(program, cb_handle, cb_desc.total_size);
-        }
-        const auto& current_page_sizes = cb_config.page_sizes();
-        for (const auto& format_desc : cb_desc.format_descriptors) {
-            if (current_page_sizes[format_desc.buffer_index].has_value() &&
-                current_page_sizes[format_desc.buffer_index].value() != format_desc.page_size) {
-                UpdateCircularBufferPageSize(program, cb_handle, format_desc.buffer_index, format_desc.page_size);
-            }
-        }
-        if (cb_desc.buffer != nullptr) {
-            UpdateDynamicCircularBufferAddress(program, cb_handle, *cb_desc.buffer, cb_desc.address_offset);
-        }
-        if (cb_desc.global_circular_buffer != nullptr) {
-            experimental::UpdateDynamicCircularBufferAddress(program, cb_handle, *cb_desc.global_circular_buffer);
-        }
-    }
-}
-
-void GenericMeshProgramFactory::override_runtime_arguments(
-    cached_mesh_workload_t& cached_mesh_workload,
+tt::tt_metal::ProgramDescriptor GenericMeshDescriptorFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& /*tensor_return_value*/) {
-    auto& workload_programs = cached_mesh_workload.workload.get_programs();
+    tensor_return_value_t& /*tensor_return_value*/,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
     const auto& mesh_programs = operation_attributes.mesh_programs;
+    TT_FATAL(!mesh_programs.empty(), "generic_op: MeshProgramDescriptor.mesh_programs must not be empty");
+
+    if (mesh_dispatch_coordinate.has_value()) {
+        const auto& coord = mesh_dispatch_coordinate.value();
+        for (const auto& [range, desc] : mesh_programs) {
+            if (range.contains(coord)) {
+                return desc;
+            }
+        }
+        TT_FATAL(false, "generic_op: no mesh_program entry contains mesh coordinate {}", coord);
+    }
 
     TT_FATAL(
-        workload_programs.size() == mesh_programs.size(),
-        "Size mismatch between cached workload programs ({}) and operation mesh_programs ({})",
-        workload_programs.size(),
+        mesh_programs.size() == 1,
+        "generic_op: multiple mesh_program entries ({}) require per-coordinate mesh dispatch",
         mesh_programs.size());
-
-    for (const auto& [range, program_descriptor] : mesh_programs) {
-        auto program_it = workload_programs.find(range);
-        TT_FATAL(
-            program_it != workload_programs.end(),
-            "MeshCoordinateRange {} not found in cached workload programs",
-            range);
-
-        auto& shared_vars = cached_mesh_workload.shared_variables.at(range);
-        override_program_runtime_arguments(
-            program_it->second, shared_vars.program_shared_variables, program_descriptor);
-    }
+    return mesh_programs.front().second;
 }
+
 }  // namespace ttnn::operations::generic::program

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.hpp
@@ -4,42 +4,21 @@
 
 #pragma once
 
-#include "ttnn/device_operation.hpp"
+#include <optional>
+
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "generic_op_device_operation_types.hpp"
+#include "ttnn/distributed/types.hpp"
 
 namespace ttnn::operations::generic::program {
 
-struct GenericMeshProgramFactory {
-    struct shared_variables_t {
-        uint32_t num_kernel_handles{};
-        std::vector<tt::tt_metal::CBHandle> cb_handles;
-    };
-
-    struct mesh_shared_variables_t {
-        shared_variables_t program_shared_variables;
-    };
-
-    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<mesh_shared_variables_t>;
-
-    static cached_mesh_workload_t create_mesh_workload(
-        const operation_attributes_t& operation_attributes,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_mesh_workload_t& cached_mesh_workload,
+struct GenericMeshDescriptorFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
-
-private:
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create_at(
-        const tt::tt_metal::ProgramDescriptor& program_descriptor,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        tensor_return_value_t& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 };
 
 }  // namespace ttnn::operations::generic::program


### PR DESCRIPTION
### Summary
[#42391](https://github.com/tenstorrent/tt-metal/issues/42391) 
Migrate generic from the legacy OldDeviceOperation pattern to ProgramDescriptor.

### Work done
Replace GenericMeshProgramFactory (CachedProgram-style create_mesh_workload and manual override_program_runtime_arguments) with GenericMeshDescriptorFactory, which only implements create_descriptor and opts into DescriptorMeshWorkloadFactoryAdapter for mesh workload creation, cache-hit apply_descriptor_runtime_args, and optional buffer-binding fast path. create_descriptor resolves the ProgramDescriptor from MeshProgramDescriptor using mesh_dispatch_coordinate when set (multi-range mesh programs), or requires a single mesh_program entry when the coordinate is omitted (SPMD). GenericOpDeviceOperation::program_factory_t now references GenericMeshDescriptorFactory; custom compute_program_hash for user descriptors is unchanged.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-claude)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-claude)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-claude)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-claude)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-claude)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-claude)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-claude)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-claude)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-claude)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-claude)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-claude)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-claude)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-claude)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-claude)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-claude)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/migrate-generic-to-program-descriptor-claude)