### PR TITLE
#26707: fix matmul m padding

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
@@ -453,3 +453,61 @@ def test_matmul_transpose_a_fuse_batch(device, batch, m, k, n, program_config):
     assert_numeric_metrics(
         torch_out, output, check_allclose=False, check_frobenius=False, pcc_threshold=0.999, check_ulp=False
     )
+
+
+def test_matmul_m_direction_padding(device):
+    # Create input tensors (keep the same random data for comparison)
+    torch_a = torch.randn((1, 1, 64, 2880), dtype=torch.bfloat16)
+    torch_b = torch.randn((1, 1, 2880, 2880), dtype=torch.bfloat16)
+
+    tensor_a = ttnn.from_torch(
+        torch_a, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
+    tensor_b = ttnn.from_torch(
+        torch_b, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
+
+    compute_kernel_config_HiFi4 = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        # compute_with_storage_grid_size=(13, 10),
+        compute_with_storage_grid_size=(8, 8),
+        in0_block_w=1,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=6,
+        per_core_N=22,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=True,
+    )
+
+    print(tensor_a.shape, tensor_b.shape)
+    # Perform matrix multiplication
+    result = ttnn.matmul(
+        tensor_a,
+        tensor_b,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config_HiFi4,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+        dtype=ttnn.bfloat16,
+    )
+
+    output = ttnn.to_torch(result)
+    expected = torch.matmul(torch_a, torch_b)
+
+    pcc = ttnn.pearson_correlation_coefficient(expected, output)
+    assert_numeric_metrics(
+        expected,
+        output,
+        check_allclose=False,
+        check_frobenius=True,
+        frobenius_threshold=0.02,
+        pcc_threshold=0.999,
+        check_ulp=False,
+    )

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
@@ -457,6 +457,7 @@ def test_matmul_transpose_a_fuse_batch(device, batch, m, k, n, program_config):
 
 def test_matmul_m_direction_padding(device):
     # Create input tensors (keep the same random data for comparison)
+    torch.manual_seed(0)
     torch_a = torch.randn((1, 1, 64, 2880), dtype=torch.bfloat16)
     torch_b = torch.randn((1, 1, 2880, 2880), dtype=torch.bfloat16)
 
@@ -487,7 +488,6 @@ def test_matmul_m_direction_padding(device):
         mcast_in0=True,
     )
 
-    print(tensor_a.shape, tensor_b.shape)
     # Perform matrix multiplication
     result = ttnn.matmul(
         tensor_a,
@@ -501,7 +501,6 @@ def test_matmul_m_direction_padding(device):
     output = ttnn.to_torch(result)
     expected = torch.matmul(torch_a, torch_b)
 
-    pcc = ttnn.pearson_correlation_coefficient(expected, output)
     assert_numeric_metrics(
         expected,
         output,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -896,7 +896,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         tt_metal::CreateCircularBuffer(program, all_cores, in0_transpose_cb_config);
     }
 
-    // Parameters for last row, col, or block, no need to re-calc h-dim since there's no split on height
+    // Parameters for last row, col, or block. mcast_in0 replicates M across all cores
+    // (num_blocks_y == 1), so any M-direction padding lives entirely within a single h-block.
     uint32_t last_per_core_N = N % per_core_N == 0 ? per_core_N : N % per_core_N;
     uint32_t last_out_block_w = last_per_core_N % out_block_w == 0 ? out_block_w : last_per_core_N % out_block_w;
     uint32_t last_out_num_blocks_w = ((last_per_core_N - 1) / out_block_w) + 1;
@@ -907,6 +908,17 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         output_single_tile_size * (out_subblock_w - last_subblock_of_last_block_w);
     uint32_t last_block_padded_block_tiles_w_skip =
         (out_subblock_w * out_subblock_h) * (out_block_w / out_subblock_w - last_block_num_nonzero_subblocks_w);
+
+    // M-direction padding when M < per_core_M. With num_blocks_y == 1 the last (only) h-block
+    // holds last_out_block_h valid tile rows out of out_block_h.
+    uint32_t in0_last_per_core_M = M < per_core_M ? M : per_core_M;
+    uint32_t in0_last_out_block_h =
+        in0_last_per_core_M % out_block_h == 0 ? out_block_h : in0_last_per_core_M % out_block_h;
+    uint32_t in0_last_block_num_nonzero_subblocks_h = ((in0_last_out_block_h - 1) / out_subblock_h) + 1;
+    uint32_t in0_last_subblock_of_last_block_h =
+        in0_last_out_block_h % out_subblock_h == 0 ? out_subblock_h : in0_last_out_block_h % out_subblock_h;
+    uint32_t in0_last_block_padded_block_tiles_h_skip =
+        (out_block_h / out_subblock_h - in0_last_block_num_nonzero_subblocks_h) * (out_block_w * out_subblock_h);
 
     CoreCoord start_core_noc = top_left_core_physical;
     CoreCoord end_core_noc = bottom_right_core_physical;
@@ -968,7 +980,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
                 (std::uint32_t)end_core_noc.y,    // in0_mcast_dest_noc_end_y
 
                 // padding args
-                (std::uint32_t)out_block_h,  // last_block_h
+                (std::uint32_t)in0_last_out_block_h,  // last_block_h
 
                 // sparsity args
                 (std::uint32_t)0,  // sparsity_addr
@@ -1021,9 +1033,9 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
                 mm_in1_sender_writer_args.push_back(last_out_block_w);
 
                 // padding args (WRITER)
-                mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
-                mm_in1_sender_writer_args.push_back(out_subblock_h);
-                mm_in1_sender_writer_args.push_back(0);
+                mm_in1_sender_writer_args.push_back(in0_last_block_num_nonzero_subblocks_h);
+                mm_in1_sender_writer_args.push_back(in0_last_subblock_of_last_block_h);
+                mm_in1_sender_writer_args.push_back(in0_last_block_padded_block_tiles_h_skip);
                 mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);  // out_num_nonzero_subblocks_w
                 mm_in1_sender_writer_args.push_back(last_block_num_nonzero_subblocks_w);
                 mm_in1_sender_writer_args.push_back(last_subblock_of_last_block_w);
@@ -1034,9 +1046,9 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
                 mm_in1_sender_writer_args.push_back(out_block_w);
 
                 // padding args (WRITER)
-                mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
-                mm_in1_sender_writer_args.push_back(out_subblock_h);
-                mm_in1_sender_writer_args.push_back(0);
+                mm_in1_sender_writer_args.push_back(in0_last_block_num_nonzero_subblocks_h);
+                mm_in1_sender_writer_args.push_back(in0_last_subblock_of_last_block_h);
+                mm_in1_sender_writer_args.push_back(in0_last_block_padded_block_tiles_h_skip);
                 mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);  // out_num_nonzero_subblocks_w
                 mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
                 mm_in1_sender_writer_args.push_back(out_subblock_w);

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -3031,6 +3031,16 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
     uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
     uint32_t num_cores_with_work = num_blocks_total;
 
+    // mcast_in0 broadcasts a single M-block across all cores; only the start_core gets in0 sender
+    // runtime args (with output_idx_y == 0), so M must fit within per_core_M.
+    TT_FATAL(
+        num_blocks_y == 1,
+        "matmul_multicore_reuse_mcast_1d requires num_blocks_y == 1 (M <= per_core_M) for mcast_in0. "
+        "Got M={}, per_core_M={}, num_blocks_y={}.",
+        M,
+        per_core_M,
+        num_blocks_y);
+
     uint32_t in0_sender_num_cores = in0_is_sharded ? a.shard_spec().value().grid.num_cores() : 1;
     uint32_t num_cores = in0_is_sharded ? std::max(num_cores_with_work, in0_sender_num_cores) : num_cores_with_work;
 
@@ -3731,7 +3741,8 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
     ////////////////////////////////////////////////////////////////////////////
     //                      Runtime Args (per-core loop)
     ////////////////////////////////////////////////////////////////////////////
-    // Parameters for last row, col, or block, no need to re-calc h-dim since there's no split on height
+    // Parameters for last row, col, or block. mcast_in0 replicates M across all cores
+    // (num_blocks_y == 1), so any M-direction padding lives entirely within a single h-block.
     uint32_t last_per_core_N = N % per_core_N == 0 ? per_core_N : N % per_core_N;
     uint32_t last_out_block_w = last_per_core_N % out_block_w == 0 ? out_block_w : last_per_core_N % out_block_w;
     uint32_t last_out_num_blocks_w = ((last_per_core_N - 1) / out_block_w) + 1;
@@ -3742,6 +3753,17 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
         output_single_tile_size * (out_subblock_w - last_subblock_of_last_block_w);
     uint32_t last_block_padded_block_tiles_w_skip =
         (out_subblock_w * out_subblock_h) * (out_block_w / out_subblock_w - last_block_num_nonzero_subblocks_w);
+
+    // M-direction padding when M < per_core_M. With num_blocks_y == 1 the last (only) h-block
+    // holds last_out_block_h valid tile rows out of out_block_h.
+    uint32_t in0_last_per_core_M = M < per_core_M ? M : per_core_M;
+    uint32_t in0_last_out_block_h =
+        in0_last_per_core_M % out_block_h == 0 ? out_block_h : in0_last_per_core_M % out_block_h;
+    uint32_t in0_last_block_num_nonzero_subblocks_h = ((in0_last_out_block_h - 1) / out_subblock_h) + 1;
+    uint32_t in0_last_subblock_of_last_block_h =
+        in0_last_out_block_h % out_subblock_h == 0 ? out_subblock_h : in0_last_out_block_h % out_subblock_h;
+    uint32_t in0_last_block_padded_block_tiles_h_skip =
+        (out_block_h / out_subblock_h - in0_last_block_num_nonzero_subblocks_h) * (out_block_w * out_subblock_h);
 
     CoreCoord start_core_noc = top_left_core_physical;
     CoreCoord end_core_noc = bottom_right_core_physical;
@@ -3791,7 +3813,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
                 (std::uint32_t)end_core_noc.y,    // in0_mcast_dest_noc_end_y
 
                 // padding args
-                (std::uint32_t)out_block_h,  // last_block_h
+                (std::uint32_t)in0_last_out_block_h,  // last_block_h
 
                 // sparsity args
                 (std::uint32_t)0,  // sparsity_addr
@@ -3844,9 +3866,9 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
                 mm_in1_sender_writer_args.push_back(last_out_block_w);
 
                 // padding args (WRITER)
-                mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
-                mm_in1_sender_writer_args.push_back(out_subblock_h);
-                mm_in1_sender_writer_args.push_back(0);
+                mm_in1_sender_writer_args.push_back(in0_last_block_num_nonzero_subblocks_h);
+                mm_in1_sender_writer_args.push_back(in0_last_subblock_of_last_block_h);
+                mm_in1_sender_writer_args.push_back(in0_last_block_padded_block_tiles_h_skip);
                 mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);  // out_num_nonzero_subblocks_w
                 mm_in1_sender_writer_args.push_back(last_block_num_nonzero_subblocks_w);
                 mm_in1_sender_writer_args.push_back(last_subblock_of_last_block_w);
@@ -3857,9 +3879,9 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
                 mm_in1_sender_writer_args.push_back(out_block_w);
 
                 // padding args (WRITER)
-                mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
-                mm_in1_sender_writer_args.push_back(out_subblock_h);
-                mm_in1_sender_writer_args.push_back(0);
+                mm_in1_sender_writer_args.push_back(in0_last_block_num_nonzero_subblocks_h);
+                mm_in1_sender_writer_args.push_back(in0_last_subblock_of_last_block_h);
+                mm_in1_sender_writer_args.push_back(in0_last_block_padded_block_tiles_h_skip);
                 mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);  // out_num_nonzero_subblocks_w
                 mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
                 mm_in1_sender_writer_args.push_back(out_subblock_w);

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -203,6 +203,16 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
     uint32_t num_cores_with_work = num_blocks_total;
 
+    // mcast_in0 broadcasts a single M-block across all cores; only the start_core gets in0 sender
+    // runtime args (with output_idx_y == 0), so M must fit within per_core_M.
+    TT_FATAL(
+        num_blocks_y == 1,
+        "matmul_multicore_reuse_mcast_1d requires num_blocks_y == 1 (M <= per_core_M) for mcast_in0. "
+        "Got M={}, per_core_M={}, num_blocks_y={}.",
+        M,
+        per_core_M,
+        num_blocks_y);
+
     uint32_t in0_sender_num_cores = in0_is_sharded ? a.shard_spec().value().grid.num_cores() : 1;
     uint32_t num_cores = in0_is_sharded ? std::max(num_cores_with_work, in0_sender_num_cores) : num_cores_with_work;
 


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Closes #26707 

M-direction padding when M < per_core_M was not set up properly.

This is being fixed and a test added.


### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-26707_mm_m_padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-26707_mm_m_padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-26707_mm_m_padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-26707_mm_m_padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-26707_mm_m_padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-26707_mm_m_padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-26707_mm_m_padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-26707_mm_m_padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-26707_mm_m_padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-26707_mm_m_padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-26707_mm_m_padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-26707_mm_m_padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-26707_mm_m_padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-26707_mm_m_padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-26707_mm_m_padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-26707_mm_m_padding)