### PR TITLE
[Test]: Enable SD Enable test_prefetcher.cpp

### DIFF
--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -164,8 +164,9 @@
 # --- FD2 Dispatch Tests (prefetcher + dispatcher) ---
 - name: runtime_fd2
   cmd: |
-    ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher
+    ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher --gtest_filter='-*SlowDispatch*'
     ./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher --gtest_filter='-*SlowDispatch*'
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher --gtest_filter='*SlowDispatch*'
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher --gtest_filter='*SlowDispatch*'
   skus:
     wh_n150_civ2:

--- a/tests/scripts/run_cpp_fd2_tests.sh
+++ b/tests/scripts/run_cpp_fd2_tests.sh
@@ -21,7 +21,7 @@ run_test_with_watcher() {
     #############################################
     echo "Running test_prefetcher with fast dispatch mode..";
 
-    run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher"
+    run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher --gtest_filter=-*SlowDispatch*"
 
     #############################################
     # TEST_DISPATCHER TESTS                     #
@@ -30,6 +30,13 @@ run_test_with_watcher() {
 
     run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher --gtest_filter=-*SlowDispatch*"
 )
+
+#############################################
+# TEST_PREFETCHER TESTS (SD)                #
+#############################################
+echo "Running test_prefetcher with slow dispatch mode..";
+
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher --gtest_filter='*SlowDispatch*'
 
 #############################################
 # TEST_DISPATCHER TESTS (SD)                #

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -926,7 +926,7 @@ inline uint32_t clamp_to_max_fetch(
 // Page size and block count reuse the canonical DispatchSettings values.
 // pages-per-block is derived inside cq_dispatch.cpp as DISPATCH_CB_PAGES / DISPATCH_CB_BLOCKS.
 static constexpr uint32_t SD_DISPATCH_BUFFER_PAGE_SIZE = 1u << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
-static constexpr uint32_t SD_DISPATCH_BUFFER_SIZE_BYTES = 768 * 1024;
+static constexpr uint32_t SD_DISPATCH_BUFFER_SIZE_BYTES = 512 * 1024;
 static constexpr uint32_t SD_PREFETCHER_PAGE_BATCH_SIZE = 1;
 static_assert(SD_DISPATCH_BUFFER_SIZE_BYTES % SD_DISPATCH_BUFFER_PAGE_SIZE == 0);
 static_assert(
@@ -940,9 +940,9 @@ static constexpr uint32_t SD_PREFETCH_CMDDAT_LOG_PAGE_SIZE = DispatchSettings::P
 static constexpr uint32_t SD_PREFETCH_CMDDAT_PAGE_SIZE = 1u << SD_PREFETCH_CMDDAT_LOG_PAGE_SIZE;
 static constexpr uint32_t SD_PREFETCH_CMDDAT_BLOCKS = DispatchSettings::PREFETCH_D_BUFFER_BLOCKS;
 static constexpr uint32_t SD_PREFETCH_SCRATCH_DB_SIZE = 128 * 1024;
-static constexpr uint32_t SD_HUGEPAGE_ISSUE_BUFFER_SIZE = 8 * 1024 * 1024;
-static constexpr uint32_t SD_COMPLETION_QUEUE_SIZE = 4 * 1024 * 1024;
-static constexpr uint32_t SD_PREFETCH_Q_ENTRIES = 1024;
+static constexpr uint32_t SD_HUGEPAGE_ISSUE_BUFFER_SIZE = 256u * 1024u * 1024u;
+static constexpr uint32_t SD_COMPLETION_QUEUE_SIZE = 256u * 1024u * 1024u;
+static constexpr uint32_t SD_PREFETCH_Q_ENTRIES = 1534;
 inline constexpr CoreCoord sd_prefetch_core = {0, 0};    // combined prefetch_hd
 inline constexpr CoreCoord sd_prefetch_d_core = {3, 0};  // kept for spoof_prefetch (FD tests)
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -923,28 +923,19 @@ inline uint32_t clamp_to_max_fetch(
 }  // namespace PackedWriteUtils
 
 // SD (slow dispatch) dispatch-buffer constants — consumed by execute_generated_commands.
-// Page size and block count reuse the canonical DispatchSettings values.
-// pages-per-block is derived inside cq_dispatch.cpp as DISPATCH_CB_PAGES / DISPATCH_CB_BLOCKS.
+// Sizes that vary per-arch (dispatch_size, prefetch_q_entries, prefetch_scratch_db_size) are
+// read directly from memmap.settings at call sites; only the truly constexpr knobs live here.
 static constexpr uint32_t SD_DISPATCH_BUFFER_PAGE_SIZE = 1u << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
-static constexpr uint32_t SD_DISPATCH_BUFFER_SIZE_BYTES = 512 * 1024;
 static constexpr uint32_t SD_PREFETCHER_PAGE_BATCH_SIZE = 1;
-static_assert(SD_DISPATCH_BUFFER_SIZE_BYTES % SD_DISPATCH_BUFFER_PAGE_SIZE == 0);
-static_assert(
-    (SD_DISPATCH_BUFFER_SIZE_BYTES / SD_DISPATCH_BUFFER_PAGE_SIZE) % DispatchSettings::DISPATCH_BUFFER_SIZE_BLOCKS ==
-    0);
 // spoof_prefetch loop uses (cmd_cb_pages-1)/page_batch_size with no remainder handling
 static_assert(SD_PREFETCHER_PAGE_BATCH_SIZE == 1);
 
-// SD (slow dispatch) prefetch constants - consumed by SDPrefetchTestBase.
 static constexpr uint32_t SD_PREFETCH_CMDDAT_LOG_PAGE_SIZE = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
 static constexpr uint32_t SD_PREFETCH_CMDDAT_PAGE_SIZE = 1u << SD_PREFETCH_CMDDAT_LOG_PAGE_SIZE;
 static constexpr uint32_t SD_PREFETCH_CMDDAT_BLOCKS = DispatchSettings::PREFETCH_D_BUFFER_BLOCKS;
-static constexpr uint32_t SD_PREFETCH_SCRATCH_DB_SIZE = 128 * 1024;
-static constexpr uint32_t SD_HUGEPAGE_ISSUE_BUFFER_SIZE = 256u * 1024u * 1024u;
-static constexpr uint32_t SD_COMPLETION_QUEUE_SIZE = 256u * 1024u * 1024u;
-static constexpr uint32_t SD_PREFETCH_Q_ENTRIES = 1534;
-inline constexpr CoreCoord sd_prefetch_core = {0, 0};    // combined prefetch_hd
-inline constexpr CoreCoord sd_prefetch_d_core = {3, 0};  // kept for spoof_prefetch (FD tests)
+static constexpr uint32_t SD_HUGEPAGE_ISSUE_BUFFER_SIZE = DispatchSettings::MAX_DEV_CHANNEL_SIZE;
+static constexpr uint32_t SD_COMPLETION_QUEUE_SIZE = DispatchSettings::MAX_DEV_CHANNEL_SIZE;
+inline constexpr CoreCoord sd_prefetch_core = {0, 0};  // combined prefetch_hd
 
 // BaseTestFixture forms the basis for prefetch and dispatcher tests.
 // Inherits from GenericMeshDeviceFixture which determines the mesh device type automatically
@@ -1195,6 +1186,10 @@ inline constexpr CoreCoord sd_dispatch_core = {4, 0};
 // SD drives only the core dispatch fields; all fabric-mux, multi-CQ, go-signal, and downstream
 // fields are zeroed since the spoof path never uses them.
 //
+// completion_queue_{base,size} default to 0 for SD dispatcher tests (no host-text writeback).
+// SD prefetcher tests that exercise host writeback must pass real values - cq_dispatch.cpp
+// computes the host PCIe destination from COMPLETION_QUEUE_BASE_ADDR.
+//
 // KEEP IN SYNC WITH: tt_metal/impl/dispatch/kernel_config/dispatch.cpp (the defines block starting
 // around "Add all the dispatch-specific defines"). If a new define is added or removed there,
 // update this map to match - the failure mode is a kernel compile error.
@@ -1311,9 +1306,11 @@ inline std::map<std::string, std::string> make_sd_prefetch_defines(
     uint32_t prefetch_q_base,
     uint32_t prefetch_q_size,
     uint32_t prefetch_q_rd_ptr_addr,
+    uint32_t prefetch_q_pcie_rd_ptr_addr,
     uint32_t cmddat_q_base,
     uint32_t cmddat_q_pages,
     uint32_t scratch_db_base,
+    uint32_t scratch_db_size,
     uint32_t dispatch_cb_base,
     uint32_t dispatch_cb_pages,
     uint32_t dispatch_cb_sem_id,
@@ -1343,11 +1340,11 @@ inline std::map<std::string, std::string> make_sd_prefetch_defines(
         {"PREFETCH_Q_BASE", std::to_string(prefetch_q_base)},
         {"PREFETCH_Q_SIZE", std::to_string(prefetch_q_size)},
         {"PREFETCH_Q_RD_PTR_ADDR", std::to_string(prefetch_q_rd_ptr_addr)},
-        {"PREFETCH_Q_PCIE_RD_PTR_ADDR", std::to_string(prefetch_q_rd_ptr_addr + sizeof(uint32_t))},
+        {"PREFETCH_Q_PCIE_RD_PTR_ADDR", std::to_string(prefetch_q_pcie_rd_ptr_addr)},
         {"CMDDAT_Q_BASE", std::to_string(cmddat_q_base)},
         {"CMDDAT_Q_SIZE", std::to_string(cmddat_q_pages * SD_PREFETCH_CMDDAT_PAGE_SIZE)},
         {"SCRATCH_DB_BASE", std::to_string(scratch_db_base)},
-        {"SCRATCH_DB_SIZE", std::to_string(SD_PREFETCH_SCRATCH_DB_SIZE)},
+        {"SCRATCH_DB_SIZE", std::to_string(scratch_db_size)},
         {"DOWNSTREAM_SYNC_SEM_ID", std::to_string(downstream_sync_sem_id)},
         {"CMDDAT_Q_PAGES", std::to_string(cmddat_q_pages)},
         {"MY_UPSTREAM_CB_SEM_ID", "0"},  // not used when IS_H_VARIANT=1
@@ -1359,7 +1356,7 @@ inline std::map<std::string, std::string> make_sd_prefetch_defines(
         {"DOWNSTREAM_DISPATCH_S_CB_SEM_ID", "0"},
         {"DISPATCH_S_BUFFER_SIZE", "0"},
         {"DISPATCH_S_CB_LOG_PAGE_SIZE", "0"},
-        {"RINGBUFFER_SIZE", std::to_string(SD_PREFETCH_SCRATCH_DB_SIZE)},
+        {"RINGBUFFER_SIZE", std::to_string(scratch_db_size)},
         {"FABRIC_HEADER_RB_BASE", "0"},
         {"FABRIC_HEADER_RB_ENTRIES", "0"},
         {"MY_FABRIC_SYNC_STATUS_ADDR", "0"},

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -933,8 +933,14 @@ static_assert(SD_PREFETCHER_PAGE_BATCH_SIZE == 1);
 static constexpr uint32_t SD_PREFETCH_CMDDAT_LOG_PAGE_SIZE = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
 static constexpr uint32_t SD_PREFETCH_CMDDAT_PAGE_SIZE = 1u << SD_PREFETCH_CMDDAT_LOG_PAGE_SIZE;
 static constexpr uint32_t SD_PREFETCH_CMDDAT_BLOCKS = DispatchSettings::PREFETCH_D_BUFFER_BLOCKS;
-static constexpr uint32_t SD_HUGEPAGE_ISSUE_BUFFER_SIZE = DispatchSettings::MAX_DEV_CHANNEL_SIZE;
-static constexpr uint32_t SD_COMPLETION_QUEUE_SIZE = DispatchSettings::MAX_DEV_CHANNEL_SIZE;
+// Issue + completion must fit in one device's hugepage slot (MAX_DEV_CHANNEL_SIZE = 256 MB);
+// 50/50 split. Production FD splits ~75/25 (issue/completion); SD often needs more completion
+// (host-readback tests), so the even split is a reasonable middle ground.
+static constexpr uint32_t SD_HUGEPAGE_ISSUE_BUFFER_SIZE = DispatchSettings::MAX_DEV_CHANNEL_SIZE / 2;
+static constexpr uint32_t SD_COMPLETION_QUEUE_SIZE = DispatchSettings::MAX_DEV_CHANNEL_SIZE / 2;
+static_assert(
+    SD_HUGEPAGE_ISSUE_BUFFER_SIZE + SD_COMPLETION_QUEUE_SIZE <= DispatchSettings::MAX_DEV_CHANNEL_SIZE,
+    "SD issue + completion exceed per-device hugepage slot");
 inline constexpr CoreCoord sd_prefetch_core = {0, 0};  // combined prefetch_hd
 
 // BaseTestFixture forms the basis for prefetch and dispatcher tests.

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -1323,6 +1323,7 @@ inline std::map<std::string, std::string> make_sd_prefetch_defines(
     uint32_t dispatch_cb_pages,
     uint32_t dispatch_cb_sem_id,
     uint32_t downstream_sync_sem_id,
+    uint32_t entry_size,
     const CoreCoord& phys_prefetch,
     const CoreCoord& phys_dispatch) {
     const auto my_virtual = device->virtual_noc0_coordinate(tt_metal::NOC::NOC_0, phys_prefetch);
@@ -1393,6 +1394,7 @@ inline std::map<std::string, std::string> make_sd_prefetch_defines(
         {"OFFSETOF_TO_DEV_ID", "1"},
         {"OFFSETOF_ROUTER_DIRECTION", "2"},
         {"FD_CORE_TYPE", "0"},
+        {"PREFETCH_Q_ENTRY_BITS", std::to_string(entry_size * 8)},
         // FABRIC_RELAY intentionally omitted - must be undefined for #if defined(FABRIC_RELAY) to be false
     };
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -1246,6 +1246,8 @@ inline std::map<std::string, std::string> make_sd_dispatch_defines(
          std::to_string(memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD))},
         {"DEV_DISPATCH_PROGRESS_PTR",
          std::to_string(memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_PROGRESS))},
+        {"REALTIME_PROFILER_MSG_ADDR",
+         std::to_string(memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::REALTIME_PROFILER_MSG))},
         {"FIRST_STREAM_USED", std::to_string(memmap.get_dispatch_stream_index(0))},
         {"VIRTUALIZE_UNICAST_CORES", "0"},
         {"NUM_VIRTUAL_UNICAST_CORES", "0"},

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -935,6 +935,17 @@ static_assert(
 // spoof_prefetch loop uses (cmd_cb_pages-1)/page_batch_size with no remainder handling
 static_assert(SD_PREFETCHER_PAGE_BATCH_SIZE == 1);
 
+// SD (slow dispatch) prefetch constants - consumed by SDPrefetchTestBase.
+static constexpr uint32_t SD_PREFETCH_CMDDAT_LOG_PAGE_SIZE = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
+static constexpr uint32_t SD_PREFETCH_CMDDAT_PAGE_SIZE = 1u << SD_PREFETCH_CMDDAT_LOG_PAGE_SIZE;
+static constexpr uint32_t SD_PREFETCH_CMDDAT_BLOCKS = DispatchSettings::PREFETCH_D_BUFFER_BLOCKS;
+static constexpr uint32_t SD_PREFETCH_SCRATCH_DB_SIZE = 128 * 1024;
+static constexpr uint32_t SD_HUGEPAGE_ISSUE_BUFFER_SIZE = 8 * 1024 * 1024;
+static constexpr uint32_t SD_COMPLETION_QUEUE_SIZE = 4 * 1024 * 1024;
+static constexpr uint32_t SD_PREFETCH_Q_ENTRIES = 1024;
+inline constexpr CoreCoord sd_prefetch_core = {0, 0};    // combined prefetch_hd
+inline constexpr CoreCoord sd_prefetch_d_core = {3, 0};  // kept for spoof_prefetch (FD tests)
+
 // BaseTestFixture forms the basis for prefetch and dispatcher tests.
 // Inherits from GenericMeshDeviceFixture which determines the mesh device type automatically
 class BaseTestFixture : public tt_metal::GenericMeshDeviceFixture {
@@ -1194,7 +1205,9 @@ inline std::map<std::string, std::string> make_sd_dispatch_defines(
     uint32_t prefetch_sync_sem,
     const CoreCoord& phys_spoof,
     const CoreCoord& phys_disp,
-    const tt_metal::DispatchMemMap& memmap) {
+    const tt_metal::DispatchMemMap& memmap,
+    uint32_t completion_queue_base = 0,
+    uint32_t completion_queue_size = 0) {
     const uint32_t l1_buf_base = memmap.dispatch_buffer_base();
     const uint32_t num_compute_cores =
         device_->compute_with_storage_grid_size().x * device_->compute_with_storage_grid_size().y;
@@ -1213,8 +1226,8 @@ inline std::map<std::string, std::string> make_sd_dispatch_defines(
         {"UPSTREAM_SYNC_SEM", std::to_string(prefetch_sync_sem)},
         {"DISPATCH_D_SHUTDOWN_SEM_ID", "0"},  // no dispatch_s in SD; disables dispatch_s_enabled path
         {"COMMAND_QUEUE_BASE_ADDR", "0"},
-        {"COMPLETION_QUEUE_BASE_ADDR", "0"},
-        {"COMPLETION_QUEUE_SIZE", "0"},
+        {"COMPLETION_QUEUE_BASE_ADDR", std::to_string(completion_queue_base)},
+        {"COMPLETION_QUEUE_SIZE", std::to_string(completion_queue_size)},
         {"DOWNSTREAM_CB_BASE", "0"},
         {"DOWNSTREAM_CB_SIZE", "0"},
         {"MY_DOWNSTREAM_CB_SEM_ID", "0"},
@@ -1282,6 +1295,100 @@ inline std::map<std::string, std::string> make_sd_dispatch_defines(
         {"FD_CORE_TYPE", "0"},
         {"IS_D_VARIANT", "1"},
         {"IS_H_VARIANT", "1"},
+    };
+}
+
+// Builds compile-time defines for cq_prefetch.cpp in SD combined IS_H_VARIANT+IS_D_VARIANT mode.
+// The kernel runs as a full prefetch_hd on one core: the H side reads commands from the PCIe
+// hugepage via the FetchQ, the D side processes them and relays to dispatch.
+// FABRIC_RELAY is intentionally omitted - leaving it undefined disables the fabric code path.
+//
+// KEEP IN SYNC WITH: tt_metal/impl/dispatch/kernel_config/prefetch.cpp (CreateKernel defines block).
+inline std::map<std::string, std::string> make_sd_prefetch_defines(
+    tt_metal::IDevice* device,
+    uint32_t pcie_base,
+    uint32_t pcie_size,
+    uint32_t prefetch_q_base,
+    uint32_t prefetch_q_size,
+    uint32_t prefetch_q_rd_ptr_addr,
+    uint32_t cmddat_q_base,
+    uint32_t cmddat_q_pages,
+    uint32_t scratch_db_base,
+    uint32_t dispatch_cb_base,
+    uint32_t dispatch_cb_pages,
+    uint32_t dispatch_cb_sem_id,
+    uint32_t downstream_sync_sem_id,
+    const CoreCoord& phys_prefetch,
+    const CoreCoord& phys_dispatch) {
+    const auto my_virtual = device->virtual_noc0_coordinate(tt_metal::NOC::NOC_0, phys_prefetch);
+    const auto downstream_virtual = device->virtual_noc0_coordinate(tt_metal::NOC::NOC_0, phys_dispatch);
+    return {
+        {"MY_NOC_X", std::to_string(my_virtual.x)},
+        {"MY_NOC_Y", std::to_string(my_virtual.y)},
+        {"UPSTREAM_NOC_INDEX", std::to_string(static_cast<uint32_t>(tt_metal::NOC::NOC_0))},
+        {"UPSTREAM_NOC_X", std::to_string(my_virtual.x)},
+        {"UPSTREAM_NOC_Y", std::to_string(my_virtual.y)},
+        {"DOWNSTREAM_NOC_X", std::to_string(downstream_virtual.x)},
+        {"DOWNSTREAM_NOC_Y", std::to_string(downstream_virtual.y)},
+        {"DOWNSTREAM_SUBORDINATE_NOC_X", "255"},
+        {"DOWNSTREAM_SUBORDINATE_NOC_Y", "255"},
+        {"DOWNSTREAM_CB_BASE", std::to_string(dispatch_cb_base)},
+        {"DOWNSTREAM_CB_LOG_PAGE_SIZE", std::to_string(DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE)},
+        {"DOWNSTREAM_CB_PAGES", std::to_string(dispatch_cb_pages)},
+        {"MY_DOWNSTREAM_CB_SEM_ID", std::to_string(dispatch_cb_sem_id)},
+        {"DOWNSTREAM_CB_SEM_ID", std::to_string(dispatch_cb_sem_id)},
+        {"IS_CQ_DRAM_BACKED", "0"},
+        {"PCIE_BASE", std::to_string(pcie_base)},
+        {"PCIE_SIZE", std::to_string(pcie_size)},
+        {"PREFETCH_Q_BASE", std::to_string(prefetch_q_base)},
+        {"PREFETCH_Q_SIZE", std::to_string(prefetch_q_size)},
+        {"PREFETCH_Q_RD_PTR_ADDR", std::to_string(prefetch_q_rd_ptr_addr)},
+        {"PREFETCH_Q_PCIE_RD_PTR_ADDR", std::to_string(prefetch_q_rd_ptr_addr + sizeof(uint32_t))},
+        {"CMDDAT_Q_BASE", std::to_string(cmddat_q_base)},
+        {"CMDDAT_Q_SIZE", std::to_string(cmddat_q_pages * SD_PREFETCH_CMDDAT_PAGE_SIZE)},
+        {"SCRATCH_DB_BASE", std::to_string(scratch_db_base)},
+        {"SCRATCH_DB_SIZE", std::to_string(SD_PREFETCH_SCRATCH_DB_SIZE)},
+        {"DOWNSTREAM_SYNC_SEM_ID", std::to_string(downstream_sync_sem_id)},
+        {"CMDDAT_Q_PAGES", std::to_string(cmddat_q_pages)},
+        {"MY_UPSTREAM_CB_SEM_ID", "0"},  // not used when IS_H_VARIANT=1
+        {"UPSTREAM_CB_SEM_ID", "0"},
+        {"CMDDAT_Q_LOG_PAGE_SIZE", std::to_string(SD_PREFETCH_CMDDAT_LOG_PAGE_SIZE)},
+        {"CMDDAT_Q_BLOCKS", std::to_string(SD_PREFETCH_CMDDAT_BLOCKS)},
+        {"DISPATCH_S_BUFFER_BASE", "0"},
+        {"MY_DISPATCH_S_CB_SEM_ID", "0"},
+        {"DOWNSTREAM_DISPATCH_S_CB_SEM_ID", "0"},
+        {"DISPATCH_S_BUFFER_SIZE", "0"},
+        {"DISPATCH_S_CB_LOG_PAGE_SIZE", "0"},
+        {"RINGBUFFER_SIZE", std::to_string(SD_PREFETCH_SCRATCH_DB_SIZE)},
+        {"FABRIC_HEADER_RB_BASE", "0"},
+        {"FABRIC_HEADER_RB_ENTRIES", "0"},
+        {"MY_FABRIC_SYNC_STATUS_ADDR", "0"},
+        {"FABRIC_MUX_X", "0"},
+        {"FABRIC_MUX_Y", "0"},
+        {"FABRIC_MUX_NUM_BUFFERS_PER_CHANNEL", "0"},
+        {"FABRIC_MUX_CHANNEL_BUFFER_SIZE_BYTES", "0"},
+        {"FABRIC_MUX_CHANNEL_BASE_ADDRESS", "0"},
+        {"FABRIC_MUX_CONNECTION_INFO_ADDRESS", "0"},
+        {"FABRIC_MUX_CONNECTION_HANDSHAKE_ADDRESS", "0"},
+        {"FABRIC_MUX_FLOW_CONTROL_ADDRESS", "0"},
+        {"FABRIC_MUX_BUFFER_INDEX_ADDRESS", "0"},
+        {"FABRIC_MUX_STATUS_ADDRESS", "0"},
+        {"FABRIC_MUX_TERMINATION_SIGNAL_ADDRESS", "0"},
+        {"WORKER_CREDITS_STREAM_ID", "0"},
+        {"FABRIC_WORKER_FLOW_CONTROL_SEM", "0"},
+        {"FABRIC_WORKER_TEARDOWN_SEM", "0"},
+        {"FABRIC_WORKER_BUFFER_INDEX_SEM", "0"},
+        {"NUM_HOPS", "0"},
+        {"EW_DIM", "0"},
+        {"TO_MESH_ID", "0"},
+        {"FABRIC_2D", "0"},
+        {"IS_D_VARIANT", "1"},
+        {"IS_H_VARIANT", "1"},
+        {"OFFSETOF_MY_DEV_ID", "0"},
+        {"OFFSETOF_TO_DEV_ID", "1"},
+        {"OFFSETOF_ROUTER_DIRECTION", "2"},
+        {"FD_CORE_TYPE", "0"},
+        // FABRIC_RELAY intentionally omitted - must be undefined for #if defined(FABRIC_RELAY) to be false
     };
 }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -1114,8 +1114,12 @@ public:
             append_dispatch_payload(raw, term_cmd);
         }
 
+        const auto& memmap = tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
+        const uint32_t l1_buf_base = memmap.dispatch_buffer_base();
+        const uint32_t dispatch_buffer_pages = memmap.dispatch_buffer_pages();
+        const uint32_t dispatch_buffer_size = dispatch_buffer_pages * page_size;
+
         const uint32_t cmd_cb_pages = raw.size() / page_size;
-        const uint32_t dispatch_buffer_pages = Common::SD_DISPATCH_BUFFER_SIZE_BYTES / page_size;
         log_info(
             tt::LogTest,
             "SD: cmd_cb_pages={} dispatch_buffer_pages={} raw_bytes={}",
@@ -1123,14 +1127,9 @@ public:
             dispatch_buffer_pages,
             raw.size());
 
-        const auto& memmap = tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
-        const uint32_t l1_buf_base = memmap.dispatch_buffer_base();
-
         const auto& soc_desc = tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->device_->id());
         TT_FATAL(raw.size() + l1_buf_base <= soc_desc.worker_l1_size, "SD command buffer too large for L1");
-        TT_FATAL(
-            Common::SD_DISPATCH_BUFFER_SIZE_BYTES + l1_buf_base <= soc_desc.worker_l1_size,
-            "SD dispatch buffer too large for L1");
+        TT_FATAL(dispatch_buffer_size + l1_buf_base <= soc_desc.worker_l1_size, "SD dispatch buffer too large for L1");
 
         const CoreCoord phys_spoof = this->device_->worker_core_from_logical_core(Common::sd_spoof_prefetch_core);
         const CoreCoord phys_disp = this->device_->worker_core_from_logical_core(Common::sd_dispatch_core);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -3207,11 +3207,13 @@ public:
         const uint64_t hugepage_issue_end =
             static_cast<uint64_t>(dev_hugepage_base) + Common::SD_HUGEPAGE_ISSUE_BUFFER_SIZE;
 
+        const uint32_t host_align = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
+
         // nt_memcpy: non-temporal store of n bytes (n must be a multiple of 64).
-        auto nt_memcpy_local = [](uint8_t* __restrict dst, const uint8_t* __restrict src, size_t n) {
-            TT_FATAL(n % 64 == 0, "nt_memcpy: size {} not a multiple of 64", n);
-            for (size_t i = 0; i < n; i += 64) {
-                for (size_t j = 0; j < 64; j += sizeof(__m128i)) {
+        auto nt_memcpy_local = [&host_align](uint8_t* __restrict dst, const uint8_t* __restrict src, size_t n) {
+            TT_FATAL(n % host_align == 0, "nt_memcpy: size {} not a multiple of {}", n, host_align);
+            for (size_t i = 0; i < n; i += host_align) {
+                for (size_t j = 0; j < host_align; j += sizeof(__m128i)) {
                     __m128i blk = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + i + j));
                     _mm_stream_si128(reinterpret_cast<__m128i*>(dst + i + j), blk);
                 }
@@ -3222,7 +3224,6 @@ public:
         // write_prefetcher_cmd: nt_memcpy cmd to hugepage + write one FetchQ entry via TLB.
         // cmd_size_bytes must be a multiple of 64 (host alignment) and cmd_size_entry is the
         // pre-computed FetchQ value (may have MSB stall flag set for exec_buf).
-        const uint32_t host_align = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
         auto write_prefetcher_cmd = [&](const uint32_t* src, uint32_t cmd_size_bytes, entry_t cmd_size_entry) {
             TT_FATAL(
                 cmd_size_bytes % host_align == 0,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -19,10 +19,14 @@
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h"
 #include <impl/dispatch/dispatch_query_manager.hpp>
 
+#include <emmintrin.h>
+#include <umd/device/pcie/tlb_window.hpp>
+
 #include <chrono>
 #include <cerrno>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <vector>
 
 /*
@@ -425,6 +429,14 @@ protected:
 
     // Exec Buf Configuration
     bool use_exec_buf_{};
+
+    void init_params(const PagedReadParams& p) {
+        page_size_ = p.page_size;
+        num_pages_ = p.num_pages;
+        num_iterations_ = p.num_iterations;
+        dram_data_size_words_ = p.dram_data_size_words;
+        use_exec_buf_ = p.use_exec_buf;
+    }
 
     void SetUp() override {
         BaseTestFixture::SetUp();
@@ -3054,6 +3066,877 @@ INSTANTIATE_TEST_SUITE_P(
         return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
                std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
                "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+// Slow Dispatch Prefetcher Tests
+// Validates cq_prefetch.cpp (IS_D_VARIANT=1) in isolation without FD infrastructure.
+// Two modes via PagedReadParams::use_exec_buf:
+//   false - commands written directly to prefetch_d cmddat_q L1
+//   true  - commands written banked to DRAM; a single CQ_PREFETCH_CMD_EXEC_BUF pointer in cmddat_q
+//
+// The upstream semaphore self-loop (MY_UPSTREAM_CB_SEM_ID == UPSTREAM_CB_SEM_ID on the prefetch_d
+// core, initialized to cmd_cb_pages) pre-signals all pages so the kernel sees them immediately.
+template <typename FDFixture>
+class SDPrefetchTestBase : public FDFixture {
+public:
+    void SetUp() override {
+        if (!getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
+            GTEST_SKIP() << "Requires TT_METAL_SLOW_DISPATCH_MODE";
+        }
+        this->device_ = tt_metal::CreateDevice(0);
+
+        Common::DispatchPayloadGenerator::Config pgcfg;
+        pgcfg.use_coherent_data = this->cfg_.use_coherent_data;
+        pgcfg.perf_test = this->cfg_.perf_test;
+        pgcfg.min_xfer_size_bytes = this->cfg_.min_xfer_size_bytes;
+        pgcfg.max_xfer_size_bytes = this->cfg_.max_xfer_size_bytes;
+        std::random_device rd;
+        pgcfg.seed = rd();
+        this->payload_generator_ = std::make_unique<Common::DispatchPayloadGenerator>(pgcfg);
+        log_info(tt::LogTest, "Random seed set to {}", pgcfg.seed);
+
+        this->dispatch_buffer_page_size_ = this->cfg_.dispatch_buffer_page_size;
+        this->send_to_all_ = this->cfg_.send_to_all;
+        this->host_alignment_ = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
+        // Cap inline command size to avoid cmddat_q L1 overflow on the prefetch-d core.
+        this->max_fetch_bytes_ = Common::SD_PREFETCH_SCRATCH_DB_SIZE;
+
+        this->dram_base_ = this->device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
+        this->num_banks_ = this->device_->allocator_impl()->get_num_banks(BufferType::DRAM);
+        this->l1_alignment_ = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::L1);
+        this->packed_write_max_unicast_sub_cmds_ =
+            this->device_->compute_with_storage_grid_size().x * this->device_->compute_with_storage_grid_size().y;
+
+        this->init_params(this->GetParam());
+    }
+
+    void TearDown() override {
+        if (this->device_) {
+            tt_metal::CloseDevice(this->device_);
+            this->device_ = nullptr;
+        }
+    }
+
+    // Launches cq_prefetch.cpp (combined IS_H_VARIANT+IS_D_VARIANT) + cq_dispatch.cpp under
+    // slow dispatch by writing commands to the PCIe hugepage and notifying the prefetcher via
+    // the FetchQ ring - the same mechanism used by the FD runtime.
+    //
+    // All hugepage writes and FetchQ entries are committed before LaunchProgram so the
+    // kernel finds all data ready when it starts.  num_cores_to_log / wait_for_* match the
+    // FD virtual signature but are unused (LaunchProgram is synchronous).
+    void execute_generated_commands(
+        const std::vector<HostMemDeviceCommand>& commands_per_iteration,
+        Common::DeviceData& device_data,
+        size_t /*num_cores_to_log*/,
+        uint32_t num_iterations,
+        bool /*wait_for_completion*/ = true,
+        bool /*wait_for_host_writes*/ = false) override {
+        using entry_t = DispatchSettings::prefetch_q_entry_type;  // uint16_t
+
+        const auto& memmap = tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
+        const uint32_t dispatch_cb_base = memmap.dispatch_buffer_base();
+        const uint32_t dispatch_buffer_pages =
+            Common::SD_DISPATCH_BUFFER_SIZE_BYTES / Common::SD_DISPATCH_BUFFER_PAGE_SIZE;
+
+        // L1 layout on the prefetch_hd core
+        // Place FetchQ ring + rd_ptr immediately after the first allocatable L1 page.
+        // cmddat_q and scratch_db follow the FetchQ.
+        const uint32_t l1_unrsv = this->device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        const uint32_t page_size = Common::SD_PREFETCH_CMDDAT_PAGE_SIZE;
+        const uint32_t l1_unrsv_aligned = tt::align(l1_unrsv, page_size);
+
+        // prefetch_q_rd_ptr_addr (4 B) and pcie_rd_ptr_addr (next 4 B) live at l1_unrsv_aligned.
+        // The FetchQ ring starts one full page later so it is page-aligned.
+        const uint32_t prefetch_q_rd_ptr_addr = l1_unrsv_aligned;
+        const uint32_t prefetch_q_base = l1_unrsv_aligned + page_size;
+        const uint32_t prefetch_q_size = Common::SD_PREFETCH_Q_ENTRIES * sizeof(entry_t);
+
+        // cmddat_q: after FetchQ, aligned to host (NOC) alignment.
+        const uint32_t noc_align = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
+        const uint32_t cmddat_q_base = prefetch_q_base + tt::align(prefetch_q_size, noc_align);
+        // Use the same cmddat_q size as the FD runtime (256KB on worker). read_from_pcie issues one DMA per
+        // FetchQ entry, so cmddat_q must be >= max single command size (prefetch_max_cmd_size = 128KB).
+        const uint32_t cmddat_q_bytes = memmap.cmddat_q_size();
+        const uint32_t cmddat_q_pages = tt::align(cmddat_q_bytes / page_size, Common::SD_PREFETCH_CMDDAT_BLOCKS);
+        const uint32_t scratch_db_base = cmddat_q_base + cmddat_q_pages * page_size;
+
+        const auto& soc_desc = tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->device_->id());
+        TT_FATAL(
+            scratch_db_base + Common::SD_PREFETCH_SCRATCH_DB_SIZE <= soc_desc.worker_l1_size,
+            "SD prefetch hd: prefetch_q + cmddat_q + scratch_db exceeds worker L1");
+
+        // Hugepage addressing
+        // Use the same hugepage region that the FD runtime uses for the issue queue
+        // (safe since SD mode never runs the FD runtime concurrently).
+        const uint32_t dev_hugepage_base = memmap.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
+
+        const ChipId mmio_id =
+            tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->device_->id());
+        const uint16_t channel =
+            tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(this->device_->id());
+        char* hugepage_bar_base =
+            static_cast<char*>(tt_metal::MetalContext::instance().get_cluster().host_dma_address(0, mmio_id, channel));
+        hugepage_bar_base += (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
+        void* const host_hugepage_base = hugepage_bar_base + dev_hugepage_base;
+
+        // Physical cores
+        const CoreCoord phys_prefetch = this->device_->worker_core_from_logical_core(Common::sd_prefetch_core);
+        const CoreCoord phys_disp = this->device_->worker_core_from_logical_core(Common::sd_dispatch_core);
+        const tt_cxy_pair prefetch_cxy(this->device_->id(), phys_prefetch);
+
+        auto& cluster = tt_metal::MetalContext::instance().get_cluster();
+
+        // Init FetchQ ring and rd_ptrs in prefetch_hd L1
+        // Clear the entire FetchQ ring to zero (kernel spins on non-zero entries).
+        {
+            std::vector<uint32_t> q_zeros(prefetch_q_size / sizeof(uint32_t), 0u);
+            cluster.write_core(q_zeros.data(), q_zeros.size() * sizeof(uint32_t), prefetch_cxy, prefetch_q_base);
+        }
+        // prefetch_q_rd_ptr_addr: kernel writes its consumed position here so the host can poll.
+        // Initialise to the ring base so the host-side fence logic sees the ring as empty.
+        {
+            const uint32_t init_rd_ptr = prefetch_q_base;
+            cluster.write_core(&init_rd_ptr, sizeof(uint32_t), prefetch_cxy, prefetch_q_rd_ptr_addr);
+        }
+        // pcie_rd_ptr_addr (prefetch_q_rd_ptr_addr + 4): initialise to 0.
+        {
+            const uint32_t init_pcie_rd = 0u;
+            cluster.write_core(
+                &init_pcie_rd, sizeof(uint32_t), prefetch_cxy, prefetch_q_rd_ptr_addr + sizeof(uint32_t));
+        }
+
+        // TLB window for writing FetchQ entries
+        tt::umd::TlbWindow* prefetch_q_tlb = cluster.get_static_tlb_window(prefetch_cxy);
+
+        // Host-side FetchQ write state.
+        uint32_t prefetch_q_dev_ptr = prefetch_q_base;
+        const uint32_t prefetch_q_dev_fence = prefetch_q_base + prefetch_q_size;
+
+        // Hugepage write state.
+        uint32_t* host_mem_ptr = static_cast<uint32_t*>(host_hugepage_base);
+        const uint64_t hugepage_issue_end =
+            static_cast<uint64_t>(dev_hugepage_base) + Common::SD_HUGEPAGE_ISSUE_BUFFER_SIZE;
+
+        // nt_memcpy: non-temporal store of n bytes (n must be a multiple of 64).
+        auto nt_memcpy_local = [](uint8_t* __restrict dst, const uint8_t* __restrict src, size_t n) {
+            TT_FATAL(n % 64 == 0, "nt_memcpy: size {} not a multiple of 64", n);
+            for (size_t i = 0; i < n; i += 64) {
+                for (size_t j = 0; j < 64; j += sizeof(__m128i)) {
+                    __m128i blk = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + i + j));
+                    _mm_stream_si128(reinterpret_cast<__m128i*>(dst + i + j), blk);
+                }
+            }
+            tt_driver_atomics::sfence();
+        };
+
+        // write_prefetcher_cmd: nt_memcpy cmd to hugepage + write one FetchQ entry via TLB.
+        // cmd_size_bytes must be a multiple of 64 (host alignment) and cmd_size_entry is the
+        // pre-computed FetchQ value (may have MSB stall flag set for exec_buf).
+        const uint32_t host_align = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
+        auto write_prefetcher_cmd = [&](const uint32_t* src, uint32_t cmd_size_bytes, entry_t cmd_size_entry) {
+            TT_FATAL(
+                cmd_size_bytes % host_align == 0,
+                "SD prefetch: cmd_size_bytes {} not aligned to host alignment {}",
+                cmd_size_bytes,
+                host_align);
+
+            // Poll for FetchQ ring space (should not spin in normal SD operation).
+            while (prefetch_q_dev_ptr == prefetch_q_dev_fence) {
+                uint32_t rd_ptr;
+                cluster.read_core(&rd_ptr, sizeof(uint32_t), prefetch_cxy, prefetch_q_rd_ptr_addr);
+                if (rd_ptr != prefetch_q_dev_ptr) {
+                    break;
+                }
+            }
+
+            // Hugepage wrap: if the command would exceed the issue buffer, reset to base.
+            const uint64_t host_offset =
+                static_cast<uint64_t>(reinterpret_cast<char*>(host_mem_ptr) - static_cast<char*>(host_hugepage_base));
+            if (dev_hugepage_base + host_offset + cmd_size_bytes > hugepage_issue_end) {
+                host_mem_ptr = static_cast<uint32_t*>(host_hugepage_base);
+            }
+
+            nt_memcpy_local(
+                reinterpret_cast<uint8_t*>(host_mem_ptr), reinterpret_cast<const uint8_t*>(src), cmd_size_bytes);
+            host_mem_ptr += cmd_size_bytes / sizeof(uint32_t);
+
+            prefetch_q_tlb->write16(prefetch_q_dev_ptr, cmd_size_entry);
+            prefetch_q_dev_ptr += sizeof(entry_t);
+            if (prefetch_q_dev_ptr >= prefetch_q_dev_fence) {
+                prefetch_q_dev_ptr = prefetch_q_base;
+            }
+        };
+
+        if (this->use_exec_buf_) {
+            // exec_buf=true
+            // 1. Build DRAM exec_buf payload: commands x iterations + dispatch_wait + exec_buf_end.
+            std::vector<uint8_t> exec_buf_data;
+            for (uint32_t i = 0; i < num_iterations; ++i) {
+                for (const auto& cmd : commands_per_iteration) {
+                    const auto* p = reinterpret_cast<const uint8_t*>(cmd.data());
+                    exec_buf_data.insert(exec_buf_data.end(), p, p + cmd.size_bytes());
+                }
+            }
+            {
+                DeviceCommandCalculator wc;
+                wc.add_dispatch_wait();
+                HostMemDeviceCommand wait_cmd(wc.write_offset_bytes());
+                wait_cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
+                const auto* p = reinterpret_cast<const uint8_t*>(wait_cmd.data());
+                exec_buf_data.insert(exec_buf_data.end(), p, p + wait_cmd.size_bytes());
+            }
+            {
+                DeviceCommandCalculator ec;
+                ec.add_prefetch_exec_buf_end();
+                HostMemDeviceCommand end_cmd(ec.write_offset_bytes());
+                end_cmd.add_prefetch_exec_buf_end();
+                const auto* p = reinterpret_cast<const uint8_t*>(end_cmd.data());
+                exec_buf_data.insert(exec_buf_data.end(), p, p + end_cmd.size_bytes());
+            }
+            const uint32_t eb_page = 1u << FDFixture::DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE;
+            const size_t padded = tt::align(exec_buf_data.size(), eb_page);
+            exec_buf_data.resize(padded, 0u);
+            const uint32_t exec_buf_pages = static_cast<uint32_t>(padded) / eb_page;
+            log_info(tt::LogTest, "SD prefetch hd exec_buf: {} bytes ({} DRAM pages)", padded, exec_buf_pages);
+
+            // 2. Write exec_buf payload to DRAM.
+            for (uint32_t page_idx = 0; page_idx < exec_buf_pages; ++page_idx) {
+                const uint32_t bank_id = page_idx % this->num_banks_;
+                const uint32_t bank_offset = (page_idx / this->num_banks_) * eb_page;
+                const uint32_t addr = FDFixture::DRAM_EXEC_BUF_DEFAULT_BASE_ADDR + bank_offset;
+                std::vector<uint8_t> pg(
+                    exec_buf_data.begin() + page_idx * eb_page, exec_buf_data.begin() + page_idx * eb_page + eb_page);
+                detail::WriteToDeviceDRAMChannel(this->device_, bank_id, addr, pg);
+            }
+            tt_metal::MetalContext::instance().get_cluster().dram_barrier(this->device_->id());
+
+            // 3. Write CQ_PREFETCH_CMD_EXEC_BUF to hugepage with MSB stall flag.
+            {
+                DeviceCommandCalculator ec;
+                ec.add_prefetch_exec_buf();
+                HostMemDeviceCommand exec_cmd(ec.write_offset_bytes());
+                exec_cmd.add_prefetch_exec_buf(
+                    FDFixture::DRAM_EXEC_BUF_DEFAULT_BASE_ADDR,
+                    FDFixture::DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE,
+                    exec_buf_pages);
+                const uint32_t cmd_size_bytes = tt::align(exec_cmd.size_bytes(), host_align);
+                entry_t cmd_size_entry =
+                    static_cast<entry_t>(cmd_size_bytes >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
+                // MSB stall flag: prefetcher stalls after fetching this command (exec_buf replays from DRAM).
+                cmd_size_entry |= static_cast<entry_t>(1u << (sizeof(entry_t) * 8u - 1u));
+                std::vector<uint8_t> exec_cmd_padded(cmd_size_bytes, 0u);
+                std::memcpy(exec_cmd_padded.data(), exec_cmd.data(), exec_cmd.size_bytes());
+                write_prefetcher_cmd(
+                    reinterpret_cast<const uint32_t*>(exec_cmd_padded.data()), cmd_size_bytes, cmd_size_entry);
+            }
+            // 4. Terminate: relay_inline(dispatch_wait), relay_inline(dispatch_terminate), prefetch_terminate.
+            // Each add_dispatch_*/add_prefetch_* already wraps the cmd in relay_inline internally.
+            {
+                DeviceCommandCalculator wc;
+                wc.add_dispatch_wait();
+                HostMemDeviceCommand wait_cmd(wc.write_offset_bytes());
+                wait_cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
+                const uint32_t wait_size = tt::align(wait_cmd.size_bytes(), host_align);
+                std::vector<uint8_t> wait_padded(wait_size, 0u);
+                std::memcpy(wait_padded.data(), wait_cmd.data(), wait_cmd.size_bytes());
+                entry_t wait_entry = static_cast<entry_t>(wait_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
+                write_prefetcher_cmd(reinterpret_cast<const uint32_t*>(wait_padded.data()), wait_size, wait_entry);
+            }
+            {
+                DeviceCommandCalculator dc;
+                dc.add_dispatch_terminate();
+                HostMemDeviceCommand disp_term(dc.write_offset_bytes());
+                disp_term.add_dispatch_terminate();
+                const uint32_t dterm_size = tt::align(disp_term.size_bytes(), host_align);
+                std::vector<uint8_t> dterm_padded(dterm_size, 0u);
+                std::memcpy(dterm_padded.data(), disp_term.data(), disp_term.size_bytes());
+                entry_t dterm_entry = static_cast<entry_t>(dterm_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
+                write_prefetcher_cmd(reinterpret_cast<const uint32_t*>(dterm_padded.data()), dterm_size, dterm_entry);
+            }
+            {
+                DeviceCommandCalculator pc;
+                pc.add_prefetch_terminate();
+                HostMemDeviceCommand pref_term(pc.write_offset_bytes());
+                pref_term.add_prefetch_terminate();
+                const uint32_t pterm_size = tt::align(pref_term.size_bytes(), host_align);
+                std::vector<uint8_t> pterm_padded(pterm_size, 0u);
+                std::memcpy(pterm_padded.data(), pref_term.data(), pref_term.size_bytes());
+                entry_t pterm_entry = static_cast<entry_t>(pterm_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
+                write_prefetcher_cmd(reinterpret_cast<const uint32_t*>(pterm_padded.data()), pterm_size, pterm_entry);
+            }
+        } else {
+            // exec_buf=false
+            // Write each command as a separate FetchQ entry.
+            for (uint32_t i = 0; i < num_iterations; ++i) {
+                for (const auto& cmd : commands_per_iteration) {
+                    const uint32_t cmd_size = tt::align(cmd.size_bytes(), host_align);
+                    entry_t cmd_entry = static_cast<entry_t>(cmd_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
+                    TT_FATAL(
+                        (cmd_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE) == (uint32_t)cmd_entry,
+                        "SD prefetch: command size {} B overflows 15-bit FetchQ entry (max {} B)",
+                        cmd_size,
+                        (uint32_t)0x7FFF << DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
+                    std::vector<uint8_t> cmd_padded(cmd_size, 0u);
+                    std::memcpy(cmd_padded.data(), cmd.data(), cmd.size_bytes());
+                    write_prefetcher_cmd(reinterpret_cast<const uint32_t*>(cmd_padded.data()), cmd_size, cmd_entry);
+                }
+            }
+            // Terminate: relay_inline(dispatch_wait), relay_inline(dispatch_terminate), prefetch_terminate.
+            // Each add_dispatch_*/add_prefetch_* already wraps the cmd in relay_inline internally.
+            {
+                DeviceCommandCalculator wc;
+                wc.add_dispatch_wait();
+                HostMemDeviceCommand wait_cmd(wc.write_offset_bytes());
+                wait_cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
+                const uint32_t wait_size = tt::align(wait_cmd.size_bytes(), host_align);
+                std::vector<uint8_t> wait_padded(wait_size, 0u);
+                std::memcpy(wait_padded.data(), wait_cmd.data(), wait_cmd.size_bytes());
+                entry_t wait_entry = static_cast<entry_t>(wait_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
+                write_prefetcher_cmd(reinterpret_cast<const uint32_t*>(wait_padded.data()), wait_size, wait_entry);
+            }
+            {
+                DeviceCommandCalculator dc;
+                dc.add_dispatch_terminate();
+                HostMemDeviceCommand disp_term(dc.write_offset_bytes());
+                disp_term.add_dispatch_terminate();
+                const uint32_t dterm_size = tt::align(disp_term.size_bytes(), host_align);
+                std::vector<uint8_t> dterm_padded(dterm_size, 0u);
+                std::memcpy(dterm_padded.data(), disp_term.data(), disp_term.size_bytes());
+                entry_t dterm_entry = static_cast<entry_t>(dterm_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
+                write_prefetcher_cmd(reinterpret_cast<const uint32_t*>(dterm_padded.data()), dterm_size, dterm_entry);
+            }
+            {
+                DeviceCommandCalculator pc;
+                pc.add_prefetch_terminate();
+                HostMemDeviceCommand pref_term(pc.write_offset_bytes());
+                pref_term.add_prefetch_terminate();
+                const uint32_t pterm_size = tt::align(pref_term.size_bytes(), host_align);
+                std::vector<uint8_t> pterm_padded(pterm_size, 0u);
+                std::memcpy(pterm_padded.data(), pref_term.data(), pref_term.size_bytes());
+                entry_t pterm_entry = static_cast<entry_t>(pterm_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
+                write_prefetcher_cmd(reinterpret_cast<const uint32_t*>(pterm_padded.data()), pterm_size, pterm_entry);
+            }
+        }
+
+        // Semaphores
+        tt_metal::Program program = tt_metal::CreateProgram();
+
+        // Slot 0: prefetch_sync_sem - dispatch signals prefetch when a stall round-trip is done.
+        const uint32_t pf_sync_sem = tt_metal::CreateSemaphore(program, {Common::sd_prefetch_core}, 0u);
+        const uint32_t di_sync_sem = tt_metal::CreateSemaphore(program, {Common::sd_dispatch_core}, 0u);
+        TT_FATAL(pf_sync_sem == di_sync_sem, "prefetch_sync_sem slot mismatch ({} vs {})", pf_sync_sem, di_sync_sem);
+
+        // Slot 1: downstream_cb_sem on prefetch (init=dispatch_buffer_pages); dispatch_cb_sem on dispatch (init=0).
+        const uint32_t pf_downstream_cb_sem =
+            tt_metal::CreateSemaphore(program, {Common::sd_prefetch_core}, dispatch_buffer_pages);
+        const uint32_t di_dispatch_cb_sem = tt_metal::CreateSemaphore(program, {Common::sd_dispatch_core}, 0u);
+        TT_FATAL(
+            pf_downstream_cb_sem == di_dispatch_cb_sem,
+            "dispatch_cb sem slot mismatch ({} vs {})",
+            pf_downstream_cb_sem,
+            di_dispatch_cb_sem);
+
+        // Kernel defines and creation
+        auto prefetch_defines = Common::make_sd_prefetch_defines(
+            this->device_,
+            dev_hugepage_base,
+            Common::SD_HUGEPAGE_ISSUE_BUFFER_SIZE,
+            prefetch_q_base,
+            prefetch_q_size,
+            prefetch_q_rd_ptr_addr,
+            cmddat_q_base,
+            cmddat_q_pages,
+            scratch_db_base,
+            dispatch_cb_base,
+            dispatch_buffer_pages,
+            pf_downstream_cb_sem,
+            pf_sync_sem,
+            phys_prefetch,
+            phys_disp);
+        auto prefetch_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",
+            {Common::sd_prefetch_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::NOC_0,
+                .defines = prefetch_defines});
+        tt_metal::SetRuntimeArgs(program, prefetch_kernel, Common::sd_prefetch_core, {0u, 0u, 0u});
+
+        const uint32_t dev_completion_base = dev_hugepage_base + Common::SD_HUGEPAGE_ISSUE_BUFFER_SIZE;
+        auto dispatch_defines = Common::make_sd_dispatch_defines(
+            this->device_,
+            dispatch_buffer_pages,
+            di_dispatch_cb_sem,
+            di_sync_sem,
+            phys_prefetch,
+            phys_disp,
+            memmap,
+            dev_completion_base,
+            Common::SD_COMPLETION_QUEUE_SIZE);
+        auto dispatch_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
+            {Common::sd_dispatch_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::NOC_0,
+                .defines = dispatch_defines});
+        tt_metal::SetRuntimeArgs(program, dispatch_kernel, Common::sd_dispatch_core, {0u, 0u, 0u});
+
+        device_data.overflow_check(this->device_);
+        tt_metal::detail::LaunchProgram(this->device_, program);
+        // Ensure host CPU sees any PCIe-written completion queue data before validating.
+        tt_driver_atomics::mfence();
+        EXPECT_TRUE(device_data.validate(this->device_)) << "SD prefetch test failed validation";
+    }
+};
+
+class SDPrefetchDRAMToL1TestFixture : public SDPrefetchTestBase<BasePrefetcherTestFixture> {};
+class SDPrefetchPackedReadTestFixture : public SDPrefetchTestBase<PrefetcherPackedReadTestFixture> {};
+class SDPrefetchRandomTestFixture : public SDPrefetchTestBase<RandomTestFixture> {};
+
+TEST_P(SDPrefetchDRAMToL1TestFixture, DRAMToL1PagedRead) {
+    log_info(tt::LogTest, "SDPrefetchDRAMToL1TestFixture - DRAMToL1PagedRead - Test Start");
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+
+    const CoreRange worker_range(default_worker_start, default_worker_start);
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+    Common::DeviceData device_data(
+        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+    auto commands_per_iteration =
+        generate_paged_read_commands(worker_range, get_page_size(), get_num_pages(), device_data);
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+}
+
+TEST_P(SDPrefetchDRAMToL1TestFixture, TestTerminate) {
+    log_info(tt::LogTest, "SDPrefetchDRAMToL1TestFixture - TestTerminate - Test Start");
+    constexpr uint32_t xfer_size_bytes = 16;
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+
+    const CoreCoord first_worker = default_worker_start;
+    const CoreRange worker_range = {first_worker, {first_worker.x + 1, first_worker.y + 1}};
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+
+    Common::DeviceData device_data(
+        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+    const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
+    const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+    const uint32_t l1_addr = device_data.get_result_data_addr(first_worker, 0);
+
+    std::vector<uint32_t> payload = payload_generator_->generate_payload(xfer_size_bytes);
+    std::vector<HostMemDeviceCommand> work_cmds;
+    work_cmds.push_back(Common::CommandBuilder::build_linear_write_command<true, true>(
+        payload, worker_range, false, noc_xy, l1_addr, xfer_size_bytes));
+
+    execute_generated_commands(work_cmds, device_data, worker_range.size(), num_iterations);
+}
+
+TEST_P(SDPrefetchPackedReadTestFixture, PackedReadTest) {
+    log_info(tt::LogTest, "SDPrefetchPackedReadTestFixture - PackedReadTest - Test Start");
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+
+    const CoreRange worker_range(default_worker_start, default_worker_start);
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
+    Common::DeviceData device_data(
+        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+    auto commands_per_iteration = generate_packed_read_commands(default_worker_start, dram_alignment, device_data);
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+}
+
+TEST_P(SDPrefetchPackedReadTestFixture, SmokeTest) {
+    log_info(tt::LogTest, "SDPrefetchPackedReadTestFixture - SmokeTest - Test Start");
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+
+    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord last_worker = first_worker;
+    const CoreRange worker_range = {first_worker, last_worker};
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+
+    Common::DeviceData device_data(
+        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+    std::vector<HostMemDeviceCommand> commands_per_iteration;
+    HelperInfo info{
+        dram_base_, num_banks_, l1_alignment_, packed_write_max_unicast_sub_cmds_, dispatch_buffer_page_size_};
+    SmokeTestHelper helper(device_, device_data, commands_per_iteration, info);
+
+    helper.add_unicast_write(worker_range, 32);
+    helper.add_unicast_write(worker_range, 1026);
+    helper.add_unicast_write(worker_range, 8448);
+    helper.add_unicast_write(worker_range, dispatch_buffer_page_size_);
+    helper.add_unicast_write(worker_range, dispatch_buffer_page_size_ - sizeof(CQDispatchCmdLarge));
+    helper.add_unicast_write(worker_range, 2 * dispatch_buffer_page_size_);
+    helper.add_unicast_write(worker_range, (2 * dispatch_buffer_page_size_) - sizeof(CQDispatchCmdLarge));
+
+    helper.add_merged_unicast_writes(worker_range, {112, 608, 64, 96});
+
+    constexpr uint32_t log_packed_read_page_size = 10;
+    const uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
+    const uint32_t length_to_read = tt::align(2080, dram_alignment);
+    const uint32_t length_to_read_sdb = tt::align(DEFAULT_SCRATCH_DB_SIZE / 8, dram_alignment);
+    auto build_packed = [this](
+                            const std::vector<uint32_t>& lengths,
+                            Common::DeviceData& device_data,
+                            uint32_t log_page_sz,
+                            uint32_t n_sub_cmds) {
+        return PrefetcherPackedReadTestFixture::build_sub_cmds(lengths, device_data, log_page_sz, n_sub_cmds);
+    };
+    helper.add_packed_dram_read(worker_range, log_packed_read_page_size, {256, 512}, build_packed);
+    helper.add_packed_dram_read(worker_range, log_packed_read_page_size, {1024, 2048}, build_packed);
+    helper.add_packed_dram_read(worker_range, log_packed_read_page_size, {length_to_read}, build_packed);
+    helper.add_packed_dram_read(
+        worker_range, log_packed_read_page_size + 1, {length_to_read, length_to_read}, build_packed);
+
+    std::vector<uint32_t> lengths{
+        length_to_read_sdb,
+        length_to_read_sdb,
+        length_to_read_sdb,
+        tt::align(DEFAULT_SCRATCH_DB_SIZE / 4, dram_alignment),
+        tt::align(DEFAULT_SCRATCH_DB_SIZE / 2, dram_alignment)};
+    helper.add_packed_dram_read(worker_range, log_packed_read_page_size + 1, lengths, build_packed);
+
+    lengths.clear();
+    lengths.push_back(tt::align((DEFAULT_SCRATCH_DB_SIZE / 4) + (2 * 1024) + 32, dram_alignment));
+    lengths.push_back(tt::align((DEFAULT_SCRATCH_DB_SIZE / 4) + (3 * 1024) + 32, dram_alignment));
+    lengths.push_back(tt::align(DEFAULT_SCRATCH_DB_SIZE / 2, dram_alignment));
+    lengths.push_back(tt::align((DEFAULT_SCRATCH_DB_SIZE / 8) + (5 * 1024) + 96, dram_alignment));
+    helper.add_packed_dram_read(worker_range, log_packed_read_page_size, lengths, build_packed);
+
+    helper.add_paged_dram_read(worker_range, 0, 0, dram_alignment, num_banks_, 0);
+    helper.add_paged_dram_read(worker_range, 4, dram_alignment, dram_alignment * 2, num_banks_, 0);
+    helper.add_paged_dram_read(worker_range, 4, dram_alignment, dram_alignment * 2, num_banks_, 0);
+    helper.add_paged_dram_read(worker_range, 0, 0, 128, 128, 0);
+    helper.add_paged_dram_read(worker_range, 4, dram_alignment, 2048, num_banks_ + 4, 0);
+    helper.add_paged_dram_read(worker_range, 5, dram_alignment, 2048, (num_banks_ * 3) + 1, 0);
+    helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_ - 1, 0);
+    helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_ - 1, 0);
+    helper.add_paged_dram_read(worker_range, 0, 0, 128, 128, 32);
+    helper.add_paged_dram_read(worker_range, 4, dram_alignment, 2048, num_banks_ * 2, 1536);
+    helper.add_paged_dram_read(worker_range, 5, dram_alignment, 2048, (num_banks_ * 2) + 1, 256);
+    helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_ - 1, 640);
+    helper.add_paged_dram_read(worker_range, 0, 0, DEFAULT_SCRATCH_DB_SIZE / 2 + dram_alignment, 2, 128);
+    helper.add_paged_dram_read(worker_range, 0, 0, DEFAULT_SCRATCH_DB_SIZE, 2, 0);
+    uint32_t page_size = 256 + dram_alignment;
+    uint32_t length = (DEFAULT_SCRATCH_DB_SIZE / 2 / page_size * page_size) + page_size;
+    helper.add_paged_dram_read(worker_range, 3, 128, page_size, length / page_size, 160);
+
+    const CoreRange worker_range_2x2 = {default_worker_start, {default_worker_start.x + 1, default_worker_start.y + 1}};
+    std::vector<CoreCoord> worker_cores{default_worker_start};
+    helper.add_packed_write(worker_cores, 4);
+    worker_cores.clear();
+    for (uint32_t y = worker_range_2x2.start_coord.y; y <= worker_range_2x2.end_coord.y; ++y) {
+        for (uint32_t x = worker_range_2x2.start_coord.x; x <= worker_range_2x2.end_coord.x; ++x) {
+            worker_cores.push_back({x, y});
+        }
+    }
+    helper.add_packed_write(worker_cores, 12);
+    helper.add_packed_write(worker_cores, 12, true);
+    worker_cores.clear();
+    worker_cores.push_back(default_worker_start);
+    worker_cores.push_back({default_worker_start.x + 1, default_worker_start.y + 1});
+    helper.add_packed_write(worker_cores, 156);
+
+    helper.add_linear_read(worker_range, 32);
+    helper.add_linear_read(worker_range, 65 * 1024);
+    helper.add_linear_read(worker_range, dispatch_buffer_page_size_ - sizeof(CQDispatchCmdLarge));
+    helper.add_linear_read(worker_range, (2 * dispatch_buffer_page_size_) - sizeof(CQDispatchCmdLarge));
+    helper.add_linear_read(worker_range, (2 * dispatch_buffer_page_size_));
+    helper.add_unicast_write(worker_range, 1024);
+    HostMemDeviceCommand stall_cmd = CommandBuilder::build_dispatch_prefetch_stall();
+    commands_per_iteration.push_back(std::move(stall_cmd));
+    uint32_t length_bytes = 32;
+    uint32_t offset_words = device_data.size_at(worker_range.start_coord, 0) - (length_bytes / sizeof(uint32_t));
+    helper.add_linear_read(worker_range, length_bytes, offset_words * sizeof(uint32_t));
+
+    std::array<uint32_t, CQ_DISPATCH_MAX_WRITE_OFFSETS> write_offset1 = {48, 0, 0, 0};
+    std::array<uint32_t, CQ_DISPATCH_MAX_WRITE_OFFSETS> write_offset2 = {};
+    commands_per_iteration.push_back(CommandBuilder::build_dispatch_write_offset(write_offset1));
+    commands_per_iteration.push_back(CommandBuilder::build_dispatch_write_offset(write_offset2));
+
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+}
+
+TEST_P(SDPrefetchRandomTestFixture, RandomTest) {
+    log_info(tt::LogTest, "SDPrefetchRandomTestFixture - RandomTest - Test Start");
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+
+    const CoreCoord first_worker = default_worker_start;
+    const CoreRange worker_range = {first_worker, {first_worker.x + 1, first_worker.y + 1}};
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+    Common::DeviceData device_data(
+        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+    std::vector<HostMemDeviceCommand> commands_per_iteration;
+    uint32_t remaining_bytes = DEVICE_DATA_SIZE;
+
+    while (remaining_bytes > 0) {
+        uint32_t cmd = payload_generator_->get_rand<uint32_t>(0, CQ_PREFETCH_CMD_TERMINATE - 1);
+        const uint32_t limit_x = (worker_range.end_coord.x - first_worker.x - 1);
+        const uint32_t limit_y = (worker_range.end_coord.y - first_worker.y - 1);
+        uint32_t x = payload_generator_->get_rand<uint32_t>(0, limit_x);
+        uint32_t y = payload_generator_->get_rand<uint32_t>(0, limit_y);
+        CoreCoord worker_core(first_worker.x + x, first_worker.y + y);
+        const CoreCoord worker_core_virt = device_->virtual_core_from_logical_core(worker_core, CoreType::WORKER);
+        const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, worker_core_virt);
+
+        switch (cmd) {
+            case CQ_PREFETCH_CMD_RELAY_LINEAR:
+            case CQ_PREFETCH_CMD_RELAY_PAGED: {
+                CoreRange single_worker_range = {worker_core, worker_core};
+                auto result =
+                    gen_random_dram_paged_cmd(device_data, worker_core, single_worker_range, noc_xy, remaining_bytes);
+                if (result.has_value()) {
+                    commands_per_iteration.push_back(std::move(*result));
+                }
+                break;
+            }
+            case CQ_PREFETCH_CMD_RELAY_INLINE: {
+                CoreRange multi_worker_range = {worker_core, {worker_core.x + 1, worker_core.y + 1}};
+                auto result = gen_random_inline_cmd(device_data, multi_worker_range, noc_xy, remaining_bytes);
+                if (result.has_value()) {
+                    commands_per_iteration.push_back(std::move(*result));
+                }
+                break;
+            }
+            default: break;
+        }
+    }
+
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    SDPrefetchDRAMToL1TestFixture,
+    ::testing::Values(
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedReadParams{8192, 8, 1, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedReadParams{8192, 8, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + (info.param.use_exec_buf ? "exec_buf" : "direct");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    SDPrefetchPackedReadTestFixture,
+    ::testing::Values(
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + (info.param.use_exec_buf ? "exec_buf" : "direct");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    SDPrefetchRandomTestFixture,
+    ::testing::Values(PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, false}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + (info.param.use_exec_buf ? "exec_buf" : "direct");
+    });
+
+class SDPrefetchLinearPackedReadTestFixture : public SDPrefetchTestBase<PrefetcherLinearPackedReadTestFixture> {};
+
+TEST_P(SDPrefetchLinearPackedReadTestFixture, LinearPackedReadTest) {
+    log_info(tt::LogTest, "SDPrefetchLinearPackedReadTestFixture - LinearPackedReadTest - Test Start");
+    const uint32_t num_iterations = 1;
+
+    const CoreCoord first_worker = default_worker_start;
+    const CoreRange worker_range = {first_worker, {first_worker.x + 1, first_worker.y + 1}};
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+    const auto l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+
+    // Pre-populate L1 with sequential test data for the prefetcher to read
+    const uint32_t l1_data_size_words = DEVICE_DATA_SIZE / sizeof(uint32_t);
+    std::vector<uint32_t> l1_data(l1_data_size_words);
+    for (uint32_t i = 0; i < l1_data_size_words; i++) {
+        l1_data[i] = i;
+    }
+    const CoreCoord phys_worker_core = device_->worker_core_from_logical_core(first_worker);
+    MetalContext::instance().get_cluster().write_core(device_->id(), phys_worker_core, l1_data, l1_base);
+    MetalContext::instance().get_cluster().l1_barrier(device_->id());
+
+    // Initialize DRAM bank 0 with sentinel to detect unwritten regions
+    constexpr uint32_t dest_bank_id = 0;
+    constexpr uint32_t sentinel_pattern = 0x99999999;
+    const uint32_t dram_size_words = DEVICE_DATA_SIZE_LARGE / sizeof(uint32_t);
+    std::vector<uint32_t> sentinel_data(dram_size_words, sentinel_pattern);
+    tt::tt_metal::detail::WriteToDeviceDRAMChannel(device_, dest_bank_id, dram_base_, sentinel_data);
+    MetalContext::instance().get_cluster().dram_barrier(device_->id());
+
+    Common::DeviceData device_data(device_, worker_range, l1_base, dram_base_, nullptr, false, 0, cfg_);
+
+    auto commands_per_iteration = generate_linear_packed_read_commands(first_worker, l1_alignment, device_data);
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    SDPrefetchLinearPackedReadTestFixture,
+    ::testing::Values(
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + (info.param.use_exec_buf ? "exec_buf" : "direct");
+    });
+
+class SDPrefetchRingbufferReadTestFixture : public SDPrefetchTestBase<PrefetcherRingbufferReadTestFixture> {};
+
+TEST_P(SDPrefetchRingbufferReadTestFixture, RingbufferReadTest) {
+    log_info(tt::LogTest, "SDPrefetchRingbufferReadTestFixture - RingbufferReadTest - Test Start");
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+
+    const CoreCoord first_worker = default_worker_start;
+    const CoreRange worker_range = {first_worker, {first_worker.x + 1, first_worker.y + 1}};
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+    const auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
+
+    Common::DeviceData device_data(
+        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+    auto commands_per_iteration = generate_ringbuffer_relay_commands(first_worker, dram_alignment, device_data);
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    SDPrefetchRingbufferReadTestFixture,
+    ::testing::Values(
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + (info.param.use_exec_buf ? "exec_buf" : "direct");
+    });
+
+// SD end-to-end paged write+read: dispatcher writes to DRAM banks, prefetcher relays back to L1
+class SDPrefetchPagedReadWriteTestFixture : public SDPrefetchTestBase<BasePrefetcherTestFixture> {};
+
+TEST_P(SDPrefetchPagedReadWriteTestFixture, PagedReadWriteTest) {
+    log_info(tt::LogTest, "SDPrefetchPagedReadWriteTestFixture - PagedReadWriteTest - Test Start");
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+    const uint32_t page_size_bytes = get_page_size();
+    const uint32_t num_pages = get_num_pages();
+
+    const CoreCoord first_worker = default_worker_start;
+    const CoreRange worker_range = {first_worker, first_worker};
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+
+    Common::DeviceData device_data(
+        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+    auto commands_per_iteration =
+        generate_paged_end_to_end_commands(first_worker, page_size_bytes, num_pages, device_data);
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    SDPrefetchPagedReadWriteTestFixture,
+    ::testing::Values(
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedReadParams{8192, 8, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + (info.param.use_exec_buf ? "exec_buf" : "direct");
+    });
+
+// SD paged DRAM write throughput: exercises the WRITE_PAGED dispatcher command path
+class SDPrefetchThroughputTestFixture : public SDPrefetchTestBase<PrefetcherThroughputTestFixture> {};
+
+TEST_P(SDPrefetchThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
+    log_info(tt::LogTest, "SDPrefetchThroughputTestFixture - HostToDRAMPagedWriteThroughput - Test Start");
+
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+    const uint32_t page_size_bytes = get_page_size();
+    const uint32_t requested_pages_per_cmd = get_num_pages();
+    TT_FATAL(page_size_bytes % sizeof(uint32_t) == 0U, "page_size_bytes must be a multiple of 4");
+
+    constexpr CoreCoord first_worker = default_worker_start;
+    constexpr CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+    const CoreRange worker_range = {first_worker, last_worker};
+
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
+    const uint32_t page_alignment_bytes = device_->allocator_impl()->get_alignment(BufferType::DRAM);
+
+    Common::DeviceData device_data(
+        device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
+
+    // Find the maximum pages per command that fits within the configured max prefetch command size.
+    uint32_t pages_per_cmd = 1U;
+    for (uint32_t pages = 1U; pages <= requested_pages_per_cmd; ++pages) {
+        DeviceCommandCalculator calc;
+        calc.add_dispatch_write_paged<hugepage_write_>(page_size_bytes, pages);
+        if (calc.write_offset_bytes() > max_fetch_bytes_) {
+            break;
+        }
+        pages_per_cmd = pages;
+    }
+
+    constexpr uint32_t total_cmds = 32U;
+    const uint32_t page_size_words = page_size_bytes / sizeof(uint32_t);
+    uint32_t absolute_start_page = 0U;
+
+    std::vector<HostMemDeviceCommand> commands_per_iteration;
+    commands_per_iteration.reserve(total_cmds);
+
+    for (uint32_t cmd_idx = 0U; cmd_idx < total_cmds; ++cmd_idx) {
+        std::vector<uint32_t> chunk_payload;
+        chunk_payload.reserve(pages_per_cmd * page_size_words);
+
+        for (uint32_t page = 0U; page < pages_per_cmd; ++page) {
+            const uint32_t page_id = absolute_start_page + page;
+            const uint32_t bank_id = page_id % num_banks_;
+            const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
+            const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
+            std::vector<uint32_t> page_payload =
+                payload_generator_->generate_payload_with_page_id(page_size_words, page_id);
+            Common::DeviceDataUpdater::update_paged_write(
+                page_payload, device_data, bank_core, bank_id, page_alignment_bytes);
+            chunk_payload.insert(chunk_payload.end(), page_payload.begin(), page_payload.end());
+        }
+
+        const uint32_t bank_offset =
+            tt::align(page_size_bytes, page_alignment_bytes) * (absolute_start_page / num_banks_);
+        const uint32_t base_addr = device_data.get_base_result_addr(tt::CoreType::DRAM) + bank_offset;
+        const uint16_t start_page_cmd = absolute_start_page % num_banks_;
+
+        HostMemDeviceCommand cmd = Common::CommandBuilder::build_paged_write_command<hugepage_write_>(
+            chunk_payload, base_addr, page_size_bytes, pages_per_cmd, start_page_cmd, /*is_dram=*/true);
+        commands_per_iteration.push_back(std::move(cmd));
+
+        absolute_start_page += pages_per_cmd;
+    }
+
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), /*num_iterations=*/1U);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    SDPrefetchThroughputTestFixture,
+    ::testing::Values(
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedReadParams{8192, 8, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + (info.param.use_exec_buf ? "exec_buf" : "direct");
     });
 
 }  // namespace tt::tt_metal::tt_dispatch_tests::prefetcher_tests

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -30,11 +30,11 @@
 #include <vector>
 
 /*
- * FAST PREFETCHER MICROBENCHMARK SUITE
+ * DISPATCHER MICROBENCHMARK SUITE (Fast Dispatch + Slow Dispatch)
  *
  * Architecture Overview:
- * This test suite validates the Fast Dispatcher (FD) kernel mechanisms by bypassing the
- * standard high-level Enqueue APIs and directly constructing low-level command sequences.
+ * This test suite validates the Prefetcher kernel in both Fast Dispatch (FD) and Slow Dispatch (SD)
+ * modes by bypassing the standard high-level Enqueue APIs and directly constructing low-level command sequences.
  *
  * The test flow follows a "Shadow Model" pattern:
  * 1. Plan: Determine transfer sizes, destinations, and command types.
@@ -45,10 +45,18 @@
  *    Read back device memory and compare against `Common::DeviceData` to validate the correctness of the command
  * execution.
  *
+ * Execution backends:
+ * - FD: Commands are pushed into the Issue Queue via FDMeshCommandQueue; the Prefetcher relays
+ *   them to the Dispatcher.
+ * - SD: Commands are written to the PCIe hugepage issue buffer; the host notifies the real
+ *   cq_prefetch.cpp kernel via FetchQ entries written through a TLB window. cq_prefetch.cpp
+ *   relays them to cq_dispatch.cpp exactly as in FD, but all hugepage writes and FetchQ entries
+ *   are committed before LaunchProgram so the kernel finds everything ready at startup.
+ *
  * Key Concepts:
- * - Issue Queue: Host-resident ring buffer where commands are written.
+ * - Issue Queue: Host-resident ring buffer where FD commands are written.
  * - Fetch Queue: Device-resident ring buffer (pointers) telling the Prefetcher where to look.
- * - Prefetcher: Kernel that pulls commands from Host/DRAM and relays them.
+ * - Prefetcher: Kernel that pulls commands from Host/DRAM and relays them to the Dispatcher.
  * - Dispatcher: Kernel that parses commands and issues writes/signals to Worker cores.
  */
 
@@ -1978,6 +1986,433 @@ public:
     }
 };
 
+// Throughput-focused test.
+// Stresses the prefetcher "issue queue -> device" path by issuing large paged DRAM writes with inline host payload.
+class PrefetcherThroughputTestFixture : public BasePrefetcherTestFixture {};
+
+// Slow Dispatch Prefetcher Tests
+// Validates cq_prefetch.cpp (IS_D_VARIANT=1) in isolation without FD infrastructure.
+// Two modes via PagedReadParams::use_exec_buf:
+//   false - commands written directly to prefetch_d cmddat_q L1
+//   true  - commands written banked to DRAM; a single CQ_PREFETCH_CMD_EXEC_BUF pointer in cmddat_q
+//
+// The upstream semaphore self-loop (MY_UPSTREAM_CB_SEM_ID == UPSTREAM_CB_SEM_ID on the prefetch_d
+// core, initialized to cmd_cb_pages) pre-signals all pages so the kernel sees them immediately.
+template <typename FDFixture>
+class SDPrefetchTestBase : public FDFixture {
+public:
+    void SetUp() override {
+        if (!getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
+            GTEST_SKIP() << "Requires TT_METAL_SLOW_DISPATCH_MODE";
+        }
+        this->device_ = tt_metal::CreateDevice(0);
+
+        Common::DispatchPayloadGenerator::Config pgcfg;
+        pgcfg.use_coherent_data = this->cfg_.use_coherent_data;
+        pgcfg.perf_test = this->cfg_.perf_test;
+        pgcfg.min_xfer_size_bytes = this->cfg_.min_xfer_size_bytes;
+        pgcfg.max_xfer_size_bytes = this->cfg_.max_xfer_size_bytes;
+        std::random_device rd;
+        pgcfg.seed = rd();
+        this->payload_generator_ = std::make_unique<Common::DispatchPayloadGenerator>(pgcfg);
+        log_info(tt::LogTest, "Random seed set to {}", pgcfg.seed);
+
+        this->dispatch_buffer_page_size_ = this->cfg_.dispatch_buffer_page_size;
+        this->send_to_all_ = this->cfg_.send_to_all;
+        this->host_alignment_ = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
+        // Cap inline command size to avoid cmddat_q L1 overflow on the prefetch-d core.
+        this->max_fetch_bytes_ = Common::SD_PREFETCH_SCRATCH_DB_SIZE;
+
+        this->dram_base_ = this->device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
+        this->num_banks_ = this->device_->allocator_impl()->get_num_banks(BufferType::DRAM);
+        this->l1_alignment_ = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::L1);
+        this->packed_write_max_unicast_sub_cmds_ =
+            this->device_->compute_with_storage_grid_size().x * this->device_->compute_with_storage_grid_size().y;
+
+        this->init_params(this->GetParam());
+    }
+
+    void TearDown() override {
+        if (this->device_) {
+            tt_metal::CloseDevice(this->device_);
+            this->device_ = nullptr;
+        }
+    }
+
+    // Launches cq_prefetch.cpp (combined IS_H_VARIANT+IS_D_VARIANT) + cq_dispatch.cpp under
+    // slow dispatch by writing commands to the PCIe hugepage and notifying the prefetcher via
+    // the FetchQ ring - the same mechanism used by the FD runtime.
+    //
+    // All hugepage writes and FetchQ entries are committed before LaunchProgram so the
+    // kernel finds all data ready when it starts.  num_cores_to_log / wait_for_* match the
+    // FD virtual signature but are unused (LaunchProgram is synchronous).
+    void execute_generated_commands(
+        const std::vector<HostMemDeviceCommand>& commands_per_iteration,
+        Common::DeviceData& device_data,
+        size_t /*num_cores_to_log*/,
+        uint32_t num_iterations,
+        bool /*wait_for_completion*/ = true,
+        bool /*wait_for_host_writes*/ = false) override {
+        using entry_t = DispatchSettings::prefetch_q_entry_type;  // uint16_t
+
+        const auto& memmap = tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
+        const uint32_t dispatch_cb_base = memmap.dispatch_buffer_base();
+        const uint32_t dispatch_buffer_pages =
+            Common::SD_DISPATCH_BUFFER_SIZE_BYTES / Common::SD_DISPATCH_BUFFER_PAGE_SIZE;
+
+        // L1 layout on the prefetch_hd core
+        // Place FetchQ ring + rd_ptr immediately after the first allocatable L1 page.
+        // cmddat_q and scratch_db follow the FetchQ.
+        const uint32_t l1_unrsv = this->device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        const uint32_t page_size = Common::SD_PREFETCH_CMDDAT_PAGE_SIZE;
+        const uint32_t l1_unrsv_aligned = tt::align(l1_unrsv, page_size);
+
+        // prefetch_q_rd_ptr_addr (4 B) and pcie_rd_ptr_addr (next 4 B) live at l1_unrsv_aligned.
+        // The FetchQ ring starts one full page later so it is page-aligned.
+        const uint32_t prefetch_q_rd_ptr_addr = l1_unrsv_aligned;
+        const uint32_t prefetch_q_base = l1_unrsv_aligned + page_size;
+        const uint32_t prefetch_q_size = Common::SD_PREFETCH_Q_ENTRIES * sizeof(entry_t);
+
+        // cmddat_q: after FetchQ, aligned to host (NOC) alignment.
+        const uint32_t noc_align = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
+        const uint32_t cmddat_q_base = prefetch_q_base + tt::align(prefetch_q_size, noc_align);
+        // Use the same cmddat_q size as the FD runtime (256KB on worker). read_from_pcie issues one DMA per
+        // FetchQ entry, so cmddat_q must be >= max single command size (prefetch_max_cmd_size = 128KB).
+        const uint32_t cmddat_q_bytes = memmap.cmddat_q_size();
+        const uint32_t cmddat_q_pages = tt::align(cmddat_q_bytes / page_size, Common::SD_PREFETCH_CMDDAT_BLOCKS);
+        const uint32_t scratch_db_base = cmddat_q_base + cmddat_q_pages * page_size;
+
+        const auto& soc_desc = tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->device_->id());
+        TT_FATAL(
+            scratch_db_base + Common::SD_PREFETCH_SCRATCH_DB_SIZE <= soc_desc.worker_l1_size,
+            "SD prefetch hd: prefetch_q + cmddat_q + scratch_db exceeds worker L1");
+
+        // Hugepage addressing
+        // Use the same hugepage region that the FD runtime uses for the issue queue
+        // (safe since SD mode never runs the FD runtime concurrently).
+        const uint32_t dev_hugepage_base = memmap.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
+
+        const ChipId mmio_id =
+            tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->device_->id());
+        const uint16_t channel =
+            tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(this->device_->id());
+        char* hugepage_bar_base =
+            static_cast<char*>(tt_metal::MetalContext::instance().get_cluster().host_dma_address(0, mmio_id, channel));
+        hugepage_bar_base += (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
+        void* const host_hugepage_base = hugepage_bar_base + dev_hugepage_base;
+
+        // Physical cores
+        const CoreCoord phys_prefetch = this->device_->worker_core_from_logical_core(Common::sd_prefetch_core);
+        const CoreCoord phys_disp = this->device_->worker_core_from_logical_core(Common::sd_dispatch_core);
+        const tt_cxy_pair prefetch_cxy(this->device_->id(), phys_prefetch);
+
+        auto& cluster = tt_metal::MetalContext::instance().get_cluster();
+
+        // prefetch_q_rd_ptr_addr: kernel writes its consumed position here so the host can poll.
+        // Initialise to the ring base so the host-side fence logic sees the ring as empty.
+        const uint32_t init_rd_ptr = prefetch_q_base;
+        cluster.write_core(&init_rd_ptr, sizeof(uint32_t), prefetch_cxy, prefetch_q_rd_ptr_addr);
+        // pcie_rd_ptr_addr (prefetch_q_rd_ptr_addr + 4): initialise to 0.
+        // const uint32_t init_pcie_rd = 0u;
+        // cluster.write_core(
+        //     &init_pcie_rd, sizeof(uint32_t), prefetch_cxy, prefetch_q_rd_ptr_addr + sizeof(uint32_t));
+
+        // TLB window for writing FetchQ entries
+        tt::umd::TlbWindow* prefetch_q_tlb = cluster.get_static_tlb_window(prefetch_cxy);
+
+        // Host-side FetchQ write state.
+        uint32_t prefetch_q_dev_ptr = prefetch_q_base;
+        const uint32_t prefetch_q_dev_fence = prefetch_q_base + prefetch_q_size;
+
+        // Hugepage write state.
+        uint32_t* host_mem_ptr = static_cast<uint32_t*>(host_hugepage_base);
+        const uint64_t hugepage_issue_end =
+            static_cast<uint64_t>(dev_hugepage_base) + Common::SD_HUGEPAGE_ISSUE_BUFFER_SIZE;
+
+        const uint32_t host_align = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
+
+        // nt_memcpy: non-temporal store of n bytes (n must be a multiple of 64).
+        auto nt_memcpy_local = [&host_align](uint8_t* __restrict dst, const uint8_t* __restrict src, size_t n) {
+            TT_FATAL(n % host_align == 0, "nt_memcpy: size {} not a multiple of {}", n, host_align);
+            for (size_t i = 0; i < n; i += host_align) {
+                for (size_t j = 0; j < host_align; j += sizeof(__m128i)) {
+                    __m128i blk = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + i + j));
+                    _mm_stream_si128(reinterpret_cast<__m128i*>(dst + i + j), blk);
+                }
+            }
+            tt_driver_atomics::sfence();
+        };
+
+        // write_prefetcher_cmd: nt_memcpy cmd to hugepage + write one FetchQ entry via TLB.
+        // cmd_size_bytes must be a multiple of 64 (host alignment) and cmd_size_entry is the
+        // pre-computed FetchQ value (may have MSB stall flag set for exec_buf).
+        auto write_prefetcher_cmd = [&](const uint32_t* src, uint32_t cmd_size_bytes, entry_t cmd_size_entry) {
+            TT_FATAL(
+                cmd_size_bytes % host_align == 0,
+                "SD prefetch: cmd_size_bytes {} not aligned to host alignment {}",
+                cmd_size_bytes,
+                host_align);
+
+            // Poll for FetchQ ring space (should not spin in normal SD operation).
+            while (prefetch_q_dev_ptr == prefetch_q_dev_fence) {
+                uint32_t rd_ptr;
+                cluster.read_core(&rd_ptr, sizeof(uint32_t), prefetch_cxy, prefetch_q_rd_ptr_addr);
+                if (rd_ptr != prefetch_q_dev_ptr) {
+                    break;
+                }
+            }
+
+            // Hugepage wrap: if the command would exceed the issue buffer, reset to base.
+            const uint64_t host_offset =
+                static_cast<uint64_t>(reinterpret_cast<char*>(host_mem_ptr) - static_cast<char*>(host_hugepage_base));
+            if (dev_hugepage_base + host_offset + cmd_size_bytes > hugepage_issue_end) {
+                host_mem_ptr = static_cast<uint32_t*>(host_hugepage_base);
+            }
+
+            nt_memcpy_local(
+                reinterpret_cast<uint8_t*>(host_mem_ptr), reinterpret_cast<const uint8_t*>(src), cmd_size_bytes);
+            host_mem_ptr += cmd_size_bytes / sizeof(uint32_t);
+
+            prefetch_q_tlb->write16(prefetch_q_dev_ptr, cmd_size_entry);
+            prefetch_q_dev_ptr += sizeof(entry_t);
+            if (prefetch_q_dev_ptr >= prefetch_q_dev_fence) {
+                prefetch_q_dev_ptr = prefetch_q_base;
+            }
+        };
+
+        // Helper: align, pad, and enqueue any HostMemDeviceCommand to hugepage + FetchQ.
+        auto write_cmd = [&](const HostMemDeviceCommand& cmd, bool stall = false) {
+            const uint32_t size = tt::align(cmd.size_bytes(), host_align);
+            std::vector<uint8_t> padded(size, 0u);
+            std::memcpy(padded.data(), cmd.data(), cmd.size_bytes());
+            entry_t entry = static_cast<entry_t>(size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
+            if (stall) {
+                entry |= static_cast<entry_t>(1u << 15);
+            }
+            write_prefetcher_cmd(reinterpret_cast<const uint32_t*>(padded.data()), size, entry);
+        };
+
+        if (this->use_exec_buf_) {
+            execute_generated_commands_exec_buf(commands_per_iteration, num_iterations, write_cmd);
+        } else {
+            for (uint32_t i = 0; i < num_iterations; ++i) {
+                for (const auto& cmd : commands_per_iteration) {
+                    const uint32_t size = tt::align(cmd.size_bytes(), host_align);
+                    TT_FATAL(
+                        (size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE) <=
+                            (uint32_t)std::numeric_limits<entry_t>::max() >> 1,
+                        "SD prefetch: command size {} B overflows 15-bit FetchQ entry (max {} B)",
+                        size,
+                        (uint32_t)0x7FFF << DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
+                    write_cmd(cmd);
+                }
+            }
+        }
+
+        // Terminate: dispatch_wait + dispatch_terminate + prefetch_terminate (shared by both paths).
+        // SD mode has no dispatch_s kernel, so build the dispatch terminate manually rather than
+        // using CommandBuilder::build_dispatch_terminate() which conditionally appends a subordinate
+        // terminate that would hang the dispatcher with no downstream to receive it.
+        {
+            DeviceCommandCalculator calc;
+            calc.add_dispatch_wait();
+            calc.add_dispatch_terminate();
+            HostMemDeviceCommand disp_term(calc.write_offset_bytes());
+            disp_term.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
+            disp_term.add_dispatch_terminate();
+            write_cmd(disp_term);
+        }
+        write_cmd(CommandBuilder::build_prefetch_terminate());
+
+        // Semaphores
+        tt_metal::Program program = tt_metal::CreateProgram();
+
+        // Slot 0: prefetch_sync_sem - dispatch signals prefetch when a stall round-trip is done.
+        const uint32_t pf_sync_sem = tt_metal::CreateSemaphore(program, {Common::sd_prefetch_core}, 0u);
+        const uint32_t di_sync_sem = tt_metal::CreateSemaphore(program, {Common::sd_dispatch_core}, 0u);
+        TT_FATAL(pf_sync_sem == di_sync_sem, "prefetch_sync_sem slot mismatch ({} vs {})", pf_sync_sem, di_sync_sem);
+
+        // Slot 1: downstream_cb_sem on prefetch (init=dispatch_buffer_pages); dispatch_cb_sem on dispatch (init=0).
+        const uint32_t pf_downstream_cb_sem =
+            tt_metal::CreateSemaphore(program, {Common::sd_prefetch_core}, dispatch_buffer_pages);
+        const uint32_t di_dispatch_cb_sem = tt_metal::CreateSemaphore(program, {Common::sd_dispatch_core}, 0u);
+        TT_FATAL(
+            pf_downstream_cb_sem == di_dispatch_cb_sem,
+            "dispatch_cb sem slot mismatch ({} vs {})",
+            pf_downstream_cb_sem,
+            di_dispatch_cb_sem);
+
+        // Kernel defines and creation
+        auto prefetch_defines = Common::make_sd_prefetch_defines(
+            this->device_,
+            dev_hugepage_base,
+            Common::SD_HUGEPAGE_ISSUE_BUFFER_SIZE,
+            prefetch_q_base,
+            prefetch_q_size,
+            prefetch_q_rd_ptr_addr,
+            cmddat_q_base,
+            cmddat_q_pages,
+            scratch_db_base,
+            dispatch_cb_base,
+            dispatch_buffer_pages,
+            pf_downstream_cb_sem,
+            pf_sync_sem,
+            phys_prefetch,
+            phys_disp);
+        auto prefetch_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",
+            {Common::sd_prefetch_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::NOC_0,
+                .defines = prefetch_defines});
+        tt_metal::SetRuntimeArgs(program, prefetch_kernel, Common::sd_prefetch_core, {0u, 0u, 0u});
+
+        const uint32_t dev_completion_base = dev_hugepage_base + Common::SD_HUGEPAGE_ISSUE_BUFFER_SIZE;
+        auto dispatch_defines = Common::make_sd_dispatch_defines(
+            this->device_,
+            dispatch_buffer_pages,
+            di_dispatch_cb_sem,
+            di_sync_sem,
+            phys_prefetch,
+            phys_disp,
+            memmap,
+            dev_completion_base,
+            Common::SD_COMPLETION_QUEUE_SIZE);
+        auto dispatch_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
+            {Common::sd_dispatch_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::NOC_0,
+                .defines = dispatch_defines});
+        tt_metal::SetRuntimeArgs(program, dispatch_kernel, Common::sd_dispatch_core, {0u, 0u, 0u});
+
+        // Initialize the dispatcher's completion queue write/read pointers in L1, mirroring
+        // what topology.cpp does for FD mode.  The kernel reads this slot at startup; without
+        // this write it gets a stale or zeroed value and writes completion data to the wrong PCIe address.
+        {
+            const tt_cxy_pair dispatch_cxy(this->device_->id(), phys_disp);
+            const uint32_t completion_q_wr_l1 =
+                memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_WR);
+            const uint32_t completion_q_rd_l1 =
+                memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD);
+            const uint32_t completion_q0_last_event_l1 =
+                memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q0_LAST_EVENT);
+            const uint32_t completion_q1_last_event_l1 =
+                memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q1_LAST_EVENT);
+            const uint32_t completion_wr_ptr_16B = dev_completion_base >> 4;
+            const uint32_t zero = 0u;
+            cluster.write_core(&completion_wr_ptr_16B, sizeof(uint32_t), dispatch_cxy, completion_q_wr_l1);
+            cluster.write_core(&completion_wr_ptr_16B, sizeof(uint32_t), dispatch_cxy, completion_q_rd_l1);
+            cluster.write_core(&zero, sizeof(uint32_t), dispatch_cxy, completion_q0_last_event_l1);
+            cluster.write_core(&zero, sizeof(uint32_t), dispatch_cxy, completion_q1_last_event_l1);
+        }
+
+        device_data.overflow_check(this->device_);
+        tt_metal::detail::LaunchProgram(this->device_, program);
+        // Ensure host CPU sees any PCIe-written completion queue data before validating.
+        tt_driver_atomics::mfence();
+        EXPECT_TRUE(device_data.validate(this->device_)) << "SD prefetch test failed validation";
+    }
+
+private:
+    // Orchestrates exec_buf execution: builds DRAM payload, writes to DRAM, then issues the
+    // exec_buf command with the MSB stall flag so the prefetcher switches to DRAM mode.
+    // Mirrors BasePrefetcherTestFixture::execute_generated_commands_exec_buff for SD.
+    template <typename WriteCmd>
+    void execute_generated_commands_exec_buf(
+        const std::vector<HostMemDeviceCommand>& commands_per_iteration,
+        uint32_t num_iterations,
+        WriteCmd&& write_cmd) {
+        // 1. Concatenate all commands into a single exec_buf payload.
+        std::vector<uint8_t> exec_buf_data;
+        for (uint32_t i = 0; i < num_iterations; i++) {
+            for (const auto& cmd : commands_per_iteration) {
+                const uint8_t* src_ptr = reinterpret_cast<const uint8_t*>(cmd.data());
+                const uint8_t* end_ptr = src_ptr + cmd.size_bytes();
+                exec_buf_data.insert(exec_buf_data.end(), src_ptr, end_ptr);
+            }
+        }
+
+        // Append barrier wait to flush all commands before exec_buf_end.
+        DeviceCommandCalculator wait_calc;
+        wait_calc.add_dispatch_wait();
+        HostMemDeviceCommand wait_cmd(wait_calc.write_offset_bytes());
+        wait_cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
+        const uint8_t* wptr = reinterpret_cast<const uint8_t*>(wait_cmd.data());
+        exec_buf_data.insert(exec_buf_data.end(), wptr, wptr + wait_cmd.size_bytes());
+
+        // 2. Append exec_buf_end (terminates DRAM execution and returns to issue queue).
+        DeviceCommandCalculator exec_buf_end_calc;
+        exec_buf_end_calc.add_prefetch_exec_buf_end();
+        HostMemDeviceCommand exec_terminate(exec_buf_end_calc.write_offset_bytes());
+        exec_terminate.add_prefetch_exec_buf_end();
+        const uint8_t* src_ptr = reinterpret_cast<const uint8_t*>(exec_terminate.data());
+        exec_buf_data.insert(exec_buf_data.end(), src_ptr, src_ptr + exec_terminate.size_bytes());
+
+        // 3. Write exec_buf data to DRAM, paged across banks.
+        const uint32_t page_size = 1u << this->DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE;
+        const uint32_t exec_buf_base_addr = this->DRAM_EXEC_BUF_DEFAULT_BASE_ADDR;
+
+        const size_t size_bytes = exec_buf_data.size();
+        const size_t padded_size_bytes = tt::align(size_bytes, page_size);
+        exec_buf_data.resize(padded_size_bytes, 0u);
+        const uint32_t num_pages = static_cast<uint32_t>(padded_size_bytes) / page_size;
+        log_info(tt::LogTest, "Total exec buf bytes: {} (padded: {})", size_bytes, padded_size_bytes);
+
+        uint32_t data_idx = 0;
+        for (uint32_t page_idx = 0; page_idx < num_pages; ++page_idx) {
+            const uint32_t bank_id = page_idx % this->num_banks_;
+            const uint32_t bank_offset = (page_idx / this->num_banks_) * page_size;
+            const uint32_t addr = exec_buf_base_addr + bank_offset;
+            std::vector<uint8_t> page_data(
+                exec_buf_data.begin() + data_idx, exec_buf_data.begin() + data_idx + page_size);
+            detail::WriteToDeviceDRAMChannel(this->device_, bank_id, addr, page_data);
+            data_idx += page_size;
+        }
+        tt_metal::MetalContext::instance().get_cluster().dram_barrier(this->device_->id());
+
+        // 4. Write exec_buf command with MSB stall flag so prefetcher switches to DRAM execution.
+        DeviceCommandCalculator exec_buf_calc;
+        exec_buf_calc.add_prefetch_exec_buf();
+        HostMemDeviceCommand exec_cmd(exec_buf_calc.write_offset_bytes());
+        exec_cmd.add_prefetch_exec_buf(exec_buf_base_addr, this->DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE, num_pages);
+        write_cmd(exec_cmd, /*stall=*/true);
+    }
+};
+
+class SDPrefetchDRAMToL1TestFixture : public SDPrefetchTestBase<BasePrefetcherTestFixture> {};
+class SDPrefetchPackedReadTestFixture : public SDPrefetchTestBase<PrefetcherPackedReadTestFixture> {};
+class SDPrefetchRandomTestFixture : public SDPrefetchTestBase<RandomTestFixture> {};
+
+class SDPrefetchHostTextFixture : public SDPrefetchTestBase<PrefetcherHostTextFixture> {
+public:
+    // Returns a host pointer to the SD completion queue region in the hugepage.
+    // The dispatch kernel is configured to write to dev_hugepage_base + SD_HUGEPAGE_ISSUE_BUFFER_SIZE,
+    // so this pointer is the host-side view of that same region.
+    void* get_host_completion_ptr() const {
+        const auto& memmap = tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
+        const uint32_t dev_hugepage_base = memmap.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
+        const ChipId mmio_id =
+            tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->device_->id());
+        const uint16_t channel =
+            tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(this->device_->id());
+        char* hugepage_bar_base =
+            static_cast<char*>(tt_metal::MetalContext::instance().get_cluster().host_dma_address(0, mmio_id, channel));
+        hugepage_bar_base += (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
+        return hugepage_bar_base + dev_hugepage_base + Common::SD_HUGEPAGE_ISSUE_BUFFER_SIZE;
+    }
+    uint32_t get_host_completion_size() const { return Common::SD_COMPLETION_QUEUE_SIZE; }
+};
+
+class SDPrefetchLinearPackedReadTestFixture : public SDPrefetchTestBase<PrefetcherLinearPackedReadTestFixture> {};
+class SDPrefetchRingbufferReadTestFixture : public SDPrefetchTestBase<PrefetcherRingbufferReadTestFixture> {};
+// SD paged DRAM write throughput: exercises the WRITE_PAGED dispatcher command path
+class SDPrefetchThroughputTestFixture : public SDPrefetchTestBase<PrefetcherThroughputTestFixture> {};
+
 // In this we, we test the terminate command by adding a linear write unicast
 // with a small payload followed by commands to terminate prefetcher and dispatcher.
 // exec_buf enabled execution needs special handling
@@ -2675,10 +3110,6 @@ TEST_P(PrefetcherHostTextFixture, HostSmokeTest) {
         wait_for_host_writes);
 }
 
-// Throughput-focused test.
-// Stresses the prefetcher "issue queue -> device" path by issuing large paged DRAM writes with inline host payload.
-class PrefetcherThroughputTestFixture : public BasePrefetcherTestFixture {};
-
 TEST_P(PrefetcherThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
     log_info(tt::LogTest, "PrefetcherThroughputTestFixture - HostToDRAMPagedWriteThroughput - Test Start");
 
@@ -2722,7 +3153,7 @@ TEST_P(PrefetcherThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
 
     log_info(
         tt::LogTest,
-        "Throughput workload: {} cmds × {} pages/cmd × {} B/page = {} B total",
+        "Throughput workload: {} cmds x {} pages/cmd x {} B/page = {} B total",
         total_cmds,
         pages_per_cmd,
         page_size_bytes,
@@ -2841,609 +3272,6 @@ TEST_P(PrefetcherThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
         }
     }
 }
-
-// All BasePrefetcherTestFixture tests with exec buff enabled / disabled
-INSTANTIATE_TEST_SUITE_P(
-    PrefetcherTests,
-    BasePrefetcherTestFixture,
-    ::testing::Values(
-        // With exec buf disabled
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS,
-            Common::DRAM_DATA_SIZE_WORDS,
-            false},
-        // With exec buf enabled
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS,
-            Common::DRAM_DATA_SIZE_WORDS,
-            true}),
-    [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
-               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
-               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
-    });
-
-// PrefetcherPackedReadTestFixture tests with exec buff enabled / disabled
-INSTANTIATE_TEST_SUITE_P(
-    PrefetcherTests,
-    PrefetcherPackedReadTestFixture,
-    ::testing::Values(
-        // With exec buf disabled
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS,
-            Common::DRAM_DATA_SIZE_WORDS,
-            false},
-        // With exec buf enabled
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, DEFAULT_ITERATIONS, Common::DRAM_DATA_SIZE_WORDS, true},
-        // With exec buf disabled + higher iterations
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS_SMOKE_RANDOM,
-            Common::DRAM_DATA_SIZE_WORDS,
-            false},
-        // With exec buf enabled + higher iterations
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS_SMOKE_RANDOM,
-            Common::DRAM_DATA_SIZE_WORDS,
-            true}),
-    [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
-               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
-               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
-    });
-
-// PrefetcherLinearPackedReadTestFixture tests with exec buff enabled / disabled
-INSTANTIATE_TEST_SUITE_P(
-    PrefetcherTests,
-    PrefetcherLinearPackedReadTestFixture,
-    ::testing::Values(
-        // With exec buf disabled
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS,
-            Common::DRAM_DATA_SIZE_WORDS,
-            false},
-        // With exec buf enabled
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS,
-            Common::DRAM_DATA_SIZE_WORDS,
-            true}),
-    [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
-               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
-               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
-    });
-
-// PrefetcherHostTextFixture test with exec buff enabled / disabled
-INSTANTIATE_TEST_SUITE_P(
-    PrefetcherTests,
-    PrefetcherHostTextFixture,
-    ::testing::Values(
-        // With exec buf disabled
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS,
-            Common::DRAM_DATA_SIZE_WORDS,
-            false},
-        // With exec buf enabled
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS,
-            Common::DRAM_DATA_SIZE_WORDS,
-            true}),
-    [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
-               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
-               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
-    });
-
-// PrefetcherRingbufferReadTestFixture test with exec buff enabled / disabled
-INSTANTIATE_TEST_SUITE_P(
-    PrefetcherTests,
-    PrefetcherRingbufferReadTestFixture,
-    ::testing::Values(
-        // With exec buf disabled
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS,
-            Common::DRAM_DATA_SIZE_WORDS,
-            false},
-        // With exec buf enabled
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS,
-            Common::DRAM_DATA_SIZE_WORDS,
-            true}),
-    [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
-               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
-               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
-    });
-
-// RandomTestFixture test with exec buff enabled / disabled
-INSTANTIATE_TEST_SUITE_P(
-    PrefetcherTests,
-    RandomTestFixture,
-    ::testing::Values(
-        // With exec buf disabled
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS,
-            Common::DRAM_DATA_SIZE_WORDS,
-            false},
-        // With exec buf enabled
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, DEFAULT_ITERATIONS, Common::DRAM_DATA_SIZE_WORDS, true},
-        // With exec buf disabled + higher iterations
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS_SMOKE_RANDOM,
-            Common::DRAM_DATA_SIZE_WORDS,
-            false},
-        // With exec buf enabled + higher iterations
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS_SMOKE_RANDOM,
-            Common::DRAM_DATA_SIZE_WORDS,
-            true}),
-    [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
-               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
-               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
-    });
-
-// Runs only with exec buff disabled - RELAY_LINEAR_H must be standalone
-// Uses larger data size (100MB total) to better test DRAM capacity
-INSTANTIATE_TEST_SUITE_P(
-    PrefetcherTests,
-    PrefetchRelayLinearHTestFixture,
-    ::testing::Values(
-        // With exec buf disabled - 20MB per iteration × 5 iterations = 100MB total
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS,
-            DEVICE_DATA_SIZE_LARGE / sizeof(uint32_t),  // 20MB in words
-            false}),
-    [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
-               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
-               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
-    });
-
-// Runs only with exec buff disabled - RELAY_LINEAR_PACKED_H must be standalone
-// Uses larger data size (100MB total) to better test DRAM capacity
-INSTANTIATE_TEST_SUITE_P(
-    PrefetcherTests,
-    PrefetcherLinearPackedHTestFixture,
-    ::testing::Values(
-        // With exec buf disabled - 20MB per iteration × 5 iterations = 100MB total
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS,
-            DEVICE_DATA_SIZE_LARGE / sizeof(uint32_t),  // 20MB in words
-            false}),
-    [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
-               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
-               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
-    });
-
-// PrefetcherThroughputTestFixture test - Runs only with exec buff disabled
-INSTANTIATE_TEST_SUITE_P(
-    PrefetcherTests,
-    PrefetcherThroughputTestFixture,
-    ::testing::Values(
-        // With exec buf disabled
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS,
-            Common::DRAM_DATA_SIZE_WORDS,
-            false}),
-    [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
-               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
-               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
-    });
-
-// Slow Dispatch Prefetcher Tests
-// Validates cq_prefetch.cpp (IS_D_VARIANT=1) in isolation without FD infrastructure.
-// Two modes via PagedReadParams::use_exec_buf:
-//   false - commands written directly to prefetch_d cmddat_q L1
-//   true  - commands written banked to DRAM; a single CQ_PREFETCH_CMD_EXEC_BUF pointer in cmddat_q
-//
-// The upstream semaphore self-loop (MY_UPSTREAM_CB_SEM_ID == UPSTREAM_CB_SEM_ID on the prefetch_d
-// core, initialized to cmd_cb_pages) pre-signals all pages so the kernel sees them immediately.
-template <typename FDFixture>
-class SDPrefetchTestBase : public FDFixture {
-public:
-    void SetUp() override {
-        if (!getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
-            GTEST_SKIP() << "Requires TT_METAL_SLOW_DISPATCH_MODE";
-        }
-        this->device_ = tt_metal::CreateDevice(0);
-
-        Common::DispatchPayloadGenerator::Config pgcfg;
-        pgcfg.use_coherent_data = this->cfg_.use_coherent_data;
-        pgcfg.perf_test = this->cfg_.perf_test;
-        pgcfg.min_xfer_size_bytes = this->cfg_.min_xfer_size_bytes;
-        pgcfg.max_xfer_size_bytes = this->cfg_.max_xfer_size_bytes;
-        std::random_device rd;
-        pgcfg.seed = rd();
-        this->payload_generator_ = std::make_unique<Common::DispatchPayloadGenerator>(pgcfg);
-        log_info(tt::LogTest, "Random seed set to {}", pgcfg.seed);
-
-        this->dispatch_buffer_page_size_ = this->cfg_.dispatch_buffer_page_size;
-        this->send_to_all_ = this->cfg_.send_to_all;
-        this->host_alignment_ = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
-        // Cap inline command size to avoid cmddat_q L1 overflow on the prefetch-d core.
-        this->max_fetch_bytes_ = Common::SD_PREFETCH_SCRATCH_DB_SIZE;
-
-        this->dram_base_ = this->device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
-        this->num_banks_ = this->device_->allocator_impl()->get_num_banks(BufferType::DRAM);
-        this->l1_alignment_ = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::L1);
-        this->packed_write_max_unicast_sub_cmds_ =
-            this->device_->compute_with_storage_grid_size().x * this->device_->compute_with_storage_grid_size().y;
-
-        this->init_params(this->GetParam());
-    }
-
-    void TearDown() override {
-        if (this->device_) {
-            tt_metal::CloseDevice(this->device_);
-            this->device_ = nullptr;
-        }
-    }
-
-    // Launches cq_prefetch.cpp (combined IS_H_VARIANT+IS_D_VARIANT) + cq_dispatch.cpp under
-    // slow dispatch by writing commands to the PCIe hugepage and notifying the prefetcher via
-    // the FetchQ ring - the same mechanism used by the FD runtime.
-    //
-    // All hugepage writes and FetchQ entries are committed before LaunchProgram so the
-    // kernel finds all data ready when it starts.  num_cores_to_log / wait_for_* match the
-    // FD virtual signature but are unused (LaunchProgram is synchronous).
-    void execute_generated_commands(
-        const std::vector<HostMemDeviceCommand>& commands_per_iteration,
-        Common::DeviceData& device_data,
-        size_t /*num_cores_to_log*/,
-        uint32_t num_iterations,
-        bool /*wait_for_completion*/ = true,
-        bool /*wait_for_host_writes*/ = false) override {
-        using entry_t = DispatchSettings::prefetch_q_entry_type;  // uint16_t
-
-        const auto& memmap = tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
-        const uint32_t dispatch_cb_base = memmap.dispatch_buffer_base();
-        const uint32_t dispatch_buffer_pages =
-            Common::SD_DISPATCH_BUFFER_SIZE_BYTES / Common::SD_DISPATCH_BUFFER_PAGE_SIZE;
-
-        // L1 layout on the prefetch_hd core
-        // Place FetchQ ring + rd_ptr immediately after the first allocatable L1 page.
-        // cmddat_q and scratch_db follow the FetchQ.
-        const uint32_t l1_unrsv = this->device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-        const uint32_t page_size = Common::SD_PREFETCH_CMDDAT_PAGE_SIZE;
-        const uint32_t l1_unrsv_aligned = tt::align(l1_unrsv, page_size);
-
-        // prefetch_q_rd_ptr_addr (4 B) and pcie_rd_ptr_addr (next 4 B) live at l1_unrsv_aligned.
-        // The FetchQ ring starts one full page later so it is page-aligned.
-        const uint32_t prefetch_q_rd_ptr_addr = l1_unrsv_aligned;
-        const uint32_t prefetch_q_base = l1_unrsv_aligned + page_size;
-        const uint32_t prefetch_q_size = Common::SD_PREFETCH_Q_ENTRIES * sizeof(entry_t);
-
-        // cmddat_q: after FetchQ, aligned to host (NOC) alignment.
-        const uint32_t noc_align = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
-        const uint32_t cmddat_q_base = prefetch_q_base + tt::align(prefetch_q_size, noc_align);
-        // Use the same cmddat_q size as the FD runtime (256KB on worker). read_from_pcie issues one DMA per
-        // FetchQ entry, so cmddat_q must be >= max single command size (prefetch_max_cmd_size = 128KB).
-        const uint32_t cmddat_q_bytes = memmap.cmddat_q_size();
-        const uint32_t cmddat_q_pages = tt::align(cmddat_q_bytes / page_size, Common::SD_PREFETCH_CMDDAT_BLOCKS);
-        const uint32_t scratch_db_base = cmddat_q_base + cmddat_q_pages * page_size;
-
-        const auto& soc_desc = tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->device_->id());
-        TT_FATAL(
-            scratch_db_base + Common::SD_PREFETCH_SCRATCH_DB_SIZE <= soc_desc.worker_l1_size,
-            "SD prefetch hd: prefetch_q + cmddat_q + scratch_db exceeds worker L1");
-
-        // Hugepage addressing
-        // Use the same hugepage region that the FD runtime uses for the issue queue
-        // (safe since SD mode never runs the FD runtime concurrently).
-        const uint32_t dev_hugepage_base = memmap.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
-
-        const ChipId mmio_id =
-            tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->device_->id());
-        const uint16_t channel =
-            tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(this->device_->id());
-        char* hugepage_bar_base =
-            static_cast<char*>(tt_metal::MetalContext::instance().get_cluster().host_dma_address(0, mmio_id, channel));
-        hugepage_bar_base += (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
-        void* const host_hugepage_base = hugepage_bar_base + dev_hugepage_base;
-
-        // Physical cores
-        const CoreCoord phys_prefetch = this->device_->worker_core_from_logical_core(Common::sd_prefetch_core);
-        const CoreCoord phys_disp = this->device_->worker_core_from_logical_core(Common::sd_dispatch_core);
-        const tt_cxy_pair prefetch_cxy(this->device_->id(), phys_prefetch);
-
-        auto& cluster = tt_metal::MetalContext::instance().get_cluster();
-
-        // prefetch_q_rd_ptr_addr: kernel writes its consumed position here so the host can poll.
-        // Initialise to the ring base so the host-side fence logic sees the ring as empty.
-        const uint32_t init_rd_ptr = prefetch_q_base;
-        cluster.write_core(&init_rd_ptr, sizeof(uint32_t), prefetch_cxy, prefetch_q_rd_ptr_addr);
-        // pcie_rd_ptr_addr (prefetch_q_rd_ptr_addr + 4): initialise to 0.
-        // const uint32_t init_pcie_rd = 0u;
-        // cluster.write_core(
-        //     &init_pcie_rd, sizeof(uint32_t), prefetch_cxy, prefetch_q_rd_ptr_addr + sizeof(uint32_t));
-
-        // TLB window for writing FetchQ entries
-        tt::umd::TlbWindow* prefetch_q_tlb = cluster.get_static_tlb_window(prefetch_cxy);
-
-        // Host-side FetchQ write state.
-        uint32_t prefetch_q_dev_ptr = prefetch_q_base;
-        const uint32_t prefetch_q_dev_fence = prefetch_q_base + prefetch_q_size;
-
-        // Hugepage write state.
-        uint32_t* host_mem_ptr = static_cast<uint32_t*>(host_hugepage_base);
-        const uint64_t hugepage_issue_end =
-            static_cast<uint64_t>(dev_hugepage_base) + Common::SD_HUGEPAGE_ISSUE_BUFFER_SIZE;
-
-        const uint32_t host_align = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
-
-        // nt_memcpy: non-temporal store of n bytes (n must be a multiple of 64).
-        auto nt_memcpy_local = [&host_align](uint8_t* __restrict dst, const uint8_t* __restrict src, size_t n) {
-            TT_FATAL(n % host_align == 0, "nt_memcpy: size {} not a multiple of {}", n, host_align);
-            for (size_t i = 0; i < n; i += host_align) {
-                for (size_t j = 0; j < host_align; j += sizeof(__m128i)) {
-                    __m128i blk = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + i + j));
-                    _mm_stream_si128(reinterpret_cast<__m128i*>(dst + i + j), blk);
-                }
-            }
-            tt_driver_atomics::sfence();
-        };
-
-        // write_prefetcher_cmd: nt_memcpy cmd to hugepage + write one FetchQ entry via TLB.
-        // cmd_size_bytes must be a multiple of 64 (host alignment) and cmd_size_entry is the
-        // pre-computed FetchQ value (may have MSB stall flag set for exec_buf).
-        auto write_prefetcher_cmd = [&](const uint32_t* src, uint32_t cmd_size_bytes, entry_t cmd_size_entry) {
-            TT_FATAL(
-                cmd_size_bytes % host_align == 0,
-                "SD prefetch: cmd_size_bytes {} not aligned to host alignment {}",
-                cmd_size_bytes,
-                host_align);
-
-            // Poll for FetchQ ring space (should not spin in normal SD operation).
-            while (prefetch_q_dev_ptr == prefetch_q_dev_fence) {
-                uint32_t rd_ptr;
-                cluster.read_core(&rd_ptr, sizeof(uint32_t), prefetch_cxy, prefetch_q_rd_ptr_addr);
-                if (rd_ptr != prefetch_q_dev_ptr) {
-                    break;
-                }
-            }
-
-            // Hugepage wrap: if the command would exceed the issue buffer, reset to base.
-            const uint64_t host_offset =
-                static_cast<uint64_t>(reinterpret_cast<char*>(host_mem_ptr) - static_cast<char*>(host_hugepage_base));
-            if (dev_hugepage_base + host_offset + cmd_size_bytes > hugepage_issue_end) {
-                host_mem_ptr = static_cast<uint32_t*>(host_hugepage_base);
-            }
-
-            nt_memcpy_local(
-                reinterpret_cast<uint8_t*>(host_mem_ptr), reinterpret_cast<const uint8_t*>(src), cmd_size_bytes);
-            host_mem_ptr += cmd_size_bytes / sizeof(uint32_t);
-
-            prefetch_q_tlb->write16(prefetch_q_dev_ptr, cmd_size_entry);
-            prefetch_q_dev_ptr += sizeof(entry_t);
-            if (prefetch_q_dev_ptr >= prefetch_q_dev_fence) {
-                prefetch_q_dev_ptr = prefetch_q_base;
-            }
-        };
-
-        // Helper: align, pad, and enqueue any HostMemDeviceCommand to hugepage + FetchQ.
-        auto write_cmd = [&](const HostMemDeviceCommand& cmd, bool stall = false) {
-            const uint32_t size = tt::align(cmd.size_bytes(), host_align);
-            std::vector<uint8_t> padded(size, 0u);
-            std::memcpy(padded.data(), cmd.data(), cmd.size_bytes());
-            entry_t entry = static_cast<entry_t>(size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
-            if (stall) {
-                entry |= static_cast<entry_t>(1u << 15);
-            }
-            write_prefetcher_cmd(reinterpret_cast<const uint32_t*>(padded.data()), size, entry);
-        };
-
-        if (this->use_exec_buf_) {
-            execute_generated_commands_exec_buf(commands_per_iteration, num_iterations, write_cmd);
-        } else {
-            for (uint32_t i = 0; i < num_iterations; ++i) {
-                for (const auto& cmd : commands_per_iteration) {
-                    const uint32_t size = tt::align(cmd.size_bytes(), host_align);
-                    TT_FATAL(
-                        (size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE) <=
-                            (uint32_t)std::numeric_limits<entry_t>::max() >> 1,
-                        "SD prefetch: command size {} B overflows 15-bit FetchQ entry (max {} B)",
-                        size,
-                        (uint32_t)0x7FFF << DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
-                    write_cmd(cmd);
-                }
-            }
-        }
-
-        // Terminate: dispatch_wait + dispatch_terminate + prefetch_terminate (shared by both paths).
-        // SD mode has no dispatch_s kernel, so build the dispatch terminate manually rather than
-        // using CommandBuilder::build_dispatch_terminate() which conditionally appends a subordinate
-        // terminate that would hang the dispatcher with no downstream to receive it.
-        {
-            DeviceCommandCalculator calc;
-            calc.add_dispatch_wait();
-            calc.add_dispatch_terminate();
-            HostMemDeviceCommand disp_term(calc.write_offset_bytes());
-            disp_term.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
-            disp_term.add_dispatch_terminate();
-            write_cmd(disp_term);
-        }
-        write_cmd(CommandBuilder::build_prefetch_terminate());
-
-        // Semaphores
-        tt_metal::Program program = tt_metal::CreateProgram();
-
-        // Slot 0: prefetch_sync_sem - dispatch signals prefetch when a stall round-trip is done.
-        const uint32_t pf_sync_sem = tt_metal::CreateSemaphore(program, {Common::sd_prefetch_core}, 0u);
-        const uint32_t di_sync_sem = tt_metal::CreateSemaphore(program, {Common::sd_dispatch_core}, 0u);
-        TT_FATAL(pf_sync_sem == di_sync_sem, "prefetch_sync_sem slot mismatch ({} vs {})", pf_sync_sem, di_sync_sem);
-
-        // Slot 1: downstream_cb_sem on prefetch (init=dispatch_buffer_pages); dispatch_cb_sem on dispatch (init=0).
-        const uint32_t pf_downstream_cb_sem =
-            tt_metal::CreateSemaphore(program, {Common::sd_prefetch_core}, dispatch_buffer_pages);
-        const uint32_t di_dispatch_cb_sem = tt_metal::CreateSemaphore(program, {Common::sd_dispatch_core}, 0u);
-        TT_FATAL(
-            pf_downstream_cb_sem == di_dispatch_cb_sem,
-            "dispatch_cb sem slot mismatch ({} vs {})",
-            pf_downstream_cb_sem,
-            di_dispatch_cb_sem);
-
-        // Kernel defines and creation
-        auto prefetch_defines = Common::make_sd_prefetch_defines(
-            this->device_,
-            dev_hugepage_base,
-            Common::SD_HUGEPAGE_ISSUE_BUFFER_SIZE,
-            prefetch_q_base,
-            prefetch_q_size,
-            prefetch_q_rd_ptr_addr,
-            cmddat_q_base,
-            cmddat_q_pages,
-            scratch_db_base,
-            dispatch_cb_base,
-            dispatch_buffer_pages,
-            pf_downstream_cb_sem,
-            pf_sync_sem,
-            phys_prefetch,
-            phys_disp);
-        auto prefetch_kernel = tt_metal::CreateKernel(
-            program,
-            "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",
-            {Common::sd_prefetch_core},
-            tt_metal::DataMovementConfig{
-                .processor = tt_metal::DataMovementProcessor::RISCV_0,
-                .noc = tt_metal::NOC::NOC_0,
-                .defines = prefetch_defines});
-        tt_metal::SetRuntimeArgs(program, prefetch_kernel, Common::sd_prefetch_core, {0u, 0u, 0u});
-
-        const uint32_t dev_completion_base = dev_hugepage_base + Common::SD_HUGEPAGE_ISSUE_BUFFER_SIZE;
-        auto dispatch_defines = Common::make_sd_dispatch_defines(
-            this->device_,
-            dispatch_buffer_pages,
-            di_dispatch_cb_sem,
-            di_sync_sem,
-            phys_prefetch,
-            phys_disp,
-            memmap,
-            dev_completion_base,
-            Common::SD_COMPLETION_QUEUE_SIZE);
-        auto dispatch_kernel = tt_metal::CreateKernel(
-            program,
-            "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
-            {Common::sd_dispatch_core},
-            tt_metal::DataMovementConfig{
-                .processor = tt_metal::DataMovementProcessor::RISCV_0,
-                .noc = tt_metal::NOC::NOC_0,
-                .defines = dispatch_defines});
-        tt_metal::SetRuntimeArgs(program, dispatch_kernel, Common::sd_dispatch_core, {0u, 0u, 0u});
-
-        device_data.overflow_check(this->device_);
-        tt_metal::detail::LaunchProgram(this->device_, program);
-        // Ensure host CPU sees any PCIe-written completion queue data before validating.
-        tt_driver_atomics::mfence();
-        EXPECT_TRUE(device_data.validate(this->device_)) << "SD prefetch test failed validation";
-    }
-
-private:
-    // Orchestrates exec_buf execution: builds DRAM payload, writes to DRAM, then issues the
-    // exec_buf command with the MSB stall flag so the prefetcher switches to DRAM mode.
-    // Mirrors BasePrefetcherTestFixture::execute_generated_commands_exec_buff for SD.
-    template <typename WriteCmd>
-    void execute_generated_commands_exec_buf(
-        const std::vector<HostMemDeviceCommand>& commands_per_iteration,
-        uint32_t num_iterations,
-        WriteCmd&& write_cmd) {
-        // 1. Concatenate all commands into a single exec_buf payload.
-        std::vector<uint8_t> exec_buf_data;
-        for (uint32_t i = 0; i < num_iterations; i++) {
-            for (const auto& cmd : commands_per_iteration) {
-                const uint8_t* src_ptr = reinterpret_cast<const uint8_t*>(cmd.data());
-                const uint8_t* end_ptr = src_ptr + cmd.size_bytes();
-                exec_buf_data.insert(exec_buf_data.end(), src_ptr, end_ptr);
-            }
-        }
-
-        // Append barrier wait to flush all commands before exec_buf_end.
-        DeviceCommandCalculator wait_calc;
-        wait_calc.add_dispatch_wait();
-        HostMemDeviceCommand wait_cmd(wait_calc.write_offset_bytes());
-        wait_cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
-        const uint8_t* wptr = reinterpret_cast<const uint8_t*>(wait_cmd.data());
-        exec_buf_data.insert(exec_buf_data.end(), wptr, wptr + wait_cmd.size_bytes());
-
-        // 2. Append exec_buf_end (terminates DRAM execution and returns to issue queue).
-        DeviceCommandCalculator exec_buf_end_calc;
-        exec_buf_end_calc.add_prefetch_exec_buf_end();
-        HostMemDeviceCommand exec_terminate(exec_buf_end_calc.write_offset_bytes());
-        exec_terminate.add_prefetch_exec_buf_end();
-        const uint8_t* src_ptr = reinterpret_cast<const uint8_t*>(exec_terminate.data());
-        exec_buf_data.insert(exec_buf_data.end(), src_ptr, src_ptr + exec_terminate.size_bytes());
-
-        // 3. Write exec_buf data to DRAM, paged across banks.
-        const uint32_t page_size = 1u << this->DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE;
-        const uint32_t exec_buf_base_addr = this->DRAM_EXEC_BUF_DEFAULT_BASE_ADDR;
-
-        const size_t size_bytes = exec_buf_data.size();
-        const size_t padded_size_bytes = tt::align(size_bytes, page_size);
-        exec_buf_data.resize(padded_size_bytes, 0u);
-        const uint32_t num_pages = static_cast<uint32_t>(padded_size_bytes) / page_size;
-        log_info(tt::LogTest, "Total exec buf bytes: {} (padded: {})", size_bytes, padded_size_bytes);
-
-        uint32_t data_idx = 0;
-        for (uint32_t page_idx = 0; page_idx < num_pages; ++page_idx) {
-            const uint32_t bank_id = page_idx % this->num_banks_;
-            const uint32_t bank_offset = (page_idx / this->num_banks_) * page_size;
-            const uint32_t addr = exec_buf_base_addr + bank_offset;
-            std::vector<uint8_t> page_data(
-                exec_buf_data.begin() + data_idx, exec_buf_data.begin() + data_idx + page_size);
-            detail::WriteToDeviceDRAMChannel(this->device_, bank_id, addr, page_data);
-            data_idx += page_size;
-        }
-        tt_metal::MetalContext::instance().get_cluster().dram_barrier(this->device_->id());
-
-        // 4. Write exec_buf command with MSB stall flag so prefetcher switches to DRAM execution.
-        DeviceCommandCalculator exec_buf_calc;
-        exec_buf_calc.add_prefetch_exec_buf();
-        HostMemDeviceCommand exec_cmd(exec_buf_calc.write_offset_bytes());
-        exec_cmd.add_prefetch_exec_buf(exec_buf_base_addr, this->DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE, num_pages);
-        write_cmd(exec_cmd, /*stall=*/true);
-    }
-};
-
-class SDPrefetchDRAMToL1TestFixture : public SDPrefetchTestBase<BasePrefetcherTestFixture> {};
-class SDPrefetchPackedReadTestFixture : public SDPrefetchTestBase<PrefetcherPackedReadTestFixture> {};
-class SDPrefetchRandomTestFixture : public SDPrefetchTestBase<RandomTestFixture> {};
 
 TEST_P(SDPrefetchDRAMToL1TestFixture, DRAMToL1PagedRead) {
     log_info(tt::LogTest, "SDPrefetchDRAMToL1TestFixture - DRAMToL1PagedRead - Test Start");
@@ -3664,41 +3492,6 @@ TEST_P(SDPrefetchRandomTestFixture, RandomTest) {
     execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    SlowDispatch,
-    SDPrefetchDRAMToL1TestFixture,
-    ::testing::Values(
-        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, false},
-        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, true},
-        PagedReadParams{8192, 8, 1, Common::DRAM_DATA_SIZE_WORDS, false},
-        PagedReadParams{8192, 8, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
-    [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
-               std::to_string(info.param.num_iterations) + "iter_" + (info.param.use_exec_buf ? "exec_buf" : "direct");
-    });
-
-INSTANTIATE_TEST_SUITE_P(
-    SlowDispatch,
-    SDPrefetchPackedReadTestFixture,
-    ::testing::Values(
-        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, false},
-        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
-    [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
-               std::to_string(info.param.num_iterations) + "iter_" + (info.param.use_exec_buf ? "exec_buf" : "direct");
-    });
-
-INSTANTIATE_TEST_SUITE_P(
-    SlowDispatch,
-    SDPrefetchRandomTestFixture,
-    ::testing::Values(PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, false}),
-    [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
-               std::to_string(info.param.num_iterations) + "iter_" + (info.param.use_exec_buf ? "exec_buf" : "direct");
-    });
-
-class SDPrefetchLinearPackedReadTestFixture : public SDPrefetchTestBase<PrefetcherLinearPackedReadTestFixture> {};
-
 TEST_P(SDPrefetchLinearPackedReadTestFixture, LinearPackedReadTest) {
     log_info(tt::LogTest, "SDPrefetchLinearPackedReadTestFixture - LinearPackedReadTest - Test Start");
     const uint32_t num_iterations = 1;
@@ -3732,19 +3525,6 @@ TEST_P(SDPrefetchLinearPackedReadTestFixture, LinearPackedReadTest) {
     execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    SlowDispatch,
-    SDPrefetchLinearPackedReadTestFixture,
-    ::testing::Values(
-        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, false},
-        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
-    [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
-               std::to_string(info.param.num_iterations) + "iter_" + (info.param.use_exec_buf ? "exec_buf" : "direct");
-    });
-
-class SDPrefetchRingbufferReadTestFixture : public SDPrefetchTestBase<PrefetcherRingbufferReadTestFixture> {};
-
 TEST_P(SDPrefetchRingbufferReadTestFixture, RingbufferReadTest) {
     log_info(tt::LogTest, "SDPrefetchRingbufferReadTestFixture - RingbufferReadTest - Test Start");
     const uint32_t num_iterations = get_num_iterations();
@@ -3761,17 +3541,6 @@ TEST_P(SDPrefetchRingbufferReadTestFixture, RingbufferReadTest) {
     auto commands_per_iteration = generate_ringbuffer_relay_commands(first_worker, dram_alignment, device_data);
     execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
 }
-
-INSTANTIATE_TEST_SUITE_P(
-    SlowDispatch,
-    SDPrefetchRingbufferReadTestFixture,
-    ::testing::Values(
-        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, false},
-        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
-    [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
-               std::to_string(info.param.num_iterations) + "iter_" + (info.param.use_exec_buf ? "exec_buf" : "direct");
-    });
 
 // SD end-to-end paged write+read: dispatcher writes to DRAM banks, prefetcher relays back to L1
 class SDPrefetchPagedReadWriteTestFixture : public SDPrefetchTestBase<BasePrefetcherTestFixture> {};
@@ -3795,19 +3564,93 @@ TEST_P(SDPrefetchPagedReadWriteTestFixture, PagedReadWriteTest) {
     execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    SlowDispatch,
-    SDPrefetchPagedReadWriteTestFixture,
-    ::testing::Values(
-        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, true},
-        PagedReadParams{8192, 8, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
-    [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
-               std::to_string(info.param.num_iterations) + "iter_" + (info.param.use_exec_buf ? "exec_buf" : "direct");
-    });
+TEST_P(SDPrefetchHostTextFixture, HostTest) {
+    log_info(tt::LogTest, "SDPrefetchHostTextFixture - HostTest - Test Start");
 
-// SD paged DRAM write throughput: exercises the WRITE_PAGED dispatcher command path
-class SDPrefetchThroughputTestFixture : public SDPrefetchTestBase<PrefetcherThroughputTestFixture> {};
+    const uint32_t max_data_size = DEVICE_DATA_SIZE;
+    const uint32_t max_data_size_words = max_data_size / sizeof(uint32_t);
+    const uint32_t dram_data_size_words = this->get_dram_data_size_words();
+    const uint32_t num_iterations = this->get_num_iterations();
+
+    std::vector<uint32_t> data(max_data_size_words);
+    for (uint32_t i = 0; i < max_data_size_words; i++) {
+        data[i] = i;
+    }
+
+    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+    const CoreRange worker_range = {first_worker, last_worker};
+
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+    CoreCoord phys_worker_core = device_->worker_core_from_logical_core(first_worker);
+    MetalContext::instance().get_cluster().write_core(device_->id(), phys_worker_core, data, l1_base);
+    MetalContext::instance().get_cluster().l1_barrier(device_->id());
+
+    void* completion_queue_buffer = get_host_completion_ptr();
+    dirty_host_completion_buffer(completion_queue_buffer, get_host_completion_size());
+
+    Common::DeviceData device_data(
+        device_, worker_range, l1_base, dram_base_, completion_queue_buffer, false, dram_data_size_words, cfg_);
+
+    auto commands_per_iteration = generate_host_write_commands(data, first_worker, l1_base, device_data);
+
+    // SD LaunchProgram is synchronous; no completion-queue write-pointer polling needed.
+    // mfence inside execute_generated_commands ensures CPU sees PCIe-written data before validate.
+    execute_generated_commands(
+        commands_per_iteration,
+        device_data,
+        worker_range.size(),
+        num_iterations,
+        /*wait_for_completion=*/false,
+        /*wait_for_host_writes=*/false);
+}
+
+TEST_P(SDPrefetchHostTextFixture, HostSmokeTest) {
+    log_info(tt::LogTest, "SDPrefetchHostTextFixture - HostSmokeTest - Test Start");
+
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+
+    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+    const CoreRange worker_range = {first_worker, last_worker};
+
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+
+    void* completion_queue_buffer = get_host_completion_ptr();
+    dirty_host_completion_buffer(completion_queue_buffer, get_host_completion_size());
+
+    Common::DeviceData device_data(
+        device_, worker_range, l1_base, dram_base_, completion_queue_buffer, false, dram_data_size_words, cfg_);
+
+    std::vector<HostMemDeviceCommand> commands_per_iteration;
+    HelperInfo info{
+        dram_base_, num_banks_, l1_alignment_, packed_write_max_unicast_sub_cmds_, dispatch_buffer_page_size_};
+    SmokeTestHelper helper(device_, device_data, commands_per_iteration, info);
+
+    auto add_host_write_func = [this](Common::DeviceData& device_data) {
+        PrefetcherHostTextFixture::pad_host_data(device_data);
+    };
+
+    for (uint32_t multiplier = 1; multiplier < 3; multiplier++) {
+        helper.add_host_write(multiplier * 32, add_host_write_func);
+        helper.add_host_write(multiplier * 36, add_host_write_func);
+        helper.add_host_write(multiplier * 1024, add_host_write_func);
+        helper.add_host_write(
+            (multiplier * dispatch_buffer_page_size_) - (2 * sizeof(CQDispatchCmd)), add_host_write_func);
+        helper.add_host_write((multiplier * dispatch_buffer_page_size_) - sizeof(CQDispatchCmd), add_host_write_func);
+        helper.add_host_write((multiplier * dispatch_buffer_page_size_), add_host_write_func);
+        helper.add_host_write((multiplier * dispatch_buffer_page_size_) + sizeof(CQDispatchCmd), add_host_write_func);
+    }
+
+    execute_generated_commands(
+        commands_per_iteration,
+        device_data,
+        worker_range.size(),
+        num_iterations,
+        /*wait_for_completion=*/false,
+        /*wait_for_host_writes=*/false);
+}
 
 TEST_P(SDPrefetchThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
     log_info(tt::LogTest, "SDPrefetchThroughputTestFixture - HostToDRAMPagedWriteThroughput - Test Start");
@@ -3877,6 +3720,304 @@ TEST_P(SDPrefetchThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
     execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), /*num_iterations=*/1U);
 }
 
+// All BasePrefetcherTestFixture tests with exec buff enabled / disabled
+INSTANTIATE_TEST_SUITE_P(
+    PrefetcherTests,
+    BasePrefetcherTestFixture,
+    ::testing::Values(
+        // With exec buf disabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS,
+            Common::DRAM_DATA_SIZE_WORDS,
+            false},
+        // With exec buf enabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS,
+            Common::DRAM_DATA_SIZE_WORDS,
+            true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+// PrefetcherPackedReadTestFixture tests with exec buff enabled / disabled
+INSTANTIATE_TEST_SUITE_P(
+    PrefetcherTests,
+    PrefetcherPackedReadTestFixture,
+    ::testing::Values(
+        // With exec buf disabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS,
+            Common::DRAM_DATA_SIZE_WORDS,
+            false},
+        // With exec buf enabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, DEFAULT_ITERATIONS, Common::DRAM_DATA_SIZE_WORDS, true},
+        // With exec buf disabled + higher iterations
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS_SMOKE_RANDOM,
+            Common::DRAM_DATA_SIZE_WORDS,
+            false},
+        // With exec buf enabled + higher iterations
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS_SMOKE_RANDOM,
+            Common::DRAM_DATA_SIZE_WORDS,
+            true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+// PrefetcherLinearPackedReadTestFixture tests with exec buff enabled / disabled
+INSTANTIATE_TEST_SUITE_P(
+    PrefetcherTests,
+    PrefetcherLinearPackedReadTestFixture,
+    ::testing::Values(
+        // With exec buf disabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS,
+            Common::DRAM_DATA_SIZE_WORDS,
+            false},
+        // With exec buf enabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS,
+            Common::DRAM_DATA_SIZE_WORDS,
+            true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+// PrefetcherHostTextFixture test with exec buff enabled / disabled
+INSTANTIATE_TEST_SUITE_P(
+    PrefetcherTests,
+    PrefetcherHostTextFixture,
+    ::testing::Values(
+        // With exec buf disabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS,
+            Common::DRAM_DATA_SIZE_WORDS,
+            false},
+        // With exec buf enabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS,
+            Common::DRAM_DATA_SIZE_WORDS,
+            true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+// PrefetcherRingbufferReadTestFixture test with exec buff enabled / disabled
+INSTANTIATE_TEST_SUITE_P(
+    PrefetcherTests,
+    PrefetcherRingbufferReadTestFixture,
+    ::testing::Values(
+        // With exec buf disabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS,
+            Common::DRAM_DATA_SIZE_WORDS,
+            false},
+        // With exec buf enabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS,
+            Common::DRAM_DATA_SIZE_WORDS,
+            true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+// RandomTestFixture test with exec buff enabled / disabled
+INSTANTIATE_TEST_SUITE_P(
+    PrefetcherTests,
+    RandomTestFixture,
+    ::testing::Values(
+        // With exec buf disabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS,
+            Common::DRAM_DATA_SIZE_WORDS,
+            false},
+        // With exec buf enabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, DEFAULT_ITERATIONS, Common::DRAM_DATA_SIZE_WORDS, true},
+        // With exec buf disabled + higher iterations
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS_SMOKE_RANDOM,
+            Common::DRAM_DATA_SIZE_WORDS,
+            false},
+        // With exec buf enabled + higher iterations
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS_SMOKE_RANDOM,
+            Common::DRAM_DATA_SIZE_WORDS,
+            true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+// Runs only with exec buff disabled - RELAY_LINEAR_H must be standalone
+// Uses larger data size (100MB total) to better test DRAM capacity
+INSTANTIATE_TEST_SUITE_P(
+    PrefetcherTests,
+    PrefetchRelayLinearHTestFixture,
+    ::testing::Values(
+        // With exec buf disabled - 20MB per iteration x 5 iterations = 100MB total
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS,
+            DEVICE_DATA_SIZE_LARGE / sizeof(uint32_t),  // 20MB in words
+            false}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+// Runs only with exec buff disabled - RELAY_LINEAR_PACKED_H must be standalone
+// Uses larger data size (100MB total) to better test DRAM capacity
+INSTANTIATE_TEST_SUITE_P(
+    PrefetcherTests,
+    PrefetcherLinearPackedHTestFixture,
+    ::testing::Values(
+        // With exec buf disabled - 20MB per iteration x 5 iterations = 100MB total
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS,
+            DEVICE_DATA_SIZE_LARGE / sizeof(uint32_t),  // 20MB in words
+            false}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+// PrefetcherThroughputTestFixture test - Runs only with exec buff disabled
+INSTANTIATE_TEST_SUITE_P(
+    PrefetcherTests,
+    PrefetcherThroughputTestFixture,
+    ::testing::Values(
+        // With exec buf disabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS,
+            Common::DRAM_DATA_SIZE_WORDS,
+            false}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    SDPrefetchDRAMToL1TestFixture,
+    ::testing::Values(
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedReadParams{8192, 8, 1, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedReadParams{8192, 8, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" +
+               (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    SDPrefetchPackedReadTestFixture,
+    ::testing::Values(
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" +
+               (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    SDPrefetchRandomTestFixture,
+    ::testing::Values(PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, false}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" +
+               (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    SDPrefetchLinearPackedReadTestFixture,
+    ::testing::Values(
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" +
+               (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    SDPrefetchRingbufferReadTestFixture,
+    ::testing::Values(
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" +
+               (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    SDPrefetchPagedReadWriteTestFixture,
+    ::testing::Values(
+        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, true},
+        PagedReadParams{8192, 8, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" +
+               (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
 INSTANTIATE_TEST_SUITE_P(
     SlowDispatch,
     SDPrefetchThroughputTestFixture,
@@ -3885,7 +4026,30 @@ INSTANTIATE_TEST_SUITE_P(
         PagedReadParams{8192, 8, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
     [](const testing::TestParamInfo<PagedReadParams>& info) {
         return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
-               std::to_string(info.param.num_iterations) + "iter_" + (info.param.use_exec_buf ? "exec_buf" : "direct");
+               std::to_string(info.param.num_iterations) + "iter_" +
+               (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    SlowDispatch,
+    SDPrefetchHostTextFixture,
+    ::testing::Values(
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS,
+            Common::DRAM_DATA_SIZE_WORDS,
+            false},
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS,
+            Common::DRAM_DATA_SIZE_WORDS,
+            true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" +
+               (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
     });
 
 }  // namespace tt::tt_metal::tt_dispatch_tests::prefetcher_tests

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -3186,24 +3186,14 @@ public:
 
         auto& cluster = tt_metal::MetalContext::instance().get_cluster();
 
-        // Init FetchQ ring and rd_ptrs in prefetch_hd L1
-        // Clear the entire FetchQ ring to zero (kernel spins on non-zero entries).
-        {
-            std::vector<uint32_t> q_zeros(prefetch_q_size / sizeof(uint32_t), 0u);
-            cluster.write_core(q_zeros.data(), q_zeros.size() * sizeof(uint32_t), prefetch_cxy, prefetch_q_base);
-        }
         // prefetch_q_rd_ptr_addr: kernel writes its consumed position here so the host can poll.
         // Initialise to the ring base so the host-side fence logic sees the ring as empty.
-        {
-            const uint32_t init_rd_ptr = prefetch_q_base;
-            cluster.write_core(&init_rd_ptr, sizeof(uint32_t), prefetch_cxy, prefetch_q_rd_ptr_addr);
-        }
+        const uint32_t init_rd_ptr = prefetch_q_base;
+        cluster.write_core(&init_rd_ptr, sizeof(uint32_t), prefetch_cxy, prefetch_q_rd_ptr_addr);
         // pcie_rd_ptr_addr (prefetch_q_rd_ptr_addr + 4): initialise to 0.
-        {
-            const uint32_t init_pcie_rd = 0u;
-            cluster.write_core(
-                &init_pcie_rd, sizeof(uint32_t), prefetch_cxy, prefetch_q_rd_ptr_addr + sizeof(uint32_t));
-        }
+        // const uint32_t init_pcie_rd = 0u;
+        // cluster.write_core(
+        //     &init_pcie_rd, sizeof(uint32_t), prefetch_cxy, prefetch_q_rd_ptr_addr + sizeof(uint32_t));
 
         // TLB window for writing FetchQ entries
         tt::umd::TlbWindow* prefetch_q_tlb = cluster.get_static_tlb_window(prefetch_cxy);
@@ -3267,156 +3257,49 @@ public:
             }
         };
 
+        // Helper: align, pad, and enqueue any HostMemDeviceCommand to hugepage + FetchQ.
+        auto write_cmd = [&](const HostMemDeviceCommand& cmd, bool stall = false) {
+            const uint32_t size = tt::align(cmd.size_bytes(), host_align);
+            std::vector<uint8_t> padded(size, 0u);
+            std::memcpy(padded.data(), cmd.data(), cmd.size_bytes());
+            entry_t entry = static_cast<entry_t>(size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
+            if (stall) {
+                entry |= static_cast<entry_t>(1u << 15);
+            }
+            write_prefetcher_cmd(reinterpret_cast<const uint32_t*>(padded.data()), size, entry);
+        };
+
         if (this->use_exec_buf_) {
-            // exec_buf=true
-            // 1. Build DRAM exec_buf payload: commands x iterations + dispatch_wait + exec_buf_end.
-            std::vector<uint8_t> exec_buf_data;
-            for (uint32_t i = 0; i < num_iterations; ++i) {
-                for (const auto& cmd : commands_per_iteration) {
-                    const auto* p = reinterpret_cast<const uint8_t*>(cmd.data());
-                    exec_buf_data.insert(exec_buf_data.end(), p, p + cmd.size_bytes());
-                }
-            }
-            {
-                DeviceCommandCalculator wc;
-                wc.add_dispatch_wait();
-                HostMemDeviceCommand wait_cmd(wc.write_offset_bytes());
-                wait_cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
-                const auto* p = reinterpret_cast<const uint8_t*>(wait_cmd.data());
-                exec_buf_data.insert(exec_buf_data.end(), p, p + wait_cmd.size_bytes());
-            }
-            {
-                DeviceCommandCalculator ec;
-                ec.add_prefetch_exec_buf_end();
-                HostMemDeviceCommand end_cmd(ec.write_offset_bytes());
-                end_cmd.add_prefetch_exec_buf_end();
-                const auto* p = reinterpret_cast<const uint8_t*>(end_cmd.data());
-                exec_buf_data.insert(exec_buf_data.end(), p, p + end_cmd.size_bytes());
-            }
-            const uint32_t eb_page = 1u << FDFixture::DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE;
-            const size_t padded = tt::align(exec_buf_data.size(), eb_page);
-            exec_buf_data.resize(padded, 0u);
-            const uint32_t exec_buf_pages = static_cast<uint32_t>(padded) / eb_page;
-            log_info(tt::LogTest, "SD prefetch hd exec_buf: {} bytes ({} DRAM pages)", padded, exec_buf_pages);
-
-            // 2. Write exec_buf payload to DRAM.
-            for (uint32_t page_idx = 0; page_idx < exec_buf_pages; ++page_idx) {
-                const uint32_t bank_id = page_idx % this->num_banks_;
-                const uint32_t bank_offset = (page_idx / this->num_banks_) * eb_page;
-                const uint32_t addr = FDFixture::DRAM_EXEC_BUF_DEFAULT_BASE_ADDR + bank_offset;
-                std::vector<uint8_t> pg(
-                    exec_buf_data.begin() + page_idx * eb_page, exec_buf_data.begin() + page_idx * eb_page + eb_page);
-                detail::WriteToDeviceDRAMChannel(this->device_, bank_id, addr, pg);
-            }
-            tt_metal::MetalContext::instance().get_cluster().dram_barrier(this->device_->id());
-
-            // 3. Write CQ_PREFETCH_CMD_EXEC_BUF to hugepage with MSB stall flag.
-            {
-                DeviceCommandCalculator ec;
-                ec.add_prefetch_exec_buf();
-                HostMemDeviceCommand exec_cmd(ec.write_offset_bytes());
-                exec_cmd.add_prefetch_exec_buf(
-                    FDFixture::DRAM_EXEC_BUF_DEFAULT_BASE_ADDR,
-                    FDFixture::DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE,
-                    exec_buf_pages);
-                const uint32_t cmd_size_bytes = tt::align(exec_cmd.size_bytes(), host_align);
-                entry_t cmd_size_entry =
-                    static_cast<entry_t>(cmd_size_bytes >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
-                // MSB stall flag: prefetcher stalls after fetching this command (exec_buf replays from DRAM).
-                cmd_size_entry |= static_cast<entry_t>(1u << (sizeof(entry_t) * 8u - 1u));
-                std::vector<uint8_t> exec_cmd_padded(cmd_size_bytes, 0u);
-                std::memcpy(exec_cmd_padded.data(), exec_cmd.data(), exec_cmd.size_bytes());
-                write_prefetcher_cmd(
-                    reinterpret_cast<const uint32_t*>(exec_cmd_padded.data()), cmd_size_bytes, cmd_size_entry);
-            }
-            // 4. Terminate: relay_inline(dispatch_wait), relay_inline(dispatch_terminate), prefetch_terminate.
-            // Each add_dispatch_*/add_prefetch_* already wraps the cmd in relay_inline internally.
-            {
-                DeviceCommandCalculator wc;
-                wc.add_dispatch_wait();
-                HostMemDeviceCommand wait_cmd(wc.write_offset_bytes());
-                wait_cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
-                const uint32_t wait_size = tt::align(wait_cmd.size_bytes(), host_align);
-                std::vector<uint8_t> wait_padded(wait_size, 0u);
-                std::memcpy(wait_padded.data(), wait_cmd.data(), wait_cmd.size_bytes());
-                entry_t wait_entry = static_cast<entry_t>(wait_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
-                write_prefetcher_cmd(reinterpret_cast<const uint32_t*>(wait_padded.data()), wait_size, wait_entry);
-            }
-            {
-                DeviceCommandCalculator dc;
-                dc.add_dispatch_terminate();
-                HostMemDeviceCommand disp_term(dc.write_offset_bytes());
-                disp_term.add_dispatch_terminate();
-                const uint32_t dterm_size = tt::align(disp_term.size_bytes(), host_align);
-                std::vector<uint8_t> dterm_padded(dterm_size, 0u);
-                std::memcpy(dterm_padded.data(), disp_term.data(), disp_term.size_bytes());
-                entry_t dterm_entry = static_cast<entry_t>(dterm_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
-                write_prefetcher_cmd(reinterpret_cast<const uint32_t*>(dterm_padded.data()), dterm_size, dterm_entry);
-            }
-            {
-                DeviceCommandCalculator pc;
-                pc.add_prefetch_terminate();
-                HostMemDeviceCommand pref_term(pc.write_offset_bytes());
-                pref_term.add_prefetch_terminate();
-                const uint32_t pterm_size = tt::align(pref_term.size_bytes(), host_align);
-                std::vector<uint8_t> pterm_padded(pterm_size, 0u);
-                std::memcpy(pterm_padded.data(), pref_term.data(), pref_term.size_bytes());
-                entry_t pterm_entry = static_cast<entry_t>(pterm_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
-                write_prefetcher_cmd(reinterpret_cast<const uint32_t*>(pterm_padded.data()), pterm_size, pterm_entry);
-            }
+            execute_generated_commands_exec_buf(commands_per_iteration, num_iterations, write_cmd);
         } else {
-            // exec_buf=false
-            // Write each command as a separate FetchQ entry.
             for (uint32_t i = 0; i < num_iterations; ++i) {
                 for (const auto& cmd : commands_per_iteration) {
-                    const uint32_t cmd_size = tt::align(cmd.size_bytes(), host_align);
-                    entry_t cmd_entry = static_cast<entry_t>(cmd_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
+                    const uint32_t size = tt::align(cmd.size_bytes(), host_align);
                     TT_FATAL(
-                        (cmd_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE) == (uint32_t)cmd_entry,
+                        (size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE) <=
+                            (uint32_t)std::numeric_limits<entry_t>::max() >> 1,
                         "SD prefetch: command size {} B overflows 15-bit FetchQ entry (max {} B)",
-                        cmd_size,
+                        size,
                         (uint32_t)0x7FFF << DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
-                    std::vector<uint8_t> cmd_padded(cmd_size, 0u);
-                    std::memcpy(cmd_padded.data(), cmd.data(), cmd.size_bytes());
-                    write_prefetcher_cmd(reinterpret_cast<const uint32_t*>(cmd_padded.data()), cmd_size, cmd_entry);
+                    write_cmd(cmd);
                 }
-            }
-            // Terminate: relay_inline(dispatch_wait), relay_inline(dispatch_terminate), prefetch_terminate.
-            // Each add_dispatch_*/add_prefetch_* already wraps the cmd in relay_inline internally.
-            {
-                DeviceCommandCalculator wc;
-                wc.add_dispatch_wait();
-                HostMemDeviceCommand wait_cmd(wc.write_offset_bytes());
-                wait_cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
-                const uint32_t wait_size = tt::align(wait_cmd.size_bytes(), host_align);
-                std::vector<uint8_t> wait_padded(wait_size, 0u);
-                std::memcpy(wait_padded.data(), wait_cmd.data(), wait_cmd.size_bytes());
-                entry_t wait_entry = static_cast<entry_t>(wait_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
-                write_prefetcher_cmd(reinterpret_cast<const uint32_t*>(wait_padded.data()), wait_size, wait_entry);
-            }
-            {
-                DeviceCommandCalculator dc;
-                dc.add_dispatch_terminate();
-                HostMemDeviceCommand disp_term(dc.write_offset_bytes());
-                disp_term.add_dispatch_terminate();
-                const uint32_t dterm_size = tt::align(disp_term.size_bytes(), host_align);
-                std::vector<uint8_t> dterm_padded(dterm_size, 0u);
-                std::memcpy(dterm_padded.data(), disp_term.data(), disp_term.size_bytes());
-                entry_t dterm_entry = static_cast<entry_t>(dterm_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
-                write_prefetcher_cmd(reinterpret_cast<const uint32_t*>(dterm_padded.data()), dterm_size, dterm_entry);
-            }
-            {
-                DeviceCommandCalculator pc;
-                pc.add_prefetch_terminate();
-                HostMemDeviceCommand pref_term(pc.write_offset_bytes());
-                pref_term.add_prefetch_terminate();
-                const uint32_t pterm_size = tt::align(pref_term.size_bytes(), host_align);
-                std::vector<uint8_t> pterm_padded(pterm_size, 0u);
-                std::memcpy(pterm_padded.data(), pref_term.data(), pref_term.size_bytes());
-                entry_t pterm_entry = static_cast<entry_t>(pterm_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
-                write_prefetcher_cmd(reinterpret_cast<const uint32_t*>(pterm_padded.data()), pterm_size, pterm_entry);
             }
         }
+
+        // Terminate: dispatch_wait + dispatch_terminate + prefetch_terminate (shared by both paths).
+        // SD mode has no dispatch_s kernel, so build the dispatch terminate manually rather than
+        // using CommandBuilder::build_dispatch_terminate() which conditionally appends a subordinate
+        // terminate that would hang the dispatcher with no downstream to receive it.
+        {
+            DeviceCommandCalculator calc;
+            calc.add_dispatch_wait();
+            calc.add_dispatch_terminate();
+            HostMemDeviceCommand disp_term(calc.write_offset_bytes());
+            disp_term.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
+            disp_term.add_dispatch_terminate();
+            write_cmd(disp_term);
+        }
+        write_cmd(CommandBuilder::build_prefetch_terminate());
 
         // Semaphores
         tt_metal::Program program = tt_metal::CreateProgram();
@@ -3489,6 +3372,71 @@ public:
         // Ensure host CPU sees any PCIe-written completion queue data before validating.
         tt_driver_atomics::mfence();
         EXPECT_TRUE(device_data.validate(this->device_)) << "SD prefetch test failed validation";
+    }
+
+private:
+    // Orchestrates exec_buf execution: builds DRAM payload, writes to DRAM, then issues the
+    // exec_buf command with the MSB stall flag so the prefetcher switches to DRAM mode.
+    // Mirrors BasePrefetcherTestFixture::execute_generated_commands_exec_buff for SD.
+    template <typename WriteCmd>
+    void execute_generated_commands_exec_buf(
+        const std::vector<HostMemDeviceCommand>& commands_per_iteration,
+        uint32_t num_iterations,
+        WriteCmd&& write_cmd) {
+        // 1. Concatenate all commands into a single exec_buf payload.
+        std::vector<uint8_t> exec_buf_data;
+        for (uint32_t i = 0; i < num_iterations; i++) {
+            for (const auto& cmd : commands_per_iteration) {
+                const uint8_t* src_ptr = reinterpret_cast<const uint8_t*>(cmd.data());
+                const uint8_t* end_ptr = src_ptr + cmd.size_bytes();
+                exec_buf_data.insert(exec_buf_data.end(), src_ptr, end_ptr);
+            }
+        }
+
+        // Append barrier wait to flush all commands before exec_buf_end.
+        DeviceCommandCalculator wait_calc;
+        wait_calc.add_dispatch_wait();
+        HostMemDeviceCommand wait_cmd(wait_calc.write_offset_bytes());
+        wait_cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
+        const uint8_t* wptr = reinterpret_cast<const uint8_t*>(wait_cmd.data());
+        exec_buf_data.insert(exec_buf_data.end(), wptr, wptr + wait_cmd.size_bytes());
+
+        // 2. Append exec_buf_end (terminates DRAM execution and returns to issue queue).
+        DeviceCommandCalculator exec_buf_end_calc;
+        exec_buf_end_calc.add_prefetch_exec_buf_end();
+        HostMemDeviceCommand exec_terminate(exec_buf_end_calc.write_offset_bytes());
+        exec_terminate.add_prefetch_exec_buf_end();
+        const uint8_t* src_ptr = reinterpret_cast<const uint8_t*>(exec_terminate.data());
+        exec_buf_data.insert(exec_buf_data.end(), src_ptr, src_ptr + exec_terminate.size_bytes());
+
+        // 3. Write exec_buf data to DRAM, paged across banks.
+        const uint32_t page_size = 1u << this->DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE;
+        const uint32_t exec_buf_base_addr = this->DRAM_EXEC_BUF_DEFAULT_BASE_ADDR;
+
+        const size_t size_bytes = exec_buf_data.size();
+        const size_t padded_size_bytes = tt::align(size_bytes, page_size);
+        exec_buf_data.resize(padded_size_bytes, 0u);
+        const uint32_t num_pages = static_cast<uint32_t>(padded_size_bytes) / page_size;
+        log_info(tt::LogTest, "Total exec buf bytes: {} (padded: {})", size_bytes, padded_size_bytes);
+
+        uint32_t data_idx = 0;
+        for (uint32_t page_idx = 0; page_idx < num_pages; ++page_idx) {
+            const uint32_t bank_id = page_idx % this->num_banks_;
+            const uint32_t bank_offset = (page_idx / this->num_banks_) * page_size;
+            const uint32_t addr = exec_buf_base_addr + bank_offset;
+            std::vector<uint8_t> page_data(
+                exec_buf_data.begin() + data_idx, exec_buf_data.begin() + data_idx + page_size);
+            detail::WriteToDeviceDRAMChannel(this->device_, bank_id, addr, page_data);
+            data_idx += page_size;
+        }
+        tt_metal::MetalContext::instance().get_cluster().dram_barrier(this->device_->id());
+
+        // 4. Write exec_buf command with MSB stall flag so prefetcher switches to DRAM execution.
+        DeviceCommandCalculator exec_buf_calc;
+        exec_buf_calc.add_prefetch_exec_buf();
+        HostMemDeviceCommand exec_cmd(exec_buf_calc.write_offset_bytes());
+        exec_cmd.add_prefetch_exec_buf(exec_buf_base_addr, this->DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE, num_pages);
+        write_cmd(exec_cmd, /*stall=*/true);
     }
 };
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2875,8 +2875,6 @@ public:
 
 class SDPrefetchLinearPackedReadTestFixture : public SDPrefetchTestBase<PrefetcherLinearPackedReadTestFixture> {};
 class SDPrefetchRingbufferReadTestFixture : public SDPrefetchTestBase<PrefetcherRingbufferReadTestFixture> {};
-// SD paged DRAM write throughput: exercises the WRITE_PAGED dispatcher command path
-class SDPrefetchThroughputTestFixture : public SDPrefetchTestBase<PrefetcherThroughputTestFixture> {};
 
 // In this we, we test the terminate command by adding a linear write unicast
 // with a small payload followed by commands to terminate prefetcher and dispatcher.

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -23,6 +23,7 @@
 #include <umd/device/pcie/tlb_window.hpp>
 
 #include <chrono>
+#include <functional>
 #include <cerrno>
 #include <cstdint>
 #include <cstdlib>
@@ -1871,7 +1872,6 @@ public:
         return commands_per_iteration;
     }
 
-public:
     // Ring Buffer operates differently than others
     // Data is first staged (cached) into Ringbuffer (L1) from DRAM
     // Then, we relay command header + data into dispatcher
@@ -2646,6 +2646,11 @@ public:
         // Hugepage addressing
         // Use the same hugepage region that the FD runtime uses for the issue queue
         // (safe since SD mode never runs the FD runtime concurrently).
+        // Assumption: SD always runs on device 0 / cq_id 0 (see SetUp's CreateDevice(0)).
+        // For that configuration, get_absolute_cq_offset(channel, cq_id, cq_size) = 0, so
+        // dev_hugepage_base == get_host_command_queue_addr(UNRESERVED) lands in the same
+        // PCIe region the FD runtime would use.  If SD is ever extended to non-zero channel/
+        // cq_id, switch to get_absolute_cq_offset(...) + cq_start (mirroring topology.cpp).
         const uint32_t dev_hugepage_base = memmap.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
 
         const ChipId mmio_id =
@@ -2668,6 +2673,11 @@ public:
         // Initialise to the ring base so the host-side fence logic sees the ring as empty.
         const uint32_t init_rd_ptr = prefetch_q_base;
         cluster.write_core(&init_rd_ptr, sizeof(uint32_t), prefetch_cxy, prefetch_q_rd_ptr_addr);
+
+        // Zero the FetchQ ring so cq_prefetch.cpp (which treats a 0 entry as "no work") doesn't
+        // pick up stale L1 values from a prior run.  Mirrors PrefetchKernel::ConfigureCore.
+        const std::vector<uint32_t> prefetch_q_zeros(prefetch_q_size / sizeof(uint32_t), 0u);
+        cluster.write_core(prefetch_q_zeros.data(), prefetch_q_size, prefetch_cxy, prefetch_q_base);
 
         // FetchQ entries go through the static TLB so each 2-byte write hits L1 directly
         // instead of round-tripping through the cluster API.
@@ -2830,11 +2840,10 @@ private:
     // Orchestrates exec_buf execution: builds DRAM payload, writes to DRAM, then issues the
     // exec_buf command with the MSB stall flag so the prefetcher switches to DRAM mode.
     // Mirrors BasePrefetcherTestFixture::execute_generated_commands_exec_buff for SD.
-    template <typename WriteCmd>
     void execute_generated_commands_exec_buf(
         const std::vector<HostMemDeviceCommand>& commands_per_iteration,
         uint32_t num_iterations,
-        WriteCmd&& write_cmd) {
+        const std::function<void(const HostMemDeviceCommand&, bool)>& write_cmd) {
         const uint32_t num_pages = this->build_and_write_exec_buf_to_dram(commands_per_iteration, num_iterations);
 
         DeviceCommandCalculator exec_buf_calc;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -18,8 +18,8 @@
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h"
 #include <impl/dispatch/dispatch_query_manager.hpp>
+#include "tt_metal/impl/dispatch/memcpy.hpp"
 
-#include <emmintrin.h>
 #include <umd/device/pcie/tlb_window.hpp>
 
 #include <chrono>
@@ -161,8 +161,9 @@ class PrefetcherRingbufferReadTestFixture;
 // for testing purposes.
 namespace CommandBuilder {
 
-HostMemDeviceCommand build_dispatch_terminate() {
-    bool dispatch_sub_enabled = MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled();
+HostMemDeviceCommand build_dispatch_terminate(bool include_dispatch_s = true) {
+    bool dispatch_sub_enabled =
+        MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled() && include_dispatch_s;
     DeviceCommandCalculator calc;
     calc.add_dispatch_wait();
     calc.add_dispatch_terminate();
@@ -492,10 +493,148 @@ protected:
             wait_for_host_writes);
     }
 
+    // Hooks that differ between FD and SD execution. Overridden in SDPrefetchTestBase /
+    // SDPrefetchHostTextFixture so the test bodies can be written once.
+    virtual void append_terminate_commands(std::vector<HostMemDeviceCommand>& cmds) {
+        cmds.push_back(CommandBuilder::build_dispatch_terminate());
+        cmds.push_back(CommandBuilder::build_prefetch_terminate());
+    }
+    virtual void* get_completion_queue_buffer() { return mgr_->get_completion_queue_ptr(fdcq_->id()); }
+    virtual uint32_t get_completion_queue_buffer_size() { return mgr_->get_completion_queue_size(fdcq_->id()); }
+
     uint32_t get_page_size() const { return page_size_; }
     uint32_t get_num_pages() const { return num_pages_; }
     uint32_t get_num_iterations() const { return num_iterations_; }
     uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
+
+    // Relay pre-populated data from DRAM using prefetcher to dispatcher, write it to L1 and validate it
+    void run_dram_to_l1_paged_read_test() {
+        const uint32_t num_iterations = get_num_iterations();
+        const uint32_t dram_data_size_words = get_dram_data_size_words();
+        const uint32_t page_size_bytes = get_page_size();
+        const uint32_t num_pages = get_num_pages();
+
+        // Setup target worker cores
+        const CoreRange worker_range(default_worker_start, default_worker_start);
+
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+
+        // No L1 -> Host writes, so pcie_data_addr is nullptr
+        // We test DRAM -> L1
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+        // PHASE 1: Generate paged read command metadata
+        auto commands_per_iteration =
+            generate_paged_read_commands(worker_range, page_size_bytes, num_pages, device_data);
+
+        // PHASE 2, 3, 4: Execute and Validate
+        execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    }
+
+    // End-To-End Paged/Interleaved Write+Read test that does the following:
+    //  1. Paged Write of host data to DRAM banks by dispatcher, followed by stall to avoid RAW hazard
+    //  2. Paged Read of DRAM banks by prefetcher, relay data to dispatcher for linear write to L1.
+    //  3. Do previous 2 steps in a loop, reading and writing new data until DEVICE_DATA_SIZE bytes is written to worker
+    //  core.
+    void run_paged_read_write_test() {
+        // Test parameters
+        const uint32_t num_iterations = get_num_iterations();
+        const uint32_t dram_data_size_words = get_dram_data_size_words();
+        const uint32_t page_size_bytes = get_page_size();
+        const uint32_t num_pages = get_num_pages();
+
+        // Setup target worker cores
+        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord last_worker = first_worker;  // {first_worker.x + 1, first_worker.y + 1};
+        const CoreRange worker_range = {first_worker, last_worker};
+
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+        // PHASE 1: Generate paged end to end read + write command metadata
+        auto commands_per_iteration =
+            generate_paged_end_to_end_commands(worker_range, page_size_bytes, num_pages, device_data);
+
+        // PHASE 2, 3, 4: Execute and Validate
+        execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    }
+
+    // In this we, we test the terminate command by adding a linear write unicast
+    // with a small payload followed by commands to terminate prefetcher and dispatcher.
+    // exec_buf enabled execution needs special handling.
+    // Terminate commands are appended via the append_terminate_commands hook so SD (which
+    // injects them inside execute_generated_commands) can override with a no-op and avoid
+    // duplicate termination.
+    void run_test_terminate_test() {
+        // Test parameters
+        constexpr uint32_t xfer_size_bytes = 16;  // Very small write size
+        const uint32_t num_iterations = get_num_iterations();
+        const uint32_t dram_data_size_words = get_dram_data_size_words();
+
+        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+        const CoreRange worker_range = {first_worker, last_worker};
+
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+        const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
+        const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+
+        // Capture address before updating device_data
+        const uint32_t l1_addr = device_data.get_result_data_addr(first_worker, 0);
+
+        // Generate payload
+        std::vector<uint32_t> payload = payload_generator_->generate_payload(xfer_size_bytes);
+
+        // PHASE 1: Generate terminate command metadata
+        std::vector<HostMemDeviceCommand> work_cmds;
+        work_cmds.push_back(Common::CommandBuilder::build_linear_write_command<true, true>(
+            payload, worker_range, false, noc_xy, l1_addr, xfer_size_bytes));
+
+        std::vector<HostMemDeviceCommand> terminate_cmds;
+        append_terminate_commands(terminate_cmds);
+
+        // PHASE 2, 3, 4: Execute and Validate
+        // Don't wait for Finish()
+        const bool wait_for_completion = false;
+
+        // If exec_buf is enabled, we must split execution
+        // 1. Run workload (executes in exec_buf)
+        // 2. Run terminate (must execute in issue queue, not exec_buf.
+        // Executing terminate in exec_buf leads to a hang since exec_buf_end is never reached)
+        if (use_exec_buf_) {
+            // Step 1: Execute workload in exec_buf
+            execute_generated_commands(
+                work_cmds,
+                device_data,
+                worker_range.size(),
+                num_iterations,
+                false);  // Don't wait (device not done yet)
+
+            // Step 2: Switch to Issue Queue for termination
+            use_exec_buf_ = false;
+            if (!terminate_cmds.empty()) {
+                execute_generated_commands(
+                    terminate_cmds,
+                    device_data,
+                    0,
+                    1,
+                    wait_for_completion);  // Don't wait (device terminates)
+            }
+        } else {
+            // Standard flow: All commands in one Issue Queue stream
+            work_cmds.insert(work_cmds.end(), terminate_cmds.begin(), terminate_cmds.end());
+
+            execute_generated_commands(
+                work_cmds, device_data, worker_range.size(), num_iterations, wait_for_completion);
+        }
+    }
 
 private:
     uint32_t page_size_{};
@@ -503,6 +642,56 @@ private:
     uint32_t num_iterations_{};
     uint32_t dram_data_size_words_{};
 
+public:
+    // Steps 1-3 of execute_generated_commands_exec_buff, shared with SD. Returns num_pages.
+    uint32_t build_and_write_exec_buf_to_dram(
+        const std::vector<HostMemDeviceCommand>& commands_per_iteration, uint32_t num_iterations) {
+        std::vector<uint8_t> exec_buf_data;
+        for (uint32_t i = 0; i < num_iterations; i++) {
+            for (const auto& cmd : commands_per_iteration) {
+                const uint8_t* src_ptr = reinterpret_cast<const uint8_t*>(cmd.data());
+                exec_buf_data.insert(exec_buf_data.end(), src_ptr, src_ptr + cmd.size_bytes());
+            }
+        }
+
+        DeviceCommandCalculator wait_calc;
+        wait_calc.add_dispatch_wait();
+        HostMemDeviceCommand wait_cmd(wait_calc.write_offset_bytes());
+        wait_cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
+        const uint8_t* wptr = reinterpret_cast<const uint8_t*>(wait_cmd.data());
+        exec_buf_data.insert(exec_buf_data.end(), wptr, wptr + wait_cmd.size_bytes());
+
+        DeviceCommandCalculator exec_buf_end_calc;
+        exec_buf_end_calc.add_prefetch_exec_buf_end();
+        HostMemDeviceCommand exec_terminate(exec_buf_end_calc.write_offset_bytes());
+        exec_terminate.add_prefetch_exec_buf_end();
+        const uint8_t* tptr = reinterpret_cast<const uint8_t*>(exec_terminate.data());
+        exec_buf_data.insert(exec_buf_data.end(), tptr, tptr + exec_terminate.size_bytes());
+
+        const uint32_t page_size = 1u << DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE;
+        const uint32_t exec_buf_base_addr = DRAM_EXEC_BUF_DEFAULT_BASE_ADDR;
+        const size_t size_bytes = exec_buf_data.size();
+        const size_t padded_size_bytes = tt::align(size_bytes, static_cast<size_t>(page_size));
+        exec_buf_data.resize(padded_size_bytes, 0u);
+        const uint32_t num_pages = static_cast<uint32_t>(padded_size_bytes) / page_size;
+        log_info(tt::LogTest, "Total exec buf bytes: {} (padded: {})", size_bytes, padded_size_bytes);
+
+        uint32_t data_idx = 0;
+        for (uint32_t page_idx = 0; page_idx < num_pages; ++page_idx) {
+            const uint32_t bank_id = page_idx % num_banks_;
+            const uint32_t bank_offset = (page_idx / num_banks_) * page_size;
+            const uint32_t addr = exec_buf_base_addr + bank_offset;
+            std::vector<uint8_t> page_data(
+                exec_buf_data.begin() + data_idx, exec_buf_data.begin() + data_idx + page_size);
+            detail::WriteToDeviceDRAMChannel(device_, bank_id, addr, page_data);
+            data_idx += page_size;
+        }
+        MetalContext::instance().get_cluster().dram_barrier(device_->id());
+
+        return num_pages;
+    }
+
+private:
     // Helper function to execute generated commands via exec buff on device
     // Orchestrates the command buffer reservation, writing, and submission.
     // Executing commands via using exec buf in DRAM involves below steps:
@@ -518,66 +707,7 @@ private:
         bool wait_for_completion,
         bool wait_for_host_writes,
         BasePrefetcherTestFixture& fixture) {
-        // 1. Add all commands to be uploaded into exec buff into a single vector
-        std::vector<uint8_t> exec_buf_data;
-        for (uint32_t i = 0; i < num_iterations; i++) {
-            for (const auto& cmd : commands_per_iteration) {
-                const uint8_t* src_ptr = reinterpret_cast<const uint8_t*>(cmd.data());
-                const uint8_t* end_ptr = reinterpret_cast<uint8_t*>(cmd.data()) + (cmd.size_bytes());
-                exec_buf_data.insert(exec_buf_data.end(), src_ptr, end_ptr);
-            }
-        }
-
-        // Append a barrier wait command after all commands across all iterations
-        // Helpful to ensure all commands are completed flush before exec_buf_end
-        DeviceCommandCalculator wait_calc;
-        wait_calc.add_dispatch_wait();
-        HostMemDeviceCommand wait_cmd(wait_calc.write_offset_bytes());
-        wait_cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
-        const uint8_t* wptr = reinterpret_cast<const uint8_t*>(wait_cmd.data());
-        const uint8_t* wend = wptr + (wait_cmd.size_bytes());
-        exec_buf_data.insert(exec_buf_data.end(), wptr, wend);
-
-        // 2. Append exec_buf_end command (terminate the trace execution and switch back to issue queue)
-        DeviceCommandCalculator exec_buf_end_calc;
-        exec_buf_end_calc.add_prefetch_exec_buf_end();
-        DeviceCommand exec_terminate(exec_buf_end_calc.write_offset_bytes());
-        exec_terminate.add_prefetch_exec_buf_end();
-        const uint8_t* src_ptr = reinterpret_cast<const uint8_t*>(exec_terminate.data());
-        const uint8_t* end_ptr =
-            reinterpret_cast<const uint8_t*>(exec_terminate.data()) + (exec_terminate.size_bytes());
-        exec_buf_data.insert(exec_buf_data.end(), src_ptr, end_ptr);
-
-        // 3. Write exec buff data into DRAM
-        const uint32_t page_size = 1 << fixture.DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE;
-        const uint32_t exec_buf_base_addr = fixture.DRAM_EXEC_BUF_DEFAULT_BASE_ADDR;
-
-        // Pad data to full page alignment
-        size_t size_bytes = exec_buf_data.size();
-        log_info(tt::LogTest, "Total exec buff bytes: {}", size_bytes);
-        size_t padded_size_bytes = tt::align(size_bytes, page_size);
-        exec_buf_data.resize(padded_size_bytes);
-        log_info(tt::LogTest, "Padded total exec buff bytes: {}", padded_size_bytes);
-
-        uint32_t num_pages = padded_size_bytes / page_size;
-        uint32_t data_idx = 0;
-
-        // Create pages of exec buff data and write to DRAM
-        for (uint32_t page_idx = 0; page_idx < num_pages; page_idx++) {
-            uint32_t bank_id = page_idx % fixture.num_banks_;
-            uint32_t bank_offset = (page_idx / fixture.num_banks_) * page_size;
-            uint32_t addr = exec_buf_base_addr + bank_offset;
-
-            std::vector<uint8_t> page_data(
-                exec_buf_data.begin() + data_idx, exec_buf_data.begin() + data_idx + (page_size));
-
-            detail::WriteToDeviceDRAMChannel(device_, bank_id, addr, page_data);
-
-            data_idx += (page_size);
-        }
-
-        // Ensure DRAM writes are visible to device
-        MetalContext::instance().get_cluster().dram_barrier(device_->id());
+        const uint32_t num_pages = fixture.build_and_write_exec_buf_to_dram(commands_per_iteration, num_iterations);
 
         // 4. Reserve and Write exec_buff command
         DeviceCommandCalculator exec_buf_calc;
@@ -586,7 +716,8 @@ private:
         void* cmd_buffer_base = mgr_->issue_queue_reserve(cmd_size, fdcq_->id());
         // Use DeviceCommand helper (HugepageDeviceCommand) to write to the issue queue memory
         HugepageDeviceCommand exec_cmd(cmd_buffer_base, cmd_size);
-        exec_cmd.add_prefetch_exec_buf(exec_buf_base_addr, fixture.DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE, num_pages);
+        exec_cmd.add_prefetch_exec_buf(
+            fixture.DRAM_EXEC_BUF_DEFAULT_BASE_ADDR, fixture.DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE, num_pages);
 
         // Verifies destination memory bounds
         device_data.overflow_check(device_);
@@ -771,6 +902,263 @@ public:
     }
 };
 
+struct HelperInfo {
+    uint32_t dram_base_{};
+    uint32_t num_banks_{};
+    uint32_t l1_alignment_{};
+    uint32_t packed_write_max_unicast_sub_cmds_{};
+    uint32_t dispatch_buffer_page_size_{};
+};
+
+// TODO: add CQ_PREFETCH_CMD_DEBUG
+class SmokeTestHelper {
+    tt_metal::distributed::MeshDevice::IDevice* device_;
+    Common::DeviceData& device_data_;
+    std::vector<HostMemDeviceCommand>& cmds_;
+    std::unique_ptr<Common::DispatchPayloadGenerator> payload_generator_;
+
+    HelperInfo info_{};
+
+public:
+    SmokeTestHelper(
+        tt_metal::distributed::MeshDevice::IDevice* device,
+        Common::DeviceData& device_data,
+        std::vector<HostMemDeviceCommand>& cmds,
+        HelperInfo info) :
+        device_(device), device_data_(device_data), cmds_(cmds), info_(info) {
+        // Initialize simple payload generator
+        Common::DispatchPayloadGenerator::Config cfg;
+        cfg.seed = 1234;  // Deterministic seed for smoke test
+        payload_generator_ = std::make_unique<Common::DispatchPayloadGenerator>(cfg);
+    }
+
+    void add_unicast_write(const CoreRange worker_range, uint32_t length) {
+        const auto worker = worker_range.start_coord;
+        const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(worker, CoreType::WORKER);
+        uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+        const bool is_mcast_ = false;
+        const bool flush_prefetch = true;
+        const bool inline_data = true;  // send data inline
+        // Capture address before updating device_data
+        uint32_t addr = device_data_.get_result_data_addr(worker, 0);
+        // Generate payload
+        std::vector<uint32_t> payload = payload_generator_->generate_payload(length);
+        // Update Common::DeviceData for linear write
+        Common::DeviceDataUpdater::update_linear_write(payload, device_data_, worker_range, is_mcast_);
+        // Create the HostMemDeviceCommand
+        HostMemDeviceCommand cmd = Common::CommandBuilder::build_linear_write_command<flush_prefetch, inline_data>(
+            payload, worker_range, is_mcast_, noc_xy, addr, length);
+
+        cmds_.push_back(std::move(cmd));
+    }
+
+    // Merge multiple of unicast writes into a single fetchQ command entry
+    void add_merged_unicast_writes(const CoreRange worker_range, const std::vector<uint32_t>& lengths) {
+        const auto worker = worker_range.start_coord;
+        const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(worker, CoreType::WORKER);
+        uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+        const bool is_mcast_ = false;
+        const bool flush_prefetch = true;
+        const bool inline_data = true;
+
+        // Calculate size of a single merged entry of all lengths
+        DeviceCommandCalculator cmd_calc;
+        for (const auto length : lengths) {
+            cmd_calc.add_dispatch_write_linear<flush_prefetch, inline_data>(length);
+        }
+
+        const uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
+
+        // Create the HostMemDeviceCommand for single merged entry
+        HostMemDeviceCommand cmd(command_size_bytes);
+
+        // Add all lengths into single cmd
+        for (const auto length : lengths) {
+            // Capture address before updating device_data
+            uint32_t addr = device_data_.get_result_data_addr(worker, 0);
+            // Generate payload
+            std::vector<uint32_t> payload = payload_generator_->generate_payload(length);
+            // Update Common::DeviceData for linear write
+            Common::DeviceDataUpdater::update_linear_write(payload, device_data_, worker_range, is_mcast_);
+            // Add the dispatch write linear command
+            cmd.add_dispatch_write_linear<flush_prefetch, inline_data>(
+                is_mcast_ ? worker_range.size() : 0,  // num_mcast_dests
+                noc_xy,                               // NOC coordinates
+                addr,                                 // destination address
+                length,                               // data size
+                payload.data()                        // payload data
+            );
+        }
+
+        cmds_.push_back(std::move(cmd));
+    }
+
+    void add_packed_dram_read(
+        const CoreRange worker_range,
+        const uint32_t log_packed_read_page_size,
+        const std::vector<uint32_t>& lengths,
+        const std::function<std::vector<CQPrefetchRelayPagedPackedSubCmd>(
+            const std::vector<uint32_t>& lengths, Common::DeviceData&, uint32_t log_page_sz, uint32_t n_sub_cmds)>&
+            build_packed) {
+        const auto worker = worker_range.start_coord;
+        const CoreCoord last_virt_worker = device_->virtual_core_from_logical_core(worker, CoreType::WORKER);
+        uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, last_virt_worker);
+
+        const uint32_t total_length = std::accumulate(lengths.begin(), lengths.end(), 0u);
+        const uint32_t n_sub_cmds = lengths.size();
+        const bool flush_prefetch = false;
+        const bool inline_data = false;
+
+        uint32_t l1_addr = device_data_.get_result_data_addr(worker, 0);
+
+        std::vector<CQPrefetchRelayPagedPackedSubCmd> sub_cmds =
+            build_packed(lengths, device_data_, log_packed_read_page_size, n_sub_cmds);
+
+        HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_paged_packed<flush_prefetch, inline_data>(
+            sub_cmds, noc_xy, l1_addr, total_length);
+
+        cmds_.push_back(std::move(cmd));
+    }
+
+    void add_paged_dram_read(
+        const CoreRange worker_range,
+        uint32_t start_page,
+        uint32_t base_addr_offset,
+        uint32_t page_size_bytes,
+        uint32_t num_pages,
+        uint32_t /*length_adjust*/) {
+        const auto worker = worker_range.start_coord;
+        const CoreCoord first_worker = device_->virtual_core_from_logical_core(worker, CoreType::WORKER);
+        uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_worker);
+        const bool flush_prefetch = false;
+        const bool inline_data = false;
+
+        const uint32_t max_bytes_in_chunk = num_pages * page_size_bytes;
+        const uint32_t pages_in_chunk = max_bytes_in_chunk / page_size_bytes;
+        const uint32_t page_size_words = page_size_bytes / sizeof(uint32_t);
+        const uint32_t base_addr_words = base_addr_offset / sizeof(uint32_t);
+        uint32_t base_addr = info_.dram_base_ + base_addr_offset;
+
+        // Capture address before updating device_data
+        uint32_t l1_addr = device_data_.get_result_data_addr(worker, 0);
+
+        HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_paged<flush_prefetch, inline_data>(
+            noc_xy, l1_addr, start_page, base_addr, page_size_bytes, pages_in_chunk);
+
+        for (uint32_t page = 0; page < pages_in_chunk; ++page) {
+            const uint32_t page_id = start_page + page;
+            const uint32_t bank_id = page_id % info_.num_banks_;
+            uint32_t bank_offset = base_addr_words + (page_size_words * (page_id / info_.num_banks_));
+
+            // Get the logical core for this bank
+            const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
+            const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
+
+            // Update Common::DeviceData for paged read
+            DeviceDataUpdater::update_paged_dram_read(
+                worker_range, device_data_, bank_core, bank_id, bank_offset, page_size_words);
+        }
+
+        cmds_.push_back(std::move(cmd));
+    }
+
+    // Length should always be less than max_fetch_bytes_
+    void add_packed_write(const std::vector<CoreCoord>& worker_cores, uint32_t length, bool no_stride = false) {
+        const uint32_t num_sub_cmds = static_cast<uint32_t>(worker_cores.size());
+        const uint32_t sub_cmds_bytes =
+            tt::align(num_sub_cmds * sizeof(CQDispatchWritePackedUnicastSubCmd), info_.l1_alignment_);
+
+        // Build sub-commands
+        std::vector<CQDispatchWritePackedUnicastSubCmd> sub_cmds =
+            Common::PackedWriteUtils::build_sub_cmds(device_, worker_cores, k_dispatch_downstream_noc);
+        // Relevel once before generating commands
+        device_data_.relevel(tt::CoreType::WORKER);
+
+        // Clamp for dispatch page size (no_stride mode)
+        if (no_stride) {
+            const uint32_t max_allowed = info_.dispatch_buffer_page_size_ - sizeof(CQDispatchCmd) - sub_cmds_bytes;
+            if (length > max_allowed) {
+                log_warning(tt::LogTest, "Clamping packed_write cmd w/ no_stride to fit dispatch page");
+                length = max_allowed;
+            }
+        }
+
+        const CoreCoord& fw = worker_cores[0];
+        // Capture address before updating device_data
+        uint32_t addr = device_data_.get_result_data_addr(fw);
+        // Generate Payload
+        auto payload = payload_generator_->generate_payload_with_core(fw, length);
+        // Update expected device_data for all cores
+        Common::DeviceDataUpdater::update_packed_write(payload, device_data_, worker_cores, info_.l1_alignment_);
+
+        // Build Command
+        HostMemDeviceCommand cmd = Common::CommandBuilder::build_packed_write_command(
+            payload, sub_cmds, addr, info_.l1_alignment_, info_.packed_write_max_unicast_sub_cmds_, no_stride);
+
+        cmds_.push_back(std::move(cmd));
+    }
+
+    // L1 read to L1 write in same core: copies from worker core's start of data back to the end of data
+    // For this function to run, there needs to prior data present in L1 already
+    // Note: This function needs to run after L1 writes by previous commands
+    void add_linear_read(const CoreRange worker_range, uint32_t length, uint32_t offset_from_current = 0) {
+        const auto worker = worker_range.start_coord;
+        const uint32_t bank_id = 0;
+        // Ensure we have data to read
+        const uint32_t avail_bytes = device_data_.size_at(worker, bank_id) * sizeof(uint32_t);
+        if (length == 0 || offset_from_current >= avail_bytes) {
+            return;  // nothing to copy
+        }
+
+        const CoreCoord first_worker = device_->virtual_core_from_logical_core(worker, CoreType::WORKER);
+        uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_worker);
+
+        constexpr bool flush_prefetch = false;
+        constexpr bool inline_data = false;
+
+        // Copy already existing data from exisitng addresses src core's L1 region
+        const uint32_t src_addr =
+            device_data_.get_base_result_addr(device_data_.get_core_type(worker)) + offset_from_current;
+        // Write data to the next free/append position in modeled L1 stream
+        const uint32_t dst_addr = device_data_.get_result_data_addr(worker, 0);  // append point
+
+        // Shadow model: copy existing L1 data from src offset
+        const uint32_t words = length / sizeof(uint32_t);
+        const uint32_t offset_words = offset_from_current / sizeof(uint32_t);
+        DeviceDataUpdater::update_read(worker, device_data_, worker, bank_id, offset_words, words);
+        device_data_.pad(worker, bank_id, MetalContext::instance().hal().get_alignment(HalMemType::L1));
+
+        // Barrier/stall to avoid RAW hazards
+        HostMemDeviceCommand stall_cmd = CommandBuilder::build_dispatch_prefetch_stall();
+        cmds_.push_back(std::move(stall_cmd));
+
+        // Blit: dispatcher linear write (dest) + relay linear read (src)
+        HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_linear_read<flush_prefetch, inline_data>(
+            noc_xy, dst_addr, src_addr, length);
+
+        cmds_.push_back(std::move(cmd));
+    }
+
+    // Relay inline dispatcher to host writes smoke test helper
+    void add_host_write(uint32_t length, const std::function<void(Common::DeviceData&)>& pad_host_data) {
+        constexpr bool inline_data = true;
+        std::vector<uint32_t> payload = payload_generator_->generate_payload(length);
+
+        DeviceDataUpdater::update_host_data(device_data_, payload, length);
+
+        // Create the HostMemDeviceCommand with pre-calculated size
+        HostMemDeviceCommand cmd = CommandBuilder::build_relay_inline_host<inline_data>(payload, length);
+
+        cmds_.push_back(std::move(cmd));
+
+        // The completion queue is page-aligned (4KB pages)
+        // Each write reserves full pages but only writes actual data,
+        // leaving the remainder untouched (still HOST_DATA_DIRTY_PATTERN)
+        // This ensures padding areas retain the sentinel value for validation
+        pad_host_data(device_data_);
+    }
+};
+
 class PrefetcherHostTextFixture : virtual public BasePrefetcherTestFixture {
 protected:
     void pad_host_data(Common::DeviceData& device_data) {
@@ -829,6 +1217,126 @@ protected:
         }
 
         return commands_per_iteration;
+    }
+
+public:
+    // In this test, the prefetcher reads from L1 and relays it to dispatcher. Dispatcher then
+    // writes the data to the host completion queue.
+    // Note: Since we're writing into completion queue, we skip distributed::Finish
+    void run_host_test() {
+        const uint32_t max_data_size = DEVICE_DATA_SIZE;
+        const uint32_t max_data_size_words = max_data_size / sizeof(uint32_t);
+        const uint32_t dram_data_size_words = this->get_dram_data_size_words();
+        const uint32_t num_iterations = this->get_num_iterations();
+
+        std::vector<uint32_t> data(max_data_size_words);
+        for (uint32_t i = 0; i < max_data_size_words; i++) {
+            data[i] = i;
+        }
+
+        // Setup target worker cores
+        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+        const CoreRange worker_range = {first_worker, last_worker};
+
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        const CoreCoord phys_worker_core = device_->worker_core_from_logical_core(first_worker);
+        // Write data into L1 for prefetcher to read it later
+        MetalContext::instance().get_cluster().write_core(device_->id(), phys_worker_core, data, l1_base);
+        MetalContext::instance().get_cluster().l1_barrier(device_->id());
+
+        // Get completion queue buffer pointer (FD: FDMeshCommandQueue, SD: hugepage region)
+        void* completion_queue_buffer = get_completion_queue_buffer();
+        const uint32_t completion_queue_size = get_completion_queue_buffer_size();
+        // Pre-fill with dirty pattern:
+        // The dispatcher writes commands and data but doesn't overwrite padding regions
+        // Pre-filling ensures padding areas retain the sentinel value for validation
+        dirty_host_completion_buffer(completion_queue_buffer, completion_queue_size);
+
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base_, completion_queue_buffer, false, dram_data_size_words, cfg_);
+
+        // PHASE 1: Generate host write command metadata
+        auto commands_per_iteration = generate_host_write_commands(data, first_worker, l1_base, device_data);
+
+        // PHASE 2, 3, 4: Execute and Validate
+        // Note: Skip distributed::Finish since we are manually writing into the completion queue
+        // which Finish doesn't expect
+        const bool wait_for_completion = false;
+        // For host writes, we need to wait for all writes to be written into the completion queue
+        const bool wait_for_host_writes = true;
+        execute_generated_commands(
+            commands_per_iteration,
+            device_data,
+            worker_range.size(),
+            num_iterations,
+            wait_for_completion,
+            wait_for_host_writes);
+    }
+
+    // Smoke test for writes to Host from dispatcher
+    // This needed to be separate since it executes differently than others
+    // (we skip distributed::Finish)
+    void run_host_smoke_test() {
+        const uint32_t num_iterations = get_num_iterations();
+        const uint32_t dram_data_size_words = get_dram_data_size_words();
+
+        // Setup target worker cores
+        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+        const CoreRange worker_range = {first_worker, last_worker};
+
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+
+        // Get completion queue buffer pointer (FD: FDMeshCommandQueue, SD: hugepage region)
+        void* completion_queue_buffer = get_completion_queue_buffer();
+        const uint32_t completion_queue_size = get_completion_queue_buffer_size();
+        // Pre-fill with dirty pattern:
+        // The dispatcher writes commands and data but doesn't overwrite padding regions
+        // Pre-filling ensures padding areas retain the sentinel value for validation
+        dirty_host_completion_buffer(completion_queue_buffer, completion_queue_size);
+
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base_, completion_queue_buffer, false, dram_data_size_words, cfg_);
+
+        // PHASE 1: Generate host smoke test command metadata
+        std::vector<HostMemDeviceCommand> commands_per_iteration;
+
+        HelperInfo info{
+            dram_base_, num_banks_, l1_alignment_, packed_write_max_unicast_sub_cmds_, dispatch_buffer_page_size_};
+        // Instantiate Helper
+        SmokeTestHelper helper(device_, device_data, commands_per_iteration, info);
+
+        auto add_host_write_func = [this](Common::DeviceData& device_data) {
+            PrefetcherHostTextFixture::pad_host_data(device_data);
+        };
+
+        for (uint32_t multiplier = 1; multiplier < 3; multiplier++) {
+            helper.add_host_write(multiplier * 32, add_host_write_func);
+            helper.add_host_write(multiplier * 36, add_host_write_func);
+            helper.add_host_write(multiplier * 1024, add_host_write_func);
+            helper.add_host_write(
+                (multiplier * dispatch_buffer_page_size_) - (2 * sizeof(CQDispatchCmd)), add_host_write_func);
+            helper.add_host_write(
+                (multiplier * dispatch_buffer_page_size_) - sizeof(CQDispatchCmd), add_host_write_func);
+            helper.add_host_write((multiplier * dispatch_buffer_page_size_), add_host_write_func);
+            helper.add_host_write(
+                (multiplier * dispatch_buffer_page_size_) + sizeof(CQDispatchCmd), add_host_write_func);
+        }
+
+        // PHASE 2, 3, 4: Execute and Validate
+        // Skip distributed::Finish since we are manually writing into the completion queue
+        // which Finish doesn't expect
+        const bool wait_for_completion = false;
+        // For host writes, we need to wait for all writes to be written into the completion queue
+        const bool wait_for_host_writes = true;
+        execute_generated_commands(
+            commands_per_iteration,
+            device_data,
+            worker_range.size(),
+            num_iterations,
+            wait_for_completion,
+            wait_for_host_writes);
     }
 };
 
@@ -929,6 +1437,176 @@ protected:
 
         return commands_per_iteration;
     }
+
+public:
+    // This tests relay of packed paged data using prefetcher to dispacher
+    // with multiple sub commands
+    void run_packed_read_test() {
+        const uint32_t num_iterations = 1;
+        const uint32_t dram_data_size_words = Common::DRAM_DATA_SIZE_WORDS;
+
+        // Setup target worker cores
+        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+        const CoreRange worker_range = {first_worker, last_worker};
+
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        const auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
+
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+        // PHASE 1: Generate packed read command metadata
+        auto commands_per_iteration = generate_packed_read_commands(first_worker, dram_alignment, device_data);
+
+        // PHASE 2, 3, 4: Execute and Validate
+        execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    }
+
+    // Smoke test of prefetcher/dispatcher commands except add_dispatch_write_host
+    void run_smoke_test() {
+        const uint32_t num_iterations = get_num_iterations();
+        const uint32_t dram_data_size_words = get_dram_data_size_words();
+
+        // Setup target worker cores
+        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord last_worker = first_worker;
+        const CoreRange worker_range = {first_worker, last_worker};
+
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+        // PHASE 1: Generate smoke test command metadata
+        std::vector<HostMemDeviceCommand> commands_per_iteration;
+
+        HelperInfo info{
+            dram_base_, num_banks_, l1_alignment_, packed_write_max_unicast_sub_cmds_, dispatch_buffer_page_size_};
+        // Instantiate Helper
+        SmokeTestHelper helper(device_, device_data, commands_per_iteration, info);
+
+        // Section 1: Unicast
+        // Important: reset device_data from prior tests if smoke test isn't the first
+        helper.add_unicast_write(worker_range, 32);
+        helper.add_unicast_write(worker_range, 1026);
+        helper.add_unicast_write(worker_range, 8448);
+        helper.add_unicast_write(worker_range, dispatch_buffer_page_size_);
+        helper.add_unicast_write(worker_range, dispatch_buffer_page_size_ - sizeof(CQDispatchCmdLarge));
+        helper.add_unicast_write(worker_range, 2 * dispatch_buffer_page_size_);
+        helper.add_unicast_write(worker_range, (2 * dispatch_buffer_page_size_) - sizeof(CQDispatchCmdLarge));
+
+        // Section 2: Merged Unicast Writes
+        helper.add_merged_unicast_writes(worker_range, {112, 608, 64, 96});
+
+        // Section 3: packed read
+        constexpr uint32_t log_packed_read_page_size = 10;
+        const uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
+        const uint32_t length_to_read = tt::align(2080, dram_alignment);
+        const uint32_t length_to_read_sdb = tt::align(DEFAULT_SCRATCH_DB_SIZE / 8, dram_alignment);
+        // Create and pass PrefetcherPackedReadTestFixture::build_sub_cmds callable
+        auto build_packed = [this](
+                                const std::vector<uint32_t>& lengths,
+                                Common::DeviceData& device_data,
+                                uint32_t log_page_sz,
+                                uint32_t n_sub_cmds) {
+            return PrefetcherPackedReadTestFixture::build_sub_cmds(lengths, device_data, log_page_sz, n_sub_cmds);
+        };
+        // Uses last_worker as first_worker is filling up
+        helper.add_packed_dram_read(worker_range, log_packed_read_page_size, {256, 512}, build_packed);
+        helper.add_packed_dram_read(worker_range, log_packed_read_page_size, {1024, 2048}, build_packed);
+        helper.add_packed_dram_read(worker_range, log_packed_read_page_size, {length_to_read}, build_packed);
+        helper.add_packed_dram_read(
+            worker_range, log_packed_read_page_size + 1, {length_to_read, length_to_read}, build_packed);
+
+        std::vector<uint32_t> lengths{
+            length_to_read_sdb,
+            length_to_read_sdb,
+            length_to_read_sdb,
+            tt::align(DEFAULT_SCRATCH_DB_SIZE / 4, dram_alignment),   // won't fit in first pass
+            tt::align(DEFAULT_SCRATCH_DB_SIZE / 2, dram_alignment)};  // won't fit in second pass
+        helper.add_packed_dram_read(worker_range, log_packed_read_page_size + 1, lengths, build_packed);
+
+        lengths.clear();
+        lengths.push_back(tt::align((DEFAULT_SCRATCH_DB_SIZE / 4) + (2 * 1024) + 32, dram_alignment));
+        lengths.push_back(tt::align((DEFAULT_SCRATCH_DB_SIZE / 4) + (3 * 1024) + 32, dram_alignment));
+        lengths.push_back(tt::align(DEFAULT_SCRATCH_DB_SIZE / 2, dram_alignment));
+        lengths.push_back(tt::align((DEFAULT_SCRATCH_DB_SIZE / 8) + (5 * 1024) + 96, dram_alignment));
+        helper.add_packed_dram_read(worker_range, log_packed_read_page_size, lengths, build_packed);
+
+        // Section 4: Read from dram, write to worker
+        //                              start_page,                      base addr,      page_size,           pages,
+        //                              length_adjust
+        helper.add_paged_dram_read(worker_range, 0, 0, dram_alignment, num_banks_, 0);
+        helper.add_paged_dram_read(worker_range, 4, dram_alignment, dram_alignment * 2, num_banks_, 0);
+        helper.add_paged_dram_read(worker_range, 4, dram_alignment, dram_alignment * 2, num_banks_, 0);
+        helper.add_paged_dram_read(worker_range, 0, 0, 128, 128, 0);
+        helper.add_paged_dram_read(worker_range, 4, dram_alignment, 2048, num_banks_ + 4, 0);
+        helper.add_paged_dram_read(worker_range, 5, dram_alignment, 2048, (num_banks_ * 3) + 1, 0);
+        helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_ - 1, 0);
+        helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_ - 1, 0);
+        helper.add_paged_dram_read(worker_range, 0, 0, 128, 128, 32);
+        helper.add_paged_dram_read(worker_range, 4, dram_alignment, 2048, num_banks_ * 2, 1536);
+        helper.add_paged_dram_read(worker_range, 5, dram_alignment, 2048, (num_banks_ * 2) + 1, 256);
+        helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_ - 1, 640);
+        // Large pages
+        helper.add_paged_dram_read(worker_range, 0, 0, DEFAULT_SCRATCH_DB_SIZE / 2 + dram_alignment, 2, 128);
+        helper.add_paged_dram_read(worker_range, 0, 0, DEFAULT_SCRATCH_DB_SIZE, 2, 0);
+        // Forces length_adjust to back into prior read.  Device reads pages, shouldn't be a problem...
+        uint32_t page_size = 256 + dram_alignment;
+        uint32_t length = (DEFAULT_SCRATCH_DB_SIZE / 2 / page_size * page_size) + page_size;
+        helper.add_paged_dram_read(worker_range, 3, 128, page_size, length / page_size, 160);
+
+        // Section 5: Inline packed writes
+        const CoreCoord first_worker_2x2 = default_worker_start;
+        const CoreCoord last_worker_2x2 = {first_worker_2x2.x + 1, first_worker_2x2.y + 1};
+        const CoreRange worker_range_2x2 = {first_worker_2x2, last_worker_2x2};
+        // Pick worker cores once for all commands
+        std::vector<CoreCoord> worker_cores{first_worker_2x2};
+        helper.add_packed_write(worker_cores, 4);
+        worker_cores.clear();
+        for (uint32_t y = worker_range_2x2.start_coord.y; y <= worker_range_2x2.end_coord.y; ++y) {
+            for (uint32_t x = worker_range_2x2.start_coord.x; x <= worker_range_2x2.end_coord.x; ++x) {
+                worker_cores.push_back({x, y});
+            }
+        }
+        helper.add_packed_write(worker_cores, 12);
+        helper.add_packed_write(worker_cores, 12, true);
+        worker_cores.clear();
+        worker_cores.push_back(first_worker_2x2);
+        worker_cores.push_back(last_worker_2x2);
+        helper.add_packed_write(worker_cores, 156);
+
+        // Section 6: Linear read -> Linear write test
+        // Note: this test is dependent on already written data in L1
+        // So it reads the above data from prior commands and needs to run after those
+        helper.add_linear_read(worker_range, 32);
+        helper.add_linear_read(worker_range, 65 * 1024);
+        helper.add_linear_read(worker_range, dispatch_buffer_page_size_ - sizeof(CQDispatchCmdLarge));
+        helper.add_linear_read(worker_range, (2 * dispatch_buffer_page_size_) - sizeof(CQDispatchCmdLarge));
+        helper.add_linear_read(worker_range, (2 * dispatch_buffer_page_size_));
+        // Skipping CQ_DISPATCH_CMD_DELAY from the legacy test here
+        helper.add_unicast_write(worker_range, 1024);
+        // Barrier/stall to avoid RAW hazards
+        HostMemDeviceCommand stall_cmd = CommandBuilder::build_dispatch_prefetch_stall();
+        commands_per_iteration.push_back(std::move(stall_cmd));
+        uint32_t length_bytes = 32;
+        uint32_t offset_words = device_data.size_at(worker_range.start_coord, 0) - (length_bytes / sizeof(uint32_t));
+        uint32_t offset_bytes = offset_words * sizeof(uint32_t);
+        helper.add_linear_read(worker_range, length_bytes, offset_bytes);
+
+        // Section 7: Write offset
+        // Simple Smoke test: do a change write_offset_idx to 48 and back to 0
+        std::array<uint32_t, CQ_DISPATCH_MAX_WRITE_OFFSETS> write_offset1 = {48, 0, 0, 0};
+        std::array<uint32_t, CQ_DISPATCH_MAX_WRITE_OFFSETS> write_offset2 = {};
+        HostMemDeviceCommand write_offset_cmd1 = CommandBuilder::build_dispatch_write_offset(write_offset1);
+        HostMemDeviceCommand write_offset_cmd2 = CommandBuilder::build_dispatch_write_offset(write_offset2);
+        commands_per_iteration.push_back(std::move(write_offset_cmd1));
+        commands_per_iteration.push_back(std::move(write_offset_cmd2));
+
+        // PHASE 2, 3, 4: Execute and Validate
+        execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    }
 };
 
 class PrefetcherLinearPackedReadTestFixture : virtual public BasePrefetcherTestFixture {
@@ -1027,6 +1705,46 @@ protected:
         }
 
         return commands_per_iteration;
+    }
+
+public:
+    // This tests relay of packed linear data using prefetcher to dispatcher
+    // with multiple sub commands, each with a linear address.
+    // Source: Worker L1 (can overlap), Destination: DRAM bank 0
+    void run_linear_packed_read_test() {
+        const uint32_t num_iterations = 1;
+
+        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+        const CoreRange worker_range = {first_worker, last_worker};
+
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        const auto l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+
+        // Pre-populate L1 with sequential test data [0, 1, 2, 3, ...] for the prefetcher to read
+        const uint32_t l1_data_size_words = DEVICE_DATA_SIZE / sizeof(uint32_t);
+        std::vector<uint32_t> l1_data(l1_data_size_words);
+        for (uint32_t i = 0; i < l1_data_size_words; i++) {
+            l1_data[i] = i;
+        }
+        const CoreCoord phys_worker_core = device_->worker_core_from_logical_core(first_worker);
+        MetalContext::instance().get_cluster().write_core(device_->id(), phys_worker_core, l1_data, l1_base);
+        MetalContext::instance().get_cluster().l1_barrier(device_->id());
+
+        // Initialize DRAM bank 0 with sentinel pattern to detect unwritten regions
+        constexpr uint32_t dest_bank_id = 0;
+        constexpr uint32_t sentinel_pattern = 0x99999999;
+        const uint32_t dram_size_words = DEVICE_DATA_SIZE_LARGE / sizeof(uint32_t);
+        std::vector<uint32_t> sentinel_data(dram_size_words, sentinel_pattern);
+        tt::tt_metal::detail::WriteToDeviceDRAMChannel(device_, dest_bank_id, dram_base_, sentinel_data);
+        MetalContext::instance().get_cluster().dram_barrier(device_->id());
+
+        // Initialize DeviceData tracking (do not pre-populate DRAM since we're writing to it)
+        Common::DeviceData device_data(device_, worker_range, l1_base, dram_base_, nullptr, false, 0, cfg_);
+
+        // Generate and execute commands
+        auto commands_per_iteration = generate_linear_packed_read_commands(first_worker, l1_alignment, device_data);
+        execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
     }
 };
 
@@ -1154,6 +1872,33 @@ public:
         }
 
         return commands_per_iteration;
+    }
+
+public:
+    // Ring Buffer operates differently than others
+    // Data is first staged (cached) into Ringbuffer (L1) from DRAM
+    // Then, we relay command header + data into dispatcher
+    // Note: Ring buffer is stateful as we set the ringbuffer offset on first load
+    void run_ringbuffer_read_test() {
+        const uint32_t num_iterations = get_num_iterations();
+        const uint32_t dram_data_size_words = get_dram_data_size_words();
+
+        // Setup target worker cores
+        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+        const CoreRange worker_range = {first_worker, last_worker};
+
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        const auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
+
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+        // PHASE 1: Generate ringbuffer command metadata
+        auto commands_per_iteration = generate_ringbuffer_relay_commands(first_worker, dram_alignment, device_data);
+
+        // PHASE 2, 3, 4: Execute and Validate
+        execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
     }
 };
 
@@ -1727,262 +2472,88 @@ protected:
         }
         return std::nullopt;
     }
-};
-
-struct HelperInfo {
-    uint32_t dram_base_{};
-    uint32_t num_banks_{};
-    uint32_t l1_alignment_{};
-    uint32_t packed_write_max_unicast_sub_cmds_{};
-    uint32_t dispatch_buffer_page_size_{};
-};
-
-// TODO: add CQ_PREFETCH_CMD_DEBUG
-class SmokeTestHelper {
-    tt_metal::distributed::MeshDevice::IDevice* device_;
-    Common::DeviceData& device_data_;
-    std::vector<HostMemDeviceCommand>& cmds_;
-    std::unique_ptr<Common::DispatchPayloadGenerator> payload_generator_;
-
-    HelperInfo info_{};
 
 public:
-    SmokeTestHelper(
-        tt_metal::distributed::MeshDevice::IDevice* device,
-        Common::DeviceData& device_data,
-        std::vector<HostMemDeviceCommand>& cmds,
-        HelperInfo info) :
-        device_(device), device_data_(device_data), cmds_(cmds), info_(info) {
-        // Initialize simple payload generator
-        Common::DispatchPayloadGenerator::Config cfg;
-        cfg.seed = 1234;  // Deterministic seed for smoke test
-        payload_generator_ = std::make_unique<Common::DispatchPayloadGenerator>(cfg);
-    }
+    // This tests random configurations of commands like CQ_PREFETCH_CMD_RELAY_LINEAR, CQ_PREFETCH_CMD_RELAY_PAGED,
+    // CQ_PREFETCH_CMD_RELAY_INLINE etc
+    void run_random_test() {
+        const uint32_t num_iterations = get_num_iterations();
+        const uint32_t dram_data_size_words = get_dram_data_size_words();
 
-    void add_unicast_write(const CoreRange worker_range, uint32_t length) {
-        const auto worker = worker_range.start_coord;
-        const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(worker, CoreType::WORKER);
-        uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
-        const bool is_mcast_ = false;
-        const bool flush_prefetch = true;
-        const bool inline_data = true;  // send data inline
-        // Capture address before updating device_data
-        uint32_t addr = device_data_.get_result_data_addr(worker, 0);
-        // Generate payload
-        std::vector<uint32_t> payload = payload_generator_->generate_payload(length);
-        // Update Common::DeviceData for linear write
-        Common::DeviceDataUpdater::update_linear_write(payload, device_data_, worker_range, is_mcast_);
-        // Create the HostMemDeviceCommand
-        HostMemDeviceCommand cmd = Common::CommandBuilder::build_linear_write_command<flush_prefetch, inline_data>(
-            payload, worker_range, is_mcast_, noc_xy, addr, length);
+        // Setup target worker cores
+        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+        const CoreRange worker_range = {first_worker, last_worker};
 
-        cmds_.push_back(std::move(cmd));
-    }
+        const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
 
-    // Merge multiple of unicast writes into a single fetchQ command entry
-    void add_merged_unicast_writes(const CoreRange worker_range, const std::vector<uint32_t>& lengths) {
-        const auto worker = worker_range.start_coord;
-        const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(worker, CoreType::WORKER);
-        uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
-        const bool is_mcast_ = false;
-        const bool flush_prefetch = true;
-        const bool inline_data = true;
+        Common::DeviceData device_data(
+            device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
 
-        // Calculate size of a single merged entry of all lengths
-        DeviceCommandCalculator cmd_calc;
-        for (const auto length : lengths) {
-            cmd_calc.add_dispatch_write_linear<flush_prefetch, inline_data>(length);
-        }
+        // PHASE 1: Generate random command metadata
+        std::vector<HostMemDeviceCommand> commands_per_iteration;
 
-        const uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
+        uint32_t remaining_bytes = DEVICE_DATA_SIZE;
 
-        // Create the HostMemDeviceCommand for single merged entry
-        HostMemDeviceCommand cmd(command_size_bytes);
+        while (remaining_bytes > 0) {
+            // Assumes terminate is the last command...
+            uint32_t cmd = payload_generator_->get_rand<uint32_t>(0, CQ_PREFETCH_CMD_TERMINATE - 1);
+            const uint32_t limit_x = (worker_range.end_coord.x - first_worker.x - 1);
+            const uint32_t limit_y = (worker_range.end_coord.y - first_worker.y - 1);
+            uint32_t x = payload_generator_->get_rand<uint32_t>(0, limit_x);
+            uint32_t y = payload_generator_->get_rand<uint32_t>(0, limit_y);
 
-        // Add all lengths into single cmd
-        for (const auto length : lengths) {
-            // Capture address before updating device_data
-            uint32_t addr = device_data_.get_result_data_addr(worker, 0);
-            // Generate payload
-            std::vector<uint32_t> payload = payload_generator_->generate_payload(length);
-            // Update Common::DeviceData for linear write
-            Common::DeviceDataUpdater::update_linear_write(payload, device_data_, worker_range, is_mcast_);
-            // Add the dispatch write linear command
-            cmd.add_dispatch_write_linear<flush_prefetch, inline_data>(
-                is_mcast_ ? worker_range.size() : 0,  // num_mcast_dests
-                noc_xy,                               // NOC coordinates
-                addr,                                 // destination address
-                length,                               // data size
-                payload.data()                        // payload data
-            );
-        }
+            CoreCoord worker_core(first_worker.x + x, first_worker.y + y);
+            // Compute NOC encoding once
+            const CoreCoord worker_core_virt = device_->virtual_core_from_logical_core(worker_core, CoreType::WORKER);
+            const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, worker_core_virt);
 
-        cmds_.push_back(std::move(cmd));
-    }
+            switch (cmd) {
+                case CQ_PREFETCH_CMD_RELAY_LINEAR:
+                // TODO: Temporarily dropping the linear relay from random mix.
+                // Having this test enabled leads to intermittent validation failures
+                // Issue: Randomization is probably landing on holes the hardware never wrote (padding/gaps in the
+                // model?), so we're reading old L1 content and causing intermittent validation failures Note: this was
+                // disabled in legacy as well
 
-    void add_packed_dram_read(
-        const CoreRange worker_range,
-        const uint32_t log_packed_read_page_size,
-        const std::vector<uint32_t>& lengths,
-        const std::function<std::vector<CQPrefetchRelayPagedPackedSubCmd>(
-            const std::vector<uint32_t>& lengths, Common::DeviceData&, uint32_t log_page_sz, uint32_t n_sub_cmds)>&
-            build_packed) {
-        const auto worker = worker_range.start_coord;
-        const CoreCoord last_virt_worker = device_->virtual_core_from_logical_core(worker, CoreType::WORKER);
-        uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, last_virt_worker);
-
-        const uint32_t total_length = std::accumulate(lengths.begin(), lengths.end(), 0u);
-        const uint32_t n_sub_cmds = lengths.size();
-        const bool flush_prefetch = false;
-        const bool inline_data = false;
-
-        uint32_t l1_addr = device_data_.get_result_data_addr(worker, 0);
-
-        std::vector<CQPrefetchRelayPagedPackedSubCmd> sub_cmds =
-            build_packed(lengths, device_data_, log_packed_read_page_size, n_sub_cmds);
-
-        HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_paged_packed<flush_prefetch, inline_data>(
-            sub_cmds, noc_xy, l1_addr, total_length);
-
-        cmds_.push_back(std::move(cmd));
-    }
-
-    void add_paged_dram_read(
-        const CoreRange worker_range,
-        uint32_t start_page,
-        uint32_t base_addr_offset,
-        uint32_t page_size_bytes,
-        uint32_t num_pages,
-        uint32_t /*length_adjust*/) {
-        const auto worker = worker_range.start_coord;
-        const CoreCoord first_worker = device_->virtual_core_from_logical_core(worker, CoreType::WORKER);
-        uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_worker);
-        const bool flush_prefetch = false;
-        const bool inline_data = false;
-
-        const uint32_t max_bytes_in_chunk = num_pages * page_size_bytes;
-        const uint32_t pages_in_chunk = max_bytes_in_chunk / page_size_bytes;
-        const uint32_t page_size_words = page_size_bytes / sizeof(uint32_t);
-        const uint32_t base_addr_words = base_addr_offset / sizeof(uint32_t);
-        uint32_t base_addr = info_.dram_base_ + base_addr_offset;
-
-        // Capture address before updating device_data
-        uint32_t l1_addr = device_data_.get_result_data_addr(worker, 0);
-
-        HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_paged<flush_prefetch, inline_data>(
-            noc_xy, l1_addr, start_page, base_addr, page_size_bytes, pages_in_chunk);
-
-        for (uint32_t page = 0; page < pages_in_chunk; ++page) {
-            const uint32_t page_id = start_page + page;
-            const uint32_t bank_id = page_id % info_.num_banks_;
-            uint32_t bank_offset = base_addr_words + (page_size_words * (page_id / info_.num_banks_));
-
-            // Get the logical core for this bank
-            const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
-            const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
-
-            // Update Common::DeviceData for paged read
-            DeviceDataUpdater::update_paged_dram_read(
-                worker_range, device_data_, bank_core, bank_id, bank_offset, page_size_words);
-        }
-
-        cmds_.push_back(std::move(cmd));
-    }
-
-    // Length should always be less than max_fetch_bytes_
-    void add_packed_write(const std::vector<CoreCoord>& worker_cores, uint32_t length, bool no_stride = false) {
-        const uint32_t num_sub_cmds = static_cast<uint32_t>(worker_cores.size());
-        const uint32_t sub_cmds_bytes =
-            tt::align(num_sub_cmds * sizeof(CQDispatchWritePackedUnicastSubCmd), info_.l1_alignment_);
-
-        // Build sub-commands
-        std::vector<CQDispatchWritePackedUnicastSubCmd> sub_cmds =
-            Common::PackedWriteUtils::build_sub_cmds(device_, worker_cores, k_dispatch_downstream_noc);
-        // Relevel once before generating commands
-        device_data_.relevel(tt::CoreType::WORKER);
-
-        // Clamp for dispatch page size (no_stride mode)
-        if (no_stride) {
-            const uint32_t max_allowed = info_.dispatch_buffer_page_size_ - sizeof(CQDispatchCmd) - sub_cmds_bytes;
-            if (length > max_allowed) {
-                log_warning(tt::LogTest, "Clamping packed_write cmd w/ no_stride to fit dispatch page");
-                length = max_allowed;
+                /* if (has_l1_data) {
+                //     CoreRange single_worker_range = {worker_core, worker_core};
+                //     auto result = gen_random_linear_read_cmd(device_data, worker_core, noc_xy, remaining_bytes);
+                //     if(result.has_value()){
+                //         HostMemDeviceCommand& cmd = *result;
+                //         commands_per_iteration.push_back(std::move(cmd));
+                //     }
+                //     break;
+                // }*/
+                case CQ_PREFETCH_CMD_RELAY_PAGED: {
+                    CoreRange single_worker_range = {worker_core, worker_core};
+                    auto result = gen_random_dram_paged_cmd(
+                        device_data, worker_core, single_worker_range, noc_xy, remaining_bytes);
+                    if (result.has_value()) {
+                        HostMemDeviceCommand& cmd = *result;
+                        commands_per_iteration.push_back(std::move(cmd));
+                    }
+                    break;
+                }
+                case CQ_PREFETCH_CMD_RELAY_INLINE: {
+                    const CoreCoord last_worker = {worker_core.x + 1, worker_core.y + 1};
+                    CoreRange multi_worker_range = {worker_core, last_worker};
+                    auto result = gen_random_inline_cmd(device_data, multi_worker_range, noc_xy, remaining_bytes);
+                    if (result.has_value()) {
+                        HostMemDeviceCommand& cmd = *result;
+                        commands_per_iteration.push_back(std::move(cmd));
+                    }
+                    break;
+                }
+                case CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH:
+                case CQ_PREFETCH_CMD_STALL:
+                case CQ_PREFETCH_CMD_DEBUG:
+                default: break;
             }
         }
 
-        const CoreCoord& fw = worker_cores[0];
-        // Capture address before updating device_data
-        uint32_t addr = device_data_.get_result_data_addr(fw);
-        // Generate Payload
-        auto payload = payload_generator_->generate_payload_with_core(fw, length);
-        // Update expected device_data for all cores
-        Common::DeviceDataUpdater::update_packed_write(payload, device_data_, worker_cores, info_.l1_alignment_);
-
-        // Build Command
-        HostMemDeviceCommand cmd = Common::CommandBuilder::build_packed_write_command(
-            payload, sub_cmds, addr, info_.l1_alignment_, info_.packed_write_max_unicast_sub_cmds_, no_stride);
-
-        cmds_.push_back(std::move(cmd));
-    }
-
-    // L1 read to L1 write in same core: copies from worker core's start of data back to the end of data
-    // For this function to run, there needs to prior data present in L1 already
-    // Note: This function needs to run after L1 writes by previous commands
-    void add_linear_read(const CoreRange worker_range, uint32_t length, uint32_t offset_from_current = 0) {
-        const auto worker = worker_range.start_coord;
-        const uint32_t bank_id = 0;
-        // Ensure we have data to read
-        const uint32_t avail_bytes = device_data_.size_at(worker, bank_id) * sizeof(uint32_t);
-        if (length == 0 || offset_from_current >= avail_bytes) {
-            return;  // nothing to copy
-        }
-
-        const CoreCoord first_worker = device_->virtual_core_from_logical_core(worker, CoreType::WORKER);
-        uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_worker);
-
-        constexpr bool flush_prefetch = false;
-        constexpr bool inline_data = false;
-
-        // Copy already existing data from exisitng addresses src core's L1 region
-        const uint32_t src_addr =
-            device_data_.get_base_result_addr(device_data_.get_core_type(worker)) + offset_from_current;
-        // Write data to the next free/append position in modeled L1 stream
-        const uint32_t dst_addr = device_data_.get_result_data_addr(worker, 0);  // append point
-
-        // Shadow model: copy existing L1 data from src offset
-        const uint32_t words = length / sizeof(uint32_t);
-        const uint32_t offset_words = offset_from_current / sizeof(uint32_t);
-        DeviceDataUpdater::update_read(worker, device_data_, worker, bank_id, offset_words, words);
-        device_data_.pad(worker, bank_id, MetalContext::instance().hal().get_alignment(HalMemType::L1));
-
-        // Barrier/stall to avoid RAW hazards
-        HostMemDeviceCommand stall_cmd = CommandBuilder::build_dispatch_prefetch_stall();
-        cmds_.push_back(std::move(stall_cmd));
-
-        // Blit: dispatcher linear write (dest) + relay linear read (src)
-        HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_linear_read<flush_prefetch, inline_data>(
-            noc_xy, dst_addr, src_addr, length);
-
-        cmds_.push_back(std::move(cmd));
-    }
-
-    // Relay inline dispatcher to host writes smoke test helper
-    void add_host_write(uint32_t length, const std::function<void(Common::DeviceData&)>& pad_host_data) {
-        constexpr bool inline_data = true;
-        std::vector<uint32_t> payload = payload_generator_->generate_payload(length);
-
-        DeviceDataUpdater::update_host_data(device_data_, payload, length);
-
-        // Create the HostMemDeviceCommand with pre-calculated size
-        HostMemDeviceCommand cmd = CommandBuilder::build_relay_inline_host<inline_data>(payload, length);
-
-        cmds_.push_back(std::move(cmd));
-
-        // The completion queue is page-aligned (4KB pages)
-        // Each write reserves full pages but only writes actual data,
-        // leaving the remainder untouched (still HOST_DATA_DIRTY_PATTERN)
-        // This ensures padding areas retain the sentinel value for validation
-        pad_host_data(device_data_);
+        // PHASE 2, 3, 4: Execute and Validate
+        execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
     }
 };
 
@@ -2021,7 +2592,8 @@ public:
         this->send_to_all_ = this->cfg_.send_to_all;
         this->host_alignment_ = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
         // Cap inline command size to avoid cmddat_q L1 overflow on the prefetch-d core.
-        this->max_fetch_bytes_ = Common::SD_PREFETCH_SCRATCH_DB_SIZE;
+        this->max_fetch_bytes_ =
+            tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER).scratch_db_size();
 
         this->dram_base_ = this->device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
         this->num_banks_ = this->device_->allocator_impl()->get_num_banks(BufferType::DRAM);
@@ -2057,35 +2629,22 @@ public:
 
         const auto& memmap = tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
         const uint32_t dispatch_cb_base = memmap.dispatch_buffer_base();
-        const uint32_t dispatch_buffer_pages =
-            Common::SD_DISPATCH_BUFFER_SIZE_BYTES / Common::SD_DISPATCH_BUFFER_PAGE_SIZE;
+        const uint32_t dispatch_buffer_pages = memmap.dispatch_buffer_pages();
 
-        // L1 layout on the prefetch_hd core
-        // Place FetchQ ring + rd_ptr immediately after the first allocatable L1 page.
-        // cmddat_q and scratch_db follow the FetchQ.
-        const uint32_t l1_unrsv = this->device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+        // L1 layout on the prefetch_hd core comes straight from the production memmap so SD
+        // mirrors the FD runtime exactly (PREFETCH_Q_RD/PCIE_RD scalar gap is L1-aligned, not 4 B).
+        // The memmap constructor already asserts scratch_db_base + ringbuffer_size <= l1_size.
         const uint32_t page_size = Common::SD_PREFETCH_CMDDAT_PAGE_SIZE;
-        const uint32_t l1_unrsv_aligned = tt::align(l1_unrsv, page_size);
-
-        // prefetch_q_rd_ptr_addr (4 B) and pcie_rd_ptr_addr (next 4 B) live at l1_unrsv_aligned.
-        // The FetchQ ring starts one full page later so it is page-aligned.
-        const uint32_t prefetch_q_rd_ptr_addr = l1_unrsv_aligned;
-        const uint32_t prefetch_q_base = l1_unrsv_aligned + page_size;
-        const uint32_t prefetch_q_size = Common::SD_PREFETCH_Q_ENTRIES * sizeof(entry_t);
-
-        // cmddat_q: after FetchQ, aligned to host (NOC) alignment.
-        const uint32_t noc_align = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
-        const uint32_t cmddat_q_base = prefetch_q_base + tt::align(prefetch_q_size, noc_align);
-        // Use the same cmddat_q size as the FD runtime (256KB on worker). read_from_pcie issues one DMA per
-        // FetchQ entry, so cmddat_q must be >= max single command size (prefetch_max_cmd_size = 128KB).
-        const uint32_t cmddat_q_bytes = memmap.cmddat_q_size();
-        const uint32_t cmddat_q_pages = tt::align(cmddat_q_bytes / page_size, Common::SD_PREFETCH_CMDDAT_BLOCKS);
-        const uint32_t scratch_db_base = cmddat_q_base + cmddat_q_pages * page_size;
-
-        const auto& soc_desc = tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->device_->id());
-        TT_FATAL(
-            scratch_db_base + Common::SD_PREFETCH_SCRATCH_DB_SIZE <= soc_desc.worker_l1_size,
-            "SD prefetch hd: prefetch_q + cmddat_q + scratch_db exceeds worker L1");
+        const uint32_t prefetch_q_rd_ptr_addr =
+            memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::PREFETCH_Q_RD);
+        const uint32_t prefetch_q_pcie_rd_ptr_addr =
+            memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::PREFETCH_Q_PCIE_RD);
+        const uint32_t prefetch_q_base = memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::UNRESERVED);
+        const uint32_t prefetch_q_size = memmap.prefetch_q_size();
+        const uint32_t cmddat_q_base = memmap.cmddat_q_base();
+        const uint32_t cmddat_q_pages = memmap.cmddat_q_size() / page_size;
+        const uint32_t scratch_db_base = memmap.scratch_db_base();
+        const uint32_t scratch_db_size = memmap.scratch_db_size();
 
         // Hugepage addressing
         // Use the same hugepage region that the FD runtime uses for the issue queue
@@ -2112,65 +2671,28 @@ public:
         // Initialise to the ring base so the host-side fence logic sees the ring as empty.
         const uint32_t init_rd_ptr = prefetch_q_base;
         cluster.write_core(&init_rd_ptr, sizeof(uint32_t), prefetch_cxy, prefetch_q_rd_ptr_addr);
-        // pcie_rd_ptr_addr (prefetch_q_rd_ptr_addr + 4): initialise to 0.
-        // const uint32_t init_pcie_rd = 0u;
-        // cluster.write_core(
-        //     &init_pcie_rd, sizeof(uint32_t), prefetch_cxy, prefetch_q_rd_ptr_addr + sizeof(uint32_t));
 
-        // TLB window for writing FetchQ entries
+        // FetchQ entries go through the static TLB so each 2-byte write hits L1 directly
+        // instead of round-tripping through the cluster API.
         tt::umd::TlbWindow* prefetch_q_tlb = cluster.get_static_tlb_window(prefetch_cxy);
 
-        // Host-side FetchQ write state.
         uint32_t prefetch_q_dev_ptr = prefetch_q_base;
         const uint32_t prefetch_q_dev_fence = prefetch_q_base + prefetch_q_size;
 
-        // Hugepage write state.
         uint32_t* host_mem_ptr = static_cast<uint32_t*>(host_hugepage_base);
-        const uint64_t hugepage_issue_end =
-            static_cast<uint64_t>(dev_hugepage_base) + Common::SD_HUGEPAGE_ISSUE_BUFFER_SIZE;
 
         const uint32_t host_align = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
 
-        // nt_memcpy: non-temporal store of n bytes (n must be a multiple of 64).
-        auto nt_memcpy_local = [&host_align](uint8_t* __restrict dst, const uint8_t* __restrict src, size_t n) {
-            TT_FATAL(n % host_align == 0, "nt_memcpy: size {} not a multiple of {}", n, host_align);
-            for (size_t i = 0; i < n; i += host_align) {
-                for (size_t j = 0; j < host_align; j += sizeof(__m128i)) {
-                    __m128i blk = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + i + j));
-                    _mm_stream_si128(reinterpret_cast<__m128i*>(dst + i + j), blk);
-                }
-            }
-            tt_driver_atomics::sfence();
-        };
-
-        // write_prefetcher_cmd: nt_memcpy cmd to hugepage + write one FetchQ entry via TLB.
+        // write_prefetcher_cmd: streaming-store cmd to hugepage + write one FetchQ entry via TLB.
         // cmd_size_bytes must be a multiple of 64 (host alignment) and cmd_size_entry is the
         // pre-computed FetchQ value (may have MSB stall flag set for exec_buf).
         auto write_prefetcher_cmd = [&](const uint32_t* src, uint32_t cmd_size_bytes, entry_t cmd_size_entry) {
-            TT_FATAL(
-                cmd_size_bytes % host_align == 0,
-                "SD prefetch: cmd_size_bytes {} not aligned to host alignment {}",
-                cmd_size_bytes,
-                host_align);
-
-            // Poll for FetchQ ring space (should not spin in normal SD operation).
-            while (prefetch_q_dev_ptr == prefetch_q_dev_fence) {
-                uint32_t rd_ptr;
-                cluster.read_core(&rd_ptr, sizeof(uint32_t), prefetch_cxy, prefetch_q_rd_ptr_addr);
-                if (rd_ptr != prefetch_q_dev_ptr) {
-                    break;
-                }
-            }
-
-            // Hugepage wrap: if the command would exceed the issue buffer, reset to base.
             const uint64_t host_offset =
                 static_cast<uint64_t>(reinterpret_cast<char*>(host_mem_ptr) - static_cast<char*>(host_hugepage_base));
-            if (dev_hugepage_base + host_offset + cmd_size_bytes > hugepage_issue_end) {
-                host_mem_ptr = static_cast<uint32_t*>(host_hugepage_base);
-            }
-
-            nt_memcpy_local(
-                reinterpret_cast<uint8_t*>(host_mem_ptr), reinterpret_cast<const uint8_t*>(src), cmd_size_bytes);
+            TT_FATAL(
+                host_offset + cmd_size_bytes <= Common::SD_HUGEPAGE_ISSUE_BUFFER_SIZE,
+                "SD prefetch: command stream exceeds SD_HUGEPAGE_ISSUE_BUFFER_SIZE");
+            tt::tt_metal::memcpy_to_device<true>(host_mem_ptr, src, cmd_size_bytes);
             host_mem_ptr += cmd_size_bytes / sizeof(uint32_t);
 
             prefetch_q_tlb->write16(prefetch_q_dev_ptr, cmd_size_entry);
@@ -2197,31 +2719,13 @@ public:
         } else {
             for (uint32_t i = 0; i < num_iterations; ++i) {
                 for (const auto& cmd : commands_per_iteration) {
-                    const uint32_t size = tt::align(cmd.size_bytes(), host_align);
-                    TT_FATAL(
-                        (size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE) <=
-                            (uint32_t)std::numeric_limits<entry_t>::max() >> 1,
-                        "SD prefetch: command size {} B overflows 15-bit FetchQ entry (max {} B)",
-                        size,
-                        (uint32_t)0x7FFF << DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
                     write_cmd(cmd);
                 }
             }
         }
 
         // Terminate: dispatch_wait + dispatch_terminate + prefetch_terminate (shared by both paths).
-        // SD mode has no dispatch_s kernel, so build the dispatch terminate manually rather than
-        // using CommandBuilder::build_dispatch_terminate() which conditionally appends a subordinate
-        // terminate that would hang the dispatcher with no downstream to receive it.
-        {
-            DeviceCommandCalculator calc;
-            calc.add_dispatch_wait();
-            calc.add_dispatch_terminate();
-            HostMemDeviceCommand disp_term(calc.write_offset_bytes());
-            disp_term.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
-            disp_term.add_dispatch_terminate();
-            write_cmd(disp_term);
-        }
+        write_cmd(CommandBuilder::build_dispatch_terminate(/*include_dispatch_s*/ false));
         write_cmd(CommandBuilder::build_prefetch_terminate());
 
         // Semaphores
@@ -2250,9 +2754,11 @@ public:
             prefetch_q_base,
             prefetch_q_size,
             prefetch_q_rd_ptr_addr,
+            prefetch_q_pcie_rd_ptr_addr,
             cmddat_q_base,
             cmddat_q_pages,
             scratch_db_base,
+            scratch_db_size,
             dispatch_cb_base,
             dispatch_buffer_pages,
             pf_downstream_cb_sem,
@@ -2318,6 +2824,11 @@ public:
         EXPECT_TRUE(device_data.validate(this->device_)) << "SD prefetch test failed validation";
     }
 
+    // SD's execute_generated_commands always injects dispatch_wait + dispatch_terminate +
+    // prefetch_terminate so LaunchProgram can return. The unified test bodies must not
+    // re-append them, so this hook becomes a no-op in SD.
+    void append_terminate_commands(std::vector<HostMemDeviceCommand>& /*cmds*/) override {}
+
 private:
     // Orchestrates exec_buf execution: builds DRAM payload, writes to DRAM, then issues the
     // exec_buf command with the MSB stall flag so the prefetcher switches to DRAM mode.
@@ -2327,60 +2838,14 @@ private:
         const std::vector<HostMemDeviceCommand>& commands_per_iteration,
         uint32_t num_iterations,
         WriteCmd&& write_cmd) {
-        // 1. Concatenate all commands into a single exec_buf payload.
-        std::vector<uint8_t> exec_buf_data;
-        for (uint32_t i = 0; i < num_iterations; i++) {
-            for (const auto& cmd : commands_per_iteration) {
-                const uint8_t* src_ptr = reinterpret_cast<const uint8_t*>(cmd.data());
-                const uint8_t* end_ptr = src_ptr + cmd.size_bytes();
-                exec_buf_data.insert(exec_buf_data.end(), src_ptr, end_ptr);
-            }
-        }
+        const uint32_t num_pages = this->build_and_write_exec_buf_to_dram(commands_per_iteration, num_iterations);
 
-        // Append barrier wait to flush all commands before exec_buf_end.
-        DeviceCommandCalculator wait_calc;
-        wait_calc.add_dispatch_wait();
-        HostMemDeviceCommand wait_cmd(wait_calc.write_offset_bytes());
-        wait_cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
-        const uint8_t* wptr = reinterpret_cast<const uint8_t*>(wait_cmd.data());
-        exec_buf_data.insert(exec_buf_data.end(), wptr, wptr + wait_cmd.size_bytes());
-
-        // 2. Append exec_buf_end (terminates DRAM execution and returns to issue queue).
-        DeviceCommandCalculator exec_buf_end_calc;
-        exec_buf_end_calc.add_prefetch_exec_buf_end();
-        HostMemDeviceCommand exec_terminate(exec_buf_end_calc.write_offset_bytes());
-        exec_terminate.add_prefetch_exec_buf_end();
-        const uint8_t* src_ptr = reinterpret_cast<const uint8_t*>(exec_terminate.data());
-        exec_buf_data.insert(exec_buf_data.end(), src_ptr, src_ptr + exec_terminate.size_bytes());
-
-        // 3. Write exec_buf data to DRAM, paged across banks.
-        const uint32_t page_size = 1u << this->DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE;
-        const uint32_t exec_buf_base_addr = this->DRAM_EXEC_BUF_DEFAULT_BASE_ADDR;
-
-        const size_t size_bytes = exec_buf_data.size();
-        const size_t padded_size_bytes = tt::align(size_bytes, page_size);
-        exec_buf_data.resize(padded_size_bytes, 0u);
-        const uint32_t num_pages = static_cast<uint32_t>(padded_size_bytes) / page_size;
-        log_info(tt::LogTest, "Total exec buf bytes: {} (padded: {})", size_bytes, padded_size_bytes);
-
-        uint32_t data_idx = 0;
-        for (uint32_t page_idx = 0; page_idx < num_pages; ++page_idx) {
-            const uint32_t bank_id = page_idx % this->num_banks_;
-            const uint32_t bank_offset = (page_idx / this->num_banks_) * page_size;
-            const uint32_t addr = exec_buf_base_addr + bank_offset;
-            std::vector<uint8_t> page_data(
-                exec_buf_data.begin() + data_idx, exec_buf_data.begin() + data_idx + page_size);
-            detail::WriteToDeviceDRAMChannel(this->device_, bank_id, addr, page_data);
-            data_idx += page_size;
-        }
-        tt_metal::MetalContext::instance().get_cluster().dram_barrier(this->device_->id());
-
-        // 4. Write exec_buf command with MSB stall flag so prefetcher switches to DRAM execution.
         DeviceCommandCalculator exec_buf_calc;
         exec_buf_calc.add_prefetch_exec_buf();
         HostMemDeviceCommand exec_cmd(exec_buf_calc.write_offset_bytes());
-        exec_cmd.add_prefetch_exec_buf(exec_buf_base_addr, this->DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE, num_pages);
-        write_cmd(exec_cmd, /*stall=*/true);
+        exec_cmd.add_prefetch_exec_buf(
+            this->DRAM_EXEC_BUF_DEFAULT_BASE_ADDR, this->DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE, num_pages);
+        write_cmd(exec_cmd, /*stall*/ true);
     }
 };
 
@@ -2390,22 +2855,22 @@ class SDPrefetchRandomTestFixture : public SDPrefetchTestBase<RandomTestFixture>
 
 class SDPrefetchHostTextFixture : public SDPrefetchTestBase<PrefetcherHostTextFixture> {
 public:
-    // Returns a host pointer to the SD completion queue region in the hugepage.
-    // The dispatch kernel is configured to write to dev_hugepage_base + SD_HUGEPAGE_ISSUE_BUFFER_SIZE,
-    // so this pointer is the host-side view of that same region.
-    void* get_host_completion_ptr() const {
+    // Completion-buffer hooks: in SD mode the dispatch kernel writes to the hugepage region
+    // we set up ourselves (dev_hugepage_base + SD_HUGEPAGE_ISSUE_BUFFER_SIZE), not to a
+    // runtime-managed FDMeshCommandQueue completion queue.
+    void* get_completion_queue_buffer() override {
         const auto& memmap = tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
         const uint32_t dev_hugepage_base = memmap.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         const ChipId mmio_id =
-            tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->device_->id());
+            tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_->id());
         const uint16_t channel =
-            tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(this->device_->id());
+            tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_->id());
         char* hugepage_bar_base =
             static_cast<char*>(tt_metal::MetalContext::instance().get_cluster().host_dma_address(0, mmio_id, channel));
         hugepage_bar_base += (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
         return hugepage_bar_base + dev_hugepage_base + Common::SD_HUGEPAGE_ISSUE_BUFFER_SIZE;
     }
-    uint32_t get_host_completion_size() const { return Common::SD_COMPLETION_QUEUE_SIZE; }
+    uint32_t get_completion_queue_buffer_size() override { return Common::SD_COMPLETION_QUEUE_SIZE; }
 };
 
 class SDPrefetchLinearPackedReadTestFixture : public SDPrefetchTestBase<PrefetcherLinearPackedReadTestFixture> {};
@@ -2417,225 +2882,37 @@ class SDPrefetchThroughputTestFixture : public SDPrefetchTestBase<PrefetcherThro
 // with a small payload followed by commands to terminate prefetcher and dispatcher.
 // exec_buf enabled execution needs special handling
 TEST_P(BasePrefetcherTestFixture, TestTerminate) {
-    log_info(tt::LogTest, "BasePrefetcherTestFixture - TestTerminate - Test Start");
-
-    // Test parameters
-    constexpr uint32_t xfer_size_bytes = 16;  // Very small write size
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
-
-    const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
-    uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
-
-    // Capture address before updating device_data
-    uint32_t l1_addr = device_data.get_result_data_addr(first_worker, 0);
-
-    // Generate payload
-    std::vector<uint32_t> payload = payload_generator_->generate_payload(xfer_size_bytes);
-
-    // PHASE 1: Generate terminate command metadata
-    std::vector<HostMemDeviceCommand> work_cmds;
-    HostMemDeviceCommand linear_write_cmd = Common::CommandBuilder::build_linear_write_command<true, true>(
-        payload, worker_range, false, noc_xy, l1_addr, xfer_size_bytes);
-    work_cmds.push_back(std::move(linear_write_cmd));
-
-    std::vector<HostMemDeviceCommand> terminate_cmds;
-    HostMemDeviceCommand dispatch_term_cmd = CommandBuilder::build_dispatch_terminate();
-    terminate_cmds.push_back(std::move(dispatch_term_cmd));
-    HostMemDeviceCommand prefetch_term_cmd = CommandBuilder::build_prefetch_terminate();
-    terminate_cmds.push_back(std::move(prefetch_term_cmd));
-
-    // PHASE 2, 3, 4: Execute and Validate
-    // Don't wait for Finish()
-    bool wait_for_completion = false;
-
-    // If exec_buf is enabled, we must split execution
-    // 1. Run workload (executes in exec_buf)
-    // 2. Run terminate (must execute in issue queue, not exec_buf.
-    // Executing terminate in exec_buf leads to a hang since exec_buf_end is never reached)
-    if (use_exec_buf_) {
-        // Step 1: Execute workload in exec_buf
-        execute_generated_commands(
-            work_cmds,
-            device_data,
-            worker_range.size(),
-            num_iterations,
-            false);  // Don't wait (device not done yet)
-
-        // Step 2: Switch to Issue Queue for termination
-        use_exec_buf_ = false;
-        execute_generated_commands(
-            terminate_cmds,
-            device_data,
-            0,
-            1,
-            wait_for_completion);  // Don't wait (device terminates)
-    } else {
-        // Standard flow: All commands in one Issue Queue stream
-        work_cmds.insert(work_cmds.end(), terminate_cmds.begin(), terminate_cmds.end());
-
-        execute_generated_commands(work_cmds, device_data, worker_range.size(), num_iterations, wait_for_completion);
-    }
+    log_info(tt::LogTest, "BasePrefetcherTestFixture - TestTerminate (Fast Dispatch) - Test Start");
+    run_test_terminate_test();
 }
 
 // Relay pre-populated data from DRAM using prefetcher to dispatcher, write it to L1 and validate it
 TEST_P(BasePrefetcherTestFixture, DRAMToL1PagedRead) {
-    log_info(tt::LogTest, "BasePrefetcherTestFixture - DRAMToL1PagedRead - Test Start");
-
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-    const uint32_t page_size_bytes = get_page_size();
-    const uint32_t num_pages = get_num_pages();
-
-    // Setup target worker cores
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = first_worker;
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-
-    // No L1 -> Host writes, so pcie_data_addr is nullptr
-    // We test DRAM -> L1
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
-
-    // PHASE 1: Generate paged read command metadata
-    auto commands_per_iteration = generate_paged_read_commands(first_worker, page_size_bytes, num_pages, device_data);
-
-    // PHASE 2, 3, 4: Execute and Validate
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    log_info(tt::LogTest, "BasePrefetcherTestFixture - DRAMToL1PagedRead (Fast Dispatch) - Test Start");
+    run_dram_to_l1_paged_read_test();
 }
 
 // In this test, the prefetcher reads from L1 and relays it to dispatcher. Dispatcher then
 // writes the data to the host completion queue.
 // Note: Since we're writing into completion queue, we skip distributed::Finish
 TEST_P(PrefetcherHostTextFixture, HostTest) {
-    log_info(tt::LogTest, "PrefetcherHostTextFixture - HostTest - Test Start");
-
-    const uint32_t max_data_size = DEVICE_DATA_SIZE;
-    const uint32_t max_data_size_words = max_data_size / sizeof(uint32_t);
-    const uint32_t dram_data_size_words = this->get_dram_data_size_words();
-    const uint32_t num_iterations = this->get_num_iterations();
-
-    std::vector<uint32_t> data(max_data_size_words);
-    for (uint32_t i = 0; i < max_data_size_words; i++) {
-        data[i] = i;
-    }
-
-    // Setup target worker cores
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    CoreCoord phys_worker_core = device_->worker_core_from_logical_core(first_worker);
-    // Write data into L1 for prefetcher to read it later
-    MetalContext::instance().get_cluster().write_core(device_->id(), phys_worker_core, data, l1_base);
-    MetalContext::instance().get_cluster().l1_barrier(device_->id());
-
-    // Get completion queue buffer pointer
-    void* completion_queue_buffer = mgr_->get_completion_queue_ptr(fdcq_->id());
-    uint32_t completion_queue_size = mgr_->get_completion_queue_size(fdcq_->id());
-    // Pre-fill with dirty pattern:
-    // The dispatcher writes commands and data but doesn't overwrite padding regions
-    // Pre-filling ensures padding areas retain the sentinel value for validation
-    dirty_host_completion_buffer(completion_queue_buffer, completion_queue_size);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base_, completion_queue_buffer, false, dram_data_size_words, cfg_);
-
-    // PHASE 1: Generate host write command metadata
-    auto commands_per_iteration = generate_host_write_commands(data, first_worker, l1_base, device_data);
-
-    // PHASE 2, 3, 4: Execute and Validate
-    // Note: Skip distributed::Finish since we are manually writing into the completion queue
-    // which Finish doesn't expect
-    bool wait_for_completion = false;
-    // For host writes, we need to wait for all writes to be written into the completion queue
-    bool wait_for_host_writes = true;
-    execute_generated_commands(
-        commands_per_iteration,
-        device_data,
-        worker_range.size(),
-        num_iterations,
-        wait_for_completion,
-        wait_for_host_writes);
+    log_info(tt::LogTest, "PrefetcherHostTextFixture - HostTest (Fast Dispatch) - Test Start");
+    run_host_test();
 }
 
 // This tests relay of packed paged data using prefetcher to dispacher
 // with multiple sub commands
 TEST_P(PrefetcherPackedReadTestFixture, PackedReadTest) {
-    log_info(tt::LogTest, "PrefetcherPackedReadTestFixture - PackedReadTest - Test Start");
-
-    const uint32_t num_iterations = 1;
-    const uint32_t dram_data_size_words = Common::DRAM_DATA_SIZE_WORDS;
-
-    // Setup target worker cores
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    const auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
-
-    // PHASE 1: Generate packed read command metadata
-    auto commands_per_iteration = generate_packed_read_commands(first_worker, dram_alignment, device_data);
-
-    // PHASE 2, 3, 4: Execute and Validate
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    log_info(tt::LogTest, "PrefetcherPackedReadTestFixture - PackedReadTest (Fast Dispatch) - Test Start");
+    run_packed_read_test();
 }
 
 // This tests relay of packed linear data using prefetcher to dispatcher
 // with multiple sub commands, each with a linear address.
 // Source: Worker L1 (can overlap), Destination: DRAM bank 0
 TEST_P(PrefetcherLinearPackedReadTestFixture, LinearPackedReadTest) {
-    log_info(tt::LogTest, "PrefetcherLinearPackedReadTestFixture - LinearPackedReadTest - Test Start");
-
-    const uint32_t num_iterations = 1;
-
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    const auto l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
-
-    // Pre-populate L1 with sequential test data [0, 1, 2, 3, ...] for the prefetcher to read
-    const uint32_t l1_data_size_words = DEVICE_DATA_SIZE / sizeof(uint32_t);
-    std::vector<uint32_t> l1_data(l1_data_size_words);
-    for (uint32_t i = 0; i < l1_data_size_words; i++) {
-        l1_data[i] = i;
-    }
-    const CoreCoord phys_worker_core = device_->worker_core_from_logical_core(first_worker);
-    MetalContext::instance().get_cluster().write_core(device_->id(), phys_worker_core, l1_data, l1_base);
-    MetalContext::instance().get_cluster().l1_barrier(device_->id());
-
-    // Initialize DRAM bank 0 with sentinel pattern to detect unwritten regions
-    constexpr uint32_t dest_bank_id = 0;
-    constexpr uint32_t sentinel_pattern = 0x99999999;
-    const uint32_t dram_size_words = DEVICE_DATA_SIZE_LARGE / sizeof(uint32_t);
-    std::vector<uint32_t> sentinel_data(dram_size_words, sentinel_pattern);
-    tt::tt_metal::detail::WriteToDeviceDRAMChannel(device_, dest_bank_id, dram_base_, sentinel_data);
-    MetalContext::instance().get_cluster().dram_barrier(device_->id());
-
-    // Initialize DeviceData tracking (do not pre-populate DRAM since we're writing to it)
-    Common::DeviceData device_data(device_, worker_range, l1_base, dram_base_, nullptr, false, 0, cfg_);
-
-    // Generate and execute commands
-    auto commands_per_iteration = generate_linear_packed_read_commands(first_worker, l1_alignment, device_data);
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    log_info(tt::LogTest, "PrefetcherLinearPackedReadTestFixture - LinearPackedReadTest (Fast Dispatch) - Test Start");
+    run_linear_packed_read_test();
 }
 
 // Ring Buffer operates differently than others
@@ -2643,27 +2920,8 @@ TEST_P(PrefetcherLinearPackedReadTestFixture, LinearPackedReadTest) {
 // Then, we relay command header + data into dispatcher
 // Note: Ring buffer is stateful as we set the ringbuffer offset on first load
 TEST_P(PrefetcherRingbufferReadTestFixture, RingbufferReadTest) {
-    log_info(tt::LogTest, "PrefetcherRingbufferReadTestFixture - RingbufferReadTest - Test Start");
-
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-
-    // Setup target worker cores
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    const auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
-
-    // PHASE 1: Generate ringbuffer command metadata
-    auto commands_per_iteration = generate_ringbuffer_relay_commands(first_worker, dram_alignment, device_data);
-
-    // PHASE 2, 3, 4: Execute and Validate
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    log_info(tt::LogTest, "PrefetcherRingbufferReadTestFixture - RingbufferReadTest (Fast Dispatch) - Test Start");
+    run_ringbuffer_read_test();
 }
 
 // End-To-End Paged/Interleaved Write+Read test that does the following:
@@ -2672,114 +2930,15 @@ TEST_P(PrefetcherRingbufferReadTestFixture, RingbufferReadTest) {
 //  3. Do previous 2 steps in a loop, reading and writing new data until DEVICE_DATA_SIZE bytes is written to worker
 //  core.
 TEST_P(BasePrefetcherTestFixture, PagedReadWriteTest) {
-    log_info(tt::LogTest, "BasePrefetcherTestFixture - PagedReadWriteTest - Test Start");
-
-    // Test parameters
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-    const uint32_t page_size_bytes = get_page_size();
-    const uint32_t num_pages = get_num_pages();
-
-    // Setup target worker cores
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = first_worker;  // {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
-
-    // PHASE 1: Generate paged end to end read + write command metadata
-    auto commands_per_iteration =
-        generate_paged_end_to_end_commands(first_worker, page_size_bytes, num_pages, device_data);
-
-    // PHASE 2, 3, 4: Execute and Validate
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    log_info(tt::LogTest, "BasePrefetcherTestFixture - PagedReadWriteTest (Fast Dispatch) - Test Start");
+    run_paged_read_write_test();
 }
 
 // This tests random configurations of commands like CQ_PREFETCH_CMD_RELAY_LINEAR, CQ_PREFETCH_CMD_RELAY_PAGED,
 // CQ_PREFETCH_CMD_RELAY_INLINE etc
 TEST_P(RandomTestFixture, RandomTest) {
-    log_info(tt::LogTest, "RandomTestFixture - RandomTest - Test Start");
-
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-
-    // Setup target worker cores
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
-
-    // PHASE 1: Generate random command metadata
-    std::vector<HostMemDeviceCommand> commands_per_iteration;
-
-    uint32_t remaining_bytes = DEVICE_DATA_SIZE;
-
-    while (remaining_bytes > 0) {
-        // Assumes terminate is the last command...
-        uint32_t cmd = payload_generator_->get_rand<uint32_t>(0, CQ_PREFETCH_CMD_TERMINATE - 1);
-        const uint32_t limit_x = (worker_range.end_coord.x - first_worker.x - 1);
-        const uint32_t limit_y = (worker_range.end_coord.y - first_worker.y - 1);
-        uint32_t x = payload_generator_->get_rand<uint32_t>(0, limit_x);
-        uint32_t y = payload_generator_->get_rand<uint32_t>(0, limit_y);
-
-        CoreCoord worker_core(first_worker.x + x, first_worker.y + y);
-        // Compute NOC encoding once
-        const CoreCoord worker_core_virt = device_->virtual_core_from_logical_core(worker_core, CoreType::WORKER);
-        const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, worker_core_virt);
-
-        switch (cmd) {
-            case CQ_PREFETCH_CMD_RELAY_LINEAR:
-            // TODO: Temporarily dropping the linear relay from random mix.
-            // Having this test enabled leads to intermittent validation failures
-            // Issue: Randomization is probably landing on holes the hardware never wrote (padding/gaps in the model?),
-            // so we're reading old L1 content and causing intermittent validation failures
-            // Note: this was disabled in legacy as well
-
-            /* if (has_l1_data) {
-            //     CoreRange single_worker_range = {worker_core, worker_core};
-            //     auto result = gen_random_linear_read_cmd(device_data, worker_core, noc_xy, remaining_bytes);
-            //     if(result.has_value()){
-            //         HostMemDeviceCommand& cmd = *result;
-            //         commands_per_iteration.push_back(std::move(cmd));
-            //     }
-            //     break;
-            // }*/
-            case CQ_PREFETCH_CMD_RELAY_PAGED: {
-                CoreRange single_worker_range = {worker_core, worker_core};
-                auto result =
-                    gen_random_dram_paged_cmd(device_data, worker_core, single_worker_range, noc_xy, remaining_bytes);
-                if (result.has_value()) {
-                    HostMemDeviceCommand& cmd = *result;
-                    commands_per_iteration.push_back(std::move(cmd));
-                }
-                break;
-            }
-            case CQ_PREFETCH_CMD_RELAY_INLINE: {
-                const CoreCoord last_worker = {worker_core.x + 1, worker_core.y + 1};
-                CoreRange multi_worker_range = {worker_core, last_worker};
-                auto result = gen_random_inline_cmd(device_data, multi_worker_range, noc_xy, remaining_bytes);
-                if (result.has_value()) {
-                    HostMemDeviceCommand& cmd = *result;
-                    commands_per_iteration.push_back(std::move(cmd));
-                }
-                break;
-            }
-            case CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH:
-            case CQ_PREFETCH_CMD_STALL:
-            case CQ_PREFETCH_CMD_DEBUG:
-            default: break;
-        }
-    }
-
-    // PHASE 2, 3, 4: Execute and Validate
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    log_info(tt::LogTest, "RandomTestFixture - RandomTest (Fast Dispatch) - Test Start");
+    run_random_test();
 }
 
 // This test targets relay linear H command: PREFETCH_H (MMIO) -> PREFETCH_D (Remote) -> DISPATCHER (Remote)
@@ -2900,214 +3059,16 @@ TEST_P(PrefetcherLinearPackedHTestFixture, RelayLinearPackedHTest) {
 
 // Smoke test of prefetcher/dispatcher commands except add_dispatch_write_host
 TEST_P(PrefetcherPackedReadTestFixture, SmokeTest) {
-    log_info(tt::LogTest, "PrefetcherPackedReadTestFixture - SmokeTest - Test Start");
-
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-
-    // Setup target worker cores
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = first_worker;
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
-
-    // PHASE 1: Generate smoke test command metadata
-    std::vector<HostMemDeviceCommand> commands_per_iteration;
-
-    HelperInfo info{
-        dram_base_, num_banks_, l1_alignment_, packed_write_max_unicast_sub_cmds_, dispatch_buffer_page_size_};
-    // Instantiate Helper
-    SmokeTestHelper helper(device_, device_data, commands_per_iteration, info);
-
-    // Section 1: Unicast
-    // Important: reset device_data from prior tests if smoke test isn't the first
-    helper.add_unicast_write(worker_range, 32);
-    helper.add_unicast_write(worker_range, 1026);
-    helper.add_unicast_write(worker_range, 8448);
-    helper.add_unicast_write(worker_range, dispatch_buffer_page_size_);
-    helper.add_unicast_write(worker_range, dispatch_buffer_page_size_ - sizeof(CQDispatchCmdLarge));
-    helper.add_unicast_write(worker_range, 2 * dispatch_buffer_page_size_);
-    helper.add_unicast_write(worker_range, (2 * dispatch_buffer_page_size_) - sizeof(CQDispatchCmdLarge));
-
-    // Section 2: Merged Unicast Writes
-    helper.add_merged_unicast_writes(worker_range, {112, 608, 64, 96});
-
-    // Section 3: packed read
-    constexpr uint32_t log_packed_read_page_size = 10;
-    const uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
-    const uint32_t length_to_read = tt::align(2080, dram_alignment);
-    const uint32_t length_to_read_sdb = tt::align(DEFAULT_SCRATCH_DB_SIZE / 8, dram_alignment);
-    // Create and pass PrefetcherPackedReadTestFixture::build_sub_cmds callable
-    auto build_packed = [this](
-                            const std::vector<uint32_t>& lengths,
-                            Common::DeviceData& device_data,
-                            uint32_t log_page_sz,
-                            uint32_t n_sub_cmds) {
-        return PrefetcherPackedReadTestFixture::build_sub_cmds(lengths, device_data, log_page_sz, n_sub_cmds);
-    };
-    // Uses last_worker as first_worker is filling up
-    helper.add_packed_dram_read(worker_range, log_packed_read_page_size, {256, 512}, build_packed);
-    helper.add_packed_dram_read(worker_range, log_packed_read_page_size, {1024, 2048}, build_packed);
-    helper.add_packed_dram_read(worker_range, log_packed_read_page_size, {length_to_read}, build_packed);
-    helper.add_packed_dram_read(
-        worker_range, log_packed_read_page_size + 1, {length_to_read, length_to_read}, build_packed);
-
-    std::vector<uint32_t> lengths{
-        length_to_read_sdb,
-        length_to_read_sdb,
-        length_to_read_sdb,
-        tt::align(DEFAULT_SCRATCH_DB_SIZE / 4, dram_alignment),   // won't fit in first pass
-        tt::align(DEFAULT_SCRATCH_DB_SIZE / 2, dram_alignment)};  // won't fit in second pass
-    helper.add_packed_dram_read(worker_range, log_packed_read_page_size + 1, lengths, build_packed);
-
-    lengths.clear();
-    lengths.push_back(tt::align((DEFAULT_SCRATCH_DB_SIZE / 4) + (2 * 1024) + 32, dram_alignment));
-    lengths.push_back(tt::align((DEFAULT_SCRATCH_DB_SIZE / 4) + (3 * 1024) + 32, dram_alignment));
-    lengths.push_back(tt::align(DEFAULT_SCRATCH_DB_SIZE / 2, dram_alignment));
-    lengths.push_back(tt::align((DEFAULT_SCRATCH_DB_SIZE / 8) + (5 * 1024) + 96, dram_alignment));
-    helper.add_packed_dram_read(worker_range, log_packed_read_page_size, lengths, build_packed);
-
-    // Section 4: Read from dram, write to worker
-    //                              start_page,                      base addr,      page_size,           pages,
-    //                              length_adjust
-    helper.add_paged_dram_read(worker_range, 0, 0, dram_alignment, num_banks_, 0);
-    helper.add_paged_dram_read(worker_range, 4, dram_alignment, dram_alignment * 2, num_banks_, 0);
-    helper.add_paged_dram_read(worker_range, 4, dram_alignment, dram_alignment * 2, num_banks_, 0);
-    helper.add_paged_dram_read(worker_range, 0, 0, 128, 128, 0);
-    helper.add_paged_dram_read(worker_range, 4, dram_alignment, 2048, num_banks_ + 4, 0);
-    helper.add_paged_dram_read(worker_range, 5, dram_alignment, 2048, (num_banks_ * 3) + 1, 0);
-    helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_ - 1, 0);
-    helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_ - 1, 0);
-    helper.add_paged_dram_read(worker_range, 0, 0, 128, 128, 32);
-    helper.add_paged_dram_read(worker_range, 4, dram_alignment, 2048, num_banks_ * 2, 1536);
-    helper.add_paged_dram_read(worker_range, 5, dram_alignment, 2048, (num_banks_ * 2) + 1, 256);
-    helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_ - 1, 640);
-    // Large pages
-    helper.add_paged_dram_read(worker_range, 0, 0, DEFAULT_SCRATCH_DB_SIZE / 2 + dram_alignment, 2, 128);
-    helper.add_paged_dram_read(worker_range, 0, 0, DEFAULT_SCRATCH_DB_SIZE, 2, 0);
-    // Forces length_adjust to back into prior read.  Device reads pages, shouldn't be a problem...
-    uint32_t page_size = 256 + dram_alignment;
-    uint32_t length = (DEFAULT_SCRATCH_DB_SIZE / 2 / page_size * page_size) + page_size;
-    helper.add_paged_dram_read(worker_range, 3, 128, page_size, length / page_size, 160);
-
-    // Section 5: Inline packed writes
-    const CoreCoord first_worker_2x2 = default_worker_start;
-    const CoreCoord last_worker_2x2 = {first_worker_2x2.x + 1, first_worker_2x2.y + 1};
-    const CoreRange worker_range_2x2 = {first_worker_2x2, last_worker_2x2};
-    // Pick worker cores once for all commands
-    std::vector<CoreCoord> worker_cores{first_worker_2x2};
-    helper.add_packed_write(worker_cores, 4);
-    worker_cores.clear();
-    for (uint32_t y = worker_range_2x2.start_coord.y; y <= worker_range_2x2.end_coord.y; ++y) {
-        for (uint32_t x = worker_range_2x2.start_coord.x; x <= worker_range_2x2.end_coord.x; ++x) {
-            worker_cores.push_back({x, y});
-        }
-    }
-    helper.add_packed_write(worker_cores, 12);
-    helper.add_packed_write(worker_cores, 12, true);
-    worker_cores.clear();
-    worker_cores.push_back(first_worker_2x2);
-    worker_cores.push_back(last_worker_2x2);
-    helper.add_packed_write(worker_cores, 156);
-
-    // Section 6: Linear read -> Linear write test
-    // Note: this test is dependent on already written data in L1
-    // So it reads the above data from prior commands and needs to run after those
-    helper.add_linear_read(worker_range, 32);
-    helper.add_linear_read(worker_range, 65 * 1024);
-    helper.add_linear_read(worker_range, dispatch_buffer_page_size_ - sizeof(CQDispatchCmdLarge));
-    helper.add_linear_read(worker_range, (2 * dispatch_buffer_page_size_) - sizeof(CQDispatchCmdLarge));
-    helper.add_linear_read(worker_range, (2 * dispatch_buffer_page_size_));
-    // Skipping CQ_DISPATCH_CMD_DELAY from the legacy test here
-    helper.add_unicast_write(worker_range, 1024);
-    // Barrier/stall to avoid RAW hazards
-    HostMemDeviceCommand stall_cmd = CommandBuilder::build_dispatch_prefetch_stall();
-    commands_per_iteration.push_back(std::move(stall_cmd));
-    uint32_t length_bytes = 32;
-    uint32_t offset_words = device_data.size_at(worker_range.start_coord, 0) - (length_bytes / sizeof(uint32_t));
-    uint32_t offset_bytes = offset_words * sizeof(uint32_t);
-    helper.add_linear_read(worker_range, length_bytes, offset_bytes);
-
-    // Section 7: Write offset
-    // Simple Smoke test: do a change write_offset_idx to 48 and back to 0
-    std::array<uint32_t, CQ_DISPATCH_MAX_WRITE_OFFSETS> write_offset1 = {48, 0, 0, 0};
-    std::array<uint32_t, CQ_DISPATCH_MAX_WRITE_OFFSETS> write_offset2 = {};
-    HostMemDeviceCommand write_offset_cmd1 = CommandBuilder::build_dispatch_write_offset(write_offset1);
-    HostMemDeviceCommand write_offset_cmd2 = CommandBuilder::build_dispatch_write_offset(write_offset2);
-    commands_per_iteration.push_back(std::move(write_offset_cmd1));
-    commands_per_iteration.push_back(std::move(write_offset_cmd2));
-
-    // PHASE 2, 3, 4: Execute and Validate
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    log_info(tt::LogTest, "PrefetcherPackedReadTestFixture - SmokeTest (Fast Dispatch) - Test Start");
+    run_smoke_test();
 }
 
 // Smoke test for writes to Host from dispatcher
 // This needed to be separate since it executes differently than others
 // (we skip distributed::Finish)
 TEST_P(PrefetcherHostTextFixture, HostSmokeTest) {
-    log_info(tt::LogTest, "PrefetcherHostTextFixture - HostSmokeTest - Test Start");
-
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-
-    // Setup target worker cores
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-
-    // Get completion queue buffer pointer
-    void* completion_queue_buffer = mgr_->get_completion_queue_ptr(fdcq_->id());
-    uint32_t completion_queue_size = mgr_->get_completion_queue_size(fdcq_->id());
-    // Pre-fill with dirty pattern:
-    // The dispatcher writes commands and data but doesn't overwrite padding regions
-    // Pre-filling ensures padding areas retain the sentinel value for validation
-    dirty_host_completion_buffer(completion_queue_buffer, completion_queue_size);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base_, completion_queue_buffer, false, dram_data_size_words, cfg_);
-
-    // PHASE 1: Generate host smoke test command metadata
-    std::vector<HostMemDeviceCommand> commands_per_iteration;
-
-    HelperInfo info{
-        dram_base_, num_banks_, l1_alignment_, packed_write_max_unicast_sub_cmds_, dispatch_buffer_page_size_};
-    // Instantiate Helper
-    SmokeTestHelper helper(device_, device_data, commands_per_iteration, info);
-
-    auto add_host_write_func = [this](Common::DeviceData& device_data) {
-        PrefetcherHostTextFixture::pad_host_data(device_data);
-    };
-
-    for (uint32_t multiplier = 1; multiplier < 3; multiplier++) {
-        helper.add_host_write(multiplier * 32, add_host_write_func);
-        helper.add_host_write(multiplier * 36, add_host_write_func);
-        helper.add_host_write(multiplier * 1024, add_host_write_func);
-        helper.add_host_write(
-            (multiplier * dispatch_buffer_page_size_) - (2 * sizeof(CQDispatchCmd)), add_host_write_func);
-        helper.add_host_write((multiplier * dispatch_buffer_page_size_) - sizeof(CQDispatchCmd), add_host_write_func);
-        helper.add_host_write((multiplier * dispatch_buffer_page_size_), add_host_write_func);
-        helper.add_host_write((multiplier * dispatch_buffer_page_size_) + sizeof(CQDispatchCmd), add_host_write_func);
-    }
-
-    // PHASE 2, 3, 4: Execute and Validate
-    // Skip distributed::Finish since we are manually writing into the completion queue
-    // which Finish doesn't expect
-    bool wait_for_completion = false;
-    // For host writes, we need to wait for all writes to be written into the completion queue
-    bool wait_for_host_writes = true;
-    execute_generated_commands(
-        commands_per_iteration,
-        device_data,
-        worker_range.size(),
-        num_iterations,
-        wait_for_completion,
-        wait_for_host_writes);
+    log_info(tt::LogTest, "PrefetcherHostTextFixture - HostSmokeTest (Fast Dispatch) - Test Start");
+    run_host_smoke_test();
 }
 
 TEST_P(PrefetcherThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
@@ -3153,7 +3114,7 @@ TEST_P(PrefetcherThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
 
     log_info(
         tt::LogTest,
-        "Throughput workload: {} cmds x {} pages/cmd x {} B/page = {} B total",
+        "Throughput workload: {} cmds × {} pages/cmd × {} B/page = {} B total",
         total_cmds,
         pages_per_cmd,
         page_size_bytes,
@@ -3274,450 +3235,56 @@ TEST_P(PrefetcherThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
 }
 
 TEST_P(SDPrefetchDRAMToL1TestFixture, DRAMToL1PagedRead) {
-    log_info(tt::LogTest, "SDPrefetchDRAMToL1TestFixture - DRAMToL1PagedRead - Test Start");
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-
-    const CoreRange worker_range(default_worker_start, default_worker_start);
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
-
-    auto commands_per_iteration =
-        generate_paged_read_commands(worker_range, get_page_size(), get_num_pages(), device_data);
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    log_info(tt::LogTest, "SDPrefetchDRAMToL1TestFixture - DRAMToL1PagedRead (Slow Dispatch) - Test Start");
+    run_dram_to_l1_paged_read_test();
 }
 
 TEST_P(SDPrefetchDRAMToL1TestFixture, TestTerminate) {
-    log_info(tt::LogTest, "SDPrefetchDRAMToL1TestFixture - TestTerminate - Test Start");
-    constexpr uint32_t xfer_size_bytes = 16;
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-
-    const CoreCoord first_worker = default_worker_start;
-    const CoreRange worker_range = {first_worker, {first_worker.x + 1, first_worker.y + 1}};
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
-
-    const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
-    const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
-    const uint32_t l1_addr = device_data.get_result_data_addr(first_worker, 0);
-
-    std::vector<uint32_t> payload = payload_generator_->generate_payload(xfer_size_bytes);
-    std::vector<HostMemDeviceCommand> work_cmds;
-    work_cmds.push_back(Common::CommandBuilder::build_linear_write_command<true, true>(
-        payload, worker_range, false, noc_xy, l1_addr, xfer_size_bytes));
-
-    execute_generated_commands(work_cmds, device_data, worker_range.size(), num_iterations);
+    log_info(tt::LogTest, "SDPrefetchDRAMToL1TestFixture - TestTerminate (Slow Dispatch) - Test Start");
+    run_test_terminate_test();
 }
 
 TEST_P(SDPrefetchPackedReadTestFixture, PackedReadTest) {
-    log_info(tt::LogTest, "SDPrefetchPackedReadTestFixture - PackedReadTest - Test Start");
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-
-    const CoreRange worker_range(default_worker_start, default_worker_start);
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
-
-    auto commands_per_iteration = generate_packed_read_commands(default_worker_start, dram_alignment, device_data);
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    log_info(tt::LogTest, "SDPrefetchPackedReadTestFixture - PackedReadTest (Slow Dispatch) - Test Start");
+    run_packed_read_test();
 }
 
 TEST_P(SDPrefetchPackedReadTestFixture, SmokeTest) {
-    log_info(tt::LogTest, "SDPrefetchPackedReadTestFixture - SmokeTest - Test Start");
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = first_worker;
-    const CoreRange worker_range = {first_worker, last_worker};
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
-
-    std::vector<HostMemDeviceCommand> commands_per_iteration;
-    HelperInfo info{
-        dram_base_, num_banks_, l1_alignment_, packed_write_max_unicast_sub_cmds_, dispatch_buffer_page_size_};
-    SmokeTestHelper helper(device_, device_data, commands_per_iteration, info);
-
-    helper.add_unicast_write(worker_range, 32);
-    helper.add_unicast_write(worker_range, 1026);
-    helper.add_unicast_write(worker_range, 8448);
-    helper.add_unicast_write(worker_range, dispatch_buffer_page_size_);
-    helper.add_unicast_write(worker_range, dispatch_buffer_page_size_ - sizeof(CQDispatchCmdLarge));
-    helper.add_unicast_write(worker_range, 2 * dispatch_buffer_page_size_);
-    helper.add_unicast_write(worker_range, (2 * dispatch_buffer_page_size_) - sizeof(CQDispatchCmdLarge));
-
-    helper.add_merged_unicast_writes(worker_range, {112, 608, 64, 96});
-
-    constexpr uint32_t log_packed_read_page_size = 10;
-    const uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
-    const uint32_t length_to_read = tt::align(2080, dram_alignment);
-    const uint32_t length_to_read_sdb = tt::align(DEFAULT_SCRATCH_DB_SIZE / 8, dram_alignment);
-    auto build_packed = [this](
-                            const std::vector<uint32_t>& lengths,
-                            Common::DeviceData& device_data,
-                            uint32_t log_page_sz,
-                            uint32_t n_sub_cmds) {
-        return PrefetcherPackedReadTestFixture::build_sub_cmds(lengths, device_data, log_page_sz, n_sub_cmds);
-    };
-    helper.add_packed_dram_read(worker_range, log_packed_read_page_size, {256, 512}, build_packed);
-    helper.add_packed_dram_read(worker_range, log_packed_read_page_size, {1024, 2048}, build_packed);
-    helper.add_packed_dram_read(worker_range, log_packed_read_page_size, {length_to_read}, build_packed);
-    helper.add_packed_dram_read(
-        worker_range, log_packed_read_page_size + 1, {length_to_read, length_to_read}, build_packed);
-
-    std::vector<uint32_t> lengths{
-        length_to_read_sdb,
-        length_to_read_sdb,
-        length_to_read_sdb,
-        tt::align(DEFAULT_SCRATCH_DB_SIZE / 4, dram_alignment),
-        tt::align(DEFAULT_SCRATCH_DB_SIZE / 2, dram_alignment)};
-    helper.add_packed_dram_read(worker_range, log_packed_read_page_size + 1, lengths, build_packed);
-
-    lengths.clear();
-    lengths.push_back(tt::align((DEFAULT_SCRATCH_DB_SIZE / 4) + (2 * 1024) + 32, dram_alignment));
-    lengths.push_back(tt::align((DEFAULT_SCRATCH_DB_SIZE / 4) + (3 * 1024) + 32, dram_alignment));
-    lengths.push_back(tt::align(DEFAULT_SCRATCH_DB_SIZE / 2, dram_alignment));
-    lengths.push_back(tt::align((DEFAULT_SCRATCH_DB_SIZE / 8) + (5 * 1024) + 96, dram_alignment));
-    helper.add_packed_dram_read(worker_range, log_packed_read_page_size, lengths, build_packed);
-
-    helper.add_paged_dram_read(worker_range, 0, 0, dram_alignment, num_banks_, 0);
-    helper.add_paged_dram_read(worker_range, 4, dram_alignment, dram_alignment * 2, num_banks_, 0);
-    helper.add_paged_dram_read(worker_range, 4, dram_alignment, dram_alignment * 2, num_banks_, 0);
-    helper.add_paged_dram_read(worker_range, 0, 0, 128, 128, 0);
-    helper.add_paged_dram_read(worker_range, 4, dram_alignment, 2048, num_banks_ + 4, 0);
-    helper.add_paged_dram_read(worker_range, 5, dram_alignment, 2048, (num_banks_ * 3) + 1, 0);
-    helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_ - 1, 0);
-    helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_ - 1, 0);
-    helper.add_paged_dram_read(worker_range, 0, 0, 128, 128, 32);
-    helper.add_paged_dram_read(worker_range, 4, dram_alignment, 2048, num_banks_ * 2, 1536);
-    helper.add_paged_dram_read(worker_range, 5, dram_alignment, 2048, (num_banks_ * 2) + 1, 256);
-    helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_ - 1, 640);
-    helper.add_paged_dram_read(worker_range, 0, 0, DEFAULT_SCRATCH_DB_SIZE / 2 + dram_alignment, 2, 128);
-    helper.add_paged_dram_read(worker_range, 0, 0, DEFAULT_SCRATCH_DB_SIZE, 2, 0);
-    uint32_t page_size = 256 + dram_alignment;
-    uint32_t length = (DEFAULT_SCRATCH_DB_SIZE / 2 / page_size * page_size) + page_size;
-    helper.add_paged_dram_read(worker_range, 3, 128, page_size, length / page_size, 160);
-
-    const CoreRange worker_range_2x2 = {default_worker_start, {default_worker_start.x + 1, default_worker_start.y + 1}};
-    std::vector<CoreCoord> worker_cores{default_worker_start};
-    helper.add_packed_write(worker_cores, 4);
-    worker_cores.clear();
-    for (uint32_t y = worker_range_2x2.start_coord.y; y <= worker_range_2x2.end_coord.y; ++y) {
-        for (uint32_t x = worker_range_2x2.start_coord.x; x <= worker_range_2x2.end_coord.x; ++x) {
-            worker_cores.push_back({x, y});
-        }
-    }
-    helper.add_packed_write(worker_cores, 12);
-    helper.add_packed_write(worker_cores, 12, true);
-    worker_cores.clear();
-    worker_cores.push_back(default_worker_start);
-    worker_cores.push_back({default_worker_start.x + 1, default_worker_start.y + 1});
-    helper.add_packed_write(worker_cores, 156);
-
-    helper.add_linear_read(worker_range, 32);
-    helper.add_linear_read(worker_range, 65 * 1024);
-    helper.add_linear_read(worker_range, dispatch_buffer_page_size_ - sizeof(CQDispatchCmdLarge));
-    helper.add_linear_read(worker_range, (2 * dispatch_buffer_page_size_) - sizeof(CQDispatchCmdLarge));
-    helper.add_linear_read(worker_range, (2 * dispatch_buffer_page_size_));
-    helper.add_unicast_write(worker_range, 1024);
-    HostMemDeviceCommand stall_cmd = CommandBuilder::build_dispatch_prefetch_stall();
-    commands_per_iteration.push_back(std::move(stall_cmd));
-    uint32_t length_bytes = 32;
-    uint32_t offset_words = device_data.size_at(worker_range.start_coord, 0) - (length_bytes / sizeof(uint32_t));
-    helper.add_linear_read(worker_range, length_bytes, offset_words * sizeof(uint32_t));
-
-    std::array<uint32_t, CQ_DISPATCH_MAX_WRITE_OFFSETS> write_offset1 = {48, 0, 0, 0};
-    std::array<uint32_t, CQ_DISPATCH_MAX_WRITE_OFFSETS> write_offset2 = {};
-    commands_per_iteration.push_back(CommandBuilder::build_dispatch_write_offset(write_offset1));
-    commands_per_iteration.push_back(CommandBuilder::build_dispatch_write_offset(write_offset2));
-
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    log_info(tt::LogTest, "SDPrefetchPackedReadTestFixture - SmokeTest (Slow Dispatch) - Test Start");
+    run_smoke_test();
 }
 
 TEST_P(SDPrefetchRandomTestFixture, RandomTest) {
-    log_info(tt::LogTest, "SDPrefetchRandomTestFixture - RandomTest - Test Start");
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-
-    const CoreCoord first_worker = default_worker_start;
-    const CoreRange worker_range = {first_worker, {first_worker.x + 1, first_worker.y + 1}};
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
-
-    std::vector<HostMemDeviceCommand> commands_per_iteration;
-    uint32_t remaining_bytes = DEVICE_DATA_SIZE;
-
-    while (remaining_bytes > 0) {
-        uint32_t cmd = payload_generator_->get_rand<uint32_t>(0, CQ_PREFETCH_CMD_TERMINATE - 1);
-        const uint32_t limit_x = (worker_range.end_coord.x - first_worker.x - 1);
-        const uint32_t limit_y = (worker_range.end_coord.y - first_worker.y - 1);
-        uint32_t x = payload_generator_->get_rand<uint32_t>(0, limit_x);
-        uint32_t y = payload_generator_->get_rand<uint32_t>(0, limit_y);
-        CoreCoord worker_core(first_worker.x + x, first_worker.y + y);
-        const CoreCoord worker_core_virt = device_->virtual_core_from_logical_core(worker_core, CoreType::WORKER);
-        const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, worker_core_virt);
-
-        switch (cmd) {
-            case CQ_PREFETCH_CMD_RELAY_LINEAR:
-            case CQ_PREFETCH_CMD_RELAY_PAGED: {
-                CoreRange single_worker_range = {worker_core, worker_core};
-                auto result =
-                    gen_random_dram_paged_cmd(device_data, worker_core, single_worker_range, noc_xy, remaining_bytes);
-                if (result.has_value()) {
-                    commands_per_iteration.push_back(std::move(*result));
-                }
-                break;
-            }
-            case CQ_PREFETCH_CMD_RELAY_INLINE: {
-                CoreRange multi_worker_range = {worker_core, {worker_core.x + 1, worker_core.y + 1}};
-                auto result = gen_random_inline_cmd(device_data, multi_worker_range, noc_xy, remaining_bytes);
-                if (result.has_value()) {
-                    commands_per_iteration.push_back(std::move(*result));
-                }
-                break;
-            }
-            default: break;
-        }
-    }
-
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    log_info(tt::LogTest, "SDPrefetchRandomTestFixture - RandomTest (Slow Dispatch) - Test Start");
+    run_random_test();
 }
 
 TEST_P(SDPrefetchLinearPackedReadTestFixture, LinearPackedReadTest) {
-    log_info(tt::LogTest, "SDPrefetchLinearPackedReadTestFixture - LinearPackedReadTest - Test Start");
-    const uint32_t num_iterations = 1;
-
-    const CoreCoord first_worker = default_worker_start;
-    const CoreRange worker_range = {first_worker, {first_worker.x + 1, first_worker.y + 1}};
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    const auto l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
-
-    // Pre-populate L1 with sequential test data for the prefetcher to read
-    const uint32_t l1_data_size_words = DEVICE_DATA_SIZE / sizeof(uint32_t);
-    std::vector<uint32_t> l1_data(l1_data_size_words);
-    for (uint32_t i = 0; i < l1_data_size_words; i++) {
-        l1_data[i] = i;
-    }
-    const CoreCoord phys_worker_core = device_->worker_core_from_logical_core(first_worker);
-    MetalContext::instance().get_cluster().write_core(device_->id(), phys_worker_core, l1_data, l1_base);
-    MetalContext::instance().get_cluster().l1_barrier(device_->id());
-
-    // Initialize DRAM bank 0 with sentinel to detect unwritten regions
-    constexpr uint32_t dest_bank_id = 0;
-    constexpr uint32_t sentinel_pattern = 0x99999999;
-    const uint32_t dram_size_words = DEVICE_DATA_SIZE_LARGE / sizeof(uint32_t);
-    std::vector<uint32_t> sentinel_data(dram_size_words, sentinel_pattern);
-    tt::tt_metal::detail::WriteToDeviceDRAMChannel(device_, dest_bank_id, dram_base_, sentinel_data);
-    MetalContext::instance().get_cluster().dram_barrier(device_->id());
-
-    Common::DeviceData device_data(device_, worker_range, l1_base, dram_base_, nullptr, false, 0, cfg_);
-
-    auto commands_per_iteration = generate_linear_packed_read_commands(first_worker, l1_alignment, device_data);
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    log_info(tt::LogTest, "SDPrefetchLinearPackedReadTestFixture - LinearPackedReadTest (Slow Dispatch) - Test Start");
+    run_linear_packed_read_test();
 }
 
 TEST_P(SDPrefetchRingbufferReadTestFixture, RingbufferReadTest) {
-    log_info(tt::LogTest, "SDPrefetchRingbufferReadTestFixture - RingbufferReadTest - Test Start");
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-
-    const CoreCoord first_worker = default_worker_start;
-    const CoreRange worker_range = {first_worker, {first_worker.x + 1, first_worker.y + 1}};
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    const auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
-
-    auto commands_per_iteration = generate_ringbuffer_relay_commands(first_worker, dram_alignment, device_data);
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    log_info(tt::LogTest, "SDPrefetchRingbufferReadTestFixture - RingbufferReadTest (Slow Dispatch) - Test Start");
+    run_ringbuffer_read_test();
 }
 
 // SD end-to-end paged write+read: dispatcher writes to DRAM banks, prefetcher relays back to L1
 class SDPrefetchPagedReadWriteTestFixture : public SDPrefetchTestBase<BasePrefetcherTestFixture> {};
 
 TEST_P(SDPrefetchPagedReadWriteTestFixture, PagedReadWriteTest) {
-    log_info(tt::LogTest, "SDPrefetchPagedReadWriteTestFixture - PagedReadWriteTest - Test Start");
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-    const uint32_t page_size_bytes = get_page_size();
-    const uint32_t num_pages = get_num_pages();
-
-    const CoreCoord first_worker = default_worker_start;
-    const CoreRange worker_range = {first_worker, first_worker};
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
-
-    auto commands_per_iteration =
-        generate_paged_end_to_end_commands(first_worker, page_size_bytes, num_pages, device_data);
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+    log_info(tt::LogTest, "SDPrefetchPagedReadWriteTestFixture - PagedReadWriteTest (Slow Dispatch) - Test Start");
+    run_paged_read_write_test();
 }
 
 TEST_P(SDPrefetchHostTextFixture, HostTest) {
-    log_info(tt::LogTest, "SDPrefetchHostTextFixture - HostTest - Test Start");
-
-    const uint32_t max_data_size = DEVICE_DATA_SIZE;
-    const uint32_t max_data_size_words = max_data_size / sizeof(uint32_t);
-    const uint32_t dram_data_size_words = this->get_dram_data_size_words();
-    const uint32_t num_iterations = this->get_num_iterations();
-
-    std::vector<uint32_t> data(max_data_size_words);
-    for (uint32_t i = 0; i < max_data_size_words; i++) {
-        data[i] = i;
-    }
-
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    CoreCoord phys_worker_core = device_->worker_core_from_logical_core(first_worker);
-    MetalContext::instance().get_cluster().write_core(device_->id(), phys_worker_core, data, l1_base);
-    MetalContext::instance().get_cluster().l1_barrier(device_->id());
-
-    void* completion_queue_buffer = get_host_completion_ptr();
-    dirty_host_completion_buffer(completion_queue_buffer, get_host_completion_size());
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base_, completion_queue_buffer, false, dram_data_size_words, cfg_);
-
-    auto commands_per_iteration = generate_host_write_commands(data, first_worker, l1_base, device_data);
-
-    // SD LaunchProgram is synchronous; no completion-queue write-pointer polling needed.
-    // mfence inside execute_generated_commands ensures CPU sees PCIe-written data before validate.
-    execute_generated_commands(
-        commands_per_iteration,
-        device_data,
-        worker_range.size(),
-        num_iterations,
-        /*wait_for_completion=*/false,
-        /*wait_for_host_writes=*/false);
+    log_info(tt::LogTest, "SDPrefetchHostTextFixture - HostTest (Slow Dispatch) - Test Start");
+    run_host_test();
 }
 
 TEST_P(SDPrefetchHostTextFixture, HostSmokeTest) {
-    log_info(tt::LogTest, "SDPrefetchHostTextFixture - HostSmokeTest - Test Start");
-
-    const uint32_t num_iterations = get_num_iterations();
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-
-    const CoreCoord first_worker = default_worker_start;
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-
-    void* completion_queue_buffer = get_host_completion_ptr();
-    dirty_host_completion_buffer(completion_queue_buffer, get_host_completion_size());
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base_, completion_queue_buffer, false, dram_data_size_words, cfg_);
-
-    std::vector<HostMemDeviceCommand> commands_per_iteration;
-    HelperInfo info{
-        dram_base_, num_banks_, l1_alignment_, packed_write_max_unicast_sub_cmds_, dispatch_buffer_page_size_};
-    SmokeTestHelper helper(device_, device_data, commands_per_iteration, info);
-
-    auto add_host_write_func = [this](Common::DeviceData& device_data) {
-        PrefetcherHostTextFixture::pad_host_data(device_data);
-    };
-
-    for (uint32_t multiplier = 1; multiplier < 3; multiplier++) {
-        helper.add_host_write(multiplier * 32, add_host_write_func);
-        helper.add_host_write(multiplier * 36, add_host_write_func);
-        helper.add_host_write(multiplier * 1024, add_host_write_func);
-        helper.add_host_write(
-            (multiplier * dispatch_buffer_page_size_) - (2 * sizeof(CQDispatchCmd)), add_host_write_func);
-        helper.add_host_write((multiplier * dispatch_buffer_page_size_) - sizeof(CQDispatchCmd), add_host_write_func);
-        helper.add_host_write((multiplier * dispatch_buffer_page_size_), add_host_write_func);
-        helper.add_host_write((multiplier * dispatch_buffer_page_size_) + sizeof(CQDispatchCmd), add_host_write_func);
-    }
-
-    execute_generated_commands(
-        commands_per_iteration,
-        device_data,
-        worker_range.size(),
-        num_iterations,
-        /*wait_for_completion=*/false,
-        /*wait_for_host_writes=*/false);
-}
-
-TEST_P(SDPrefetchThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
-    log_info(tt::LogTest, "SDPrefetchThroughputTestFixture - HostToDRAMPagedWriteThroughput - Test Start");
-
-    const uint32_t dram_data_size_words = get_dram_data_size_words();
-    const uint32_t page_size_bytes = get_page_size();
-    const uint32_t requested_pages_per_cmd = get_num_pages();
-    TT_FATAL(page_size_bytes % sizeof(uint32_t) == 0U, "page_size_bytes must be a multiple of 4");
-
-    constexpr CoreCoord first_worker = default_worker_start;
-    constexpr CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
-
-    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
-    const uint32_t page_alignment_bytes = device_->allocator_impl()->get_alignment(BufferType::DRAM);
-
-    Common::DeviceData device_data(
-        device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
-
-    // Find the maximum pages per command that fits within the configured max prefetch command size.
-    uint32_t pages_per_cmd = 1U;
-    for (uint32_t pages = 1U; pages <= requested_pages_per_cmd; ++pages) {
-        DeviceCommandCalculator calc;
-        calc.add_dispatch_write_paged<hugepage_write_>(page_size_bytes, pages);
-        if (calc.write_offset_bytes() > max_fetch_bytes_) {
-            break;
-        }
-        pages_per_cmd = pages;
-    }
-
-    constexpr uint32_t total_cmds = 32U;
-    const uint32_t page_size_words = page_size_bytes / sizeof(uint32_t);
-    uint32_t absolute_start_page = 0U;
-
-    std::vector<HostMemDeviceCommand> commands_per_iteration;
-    commands_per_iteration.reserve(total_cmds);
-
-    for (uint32_t cmd_idx = 0U; cmd_idx < total_cmds; ++cmd_idx) {
-        std::vector<uint32_t> chunk_payload;
-        chunk_payload.reserve(pages_per_cmd * page_size_words);
-
-        for (uint32_t page = 0U; page < pages_per_cmd; ++page) {
-            const uint32_t page_id = absolute_start_page + page;
-            const uint32_t bank_id = page_id % num_banks_;
-            const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
-            const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
-            std::vector<uint32_t> page_payload =
-                payload_generator_->generate_payload_with_page_id(page_size_words, page_id);
-            Common::DeviceDataUpdater::update_paged_write(
-                page_payload, device_data, bank_core, bank_id, page_alignment_bytes);
-            chunk_payload.insert(chunk_payload.end(), page_payload.begin(), page_payload.end());
-        }
-
-        const uint32_t bank_offset =
-            tt::align(page_size_bytes, page_alignment_bytes) * (absolute_start_page / num_banks_);
-        const uint32_t base_addr = device_data.get_base_result_addr(tt::CoreType::DRAM) + bank_offset;
-        const uint16_t start_page_cmd = absolute_start_page % num_banks_;
-
-        HostMemDeviceCommand cmd = Common::CommandBuilder::build_paged_write_command<hugepage_write_>(
-            chunk_payload, base_addr, page_size_bytes, pages_per_cmd, start_page_cmd, /*is_dram=*/true);
-        commands_per_iteration.push_back(std::move(cmd));
-
-        absolute_start_page += pages_per_cmd;
-    }
-
-    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), /*num_iterations=*/1U);
+    log_info(tt::LogTest, "SDPrefetchHostTextFixture - HostSmokeTest (Slow Dispatch) - Test Start");
+    run_host_smoke_test();
 }
 
 // All BasePrefetcherTestFixture tests with exec buff enabled / disabled
@@ -3896,7 +3463,7 @@ INSTANTIATE_TEST_SUITE_P(
     PrefetcherTests,
     PrefetchRelayLinearHTestFixture,
     ::testing::Values(
-        // With exec buf disabled - 20MB per iteration x 5 iterations = 100MB total
+        // With exec buf disabled - 20MB per iteration × 5 iterations = 100MB total
         PagedReadParams{
             DRAM_PAGE_SIZE_DEFAULT,
             DRAM_PAGES_TO_READ_DEFAULT,
@@ -3915,7 +3482,7 @@ INSTANTIATE_TEST_SUITE_P(
     PrefetcherTests,
     PrefetcherLinearPackedHTestFixture,
     ::testing::Values(
-        // With exec buf disabled - 20MB per iteration x 5 iterations = 100MB total
+        // With exec buf disabled - 20MB per iteration × 5 iterations = 100MB total
         PagedReadParams{
             DRAM_PAGE_SIZE_DEFAULT,
             DRAM_PAGES_TO_READ_DEFAULT,
@@ -4009,18 +3576,6 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     SlowDispatch,
     SDPrefetchPagedReadWriteTestFixture,
-    ::testing::Values(
-        PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, true},
-        PagedReadParams{8192, 8, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
-    [](const testing::TestParamInfo<PagedReadParams>& info) {
-        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
-               std::to_string(info.param.num_iterations) + "iter_" +
-               (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
-    });
-
-INSTANTIATE_TEST_SUITE_P(
-    SlowDispatch,
-    SDPrefetchThroughputTestFixture,
     ::testing::Values(
         PagedReadParams{4096, 16, 1, Common::DRAM_DATA_SIZE_WORDS, true},
         PagedReadParams{8192, 8, 1, Common::DRAM_DATA_SIZE_WORDS, true}),

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1595,14 +1595,11 @@ public:
         uint32_t offset_bytes = offset_words * sizeof(uint32_t);
         helper.add_linear_read(worker_range, length_bytes, offset_bytes);
 
-        // Section 7: Write offset
-        // Simple Smoke test: do a change write_offset_idx to 48 and back to 0
-        std::array<uint32_t, CQ_DISPATCH_MAX_WRITE_OFFSETS> write_offset1 = {48, 0, 0, 0};
-        std::array<uint32_t, CQ_DISPATCH_MAX_WRITE_OFFSETS> write_offset2 = {};
-        HostMemDeviceCommand write_offset_cmd1 = CommandBuilder::build_dispatch_write_offset(write_offset1);
-        HostMemDeviceCommand write_offset_cmd2 = CommandBuilder::build_dispatch_write_offset(write_offset2);
-        commands_per_iteration.push_back(std::move(write_offset_cmd1));
-        commands_per_iteration.push_back(std::move(write_offset_cmd2));
+        // CQ_DISPATCH_CMD_SET_WRITE_OFFSET is exercised indirectly by every test that launches
+        // a real program (EnqueueProgram emits it via add_dispatch_set_write_offset).  No
+        // standalone smoke coverage here: the profiler integration in cq_dispatch.cpp's handler
+        // spins on program_id_fifo_append when realtime_profiler_core_noc_xy != 0 (FD), and
+        // synthetic commands have no paired profiler-side drain.
 
         // PHASE 2, 3, 4: Execute and Validate
         execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2622,9 +2622,9 @@ public:
         uint32_t num_iterations,
         bool /*wait_for_completion*/ = true,
         bool /*wait_for_host_writes*/ = false) override {
-        using entry_t = DispatchSettings::prefetch_q_entry_type;  // uint16_t
-
         const auto& memmap = tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
+        const uint32_t entry_size = memmap.prefetch_q_entry_size_bytes();
+        TT_FATAL(entry_size == 4, "Entry size must be 32 bits for worker cores used to launch prefetcher in this test");
         const uint32_t dispatch_cb_base = memmap.dispatch_buffer_base();
         const uint32_t dispatch_buffer_pages = memmap.dispatch_buffer_pages();
 
@@ -2693,7 +2693,7 @@ public:
         // write_prefetcher_cmd: streaming-store cmd to hugepage + write one FetchQ entry via TLB.
         // cmd_size_bytes must be a multiple of 64 (host alignment) and cmd_size_entry is the
         // pre-computed FetchQ value (may have MSB stall flag set for exec_buf).
-        auto write_prefetcher_cmd = [&](const uint32_t* src, uint32_t cmd_size_bytes, entry_t cmd_size_entry) {
+        auto write_prefetcher_cmd = [&](const uint32_t* src, uint32_t cmd_size_bytes, uint32_t cmd_size_entry) {
             const uint64_t host_offset =
                 static_cast<uint64_t>(reinterpret_cast<char*>(host_mem_ptr) - static_cast<char*>(host_hugepage_base));
             TT_FATAL(
@@ -2702,8 +2702,9 @@ public:
             tt::tt_metal::memcpy_to_device<true>(host_mem_ptr, src, cmd_size_bytes);
             host_mem_ptr += cmd_size_bytes / sizeof(uint32_t);
 
-            prefetch_q_tlb->write16(prefetch_q_dev_ptr, cmd_size_entry);
-            prefetch_q_dev_ptr += sizeof(entry_t);
+            prefetch_q_tlb->write32(prefetch_q_dev_ptr, cmd_size_entry);
+            // this->prefetch_q_windows[cq_id]->write32(this->prefetch_q_dev_ptrs[cq_id], entry_val);
+            prefetch_q_dev_ptr += entry_size;
             if (prefetch_q_dev_ptr >= prefetch_q_dev_fence) {
                 prefetch_q_dev_ptr = prefetch_q_base;
             }
@@ -2714,9 +2715,11 @@ public:
             const uint32_t size = tt::align(cmd.size_bytes(), host_align);
             std::vector<uint8_t> padded(size, 0u);
             std::memcpy(padded.data(), cmd.data(), cmd.size_bytes());
-            entry_t entry = static_cast<entry_t>(size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
+            uint32_t entry = static_cast<uint32_t>(size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
             if (stall) {
-                entry |= static_cast<entry_t>(1u << 15);
+                const uint32_t shift_for_msb = entry_size * 8 - 1;
+                const uint32_t max_encodable = 1u << shift_for_msb;
+                entry |= max_encodable;
             }
             write_prefetcher_cmd(reinterpret_cast<const uint32_t*>(padded.data()), size, entry);
         };
@@ -2770,6 +2773,7 @@ public:
             dispatch_buffer_pages,
             pf_downstream_cb_sem,
             pf_sync_sem,
+            entry_size,
             phys_prefetch,
             phys_disp);
         auto prefetch_kernel = tt_metal::CreateKernel(


### PR DESCRIPTION
### Summary
PR https://github.com/tenstorrent/tt-metal/pull/33870 refactored `test_prefetcher.cpp` to a unified command generation + FD test + gtest TEST_P architecture but dropped the slow dispatch (SD) validation path. This PR restores it: command generation is shared with the FD path via a `SDPrefetchTestBase <FDFixture>` template that overrides only the execution backend (launching kernels cq_prefetch.cpp + cq_dispatch.cpp directly, vs FDMeshCommandQueue for FD). Useful during bringup of dispatcher/prefetcher on new hardware in SD mode.

### Notes for reviewers
- SDPrefetchTestBase<FDFixture>: overrides execute_generated_commands to drive cq_prefetch + cq_dispatch directly. Each SD fixture is an empty subclass; all setup and init_params dispatch live in the template. No FD fixture code touched.
- make_sd_prefetch_defines / make_sd_prefetch_defines(): supplies compile-time defines cq_prefetch.cpp/cq_dispatch.cpp require. Fields not driven by SD are zeroed.
- SD currently covers the combined prefetch + dispatch (HD) on the MMIO chip. Split-prefetch / remote commands to non-MMIO devices are not supported in SD yet.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/sd_mode_test_prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/sd_mode_test_prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/sd_mode_test_prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/sd_mode_test_prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/sd_mode_test_prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/sd_mode_test_prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/sd_mode_test_prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/sd_mode_test_prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/sd_mode_test_prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/sd_mode_test_prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/sd_mode_test_prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/sd_mode_test_prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/sd_mode_test_prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/sd_mode_test_prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/sd_mode_test_prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/sd_mode_test_prefetcher)