### PR TITLE
[Bug Fix] Skip reserved DMs when electing thread_0_hartid in dmk.cc

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
@@ -50,7 +50,15 @@ uint32_t _start() {
     uint32_t thread_0_hartid = hartid;
     if (launch_msg->kernel_config.enables & (1u << hartid)) {
         for (uint32_t j = 0; j < MaxDMProcessorsPerCoreType; j++) {
-            if (launch_msg->kernel_config.kernel_text_offset[j] == my_kt) {
+            // DM0 and DM1 are reserved, so their kernel_text_offset[] slots are
+            // left zero-initialized. Skip reserved slots here, otherwise if the
+            // user binary happens to land at offset 0 (e.g. no RTAs/CRTAs/sems/CBs/DFBs
+            // precede it in the kernel-config ring buffer), the search would falsely
+            // match slot 0 and set thread_0_hartid = 0. DM0 never sets
+            // shared_globals_ready[0] = GO, so the user DMs hang forever in the
+            // wait loop below.
+            if ((launch_msg->kernel_config.enables & (1u << j)) &&
+                launch_msg->kernel_config.kernel_text_offset[j] == my_kt) {
                 thread_0_hartid = j;
                 break;
             }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Fix a Quasar firmware hang caused by `dmk.cc::_start()`'s `thread_0_hartid` election. The issue was uncovered during the Metal 2.0 host-API migration on KernelSpecs that declare only CTAs (no RTAs / CRTAs / semaphores / CBs / DFBs).

In that case the user kernel binary lands at kernel_text_offset = 0, and the zero-initialized DM0 slot is matched, setting thread_0_hartid = 0. DM0 never sets shared_globals_ready[0] = GO, and the user DMs hang.

Fix: gate the inner candidate test on enables & (1u << j) so reserved DM slots can never qualify.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=shengxiangji/firmware-fix-cta-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:shengxiangji/firmware-fix-cta-only) (known issue, not caused by this PR)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=shengxiangji/firmware-fix-cta-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:shengxiangji/firmware-fix-cta-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=shengxiangji/firmware-fix-cta-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:shengxiangji/firmware-fix-cta-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=shengxiangji/firmware-fix-cta-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:shengxiangji/firmware-fix-cta-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=shengxiangji/firmware-fix-cta-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:shengxiangji/firmware-fix-cta-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=shengxiangji/firmware-fix-cta-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:shengxiangji/firmware-fix-cta-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=shengxiangji/firmware-fix-cta-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:shengxiangji/firmware-fix-cta-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=shengxiangji/firmware-fix-cta-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:shengxiangji/firmware-fix-cta-only)