### PR TITLE
Fix unroll pragmas, warn on unknown pragma

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp
@@ -80,11 +80,8 @@ void kernel_main() {
             }
         }
 
-#pragma unroll(get_compile_time_arg_val(0))
         for (volatile uint32_t i = 0; i < outer_loop; i++) {
-#pragma unroll(get_compile_time_arg_val(1))
             for (volatile uint32_t j = 0; j < middle_loop; j++) {
-#pragma unroll(get_compile_time_arg_val(2))
                 for (volatile uint32_t k = 0; k < inner_loop; k++) {
                     // Do nothing
                 }

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -407,7 +407,7 @@ FORCE_INLINE void update_packet_header_for_next_hop(
         new_value = cached_routing_fields.route_buffer[0];
 
 // Shift buffer left
-#pragma unroll
+#pragma GCC unroll 16
         for (uint32_t i = 0; i < EXT - 1; i++) {
             const_cast<uint32_t*>(packet_header->routing_fields.route_buffer)[i] =
                 cached_routing_fields.route_buffer[i + 1];
@@ -415,7 +415,7 @@ FORCE_INLINE void update_packet_header_for_next_hop(
         const_cast<uint32_t*>(packet_header->routing_fields.route_buffer)[EXT - 1] = 0;
     } else {
 // No refill needed - just copy buffer as-is
-#pragma unroll
+#pragma GCC unroll 16
         for (uint32_t i = 0; i < EXT; i++) {
             const_cast<uint32_t*>(packet_header->routing_fields.route_buffer)[i] =
                 cached_routing_fields.route_buffer[i];

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -144,7 +144,7 @@ void JitBuildEnv::init(
     this->cflags_ +=
         "-MMD "
         "-fno-use-cxa-atexit "
-        "-Wall -Werror -Wno-unknown-pragmas "
+        "-Wall -Werror "
         "-Wno-deprecated-declarations "
         "-Wno-error=multistatement-macros -Wno-error=parentheses "
         "-Wno-error=unused-but-set-variable -Wno-unused-variable "

--- a/ttnn/cpp/ttnn/operations/kernel_helper_functions/pad_tile.hpp
+++ b/ttnn/cpp/ttnn/operations/kernel_helper_functions/pad_tile.hpp
@@ -77,9 +77,9 @@ void fill_pad_face(T* tile_ptr, T fill_value) {
                                         : face_w_offset + FACE_WIDTH - num_elements_unpadded_w;
 
     if constexpr (face_pad_w > 0) {
-#pragma unroll
         for (uint32_t row = 0; row < FACE_HEIGHT; ++row) {
             auto row_ptr = face_ptr + row * FACE_WIDTH;
+#pragma GCC unroll 32
             for (uint32_t col = FACE_WIDTH - face_pad_w; col < FACE_WIDTH; ++col) {
                 row_ptr[col] = fill_value;
             }
@@ -94,9 +94,9 @@ void fill_pad_face(T* tile_ptr, T fill_value) {
                                         : face_h_offset + FACE_HEIGHT - num_elements_unpadded_h;
 
     if constexpr (face_pad_h > 0) {
-#pragma unroll
         for (uint32_t row = FACE_HEIGHT - face_pad_h; row < FACE_HEIGHT; ++row) {
             auto row_ptr = face_ptr + row * FACE_WIDTH;
+#pragma GCC unroll 32
             for (uint32_t col = 0; col < FACE_WIDTH; ++col) {
                 row_ptr[col] = fill_value;
             }

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
@@ -356,7 +356,6 @@ void kernel_main() {
 
         // Process each channel block
         uint32_t block_offset = 0;
-#pragma unroll
         for (uint32_t i = 0; i < blocks; i++) {
             tilize_reduce_cb.reserve_back(4);
 


### PR DESCRIPTION
### PR Category
BUG FIX

### Summary
A recent perf regression showed that we had
*) non-existant 'unroll' pragmas
*) disabled the warning about unknown pragmas.

This patch
1) Corrects the pragma syntax
2) Stops turning off the warning

I'm not sure what the nested loops in `tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp` is trying to achieve.  Because both the loop bound and the iterator are volatile, the compiler keeps loading them and checking for termination condition.  All unrolling would achieve is bloating the code, not a reduction in the number of insns executed.  But anyway, as the pragma was ignored, we're left with the compiler's heuristics.  So I dropped them.

In the other cases I guessed at sensible unroll limits.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/pragmata)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/pragmata)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/pragmata)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/pragmata)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/pragmata)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/pragmata)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/pragmata)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/pragmata)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/pragmata)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/pragmata)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/pragmata)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/pragmata)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/pragmata)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/pragmata)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/pragmata)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/pragmata)