### PR TITLE
[tt-train] Optimize Deepseek MLA — head reshapes and transposes

### DIFF
--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -58,6 +58,8 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/linear_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/losses.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/matmul_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ops/mla_qkv_assemble_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ops/mla_qkv_assemble_op.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/multi_head_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/polynorm_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/reshape_op.cpp
@@ -186,6 +188,14 @@ set(METAL_OPS_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/frobenius_normalize/frobenius_normalize.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/frobenius_normalize/device/frobenius_normalize_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/frobenius_normalize/device/frobenius_normalize_program_factory.cpp
+    # MLA QKV Assemble Forward (DeepSeek)
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/mla_qkv_assemble_fw/mla_qkv_assemble_fw.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_program_factory.cpp
+    # MLA QKV Assemble Backward (DeepSeek)
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/mla_qkv_assemble_bw/mla_qkv_assemble_bw.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.cpp
 )
 
 list(APPEND SOURCES ${METAL_OPS_FILES})

--- a/tt-train/sources/ttml/metal/operations.hpp
+++ b/tt-train/sources/ttml/metal/operations.hpp
@@ -6,8 +6,11 @@
 
 #include "ops/cross_entropy_bw/cross_entropy_bw.hpp"
 #include "ops/cross_entropy_fw/cross_entropy_fw.hpp"
+#include "ops/frobenius_normalize/frobenius_normalize.hpp"
 #include "ops/layernorm_bw/layernorm_bw.hpp"
 #include "ops/layernorm_fw/layernorm_fw.hpp"
+#include "ops/mla_qkv_assemble_bw/mla_qkv_assemble_bw.hpp"
+#include "ops/mla_qkv_assemble_fw/mla_qkv_assemble_fw.hpp"
 #include "ops/polynorm_fw/polynorm_fw.hpp"
 #include "ops/profiler_no_op/profiler_no_op.hpp"
 #include "ops/rmsnorm_bw/rmsnorm_bw.hpp"
@@ -18,6 +21,5 @@
 #include "ops/softmax/softmax.hpp"
 #include "ops/softmax_backward/softmax_backward.hpp"
 #include "ops/swiglu_elemwise_bw/swiglu_elemwise_bw.hpp"
-#include "ops/frobenius_normalize/frobenius_normalize.hpp"
 #include "optimizers/adamw/adamw.hpp"
 #include "optimizers/sgd/sgd.hpp"

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/compute/mla_qkv_assemble_bw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/compute/mla_qkv_assemble_bw_kernel.cpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/tile_move_copy.h"
+
+constexpr uint32_t Tr = get_compile_time_arg_val(0);
+constexpr uint32_t n_heads = get_compile_time_arg_val(1);
+
+constexpr auto cb_dkpe_in = tt::CBIndex::c_3;
+constexpr auto cb_dkpe_out = tt::CBIndex::c_4;
+
+constexpr uint32_t onetile = 1U;
+
+void kernel_main() {
+    uint32_t num_blocks = get_arg_val<uint32_t>(0);
+
+    binary_op_init_common(cb_dkpe_in, cb_dkpe_in, cb_dkpe_out);
+
+    for (uint32_t block = 0U; block < num_blocks; ++block) {
+        // DST registers 0..Tr-1 hold the running head-axis sum across the block;
+        // slot Tr is the working temp for each new head's incoming tile.
+        tile_regs_acquire();
+
+        // Head 0: copy the first head's Tr tiles into the accumulator (dst 0..Tr-1).
+        cb_wait_front(cb_dkpe_in, Tr);
+        copy_tile_init(cb_dkpe_in);
+        for (uint32_t w = 0U; w < Tr; ++w) {
+            copy_tile(cb_dkpe_in, w, /* dst_idx */ w);
+        }
+        cb_pop_front(cb_dkpe_in, Tr);
+
+        // Heads 1..H-1: load each tile into dst[Tr] and add into dst[w].
+        for (uint32_t h = 1U; h < n_heads; ++h) {
+            cb_wait_front(cb_dkpe_in, Tr);
+            copy_tile_init(cb_dkpe_in);
+            for (uint32_t w = 0U; w < Tr; ++w) {
+                constexpr uint32_t tmp_dst = Tr;
+                copy_tile(cb_dkpe_in, w, /* dst_idx */ tmp_dst);
+                add_binary_tile_init();
+                add_binary_tile(/* dst_a */ w, /* dst_b */ tmp_dst, /* dst_dest */ w);
+            }
+            cb_pop_front(cb_dkpe_in, Tr);
+        }
+
+        tile_regs_commit();
+        tile_regs_wait();
+
+        cb_reserve_back(cb_dkpe_out, Tr);
+        pack_reconfig_data_format(cb_dkpe_out);
+        for (uint32_t w = 0U; w < Tr; ++w) {
+            pack_tile(/* dst_idx */ w, cb_dkpe_out);
+        }
+        cb_push_back(cb_dkpe_out, Tr);
+
+        tile_regs_release();
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/reader_mla_qkv_assemble_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/reader_mla_qkv_assemble_bw.cpp
@@ -13,8 +13,10 @@ void kernel_main() {
     uint32_t dK_addr = get_arg_val<uint32_t>(runtime_args_counter++);
     uint32_t dV_addr = get_arg_val<uint32_t>(runtime_args_counter++);
     uint32_t num_blocks = get_arg_val<uint32_t>(runtime_args_counter++);
-    uint32_t sb = get_arg_val<uint32_t>(runtime_args_counter++);             // s-tile-row in current batch
-    uint32_t dQ_block_base = get_arg_val<uint32_t>(runtime_args_counter++);  // head 0 of (b, sb), w=0
+    uint32_t sb = get_arg_val<uint32_t>(runtime_args_counter++);  // s-tile-row in current batch
+    // Shared dQ/dK base — validation enforces same shape, so the per-head head_dim is
+    // identical and a single base + h*kq_HtWt addresses both tensors.
+    uint32_t dQK_block_base = get_arg_val<uint32_t>(runtime_args_counter++);  // head 0 of (b, sb), w=0
     uint32_t dV_block_base = get_arg_val<uint32_t>(runtime_args_counter++);
 
     constexpr uint32_t cb_dq = tt::CBIndex::c_0;
@@ -39,8 +41,7 @@ void kernel_main() {
     const auto dK_addr_gen = TensorAccessor(dK_args, dK_addr);
     const auto dV_addr_gen = TensorAccessor(dV_args, dV_addr);
 
-    // dK shares dQ's per-head head_dim, so kq_HtWt is the head stride for both.
-    // End-of-batch jump to advance dQ_block_base across batch boundary:
+    // End-of-batch jump to advance dQK_block_base across batch boundary:
     //   from b * H*kq_HtWt + (S_t-1)*Th  →  (b+1) * H*kq_HtWt
     //   = current + ((H-1)*S_t + 1) * Th
     constexpr uint32_t end_of_batch_jump_q = ((n_heads - 1U) * S_t + 1U) * Th;
@@ -48,8 +49,8 @@ void kernel_main() {
 
     for (uint32_t block = 0U; block < num_blocks; ++block) {
         for (uint32_t h = 0U; h < n_heads; ++h) {
-            const uint32_t head_dq = dQ_block_base + h * kq_HtWt;
-            const uint32_t head_dk = dQ_block_base + h * kq_HtWt;  // dK same layout as dQ
+            const uint32_t head_dq = dQK_block_base + h * kq_HtWt;
+            const uint32_t head_dk = dQK_block_base + h * kq_HtWt;
             const uint32_t head_dv = dV_block_base + h * v_HtWt;
 
             // Th dQ tiles
@@ -88,11 +89,11 @@ void kernel_main() {
         // Advance to next block.
         ++sb;
         if (sb < S_t) {
-            dQ_block_base += Th;
+            dQK_block_base += Th;
             dV_block_base += Tv;
         } else {
             sb = 0U;
-            dQ_block_base += end_of_batch_jump_q;
+            dQK_block_base += end_of_batch_jump_q;
             dV_block_base += end_of_batch_jump_v;
         }
     }

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/reader_mla_qkv_assemble_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/reader_mla_qkv_assemble_bw.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
+
+void kernel_main() {
+    uint32_t runtime_args_counter = 0U;
+    uint32_t dQ_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t dK_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t dV_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t num_blocks = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t sb = get_arg_val<uint32_t>(runtime_args_counter++);             // s-tile-row in current batch
+    uint32_t dQ_block_base = get_arg_val<uint32_t>(runtime_args_counter++);  // head 0 of (b, sb), w=0
+    uint32_t dV_block_base = get_arg_val<uint32_t>(runtime_args_counter++);
+
+    constexpr uint32_t cb_dq = tt::CBIndex::c_0;
+    constexpr uint32_t cb_dknope = tt::CBIndex::c_1;
+    constexpr uint32_t cb_dv = tt::CBIndex::c_2;
+    constexpr uint32_t cb_dkpe_in = tt::CBIndex::c_3;
+
+    constexpr uint32_t Th = get_compile_time_arg_val(0);
+    constexpr uint32_t Tn = get_compile_time_arg_val(1);
+    constexpr uint32_t Tr = get_compile_time_arg_val(2);
+    constexpr uint32_t Tv = get_compile_time_arg_val(3);
+    constexpr uint32_t n_heads = get_compile_time_arg_val(4);
+    constexpr uint32_t kq_HtWt = get_compile_time_arg_val(5);  // S_t * Th
+    constexpr uint32_t v_HtWt = get_compile_time_arg_val(6);   // S_t * Tv
+    constexpr uint32_t S_t = get_compile_time_arg_val(7);
+
+    constexpr auto dQ_args = TensorAccessorArgs<8>();
+    constexpr auto dK_args = TensorAccessorArgs<dQ_args.next_compile_time_args_offset()>();
+    constexpr auto dV_args = TensorAccessorArgs<dK_args.next_compile_time_args_offset()>();
+
+    const auto dQ_addr_gen = TensorAccessor(dQ_args, dQ_addr);
+    const auto dK_addr_gen = TensorAccessor(dK_args, dK_addr);
+    const auto dV_addr_gen = TensorAccessor(dV_args, dV_addr);
+
+    // dK shares dQ's per-head head_dim, so kq_HtWt is the head stride for both.
+    // End-of-batch jump to advance dQ_block_base across batch boundary:
+    //   from b * H*kq_HtWt + (S_t-1)*Th  →  (b+1) * H*kq_HtWt
+    //   = current + ((H-1)*S_t + 1) * Th
+    constexpr uint32_t end_of_batch_jump_q = ((n_heads - 1U) * S_t + 1U) * Th;
+    constexpr uint32_t end_of_batch_jump_v = ((n_heads - 1U) * S_t + 1U) * Tv;
+
+    for (uint32_t block = 0U; block < num_blocks; ++block) {
+        for (uint32_t h = 0U; h < n_heads; ++h) {
+            const uint32_t head_dq = dQ_block_base + h * kq_HtWt;
+            const uint32_t head_dk = dQ_block_base + h * kq_HtWt;  // dK same layout as dQ
+            const uint32_t head_dv = dV_block_base + h * v_HtWt;
+
+            // Th dQ tiles
+            for (uint32_t w = 0U; w < Th; ++w) {
+                cb_reserve_back(cb_dq, onetile);
+                noc_async_read_page(head_dq + w, dQ_addr_gen, get_write_ptr(cb_dq));
+                noc_async_read_barrier();
+                cb_push_back(cb_dq, onetile);
+            }
+
+            // Tn dK_nope tiles
+            for (uint32_t w = 0U; w < Tn; ++w) {
+                cb_reserve_back(cb_dknope, onetile);
+                noc_async_read_page(head_dk + w, dK_addr_gen, get_write_ptr(cb_dknope));
+                noc_async_read_barrier();
+                cb_push_back(cb_dknope, onetile);
+            }
+
+            // Tr dK_pe tiles → compute
+            for (uint32_t w = 0U; w < Tr; ++w) {
+                cb_reserve_back(cb_dkpe_in, onetile);
+                noc_async_read_page(head_dk + Tn + w, dK_addr_gen, get_write_ptr(cb_dkpe_in));
+                noc_async_read_barrier();
+                cb_push_back(cb_dkpe_in, onetile);
+            }
+
+            // Tv dV tiles
+            for (uint32_t w = 0U; w < Tv; ++w) {
+                cb_reserve_back(cb_dv, onetile);
+                noc_async_read_page(head_dv + w, dV_addr_gen, get_write_ptr(cb_dv));
+                noc_async_read_barrier();
+                cb_push_back(cb_dv, onetile);
+            }
+        }
+
+        // Advance to next block.
+        ++sb;
+        if (sb < S_t) {
+            dQ_block_base += Th;
+            dV_block_base += Tv;
+        } else {
+            sb = 0U;
+            dQ_block_base += end_of_batch_jump_q;
+            dV_block_base += end_of_batch_jump_v;
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/writer_mla_qkv_assemble_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/writer_mla_qkv_assemble_bw.cpp
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
+
+void kernel_main() {
+    uint32_t runtime_args_counter = 0U;
+    uint32_t dq_pre_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t dkv_up_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t dk_pe_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t num_blocks = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t dq_pre_block_base = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t dkv_up_block_base = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t dk_pe_block_base = get_arg_val<uint32_t>(runtime_args_counter++);
+
+    constexpr uint32_t cb_dq = tt::CBIndex::c_0;
+    constexpr uint32_t cb_dknope = tt::CBIndex::c_1;
+    constexpr uint32_t cb_dv = tt::CBIndex::c_2;
+    constexpr uint32_t cb_dkpe_out = tt::CBIndex::c_4;
+
+    constexpr uint32_t Th = get_compile_time_arg_val(0);
+    constexpr uint32_t Tn = get_compile_time_arg_val(1);
+    constexpr uint32_t Tr = get_compile_time_arg_val(2);
+    constexpr uint32_t Tv = get_compile_time_arg_val(3);
+    constexpr uint32_t n_heads = get_compile_time_arg_val(4);
+    constexpr uint32_t kv_per_head = Tn + Tv;
+
+    constexpr auto dq_pre_args = TensorAccessorArgs<5>();
+    constexpr auto dkv_up_args = TensorAccessorArgs<dq_pre_args.next_compile_time_args_offset()>();
+    constexpr auto dk_pe_args = TensorAccessorArgs<dkv_up_args.next_compile_time_args_offset()>();
+
+    const auto dq_pre_addr_gen = TensorAccessor(dq_pre_args, dq_pre_addr);
+    const auto dkv_up_addr_gen = TensorAccessor(dkv_up_args, dkv_up_addr);
+    const auto dk_pe_addr_gen = TensorAccessor(dk_pe_args, dk_pe_addr);
+
+    for (uint32_t block = 0U; block < num_blocks; ++block) {
+        for (uint32_t h = 0U; h < n_heads; ++h) {
+            const uint32_t dq_head_base = dq_pre_block_base + h * Th;
+            const uint32_t dkv_head_base = dkv_up_block_base + h * kv_per_head;
+
+            // dq_pre[block_base + h*Th + w] ← cb_dq tile
+            for (uint32_t w = 0U; w < Th; ++w) {
+                cb_wait_front(cb_dq, onetile);
+                noc_async_write_page(dq_head_base + w, dq_pre_addr_gen, get_read_ptr(cb_dq));
+                noc_async_write_barrier();
+                cb_pop_front(cb_dq, onetile);
+            }
+
+            // dkv_up[block_base + h*kv_per_head + 0..Tn) ← cb_dknope tiles
+            for (uint32_t w = 0U; w < Tn; ++w) {
+                cb_wait_front(cb_dknope, onetile);
+                noc_async_write_page(dkv_head_base + w, dkv_up_addr_gen, get_read_ptr(cb_dknope));
+                noc_async_write_barrier();
+                cb_pop_front(cb_dknope, onetile);
+            }
+
+            // dkv_up[block_base + h*kv_per_head + Tn..Tn+Tv) ← cb_dv tiles
+            for (uint32_t w = 0U; w < Tv; ++w) {
+                cb_wait_front(cb_dv, onetile);
+                noc_async_write_page(dkv_head_base + Tn + w, dkv_up_addr_gen, get_read_ptr(cb_dv));
+                noc_async_write_barrier();
+                cb_pop_front(cb_dv, onetile);
+            }
+        }
+
+        // dk_pe[block_base + 0..Tr) ← Tr tiles produced by compute (head-axis sum).
+        cb_wait_front(cb_dkpe_out, Tr);
+        const uint32_t l1_kpe = get_read_ptr(cb_dkpe_out);
+        for (uint32_t w = 0U; w < Tr; ++w) {
+            noc_async_write_page(dk_pe_block_base + w, dk_pe_addr_gen, l1_kpe + w * get_tile_size(cb_dkpe_out));
+        }
+        noc_async_write_barrier();
+        cb_pop_front(cb_dkpe_out, Tr);
+
+        // Outputs are flat across blocks, so advance is constant.
+        dq_pre_block_base += n_heads * Th;
+        dkv_up_block_base += n_heads * kv_per_head;
+        dk_pe_block_base += Tr;
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/writer_mla_qkv_assemble_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/writer_mla_qkv_assemble_bw.cpp
@@ -70,8 +70,9 @@ void kernel_main() {
         // dk_pe[block_base + 0..Tr) ← Tr tiles produced by compute (head-axis sum).
         cb_wait_front(cb_dkpe_out, Tr);
         const uint32_t l1_kpe = get_read_ptr(cb_dkpe_out);
+        const uint32_t dkpe_tile_bytes = get_tile_size(cb_dkpe_out);
         for (uint32_t w = 0U; w < Tr; ++w) {
-            noc_async_write_page(dk_pe_block_base + w, dk_pe_addr_gen, l1_kpe + w * get_tile_size(cb_dkpe_out));
+            noc_async_write_page(dk_pe_block_base + w, dk_pe_addr_gen, l1_kpe + w * dkpe_tile_bytes);
         }
         noc_async_write_barrier();
         cb_pop_front(cb_dkpe_out, Tr);

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mla_qkv_assemble_bw_device_operation.hpp"
+
+#include <enchantum/enchantum.hpp>
+
+#include "mla_qkv_assemble_bw_program_factory.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttml::metal::ops::mla_qkv_assemble_bw::device {
+
+void MLAQKVAssembleBwDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    using namespace tt::constants;
+
+    auto check_tensor = [](const ttnn::Tensor& tensor, const std::string& name) {
+        TT_FATAL(
+            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            "MLAQKVAssembleBw requires {} to be on device. Got storage type: {}",
+            name,
+            enchantum::to_string(tensor.storage_type()));
+        TT_FATAL(tensor.buffer() != nullptr, "MLAQKVAssembleBw: {} buffer must be allocated.", name);
+        TT_FATAL(
+            tensor.layout() == tt::tt_metal::Layout::TILE,
+            "MLAQKVAssembleBw requires {} to be in TILE layout. Got: {}",
+            name,
+            enchantum::to_string(tensor.layout()));
+        TT_FATAL(
+            tensor.dtype() == tt::tt_metal::DataType::BFLOAT16,
+            "MLAQKVAssembleBw requires {} dtype to be BFLOAT16. Got: {}",
+            name,
+            enchantum::to_string(tensor.dtype()));
+        TT_FATAL(
+            tensor.memory_config().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED,
+            "MLAQKVAssembleBw requires {} memory layout to be INTERLEAVED. Got: {}",
+            name,
+            enchantum::to_string(tensor.memory_config().memory_layout()));
+    };
+
+    const auto& dQ = tensor_args.dQ;
+    const auto& dK = tensor_args.dK;
+    const auto& dV = tensor_args.dV;
+    check_tensor(dQ, "dQ");
+    check_tensor(dK, "dK");
+    check_tensor(dV, "dV");
+
+    const auto dQ_shape = dQ.padded_shape();
+    const auto dK_shape = dK.padded_shape();
+    const auto dV_shape = dV.padded_shape();
+
+    TT_FATAL(dQ_shape.rank() == 4U, "MLAQKVAssembleBw: dQ must be rank-4");
+    TT_FATAL(dK_shape.rank() == 4U, "MLAQKVAssembleBw: dK must be rank-4");
+    TT_FATAL(dV_shape.rank() == 4U, "MLAQKVAssembleBw: dV must be rank-4");
+
+    TT_FATAL(
+        dQ_shape[0] == dK_shape[0] && dK_shape[0] == dV_shape[0],
+        "MLAQKVAssembleBw: batch dim must match across dQ ({}), dK ({}), dV ({}).",
+        dQ_shape[0],
+        dK_shape[0],
+        dV_shape[0]);
+    TT_FATAL(
+        dQ_shape[1] == args.n_heads && dK_shape[1] == args.n_heads && dV_shape[1] == args.n_heads,
+        "MLAQKVAssembleBw: dim 1 (heads) must equal n_heads ({}). Got dQ={}, dK={}, dV={}.",
+        args.n_heads,
+        dQ_shape[1],
+        dK_shape[1],
+        dV_shape[1]);
+    TT_FATAL(
+        dQ_shape[2] == dK_shape[2] && dK_shape[2] == dV_shape[2],
+        "MLAQKVAssembleBw: seq dim must match across dQ ({}), dK ({}), dV ({}).",
+        dQ_shape[2],
+        dK_shape[2],
+        dV_shape[2]);
+
+    const uint32_t qk_head = args.qk_nope_dim + args.qk_rope_dim;
+    TT_FATAL(
+        dQ_shape[3] == qk_head,
+        "MLAQKVAssembleBw: dQ dim 3 must equal qk_nope_dim + qk_rope_dim = {}. Got {}",
+        qk_head,
+        dQ_shape[3]);
+    TT_FATAL(
+        dK_shape[3] == qk_head,
+        "MLAQKVAssembleBw: dK dim 3 must equal qk_nope_dim + qk_rope_dim = {}. Got {}",
+        qk_head,
+        dK_shape[3]);
+    TT_FATAL(
+        dV_shape[3] == args.v_dim, "MLAQKVAssembleBw: dV dim 3 must equal v_dim = {}. Got {}", args.v_dim, dV_shape[3]);
+
+    TT_FATAL(args.qk_nope_dim % TILE_WIDTH == 0, "qk_nope_dim must be tile-aligned");
+    TT_FATAL(args.qk_rope_dim % TILE_WIDTH == 0, "qk_rope_dim must be tile-aligned");
+    TT_FATAL(args.v_dim % TILE_WIDTH == 0, "v_dim must be tile-aligned");
+    TT_FATAL(dQ_shape[2] % TILE_HEIGHT == 0, "S must be tile-aligned");
+}
+
+MLAQKVAssembleBwDeviceOperation::spec_return_value_t MLAQKVAssembleBwDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    spec_return_value_t output_specs;
+    output_specs.reserve(3U);
+
+    const auto& dQ = tensor_args.dQ;
+    const auto dQ_shape = dQ.logical_shape();
+    const uint32_t B = dQ_shape[0];
+    const uint32_t S = dQ_shape[2];
+    const uint32_t qk_head = args.qk_nope_dim + args.qk_rope_dim;
+
+    const ttnn::Shape dq_pre_shape({B, 1U, S, args.n_heads * qk_head});
+    const ttnn::Shape dkv_up_shape({B, 1U, S, args.n_heads * (args.qk_nope_dim + args.v_dim)});
+    const ttnn::Shape dk_pe_shape({B, 1U, S, args.qk_rope_dim});
+
+    auto layout = tt::tt_metal::TensorLayout(dQ.dtype(), tt::tt_metal::Layout::TILE, dQ.memory_config());
+    output_specs.emplace_back(dq_pre_shape, layout);
+    output_specs.emplace_back(dkv_up_shape, layout);
+    output_specs.emplace_back(dk_pe_shape, layout);
+
+    return output_specs;
+}
+
+MLAQKVAssembleBwDeviceOperation::tensor_return_value_t MLAQKVAssembleBwDeviceOperation::create_output_tensors(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    auto specs = compute_output_specs(args, tensor_args);
+    auto* device = tensor_args.dQ.device();
+    return {
+        create_device_tensor(specs[0], device),
+        create_device_tensor(specs[1], device),
+        create_device_tensor(specs[2], device)};
+}
+
+ttsl::hash::hash_t MLAQKVAssembleBwDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    return tt::tt_metal::operation::hash_operation<MLAQKVAssembleBwDeviceOperation>(
+        args,
+        tensor_args.dQ.dtype(),
+        tensor_args.dQ.logical_shape(),
+        tensor_args.dK.logical_shape(),
+        tensor_args.dV.logical_shape());
+}
+
+MLAQKVAssembleBwDeviceOperation::program_factory_t MLAQKVAssembleBwDeviceOperation::select_program_factory(
+    const operation_attributes_t& /*args*/, const tensor_args_t& /*tensor_args*/) {
+    return MLAQKVAssembleBwProgramFactory{};
+}
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_bw::device
+
+namespace ttnn::prim {
+
+ttml::metal::ops::mla_qkv_assemble_bw::device::MLAQKVAssembleBwDeviceOperation::tensor_return_value_t
+ttml_mla_qkv_assemble_bw(
+    const ttnn::Tensor& dQ,
+    const ttnn::Tensor& dK,
+    const ttnn::Tensor& dV,
+    uint32_t n_heads,
+    uint32_t qk_nope_dim,
+    uint32_t qk_rope_dim,
+    uint32_t v_dim) {
+    using OperationType = ttml::metal::ops::mla_qkv_assemble_bw::device::MLAQKVAssembleBwDeviceOperation;
+
+    auto attrs = OperationType::operation_attributes_t{
+        .n_heads = n_heads,
+        .qk_nope_dim = qk_nope_dim,
+        .qk_rope_dim = qk_rope_dim,
+        .v_dim = v_dim,
+    };
+    auto tensor_args = OperationType::tensor_args_t{.dQ = dQ, .dK = dK, .dV = dV};
+    return ttnn::device_operation::launch<OperationType>(attrs, tensor_args);
+}
+
+}  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
@@ -88,10 +88,26 @@ void MLAQKVAssembleBwDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         dV_shape[3] == args.v_dim, "MLAQKVAssembleBw: dV dim 3 must equal v_dim = {}. Got {}", args.v_dim, dV_shape[3]);
 
-    TT_FATAL(args.qk_nope_dim % TILE_WIDTH == 0, "qk_nope_dim must be tile-aligned");
-    TT_FATAL(args.qk_rope_dim % TILE_WIDTH == 0, "qk_rope_dim must be tile-aligned");
-    TT_FATAL(args.v_dim % TILE_WIDTH == 0, "v_dim must be tile-aligned");
-    TT_FATAL(dQ_shape[2] % TILE_HEIGHT == 0, "S must be tile-aligned");
+    TT_FATAL(
+        args.qk_nope_dim % TILE_WIDTH == 0,
+        "MLAQKVAssembleBw: qk_nope_dim ({}) must be a multiple of TILE_WIDTH ({}).",
+        args.qk_nope_dim,
+        TILE_WIDTH);
+    TT_FATAL(
+        args.qk_rope_dim % TILE_WIDTH == 0,
+        "MLAQKVAssembleBw: qk_rope_dim ({}) must be a multiple of TILE_WIDTH ({}).",
+        args.qk_rope_dim,
+        TILE_WIDTH);
+    TT_FATAL(
+        args.v_dim % TILE_WIDTH == 0,
+        "MLAQKVAssembleBw: v_dim ({}) must be a multiple of TILE_WIDTH ({}).",
+        args.v_dim,
+        TILE_WIDTH);
+    TT_FATAL(
+        dQ_shape[2] % TILE_HEIGHT == 0,
+        "MLAQKVAssembleBw: S ({}) must be a multiple of TILE_HEIGHT ({}).",
+        dQ_shape[2],
+        TILE_HEIGHT);
 }
 
 MLAQKVAssembleBwDeviceOperation::spec_return_value_t MLAQKVAssembleBwDeviceOperation::compute_output_specs(
@@ -100,6 +116,7 @@ MLAQKVAssembleBwDeviceOperation::spec_return_value_t MLAQKVAssembleBwDeviceOpera
     output_specs.reserve(3U);
 
     const auto& dQ = tensor_args.dQ;
+    const auto& dK = tensor_args.dK;
     const auto dQ_shape = dQ.logical_shape();
     const uint32_t B = dQ_shape[0];
     const uint32_t S = dQ_shape[2];
@@ -109,10 +126,13 @@ MLAQKVAssembleBwDeviceOperation::spec_return_value_t MLAQKVAssembleBwDeviceOpera
     const ttnn::Shape dkv_up_shape({B, 1U, S, args.n_heads * (args.qk_nope_dim + args.v_dim)});
     const ttnn::Shape dk_pe_shape({B, 1U, S, args.qk_rope_dim});
 
-    auto layout = tt::tt_metal::TensorLayout(dQ.dtype(), tt::tt_metal::Layout::TILE, dQ.memory_config());
-    output_specs.emplace_back(dq_pre_shape, layout);
-    output_specs.emplace_back(dkv_up_shape, layout);
-    output_specs.emplace_back(dk_pe_shape, layout);
+    // Each output inherits from its primary input source. Validation requires all three
+    // inputs share dtype + memory_config, so these layouts are equal in practice.
+    auto dq_layout = tt::tt_metal::TensorLayout(dQ.dtype(), tt::tt_metal::Layout::TILE, dQ.memory_config());
+    auto dk_layout = tt::tt_metal::TensorLayout(dK.dtype(), tt::tt_metal::Layout::TILE, dK.memory_config());
+    output_specs.emplace_back(dq_pre_shape, dq_layout);
+    output_specs.emplace_back(dkv_up_shape, dk_layout);
+    output_specs.emplace_back(dk_pe_shape, dk_layout);
 
     return output_specs;
 }

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.hpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+#include "mla_qkv_assemble_bw_device_operation_types.hpp"
+#include "mla_qkv_assemble_bw_program_factory.hpp"
+
+namespace ttml::metal::ops::mla_qkv_assemble_bw::device {
+
+struct MLAQKVAssembleBwDeviceOperation {
+    using operation_attributes_t = ttml::metal::ops::mla_qkv_assemble_bw::device::operation_attributes_t;
+    using tensor_args_t = ttml::metal::ops::mla_qkv_assemble_bw::device::tensor_args_t;
+    using spec_return_value_t = ttml::metal::ops::mla_qkv_assemble_bw::device::spec_return_value_t;
+    using tensor_return_value_t = ttml::metal::ops::mla_qkv_assemble_bw::device::tensor_return_value_t;
+    using program_factory_t = std::variant<MLAQKVAssembleBwProgramFactory>;
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_bw::device
+
+namespace ttnn::prim {
+
+ttml::metal::ops::mla_qkv_assemble_bw::device::MLAQKVAssembleBwDeviceOperation::tensor_return_value_t
+ttml_mla_qkv_assemble_bw(
+    const ttnn::Tensor& dQ,
+    const ttnn::Tensor& dK,
+    const ttnn::Tensor& dV,
+    uint32_t n_heads,
+    uint32_t qk_nope_dim,
+    uint32_t qk_rope_dim,
+    uint32_t v_dim);
+
+}  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation_types.hpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "metal/ttnn_all_includes.hpp"
+
+namespace ttml::metal::ops::mla_qkv_assemble_bw::device {
+
+struct operation_attributes_t {
+    uint32_t n_heads{};
+    uint32_t qk_nope_dim{};
+    uint32_t qk_rope_dim{};
+    uint32_t v_dim{};
+};
+
+struct tensor_args_t {
+    const ttnn::Tensor& dQ;
+    const ttnn::Tensor& dK;
+    const ttnn::Tensor& dV;
+};
+
+using tensor_return_value_t = std::vector<ttnn::Tensor>;
+using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_bw::device

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.cpp
@@ -97,11 +97,11 @@ static void assign_per_core_runtime_args(
         }
 
         // Inputs are head-major: tile_id(b, h, sb, w) = b*H*HtWt + h*HtWt + sb*Wt + w.
+        // dQ and dK share per-head head_dim (validated), so a single base addresses both.
         const uint32_t b_start = num_blocks_written / S_t;
         const uint32_t sb_start = num_blocks_written % S_t;
-        const uint32_t dQ_block_base_start = b_start * n_heads * kq_HtWt + sb_start * Th;
+        const uint32_t dQK_block_base_start = b_start * n_heads * kq_HtWt + sb_start * Th;
         const uint32_t dV_block_base_start = b_start * n_heads * v_HtWt + sb_start * Tv;
-        // dK shares dQ's layout (same per-head width).
 
         // Outputs are flat across blocks: head 0 of (b, sb) at (b*S_t + sb) * (per_block_tiles).
         const uint32_t flat_block_idx = num_blocks_written;
@@ -118,7 +118,7 @@ static void assign_per_core_runtime_args(
              dV_buffer->address(),
              num_blocks_per_core,
              sb_start,
-             dQ_block_base_start,
+             dQK_block_base_start,
              dV_block_base_start});
 
         SetRuntimeArgs(
@@ -184,6 +184,8 @@ MLAQKVAssembleBwProgramFactory::cached_program_t MLAQKVAssembleBwProgramFactory:
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_blocks);
 
     // ── CBs ──
+    // Validation guarantees dQ / dK / dV share dtype, so any of them yields the same
+    // data_format. dQ is picked because it's also the source-of-truth for B and S above.
     tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(dQ.dtype());
     const uint32_t single_tile_size = tt::tile_size(data_format);
 

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.cpp
@@ -1,0 +1,300 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mla_qkv_assemble_bw_program_factory.hpp"
+
+#include <cstdint>
+#include <enchantum/enchantum.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+
+#include "metal/common/program_utils.hpp"
+#include "mla_qkv_assemble_bw_device_operation_types.hpp"
+
+namespace {
+
+constexpr auto kReaderKernelPath =
+    "tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/"
+    "reader_mla_qkv_assemble_bw.cpp";
+
+constexpr auto kWriterKernelPath =
+    "tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/"
+    "writer_mla_qkv_assemble_bw.cpp";
+
+constexpr auto kComputeKernelPath =
+    "tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/compute/"
+    "mla_qkv_assemble_bw_kernel.cpp";
+
+// reader runtime arg indices (for override_runtime_arguments)
+constexpr uint32_t kReaderArgDQAddr = 0;
+constexpr uint32_t kReaderArgDKAddr = 1;
+constexpr uint32_t kReaderArgDVAddr = 2;
+
+// writer runtime arg indices
+constexpr uint32_t kWriterArgDQPreAddr = 0;
+constexpr uint32_t kWriterArgDKVUpAddr = 1;
+constexpr uint32_t kWriterArgDKPeAddr = 2;
+
+// CB indices
+constexpr auto kDQCbIndex = tt::CBIndex::c_0;
+constexpr auto kDKnopeCbIndex = tt::CBIndex::c_1;
+constexpr auto kDVCbIndex = tt::CBIndex::c_2;
+constexpr auto kDKpeInCbIndex = tt::CBIndex::c_3;
+constexpr auto kDKpeOutCbIndex = tt::CBIndex::c_4;
+
+// CB sizing
+constexpr uint32_t kDQCbNumTiles = 4U;
+constexpr uint32_t kDKnopeCbNumTiles = 4U;
+constexpr uint32_t kDVCbNumTiles = 4U;
+
+}  // namespace
+
+namespace ttml::metal::ops::mla_qkv_assemble_bw::device {
+
+using namespace tt::constants;
+
+struct MLAQKVAssembleBwKernels {
+    tt::tt_metal::KernelHandle reader;
+    tt::tt_metal::KernelHandle writer;
+    tt::tt_metal::KernelHandle compute;
+};
+
+static void assign_per_core_runtime_args(
+    tt::tt_metal::Program& program,
+    const MLAQKVAssembleBwKernels& kernels,
+    const tt::tt_metal::Buffer* dQ_buffer,
+    const tt::tt_metal::Buffer* dK_buffer,
+    const tt::tt_metal::Buffer* dV_buffer,
+    const tt::tt_metal::Buffer* dq_pre_buffer,
+    const tt::tt_metal::Buffer* dkv_up_buffer,
+    const tt::tt_metal::Buffer* dk_pe_buffer,
+    uint32_t num_cores,
+    uint32_t num_cores_y,
+    uint32_t num_blocks_per_core_group_1,
+    uint32_t num_blocks_per_core_group_2,
+    const tt::tt_metal::CoreRangeSet& core_group_1,
+    const tt::tt_metal::CoreRangeSet& core_group_2,
+    uint32_t S_t,
+    uint32_t Th,
+    uint32_t Tn,
+    uint32_t Tr,
+    uint32_t Tv,
+    uint32_t kq_HtWt,
+    uint32_t v_HtWt,
+    uint32_t n_heads) {
+    for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; ++i) {
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        uint32_t num_blocks_per_core = 0;
+        if (core_group_1.contains(core)) {
+            num_blocks_per_core = num_blocks_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_blocks_per_core = num_blocks_per_core_group_2;
+        } else {
+            TT_FATAL(false, "MLAQKVAssembleBw: core not in any work group");
+        }
+
+        // Inputs are head-major: tile_id(b, h, sb, w) = b*H*HtWt + h*HtWt + sb*Wt + w.
+        const uint32_t b_start = num_blocks_written / S_t;
+        const uint32_t sb_start = num_blocks_written % S_t;
+        const uint32_t dQ_block_base_start = b_start * n_heads * kq_HtWt + sb_start * Th;
+        const uint32_t dV_block_base_start = b_start * n_heads * v_HtWt + sb_start * Tv;
+        // dK shares dQ's layout (same per-head width).
+
+        // Outputs are flat across blocks: head 0 of (b, sb) at (b*S_t + sb) * (per_block_tiles).
+        const uint32_t flat_block_idx = num_blocks_written;
+        const uint32_t dq_pre_block_base_start = flat_block_idx * n_heads * Th;
+        const uint32_t dkv_up_block_base_start = flat_block_idx * n_heads * (Tn + Tv);
+        const uint32_t dk_pe_block_base_start = flat_block_idx * Tr;
+
+        SetRuntimeArgs(
+            program,
+            kernels.reader,
+            core,
+            {dQ_buffer->address(),
+             dK_buffer->address(),
+             dV_buffer->address(),
+             num_blocks_per_core,
+             sb_start,
+             dQ_block_base_start,
+             dV_block_base_start});
+
+        SetRuntimeArgs(
+            program,
+            kernels.writer,
+            core,
+            {dq_pre_buffer->address(),
+             dkv_up_buffer->address(),
+             dk_pe_buffer->address(),
+             num_blocks_per_core,
+             dq_pre_block_base_start,
+             dkv_up_block_base_start,
+             dk_pe_block_base_start});
+
+        SetRuntimeArgs(program, kernels.compute, core, {num_blocks_per_core});
+
+        num_blocks_written += num_blocks_per_core;
+    }
+}
+
+MLAQKVAssembleBwProgramFactory::cached_program_t MLAQKVAssembleBwProgramFactory::create(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    const auto& dQ = tensor_args.dQ;
+    const auto& dK = tensor_args.dK;
+    const auto& dV = tensor_args.dV;
+    auto& dq_pre = output[0];
+    auto& dkv_up = output[1];
+    auto& dk_pe = output[2];
+
+    auto* device = dQ.device();
+    tt::tt_metal::Program program{};
+
+    // ── Tile geometry ──
+    const auto dQ_shape = dQ.padded_shape();
+    const uint32_t B = dQ_shape[0];
+    const uint32_t S = dQ_shape[2];
+    const uint32_t H = args.n_heads;
+
+    const uint32_t Tn = args.qk_nope_dim / TILE_WIDTH;
+    const uint32_t Tr = args.qk_rope_dim / TILE_WIDTH;
+    const uint32_t Tv = args.v_dim / TILE_WIDTH;
+    const uint32_t Th = Tn + Tr;
+    const uint32_t S_t = S / TILE_HEIGHT;
+
+    const uint32_t kq_HtWt = S_t * Th;
+    const uint32_t v_HtWt = S_t * Tv;
+
+    const uint32_t num_blocks = B * S_t;
+
+    // Compute kernel uses Tr persistent dst-register slots as the head-axis accumulator,
+    // plus 1 temporary slot. Bound: Tr + 1 ≤ 16 (DST register count).
+    TT_FATAL(
+        Tr + 1U <= 16U,
+        "MLAQKVAssembleBw: qk_rope_dim ({}) / TILE_W = {} too large for in-register accumulator (max 15).",
+        args.qk_rope_dim,
+        Tr);
+
+    // ── Work split ──
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    const uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_blocks);
+
+    // ── CBs ──
+    tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(dQ.dtype());
+    const uint32_t single_tile_size = tt::tile_size(data_format);
+
+    [[maybe_unused]] auto cb_dq =
+        create_circular_buffer(program, all_cores, kDQCbIndex, data_format, single_tile_size, kDQCbNumTiles);
+    [[maybe_unused]] auto cb_dknope =
+        create_circular_buffer(program, all_cores, kDKnopeCbIndex, data_format, single_tile_size, kDKnopeCbNumTiles);
+    [[maybe_unused]] auto cb_dv =
+        create_circular_buffer(program, all_cores, kDVCbIndex, data_format, single_tile_size, kDVCbNumTiles);
+    // dKpe staging: hold up to 2*Tr tiles so reader can stay one head ahead of compute.
+    [[maybe_unused]] auto cb_dkpe_in =
+        create_circular_buffer(program, all_cores, kDKpeInCbIndex, data_format, single_tile_size, 2U * Tr);
+    // dKpe output: 2*Tr to allow producer/consumer pipelining across blocks.
+    [[maybe_unused]] auto cb_dkpe_out =
+        create_circular_buffer(program, all_cores, kDKpeOutCbIndex, data_format, single_tile_size, 2U * Tr);
+
+    // ── Kernels ──
+    auto* dQ_buffer = dQ.buffer();
+    auto* dK_buffer = dK.buffer();
+    auto* dV_buffer = dV.buffer();
+    auto* dq_pre_buffer = dq_pre.buffer();
+    auto* dkv_up_buffer = dkv_up.buffer();
+    auto* dk_pe_buffer = dk_pe.buffer();
+
+    std::vector<uint32_t> reader_compile_time_args = {Th, Tn, Tr, Tv, H, kq_HtWt, v_HtWt, S_t};
+    tt::tt_metal::TensorAccessorArgs(dQ_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(dK_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(dV_buffer).append_to(reader_compile_time_args);
+
+    std::vector<uint32_t> writer_compile_time_args = {Th, Tn, Tr, Tv, H};
+    tt::tt_metal::TensorAccessorArgs(dq_pre_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(dkv_up_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(dk_pe_buffer).append_to(writer_compile_time_args);
+
+    std::vector<uint32_t> compute_compile_time_args = {Tr, H};
+
+    std::map<std::string, std::string> defines;
+
+    MLAQKVAssembleBwKernels kernels;
+    kernels.reader = create_reader_kernel(program, all_cores, reader_compile_time_args, defines, kReaderKernelPath);
+    kernels.writer = create_writer_kernel(program, all_cores, writer_compile_time_args, defines, kWriterKernelPath);
+    kernels.compute = create_compute_kernel(
+        program, all_cores, compute_compile_time_args, defines, kComputeKernelPath, /*fp32_dest_acc_en=*/false);
+
+    // ── Runtime args ──
+    assign_per_core_runtime_args(
+        program,
+        kernels,
+        dQ_buffer,
+        dK_buffer,
+        dV_buffer,
+        dq_pre_buffer,
+        dkv_up_buffer,
+        dk_pe_buffer,
+        num_cores,
+        num_cores_y,
+        num_blocks_per_core_group_1,
+        num_blocks_per_core_group_2,
+        core_group_1,
+        core_group_2,
+        S_t,
+        Th,
+        Tn,
+        Tr,
+        Tv,
+        kq_HtWt,
+        v_HtWt,
+        H);
+
+    return cached_program_t{
+        std::move(program),
+        {/* reader_kernel_id  = */ kernels.reader,
+         /* writer_kernel_id  = */ kernels.writer,
+         /* compute_kernel_id = */ kernels.compute,
+         /* num_cores         = */ num_cores,
+         /* num_cores_y       = */ num_cores_y}};
+}
+
+void MLAQKVAssembleBwProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& /*args*/,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    auto& shared = cached_program.shared_variables;
+    auto& program = cached_program.program;
+
+    auto* dQ_buffer = tensor_args.dQ.buffer();
+    auto* dK_buffer = tensor_args.dK.buffer();
+    auto* dV_buffer = tensor_args.dV.buffer();
+    auto* dq_pre_buffer = output[0].buffer();
+    auto* dkv_up_buffer = output[1].buffer();
+    auto* dk_pe_buffer = output[2].buffer();
+
+    auto& reader_runtime_args = GetRuntimeArgs(program, shared.reader_kernel_id);
+    auto& writer_runtime_args = GetRuntimeArgs(program, shared.writer_kernel_id);
+
+    for (uint32_t i = 0; i < shared.num_cores; ++i) {
+        tt::tt_metal::CoreCoord core = {i / shared.num_cores_y, i % shared.num_cores_y};
+        {
+            auto& ra = reader_runtime_args[core.x][core.y];
+            ra[kReaderArgDQAddr] = dQ_buffer->address();
+            ra[kReaderArgDKAddr] = dK_buffer->address();
+            ra[kReaderArgDVAddr] = dV_buffer->address();
+        }
+        {
+            auto& ra = writer_runtime_args[core.x][core.y];
+            ra[kWriterArgDQPreAddr] = dq_pre_buffer->address();
+            ra[kWriterArgDKVUpAddr] = dkv_up_buffer->address();
+            ra[kWriterArgDKPeAddr] = dk_pe_buffer->address();
+        }
+    }
+}
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_bw::device

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+#include "mla_qkv_assemble_bw_device_operation_types.hpp"
+
+namespace ttml::metal::ops::mla_qkv_assemble_bw::device {
+
+struct MLAQKVAssembleBwProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle reader_kernel_id{};
+        tt::tt_metal::KernelHandle writer_kernel_id{};
+        tt::tt_metal::KernelHandle compute_kernel_id{};
+        uint32_t num_cores{};
+        uint32_t num_cores_y{};
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_bw::device

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/mla_qkv_assemble_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/mla_qkv_assemble_bw.cpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mla_qkv_assemble_bw.hpp"
+
+#include "device/mla_qkv_assemble_bw_device_operation.hpp"
+
+namespace ttml::metal {
+
+std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> mla_qkv_assemble_bw(
+    const ttnn::Tensor& dQ,
+    const ttnn::Tensor& dK,
+    const ttnn::Tensor& dV,
+    uint32_t n_heads,
+    uint32_t qk_nope_dim,
+    uint32_t qk_rope_dim,
+    uint32_t v_dim) {
+    auto result = ttnn::prim::ttml_mla_qkv_assemble_bw(dQ, dK, dV, n_heads, qk_nope_dim, qk_rope_dim, v_dim);
+    return {result[0], result[1], result[2]};
+}
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/mla_qkv_assemble_bw.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/mla_qkv_assemble_bw.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <tuple>
+
+#include "metal/ttnn_all_includes.hpp"
+
+namespace ttml::metal {
+
+// Backward kernel for ``mla_qkv_assemble_fw``.
+//
+// Inverts the forward op's tile routing:
+//   - dq_pre  ← head-major dQ packed flat  (reverse of head-split).
+//   - dkv_up  ← head-major [dK_nope | dV] packed flat per head.
+//   - dk_pe   ← Σ_h dK[..., qk_nope:]  (head-axis sum, runs in compute kernel).
+//
+// Shapes (TILE layout, INTERLEAVED memory):
+//   dQ      : [B, n_heads, S, qk_nope_dim + qk_rope_dim]
+//   dK      : [B, n_heads, S, qk_nope_dim + qk_rope_dim]
+//   dV      : [B, n_heads, S, v_dim]
+//   dq_pre  : [B, 1, S, n_heads * (qk_nope_dim + qk_rope_dim)]   (output)
+//   dkv_up  : [B, 1, S, n_heads * (qk_nope_dim + v_dim)]         (output)
+//   dk_pe   : [B, 1, S, qk_rope_dim]                             (output)
+//
+// Per-head dims and S must be tile-aligned.
+//
+// Returns: {dq_pre, dkv_up, dk_pe}
+std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> mla_qkv_assemble_bw(
+    const ttnn::Tensor& dQ,
+    const ttnn::Tensor& dK,
+    const ttnn::Tensor& dV,
+    uint32_t n_heads,
+    uint32_t qk_nope_dim,
+    uint32_t qk_rope_dim,
+    uint32_t v_dim);
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/kernels/dataflow/reader_mla_qkv_assemble_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/kernels/dataflow/reader_mla_qkv_assemble_fw.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
+
+void kernel_main() {
+    uint32_t runtime_args_counter = 0U;
+    uint32_t q_pre_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t kv_up_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t k_pe_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t num_blocks = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t q_pre_tile_id = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t kv_up_tile_id = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t k_pe_tile_id = get_arg_val<uint32_t>(runtime_args_counter++);
+
+    constexpr uint32_t cb_q = tt::CBIndex::c_0;
+    constexpr uint32_t cb_kv_up = tt::CBIndex::c_1;
+    constexpr uint32_t cb_kpe = tt::CBIndex::c_2;
+
+    constexpr uint32_t Th = get_compile_time_arg_val(0);                   // q tiles per head (Tn + Tr)
+    constexpr uint32_t kv_tiles_per_head = get_compile_time_arg_val(1);    // Tn + Tv
+    constexpr uint32_t kpe_tiles_per_block = get_compile_time_arg_val(2);  // Tr
+    constexpr uint32_t n_heads = get_compile_time_arg_val(3);
+
+    constexpr auto q_args = TensorAccessorArgs<4>();
+    constexpr auto kv_up_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
+    constexpr auto kpe_args = TensorAccessorArgs<kv_up_args.next_compile_time_args_offset()>();
+
+    const auto q_addr_gen = TensorAccessor(q_args, q_pre_addr);
+    const auto kv_up_addr_gen = TensorAccessor(kv_up_args, kv_up_addr);
+    const auto kpe_addr_gen = TensorAccessor(kpe_args, k_pe_addr);
+
+    const uint32_t tile_bytes = get_tile_size(cb_q);
+
+    for (uint32_t block = 0U; block < num_blocks; ++block) {
+        // Block-level: load Tr k_pe tiles (peeked by writer for every head, popped at block end).
+        read_tiles_by_row(cb_kpe, kpe_addr_gen, k_pe_tile_id, kpe_tiles_per_block, tile_bytes, kpe_tiles_per_block);
+        k_pe_tile_id += kpe_tiles_per_block;
+
+        // Per-head: stream Q tiles, then K-nope+V tiles. The writer drains them in the same order.
+        for (uint32_t h = 0U; h < n_heads; ++h) {
+            // Q for head h
+            for (uint32_t w = 0U; w < Th; ++w) {
+                cb_reserve_back(cb_q, onetile);
+                uint32_t l1_write_addr = get_write_ptr(cb_q);
+                noc_async_read_page(q_pre_tile_id + w, q_addr_gen, l1_write_addr);
+                noc_async_read_barrier();
+                cb_push_back(cb_q, onetile);
+            }
+            q_pre_tile_id += Th;
+
+            // KV (k_nope ∥ v) for head h
+            for (uint32_t w = 0U; w < kv_tiles_per_head; ++w) {
+                cb_reserve_back(cb_kv_up, onetile);
+                uint32_t l1_write_addr = get_write_ptr(cb_kv_up);
+                noc_async_read_page(kv_up_tile_id + w, kv_up_addr_gen, l1_write_addr);
+                noc_async_read_barrier();
+                cb_push_back(cb_kv_up, onetile);
+            }
+            kv_up_tile_id += kv_tiles_per_head;
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/kernels/dataflow/reader_mla_qkv_assemble_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/kernels/dataflow/reader_mla_qkv_assemble_fw.cpp
@@ -34,7 +34,7 @@ void kernel_main() {
     const auto kv_up_addr_gen = TensorAccessor(kv_up_args, kv_up_addr);
     const auto kpe_addr_gen = TensorAccessor(kpe_args, k_pe_addr);
 
-    const uint32_t tile_bytes = get_tile_size(cb_q);
+    const uint32_t tile_bytes = get_tile_size(cb_kpe);
 
     for (uint32_t block = 0U; block < num_blocks; ++block) {
         // Block-level: load Tr k_pe tiles (peeked by writer for every head, popped at block end).

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/kernels/dataflow/writer_mla_qkv_assemble_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/kernels/dataflow/writer_mla_qkv_assemble_fw.cpp
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
+
+void kernel_main() {
+    uint32_t runtime_args_counter = 0U;
+    uint32_t q_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t k_full_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t v_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t num_blocks = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t sb = get_arg_val<uint32_t>(runtime_args_counter++);         // s-tile-row index within current batch
+    uint32_t q_tile_id = get_arg_val<uint32_t>(runtime_args_counter++);  // q[b, 0, sb, 0]
+    uint32_t k_tile_id = get_arg_val<uint32_t>(runtime_args_counter++);  // k_full[b, 0, sb, 0]
+    uint32_t v_tile_id = get_arg_val<uint32_t>(runtime_args_counter++);  // v[b, 0, sb, 0]
+
+    constexpr uint32_t cb_q = tt::CBIndex::c_0;
+    constexpr uint32_t cb_kv_up = tt::CBIndex::c_1;
+    constexpr uint32_t cb_kpe = tt::CBIndex::c_2;
+
+    constexpr uint32_t Tn = get_compile_time_arg_val(0);  // qk_nope_dim / TILE_W
+    constexpr uint32_t Tr = get_compile_time_arg_val(1);  // qk_rope_dim / TILE_W
+    constexpr uint32_t Tv = get_compile_time_arg_val(2);  // v_dim       / TILE_W
+    constexpr uint32_t n_heads = get_compile_time_arg_val(3);
+    constexpr uint32_t kq_HtWt = get_compile_time_arg_val(4);  // S_t * (Tn + Tr)  — q and k share head_dim
+    constexpr uint32_t v_HtWt = get_compile_time_arg_val(5);   // S_t * Tv
+    constexpr uint32_t S_t = get_compile_time_arg_val(6);      // S / TILE_H
+
+    constexpr auto q_args = TensorAccessorArgs<7>();
+    constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
+    constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
+
+    const auto q_addr_gen = TensorAccessor(q_args, q_addr);
+    const auto k_addr_gen = TensorAccessor(k_args, k_full_addr);
+    const auto v_addr_gen = TensorAccessor(v_args, v_addr);
+
+    const uint32_t tile_bytes = get_tile_size(cb_q);
+    constexpr uint32_t Th = Tn + Tr;
+
+    // End-of-batch jump for head-major outputs:
+    //   from (b, sb=S_t-1, h=0, w=0)  to  (b+1, sb=0, h=0, w=0)
+    //   diff = H*HtWt - (S_t-1)*Wt = ((H-1)*S_t + 1) * Wt
+    constexpr uint32_t end_of_batch_jump_q = ((n_heads - 1U) * S_t + 1U) * Th;
+    constexpr uint32_t end_of_batch_jump_v = ((n_heads - 1U) * S_t + 1U) * Tv;
+
+    for (uint32_t block = 0U; block < num_blocks; ++block) {
+        // Peek-only on cb_kpe: same Tr tiles reused across all heads.
+        cb_wait_front(cb_kpe, Tr);
+        const uint32_t kpe_l1_base = get_read_ptr(cb_kpe);
+
+        uint32_t q_head_base = q_tile_id;
+        uint32_t k_head_base = k_tile_id;
+        uint32_t v_head_base = v_tile_id;
+
+        for (uint32_t h = 0U; h < n_heads; ++h) {
+            // Q (head-split, no rotation here): drain Th tiles from cb_q
+            for (uint32_t w = 0U; w < Th; ++w) {
+                cb_wait_front(cb_q, onetile);
+                const uint32_t l1_addr = get_read_ptr(cb_q);
+                noc_async_write_page(q_head_base + w, q_addr_gen, l1_addr);
+                noc_async_write_barrier();
+                cb_pop_front(cb_q, onetile);
+            }
+
+            // K nope: drain Tn tiles from cb_kv_up
+            for (uint32_t w = 0U; w < Tn; ++w) {
+                cb_wait_front(cb_kv_up, onetile);
+                const uint32_t l1_addr = get_read_ptr(cb_kv_up);
+                noc_async_write_page(k_head_base + w, k_addr_gen, l1_addr);
+                noc_async_write_barrier();
+                cb_pop_front(cb_kv_up, onetile);
+            }
+
+            // K pe: broadcast — same peeked tiles for every head
+            for (uint32_t w = 0U; w < Tr; ++w) {
+                noc_async_write_page(k_head_base + Tn + w, k_addr_gen, kpe_l1_base + w * tile_bytes);
+            }
+            noc_async_write_barrier();
+
+            // V: drain Tv tiles from cb_kv_up
+            for (uint32_t w = 0U; w < Tv; ++w) {
+                cb_wait_front(cb_kv_up, onetile);
+                const uint32_t l1_addr = get_read_ptr(cb_kv_up);
+                noc_async_write_page(v_head_base + w, v_addr_gen, l1_addr);
+                noc_async_write_barrier();
+                cb_pop_front(cb_kv_up, onetile);
+            }
+
+            q_head_base += kq_HtWt;
+            k_head_base += kq_HtWt;
+            v_head_base += v_HtWt;
+        }
+
+        cb_pop_front(cb_kpe, Tr);
+
+        ++sb;
+        if (sb < S_t) {
+            q_tile_id += Th;
+            k_tile_id += Th;
+            v_tile_id += Tv;
+        } else {
+            // q_head_base / k_head_base / v_head_base after the head loop are
+            // q_tile_id_at_block_start + n_heads * head_stride — that's the next
+            // batch start ONLY when S_t == 1. For S_t > 1 the per-w writes don't
+            // get folded into them, so use the explicit jump instead.
+            q_tile_id += end_of_batch_jump_q;
+            k_tile_id += end_of_batch_jump_q;  // q and k share Th
+            v_tile_id += end_of_batch_jump_v;
+            sb = 0U;
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/kernels/dataflow/writer_mla_qkv_assemble_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/kernels/dataflow/writer_mla_qkv_assemble_fw.cpp
@@ -10,12 +10,12 @@
 void kernel_main() {
     uint32_t runtime_args_counter = 0U;
     uint32_t q_addr = get_arg_val<uint32_t>(runtime_args_counter++);
-    uint32_t k_full_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t k_addr = get_arg_val<uint32_t>(runtime_args_counter++);
     uint32_t v_addr = get_arg_val<uint32_t>(runtime_args_counter++);
     uint32_t num_blocks = get_arg_val<uint32_t>(runtime_args_counter++);
     uint32_t sb = get_arg_val<uint32_t>(runtime_args_counter++);         // s-tile-row index within current batch
     uint32_t q_tile_id = get_arg_val<uint32_t>(runtime_args_counter++);  // q[b, 0, sb, 0]
-    uint32_t k_tile_id = get_arg_val<uint32_t>(runtime_args_counter++);  // k_full[b, 0, sb, 0]
+    uint32_t k_tile_id = get_arg_val<uint32_t>(runtime_args_counter++);  // k[b, 0, sb, 0]
     uint32_t v_tile_id = get_arg_val<uint32_t>(runtime_args_counter++);  // v[b, 0, sb, 0]
 
     constexpr uint32_t cb_q = tt::CBIndex::c_0;
@@ -35,10 +35,10 @@ void kernel_main() {
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
 
     const auto q_addr_gen = TensorAccessor(q_args, q_addr);
-    const auto k_addr_gen = TensorAccessor(k_args, k_full_addr);
+    const auto k_addr_gen = TensorAccessor(k_args, k_addr);
     const auto v_addr_gen = TensorAccessor(v_args, v_addr);
 
-    const uint32_t tile_bytes = get_tile_size(cb_q);
+    const uint32_t tile_bytes = get_tile_size(cb_kpe);
     constexpr uint32_t Th = Tn + Tr;
 
     // End-of-batch jump for head-major outputs:

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_device_operation.cpp
@@ -117,6 +117,7 @@ MLAQKVAssembleFwDeviceOperation::spec_return_value_t MLAQKVAssembleFwDeviceOpera
     spec_return_value_t output_specs;
     output_specs.reserve(3U);
 
+    const auto& q_pre = tensor_args.q_pre;
     const auto& kv_up = tensor_args.kv_up;
     const auto kv_up_shape = kv_up.logical_shape();
     const uint32_t B = kv_up_shape[0];
@@ -128,10 +129,13 @@ MLAQKVAssembleFwDeviceOperation::spec_return_value_t MLAQKVAssembleFwDeviceOpera
     const ttnn::Shape k_shape({B, args.n_heads, S, qk_head});
     const ttnn::Shape v_shape({B, args.n_heads, S, args.v_dim});
 
-    auto layout = tt::tt_metal::TensorLayout(kv_up.dtype(), tt::tt_metal::Layout::TILE, kv_up.memory_config());
-    output_specs.emplace_back(q_shape, layout);
-    output_specs.emplace_back(k_shape, layout);
-    output_specs.emplace_back(v_shape, layout);
+    // Each output inherits from its primary input source. Validation requires all three
+    // inputs share dtype + memory_config, so these layouts are equal in practice.
+    auto q_layout = tt::tt_metal::TensorLayout(q_pre.dtype(), tt::tt_metal::Layout::TILE, q_pre.memory_config());
+    auto kv_layout = tt::tt_metal::TensorLayout(kv_up.dtype(), tt::tt_metal::Layout::TILE, kv_up.memory_config());
+    output_specs.emplace_back(q_shape, q_layout);
+    output_specs.emplace_back(k_shape, kv_layout);
+    output_specs.emplace_back(v_shape, kv_layout);
 
     return output_specs;
 }
@@ -150,7 +154,7 @@ ttsl::hash::hash_t MLAQKVAssembleFwDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     return tt::tt_metal::operation::hash_operation<MLAQKVAssembleFwDeviceOperation>(
         args,
-        tensor_args.q_pre.dtype(),
+        tensor_args.kv_up.dtype(),
         tensor_args.q_pre.logical_shape(),
         tensor_args.kv_up.logical_shape(),
         tensor_args.k_pe.logical_shape());

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_device_operation.cpp
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mla_qkv_assemble_fw_device_operation.hpp"
+
+#include <enchantum/enchantum.hpp>
+
+#include "mla_qkv_assemble_fw_program_factory.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttml::metal::ops::mla_qkv_assemble_fw::device {
+
+void MLAQKVAssembleFwDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    using namespace tt::constants;
+
+    auto check_tensor = [](const ttnn::Tensor& tensor, const std::string& name) {
+        TT_FATAL(
+            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            "MLAQKVAssembleFw requires {} to be on device. Got storage type: {}",
+            name,
+            enchantum::to_string(tensor.storage_type()));
+        TT_FATAL(tensor.buffer() != nullptr, "MLAQKVAssembleFw: {} buffer must be allocated.", name);
+        TT_FATAL(
+            tensor.layout() == tt::tt_metal::Layout::TILE,
+            "MLAQKVAssembleFw requires {} to be in TILE layout. Got: {}",
+            name,
+            enchantum::to_string(tensor.layout()));
+        TT_FATAL(
+            tensor.dtype() == tt::tt_metal::DataType::BFLOAT16,
+            "MLAQKVAssembleFw requires {} dtype to be BFLOAT16. Got: {}",
+            name,
+            enchantum::to_string(tensor.dtype()));
+        TT_FATAL(
+            tensor.memory_config().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED,
+            "MLAQKVAssembleFw requires {} memory layout to be INTERLEAVED. Got: {}",
+            name,
+            enchantum::to_string(tensor.memory_config().memory_layout()));
+    };
+
+    const auto& q_pre = tensor_args.q_pre;
+    const auto& kv_up = tensor_args.kv_up;
+    const auto& k_pe = tensor_args.k_pe;
+    check_tensor(q_pre, "q_pre");
+    check_tensor(kv_up, "kv_up");
+    check_tensor(k_pe, "k_pe");
+
+    const auto q_pre_shape = q_pre.padded_shape();
+    const auto kv_up_shape = kv_up.padded_shape();
+    const auto k_pe_shape = k_pe.padded_shape();
+
+    TT_FATAL(q_pre_shape.rank() == 4U, "MLAQKVAssembleFw: q_pre must be rank-4. Got rank {}", q_pre_shape.rank());
+    TT_FATAL(kv_up_shape.rank() == 4U, "MLAQKVAssembleFw: kv_up must be rank-4. Got rank {}", kv_up_shape.rank());
+    TT_FATAL(k_pe_shape.rank() == 4U, "MLAQKVAssembleFw: k_pe must be rank-4. Got rank {}", k_pe_shape.rank());
+
+    TT_FATAL(q_pre_shape[1] == 1U, "MLAQKVAssembleFw: q_pre dim 1 must be 1. Got {}", q_pre_shape[1]);
+    TT_FATAL(kv_up_shape[1] == 1U, "MLAQKVAssembleFw: kv_up dim 1 must be 1. Got {}", kv_up_shape[1]);
+    TT_FATAL(k_pe_shape[1] == 1U, "MLAQKVAssembleFw: k_pe dim 1 must be 1. Got {}", k_pe_shape[1]);
+
+    TT_FATAL(
+        q_pre_shape[0] == kv_up_shape[0] && kv_up_shape[0] == k_pe_shape[0],
+        "MLAQKVAssembleFw: batch dim must match across q_pre ({}), kv_up ({}), k_pe ({}).",
+        q_pre_shape[0],
+        kv_up_shape[0],
+        k_pe_shape[0]);
+    TT_FATAL(
+        q_pre_shape[2] == kv_up_shape[2] && kv_up_shape[2] == k_pe_shape[2],
+        "MLAQKVAssembleFw: seq dim must match across q_pre ({}), kv_up ({}), k_pe ({}).",
+        q_pre_shape[2],
+        kv_up_shape[2],
+        k_pe_shape[2]);
+
+    const uint32_t qk_head_dim = args.qk_nope_dim + args.qk_rope_dim;
+    const uint32_t expected_q_pre_w = args.n_heads * qk_head_dim;
+    const uint32_t expected_kv_up_w = args.n_heads * (args.qk_nope_dim + args.v_dim);
+    TT_FATAL(
+        q_pre_shape[3] == expected_q_pre_w,
+        "MLAQKVAssembleFw: q_pre dim 3 must equal n_heads * (qk_nope_dim + qk_rope_dim) = {}. Got {}",
+        expected_q_pre_w,
+        q_pre_shape[3]);
+    TT_FATAL(
+        kv_up_shape[3] == expected_kv_up_w,
+        "MLAQKVAssembleFw: kv_up dim 3 must equal n_heads * (qk_nope_dim + v_dim) = {}. Got {}",
+        expected_kv_up_w,
+        kv_up_shape[3]);
+    TT_FATAL(
+        k_pe_shape[3] == args.qk_rope_dim,
+        "MLAQKVAssembleFw: k_pe dim 3 must equal qk_rope_dim = {}. Got {}",
+        args.qk_rope_dim,
+        k_pe_shape[3]);
+
+    TT_FATAL(
+        args.qk_nope_dim % TILE_WIDTH == 0,
+        "MLAQKVAssembleFw: qk_nope_dim ({}) must be a multiple of TILE_WIDTH ({}).",
+        args.qk_nope_dim,
+        TILE_WIDTH);
+    TT_FATAL(
+        args.qk_rope_dim % TILE_WIDTH == 0,
+        "MLAQKVAssembleFw: qk_rope_dim ({}) must be a multiple of TILE_WIDTH ({}).",
+        args.qk_rope_dim,
+        TILE_WIDTH);
+    TT_FATAL(
+        args.v_dim % TILE_WIDTH == 0,
+        "MLAQKVAssembleFw: v_dim ({}) must be a multiple of TILE_WIDTH ({}).",
+        args.v_dim,
+        TILE_WIDTH);
+    TT_FATAL(
+        kv_up_shape[2] % TILE_HEIGHT == 0,
+        "MLAQKVAssembleFw: S ({}) must be a multiple of TILE_HEIGHT ({}).",
+        kv_up_shape[2],
+        TILE_HEIGHT);
+}
+
+MLAQKVAssembleFwDeviceOperation::spec_return_value_t MLAQKVAssembleFwDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    spec_return_value_t output_specs;
+    output_specs.reserve(3U);
+
+    const auto& kv_up = tensor_args.kv_up;
+    const auto kv_up_shape = kv_up.logical_shape();
+    const uint32_t B = kv_up_shape[0];
+    const uint32_t S = kv_up_shape[2];
+
+    const uint32_t qk_head = args.qk_nope_dim + args.qk_rope_dim;
+
+    const ttnn::Shape q_shape({B, args.n_heads, S, qk_head});
+    const ttnn::Shape k_shape({B, args.n_heads, S, qk_head});
+    const ttnn::Shape v_shape({B, args.n_heads, S, args.v_dim});
+
+    auto layout = tt::tt_metal::TensorLayout(kv_up.dtype(), tt::tt_metal::Layout::TILE, kv_up.memory_config());
+    output_specs.emplace_back(q_shape, layout);
+    output_specs.emplace_back(k_shape, layout);
+    output_specs.emplace_back(v_shape, layout);
+
+    return output_specs;
+}
+
+MLAQKVAssembleFwDeviceOperation::tensor_return_value_t MLAQKVAssembleFwDeviceOperation::create_output_tensors(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    auto specs = compute_output_specs(args, tensor_args);
+    auto* device = tensor_args.kv_up.device();
+    return {
+        create_device_tensor(specs[0], device),
+        create_device_tensor(specs[1], device),
+        create_device_tensor(specs[2], device)};
+}
+
+ttsl::hash::hash_t MLAQKVAssembleFwDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    return tt::tt_metal::operation::hash_operation<MLAQKVAssembleFwDeviceOperation>(
+        args,
+        tensor_args.q_pre.dtype(),
+        tensor_args.q_pre.logical_shape(),
+        tensor_args.kv_up.logical_shape(),
+        tensor_args.k_pe.logical_shape());
+}
+
+MLAQKVAssembleFwDeviceOperation::program_factory_t MLAQKVAssembleFwDeviceOperation::select_program_factory(
+    const operation_attributes_t& /*args*/, const tensor_args_t& /*tensor_args*/) {
+    return MLAQKVAssembleFwProgramFactory{};
+}
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_fw::device
+
+namespace ttnn::prim {
+
+ttml::metal::ops::mla_qkv_assemble_fw::device::MLAQKVAssembleFwDeviceOperation::tensor_return_value_t
+ttml_mla_qkv_assemble_fw(
+    const ttnn::Tensor& q_pre,
+    const ttnn::Tensor& kv_up,
+    const ttnn::Tensor& k_pe,
+    uint32_t n_heads,
+    uint32_t qk_nope_dim,
+    uint32_t qk_rope_dim,
+    uint32_t v_dim) {
+    using OperationType = ttml::metal::ops::mla_qkv_assemble_fw::device::MLAQKVAssembleFwDeviceOperation;
+
+    auto attrs = OperationType::operation_attributes_t{
+        .n_heads = n_heads,
+        .qk_nope_dim = qk_nope_dim,
+        .qk_rope_dim = qk_rope_dim,
+        .v_dim = v_dim,
+    };
+    auto tensor_args = OperationType::tensor_args_t{.q_pre = q_pre, .kv_up = kv_up, .k_pe = k_pe};
+    return ttnn::device_operation::launch<OperationType>(attrs, tensor_args);
+}
+
+}  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_device_operation.hpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+#include "mla_qkv_assemble_fw_device_operation_types.hpp"
+#include "mla_qkv_assemble_fw_program_factory.hpp"
+
+namespace ttml::metal::ops::mla_qkv_assemble_fw::device {
+
+struct MLAQKVAssembleFwDeviceOperation {
+    using operation_attributes_t = ttml::metal::ops::mla_qkv_assemble_fw::device::operation_attributes_t;
+    using tensor_args_t = ttml::metal::ops::mla_qkv_assemble_fw::device::tensor_args_t;
+    using spec_return_value_t = ttml::metal::ops::mla_qkv_assemble_fw::device::spec_return_value_t;
+    using tensor_return_value_t = ttml::metal::ops::mla_qkv_assemble_fw::device::tensor_return_value_t;
+    using program_factory_t = std::variant<MLAQKVAssembleFwProgramFactory>;
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_fw::device
+
+namespace ttnn::prim {
+
+ttml::metal::ops::mla_qkv_assemble_fw::device::MLAQKVAssembleFwDeviceOperation::tensor_return_value_t
+ttml_mla_qkv_assemble_fw(
+    const ttnn::Tensor& q_pre,
+    const ttnn::Tensor& kv_up,
+    const ttnn::Tensor& k_pe,
+    uint32_t n_heads,
+    uint32_t qk_nope_dim,
+    uint32_t qk_rope_dim,
+    uint32_t v_dim);
+
+}  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_device_operation_types.hpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "metal/ttnn_all_includes.hpp"
+
+namespace ttml::metal::ops::mla_qkv_assemble_fw::device {
+
+struct operation_attributes_t {
+    uint32_t n_heads{};
+    uint32_t qk_nope_dim{};
+    uint32_t qk_rope_dim{};
+    uint32_t v_dim{};
+};
+
+struct tensor_args_t {
+    const ttnn::Tensor& q_pre;
+    const ttnn::Tensor& kv_up;
+    const ttnn::Tensor& k_pe;
+};
+
+using tensor_return_value_t = std::vector<ttnn::Tensor>;
+using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_fw::device

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_program_factory.cpp
@@ -30,7 +30,7 @@ constexpr uint32_t kReaderArgKpeAddr = 2;
 
 // writer runtime arg indices
 constexpr uint32_t kWriterArgQAddr = 0;
-constexpr uint32_t kWriterArgKFullAddr = 1;
+constexpr uint32_t kWriterArgKAddr = 1;
 constexpr uint32_t kWriterArgVAddr = 2;
 
 // CB indices
@@ -60,7 +60,7 @@ static void assign_per_core_runtime_args(
     const tt::tt_metal::Buffer* kv_up_buffer,
     const tt::tt_metal::Buffer* k_pe_buffer,
     const tt::tt_metal::Buffer* q_buffer,
-    const tt::tt_metal::Buffer* k_full_buffer,
+    const tt::tt_metal::Buffer* k_buffer,
     const tt::tt_metal::Buffer* v_buffer,
     uint32_t num_cores,
     uint32_t num_cores_y,
@@ -118,7 +118,7 @@ static void assign_per_core_runtime_args(
             kernels.writer,
             core,
             {q_buffer->address(),
-             k_full_buffer->address(),
+             k_buffer->address(),
              v_buffer->address(),
              num_blocks_per_core,
              sb_start,
@@ -136,7 +136,7 @@ MLAQKVAssembleFwProgramFactory::cached_program_t MLAQKVAssembleFwProgramFactory:
     const auto& kv_up = tensor_args.kv_up;
     const auto& k_pe = tensor_args.k_pe;
     auto& q_out = output[0];
-    auto& k_full = output[1];
+    auto& k = output[1];
     auto& v = output[2];
 
     auto* device = kv_up.device();
@@ -154,7 +154,7 @@ MLAQKVAssembleFwProgramFactory::cached_program_t MLAQKVAssembleFwProgramFactory:
     const uint32_t Th = Tn + Tr;
     const uint32_t S_t = S / TILE_HEIGHT;
 
-    // q and k_full share per-head width (qk_head). v has its own width.
+    // q and k share per-head width (qk_head). v has its own width.
     const uint32_t kq_HtWt = S_t * Th;
     const uint32_t v_HtWt = S_t * Tv;
 
@@ -172,6 +172,8 @@ MLAQKVAssembleFwProgramFactory::cached_program_t MLAQKVAssembleFwProgramFactory:
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_blocks);
 
     // ── CBs ──
+    // Validation guarantees q_pre / kv_up / k_pe share dtype, so any of them yields the same
+    // data_format. kv_up is picked because it's also the source-of-truth for B and S above.
     tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(kv_up.dtype());
     const uint32_t single_tile_size = tt::tile_size(data_format);
 
@@ -190,7 +192,7 @@ MLAQKVAssembleFwProgramFactory::cached_program_t MLAQKVAssembleFwProgramFactory:
     auto* kv_up_buffer = kv_up.buffer();
     auto* k_pe_buffer = k_pe.buffer();
     auto* q_buffer = q_out.buffer();
-    auto* k_full_buffer = k_full.buffer();
+    auto* k_buffer = k.buffer();
     auto* v_buffer = v.buffer();
 
     std::vector<uint32_t> reader_compile_time_args = {Th, Tn + Tv, Tr, H};
@@ -200,7 +202,7 @@ MLAQKVAssembleFwProgramFactory::cached_program_t MLAQKVAssembleFwProgramFactory:
 
     std::vector<uint32_t> writer_compile_time_args = {Tn, Tr, Tv, H, kq_HtWt, v_HtWt, S_t};
     tt::tt_metal::TensorAccessorArgs(q_buffer).append_to(writer_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(k_full_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(k_buffer).append_to(writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(v_buffer).append_to(writer_compile_time_args);
 
     std::map<std::string, std::string> defines;
@@ -217,7 +219,7 @@ MLAQKVAssembleFwProgramFactory::cached_program_t MLAQKVAssembleFwProgramFactory:
         kv_up_buffer,
         k_pe_buffer,
         q_buffer,
-        k_full_buffer,
+        k_buffer,
         v_buffer,
         num_cores,
         num_cores_y,
@@ -255,7 +257,7 @@ void MLAQKVAssembleFwProgramFactory::override_runtime_arguments(
     auto* kv_up_buffer = tensor_args.kv_up.buffer();
     auto* k_pe_buffer = tensor_args.k_pe.buffer();
     auto* q_buffer = output[0].buffer();
-    auto* k_full_buffer = output[1].buffer();
+    auto* k_buffer = output[1].buffer();
     auto* v_buffer = output[2].buffer();
 
     auto& reader_runtime_args = GetRuntimeArgs(program, shared.reader_kernel_id);
@@ -272,7 +274,7 @@ void MLAQKVAssembleFwProgramFactory::override_runtime_arguments(
         {
             auto& ra = writer_runtime_args[core.x][core.y];
             ra[kWriterArgQAddr] = q_buffer->address();
-            ra[kWriterArgKFullAddr] = k_full_buffer->address();
+            ra[kWriterArgKAddr] = k_buffer->address();
             ra[kWriterArgVAddr] = v_buffer->address();
         }
     }

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_program_factory.cpp
@@ -1,0 +1,281 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mla_qkv_assemble_fw_program_factory.hpp"
+
+#include <cstdint>
+#include <enchantum/enchantum.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+
+#include "metal/common/program_utils.hpp"
+#include "mla_qkv_assemble_fw_device_operation_types.hpp"
+
+namespace {
+
+constexpr auto kReaderKernelPath =
+    "tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/kernels/dataflow/"
+    "reader_mla_qkv_assemble_fw.cpp";
+
+constexpr auto kWriterKernelPath =
+    "tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/kernels/dataflow/"
+    "writer_mla_qkv_assemble_fw.cpp";
+
+// reader runtime arg indices (for override_runtime_arguments)
+constexpr uint32_t kReaderArgQPreAddr = 0;
+constexpr uint32_t kReaderArgKvUpAddr = 1;
+constexpr uint32_t kReaderArgKpeAddr = 2;
+
+// writer runtime arg indices
+constexpr uint32_t kWriterArgQAddr = 0;
+constexpr uint32_t kWriterArgKFullAddr = 1;
+constexpr uint32_t kWriterArgVAddr = 2;
+
+// CB indices
+constexpr auto kQCbIndex = tt::CBIndex::c_0;
+constexpr auto kKvUpCbIndex = tt::CBIndex::c_1;
+constexpr auto kKpeCbIndex = tt::CBIndex::c_2;
+
+// CB sizing
+constexpr uint32_t kQCbNumTiles = 4U;     // quad-buffered, single-tile micro-blocks
+constexpr uint32_t kKvUpCbNumTiles = 4U;  // quad-buffered, single-tile micro-blocks
+
+}  // namespace
+
+namespace ttml::metal::ops::mla_qkv_assemble_fw::device {
+
+using namespace tt::constants;
+
+struct MLAQKVAssembleFwKernels {
+    tt::tt_metal::KernelHandle reader;
+    tt::tt_metal::KernelHandle writer;
+};
+
+static void assign_per_core_runtime_args(
+    tt::tt_metal::Program& program,
+    const MLAQKVAssembleFwKernels& kernels,
+    const tt::tt_metal::Buffer* q_pre_buffer,
+    const tt::tt_metal::Buffer* kv_up_buffer,
+    const tt::tt_metal::Buffer* k_pe_buffer,
+    const tt::tt_metal::Buffer* q_buffer,
+    const tt::tt_metal::Buffer* k_full_buffer,
+    const tt::tt_metal::Buffer* v_buffer,
+    uint32_t num_cores,
+    uint32_t num_cores_y,
+    uint32_t num_blocks_per_core_group_1,
+    uint32_t num_blocks_per_core_group_2,
+    const tt::tt_metal::CoreRangeSet& core_group_1,
+    const tt::tt_metal::CoreRangeSet& core_group_2,
+    uint32_t S_t,
+    uint32_t q_tiles_per_block,
+    uint32_t kv_up_tiles_per_block,
+    uint32_t kpe_tiles_per_block,
+    uint32_t Th,
+    uint32_t Tv,
+    uint32_t kq_HtWt,
+    uint32_t v_HtWt,
+    uint32_t n_heads) {
+    for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; ++i) {
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        uint32_t num_blocks_per_core = 0;
+        if (core_group_1.contains(core)) {
+            num_blocks_per_core = num_blocks_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_blocks_per_core = num_blocks_per_core_group_2;
+        } else {
+            TT_FATAL(false, "MLAQKVAssembleFw: core not in any work group");
+        }
+
+        // Block index = b * S_t + sb. Inputs q_pre, kv_up, k_pe are flat across blocks.
+        const uint32_t q_pre_tile_id_start = num_blocks_written * q_tiles_per_block;
+        const uint32_t kv_up_tile_id_start = num_blocks_written * kv_up_tiles_per_block;
+        const uint32_t k_pe_tile_id_start = num_blocks_written * kpe_tiles_per_block;
+
+        // Outputs are head-major: tile_id(b, h, sb, w) = b*H*HtWt + h*HtWt + sb*Wt + w.
+        const uint32_t b_start = num_blocks_written / S_t;
+        const uint32_t sb_start = num_blocks_written % S_t;
+        const uint32_t q_tile_id_start = b_start * n_heads * kq_HtWt + sb_start * Th;
+        const uint32_t k_tile_id_start = q_tile_id_start;  // q and k share head_dim → same head-stride
+        const uint32_t v_tile_id_start = b_start * n_heads * v_HtWt + sb_start * Tv;
+
+        SetRuntimeArgs(
+            program,
+            kernels.reader,
+            core,
+            {q_pre_buffer->address(),
+             kv_up_buffer->address(),
+             k_pe_buffer->address(),
+             num_blocks_per_core,
+             q_pre_tile_id_start,
+             kv_up_tile_id_start,
+             k_pe_tile_id_start});
+
+        SetRuntimeArgs(
+            program,
+            kernels.writer,
+            core,
+            {q_buffer->address(),
+             k_full_buffer->address(),
+             v_buffer->address(),
+             num_blocks_per_core,
+             sb_start,
+             q_tile_id_start,
+             k_tile_id_start,
+             v_tile_id_start});
+
+        num_blocks_written += num_blocks_per_core;
+    }
+}
+
+MLAQKVAssembleFwProgramFactory::cached_program_t MLAQKVAssembleFwProgramFactory::create(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    const auto& q_pre = tensor_args.q_pre;
+    const auto& kv_up = tensor_args.kv_up;
+    const auto& k_pe = tensor_args.k_pe;
+    auto& q_out = output[0];
+    auto& k_full = output[1];
+    auto& v = output[2];
+
+    auto* device = kv_up.device();
+    tt::tt_metal::Program program{};
+
+    // ── Tile geometry ──
+    const auto kv_up_shape = kv_up.padded_shape();
+    const uint32_t B = kv_up_shape[0];
+    const uint32_t S = kv_up_shape[2];
+    const uint32_t H = args.n_heads;
+
+    const uint32_t Tn = args.qk_nope_dim / TILE_WIDTH;
+    const uint32_t Tr = args.qk_rope_dim / TILE_WIDTH;
+    const uint32_t Tv = args.v_dim / TILE_WIDTH;
+    const uint32_t Th = Tn + Tr;
+    const uint32_t S_t = S / TILE_HEIGHT;
+
+    // q and k_full share per-head width (qk_head). v has its own width.
+    const uint32_t kq_HtWt = S_t * Th;
+    const uint32_t v_HtWt = S_t * Tv;
+
+    const uint32_t q_tiles_per_block = H * Th;
+    const uint32_t kv_up_tiles_per_block = H * (Tn + Tv);
+    const uint32_t kpe_tiles_per_block = Tr;
+
+    const uint32_t num_blocks = B * S_t;
+
+    // ── Work split ──
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    const uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_blocks);
+
+    // ── CBs ──
+    tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(kv_up.dtype());
+    const uint32_t single_tile_size = tt::tile_size(data_format);
+
+    [[maybe_unused]] auto cb_q =
+        create_circular_buffer(program, all_cores, kQCbIndex, data_format, single_tile_size, kQCbNumTiles);
+
+    [[maybe_unused]] auto cb_kv_up =
+        create_circular_buffer(program, all_cores, kKvUpCbIndex, data_format, single_tile_size, kKvUpCbNumTiles);
+
+    // cb_kpe must hold all Tr tiles for the full block (writer peeks for every head).
+    [[maybe_unused]] auto cb_kpe =
+        create_circular_buffer(program, all_cores, kKpeCbIndex, data_format, single_tile_size, Tr);
+
+    // ── Kernels ──
+    auto* q_pre_buffer = q_pre.buffer();
+    auto* kv_up_buffer = kv_up.buffer();
+    auto* k_pe_buffer = k_pe.buffer();
+    auto* q_buffer = q_out.buffer();
+    auto* k_full_buffer = k_full.buffer();
+    auto* v_buffer = v.buffer();
+
+    std::vector<uint32_t> reader_compile_time_args = {Th, Tn + Tv, Tr, H};
+    tt::tt_metal::TensorAccessorArgs(q_pre_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(kv_up_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(k_pe_buffer).append_to(reader_compile_time_args);
+
+    std::vector<uint32_t> writer_compile_time_args = {Tn, Tr, Tv, H, kq_HtWt, v_HtWt, S_t};
+    tt::tt_metal::TensorAccessorArgs(q_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(k_full_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(v_buffer).append_to(writer_compile_time_args);
+
+    std::map<std::string, std::string> defines;
+
+    MLAQKVAssembleFwKernels kernels;
+    kernels.reader = create_reader_kernel(program, all_cores, reader_compile_time_args, defines, kReaderKernelPath);
+    kernels.writer = create_writer_kernel(program, all_cores, writer_compile_time_args, defines, kWriterKernelPath);
+
+    // ── Runtime args ──
+    assign_per_core_runtime_args(
+        program,
+        kernels,
+        q_pre_buffer,
+        kv_up_buffer,
+        k_pe_buffer,
+        q_buffer,
+        k_full_buffer,
+        v_buffer,
+        num_cores,
+        num_cores_y,
+        num_blocks_per_core_group_1,
+        num_blocks_per_core_group_2,
+        core_group_1,
+        core_group_2,
+        S_t,
+        q_tiles_per_block,
+        kv_up_tiles_per_block,
+        kpe_tiles_per_block,
+        Th,
+        Tv,
+        kq_HtWt,
+        v_HtWt,
+        H);
+
+    return cached_program_t{
+        std::move(program),
+        {/* reader_kernel_id = */ kernels.reader,
+         /* writer_kernel_id = */ kernels.writer,
+         /* num_cores        = */ num_cores,
+         /* num_cores_y      = */ num_cores_y}};
+}
+
+void MLAQKVAssembleFwProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& /*args*/,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    auto& shared = cached_program.shared_variables;
+    auto& program = cached_program.program;
+
+    auto* q_pre_buffer = tensor_args.q_pre.buffer();
+    auto* kv_up_buffer = tensor_args.kv_up.buffer();
+    auto* k_pe_buffer = tensor_args.k_pe.buffer();
+    auto* q_buffer = output[0].buffer();
+    auto* k_full_buffer = output[1].buffer();
+    auto* v_buffer = output[2].buffer();
+
+    auto& reader_runtime_args = GetRuntimeArgs(program, shared.reader_kernel_id);
+    auto& writer_runtime_args = GetRuntimeArgs(program, shared.writer_kernel_id);
+
+    for (uint32_t i = 0; i < shared.num_cores; ++i) {
+        tt::tt_metal::CoreCoord core = {i / shared.num_cores_y, i % shared.num_cores_y};
+        {
+            auto& ra = reader_runtime_args[core.x][core.y];
+            ra[kReaderArgQPreAddr] = q_pre_buffer->address();
+            ra[kReaderArgKvUpAddr] = kv_up_buffer->address();
+            ra[kReaderArgKpeAddr] = k_pe_buffer->address();
+        }
+        {
+            auto& ra = writer_runtime_args[core.x][core.y];
+            ra[kWriterArgQAddr] = q_buffer->address();
+            ra[kWriterArgKFullAddr] = k_full_buffer->address();
+            ra[kWriterArgVAddr] = v_buffer->address();
+        }
+    }
+}
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_fw::device

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_program_factory.hpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+#include "mla_qkv_assemble_fw_device_operation_types.hpp"
+
+namespace ttml::metal::ops::mla_qkv_assemble_fw::device {
+
+struct MLAQKVAssembleFwProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle reader_kernel_id{};
+        tt::tt_metal::KernelHandle writer_kernel_id{};
+        uint32_t num_cores{};
+        uint32_t num_cores_y{};
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_fw::device

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/mla_qkv_assemble_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/mla_qkv_assemble_fw.cpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mla_qkv_assemble_fw.hpp"
+
+#include "device/mla_qkv_assemble_fw_device_operation.hpp"
+
+namespace ttml::metal {
+
+std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> mla_qkv_assemble_fw(
+    const ttnn::Tensor& q_pre,
+    const ttnn::Tensor& kv_up,
+    const ttnn::Tensor& k_pe,
+    uint32_t n_heads,
+    uint32_t qk_nope_dim,
+    uint32_t qk_rope_dim,
+    uint32_t v_dim) {
+    auto result = ttnn::prim::ttml_mla_qkv_assemble_fw(q_pre, kv_up, k_pe, n_heads, qk_nope_dim, qk_rope_dim, v_dim);
+    return {result[0], result[1], result[2]};
+}
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/mla_qkv_assemble_fw.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/mla_qkv_assemble_fw.hpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <utility>
+
+#include "metal/ttnn_all_includes.hpp"
+
+namespace ttml::metal {
+
+// Fused QKV assembly for DeepSeek MLA.
+//
+// Splits Q into per-head layout, demuxes the per-head [k_nope_h | v_h] stripes
+// from a single packed projection output (the result of `wkv_b`), and
+// broadcasts the post-RoPE shared `k_pe` into every head's rope-suffix. Pure
+// data movement — RoPE on Q's rope-suffix happens *outside* this op (a
+// `rope_partial` call after).
+//
+// Shapes (TILE layout, INTERLEAVED memory):
+//   q_pre  : [B, 1, S, n_heads * (qk_nope_dim + qk_rope_dim)]
+//   kv_up  : [B, 1, S, n_heads * (qk_nope_dim + v_dim)]
+//   k_pe   : [B, 1, S, qk_rope_dim]                       (shared across heads)
+//   q      : [B, n_heads, S, qk_nope_dim + qk_rope_dim]   (output, head-split, NOT yet RoPE'd)
+//   k_full : [B, n_heads, S, qk_nope_dim + qk_rope_dim]   (output, k_nope | broadcast k_pe)
+//   v      : [B, n_heads, S, v_dim]                       (output)
+//
+// Per-head dims and S must be tile-aligned (multiples of TILE_W=TILE_H=32).
+//
+// Returns: {q, k_full, v}
+std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> mla_qkv_assemble_fw(
+    const ttnn::Tensor& q_pre,
+    const ttnn::Tensor& kv_up,
+    const ttnn::Tensor& k_pe,
+    uint32_t n_heads,
+    uint32_t qk_nope_dim,
+    uint32_t qk_rope_dim,
+    uint32_t v_dim);
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/mla_qkv_assemble_fw.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/mla_qkv_assemble_fw.hpp
@@ -17,19 +17,19 @@ namespace ttml::metal {
 // from a single packed projection output (the result of `wkv_b`), and
 // broadcasts the post-RoPE shared `k_pe` into every head's rope-suffix. Pure
 // data movement — RoPE on Q's rope-suffix happens *outside* this op (a
-// `rope_partial` call after).
+// `rope_trailing` call after).
 //
 // Shapes (TILE layout, INTERLEAVED memory):
 //   q_pre  : [B, 1, S, n_heads * (qk_nope_dim + qk_rope_dim)]
 //   kv_up  : [B, 1, S, n_heads * (qk_nope_dim + v_dim)]
 //   k_pe   : [B, 1, S, qk_rope_dim]                       (shared across heads)
 //   q      : [B, n_heads, S, qk_nope_dim + qk_rope_dim]   (output, head-split, NOT yet RoPE'd)
-//   k_full : [B, n_heads, S, qk_nope_dim + qk_rope_dim]   (output, k_nope | broadcast k_pe)
+//   k      : [B, n_heads, S, qk_nope_dim + qk_rope_dim]   (output, k_nope | broadcast k_pe)
 //   v      : [B, n_heads, S, v_dim]                       (output)
 //
 // Per-head dims and S must be tile-aligned (multiples of TILE_W=TILE_H=32).
 //
-// Returns: {q, k_full, v}
+// Returns: {q, k, v}
 std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> mla_qkv_assemble_fw(
     const ttnn::Tensor& q_pre,
     const ttnn::Tensor& kv_up,

--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -23,6 +23,7 @@
 #include "ops/linear_op.hpp"
 #include "ops/losses.hpp"
 #include "ops/matmul_op.hpp"
+#include "ops/mla_qkv_assemble_op.hpp"
 #include "ops/multi_head_utils.hpp"
 #include "ops/polynorm_op.hpp"
 #include "ops/rand_op.hpp"
@@ -56,6 +57,7 @@ void py_module_types(nb::module_& m) {
     }
 
     m.def_submodule("matmul");
+    m.def_submodule("mla");
     m.def_submodule("multi_head_utils");
     m.def_submodule("attention");
     m.def_submodule("reshape");
@@ -246,6 +248,20 @@ void py_module(nb::module_& m) {
             nb::arg("kvs"),
             nb::arg("num_heads"),
             nb::arg("num_groups"));
+    }
+
+    {
+        auto py_mla = static_cast<nb::module_>(m.attr("mla"));
+        py_mla.def(
+            "qkv_assemble",
+            &ttml::ops::mla_qkv_assemble,
+            nb::arg("q_pre"),
+            nb::arg("kv_up"),
+            nb::arg("k_pe"),
+            nb::arg("n_heads"),
+            nb::arg("qk_nope_dim"),
+            nb::arg("qk_rope_dim"),
+            nb::arg("v_dim"));
     }
 
     {

--- a/tt-train/sources/ttml/ops/mla_qkv_assemble_op.cpp
+++ b/tt-train/sources/ttml/ops/mla_qkv_assemble_op.cpp
@@ -25,11 +25,11 @@ std::tuple<autograd::TensorPtr, autograd::TensorPtr, autograd::TensorPtr> mla_qk
     uint32_t qk_nope_dim,
     uint32_t qk_rope_dim,
     uint32_t v_dim) {
-    auto [q_raw, k_full_raw, v_raw] = ttml::metal::mla_qkv_assemble_fw(
+    auto [q_raw, k_raw, v_raw] = ttml::metal::mla_qkv_assemble_fw(
         q_pre->get_value(), kv_up->get_value(), k_pe->get_value(), n_heads, qk_nope_dim, qk_rope_dim, v_dim);
 
     auto out_q = autograd::create_tensor(q_raw);
-    auto out_k = autograd::create_tensor(k_full_raw);
+    auto out_k = autograd::create_tensor(k_raw);
     auto out_v = autograd::create_tensor(v_raw);
 
     autograd::GradFunction grad =

--- a/tt-train/sources/ttml/ops/mla_qkv_assemble_op.cpp
+++ b/tt-train/sources/ttml/ops/mla_qkv_assemble_op.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mla_qkv_assemble_op.hpp"
+
+#include <cstdint>
+#include <tuple>
+#include <utility>
+
+#include "autograd/auto_context.hpp"
+#include "autograd/graph.hpp"
+#include "autograd/graph_utils.hpp"
+#include "autograd/tensor.hpp"
+#include "metal/operations.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttml::ops {
+
+std::tuple<autograd::TensorPtr, autograd::TensorPtr, autograd::TensorPtr> mla_qkv_assemble(
+    const autograd::TensorPtr& q_pre,
+    const autograd::TensorPtr& kv_up,
+    const autograd::TensorPtr& k_pe,
+    uint32_t n_heads,
+    uint32_t qk_nope_dim,
+    uint32_t qk_rope_dim,
+    uint32_t v_dim) {
+    auto [q_raw, k_full_raw, v_raw] = ttml::metal::mla_qkv_assemble_fw(
+        q_pre->get_value(), kv_up->get_value(), k_pe->get_value(), n_heads, qk_nope_dim, qk_rope_dim, v_dim);
+
+    auto out_q = autograd::create_tensor(q_raw);
+    auto out_k = autograd::create_tensor(k_full_raw);
+    auto out_v = autograd::create_tensor(v_raw);
+
+    autograd::GradFunction grad =
+        [q_pre, kv_up, k_pe, out_q, out_k, out_v, n_heads, qk_nope_dim, qk_rope_dim, v_dim]() {
+            auto [dq_pre, dkv_up, dk_pe] = ttml::metal::mla_qkv_assemble_bw(
+                out_q->get_grad(), out_k->get_grad(), out_v->get_grad(), n_heads, qk_nope_dim, qk_rope_dim, v_dim);
+            q_pre->add_grad(dq_pre);
+            kv_up->add_grad(dkv_up);
+            k_pe->add_grad(dk_pe);
+        };
+
+    auto q_node = autograd::add_backward_node(std::move(grad), out_q, q_pre, kv_up, k_pe);
+    if (q_node.has_value()) {
+        out_q->set_node(q_node);
+        // Sync nodes on out_k and out_v ensure dK and dV are populated before grad lambda runs.
+        out_k->set_node(autograd::add_backward_node_always([]() {}, out_k, q_pre, kv_up, k_pe, out_q));
+        out_v->set_node(autograd::add_backward_node_always([]() {}, out_v, q_pre, kv_up, k_pe, out_q));
+    }
+
+    return {out_q, out_k, out_v};
+}
+
+}  // namespace ttml::ops

--- a/tt-train/sources/ttml/ops/mla_qkv_assemble_op.hpp
+++ b/tt-train/sources/ttml/ops/mla_qkv_assemble_op.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <utility>
+
+#include "autograd/tensor.hpp"
+
+namespace ttml::ops {
+
+// Autograd-aware fused MLA QKV assembly. See ``ttml::metal::mla_qkv_assemble_fw``
+// for shape semantics. Forward dispatches to the metal kernel; backward is
+// composed from existing ttnn primitives (sum, slice, concat, transpose,
+// reshape) and registered with the C++ autograd graph.
+//
+// Returns {q, k_full, v}. Q is head-split but NOT yet RoPE'd — the caller
+// applies ``rope_partial`` afterward.
+std::tuple<autograd::TensorPtr, autograd::TensorPtr, autograd::TensorPtr> mla_qkv_assemble(
+    const autograd::TensorPtr& q_pre,
+    const autograd::TensorPtr& kv_up,
+    const autograd::TensorPtr& k_pe,
+    uint32_t n_heads,
+    uint32_t qk_nope_dim,
+    uint32_t qk_rope_dim,
+    uint32_t v_dim);
+
+}  // namespace ttml::ops

--- a/tt-train/sources/ttml/ops/mla_qkv_assemble_op.hpp
+++ b/tt-train/sources/ttml/ops/mla_qkv_assemble_op.hpp
@@ -12,12 +12,12 @@
 namespace ttml::ops {
 
 // Autograd-aware fused MLA QKV assembly. See ``ttml::metal::mla_qkv_assemble_fw``
-// for shape semantics. Forward dispatches to the metal kernel; backward is
-// composed from existing ttnn primitives (sum, slice, concat, transpose,
-// reshape) and registered with the C++ autograd graph.
+// for shape semantics. Forward and backward each dispatch to a dedicated metal
+// kernel (``mla_qkv_assemble_fw`` / ``mla_qkv_assemble_bw``); the backward node
+// is registered with the C++ autograd graph.
 //
-// Returns {q, k_full, v}. Q is head-split but NOT yet RoPE'd — the caller
-// applies ``rope_partial`` afterward.
+// Returns {q, k, v}. Q is head-split but NOT yet RoPE'd — the caller
+// applies ``rope_trailing`` afterward.
 std::tuple<autograd::TensorPtr, autograd::TensorPtr, autograd::TensorPtr> mla_qkv_assemble(
     const autograd::TensorPtr& q_pre,
     const autograd::TensorPtr& kv_up,

--- a/tt-train/sources/ttml/ttml/models/deepseek/autograd_ops.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/autograd_ops.py
@@ -64,43 +64,6 @@ class Slice(ttml.autograd.Function):
         return result
 
 
-class Concat(ttml.autograd.Function):
-    """Autograd-aware concat (ttnn.concat has no backward).
-
-    Forward: concatenate tensors along a dimension.
-    Backward: split gradient and distribute to each input.
-    """
-
-    @staticmethod
-    def forward(ctx, dim, *tensors):
-        sizes = [list(t.get_value().shape)[dim] for t in tensors]
-        ctx.sizes = sizes
-        ctx.dim = dim
-        ctx.num_tensors = len(tensors)
-
-        raw_tensors = [t.get_value() for t in tensors]
-        return ttnn.concat(raw_tensors, dim)
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        dim = ctx.dim
-        sizes = ctx.sizes
-        shape = list(grad_output.shape)
-
-        grads = []
-        offset = 0
-        for size in sizes:
-            start = [0] * len(shape)
-            end = list(shape)
-            start[dim] = offset
-            end[dim] = offset + size
-            grad_slice = ttnn.slice(grad_output, start, end)
-            grads.append(grad_slice)
-            offset += size
-
-        return tuple(grads)
-
-
 class Sigmoid(ttml.autograd.Function):
     """Autograd-aware sigmoid.
 
@@ -142,40 +105,67 @@ class Softmax(ttml.autograd.Function):
         return grad_input
 
 
-class SplitHeads(ttml.autograd.Function):
-    """Reshape (B, 1, S, H*D) -> (B, H, S, D) with correct data layout.
+class RoPEPartial(ttml.autograd.Function):
+    """RoPE the last ``rope_dim`` columns of a 4-D tensor; pass the prefix through.
 
-    A plain reshape would corrupt the data ordering. This does:
-      Forward:  reshape to (B, S, H, D) then transpose dims 1,2
-      Backward: transpose dims 1,2 then reshape back
+    Replaces the slice -> rope -> concat pattern (used in MLA's Q path) with a
+    single autograd node so the slice/concat backward graph is collapsed into
+    one rope-bwd call plus a same-shape concat. ``rope_dim`` is taken from
+    ``rope_params.head_dim``.
     """
 
     @staticmethod
-    def forward(ctx, input, num_heads):
-        val = input.get_value()
-        B, _, S, HD = list(val.shape)
-        head_dim = HD // num_heads
-        ctx.num_heads = num_heads
+    def forward(ctx, input, rope_params):
+        x = input.get_value()
+        B, H, S, head_dim = list(x.shape)
+        rope_dim = rope_params.head_dim
+        nope_dim = head_dim - rope_dim
+
+        suffix = ttnn.slice(x, [0, 0, 0, nope_dim], [B, H, S, head_dim])
+        suffix_squished = ttnn.reshape(suffix, [1, B * H, S, rope_dim])
+        suffix_rotated_squished = ttnn.experimental.rotary_embedding_llama(
+            suffix_squished,
+            rope_params.cos_cache,
+            rope_params.sin_cache,
+            rope_params.trans_mat,
+            is_decode_mode=False,
+        )
+        suffix_rotated = ttnn.reshape(suffix_rotated_squished, [B, H, S, rope_dim])
+
+        prefix = ttnn.slice(x, [0, 0, 0, 0], [B, H, S, nope_dim])
+        out = ttnn.concat([prefix, suffix_rotated], dim=3)
+
         ctx.B = B
+        ctx.H = H
         ctx.S = S
         ctx.head_dim = head_dim
-
-        # (B, 1, S, H*D) -> (B, S, H, D) -> (B, H, S, D)
-        reshaped = ttnn.reshape(val, [B, S, num_heads, head_dim])
-        transposed = ttnn.transpose(reshaped, 1, 2)
-        return transposed
+        ctx.rope_dim = rope_dim
+        ctx.nope_dim = nope_dim
+        ctx.rope_params = rope_params
+        return out
 
     @staticmethod
     def backward(ctx, grad_output):
-        B = ctx.B
-        S = ctx.S
-        num_heads = ctx.num_heads
+        B, H, S = ctx.B, ctx.H, ctx.S
         head_dim = ctx.head_dim
+        rope_dim = ctx.rope_dim
+        nope_dim = ctx.nope_dim
+        rope_params = ctx.rope_params
 
-        # (B, H, S, D) -> (B, S, H, D) -> (B, 1, S, H*D)
-        transposed = ttnn.transpose(grad_output, 1, 2)
-        reshaped = ttnn.reshape(transposed, [B, 1, S, num_heads * head_dim])
-        return reshaped
+        grad_suffix = ttnn.slice(grad_output, [0, 0, 0, nope_dim], [B, H, S, head_dim])
+        grad_suffix_squished = ttnn.reshape(grad_suffix, [1, B * H, S, rope_dim])
+        grad_suffix_unrotated_squished = ttnn.experimental.rotary_embedding_llama(
+            grad_suffix_squished,
+            rope_params.neg_cos_cache,
+            rope_params.neg_sin_cache,
+            rope_params.trans_mat,
+            is_decode_mode=False,
+        )
+        grad_suffix_unrotated = ttnn.reshape(grad_suffix_unrotated_squished, [B, H, S, rope_dim])
+
+        grad_prefix = ttnn.slice(grad_output, [0, 0, 0, 0], [B, H, S, nope_dim])
+        grad_input = ttnn.concat([grad_prefix, grad_suffix_unrotated], dim=3)
+        return grad_input
 
 
 class MoERoutingNormalize(ttml.autograd.Function):
@@ -252,11 +242,6 @@ def autograd_slice(tensor, start, end):
     return Slice.apply(tensor, start, end)
 
 
-def autograd_concat(tensors, dim):
-    """Concat with autograd backward."""
-    return Concat.apply(dim, *tensors)
-
-
 def autograd_sigmoid(tensor):
     """Sigmoid with autograd backward."""
     return Sigmoid.apply(tensor)
@@ -267,9 +252,12 @@ def autograd_softmax(tensor):
     return Softmax.apply(tensor)
 
 
-def split_heads(tensor, num_heads):
-    """(B, 1, S, H*D) -> (B, H, S, D) with proper transpose."""
-    return SplitHeads.apply(tensor, num_heads)
+def rope_partial(tensor, rope_params):
+    """RoPE the last ``rope_params.head_dim`` columns; prefix is identity.
+
+    Replaces the slice -> rope -> concat pattern with a single autograd node.
+    """
+    return RoPEPartial.apply(tensor, rope_params)
 
 
 def moe_routing_normalize(scores, mask, route_scale, eps=1e-20):

--- a/tt-train/sources/ttml/ttml/models/deepseek/autograd_ops.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/autograd_ops.py
@@ -105,7 +105,7 @@ class Softmax(ttml.autograd.Function):
         return grad_input
 
 
-class RoPEPartial(ttml.autograd.Function):
+class RoPETrailing(ttml.autograd.Function):
     """RoPE the last ``rope_dim`` columns of a 4-D tensor; pass the prefix through.
 
     Replaces the slice -> rope -> concat pattern (used in MLA's Q path) with a
@@ -252,12 +252,12 @@ def autograd_softmax(tensor):
     return Softmax.apply(tensor)
 
 
-def rope_partial(tensor, rope_params):
+def rope_trailing(tensor, rope_params):
     """RoPE the last ``rope_params.head_dim`` columns; prefix is identity.
 
     Replaces the slice -> rope -> concat pattern with a single autograd node.
     """
-    return RoPEPartial.apply(tensor, rope_params)
+    return RoPETrailing.apply(tensor, rope_params)
 
 
 def moe_routing_normalize(scores, mask, route_scale, eps=1e-20):

--- a/tt-train/sources/ttml/ttml/models/deepseek/mla.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/mla.py
@@ -16,22 +16,27 @@ Key features:
 from __future__ import annotations
 
 import ttml
+from ttml.common.profiler_utils import profiler_marker
 from ttml.modules import AbstractModuleBase, LinearLayer
 
 from .transformer import RMSNormLayer
-from .autograd_ops import autograd_slice, autograd_concat, split_heads
+from .autograd_ops import autograd_slice, rope_partial
 
 
 class MultiHeadLatentAttention(AbstractModuleBase):
-    """Multi-head Latent Attention (MLA) layer.
+    """Multi-head Latent Attention (MLA) layer for DeepSeek-V3.
 
-    Follows the DeepSeek-V3 naive-mode attention:
-      Q (q_lora_rank > 0): x -> wq_a -> norm -> wq_b -> split_heads
-      Q (q_lora_rank == 0): x -> wq -> split_heads   (direct, no LoRA bottleneck)
-      Both: -> [q_nope, q_pe] -> RoPE(q_pe) -> cat
-      KV: x -> wkv_a -> [kv_latent, k_pe] -> norm(kv_latent) -> wkv_b -> split_heads
-          -> [k_nope, v] + RoPE(k_pe) broadcast -> cat(k_nope, k_pe)
-      Attention: composite_SDPA(Q, K, V, mask) -> fuse_heads -> wo
+    Naive-mode flow (no KV-cache absorption):
+      Q   : x -> [wq | wq_a -> q_norm -> wq_b]                       # [B, 1, S, H*qk_head]
+      KV  : x -> wkv_a -> [kv_latent, k_pe]                          # split low-rank latent + rope-half
+            kv_latent -> kv_norm -> wkv_b                            # [B, 1, S, H*(qk_nope+v_dim)]
+            k_pe      -> RoPE                                        # [B, 1, S, qk_rope]
+      QKV : (q_pre, kv_up, k_pe) -> mla.qkv_assemble                 # head-split + broadcast k_pe + demux v
+                                  -> q  [B, H, S, qk_head]           (not yet RoPE'd)
+                                  -> k  [B, H, S, qk_head]           (k_nope | broadcast k_pe)
+                                  -> v  [B, H, S, v_dim]
+            q   -> rope_partial(rotate trailing qk_rope cols)
+      Attn: composite_SDPA(q, k, v, mask) -> heads_fusion -> wo
     """
 
     def __init__(self, config, rope_params) -> None:
@@ -75,47 +80,64 @@ class MultiHeadLatentAttention(AbstractModuleBase):
         n_heads = self.n_heads
         qk_nope = self.qk_nope_head_dim
         qk_rope = self.qk_rope_head_dim
-        qk_head = self.qk_head_dim
         v_dim = self.v_head_dim
-
-        # ── Q path ──
-        if self.q_lora_rank == 0:
-            q = self.wq(x)  # [B, 1, S, n_heads * qk_head]
-        else:
-            q = self.wq_b(self.q_norm(self.wq_a(x)))  # [B, 1, S, n_heads * qk_head]
-        q = split_heads(q, n_heads)  # [B, n_heads, S, qk_head]
-
-        q_nope = autograd_slice(q, [0, 0, 0, 0], [B, n_heads, S, qk_nope])
-        q_pe = autograd_slice(q, [0, 0, 0, qk_nope], [B, n_heads, S, qk_head])
-        q_pe = ttml.ops.rope.rope(q_pe, self.rope_params)
-
-        # ── KV path ──
-        kv_full = self.wkv_a(x)  # [B, 1, S, kv_lora_rank + qk_rope]
         kv_lora = self.kv_lora_rank
 
+        x_in = profiler_marker(x, "[START] [MLA]")
+
+        # ── Q projection (head-split is deferred to the fused QKV-assemble below) ──
+        x_q = profiler_marker(x_in, "[START] [MLA] Q-Proj")
+        if self.q_lora_rank == 0:
+            assert self.wq is not None, "Q projection without LoRA requires wq"
+            q_pre = self.wq(x_q)
+        else:
+            assert self.wq_a is not None, "Q projection with LoRA requires wq_a"
+            assert self.q_norm is not None, "Q projection with LoRA requires q_norm"
+            assert self.wq_b is not None, "Q projection with LoRA requires wq_b"
+            q_pre = self.wq_b(self.q_norm(self.wq_a(x_q)))
+        # q_pre : [B, 1, S, n_heads * qk_head]
+        q_pre = profiler_marker(q_pre, "[END] [MLA] Q-Proj")
+
+        # ── KV down-projection: split into low-rank latent and the shared rope-half ──
+        x_kv = profiler_marker(x_in, "[START] [MLA] KV-Down")
+        kv_full = self.wkv_a(x_kv)  # [B, 1, S, kv_lora + qk_rope]
         kv = autograd_slice(kv_full, [0, 0, 0, 0], [B, 1, S, kv_lora])
         k_pe = autograd_slice(kv_full, [0, 0, 0, kv_lora], [B, 1, S, kv_lora + qk_rope])
+        k_pe = profiler_marker(k_pe, "[END] [MLA] KV-Down")
 
-        # RoPE on k_pe (shared across heads, shape [B, 1, S, qk_rope])
-        k_pe = ttml.ops.rope.rope(k_pe, self.rope_params)
+        # ── RoPE on shared k_pe (per-token, not per-head) ──
+        k_pe = profiler_marker(k_pe, "[START] [MLA] RoPE-K")
+        k_pe = ttml.ops.rope.rope(k_pe, self.rope_params)  # [B, 1, S, qk_rope]
+        k_pe = profiler_marker(k_pe, "[END] [MLA] RoPE-K")
 
-        # Expand k_pe to all heads: [B, 1, S, qk_rope] -> [B, n_heads, S, qk_rope]
-        k_pe = autograd_concat([k_pe] * n_heads, dim=1)
-
-        # Up-project KV latent and split into per-head k_nope and v
+        # ── KV up-projection (produces packed per-head [k_nope | v]) ──
+        kv = profiler_marker(kv, "[START] [MLA] KV-Up")
         kv_up = self.wkv_b(self.kv_norm(kv))  # [B, 1, S, n_heads * (qk_nope + v_dim)]
-        kv_up = split_heads(kv_up, n_heads)  # [B, n_heads, S, qk_nope + v_dim]
+        kv_up = profiler_marker(kv_up, "[END] [MLA] KV-Up")
 
-        k_nope = autograd_slice(kv_up, [0, 0, 0, 0], [B, n_heads, S, qk_nope])
-        v = autograd_slice(kv_up, [0, 0, 0, qk_nope], [B, n_heads, S, qk_nope + v_dim])
+        # ── Fused QKV assembly ──
+        # Q head-split, KV demux into per-head (k_nope, v), and broadcast k_pe
+        # into every head's rope-suffix of K. Q is emitted head-split but NOT
+        # yet rotated; rope_partial below applies RoPE to Q's rope-suffix.
+        q_pre = profiler_marker(q_pre, "[START] [MLA] QKV-Assemble")
+        q, k_full, v = ttml.ops.mla.qkv_assemble(q_pre, kv_up, k_pe, n_heads, qk_nope, qk_rope, v_dim)
+        # q, k_full : [B, n_heads, S, qk_head]
+        # v         : [B, n_heads, S, v_dim]
+        q = profiler_marker(q, "[END] [MLA] QKV-Assemble")
 
-        # Assemble full Q and K
-        q_full = autograd_concat([q_nope, q_pe], dim=3)  # [B, H, S, qk_head]
-        k_full = autograd_concat([k_nope, k_pe], dim=3)  # [B, H, S, qk_head]
+        q = profiler_marker(q, "[START] [MLA] RoPE-Q")
+        q = rope_partial(q, self.rope_params)
+        q = profiler_marker(q, "[END] [MLA] RoPE-Q")
 
         # ── Attention (composite path supports v_dim != qk_head) ──
-        attn = ttml.ops.attention.scaled_dot_product_attention_composite(q_full, k_full, v, mask)
+        q = profiler_marker(q, "[START] [MLA] SDPA")
+        attn = ttml.ops.attention.scaled_dot_product_attention_composite(q, k_full, v, mask)
+        attn = profiler_marker(attn, "[END] [MLA] SDPA")
 
-        # ── Output ──
+        # ── Output projection ──
+        attn = profiler_marker(attn, "[START] [MLA] Output")
         attn = ttml.ops.multi_head_utils.heads_fusion(attn)  # [B, 1, S, n_heads * v_dim]
-        return self.wo(attn)
+        out = self.wo(attn)
+        out = profiler_marker(out, "[END] [MLA] Output")
+
+        return profiler_marker(out, "[END] [MLA]")

--- a/tt-train/sources/ttml/ttml/models/deepseek/mla.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/mla.py
@@ -20,7 +20,7 @@ from ttml.common.profiler_utils import profiler_marker
 from ttml.modules import AbstractModuleBase, LinearLayer
 
 from .transformer import RMSNormLayer
-from .autograd_ops import autograd_slice, rope_partial
+from .autograd_ops import autograd_slice, rope_trailing
 
 
 class MultiHeadLatentAttention(AbstractModuleBase):
@@ -29,13 +29,13 @@ class MultiHeadLatentAttention(AbstractModuleBase):
     Naive-mode flow (no KV-cache absorption):
       Q   : x -> [wq | wq_a -> q_norm -> wq_b]                       # [B, 1, S, H*qk_head]
       KV  : x -> wkv_a -> [kv_latent, k_pe]                          # split low-rank latent + rope-half
-            kv_latent -> kv_norm -> wkv_b                            # [B, 1, S, H*(qk_nope+v_dim)]
-            k_pe      -> RoPE                                        # [B, 1, S, qk_rope]
+            kv_latent -> kv_norm -> wkv_b                            # [B, 1, S, H*(qk_nope_dim+v_dim)]
+            k_pe      -> RoPE                                        # [B, 1, S, qk_rope_dim]
       QKV : (q_pre, kv_up, k_pe) -> mla.qkv_assemble                 # head-split + broadcast k_pe + demux v
                                   -> q  [B, H, S, qk_head]           (not yet RoPE'd)
                                   -> k  [B, H, S, qk_head]           (k_nope | broadcast k_pe)
                                   -> v  [B, H, S, v_dim]
-            q   -> rope_partial(rotate trailing qk_rope cols)
+            q   -> rope_trailing(rotate trailing qk_rope_dim cols)
       Attn: composite_SDPA(q, k, v, mask) -> heads_fusion -> wo
     """
 
@@ -78,10 +78,10 @@ class MultiHeadLatentAttention(AbstractModuleBase):
     def forward(self, x: ttml.autograd.Tensor, mask: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
         B, _, S, _ = list(x.get_value().shape)
         n_heads = self.n_heads
-        qk_nope = self.qk_nope_head_dim
-        qk_rope = self.qk_rope_head_dim
+        qk_nope_dim = self.qk_nope_head_dim
+        qk_rope_dim = self.qk_rope_head_dim
         v_dim = self.v_head_dim
-        kv_lora = self.kv_lora_rank
+        kv_latent_rank = self.kv_lora_rank
 
         x_in = profiler_marker(x, "[START] [MLA]")
 
@@ -100,33 +100,33 @@ class MultiHeadLatentAttention(AbstractModuleBase):
 
         # ── KV down-projection: split into low-rank latent and the shared rope-half ──
         x_kv = profiler_marker(x_in, "[START] [MLA] KV-Down")
-        kv_full = self.wkv_a(x_kv)  # [B, 1, S, kv_lora + qk_rope]
-        kv = autograd_slice(kv_full, [0, 0, 0, 0], [B, 1, S, kv_lora])
-        k_pe = autograd_slice(kv_full, [0, 0, 0, kv_lora], [B, 1, S, kv_lora + qk_rope])
+        kv_down = self.wkv_a(x_kv)  # [B, 1, S, kv_latent_rank + qk_rope_dim]
+        kv_latent = autograd_slice(kv_down, [0, 0, 0, 0], [B, 1, S, kv_latent_rank])
+        k_pe = autograd_slice(kv_down, [0, 0, 0, kv_latent_rank], [B, 1, S, kv_latent_rank + qk_rope_dim])
         k_pe = profiler_marker(k_pe, "[END] [MLA] KV-Down")
 
         # ── RoPE on shared k_pe (per-token, not per-head) ──
         k_pe = profiler_marker(k_pe, "[START] [MLA] RoPE-K")
-        k_pe = ttml.ops.rope.rope(k_pe, self.rope_params)  # [B, 1, S, qk_rope]
+        k_pe = ttml.ops.rope.rope(k_pe, self.rope_params)  # [B, 1, S, qk_rope_dim]
         k_pe = profiler_marker(k_pe, "[END] [MLA] RoPE-K")
 
         # ── KV up-projection (produces packed per-head [k_nope | v]) ──
-        kv = profiler_marker(kv, "[START] [MLA] KV-Up")
-        kv_up = self.wkv_b(self.kv_norm(kv))  # [B, 1, S, n_heads * (qk_nope + v_dim)]
+        kv_latent = profiler_marker(kv_latent, "[START] [MLA] KV-Up")
+        kv_up = self.wkv_b(self.kv_norm(kv_latent))  # [B, 1, S, n_heads * (qk_nope_dim + v_dim)]
         kv_up = profiler_marker(kv_up, "[END] [MLA] KV-Up")
 
         # ── Fused QKV assembly ──
         # Q head-split, KV demux into per-head (k_nope, v), and broadcast k_pe
         # into every head's rope-suffix of K. Q is emitted head-split but NOT
-        # yet rotated; rope_partial below applies RoPE to Q's rope-suffix.
+        # yet rotated; rope_trailing below applies RoPE to Q's rope-suffix.
         q_pre = profiler_marker(q_pre, "[START] [MLA] QKV-Assemble")
-        q, k_full, v = ttml.ops.mla.qkv_assemble(q_pre, kv_up, k_pe, n_heads, qk_nope, qk_rope, v_dim)
+        q, k_full, v = ttml.ops.mla.qkv_assemble(q_pre, kv_up, k_pe, n_heads, qk_nope_dim, qk_rope_dim, v_dim)
         # q, k_full : [B, n_heads, S, qk_head]
         # v         : [B, n_heads, S, v_dim]
         q = profiler_marker(q, "[END] [MLA] QKV-Assemble")
 
         q = profiler_marker(q, "[START] [MLA] RoPE-Q")
-        q = rope_partial(q, self.rope_params)
+        q = rope_trailing(q, self.rope_params)
         q = profiler_marker(q, "[END] [MLA] RoPE-Q")
 
         # ── Attention (composite path supports v_dim != qk_head) ──


### PR DESCRIPTION
### Summary

- Add `mla_qkv_assemble_fw` metal op (reader+writer kernels, no compute) under `tt-train/sources/ttml/metal/ops/`.
- Add `mla_qkv_assemble_bw` metal op (reader+compute+writer; compute does head-axis sum-reduction for `dk_pe` via DST-register accumulation).
- Add `ttml::ops::mla_qkv_assemble` autograd wrapper and Python binding `ttml.ops.mla.qkv_assemble`.
- Add `RoPETrailing` autograd Function (`rope_trailing`) — RoPE on the trailing `rope_dim` columns of a tensor, prefix passes through.
- Replace MLA's split_heads + slices + 128× k_pe broadcast + concats with a single `ttml.ops.mla.qkv_assemble` call followed by `rope_trailing`.
- Drop now-unused `Concat`/`autograd_concat` and `SplitHeads`/`split_heads` from `deepseek/autograd_ops.py`.
- Add profiler markers in `mla.py`: `[MLA]`, `Q-Proj`, `KV-Down`, `RoPE-K`, `KV-Up`, `QKV-Assemble`, `RoPE-Q`, `SDPA`, `Output`.

#### Why

Reshapes and transposes in the MLA were taking an unreasonable amount of device time, ranking 2nd and 4th among ops taking the most total device time.

<img width="989" height="590" alt="bar_sum_device" src="https://github.com/user-attachments/assets/171970a4-c80b-4e56-967d-a390d6f6635f" />

After changes their sum device time falls considerably (both under 2 ms), while the new operation `MLAQKVAssemble[Fw|Bw]DeviceOperation` takes no more than a few milliseconds.

<img width="989" height="590" alt="bar_sum_device_post" src="https://github.com/user-attachments/assets/dc681728-595a-4689-ac92-dd5531950302" />

### What got fused

Inside MLA

```
q = split_heads(q, n_heads)
q_nope = autograd_slice(q, [0, 0, 0, 0], [B, n_heads, S, qk_nope])
q_pe   = autograd_slice(q, [0, 0, 0, qk_nope], [B, n_heads, S, qk_head])
q_pe   = ttml.ops.rope.rope(q_pe, self.rope_params)
...
k_pe   = autograd_concat([k_pe] * n_heads, dim=1)
...
kv_up  = split_heads(kv_up, n_heads)
k_nope = autograd_slice(kv_up, [0, 0, 0, 0], [B, n_heads, S, qk_nope])
v      = autograd_slice(kv_up, [0, 0, 0, qk_nope], [B, n_heads, S, qk_nope + v_dim])
q_full = autograd_concat([q_nope, q_pe], dim=3)
k_full = autograd_concat([k_nope, k_pe], dim=3)
```

into

```
q, k_full, v = ttml.ops.mla.qkv_assemble(q_pre, kv_up, k_pe, n_heads, qk_nope, qk_rope, v_dim)
q = rope_trailing(q, self.rope_params)
```

### Benchmarks

> Collected from training with the `training_shakespeare_nano_deepseek_char.yaml` config on a single Blackhole card.

#### Summary

- 61% reduction in MLA time per step (fw+bw)
- 30% reduction in total device step time
- 8% memory peak reduction (366 MB)

#### 30-step training data

##### Before changes

```
Step: 1, Loss: 4.812500, Time: 26314.88 ms, TPS: 311, TFLOPS: 0.04, MFU: 0.0%
Step: 2, Loss: 3.968750, Time: 2952.81 ms, TPS: 2774, TFLOPS: 0.35, MFU: 0.2%
Step: 3, Loss: 4.343750, Time: 2847.09 ms, TPS: 2877, TFLOPS: 0.36, MFU: 0.2%
Step: 4, Loss: 3.812500, Time: 2847.68 ms, TPS: 2877, TFLOPS: 0.36, MFU: 0.2%
Step: 5, Loss: 3.687500, Time: 2841.02 ms, TPS: 2883, TFLOPS: 0.36, MFU: 0.2%
Step: 6, Loss: 3.437500, Time: 2837.03 ms, TPS: 2888, TFLOPS: 0.36, MFU: 0.2%
Step: 7, Loss: 3.437500, Time: 2838.05 ms, TPS: 2886, TFLOPS: 0.36, MFU: 0.2%
Step: 8, Loss: 3.390625, Time: 2837.27 ms, TPS: 2887, TFLOPS: 0.36, MFU: 0.2%
Step: 9, Loss: 3.375000, Time: 2837.14 ms, TPS: 2887, TFLOPS: 0.36, MFU: 0.2%
Step: 10, Loss: 3.281250, Time: 2835.19 ms, TPS: 2889, TFLOPS: 0.36, MFU: 0.2%
Step: 11, Loss: 3.250000, Time: 2838.05 ms, TPS: 2886, TFLOPS: 0.36, MFU: 0.2%
Step: 12, Loss: 3.312500, Time: 2837.86 ms, TPS: 2887, TFLOPS: 0.36, MFU: 0.2%
Step: 13, Loss: 3.234375, Time: 2840.11 ms, TPS: 2884, TFLOPS: 0.36, MFU: 0.2%
Step: 14, Loss: 3.109375, Time: 2839.80 ms, TPS: 2885, TFLOPS: 0.36, MFU: 0.2%
Step: 15, Loss: 3.078125, Time: 2834.71 ms, TPS: 2890, TFLOPS: 0.36, MFU: 0.2%
Step: 16, Loss: 3.031250, Time: 2834.83 ms, TPS: 2890, TFLOPS: 0.36, MFU: 0.2%
Step: 17, Loss: 3.015625, Time: 2836.09 ms, TPS: 2888, TFLOPS: 0.36, MFU: 0.2%
Step: 18, Loss: 2.984375, Time: 2835.01 ms, TPS: 2890, TFLOPS: 0.36, MFU: 0.2%
Step: 19, Loss: 2.859375, Time: 2835.45 ms, TPS: 2889, TFLOPS: 0.36, MFU: 0.2%
Step: 20, Loss: 2.859375, Time: 2833.90 ms, TPS: 2891, TFLOPS: 0.36, MFU: 0.2%
Step: 21, Loss: 2.812500, Time: 2834.95 ms, TPS: 2890, TFLOPS: 0.36, MFU: 0.2%
Step: 22, Loss: 2.750000, Time: 2833.39 ms, TPS: 2891, TFLOPS: 0.36, MFU: 0.2%
Step: 23, Loss: 2.796875, Time: 2833.25 ms, TPS: 2891, TFLOPS: 0.36, MFU: 0.2%
Step: 24, Loss: 2.703125, Time: 2833.35 ms, TPS: 2891, TFLOPS: 0.36, MFU: 0.2%
Step: 25, Loss: 2.656250, Time: 2835.98 ms, TPS: 2889, TFLOPS: 0.36, MFU: 0.2%
Step: 26, Loss: 2.656250, Time: 2839.55 ms, TPS: 2885, TFLOPS: 0.36, MFU: 0.2%
Step: 27, Loss: 2.609375, Time: 2839.65 ms, TPS: 2885, TFLOPS: 0.36, MFU: 0.2%
Step: 28, Loss: 2.593750, Time: 2845.35 ms, TPS: 2879, TFLOPS: 0.36, MFU: 0.2%
Step: 29, Loss: 2.609375, Time: 2854.23 ms, TPS: 2870, TFLOPS: 0.36, MFU: 0.2%
Step: 30, Loss: 2.609375, Time: 2841.62 ms, TPS: 2883, TFLOPS: 0.36, MFU: 0.2%
```

##### After changes

```
Step: 1, Loss: 4.843750, Time: 4011.96 ms, TPS: 2042, TFLOPS: 0.26, MFU: 0.2%
Step: 2, Loss: 3.968750, Time: 2361.66 ms, TPS: 3469, TFLOPS: 0.44, MFU: 0.3%
Step: 3, Loss: 4.343750, Time: 2254.37 ms, TPS: 3634, TFLOPS: 0.46, MFU: 0.3%
Step: 4, Loss: 3.828125, Time: 2256.26 ms, TPS: 3631, TFLOPS: 0.46, MFU: 0.3%
Step: 5, Loss: 3.687500, Time: 2251.84 ms, TPS: 3638, TFLOPS: 0.46, MFU: 0.3%
Step: 6, Loss: 3.437500, Time: 2253.57 ms, TPS: 3635, TFLOPS: 0.46, MFU: 0.3%
Step: 7, Loss: 3.437500, Time: 2254.17 ms, TPS: 3634, TFLOPS: 0.46, MFU: 0.3%
Step: 8, Loss: 3.390625, Time: 2256.33 ms, TPS: 3631, TFLOPS: 0.46, MFU: 0.3%
Step: 9, Loss: 3.375000, Time: 2254.88 ms, TPS: 3633, TFLOPS: 0.46, MFU: 0.3%
Step: 10, Loss: 3.281250, Time: 2253.80 ms, TPS: 3635, TFLOPS: 0.46, MFU: 0.3%
Step: 11, Loss: 3.265625, Time: 2255.97 ms, TPS: 3631, TFLOPS: 0.46, MFU: 0.3%
Step: 12, Loss: 3.296875, Time: 2254.34 ms, TPS: 3634, TFLOPS: 0.46, MFU: 0.3%
Step: 13, Loss: 3.234375, Time: 2256.15 ms, TPS: 3631, TFLOPS: 0.46, MFU: 0.3%
Step: 14, Loss: 3.125000, Time: 2255.09 ms, TPS: 3633, TFLOPS: 0.46, MFU: 0.3%
Step: 15, Loss: 3.078125, Time: 2256.86 ms, TPS: 3630, TFLOPS: 0.46, MFU: 0.3%
Step: 16, Loss: 3.031250, Time: 2253.81 ms, TPS: 3635, TFLOPS: 0.46, MFU: 0.3%
Step: 17, Loss: 3.031250, Time: 2257.80 ms, TPS: 3628, TFLOPS: 0.46, MFU: 0.3%
Step: 18, Loss: 2.953125, Time: 2255.28 ms, TPS: 3632, TFLOPS: 0.46, MFU: 0.3%
Step: 19, Loss: 2.859375, Time: 2256.00 ms, TPS: 3631, TFLOPS: 0.46, MFU: 0.3%
Step: 20, Loss: 2.875000, Time: 2253.41 ms, TPS: 3635, TFLOPS: 0.46, MFU: 0.3%
Step: 21, Loss: 2.812500, Time: 2255.78 ms, TPS: 3632, TFLOPS: 0.46, MFU: 0.3%
Step: 22, Loss: 2.750000, Time: 2256.45 ms, TPS: 3630, TFLOPS: 0.46, MFU: 0.3%
Step: 23, Loss: 2.796875, Time: 2253.29 ms, TPS: 3636, TFLOPS: 0.46, MFU: 0.3%
Step: 24, Loss: 2.703125, Time: 2257.94 ms, TPS: 3628, TFLOPS: 0.46, MFU: 0.3%
Step: 25, Loss: 2.671875, Time: 2255.78 ms, TPS: 3632, TFLOPS: 0.46, MFU: 0.3%
Step: 26, Loss: 2.671875, Time: 2255.38 ms, TPS: 3632, TFLOPS: 0.46, MFU: 0.3%
Step: 27, Loss: 2.625000, Time: 2252.31 ms, TPS: 3637, TFLOPS: 0.46, MFU: 0.3%
Step: 28, Loss: 2.593750, Time: 2256.31 ms, TPS: 3631, TFLOPS: 0.46, MFU: 0.3%
Step: 29, Loss: 2.625000, Time: 2256.00 ms, TPS: 3631, TFLOPS: 0.46, MFU: 0.3%
Step: 30, Loss: 2.609375, Time: 2257.28 ms, TPS: 3629, TFLOPS: 0.46, MFU: 0.3%
```

#### Step time breakdown

##### Before changes

> QKV-Assemble marker captures the total time of the operations that got absorbed by the new `mla_qkv_assemble` kernel.

```
Device 0, Iteration 2

- Whole Step  [227.11 ms] [100.0%]
- - Forward (full)  [91.78 ms] [40.4%]
- - - [FWD] [MLA] (×8)  [51.90 ms] [22.9%]
- - - - [FWD] [MLA] Q-Proj (×8)  [1.81 ms] [0.8%]
- - - - [FWD] [MLA] QKV-Assemble (×24)  [35.22 ms] [15.5%]
- - - - [FWD] [MLA] RoPE-Q (×8)  [1.24 ms] [0.5%]
- - - - [FWD] [MLA] KV-Down (×8)  [0.61 ms] [0.3%]
- - - - [FWD] [MLA] RoPE-K (×8)  [0.19 ms] [0.1%]
- - - - [FWD] [MLA] KV-Up (×8)  [0.84 ms] [0.4%]
- - - - [FWD] [MLA] SDPA (×8)  [10.83 ms] [4.8%]
- - - - [FWD] [MLA] Output (×8)  [1.16 ms] [0.5%]
- - - - Other  [-0.00 ms] [-0.0%]
- - - [FWD] [MoE] (×6)  [34.98 ms] [15.4%]
- - - - [FWD] [MoE] Routing (×6)  [10.58 ms] [4.7%]
- - - - [FWD] [MoE] Experts (×6)  [22.32 ms] [9.8%]
- - - - - [FWD] [MoE] Expert (×48)  [13.59 ms] [6.0%]
- - - - - Other  [8.72 ms] [3.8%]
- - - - [FWD] [MoE] SharedExp (×6)  [1.70 ms] [0.7%]
- - - - Other  [0.38 ms] [0.2%]
- - - Other  [4.90 ms] [2.2%]
- - Backward (full)  [124.47 ms] [54.8%]
- - - [BWD] [MLA] (×8)  [57.60 ms] [25.4%]
- - - - [BWD] [MLA] SDPA (×8)  [33.55 ms] [14.8%]
- - - - - [BWD] [MLA] QKV-Assemble (×23)  [117.34 ms] [51.7%]
- - - - - - [BWD] [MoE] (×6)  [54.95 ms] [24.2%]
- - - - - - - [BWD] [MoE] SharedExp (×6)  [3.95 ms] [1.7%]
- - - - - - - [BWD] [MoE] Experts (×6)  [50.61 ms] [22.3%]
- - - - - - - - [BWD] [MoE] Expert (×48)  [31.62 ms] [13.9%]
- - - - - - - - Other  [19.00 ms] [8.4%]
- - - - - - - Other  [0.39 ms] [0.2%]
- - - - - - [BWD] [MLA] Output (×8)  [2.46 ms] [1.1%]
- - - - - - [BWD] [MLA] RoPE-Q (×8)  [1.25 ms] [0.5%]
- - - - - - [BWD] [MLA] Q-Proj (×8)  [4.03 ms] [1.8%]
- - - - - - Other  [54.66 ms] [24.1%]
- - - - - [BWD] [MLA] RoPE-K (×8)  [0.20 ms] [0.1%]
- - - - - [BWD] [MLA] KV-Down (×8)  [22.97 ms] [10.1%]
- - - - - - [BWD] [MLA] KV-Up (×8)  [2.57 ms] [1.1%]
- - - - - - Other  [20.40 ms] [9.0%]
- - - - - Other  [-106.96 ms] [-47.1%]
- - - - Other  [24.06 ms] [10.6%]
- - - Other  [66.87 ms] [29.4%]
- - Optimizer Step (full)  [10.75 ms] [4.7%]
- - Other  [0.11 ms] [0.1%]
```

##### After changes

```
Device 0, Iteration 2

- Whole Step  [160.49 ms] [100.0%]
- - Forward (full)  [59.16 ms] [36.9%]
- - - [FWD] [MLA] (×8)  [19.29 ms] [12.0%]
- - - - [FWD] [MLA] Q-Proj (×8)  [1.81 ms] [1.1%]
- - - - [FWD] [MLA] KV-Down (×8)  [0.61 ms] [0.4%]
- - - - [FWD] [MLA] RoPE-K (×8)  [0.20 ms] [0.1%]
- - - - [FWD] [MLA] KV-Up (×8)  [0.84 ms] [0.5%]
- - - - [FWD] [MLA] QKV-Assemble (×8)  [1.42 ms] [0.9%]
- - - - [FWD] [MLA] RoPE-Q (×8)  [2.44 ms] [1.5%]
- - - - [FWD] [MLA] SDPA (×8)  [10.82 ms] [6.7%]
- - - - [FWD] [MLA] Output (×8)  [1.16 ms] [0.7%]
- - - - Other  [0.00 ms] [0.0%]
- - - [FWD] [MoE] (×6)  [34.98 ms] [21.8%]
- - - - [FWD] [MoE] Routing (×6)  [10.59 ms] [6.6%]
- - - - [FWD] [MoE] Experts (×6)  [22.30 ms] [13.9%]
- - - - - [FWD] [MoE] Expert (×48)  [13.56 ms] [8.5%]
- - - - - Other  [8.74 ms] [5.4%]
- - - - [FWD] [MoE] SharedExp (×6)  [1.70 ms] [1.1%]
- - - - Other  [0.38 ms] [0.2%]
- - - Other  [4.89 ms] [3.0%]
- - Backward (full)  [90.49 ms] [56.4%]
- - - [BWD] [MoE] (×6)  [54.98 ms] [34.3%]
- - - - [BWD] [MoE] SharedExp (×6)  [3.95 ms] [2.5%]
- - - - [BWD] [MoE] Experts (×6)  [50.64 ms] [31.6%]
- - - - - [BWD] [MoE] Expert (×48)  [31.63 ms] [19.7%]
- - - - - Other  [19.01 ms] [11.8%]
- - - - Other  [0.38 ms] [0.2%]
- - - [BWD] [MLA] (×8)  [23.61 ms] [14.7%]
- - - - [BWD] [MLA] Output (×8)  [2.47 ms] [1.5%]
- - - - [BWD] [MLA] SDPA (×8)  [8.49 ms] [5.3%]
- - - - [BWD] [MLA] RoPE-Q (×8)  [2.45 ms] [1.5%]
- - - - [BWD] [MLA] QKV-Assemble (×8)  [5.67 ms] [3.5%]
- - - - - [BWD] [MLA] RoPE-K (×8)  [0.20 ms] [0.1%]
- - - - - [BWD] [MLA] KV-Down (×8)  [4.10 ms] [2.6%]
- - - - - - [BWD] [MLA] KV-Up (×8)  [2.56 ms] [1.6%]
- - - - - - Other  [1.55 ms] [1.0%]
- - - - - Other  [1.37 ms] [0.9%]
- - - - [BWD] [MLA] Q-Proj (×8)  [4.03 ms] [2.5%]
- - - - Other  [0.51 ms] [0.3%]
- - - Other  [11.90 ms] [7.4%]
- - Optimizer Step (full)  [10.73 ms] [6.7%]
- - Other  [0.11 ms] [0.1%]
```

#### Memory

##### Before changes

```
=== Memory Usage Summary ===

--- MODEL_CREATION ---
  DRAM: Segment Peak 63.14 MB, Allocations 125.07 MB, Deallocations 62.02 MB, Segment Change +63.05 MB
  DRAM: Cumulative Peak 63.14 MB, Cumulative Current 63.05 MB
  L1: Peak CB 0.06 MB, Peak Buffer 0.00 MB, Peak Total 0.06 MB
--- OPTIMIZER_CREATION ---
  DRAM: Segment Peak 377.21 MB, Allocations 377.21 MB, Deallocations 0.00 MB, Segment Change +377.21 MB
  DRAM: Cumulative Peak 440.26 MB, Cumulative Current 440.26 MB
  L1: Peak CB 0.01 MB, Peak Buffer 0.00 MB, Peak Total 0.01 MB
--- FORWARD_PASS ---
  DRAM: Segment Peak 4117.77 MB, Allocations 6016.13 MB, Deallocations 1899.40 MB, Segment Change +4116.73 MB
  DRAM: Cumulative Peak 4558.03 MB, Cumulative Current 4557.00 MB
  L1: Peak CB 1.25 MB, Peak Buffer 0.00 MB, Peak Total 1.25 MB
--- BACKWARD_PASS ---
  DRAM: Segment Peak 42.28 MB, Allocations 8623.64 MB, Deallocations 12637.50 MB, Segment Change -4013.86 MB
  DRAM: Cumulative Peak 4599.27 MB, Cumulative Current 543.14 MB
  L1: Peak CB 1.25 MB, Peak Buffer 0.00 MB, Peak Total 1.25 MB
--- FIRST_ITERATION_COMPLETE ---
  DRAM: Segment Peak 0.00 MB, Allocations 64.12 MB, Deallocations 72.44 MB, Segment Change -8.32 MB
  DRAM: Cumulative Peak 4599.27 MB, Cumulative Current 534.82 MB
  L1: Peak CB 0.08 MB, Peak Buffer 0.00 MB, Peak Total 0.08 MB

=== Final Totals ===
Overall DRAM Peak: 4599.27 MB, Final DRAM Usage: 534.82 MB
```

##### After changes

```
=== Memory Usage Summary ===

--- MODEL_CREATION ---
  DRAM: Segment Peak 63.14 MB, Allocations 125.07 MB, Deallocations 62.02 MB, Segment Change +63.05 MB
  DRAM: Cumulative Peak 63.14 MB, Cumulative Current 63.05 MB
  L1: Peak CB 0.06 MB, Peak Buffer 0.00 MB, Peak Total 0.06 MB
--- OPTIMIZER_CREATION ---
  DRAM: Segment Peak 377.21 MB, Allocations 377.21 MB, Deallocations 0.00 MB, Segment Change +377.21 MB
  DRAM: Cumulative Peak 440.26 MB, Cumulative Current 440.26 MB
  L1: Peak CB 0.01 MB, Peak Buffer 0.00 MB, Peak Total 0.01 MB
--- FORWARD_PASS ---
  DRAM: Segment Peak 3751.75 MB, Allocations 4882.11 MB, Deallocations 1131.40 MB, Segment Change +3750.71 MB
  DRAM: Cumulative Peak 4192.01 MB, Cumulative Current 4190.97 MB
  L1: Peak CB 1.25 MB, Peak Buffer 0.00 MB, Peak Total 1.25 MB
--- BACKWARD_PASS ---
  DRAM: Segment Peak 42.28 MB, Allocations 6761.61 MB, Deallocations 10437.50 MB, Segment Change -3675.89 MB
  DRAM: Cumulative Peak 4233.25 MB, Cumulative Current 515.08 MB
  L1: Peak CB 1.25 MB, Peak Buffer 0.00 MB, Peak Total 1.25 MB
--- FIRST_ITERATION_COMPLETE ---
  DRAM: Segment Peak 0.00 MB, Allocations 64.12 MB, Deallocations 72.44 MB, Segment Change -8.32 MB
  DRAM: Cumulative Peak 4233.25 MB, Cumulative Current 506.76 MB
  L1: Peak CB 0.08 MB, Peak Buffer 0.00 MB, Peak Total 0.08 MB

=== Final Totals ===
Overall DRAM Peak: 4233.25 MB, Final DRAM Usage: 506.76 MB
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=imichalak/ttml-deepseek-optimize-mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:imichalak/ttml-deepseek-optimize-mla)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=imichalak/ttml-deepseek-optimize-mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:imichalak/ttml-deepseek-optimize-mla)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=imichalak/ttml-deepseek-optimize-mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:imichalak/ttml-deepseek-optimize-mla)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=imichalak/ttml-deepseek-optimize-mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:imichalak/ttml-deepseek-optimize-mla)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=imichalak/ttml-deepseek-optimize-mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:imichalak/ttml-deepseek-optimize-mla)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=imichalak/ttml-deepseek-optimize-mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:imichalak/ttml-deepseek-optimize-mla)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=imichalak/ttml-deepseek-optimize-mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:imichalak/ttml-deepseek-optimize-mla)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=imichalak/ttml-deepseek-optimize-mla)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:imichalak/ttml-deepseek-optimize-mla)