### PR TITLE
Migrate data_movement family (26 ops) to ProgramDescriptor framework

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fill_rm_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "fill_rm_program_factory.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_device_operation.hpp
@@ -41,6 +41,6 @@ ttnn::Tensor fill_rm(
     const Tensor& input,
     float val_hi,
     float val_lo,
-    const MemoryConfig& output_memory_config);
+    const tt::tt_metal::MemoryConfig& output_memory_config);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_program_factory.cpp
@@ -3,17 +3,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fill_rm_program_factory.hpp"
-#include <tt-metalium/tilize_utils.hpp>
+
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 namespace ttnn::prim {
 
-FillRMProgramFactory::cached_program_t FillRMProgramFactory::create(
-    const FillRmParams& operation_attributes, const FillRmInputs& tensor_args, Tensor& tensor_return_value) {
-    using namespace tt::tt_metal;
+using namespace tt::tt_metal;
 
+ProgramDescriptor FillRMProgramFactory::create_descriptor(
+    const FillRmParams& operation_attributes, const FillRmInputs& tensor_args, Tensor& tensor_return_value) {
     const Tensor& input = tensor_args.input;
     Tensor& output = tensor_return_value;
     const uint32_t N = operation_attributes.N;
@@ -25,8 +28,7 @@ FillRMProgramFactory::cached_program_t FillRMProgramFactory::create(
     const float val_hi = operation_attributes.val_hi;
     const float val_lo = operation_attributes.val_lo;
 
-    Program program = CreateProgram();
-    const CoreRange core({0, 0}, {0, 0});
+    const CoreRangeSet core_ranges{CoreRange{{0, 0}, {0, 0}}};
 
     const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
     const uint32_t single_tile_size = tt::tile_size(cb_data_format);
@@ -42,28 +44,44 @@ FillRMProgramFactory::cached_program_t FillRMProgramFactory::create(
         W,
         num_cb_tiles);
 
-    const CircularBufferConfig cb_src0_config =
-        CircularBufferConfig(num_cb_tiles * single_tile_size, {{0, cb_data_format}}).set_page_size(0, single_tile_size);
-    CreateCircularBuffer(program, core, cb_src0_config);
+    ProgramDescriptor desc;
 
-    const CircularBufferConfig cb_src1_config =
-        CircularBufferConfig(num_cb_tiles * single_tile_size, {{1, cb_data_format}}).set_page_size(1, single_tile_size);
-    CreateCircularBuffer(program, core, cb_src1_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cb_tiles * single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = 0,
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cb_tiles * single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = 1,
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
 
     std::vector<uint32_t> reader_compile_time_args;
     TensorAccessorArgs(*dst_buffer).append_to(reader_compile_time_args);
 
-    const KernelHandle reader_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/kernels/dataflow/fill_rm_interleaved.cpp",
-        core,
-        ReaderDataMovementConfig(reader_compile_time_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/kernels/dataflow/fill_rm_interleaved.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core_ranges;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    SetRuntimeArgs(
-        program,
-        reader_kernel_id,
-        core,
-        {dst_buffer->address(),
+    // Buffer* triggers a binding entry for dst_buffer at arg slot 0; the framework
+    // patches its address on cache hits without rebuilding the descriptor.
+    reader_desc.emplace_runtime_args(
+        CoreCoord{0, 0},
+        {dst_buffer,
          uint32_t(N * C),
          uint32_t(H),
          uint32_t(W),
@@ -72,25 +90,9 @@ FillRMProgramFactory::cached_program_t FillRMProgramFactory::create(
          uint32_t(std::bit_cast<uint16_t>(bfloat16(val_hi))),
          uint32_t(std::bit_cast<uint16_t>(bfloat16(val_lo)))});
 
-    return cached_program_t{std::move(program), shared_variables_t{.kernel_id = reader_kernel_id}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
 
-void FillRMProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const FillRmParams& /*operation_attributes*/,
-    const FillRmInputs& /*tensor_args*/,
-    Tensor& tensor_return_value) {
-    using namespace tt::tt_metal;
-
-    Buffer* dst_buffer = tensor_return_value.buffer();
-
-    Program& program = cached_program.program;
-    const KernelHandle kernel_id = cached_program.shared_variables.kernel_id;
-
-    const CoreCoord core = {0, 0};
-
-    auto& runtime_args = GetRuntimeArgs(program, kernel_id, core);
-    runtime_args[0] = dst_buffer->address();
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_program_factory.hpp
@@ -4,27 +4,15 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
 #include "fill_rm_device_operation_types.hpp"
-#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
-struct FillRMSharedVariables {
-    tt::tt_metal::KernelHandle kernel_id = 0;
-};
-
 struct FillRMProgramFactory {
-    using shared_variables_t = FillRMSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const FillRmParams& operation_attributes, const FillRmInputs& tensor_args, Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const FillRmParams& operation_attributes,
-        const FillRmInputs& tensor_args,
-        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include <vector>
+#include <variant>
 
-#include "tt-metalium/kernel_types.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operation.hpp"
 #include "ttnn/device_operation.hpp"
@@ -28,43 +28,14 @@ struct Fold {
     using tensor_return_value_t = Tensor;
 
     struct MultiCore {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle reader_kernel_id;
-            tt::tt_metal::KernelHandle writer_kernel_id;
-            uint32_t stride_h;
-            uint32_t stride_w;
-            tt::tt_metal::CBHandle cb_src0;
-            tt::tt_metal::CBHandle cb_dst0;
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& output_tensor);
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& output_tensor);
     };
 
     struct MultiCoreDRAMFold {
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle writer_kernel_id{};
-            tt::tt_metal::KernelHandle reader_kernel_id{};
-            std::vector<CoreCoord> cores_with_rtargs;
-        };
-
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& output_tensor);
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& output_tensor);

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -2,44 +2,47 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "fold_device_op.hpp"
+
 #include "hostdevcommon/kernel_structs.h"
 #include "ttnn/common/constants.hpp"
-#include "ttnn/tensor/host_buffer/functions.hpp"
-#include <tt-metalium/work_split.hpp>
+#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/math.hpp"
+#include "ttnn/operation.hpp"
+#include "ttnn/tensor/host_buffer/functions.hpp"
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/types.hpp"
+
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
-#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
-#include "ttnn/operation.hpp"
-#include "ttnn/operations/data_movement/common/common.hpp"
-#include "ttnn/tensor/types.hpp"
-#include "ttnn/types.hpp"
-#include <tt-metalium/tt_align.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include "fold_device_op.hpp"
+#include <tt-metalium/tt_align.hpp>
+#include <tt-metalium/work_split.hpp>
+
 namespace ttnn::operations::data_movement {
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
-Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
+namespace {
+
+ProgramDescriptor fold_multi_core_tiled_interleaved(
     const Tensor& input_tensor, const Tensor& output, const uint32_t stride_h, const uint32_t stride_w) {
-    // Get device and create a new program
     auto* device = input_tensor.device();
-    auto program = tt::tt_metal::CreateProgram();
 
     const uint32_t input_width = input_tensor.logical_shape()[2];
 
-    // Get compute grid size and buffer pointers
     Buffer* src0_buffer = input_tensor.buffer();
     Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
-    tt::DataFormat out_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat out_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t out_single_tile_size = tt::tile_size(out_cb_data_format);
 
     ttnn::Shape output_padded_shape = output.padded_shape();
@@ -51,15 +54,14 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
     log_debug(tt::LogOp, "input_tensor_shape: {}", input_padded_shape);
     log_debug(tt::LogOp, "output_tensor_shape: {}", output_padded_shape);
 
-    // Calculate memory layout parameters
-    auto stick_nbytes =
-        output_padded_shape[3] * tt::datum_size(tt::tt_metal::datatype_to_dataformat_converter(output.dtype()));
+    // Memory layout parameters
+    auto stick_nbytes = output_padded_shape[3] * tt::datum_size(datatype_to_dataformat_converter(output.dtype()));
     uint32_t ntiles = input_tensor.physical_volume() / TILE_HW;
     uint32_t tiles_per_channel_dim = tt::div_up(input_padded_shape[-1], TILE_WIDTH);
     uint32_t tiles_per_width_dim = tt::div_up(input_padded_shape[-2], TILE_HEIGHT);
     uint32_t tiles_per_complete_row = tiles_per_width_dim * tiles_per_channel_dim;
-    uint32_t num_blocks =
-        std::ceil(static_cast<float>(ntiles) / (tiles_per_complete_row));  // Total number of blocks for batch * height
+    // Total number of blocks for batch * height
+    uint32_t num_blocks = std::ceil(static_cast<float>(ntiles) / (tiles_per_complete_row));
 
     uint32_t aligned_stick_nbytes = tt::align(stick_nbytes, TILE_WIDTH * tt::datum_size(out_cb_data_format));
     log_debug(
@@ -76,23 +78,39 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
         ncores,
         nblocks_per_core,
         nblocks_per_core_cliff);
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
-    uint32_t num_input_tiles = tiles_per_channel_dim;
 
-    // Create circular buffer configurations for source and destination
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    ProgramDescriptor desc;
 
-    uint32_t src1_cb_index = tt::CBIndex::c_1;
-    tt::tt_metal::CircularBufferConfig cb_src1_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_input_tiles * out_single_tile_size, {{src1_cb_index, out_cb_data_format}})
-            .set_page_size(src1_cb_index, out_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
+    const uint32_t src0_cb_index = tt::CBIndex::c_0;
+    const uint32_t num_input_tiles = tiles_per_channel_dim;
 
-    // Configure compile-time arguments for reader kernel
+    // Source CB
+    {
+        CBDescriptor cb;
+        cb.total_size = num_input_tiles * single_tile_size;
+        cb.core_ranges = all_cores;
+        cb.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        });
+        desc.cbs.push_back(std::move(cb));
+    }
+
+    const uint32_t src1_cb_index = tt::CBIndex::c_1;
+    {
+        CBDescriptor cb;
+        cb.total_size = num_input_tiles * out_single_tile_size;
+        cb.core_ranges = all_cores;
+        cb.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src1_cb_index),
+            .data_format = out_cb_data_format,
+            .page_size = out_single_tile_size,
+        });
+        desc.cbs.push_back(std::move(cb));
+    }
+
+    // Reader kernel compile-time args
     std::vector<uint32_t> reader_compile_time_args = {
         tiles_per_channel_dim,
         tiles_per_width_dim,
@@ -100,7 +118,7 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
     };
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
-    // Configure compile-time arguments for writer kernel
+    // Writer kernel compile-time args
     std::vector<uint32_t> writer_compile_time_args = {
         input_width,
         stride_h,
@@ -114,21 +132,26 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
     };
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
-    // Create reader kernel for DRAM to circular buffer data movement
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_tiled.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    // Reader kernel: DRAM -> CB
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_tiled.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    // Create writer kernel for circular buffer to DRAM data movement
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    // Writer kernel: CB -> DRAM
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_tiled_input.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    // Configure compute kernel arguments
+    // Compute kernel arguments — main grid and (optional) cliff grid handle the
+    // last core when the work doesn't divide evenly.
     std::vector<uint32_t> compute_compile_time_args = {
         nblocks_per_core * tiles_per_width_dim,
         tiles_per_channel_dim,
@@ -143,35 +166,35 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
         src1_cb_index,
     };
 
-    bool fp32_dest_acc_en = cb_data_format == tt::DataFormat::Float32;
-    std::string compute_kernel_name =
+    const bool fp32_dest_acc_en = cb_data_format == tt::DataFormat::Float32;
+    const std::string compute_kernel_name =
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp";
 
     log_debug(tt::LogOp, "compute_kernel_name: {}", compute_kernel_name);
 
-    // Create main compute kernel
-    tt::tt_metal::CreateKernel(
-        program,
-        compute_kernel_name,
-        core_range,
-        tt::tt_metal::ComputeConfig{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .compile_args = compute_compile_time_args,
-        });
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = compute_kernel_name;
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = core_range;
+    compute_desc.compile_time_args = std::move(compute_compile_time_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    };
 
-    // Create cliff compute kernel if needed (for handling edge cases)
+    std::optional<KernelDescriptor> compute_cliff_desc;
     if (!core_range_cliff.ranges().empty()) {
-        tt::tt_metal::CreateKernel(
-            program,
-            compute_kernel_name,
-            core_range_cliff,
-            tt::tt_metal::ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .compile_args = compute_compile_time_args_cliff,
-            });
+        KernelDescriptor cliff;
+        cliff.kernel_source = compute_kernel_name;
+        cliff.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cliff.core_ranges = core_range_cliff;
+        cliff.compile_time_args = std::move(compute_compile_time_args_cliff);
+        cliff.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+        };
+        compute_cliff_desc = std::move(cliff);
     }
 
-    // Calculate core distribution for work
+    // Determine the "full" core set vs. the cliff core for runtime arg distribution.
     uint32_t ncores_full = ncores;
     auto full_cores = all_cores;
     if (nblocks_per_core_cliff > 0 && nblocks_per_core_cliff < nblocks_per_core) {
@@ -179,44 +202,30 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
         full_cores = core_range;
     }
 
-    // Set up runtime arguments for each core
     uint32_t block_start_id = 0;
     auto ncores_x = grid_size.x;
     auto ncores_y = std::ceil(static_cast<float>(ncores) / ncores_x);
     auto cores = grid_to_cores(ncores_x * ncores_y, ncores_x, ncores_y, true);
-    std::vector<CoreCoord> cores_with_rtargs;
 
-    const uint32_t patch_size = stride_h * stride_w;         // Size of each patch
-    const uint32_t output_width = input_width / stride_w;    // Output width
-    // Configure runtime arguments for each core
+    const uint32_t patch_size = stride_h * stride_w;       // Size of each patch
+    const uint32_t output_width = input_width / stride_w;  // Output width
     for (auto core : cores) {
         uint32_t curr_input_height_idx = block_start_id;
         uint32_t curr_output_height_idx = curr_input_height_idx / stride_h;
         uint32_t patch_height_offset = curr_input_height_idx % stride_h;
-        uint32_t output_offset = (patch_size * curr_output_height_idx * output_width) +
-                                 (patch_height_offset * stride_w);  // Total output height * width
+        // Total output height * width
+        uint32_t output_offset =
+            (patch_size * curr_output_height_idx * output_width) + (patch_height_offset * stride_w);
         if (!full_cores.contains(core)) {
             continue;
         }
-        std::vector<uint32_t> reader_runtime_args = {
-            src0_buffer->address(),
-            block_start_id,
-            nblocks_per_core,
-        };
-        std::vector<uint32_t> writer_runtime_args = {
-            dst_buffer->address(),
-            block_start_id,
-            nblocks_per_core,
-            patch_height_offset,
-            output_offset,
-        };
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_runtime_args);
+        // Buffer* slots register BufferBindings so the framework patches addresses on cache hits.
+        reader_desc.emplace_runtime_args(core, {src0_buffer, block_start_id, nblocks_per_core});
+        writer_desc.emplace_runtime_args(
+            core, {dst_buffer, block_start_id, nblocks_per_core, patch_height_offset, output_offset});
         block_start_id += nblocks_per_core;
-        cores_with_rtargs.push_back(core);
     }
 
-    // Handle edge case for cliff cores
     if (ncores_full < ncores) {
         uint32_t curr_input_height_idx = block_start_id;
         uint32_t curr_output_height_idx = curr_input_height_idx / stride_h;
@@ -224,30 +233,24 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
         uint32_t output_offset =
             (patch_size * curr_output_height_idx * output_width) + (patch_height_offset * stride_w);
         CoreCoord core = CoreCoord{ncores_full % ncores_x, ncores_full / ncores_x};
-        std::vector<uint32_t> reader_runtime_args = {
-            src0_buffer->address(),
-            block_start_id,
-            nblocks_per_core_cliff,
-        };
-        std::vector<uint32_t> writer_runtime_args = {
-            dst_buffer->address(),
-            block_start_id,
-            nblocks_per_core_cliff,
-            patch_height_offset,
-            output_offset,
-        };
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_runtime_args);
-        cores_with_rtargs.push_back(core);
+        reader_desc.emplace_runtime_args(core, {src0_buffer, block_start_id, nblocks_per_core_cliff});
+        writer_desc.emplace_runtime_args(
+            core, {dst_buffer, block_start_id, nblocks_per_core_cliff, patch_height_offset, output_offset});
     }
 
-    return {std::move(program), {unary_writer_kernel_id, unary_reader_kernel_id, cores_with_rtargs}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+    if (compute_cliff_desc.has_value()) {
+        desc.kernels.push_back(std::move(*compute_cliff_desc));
+    }
+
+    return desc;
 }
 
-Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
+ProgramDescriptor fold_multi_core_row_major_interleaved(
     const Tensor& input_tensor, const Tensor& output, const uint32_t stride_h, const uint32_t stride_w) {
     auto* device = input_tensor.device();
-    auto program = tt::tt_metal::CreateProgram();
 
     const uint32_t batch_size = input_tensor.logical_shape()[0];
     const uint32_t input_height = input_tensor.logical_shape()[1];
@@ -257,12 +260,11 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
     Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
 
-    // Calculate total input work
+    // Total input work
     uint32_t total_patches = (batch_size * input_height * input_width) / (stride_h * stride_w);
 
-    // Get compute grid size and calculate work distribution
     auto compute_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_grid_size.x;
     uint32_t num_cores_y = compute_grid_size.y;
@@ -271,7 +273,6 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
     log_debug(tt::LogOp, "input_tensor_shape: {}", input_tensor.padded_shape());
     log_debug(tt::LogOp, "output_tensor_shape: {}", output.padded_shape());
 
-    // Calculate work per core based on input dimensions
     uint32_t patches_per_core = tt::div_up(total_patches, num_cores_total);
 
     log_debug(
@@ -281,16 +282,13 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
         num_cores_total,
         patches_per_core);
 
-    // Create core ranges
-    CoreRange all_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    CoreRangeSet all_cores{CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1})};
     auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, true);
 
-    // Setup circular buffers
-    uint32_t cb_src0_index = tt::CBIndex::c_0;
+    const uint32_t cb_src0_index = tt::CBIndex::c_0;
 
-    // Calculate buffer sizes
     uint32_t stick_nbytes = input_tensor.padded_shape()[3] * tt::datum_size(cb_data_format);
-    // align to DRAM read alignment.
+    // Align to DRAM read alignment.
     uint32_t aligned_stick_nbytes = tt::align(stick_nbytes, hal::get_dram_alignment());
 
     log_debug(
@@ -300,24 +298,36 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
         aligned_stick_nbytes,
         hal::get_dram_alignment());
 
-    int double_buffer = 2;
-    // Create source circular buffer
-    auto src_cb_config =
-        CircularBufferConfig(
-            double_buffer * aligned_stick_nbytes * stride_w * stride_h, {{cb_src0_index, cb_data_format}})
-            .set_page_size(cb_src0_index, aligned_stick_nbytes * stride_w * stride_h);
-    CreateCircularBuffer(program, all_cores, src_cb_config);
+    ProgramDescriptor desc;
 
-    bool is_l1_aligned = stick_nbytes == aligned_stick_nbytes;
+    const int double_buffer = 2;
+    {
+        CBDescriptor cb;
+        cb.total_size = double_buffer * aligned_stick_nbytes * stride_w * stride_h;
+        cb.core_ranges = all_cores;
+        cb.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_src0_index),
+            .data_format = cb_data_format,
+            .page_size = aligned_stick_nbytes * stride_w * stride_h,
+        });
+        desc.cbs.push_back(std::move(cb));
+    }
 
-    uint32_t cb_src1_index = tt::CBIndex::c_1;
+    const bool is_l1_aligned = stick_nbytes == aligned_stick_nbytes;
+
+    const uint32_t cb_src1_index = tt::CBIndex::c_1;
     if (!is_l1_aligned) {
-        // If not L1 aligned, use a separate circular buffer for src1
+        // If not L1 aligned, use a separate circular buffer for src1 as an intermediate scratch.
         log_debug(tt::LogOp, "Using intermediate L1 scratch buffer for src1");
-        auto src1_cb_config =
-            CircularBufferConfig(stick_nbytes * stride_w * stride_h, {{cb_src1_index, cb_data_format}})
-                .set_page_size(cb_src1_index, stick_nbytes * stride_w * stride_h);
-        CreateCircularBuffer(program, all_cores, src1_cb_config);
+        CBDescriptor cb;
+        cb.total_size = stick_nbytes * stride_w * stride_h;
+        cb.core_ranges = all_cores;
+        cb.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_src1_index),
+            .data_format = cb_data_format,
+            .page_size = stick_nbytes * stride_w * stride_h,
+        });
+        desc.cbs.push_back(std::move(cb));
     }
 
     // Common compile-time args shared by reader and writer (indices 0..8)
@@ -332,37 +342,39 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
          cb_src1_index,
          is_l1_aligned});
 
-    // Create reader kernel with src TensorAccessorArgs
+    // Reader kernel — appends src TensorAccessorArgs to compile-time args.
     auto reader_compile_time_args = common_compile_time_args;
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    // Create writer kernel with dst TensorAccessorArgs
+    // Writer kernel — appends dst TensorAccessorArgs to compile-time args.
     auto writer_compile_time_args = common_compile_time_args;
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    // Set runtime arguments for each core
-
+    // Per-core runtime args. The Buffer* slots auto-register as BufferBindings.
     const uint32_t output_height = input_height / stride_h;
     const uint32_t output_width = input_width / stride_w;
     const uint32_t patch_size = stride_h * stride_w;
     const uint32_t output_hw = output_height * output_width;
     uint32_t curr_patches = 0;
-    std::vector<CoreCoord> cores_with_rtargs;
-    uint32_t src_idx, dst_idx, src_col_offset;
+    uint32_t src_idx = 0;
+    uint32_t dst_idx = 0;
+    uint32_t src_col_offset = 0;
     for (uint32_t i = 0; i < cores.size(); i++) {
         CoreCoord core = cores[i];
-        std::vector<uint32_t> reader_runtime_args = {src0_buffer->address()};
-        std::vector<uint32_t> writer_runtime_args = {dst_buffer->address()};
 
         if (curr_patches < total_patches) {
             uint32_t output_offset = i * patches_per_core;
@@ -380,18 +392,19 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_row_major_interleaved(
         }
 
         curr_patches += patches_per_core;
-        reader_runtime_args.push_back(src_idx);
-        reader_runtime_args.push_back(src_col_offset);
-        writer_runtime_args.push_back(dst_idx);
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
-        cores_with_rtargs.push_back(core);
+        reader_desc.emplace_runtime_args(core, {src0_buffer, src_idx, src_col_offset});
+        writer_desc.emplace_runtime_args(core, {dst_buffer, dst_idx});
     }
 
-    return {std::move(program), {writer_kernel_id, reader_kernel_id, cores_with_rtargs}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
 }
 
-Fold::MultiCoreDRAMFold::cached_program_t Fold::MultiCoreDRAMFold::create(
+}  // namespace
+
+ProgramDescriptor Fold::MultiCoreDRAMFold::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output_tensor) {
@@ -403,36 +416,6 @@ Fold::MultiCoreDRAMFold::cached_program_t Fold::MultiCoreDRAMFold::create(
     log_debug(tt::LogOp, "Fold operation with DRAM row major input");
     return fold_multi_core_row_major_interleaved(
         tensor_args.input_tensor, output_tensor, operation_attributes.stride_h, operation_attributes.stride_w);
-}
-
-void Fold::MultiCoreDRAMFold::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
-    auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    auto& cores_with_rtargs = cached_program.shared_variables.cores_with_rtargs;
-
-    auto& program = cached_program.program;
-
-    const auto& input_tensor = tensor_args.input_tensor;
-    auto* src_dram_buffer = input_tensor.buffer();
-
-    auto* dst_dram_buffer = output_tensor.buffer();
-
-    // Update runtime arguments for each core
-    for (auto core : cores_with_rtargs) {
-        {
-            auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = src_dram_buffer->address();
-        }
-
-        {
-            auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = dst_dram_buffer->address();
-        }
-    }
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_program_factory.cpp
@@ -2,22 +2,29 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/tensor/tensor.hpp"
-#include "ttnn/core.hpp"
-#include "ttnn/device_operation.hpp"
-#include "ttnn/types.hpp"
 #include "fold_device_op.hpp"
-#include "ttnn/operations/math.hpp"
+
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tt_align.hpp>
 
-using namespace tt::tt_metal;
+#include "ttnn/operations/math.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
 
 namespace ttnn::operations::data_movement {
 
-Fold::MultiCore::cached_program_t fold_multi_core(
-    const Tensor& input, const Tensor& output, uint32_t stride_h, uint32_t stride_w) {
-    Program program = CreateProgram();
+using namespace tt::tt_metal;
+
+ProgramDescriptor Fold::MultiCore::create_descriptor(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output_tensor) {
+    const Tensor& input = tensor_args.input_tensor;
+    const Tensor& output = output_tensor;
+    const uint32_t stride_h = operation_attributes.stride_h;
+    const uint32_t stride_w = operation_attributes.stride_w;
 
     auto all_cores = input.shard_spec()->grid;
     auto shard_shape = input.shard_spec()->shape;
@@ -35,22 +42,43 @@ Fold::MultiCore::cached_program_t fold_multi_core(
     uint32_t num_dst_rows = num_pixels / (width * stride_h);
     uint32_t pixels_per_dst_row = stride_h * width;
 
-    // input CB
-    uint32_t cb_src0_index = tt::CBIndex::c_0;
-    uint32_t aligned_pixel_size = tt::align(pixel_size, hal::get_l1_alignment());
-    auto src_cb_config = CircularBufferConfig(num_pixels * aligned_pixel_size, {{cb_src0_index, cb_data_format}})
-                             .set_page_size(cb_src0_index, aligned_pixel_size)
-                             .set_globally_allocated_address(*input.buffer());
-    auto cb_src0 = CreateCircularBuffer(program, all_cores, src_cb_config);
+    Buffer* src_buffer = input.buffer();
+    Buffer* dst_buffer = output.buffer();
 
-    // output CB
-    uint32_t cb_dst0_index = tt::CBIndex::c_16;
-    uint32_t aligned_dst_pixel_size = tt::align(dst_pixel_size, hal::get_l1_alignment());
-    auto dst_cb_config =
-        CircularBufferConfig(num_dst_pixels * aligned_dst_pixel_size, {{cb_dst0_index, cb_data_format}})
-            .set_page_size(cb_dst0_index, aligned_dst_pixel_size)
-            .set_globally_allocated_address(*output.buffer());
-    auto cb_dst0 = CreateCircularBuffer(program, all_cores, dst_cb_config);
+    ProgramDescriptor desc;
+
+    // Input CB — globally allocated to the sharded input buffer.
+    // The descriptor framework patches the CB address on cache hits via cb.buffer.
+    const uint32_t cb_src0_index = tt::CBIndex::c_0;
+    const uint32_t aligned_pixel_size = tt::align(pixel_size, hal::get_l1_alignment());
+    {
+        CBDescriptor cb_src0;
+        cb_src0.total_size = num_pixels * aligned_pixel_size;
+        cb_src0.core_ranges = all_cores;
+        cb_src0.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_src0_index),
+            .data_format = cb_data_format,
+            .page_size = aligned_pixel_size,
+        });
+        cb_src0.buffer = src_buffer;
+        desc.cbs.push_back(std::move(cb_src0));
+    }
+
+    // Output CB — globally allocated to the sharded output buffer.
+    const uint32_t cb_dst0_index = tt::CBIndex::c_16;
+    const uint32_t aligned_dst_pixel_size = tt::align(dst_pixel_size, hal::get_l1_alignment());
+    {
+        CBDescriptor cb_dst0;
+        cb_dst0.total_size = num_dst_pixels * aligned_dst_pixel_size;
+        cb_dst0.core_ranges = all_cores;
+        cb_dst0.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_dst0_index),
+            .data_format = cb_data_format,
+            .page_size = aligned_dst_pixel_size,
+        });
+        cb_dst0.buffer = dst_buffer;
+        desc.cbs.push_back(std::move(cb_dst0));
+    }
 
     std::vector<uint32_t> compile_time_args = {
         cb_src0_index,
@@ -66,50 +94,34 @@ Fold::MultiCore::cached_program_t fold_multi_core(
         width / stride_w,
         pixels_per_dst_row * aligned_pixel_size,
         input.element_size(),
-        true,
+        true,  // is_reader (overwritten below for the writer kernel)
     };
-    // Setup kernel
-    // Set build optimization level to Os. O2 was slower.
-    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp",
-        all_cores,
-        WriterDataMovementConfig(compile_time_args, {}, {}, tt::tt_metal::KernelBuildOptLevel::Os));
 
-    compile_time_args[13] = false;  // is_reader = false for writer
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp",
-        all_cores,
-        ReaderDataMovementConfig(compile_time_args, {}, {}, tt::tt_metal::KernelBuildOptLevel::Os));
+    // Writer kernel: shares the same source as the reader (a single kernel file selects
+    // its role from the last compile-time arg). Build optimization level Os was faster
+    // than O2 when this kernel was originally tuned.
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = compile_time_args;
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.opt_level = KernelBuildOptLevel::Os;
+    desc.kernels.push_back(std::move(writer_desc));
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, stride_h, stride_w, cb_src0, cb_dst0}};
-}
+    compile_time_args[13] = false;  // is_reader = false for the reader-data-movement variant
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+    reader_desc.opt_level = KernelBuildOptLevel::Os;
+    desc.kernels.push_back(std::move(reader_desc));
 
-Fold::MultiCore::cached_program_t Fold::MultiCore::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
-    return fold_multi_core(
-        tensor_args.input_tensor, output_tensor, operation_attributes.stride_h, operation_attributes.stride_w);
-}
-
-void Fold::MultiCore::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
-    auto& cb_src0 = cached_program.shared_variables.cb_src0;
-    auto& cb_dst0 = cached_program.shared_variables.cb_dst0;
-
-    auto& program = cached_program.program;
-    const auto& input_tensor = tensor_args.input_tensor;
-
-    auto* src_buffer = input_tensor.buffer();
-    auto* dst_buffer = output_tensor.buffer();
-
-    UpdateDynamicCircularBufferAddress(program, cb_src0, *src_buffer);
-    UpdateDynamicCircularBufferAddress(program, cb_dst0, *dst_buffer);
+    return desc;
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.cpp
@@ -159,14 +159,19 @@ ProgramDescriptor GatherDeviceOperation::SingleRowSingleCore::create_descriptor(
     for (const auto& [group, work_per_core] : work_groups) {
         for (const auto& range : group.ranges()) {
             for (const auto& core : range) {
-                reader_desc.runtime_args.emplace_back(
-                    core,
-                    KernelDescriptor::CoreRuntimeArgs{
-                        input_index_tensor_buffer->address(), work_per_core, tile_width, tile_height, id});
-                writer_desc.runtime_args.emplace_back(
-                    core,
-                    KernelDescriptor::CoreRuntimeArgs{
-                        input_tensor_buffer->address(), output_tensor_buffer->address(), work_per_core, id});
+                if (work_per_core > 0) {
+                    // Active core: register Buffer* bindings for fast cache-hit patching.
+                    reader_desc.emplace_runtime_args(
+                        core, {input_index_tensor_buffer, work_per_core, tile_width, tile_height, id});
+                    writer_desc.emplace_runtime_args(
+                        core, {input_tensor_buffer, output_tensor_buffer, work_per_core, id});
+                } else {
+                    // Idle core (work_per_core == 0): the kernel short-circuits, so no
+                    // BufferBinding is registered — that would force a GetRuntimeArgs
+                    // lookup on every cache hit for a core that never reads/writes.
+                    reader_desc.emplace_runtime_args(core, {0u, 0u, tile_width, tile_height, id});
+                    writer_desc.emplace_runtime_args(core, {0u, 0u, 0u, id});
+                }
                 id++;
             }
         }
@@ -313,14 +318,17 @@ ProgramDescriptor GatherDeviceOperation::SingleRowMultiCore::create_descriptor(
     for (const auto& [group, work_per_core] : work_groups) {
         for (const auto& range : group.ranges()) {
             for (const auto& core : range) {
-                reader_desc.runtime_args.emplace_back(
-                    core,
-                    KernelDescriptor::CoreRuntimeArgs{
-                        input_index_tensor_buffer->address(), work_per_core, tile_width, tile_height, id});
-                writer_desc.runtime_args.emplace_back(
-                    core,
-                    KernelDescriptor::CoreRuntimeArgs{
-                        input_tensor_buffer->address(), output_tensor_buffer->address(), work_per_core, id});
+                if (work_per_core > 0) {
+                    reader_desc.emplace_runtime_args(
+                        core, {input_index_tensor_buffer, work_per_core, tile_width, tile_height, id});
+                    writer_desc.emplace_runtime_args(
+                        core, {input_tensor_buffer, output_tensor_buffer, work_per_core, id});
+                } else {
+                    // Idle core: skip BufferBinding so cache-hit patching doesn't iterate
+                    // bindings that the kernel ignores (work_per_core == 0 short-circuits).
+                    reader_desc.emplace_runtime_args(core, {0u, 0u, tile_width, tile_height, id});
+                    writer_desc.emplace_runtime_args(core, {0u, 0u, 0u, id});
+                }
                 id++;
             }
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_program_factory.cpp
@@ -4,580 +4,123 @@
 
 #include "ttnn/operations/data_movement/indexed_fill/device/indexed_fill_program_factory.hpp"
 
-#include <algorithm>
-
-#include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/tile.hpp>
+#include <tt-metalium/tilize_utils.hpp>
 #include <tt-metalium/work_split.hpp>
-
-#include "ttnn/operations/cb_utils.hpp"
-#include "ttnn/operations/data_movement/indexed_fill/device/indexed_fill_utils.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-namespace {
-
-// Kernel mode encoding passed as compile-time arg 3 (see indexed_fill_reader.cpp header).
-// TODO: upgrade to two-vector RuntimeTensorShape pattern (mirrors unary_ng / binary_ng)
-constexpr uint32_t MODE_GENERIC = 0;
-constexpr uint32_t MODE_NATIVE = 1;
-constexpr uint32_t MODE_SHARD_LOCAL_INTERLEAVED_B = 2;
-constexpr uint32_t MODE_SHARD_LOCAL_SHARDED_B = 3;
-
-// Geometry shared between create() and override_runtime_arguments().
-struct IndexedFillGeometry {
-    uint32_t outer_count;
-    uint32_t inner_count;
-    uint32_t S_dim;
-    uint32_t outer_stride_a;  // doubles as output stride: output shape == input_a shape
-    uint32_t outer_stride_b;
-    uint32_t shard_ppb;
-    uint32_t total_batches_per_core;
-};
-
-IndexedFillGeometry compute_geometry(
-    const Tensor& input_a, int64_t dim, uint32_t b, uint32_t B, bool is_tile, bool is_shard_local) {
-    const int64_t rank = static_cast<int64_t>(input_a.padded_shape().rank());
-    const int64_t page_boundary = is_tile ? rank - 2 : rank - 1;
-
-    uint32_t outer_count = 1;
-    for (int64_t i = 0; i < dim; ++i) {
-        outer_count *= input_a.padded_shape()[i];
-    }
-
-    uint32_t inner_count = 1;
-    for (int64_t i = dim + 1; i < page_boundary; ++i) {
-        inner_count *= input_a.padded_shape()[i];
-    }
-    if (is_tile) {
-        inner_count *= (input_a.padded_shape()[rank - 2] / tt::constants::TILE_HEIGHT) *
-                       (input_a.padded_shape()[rank - 1] / tt::constants::TILE_WIDTH);
-    }
-
-    const uint32_t S_dim = input_a.padded_shape()[dim];
-
-    uint32_t shard_ppb = 0;
-    uint32_t total_batches_per_core = 0;
-    if (is_shard_local) {
-        const auto& shard_spec = *input_a.memory_config().shard_spec();
-        const uint32_t shard_width = shard_spec.shape[1];
-        // Rank-4 assumed ([B, H, W, D]); enforced by validate_on_program_cache_miss.
-        const uint32_t H_N = input_a.padded_shape()[1] * input_a.padded_shape()[2];
-        if (is_tile) {
-            shard_ppb = (H_N / tt::constants::TILE_HEIGHT) * (shard_width / tt::constants::TILE_WIDTH);
-        } else {
-            shard_ppb = H_N;
-        }
-        using tt::tt_metal::TensorMemoryLayout;
-        if (input_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
-            total_batches_per_core = B;
-        } else {
-            total_batches_per_core = B / shard_spec.grid.bounding_box().grid_size().y;
-        }
-    }
-
-    const uint32_t outer_stride_a = S_dim * inner_count;
-    return {
-        .outer_count = outer_count,
-        .inner_count = inner_count,
-        .S_dim = S_dim,
-        .outer_stride_a = outer_stride_a,
-        .outer_stride_b = b * inner_count,
-        .shard_ppb = shard_ppb,
-        .total_batches_per_core = total_batches_per_core,
-    };
-}
-
-// Column-offset args for the shard-local INTERLEAVED-B reader path.
-struct ShardColOffsets {
-    uint32_t b_full_ppb;
-    uint32_t shard_tile_w;
-    uint32_t full_tile_w;
-    uint32_t col_page_offset;
-    uint32_t col_byte_offset;
-};
-
-ShardColOffsets compute_shard_col_offsets(
-    const Tensor& input_a, const tt::tt_metal::ShardSpec& shard_spec, uint32_t cx, bool is_tile) {
-    // Rank-4 assumed ([B, H, W, D]); enforced by validate_on_program_cache_miss.
-    const uint32_t b_full_ppb =
-        is_tile ? (input_a.padded_shape()[1] * input_a.padded_shape()[2] / tt::constants::TILE_HEIGHT) *
-                      (input_a.padded_shape()[-1] / tt::constants::TILE_WIDTH)
-                : input_a.padded_shape()[1] * input_a.padded_shape()[2];
-    const uint32_t shard_tile_w = is_tile ? (shard_spec.shape[1] / tt::constants::TILE_WIDTH) : 1u;
-    const uint32_t full_tile_w = is_tile ? (input_a.padded_shape()[-1] / tt::constants::TILE_WIDTH) : 1u;
-    return {
-        .b_full_ppb = b_full_ppb,
-        .shard_tile_w = shard_tile_w,
-        .full_tile_w = full_tile_w,
-        .col_page_offset = is_tile ? cx * shard_tile_w : 0u,
-        .col_byte_offset = !is_tile ? cx * shard_spec.shape[1] * input_a.element_size() : 0u,
-    };
-}
-
-}  // namespace
-
-IndexedFillProgramFactory::cached_program_t IndexedFillProgramFactory::create(
-    const IndexedFillParams& operation_attributes, const IndexedFillInputs& tensor_args, Tensor& output) {
+ProgramDescriptor IndexedFillProgramFactory::create_descriptor(
+    const IndexedFillParams& /*operation_attributes*/, const IndexedFillInputs& tensor_args, Tensor& output) {
     const auto& batch_ids = tensor_args.batch_id;
     const auto& input_a = tensor_args.input_tensor_a;
     const auto& input_b = tensor_args.input_tensor_b;
 
-    Program program{};
+    IDevice* device = input_a.device();
 
-    const int64_t dim = operation_attributes.dim;
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    auto set_of_core_ranges = num_cores_to_corerangeset(num_cores_x * num_cores_y, compute_with_storage_grid_size);
+    CoreRangeSet all_cores(set_of_core_ranges);
 
-    const uint32_t B = input_a.padded_shape()[0];
-    // `b` = number of replacement slices = size of target dimension in input_b.
-    const uint32_t b = static_cast<uint32_t>(input_b.padded_shape()[dim]);
+    uint32_t B = input_a.padded_shape()[0];
+    uint32_t b = input_b.padded_shape()[0];
 
     TT_ASSERT(batch_ids.padded_shape()[-1] == b);
 
-    // Worker grid: set by get_indexed_fill_worker_grid (always non-empty).
-    const CoreRangeSet all_cores = operation_attributes.worker_grid;
-    auto cores = corerange_to_cores(all_cores, std::nullopt, /*row_wise=*/true);
-    const uint32_t num_cores_total = static_cast<uint32_t>(cores.size());
+    // parallelize across batch
+    constexpr uint32_t cb_index = 0;
+    constexpr uint32_t batch_cb_index = 1;
 
-    const uint32_t cb_index = 0;
-    const uint32_t batch_cb_index = 1;
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_a.dtype());
+    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_a.dtype());
 
-    const bool is_tile = input_a.layout() == Layout::TILE;
+    uint32_t page_size = input_a.padded_shape()[-1] * input_a.element_size();
+    uint32_t rounded_page_size = round_up_to_mul32(page_size);
+    uint32_t batch_page_size = round_up_to_mul32(b * sizeof(uint32_t));
 
-    // -----------------------------------------------------------------------------------
-    // Path selection
-    // -----------------------------------------------------------------------------------
-    // Native HEIGHT_SHARDED and shard-local WIDTH/BLOCK_SHARDED paths are designed around
-    // dim=0 (one shard per batch).  For dim != 0 the shard grid does not align with the
-    // target dimension, so always use the generic 2D-stride path instead.
-    const bool is_native = (dim == 0) && ttnn::operations::data_movement::indexed_fill::is_native_indexed_fill_sharding(
-                                             input_a.tensor_spec(),
-                                             input_b.tensor_spec(),
-                                             batch_ids.tensor_spec(),
-                                             operation_attributes.output_mem_config);
+    ProgramDescriptor desc;
 
-    const bool is_shard_local =
-        (dim == 0) && !is_native &&
-        ttnn::operations::data_movement::indexed_fill::is_shard_local_indexed_fill(
-            input_a.tensor_spec(), input_b.tensor_spec(), operation_attributes.output_mem_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * rounded_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_index),
+            .data_format = cb_data_format,
+            .page_size = rounded_page_size,
+        }}},
+    });
 
-    const bool b_same_sharded =
-        is_shard_local && input_b.is_sharded() && input_b.memory_config().shard_spec().has_value() &&
-        input_b.memory_config().shard_spec()->grid == input_a.memory_config().shard_spec()->grid;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * batch_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(batch_cb_index),
+            .data_format = cb_data_format,
+            .page_size = batch_page_size,
+        }}},
+    });
 
-    uint32_t kernel_mode = MODE_GENERIC;
-    if (is_native) {
-        kernel_mode = MODE_NATIVE;
-    } else if (is_shard_local) {
-        kernel_mode = b_same_sharded ? MODE_SHARD_LOCAL_SHARDED_B : MODE_SHARD_LOCAL_INTERLEAVED_B;
-    }
+    Buffer* batch_ids_buffer = batch_ids.buffer();
+    Buffer* input_a_buffer = input_a.buffer();
+    Buffer* input_b_buffer = input_b.buffer();
+    Buffer* output_buffer = output.buffer();
 
-    // -----------------------------------------------------------------------------------
-    // Page geometry
-    //
-    // Full-tensor geometry (native / generic paths):
-    //   page_size  = one full row (ROW_MAJOR) or one tile (TILE)
-    //   inner_count = pages per (outer, slice) pair (== pages per batch for dim=0)
-    //
-    // Shard-local geometry (shard_local path):
-    //   shard_page_size = shard_width * elem_size (ROW_MAJOR) or tile_size (TILE)
-    //   shard_ppb       = pages per batch within this shard
-    //   total_batches   = B (WIDTH) or B/n_y (BLOCK) per core
-    // -----------------------------------------------------------------------------------
-    const auto geo = compute_geometry(input_a, dim, b, B, is_tile, is_shard_local);
-    const uint32_t outer_count = geo.outer_count;
-    const uint32_t inner_count = geo.inner_count;
-    const uint32_t S_dim = geo.S_dim;
-    const uint32_t outer_stride_a = geo.outer_stride_a;
-    const uint32_t outer_stride_b = geo.outer_stride_b;
-    const uint32_t shard_ppb = geo.shard_ppb;
-    const uint32_t total_batches_per_core = geo.total_batches_per_core;
+    // Reader compile-time args + tensor accessor args for batch_ids, input_a, input_b
+    std::vector<uint32_t> reader_compile_time_args = {cb_index, batch_cb_index, page_size};
+    TensorAccessorArgs(*input_a_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*input_b_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*batch_ids_buffer).append_to(reader_compile_time_args);
 
-    // Generic path: distribute S_dim slices across num_cores_total cores using ceiling-division.
-    // Cores [0, extra) receive slices_per_core + 1 slices; others receive slices_per_core.
-    // When S_dim < num_cores_total, cores with index >= S_dim receive num_slices == 0 (idle).
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/kernels/dataflow/indexed_fill_reader.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    uint32_t page_size = 0;
-    if (is_tile) {
-        page_size = tt::tile_size(cb_data_format);
-    } else {
-        page_size = input_a.padded_shape()[-1] * input_a.element_size();
-    }
-    const uint32_t rounded_page_size = is_tile ? page_size : round_up_to_mul32(page_size);
+    std::vector<uint32_t> writer_compile_time_args = {cb_index, page_size};
+    TensorAccessorArgs(*output_buffer).append_to(writer_compile_time_args);
 
-    uint32_t shard_page_size = 0;
-    if (is_shard_local) {
-        const auto& shard_spec = *input_a.memory_config().shard_spec();
-        const uint32_t shard_width = shard_spec.shape[1];
-        shard_page_size = is_tile ? tt::tile_size(cb_data_format) : shard_width * input_a.element_size();
-    }
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = "ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    // Use shard geometry for the kernel when on the shard_local path.
-    const uint32_t kernel_page_size = is_shard_local ? shard_page_size : page_size;
-    const uint32_t kernel_rounded_page_size = is_shard_local ? round_up_to_mul32(shard_page_size) : rounded_page_size;
-    const uint32_t batch_size_in_pages = is_shard_local ? shard_ppb : inner_count;
+    auto cores = grid_to_cores(num_cores_x * num_cores_y, num_cores_x, num_cores_y, false);
 
-    // -----------------------------------------------------------------------------------
-    // Data CB (cb_index == 0).
-    //
-    // Native / shard-local path: globally allocate to the output buffer so reader writes
-    // land directly in the output's per-core L1 shard, and the writer becomes a tiny
-    // wait/pop stub. The CB must hold one full shard.
-    //
-    // Fallback path: local CB with the original double-buffered (2-page) capacity.
-    // -----------------------------------------------------------------------------------
-    CBHandle cb_data_handle{};
-    if (is_native) {
-        auto [_, handle] = create_cb(
-            cb_index,
-            program,
-            all_cores,
-            kernel_rounded_page_size,
-            batch_size_in_pages,
-            cb_data_format,
-            output.buffer());
-        cb_data_handle = handle;
-    } else if (is_shard_local) {
-        const uint32_t total_pages_in_shard = total_batches_per_core * shard_ppb;
-        auto [_, handle] = create_cb(
-            cb_index,
-            program,
-            all_cores,
-            kernel_rounded_page_size,
-            total_pages_in_shard,
-            cb_data_format,
-            output.buffer());
-        cb_data_handle = handle;
-    } else {
-        CircularBufferConfig cb_src0_config =
-            CircularBufferConfig(2 * kernel_rounded_page_size, {{cb_index, cb_data_format}})
-                .set_page_size(cb_index, kernel_rounded_page_size);
-        cb_data_handle = CreateCircularBuffer(program, all_cores, cb_src0_config);
-    }
+    uint32_t batch_size_in_sticks = input_a.padded_shape()[1] * input_a.padded_shape()[2];
 
-    const uint32_t batch_page_size = round_up_to_mul32(b * sizeof(uint32_t));
-    CircularBufferConfig batch_cb_config = CircularBufferConfig(2 * batch_page_size, {{batch_cb_index, cb_data_format}})
-                                               .set_page_size(batch_cb_index, batch_page_size);
-    CreateCircularBuffer(program, all_cores, batch_cb_config);
-
-    KernelHandle reader_kernel_id{};
-    KernelHandle writer_kernel_id{};
-
-    // ---- Reader: single unified kernel; path selected via `mode` compile-time arg.
-    {
-        std::vector<uint32_t> reader_compile_time_args = {
-            static_cast<uint32_t>(cb_index), static_cast<uint32_t>(batch_cb_index), kernel_page_size, kernel_mode};
-        TensorAccessorArgs(*input_a.buffer()).append_to(reader_compile_time_args);
-        TensorAccessorArgs(*input_b.buffer()).append_to(reader_compile_time_args);
-        TensorAccessorArgs(*batch_ids.buffer()).append_to(reader_compile_time_args);
-
-        reader_kernel_id = CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/kernels/dataflow/indexed_fill_reader.cpp",
-            all_cores,
-            ReaderDataMovementConfig(reader_compile_time_args));
-    }
-
-    // ---- Writer
-    if (is_native || is_shard_local) {
-        // CB is aliased to the output buffer: writer just synchronises on the CB.
-        std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(cb_index)};
-        writer_kernel_id = CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/kernels/dataflow/"
-            "indexed_fill_writer.cpp",
-            all_cores,
-            WriterDataMovementConfig(writer_compile_time_args));
-    } else {
-        // Generic path: scatter-write via the strided writer kernel.
-        std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(cb_index)};
-        TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
-        writer_kernel_id = CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/kernels/dataflow/"
-            "indexed_fill_writer_strided.cpp",
-            all_cores,
-            WriterDataMovementConfig(writer_compile_time_args));
-    }
-
-    // ---- Per-core runtime arguments
-    // Work-splitting for the generic path: distribute S_dim slices across available cores.
-    const uint32_t slices_per_core = (num_cores_total > 0) ? S_dim / num_cores_total : 0;
-    const uint32_t extra_slices = (num_cores_total > 0) ? S_dim % num_cores_total : 0;
-
-    const uint32_t shard_n_x = is_shard_local ? all_cores.bounding_box().grid_size().x : 0;
-
-    // Precompute per-column offsets for the shard-local path: only shard_n_x unique cx values
-    // exist, but the loop runs over all n_x * n_y cores. Avoids redundant recomputation for
-    // every core in the same column.
-    std::vector<ShardColOffsets> col_offsets;
-    if (is_shard_local && shard_n_x > 0) {
-        const auto& shard_spec_pre = *input_a.memory_config().shard_spec();
-        col_offsets.resize(shard_n_x);
-        for (uint32_t cx = 0; cx < shard_n_x; ++cx) {
-            col_offsets[cx] = compute_shard_col_offsets(input_a, shard_spec_pre, cx, is_tile);
-        }
-    }
-
-    for (uint32_t i = 0; i < num_cores_total; ++i) {
+    for (uint32_t i = 0; i < cores.size(); ++i) {
         const CoreCoord& core = cores[i];
-
-        if (is_native) {
-            const bool active = i < B;
-            const uint32_t local_b = active ? b : 0;
-            const uint32_t local_batch_size = active ? batch_size_in_pages : 0;
-
-            // input_a's per-core L1 base is the same address value on every core in the
-            // shard grid (sharded L1 buffers allocate a per-core L1 slot at a uniform offset).
-            const std::array reader_runtime_args = {
-                batch_ids.buffer()->address(),
-                local_b,
-                input_a.buffer()->address(),
-                input_b.buffer()->address(),
-                local_batch_size,
-                i,
-                0u,  // batch_offset_a (unused in native mode)
-                0u   // total_local_batches (unused in native mode)
-            };
-            SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-
-            const std::array writer_runtime_args = {local_batch_size};
-            SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
-
-        } else if (is_shard_local) {
-            // Shard row/col for BLOCK_SHARDED: indices within the shard grid bounding box.
-            const uint32_t shard_row = (shard_n_x > 0) ? (i / shard_n_x) : 0;
-            const uint32_t cx = (shard_n_x > 0) ? (i % shard_n_x) : 0;
-            const uint32_t batch_offset_a = shard_row * total_batches_per_core;
-            const uint32_t total_pages_in_shard = total_batches_per_core * shard_ppb;
-
-            // Args 8-12: column-offset state for the INTERLEAVED_B read path (precomputed above).
-            const auto& col = col_offsets[cx];
-
-            const std::array reader_runtime_args = {
-                batch_ids.buffer()->address(),
-                b,
-                input_a.buffer()->address(),
-                input_b.buffer()->address(),
-                shard_ppb,  // batch_size_in_pages == shard_ppb for this path
-                0u,         // my_batch_id (unused in shard_local mode)
-                batch_offset_a,
-                total_batches_per_core,
-                col.b_full_ppb,
-                col.shard_tile_w,
-                col.full_tile_w,
-                col.col_page_offset,
-                col.col_byte_offset};
-            SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-
-            const std::array writer_runtime_args = {total_pages_in_shard};
-            SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
-
+        if (i < B) {
+            // Active core: real work + Buffer* bindings for fast cache-hit patching.
+            reader_desc.emplace_runtime_args(
+                core, {batch_ids_buffer, b, input_a_buffer, input_b_buffer, batch_size_in_sticks, i});
+            writer_desc.emplace_runtime_args(
+                core, {output_buffer, page_size, batch_size_in_sticks, i * batch_size_in_sticks});
         } else {
-            // Generic 2D-stride path: each core handles a contiguous range of slices.
-            uint32_t slice_start, num_slices;
-            if (i < extra_slices) {
-                slice_start = i * (slices_per_core + 1);
-                num_slices = slices_per_core + 1;
-            } else if (slices_per_core > 0) {
-                slice_start = extra_slices * (slices_per_core + 1) + (i - extra_slices) * slices_per_core;
-                num_slices = slices_per_core;
-            } else {
-                // S_dim < num_cores_total: core i >= S_dim is idle.
-                slice_start = S_dim;
-                num_slices = 0;
-            }
-
-            const std::array reader_runtime_args = {
-                batch_ids.buffer()->address(),
-                b,  // arg[1] = b (kernel exits early when num_slices == 0)
-                input_a.buffer()->address(),
-                input_b.buffer()->address(),
-                inner_count,     // arg[4] = inner_count
-                slice_start,     // arg[5] = slice_start (first slice for this core)
-                outer_count,     // arg[6] = outer_count
-                outer_stride_a,  // arg[7]
-                outer_stride_b,  // arg[8]
-                num_slices,      // arg[9] = num_slices (NEW: number of slices for this core)
-            };
-            SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-
-            const std::array writer_runtime_args = {
-                output.buffer()->address(),
-                kernel_page_size,
-                outer_count,     // arg[2]
-                inner_count,     // arg[3]
-                outer_stride_a,  // arg[4] = outer stride in output
-                slice_start,     // arg[5] = slice_start (first slice for this core)
-                num_slices,      // arg[6] = num_slices (NEW)
-            };
-            SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+            // Idle core: short-circuits because local_b/local_batch_size_in_sticks are 0.
+            // Pass plain 0u for buffer slots so we don't register a BufferBinding here —
+            // those bindings would force the framework to do a GetRuntimeArgs lookup on
+            // every cache hit for cores that never read/write the buffer.  The kernel
+            // ignores the address when its work count is 0.
+            reader_desc.emplace_runtime_args(core, {0u, 0u, 0u, 0u, 0u, i});
+            writer_desc.emplace_runtime_args(core, {0u, page_size, 0u, 0u});
         }
     }
 
-    return cached_program_t{
-        std::move(program),
-        IndexedFillSharedVariables{
-            .reader_kernel_id = reader_kernel_id,
-            .writer_kernel_id = writer_kernel_id,
-            .cores = std::move(cores),
-            .page_size = kernel_page_size,
-            .is_native = is_native,
-            .is_shard_local = is_shard_local,
-            .is_tile = is_tile,
-            .cb_data_handle = cb_data_handle,
-        }};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void IndexedFillProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const IndexedFillParams& operation_attributes,
-    const IndexedFillInputs& tensor_args,
-    Tensor& output) {
-    const auto& batch_ids = tensor_args.batch_id;
-    const auto& input_a = tensor_args.input_tensor_a;
-    const auto& input_b = tensor_args.input_tensor_b;
-
-    auto& program = cached_program.program;
-    const auto& cores = cached_program.shared_variables.cores;
-    const auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    const auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    const auto& kernel_page_size = cached_program.shared_variables.page_size;
-    const bool is_native = cached_program.shared_variables.is_native;
-    const bool is_shard_local = cached_program.shared_variables.is_shard_local;
-
-    const int64_t dim = operation_attributes.dim;
-
-    const uint32_t B = input_a.padded_shape()[0];
-    const uint32_t b = static_cast<uint32_t>(input_b.padded_shape()[dim]);
-    const bool is_tile = cached_program.shared_variables.is_tile;
-
-    const auto geo = compute_geometry(input_a, dim, b, B, is_tile, is_shard_local);
-    const uint32_t outer_count = geo.outer_count;
-    const uint32_t inner_count = geo.inner_count;
-    const uint32_t S_dim = geo.S_dim;
-    const uint32_t outer_stride_a = geo.outer_stride_a;
-    const uint32_t outer_stride_b = geo.outer_stride_b;
-    const uint32_t shard_ppb = geo.shard_ppb;
-    const uint32_t total_batches_per_core = geo.total_batches_per_core;
-    const uint32_t batch_size_in_pages = inner_count;
-
-    // Work-splitting for the generic path (same formula as in create()).
-    const uint32_t num_cores = static_cast<uint32_t>(cores.size());
-    const uint32_t slices_per_core_ov = (num_cores > 0) ? S_dim / num_cores : 0;
-    const uint32_t extra_slices_ov = (num_cores > 0) ? S_dim % num_cores : 0;
-
-    uint32_t shard_n_x = 0;
-    if (is_shard_local) {
-        shard_n_x = static_cast<uint32_t>(input_a.memory_config().shard_spec()->grid.bounding_box().grid_size().x);
-    }
-
-    // Native / shard-local: re-point the data CB at the (possibly moved) output buffer.
-    if (is_native || is_shard_local) {
-        UpdateDynamicCircularBufferAddress(program, cached_program.shared_variables.cb_data_handle, *output.buffer());
-    }
-
-    // Precompute per-column offsets for the shard-local path (same reasoning as in create()).
-    std::vector<ShardColOffsets> col_offsets;
-    if (is_shard_local && shard_n_x > 0) {
-        const auto& shard_spec_pre = *input_a.memory_config().shard_spec();
-        col_offsets.resize(shard_n_x);
-        for (uint32_t cx = 0; cx < shard_n_x; ++cx) {
-            col_offsets[cx] = compute_shard_col_offsets(input_a, shard_spec_pre, cx, is_tile);
-        }
-    }
-
-    uint32_t core_id = 0;
-    for (const auto& core : cores) {
-        if (is_native) {
-            const bool active = core_id < B;
-            const uint32_t local_b = active ? b : 0;
-            const uint32_t local_batch_size = active ? batch_size_in_pages : 0;
-
-            const std::array reader_runtime_args = {
-                batch_ids.buffer()->address(),
-                local_b,
-                input_a.buffer()->address(),
-                input_b.buffer()->address(),
-                local_batch_size,
-                core_id,
-                0u,
-                0u};
-            SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-            const std::array writer_runtime_args = {local_batch_size};
-            SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
-
-        } else if (is_shard_local) {
-            const uint32_t shard_row = (shard_n_x > 0) ? (core_id / shard_n_x) : 0;
-            const uint32_t cx = (shard_n_x > 0) ? (core_id % shard_n_x) : 0;
-            const uint32_t batch_offset_a = shard_row * total_batches_per_core;
-            const uint32_t total_pages_in_shard = total_batches_per_core * shard_ppb;
-
-            const auto& col = col_offsets[cx];
-
-            const std::array reader_runtime_args = {
-                batch_ids.buffer()->address(),
-                b,
-                input_a.buffer()->address(),
-                input_b.buffer()->address(),
-                shard_ppb,
-                0u,
-                batch_offset_a,
-                total_batches_per_core,
-                col.b_full_ppb,
-                col.shard_tile_w,
-                col.full_tile_w,
-                col.col_page_offset,
-                col.col_byte_offset};
-            SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-            const std::array writer_runtime_args = {total_pages_in_shard};
-            SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
-
-        } else {
-            // Generic 2D-stride path: same work-splitting as create().
-            uint32_t slice_start, num_slices;
-            if (core_id < extra_slices_ov) {
-                slice_start = core_id * (slices_per_core_ov + 1);
-                num_slices = slices_per_core_ov + 1;
-            } else if (slices_per_core_ov > 0) {
-                slice_start =
-                    extra_slices_ov * (slices_per_core_ov + 1) + (core_id - extra_slices_ov) * slices_per_core_ov;
-                num_slices = slices_per_core_ov;
-            } else {
-                slice_start = S_dim;
-                num_slices = 0;
-            }
-
-            const std::array reader_runtime_args = {
-                batch_ids.buffer()->address(),
-                b,
-                input_a.buffer()->address(),
-                input_b.buffer()->address(),
-                inner_count,
-                slice_start,
-                outer_count,
-                outer_stride_a,
-                outer_stride_b,
-                num_slices,
-            };
-            SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-            const std::array writer_runtime_args = {
-                output.buffer()->address(),
-                kernel_page_size,
-                outer_count,
-                inner_count,
-                outer_stride_a,
-                slice_start,
-                num_slices,
-            };
-            SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
-        }
-        core_id++;
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_program_factory.hpp
@@ -4,38 +4,15 @@
 
 #pragma once
 
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/operations/data_movement/indexed_fill/device/indexed_fill_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
-struct IndexedFillSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id{};
-    tt::tt_metal::KernelHandle writer_kernel_id{};
-    std::vector<CoreCoord> cores;
-    uint32_t page_size = 0;
-    // When true, override_runtime_arguments must call UpdateDynamicCircularBufferAddress on
-    // cb_data_handle to keep the cached program's CB base in sync with the output buffer.
-    bool is_native = false;
-    // Like is_native the data CB is aliased to the output buffer, but the kernel iterates
-    // over all batches per core (WIDTH_SHARDED / BLOCK_SHARDED path).
-    bool is_shard_local = false;
-    bool is_tile = false;
-    tt::tt_metal::CBHandle cb_data_handle{};
-};
-
 struct IndexedFillProgramFactory {
-    using shared_variables_t = IndexedFillSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const IndexedFillParams& operation_attributes, const IndexedFillInputs& tensor_args, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const IndexedFillParams& operation_attributes,
-        const IndexedFillInputs& tensor_args,
-        Tensor& output);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_device_operation.hpp
@@ -7,6 +7,8 @@
 #include <variant>
 #include <optional>
 
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/core.hpp"
@@ -38,31 +40,11 @@ struct MoeExpertTokenRemapDeviceOperation {
     using tensor_return_value_t = std::vector<ttnn::Tensor>;
 
     struct Multicore {
-        // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle ternary_reader_kernel_id;
-            tt::tt_metal::KernelHandle binary_writer_kernel_id;
-            std::vector<CoreCoord> utilized_cores;
-        };
-        using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-        static cached_mesh_workload_t create_mesh_workload(
-            const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinateRangeSet& tensor_coords,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-            const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinate& mesh_coordinate,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_mesh_workload_t& cached_workload,
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
+            tensor_return_value_t& tensor_return_value,
+            const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
     };
 
     using program_factory_t = std::variant<Multicore>;

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_program_factory.cpp
@@ -3,36 +3,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/hal.hpp>
-#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/tt_align.hpp>
+#include <tt-metalium/work_split.hpp>
 
 #include "moe_expert_token_remap_device_operation.hpp"
 
 namespace ttnn::operations::data_movement {
 
-MoeExpertTokenRemapDeviceOperation::Multicore::cached_mesh_workload_t
-MoeExpertTokenRemapDeviceOperation::Multicore::create_mesh_workload(
-    const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(operation_attributes, coord, tensor_args, tensor_return_value);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(coord, std::move(cached_program.shared_variables));
-    }
-    return cached_mesh_workload_t(std::move(workload), std::move(shared_variables));
-}
+using namespace tt::tt_metal;
 
-ttnn::device_operation::CachedProgram<MoeExpertTokenRemapDeviceOperation::Multicore::shared_variables_t>
-MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
+ProgramDescriptor MoeExpertTokenRemapDeviceOperation::Multicore::create_descriptor(
     const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinate& mesh_coordinate,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    tensor_return_value_t& tensor_return_value,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
     const auto& metadata_tensor = tensor_args.metadata_tensor;
     const auto& mapping_tensor = tensor_args.mapping_tensor;
     const auto& topk_tensor = tensor_args.topk_tensor;
@@ -62,7 +49,7 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
     const auto output_mapping_page_size_bytes = output_mapping_tensor.tensor_spec().compute_page_size_bytes();
     const auto output_reduced_page_size_bytes = output_reduced_tensor.tensor_spec().compute_page_size_bytes();
 
-    Program program{};
+    ProgramDescriptor desc;
 
     // todo maybe, subdevice
     auto* mesh_device = topk_tensor.device();
@@ -73,15 +60,18 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
     uint32_t num_cores_y = grid.y;
     CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
 
-    using tt::tt_metal::CircularBufferConfig;
-
     // full mapping buffer
     const auto mapping_data_format = datatype_to_dataformat_converter(mapping_tensor.dtype());
     const auto mapping_tensor_cb_id = tt::CBIndex::c_0;
-    CircularBufferConfig cb_mapping_tensor_config =
-        CircularBufferConfig(aligned_mapping_page_size_bytes, {{mapping_tensor_cb_id, mapping_data_format}})
-            .set_page_size(mapping_tensor_cb_id, aligned_mapping_page_size_bytes);
-    CreateCircularBuffer(program, total_cores, cb_mapping_tensor_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = aligned_mapping_page_size_bytes,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(mapping_tensor_cb_id),
+            .data_format = mapping_data_format,
+            .page_size = aligned_mapping_page_size_bytes,
+        }}},
+    });
 
     // scratch space to store and share indices of per device experts
     const auto local_experts_cb_id = tt::CBIndex::c_1;
@@ -90,48 +80,75 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
         tt::align(experts_per_device * sizeof(local_experts_t), l1_alignment);
     const auto local_experts_dataformat =
         datatype_to_dataformat_converter(tt::tt_metal::convert_to_data_type<local_experts_t>());
-    CircularBufferConfig cb_local_experts_config =
-        CircularBufferConfig(aligned_local_expert_page_size_bytes, {{local_experts_cb_id, local_experts_dataformat}})
-            .set_page_size(local_experts_cb_id, aligned_local_expert_page_size_bytes);
-    CreateCircularBuffer(program, total_cores, cb_local_experts_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = aligned_local_expert_page_size_bytes,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(local_experts_cb_id),
+            .data_format = local_experts_dataformat,
+            .page_size = aligned_local_expert_page_size_bytes,
+        }}},
+    });
 
     // metadata page buffer
     constexpr uint32_t metadata_buffer_factor = 1;
     const auto metadata_data_format = datatype_to_dataformat_converter(metadata_tensor.dtype());
     const auto metadata_cb_id = tt::CBIndex::c_2;
-    CircularBufferConfig cb_metadata_config =
-        CircularBufferConfig(
-            metadata_buffer_factor * aligned_metadata_page_size_bytes, {{metadata_cb_id, metadata_data_format}})
-            .set_page_size(metadata_cb_id, aligned_metadata_page_size_bytes);
-    CreateCircularBuffer(program, total_cores, cb_metadata_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = metadata_buffer_factor * aligned_metadata_page_size_bytes,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(metadata_cb_id),
+            .data_format = metadata_data_format,
+            .page_size = aligned_metadata_page_size_bytes,
+        }}},
+    });
 
     // topk page buffer
     constexpr uint32_t topk_buffer_factor = 2;
     const auto topk_data_format = datatype_to_dataformat_converter(topk_tensor.dtype());
     const auto topk_cb_id = tt::CBIndex::c_3;
-    CircularBufferConfig cb_topk_config =
-        CircularBufferConfig(topk_buffer_factor * aligned_topk_page_size_bytes, {{topk_cb_id, topk_data_format}})
-            .set_page_size(topk_cb_id, aligned_topk_page_size_bytes);
-    CreateCircularBuffer(program, total_cores, cb_topk_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = topk_buffer_factor * aligned_topk_page_size_bytes,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(topk_cb_id),
+            .data_format = topk_data_format,
+            .page_size = aligned_topk_page_size_bytes,
+        }}},
+    });
 
     // output mapping staging buffer
     const auto output_mapping_data_format = datatype_to_dataformat_converter(output_mapping_tensor.dtype());
     const auto output_mapping_cb_id = tt::CBIndex::c_4;
-    CircularBufferConfig cb_output_mapping_config =
-        CircularBufferConfig(output_mapping_page_size_bytes, {{output_mapping_cb_id, output_mapping_data_format}})
-            .set_page_size(output_mapping_cb_id, output_mapping_page_size_bytes);
-    CreateCircularBuffer(program, total_cores, cb_output_mapping_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = output_mapping_page_size_bytes,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_mapping_cb_id),
+            .data_format = output_mapping_data_format,
+            .page_size = output_mapping_page_size_bytes,
+        }}},
+    });
 
     // output reduced staging buffer
     const auto output_reduced_data_format = datatype_to_dataformat_converter(output_reduced_tensor.dtype());
     const auto output_reduced_cb_id = tt::CBIndex::c_5;
-    CircularBufferConfig cb_output_reduced_config =
-        CircularBufferConfig(output_reduced_page_size_bytes, {{output_reduced_cb_id, output_reduced_data_format}})
-            .set_page_size(output_reduced_cb_id, output_reduced_page_size_bytes);
-    CreateCircularBuffer(program, total_cores, cb_output_reduced_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = output_reduced_page_size_bytes,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_reduced_cb_id),
+            .data_format = output_reduced_data_format,
+            .page_size = output_reduced_page_size_bytes,
+        }}},
+    });
 
     const auto& mesh_view = mesh_device->get_view();
-    const uint32_t flat_mesh_idx = (mesh_coordinate[0] * mesh_view.num_cols()) + mesh_coordinate[1];
+    // Mesh dispatch coordinate is supplied by the framework via the per-coord
+    // descriptor adapter path. Fall back to {0,0} if absent (single-device case).
+    const auto coord = mesh_dispatch_coordinate.value_or(ttnn::MeshCoordinate{0, 0});
+    const uint32_t flat_mesh_idx = (coord[0] * mesh_view.num_cols()) + coord[1];
 
     // slightly abusing this functionality since here we also have a single page if any experts are activated
     constexpr bool local_reduce = true;
@@ -150,15 +167,17 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
         mapping_page_size_bytes,
         metadata_page_size_bytes,
         local_reduce};
-    tt::tt_metal::TensorAccessorArgs(topk_tensor.buffer()).append_to(reader_ct_args);
-    tt::tt_metal::TensorAccessorArgs(mapping_tensor.buffer()).append_to(reader_ct_args);
-    tt::tt_metal::TensorAccessorArgs(metadata_tensor.buffer()).append_to(reader_ct_args);
+    TensorAccessorArgs(topk_tensor.buffer()).append_to(reader_ct_args);
+    TensorAccessorArgs(mapping_tensor.buffer()).append_to(reader_ct_args);
+    TensorAccessorArgs(metadata_tensor.buffer()).append_to(reader_ct_args);
 
-    tt::tt_metal::KernelHandle ternary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/kernels/dataflow/reader_all_to_all_combine.cpp",
-        total_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/kernels/dataflow/reader_all_to_all_combine.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = total_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
     const auto output_datum_size_bytes = tt::datum_size(output_mapping_data_format);
     const auto reduction_size = operation_attributes.reduction_size;
@@ -175,90 +194,56 @@ MoeExpertTokenRemapDeviceOperation::Multicore::create_at(
         output_reduced_page_size_bytes,
         reduction_size,
     };
-    tt::tt_metal::TensorAccessorArgs(*output_mapping_tensor.buffer()).append_to(writer_ct_args);
-    tt::tt_metal::TensorAccessorArgs(*output_reduced_tensor.buffer()).append_to(writer_ct_args);
+    TensorAccessorArgs(*output_mapping_tensor.buffer()).append_to(writer_ct_args);
+    TensorAccessorArgs(*output_reduced_tensor.buffer()).append_to(writer_ct_args);
 
-    tt::tt_metal::KernelHandle binary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/kernels/dataflow/"
-        "writer_moe_expert_token_remap.cpp",
-        total_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
+        "writer_moe_expert_token_remap.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = total_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     // split work over metadata pages (batch*seq)
     const auto num_metadata_pages = metadata_tensor.buffer()->num_pages();
 
     const auto [core_page_increments, all_cores] =
-        tt::tt_metal::split_work_to_cores_even_multiples(grid, num_metadata_pages, reduction_size);
+        split_work_to_cores_even_multiples(grid, num_metadata_pages, reduction_size);
 
-    const auto mapping_tensor_addr = mapping_tensor.buffer()->address();
-    const auto metadata_tensor_addr = metadata_tensor.buffer()->address();
-    const auto topk_tensor_addr = topk_tensor.buffer()->address();
-    const auto output_mapping_tensor_addr = output_mapping_tensor.buffer()->address();
-    const auto output_reduced_tensor_addr = output_reduced_tensor.buffer()->address();
+    Buffer* mapping_buffer = mapping_tensor.buffer();
+    Buffer* metadata_buffer = metadata_tensor.buffer();
+    Buffer* topk_buffer = topk_tensor.buffer();
+    Buffer* output_mapping_buffer = output_mapping_tensor.buffer();
+    Buffer* output_reduced_buffer = output_reduced_tensor.buffer();
 
     uint32_t page_idx_start = 0, page_idx_end = 0;
-    constexpr auto num_reader_rt_args = 5, num_writer_rt_args = 5;
     std::vector<CoreCoord> utilized_cores = corerange_to_cores(all_cores, std::nullopt);
     TT_FATAL(utilized_cores.size() == core_page_increments.size(), "Internal error");
 
     auto cit = utilized_cores.begin();
     for (auto increment : core_page_increments) {
         page_idx_end += increment;
-        const std::array<uint32_t, num_reader_rt_args> reader_runtime_args = {
-            mapping_tensor_addr, metadata_tensor_addr, topk_tensor_addr, page_idx_start, page_idx_end};
-        tt::tt_metal::SetRuntimeArgs(program, ternary_reader_kernel_id, *cit, reader_runtime_args);
+        // Buffer* entries (slots 0..2) trigger BufferBinding so the framework can
+        // patch addresses on cache hits without rebuilding the descriptor.
+        reader_desc.emplace_runtime_args(
+            *cit, {mapping_buffer, metadata_buffer, topk_buffer, page_idx_start, page_idx_end});
 
         const uint32_t reduction_idx_start = page_idx_start / reduction_size;
 
-        const std::array<uint32_t, num_writer_rt_args> writer_runtime_args = {
-            output_mapping_tensor_addr, page_idx_start, page_idx_end, output_reduced_tensor_addr, reduction_idx_start};
-
-        tt::tt_metal::SetRuntimeArgs(program, binary_writer_kernel_id, *cit, writer_runtime_args);
+        // Buffer* entries at slots 0 and 3 use BufferBinding for cache-hit address patching.
+        writer_desc.emplace_runtime_args(
+            *cit, {output_mapping_buffer, page_idx_start, page_idx_end, output_reduced_buffer, reduction_idx_start});
 
         page_idx_start += increment;
         ++cit;
     }
 
-    return {
-        std::move(program),
-        {.ternary_reader_kernel_id = ternary_reader_kernel_id,
-         .binary_writer_kernel_id = binary_writer_kernel_id,
-         .utilized_cores = utilized_cores}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
 }
 
-void MoeExpertTokenRemapDeviceOperation::Multicore::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    const auto& output_mapping_tensor = tensor_return_value.at(0);
-    const auto& output_reduced_tensor = tensor_return_value.at(1);
-
-    for (auto& [range, program] : cached_workload.workload.get_programs()) {
-        const auto& coord = range.start_coord();
-        TT_FATAL(
-            coord == range.end_coord(),
-            "Expected single coordinate per program but got range of {} to {}",
-            coord,
-            range.end_coord());
-
-        const auto& shared_variables = cached_workload.shared_variables.at(range);
-        const auto& ternary_reader_kernel_id = shared_variables.ternary_reader_kernel_id;
-        const auto& binary_writer_kernel_id = shared_variables.binary_writer_kernel_id;
-        const auto& utilized_cores = shared_variables.utilized_cores;
-
-        for (const auto& c : utilized_cores) {
-            auto& reader_runtime_args = GetRuntimeArgs(program, ternary_reader_kernel_id, c);
-            auto& writer_runtime_args = GetRuntimeArgs(program, binary_writer_kernel_id, c);
-
-            reader_runtime_args.at(0) = tensor_args.mapping_tensor.buffer()->address();
-            reader_runtime_args.at(1) = tensor_args.metadata_tensor.buffer()->address();
-            reader_runtime_args.at(2) = tensor_args.topk_tensor.buffer()->address();
-
-            writer_runtime_args.at(0) = output_mapping_tensor.buffer()->address();
-            writer_runtime_args.at(3) = output_reduced_tensor.buffer()->address();
-        }
-    }
-};
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.hpp
@@ -7,6 +7,8 @@
 #include <variant>
 #include <optional>
 
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/core.hpp"
@@ -37,31 +39,14 @@ struct MoeRoutingRemapDeviceOperation {
     using tensor_return_value_t = ttnn::Tensor;
 
     struct SingleCore {
-        // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
-        struct shared_variables_t {
-            tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-            tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-            ttnn::CoreCoord utilized_core;
-        };
-        using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
-
-        static cached_mesh_workload_t create_mesh_workload(
-            const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinateRangeSet& tensor_coords,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-            const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinate& mesh_coordinate,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_mesh_workload_t& cached_workload,
+        // Mesh-coord-aware overload: each program in the workload bakes in a per-device
+        // weight-count offset derived from cluster_axis + mesh_coordinate, so the
+        // descriptor framework dispatches one descriptor per coordinate.
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
+            tensor_return_value_t& tensor_return_value,
+            const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
     };
 
     using program_factory_t = std::variant<SingleCore>;

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_program_factory.cpp
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/hal.hpp>
-#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/tt_align.hpp>
 
@@ -26,29 +27,14 @@ uint32_t compute_weight_count_offset(
 
 namespace ttnn::operations::data_movement {
 
-MoeRoutingRemapDeviceOperation::SingleCore::cached_mesh_workload_t
-MoeRoutingRemapDeviceOperation::SingleCore::create_mesh_workload(
-    const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-    for (const auto& coord : tensor_coords.coords()) {
-        auto cached_program = create_at(operation_attributes, coord, tensor_args, tensor_return_value);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(coord, cached_program.shared_variables);
-    }
-    return cached_mesh_workload_t(std::move(workload), std::move(shared_variables));
-}
+using namespace tt::tt_metal;
 
-ttnn::device_operation::CachedProgram<MoeRoutingRemapDeviceOperation::SingleCore::shared_variables_t>
-MoeRoutingRemapDeviceOperation::SingleCore::create_at(
+ProgramDescriptor MoeRoutingRemapDeviceOperation::SingleCore::create_descriptor(
     const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinate& mesh_coordinate,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    const auto routing_weights = tensor_args.input_routing_weights;
+    tensor_return_value_t& tensor_return_value,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    const auto& routing_weights = tensor_args.input_routing_weights;
     const auto non_zero_weight_size = operation_attributes.non_zero_weight_size;
     const auto expert_parallel_size = operation_attributes.expert_parallel_size;
     const auto cluster_axis = operation_attributes.cluster_axis;
@@ -61,18 +47,23 @@ MoeRoutingRemapDeviceOperation::SingleCore::create_at(
     const auto aligned_routing_weight_page_size_bytes = tt::align(routing_weight_page_size_bytes, l1_alignment);
 
     // single core is fine
-    CoreRange total_cores({0, 0}, {0, 0});
-    Program program{};
+    const CoreRangeSet total_cores{CoreRange{{0, 0}, {0, 0}}};
+    const CoreCoord utilized_core{0, 0};
 
-    using tt::tt_metal::CircularBufferConfig;
+    ProgramDescriptor desc;
 
     // input routing weight buffer
     const auto routing_weights_cb_id = tt::CBIndex::c_0;
     const auto routing_weights_format = datatype_to_dataformat_converter(routing_weights.dtype());
-    CircularBufferConfig cb_routing_weights_config =
-        CircularBufferConfig(aligned_routing_weight_page_size_bytes, {{routing_weights_cb_id, routing_weights_format}})
-            .set_page_size(routing_weights_cb_id, aligned_routing_weight_page_size_bytes);
-    CreateCircularBuffer(program, total_cores, cb_routing_weights_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = aligned_routing_weight_page_size_bytes,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(routing_weights_cb_id),
+            .data_format = routing_weights_format,
+            .page_size = aligned_routing_weight_page_size_bytes,
+        }}},
+    });
 
     // store indices of per device non-zero weights
     const auto local_weights_idxs_cb_id = tt::CBIndex::c_1;
@@ -81,11 +72,15 @@ MoeRoutingRemapDeviceOperation::SingleCore::create_at(
         tt::align(non_zero_per_device * sizeof(local_weights_idxs_t), l1_alignment);
     const auto local_weights_idxs_dataformat =
         datatype_to_dataformat_converter(tt::tt_metal::convert_to_data_type<local_weights_idxs_t>());
-    CircularBufferConfig cb_local_weights_idxs_config =
-        CircularBufferConfig(
-            aligned_local_weights_idxs_page_size_bytes, {{local_weights_idxs_cb_id, local_weights_idxs_dataformat}})
-            .set_page_size(local_weights_idxs_cb_id, aligned_local_weights_idxs_page_size_bytes);
-    CreateCircularBuffer(program, total_cores, cb_local_weights_idxs_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = aligned_local_weights_idxs_page_size_bytes,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(local_weights_idxs_cb_id),
+            .data_format = local_weights_idxs_dataformat,
+            .page_size = aligned_local_weights_idxs_page_size_bytes,
+        }}},
+    });
 
     // output routing weight buffer
     const auto local_weights_cb_id = tt::CBIndex::c_2;
@@ -96,10 +91,18 @@ MoeRoutingRemapDeviceOperation::SingleCore::create_at(
 
     TT_FATAL(local_weights_format == routing_weights_format, "Input and output datatypes need to be the same");
 
-    CircularBufferConfig cb_local_weights_config =
-        CircularBufferConfig(aligned_local_weights_page_size_bytes, {{local_weights_cb_id, local_weights_format}})
-            .set_page_size(local_weights_cb_id, aligned_local_weights_page_size_bytes);
-    CreateCircularBuffer(program, total_cores, cb_local_weights_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = aligned_local_weights_page_size_bytes,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(local_weights_cb_id),
+            .data_format = local_weights_format,
+            .page_size = aligned_local_weights_page_size_bytes,
+        }}},
+    });
+
+    auto* const routing_weights_buffer = routing_weights.buffer();
+    auto* const local_weights_buffer = tensor_return_value.buffer();
 
     const auto input_datum_size_bytes = tt::datum_size(local_weights_format);
     std::vector<uint32_t> reader_ct_args = {
@@ -108,13 +111,15 @@ MoeRoutingRemapDeviceOperation::SingleCore::create_at(
         num_cluster_experts,
         non_zero_per_device,
         input_datum_size_bytes};
-    tt::tt_metal::TensorAccessorArgs(*routing_weights.buffer()).append_to(reader_ct_args);
+    TensorAccessorArgs(*routing_weights_buffer).append_to(reader_ct_args);
 
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/kernels/dataflow/reader_moe_routing_remap.cpp",
-        total_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/kernels/dataflow/reader_moe_routing_remap.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = total_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
     std::vector<uint32_t> writer_ct_args = {
         routing_weights_cb_id,
@@ -123,59 +128,33 @@ MoeRoutingRemapDeviceOperation::SingleCore::create_at(
         num_cluster_experts,
         non_zero_per_device,
         input_datum_size_bytes};
-    tt::tt_metal::TensorAccessorArgs(*tensor_return_value.buffer()).append_to(writer_ct_args);
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    TensorAccessorArgs(*local_weights_buffer).append_to(writer_ct_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/kernels/dataflow/"
-        "writer_moe_routing_remap.cpp",
-        total_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
+        "writer_moe_routing_remap.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = total_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    const auto routing_weights_addr = routing_weights.buffer()->address();
-    const auto local_weights_addr = tensor_return_value.buffer()->address();
-
+    // device_weights_count_offset is per-coord; baked into each program in the
+    // mesh workload (one descriptor per coord). Cache hits patch buffer addresses
+    // via BufferBinding and keep the per-coord offset intact.
+    TT_FATAL(mesh_dispatch_coordinate.has_value(), "MoeRoutingRemap requires a mesh dispatch coordinate");
     const auto device_weights_count_offset =
-        compute_weight_count_offset(mesh_coordinate, cluster_axis, non_zero_per_device);
+        compute_weight_count_offset(*mesh_dispatch_coordinate, cluster_axis, non_zero_per_device);
 
-    constexpr auto num_reader_rt_args = 2, num_writer_rt_args = 1;
-    const std::array<uint32_t, num_reader_rt_args> reader_runtime_args = {
-        routing_weights_addr, device_weights_count_offset};
-    tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, *total_cores.begin(), reader_runtime_args);
+    // Buffer* triggers a binding entry; the framework patches the address on
+    // cache hits without rebuilding the descriptor.
+    reader_desc.emplace_runtime_args(utilized_core, {routing_weights_buffer, device_weights_count_offset});
+    writer_desc.emplace_runtime_args(utilized_core, {local_weights_buffer});
 
-    const std::array<uint32_t, num_writer_rt_args> writer_runtime_args = {local_weights_addr};
-    tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, *total_cores.begin(), writer_runtime_args);
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-    return {
-        std::move(program),
-        {.unary_reader_kernel_id = unary_reader_kernel_id,
-         .unary_writer_kernel_id = unary_writer_kernel_id,
-         .utilized_core = *total_cores.begin()}};
+    return desc;
 }
 
-void MoeRoutingRemapDeviceOperation::SingleCore::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    for (auto& [range, program] : cached_workload.workload.get_programs()) {
-        const auto& coord = range.start_coord();
-        TT_FATAL(
-            coord == range.end_coord(),
-            "Expected single coordinate per program but got range of {} to {}",
-            coord,
-            range.end_coord());
-
-        const auto& shared_variables = cached_workload.shared_variables.at(range);
-
-        const auto& unary_reader_kernel_id = shared_variables.unary_reader_kernel_id;
-        const auto& unary_writer_kernel_id = shared_variables.unary_writer_kernel_id;
-        const auto& utilized_core = shared_variables.utilized_core;
-
-        auto& reader_runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, utilized_core);
-        auto& writer_runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, utilized_core);
-
-        reader_runtime_args.at(0) = tensor_args.input_routing_weights.buffer()->address();
-        writer_runtime_args.at(0) = tensor_return_value.buffer()->address();
-    }
-}
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_overlap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_overlap_program_factory.cpp
@@ -8,12 +8,16 @@
 #include <cmath>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/tilize_utils.hpp>
 
 namespace ttnn::prim {
+
+using namespace tt::tt_metal;
 
 namespace {
 
@@ -57,7 +61,7 @@ std::vector<CoreRange> get_multicast_regions(const CoreRangeSet& all_cores, cons
 
 }  // namespace
 
-MoveOverlapProgramFactory::cached_program_t MoveOverlapProgramFactory::create(
+ProgramDescriptor MoveOverlapProgramFactory::create_descriptor(
     const MoveOperationAttributes& /*operation_attributes*/,
     const MoveTensorArgs& tensor_args,
     Tensor& tensor_return_value) {
@@ -65,7 +69,6 @@ MoveOverlapProgramFactory::cached_program_t MoveOverlapProgramFactory::create(
 
     const Tensor& input = tensor_args.input_tensor;
     const Tensor& output = tensor_return_value;
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
     const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
     const bool tilized = input.layout() == Layout::TILE;
@@ -83,25 +86,39 @@ MoveOverlapProgramFactory::cached_program_t MoveOverlapProgramFactory::create(
     const uint32_t size_per_l1_bank = tt::tt_metal::detail::calculate_bank_size_spread(
         output.buffer()->size(), output.buffer()->page_size(), num_l1_banks, tt::tt_metal::hal::get_l1_alignment());
 
-    // CB is being used as temp L1 buffer to copy src data into before writing to dst
-    uint32_t cb_index = 0;
-    const uint32_t aligned_page_size = round_up_to_mul32(page_size);
-    const tt::tt_metal::CircularBufferConfig cb_config =
-        tt::tt_metal::CircularBufferConfig(size_per_l1_bank, {{cb_index, cb_data_format}})
-            .set_page_size(cb_index, aligned_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_config);
-
-    auto semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, 0);
-
     Buffer* src_buffer = input.buffer();
     Buffer* dst_buffer = output.buffer();
+
+    ProgramDescriptor desc;
+
+    // CB is being used as temp L1 buffer to copy src data into before writing to dst
+    const uint32_t cb_index = 0;
+    const uint32_t aligned_page_size = round_up_to_mul32(page_size);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = size_per_l1_bank,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_index),
+            .data_format = cb_data_format,
+            .page_size = aligned_page_size,
+        }}},
+    });
+
+    // Semaphore used by the controller core to coordinate multicast.
+    const uint32_t semaphore_id = 0;
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = semaphore_id,
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = all_cores,
+        .initial_value = 0,
+    });
 
     std::vector<uint32_t> compile_time_args = {cb_index};
     if (!tilized) {
         compile_time_args.push_back(page_size);
     }
-    tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*dst_buffer).append_to(compile_time_args);
 
     const std::string kernel_path =
         tilized
@@ -109,14 +126,19 @@ MoveOverlapProgramFactory::cached_program_t MoveOverlapProgramFactory::create(
             : "ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/"
               "move_stick_layout_interleaved_with_overlap.cpp";
 
-    const tt::tt_metal::KernelHandle kernel_id = tt::tt_metal::CreateKernel(
-        program, kernel_path, all_cores, tt::tt_metal::DataMovementConfig{.compile_args = compile_time_args});
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = kernel_path;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(compile_time_args);
+    reader_desc.config = DataMovementConfigDescriptor{};
 
     const CoreCoord logical_controller = CoreCoord{0, 0};
     const CoreCoord noc_controller = device->worker_core_from_logical_core(logical_controller);
     std::vector<CoreRange> logical_multicast_regions = get_multicast_regions(all_cores, logical_controller);
 
     std::vector<CoreRange> noc_multicast_regions;
+    noc_multicast_regions.reserve(logical_multicast_regions.size());
     for (const auto& logical_cr : logical_multicast_regions) {
         const CoreRange noc_cr(
             device->worker_core_from_logical_core(logical_cr.start_coord),
@@ -140,70 +162,45 @@ MoveOverlapProgramFactory::cached_program_t MoveOverlapProgramFactory::create(
         }
 
         const bool is_controller = (i == 0);
-        std::vector<uint32_t> runtime_args = {
-            src_buffer->address(),
-            dst_buffer->address(),
-            pages_handled_per_core,
-            num_pages_per_core,
-            semaphore_id,
-            (uint32_t)noc_controller.x,
-            (uint32_t)noc_controller.y,
-            /*control_value=*/(num_cores - 1),
-            (uint32_t)is_controller,
-            (uint32_t)range_0_noc.start_coord.x,
-            (uint32_t)range_0_noc.start_coord.y,
-            (uint32_t)range_0_noc.end_coord.x,
-            (uint32_t)range_0_noc.end_coord.y,
-            (uint32_t)logical_multicast_regions[0].size(),
-            (uint32_t)range_1_noc.start_coord.x,
-            (uint32_t)range_1_noc.start_coord.y,
-            (uint32_t)range_1_noc.end_coord.x,
-            (uint32_t)range_1_noc.end_coord.y,
-            (uint32_t)logical_multicast_regions[1].size(),
-            (uint32_t)noc_multicast_regions.back().start_coord.x,
-            (uint32_t)noc_multicast_regions.back().start_coord.y,
-            (uint32_t)noc_multicast_regions.back().end_coord.x,
-            (uint32_t)noc_multicast_regions.back().end_coord.y,
-            (uint32_t)logical_multicast_regions.back().size(),
-            (uint32_t)do_third_multicast};
+        // Buffer* entries register BufferBindings for src/dst addresses (positions 0/1);
+        // the framework patches them on cache hits without rebuilding the descriptor.
+        KernelDescriptor::RTArgList runtime_args;
+        runtime_args.reserve(tilized ? 25 : 26);
+        runtime_args.push_back(src_buffer);
+        runtime_args.push_back(dst_buffer);
+        runtime_args.push_back(pages_handled_per_core);
+        runtime_args.push_back(num_pages_per_core);
+        runtime_args.push_back(semaphore_id);
+        runtime_args.push_back(static_cast<uint32_t>(noc_controller.x));
+        runtime_args.push_back(static_cast<uint32_t>(noc_controller.y));
+        runtime_args.push_back(num_cores - 1);  // control_value
+        runtime_args.push_back(static_cast<uint32_t>(is_controller));
+        runtime_args.push_back(static_cast<uint32_t>(range_0_noc.start_coord.x));
+        runtime_args.push_back(static_cast<uint32_t>(range_0_noc.start_coord.y));
+        runtime_args.push_back(static_cast<uint32_t>(range_0_noc.end_coord.x));
+        runtime_args.push_back(static_cast<uint32_t>(range_0_noc.end_coord.y));
+        runtime_args.push_back(static_cast<uint32_t>(logical_multicast_regions[0].size()));
+        runtime_args.push_back(static_cast<uint32_t>(range_1_noc.start_coord.x));
+        runtime_args.push_back(static_cast<uint32_t>(range_1_noc.start_coord.y));
+        runtime_args.push_back(static_cast<uint32_t>(range_1_noc.end_coord.x));
+        runtime_args.push_back(static_cast<uint32_t>(range_1_noc.end_coord.y));
+        runtime_args.push_back(static_cast<uint32_t>(logical_multicast_regions[1].size()));
+        runtime_args.push_back(static_cast<uint32_t>(noc_multicast_regions.back().start_coord.x));
+        runtime_args.push_back(static_cast<uint32_t>(noc_multicast_regions.back().start_coord.y));
+        runtime_args.push_back(static_cast<uint32_t>(noc_multicast_regions.back().end_coord.x));
+        runtime_args.push_back(static_cast<uint32_t>(noc_multicast_regions.back().end_coord.y));
+        runtime_args.push_back(static_cast<uint32_t>(logical_multicast_regions.back().size()));
+        runtime_args.push_back(static_cast<uint32_t>(do_third_multicast));
         if (!tilized) {
             runtime_args.push_back(aligned_page_size);
         }
-        SetRuntimeArgs(program, kernel_id, core, runtime_args);
+        reader_desc.emplace_runtime_args(core, runtime_args);
         pages_handled_per_core += num_pages_per_core;
     }
 
-    return {
-        std::move(program),
-        MoveOverlapProgramFactory::shared_variables_t{.reader_kernel_id = kernel_id, .num_cores = num_cores}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
 
-void MoveOverlapProgramFactory::override_runtime_arguments(
-    MoveOverlapProgramFactory::cached_program_t& cached_program,
-    const MoveOperationAttributes& /*operation_attributes*/,
-    const MoveTensorArgs& tensor_args,
-    Tensor& tensor_return_value) {
-    using namespace tt::tt_metal;
-
-    auto& program = cached_program.program;
-    const Tensor& input = tensor_args.input_tensor;
-    Tensor& output = tensor_return_value;
-
-    Buffer* src_buffer = input.buffer();
-    Buffer* dst_buffer = output.buffer();
-    const uint32_t num_cores = cached_program.shared_variables.num_cores;
-    const tt::tt_metal::KernelHandle reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-
-    const CoreCoord compute_with_storage_grid_size = output.device()->compute_with_storage_grid_size();
-    const uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    const uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    const auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, false);
-
-    for (const CoreCoord& core : cores) {
-        auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-        runtime_args[0] = src_buffer->address();
-        runtime_args[1] = dst_buffer->address();
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_overlap_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_overlap_program_factory.hpp
@@ -4,26 +4,15 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
 #include "move_device_operation_types.hpp"
-#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
 // Program factory for MULTI_CORE_OVERLAP strategy
 struct MoveOverlapProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle reader_kernel_id = 0;
-        uint32_t num_cores = 0;
-    };
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const MoveOperationAttributes& operation_attributes,
-        const MoveTensorArgs& tensor_args,
-        Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const MoveOperationAttributes& operation_attributes,
         const MoveTensorArgs& tensor_args,
         Tensor& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
@@ -14,18 +15,17 @@
 
 namespace ttnn::prim {
 
-MoveShardedProgramFactory::cached_program_t MoveShardedProgramFactory::create(
+using namespace tt::tt_metal;
+
+ProgramDescriptor MoveShardedProgramFactory::create_descriptor(
     const MoveOperationAttributes& /*operation_attributes*/,
     const MoveTensorArgs& tensor_args,
     Tensor& tensor_return_value) {
     using namespace tt::constants;
-    using namespace tt::tt_metal;
     const Tensor& input = tensor_args.input_tensor;
     Tensor& output = tensor_return_value;
 
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
-
-    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
+    const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
     const auto shard_spec = input.shard_spec().value();
     const auto shard_shape = shard_spec.shape;
     const auto shard_grid = shard_spec.grid;
@@ -42,88 +42,77 @@ MoveShardedProgramFactory::cached_program_t MoveShardedProgramFactory::create(
     const uint32_t total_size_bytes = input.buffer()->aligned_size_per_bank();
     const uint32_t page_size_bytes = input.buffer()->aligned_page_size();
 
-    CircularBufferConfig src_cb_sharded_config =
-        CircularBufferConfig(total_size_bytes, {{src_cb_sharded, cb_data_format}})
-            .set_page_size(src_cb_sharded, page_size_bytes);
-    src_cb_sharded_config.set_globally_allocated_address(*input.buffer());
-    const CBHandle src_sharded_cb = tt::tt_metal::CreateCircularBuffer(program, shard_grid, src_cb_sharded_config);
-
-    CircularBufferConfig dst_cb_sharded_config =
-        CircularBufferConfig(total_size_bytes, {{dst_cb_sharded, cb_data_format}})
-            .set_page_size(dst_cb_sharded, page_size_bytes);
-    dst_cb_sharded_config.set_globally_allocated_address(*output.buffer());
-    const CBHandle dst_sharded_cb = tt::tt_metal::CreateCircularBuffer(program, shard_grid, dst_cb_sharded_config);
-
-    const uint32_t input_buffer_address = input.buffer()->address();
-    const uint32_t output_buffer_address = output.buffer()->address();
-
-    const uint32_t move_chunk_size_bytes = output_buffer_address - input_buffer_address;
-    TT_FATAL(
-        input.buffer()->alignment() == output.buffer()->alignment(),
-        "Expected input buffer alignment ({} B) and output buffer alignment ({} B) to be equal",
-        input.buffer()->alignment(),
-        output.buffer()->alignment());
-    TT_FATAL(
-        move_chunk_size_bytes % input.buffer()->alignment() == 0,
-        "Expected chunk size bytes to move to be {} byte aligned.",
-        input.buffer()->alignment());
-    const uint32_t num_chunks = total_size_bytes / move_chunk_size_bytes;
-    const uint32_t remainder_chunk_size_bytes = total_size_bytes % move_chunk_size_bytes;
-
-    std::vector<uint32_t> reader_compile_time_args = {src_cb_sharded, dst_cb_sharded};
-    KernelHandle kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/reader_unary_local_l1_copy_backwards.cpp",
-        shard_grid,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1, .compile_args = reader_compile_time_args});
-
-    const std::array runtime_args = {total_size_bytes, num_chunks, move_chunk_size_bytes, remainder_chunk_size_bytes};
-    tt::tt_metal::SetRuntimeArgs(program, kernel_id, shard_grid, runtime_args);
-
-    return {
-        std::move(program),
-        MoveShardedProgramFactory::shared_variables_t{
-            .kernel_id = kernel_id,
-            .src_sharded_cb = src_sharded_cb,
-            .dst_sharded_cb = dst_sharded_cb,
-            .total_size_bytes = total_size_bytes,
-            .cores = corerange_to_cores(shard_grid, std::nullopt, true)}};
-}
-
-void MoveShardedProgramFactory::override_runtime_arguments(
-    MoveShardedProgramFactory::cached_program_t& cached_program,
-    const MoveOperationAttributes& /*operation_attributes*/,
-    const MoveTensorArgs& tensor_args,
-    Tensor& tensor_return_value) {
-    using namespace tt::tt_metal;
-
-    Program& program = cached_program.program;
-    const Tensor& input = tensor_args.input_tensor;
-    Tensor& output = tensor_return_value;
-
     Buffer* src_buffer = input.buffer();
     Buffer* dst_buffer = output.buffer();
 
-    UpdateDynamicCircularBufferAddress(program, cached_program.shared_variables.src_sharded_cb, *src_buffer);
-    UpdateDynamicCircularBufferAddress(program, cached_program.shared_variables.dst_sharded_cb, *dst_buffer);
-
     const uint32_t input_buffer_address = src_buffer->address();
     const uint32_t output_buffer_address = dst_buffer->address();
+
     const uint32_t move_chunk_size_bytes = output_buffer_address - input_buffer_address;
-    const uint32_t num_chunks = cached_program.shared_variables.total_size_bytes / move_chunk_size_bytes;
-    const uint32_t remainder_chunk_size_bytes =
-        cached_program.shared_variables.total_size_bytes % move_chunk_size_bytes;
+    TT_FATAL(
+        src_buffer->alignment() == dst_buffer->alignment(),
+        "Expected input buffer alignment ({} B) and output buffer alignment ({} B) to be equal",
+        src_buffer->alignment(),
+        dst_buffer->alignment());
+    TT_FATAL(
+        move_chunk_size_bytes % src_buffer->alignment() == 0,
+        "Expected chunk size bytes to move to be {} byte aligned.",
+        src_buffer->alignment());
+    const uint32_t num_chunks = total_size_bytes / move_chunk_size_bytes;
+    const uint32_t remainder_chunk_size_bytes = total_size_bytes % move_chunk_size_bytes;
 
-    std::vector<uint32_t> new_runtime_args = {
-        cached_program.shared_variables.total_size_bytes,
-        num_chunks,
-        move_chunk_size_bytes,
-        remainder_chunk_size_bytes};
+    ProgramDescriptor desc;
 
-    for (const auto& core : cached_program.shared_variables.cores) {
-        SetRuntimeArgs(program, cached_program.shared_variables.kernel_id, core, new_runtime_args);
+    // Sharded src CB: dynamic globally-allocated; framework rebinds on cache hit.
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = total_size_bytes,
+        .core_ranges = shard_grid,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src_cb_sharded),
+            .data_format = cb_data_format,
+            .page_size = page_size_bytes,
+        }}},
+        .buffer = src_buffer,
+    });
+
+    // Sharded dst CB: dynamic globally-allocated; framework rebinds on cache hit.
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = total_size_bytes,
+        .core_ranges = shard_grid,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(dst_cb_sharded),
+            .data_format = cb_data_format,
+            .page_size = page_size_bytes,
+        }}},
+        .buffer = dst_buffer,
+    });
+
+    std::vector<uint32_t> reader_compile_time_args = {src_cb_sharded, dst_cb_sharded};
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/reader_unary_local_l1_copy_backwards.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = shard_grid;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = DataMovementConfigDescriptor{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1};
+
+    // Runtime args derive from the address arithmetic (output_addr - input_addr) and
+    // therefore must be recomputed every call.  We deliberately emit them as plain
+    // scalars (no Buffer* / BufferBinding) so the adapter's resolved bindings stay
+    // empty and the slow cache-hit path runs create_descriptor() again — which
+    // recomputes move_chunk_size_bytes, num_chunks, remainder_chunk_size_bytes
+    // from the freshly-allocated buffer addresses.  CB addresses are still patched
+    // via desc.cbs[*].buffer in apply_descriptor_runtime_args().
+    const auto cores = corerange_to_cores(shard_grid, std::nullopt, true);
+    for (const auto& core : cores) {
+        reader_desc.emplace_runtime_args(
+            core, {total_size_bytes, num_chunks, move_chunk_size_bytes, remainder_chunk_size_bytes});
     }
+
+    desc.kernels.push_back(std::move(reader_desc));
+
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.hpp
@@ -4,28 +4,14 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
 #include "move_device_operation_types.hpp"
-#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
 struct MoveShardedProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle kernel_id = 0;
-        tt::tt_metal::CBHandle src_sharded_cb = 0;
-        tt::tt_metal::CBHandle dst_sharded_cb = 0;
-        uint32_t total_size_bytes = 0;
-        std::vector<tt::tt_metal::CoreCoord> cores;
-    };
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const MoveOperationAttributes& operation_attributes,
-        const MoveTensorArgs& tensor_args,
-        Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const MoveOperationAttributes& operation_attributes,
         const MoveTensorArgs& tensor_args,
         Tensor& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_device_operation.hpp
@@ -20,7 +20,6 @@ struct NonZeroIndicesDeviceOperation {
     using spec_return_value_t = NonzeroResultSpec;
     using tensor_return_value_t = NonzeroResult;
     using program_factory_t = std::variant<NonZeroIndicesProgramFactory>;
-    using shared_variables_t = NonZeroIndicesProgramFactory::shared_variables_t;
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_program_factory.cpp
@@ -5,112 +5,111 @@
 #include "ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_program_factory.hpp"
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tilize_utils.hpp>
 #include <tt-metalium/work_split.hpp>
-
-using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-NonZeroIndicesProgramFactory::cached_program_t NonZeroIndicesProgramFactory::create(
+using namespace tt::tt_metal;
+
+ProgramDescriptor NonZeroIndicesProgramFactory::create_descriptor(
     const NonzeroParams& /*operation_attributes*/, const NonzeroInputs& tensor_args, NonzeroResult& output_tensors) {
     const auto& input = tensor_args.input;
     const auto& out_num_indices = std::get<0>(output_tensors);
     const auto& out_indices = std::get<1>(output_tensors);
 
-    tt::tt_metal::Program program{};
-
-    uint32_t alignment_base = 32 / input.element_size();
     // we want per core to be aligned to aligment_base per core
+    const uint32_t alignment_base = 32 / input.element_size();
+    const uint32_t aligned_elements = tt::div_up(input.padded_shape()[-1], alignment_base) * alignment_base;
+    const uint32_t actual_elements = input.padded_shape()[-1];
 
-    uint32_t aligned_elements = tt::div_up(input.padded_shape()[-1], alignment_base) * alignment_base;
-    uint32_t actual_elements = input.padded_shape()[-1];
+    const CoreCoord core = {0, 0};
+    const CoreRangeSet core_ranges{CoreRange{core, core}};
 
-    CoreCoord core = {0, 0};
+    constexpr uint32_t input_cb_index = 0;
+    constexpr uint32_t output_cb_index_0 = 1;
+    constexpr uint32_t output_cb_index_1 = 2;
 
-    uint32_t input_cb_index = 0;
-    uint32_t output_cb_index_0 = 1;
-    uint32_t output_cb_index_1 = 2;
+    const tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(input.dtype());
+    const tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(DataType::UINT32);
 
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(DataType::UINT32);
+    const uint32_t page_size = actual_elements * input.element_size();
+    const uint32_t rounded_page_size = round_up_to_mul32(page_size);
 
-    uint32_t page_size = actual_elements * input.element_size();
-    uint32_t rounded_page_size = round_up_to_mul32(page_size);
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(2 * rounded_page_size, {{input_cb_index, input_cb_data_format}})
-            .set_page_size(input_cb_index, rounded_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
+    const uint32_t dst_page_size = actual_elements * 4;
+    const uint32_t dst_rounded_page_size = round_up_to_mul32(dst_page_size);
 
-    tt::tt_metal::CircularBufferConfig cb_dst0_config =
-        tt::tt_metal::CircularBufferConfig(2 * 32, {{output_cb_index_0, output_cb_data_format}})
-            .set_page_size(output_cb_index_0, 32);
-    tt::tt_metal::CreateCircularBuffer(program, core, cb_dst0_config);
+    ProgramDescriptor desc;
 
-    uint32_t dst_page_size = actual_elements * 4;
-    uint32_t dst_rounded_page_size = round_up_to_mul32(dst_page_size);
-    tt::tt_metal::CircularBufferConfig cb_dst1_config =
-        tt::tt_metal::CircularBufferConfig(2 * dst_rounded_page_size, {{output_cb_index_1, output_cb_data_format}})
-            .set_page_size(output_cb_index_1, dst_rounded_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, core, cb_dst1_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * rounded_page_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = input_cb_index,
+            .data_format = input_cb_data_format,
+            .page_size = rounded_page_size,
+        }}},
+    });
 
-    std::map<std::string, std::string> defines;
-    defines["NUM_BYTES"] = std::to_string(input.element_size());
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * 32,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index_0,
+            .data_format = output_cb_data_format,
+            .page_size = 32,
+        }}},
+    });
 
-    // Create Kernel
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * dst_rounded_page_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index_1,
+            .data_format = output_cb_data_format,
+            .page_size = dst_rounded_page_size,
+        }}},
+    });
+
+    Buffer* const src_buffer = input.buffer();
+    Buffer* const out_num_indices_buffer = out_num_indices.buffer();
+    Buffer* const out_indices_buffer = out_indices.buffer();
+
     std::vector<uint32_t> compile_time_args = {
-        (std::uint32_t)input_cb_index,
-        (std::uint32_t)output_cb_index_0,
-        (std::uint32_t)output_cb_index_1,
+        input_cb_index,
+        output_cb_index_0,
+        output_cb_index_1,
     };
-    TensorAccessorArgs(*input.buffer()).append_to(compile_time_args);
-    TensorAccessorArgs(*out_num_indices.buffer()).append_to(compile_time_args);
-    TensorAccessorArgs(*out_indices.buffer()).append_to(compile_time_args);
+    TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*out_num_indices_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*out_indices_buffer).append_to(compile_time_args);
 
-    const std::array run_time_args = {
-        (std::uint32_t)input.buffer()->address(),
-        (std::uint32_t)out_num_indices.buffer()->address(),
-        (std::uint32_t)out_indices.buffer()->address(),
-        (std::uint32_t)aligned_elements,
-        (std::uint32_t)actual_elements,
-        (std::uint32_t)input.element_size()};
-
-    auto kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/kernels/dataflow/"
-        "non_zero_indices_sc_reader.cpp",
+        "non_zero_indices_sc_reader.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core_ranges;
+    reader_desc.compile_time_args = std::move(compile_time_args);
+    reader_desc.defines = {{"NUM_BYTES", std::to_string(input.element_size())}};
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    // Buffer* entries register as buffer bindings at their arg slots; the framework
+    // patches their addresses on cache hits without rebuilding the descriptor.
+    reader_desc.emplace_runtime_args(
         core,
-        tt::tt_metal::ReaderDataMovementConfig(compile_time_args, defines));
+        {src_buffer,
+         out_num_indices_buffer,
+         out_indices_buffer,
+         aligned_elements,
+         actual_elements,
+         uint32_t(input.element_size())});
 
-    tt::tt_metal::SetRuntimeArgs(program, kernel_id, core, run_time_args);
+    desc.kernels.push_back(std::move(reader_desc));
 
-    return cached_program_t{std::move(program), {kernel_id, core, page_size}};
-}
-
-void NonZeroIndicesProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const NonzeroParams& /*operation_attributes*/,
-    const NonzeroInputs& tensor_args,
-    NonzeroResult& output_tensors) {
-    auto& program = cached_program.program;
-    auto& shared_vars = cached_program.shared_variables;
-    auto& kernel_id = shared_vars.kernel_id;
-    auto& core = shared_vars.core;
-
-    const auto& input = tensor_args.input;
-    const auto& out_num_indices = std::get<0>(output_tensors);
-    const auto& out_indices = std::get<1>(output_tensors);
-
-    uint32_t alignment_base = 32 / input.element_size();
-    uint32_t aligned_elements = tt::div_up(input.padded_shape()[-1], alignment_base) * alignment_base;
-    uint32_t actual_elements = input.padded_shape()[-1];
-    auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, kernel_id, core);
-    runtime_args[0] = input.buffer()->address();
-    runtime_args[1] = out_num_indices.buffer()->address();
-    runtime_args[2] = out_indices.buffer()->address();
-    runtime_args[3] = aligned_elements;
-    runtime_args[4] = actual_elements;
-    runtime_args[5] = input.element_size();
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_program_factory.hpp
@@ -4,29 +4,16 @@
 
 #pragma once
 
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
-struct NonZeroIndicesSharedVariables {
-    tt::tt_metal::KernelHandle kernel_id{};
-    tt::tt_metal::CoreCoord core;
-    uint32_t page_size{};
-};
-
 struct NonZeroIndicesProgramFactory {
-    using shared_variables_t = NonZeroIndicesSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const NonzeroParams& operation_attributes, const NonzeroInputs& tensor_args, NonzeroResult& output_tensors);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const NonzeroParams& operation_attributes,
-        const NonzeroInputs& tensor_args,
-        NonzeroResult& output_tensors);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
@@ -5,9 +5,11 @@
 #include "pad_rm_reader_writer_multi_core_default_program_factory.hpp"
 
 #include <algorithm>
-#include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 
@@ -25,104 +27,14 @@ uint32_t get_num_stick_per_barrier(uint32_t stick_size_padded_aligned) {
     return std::max(tt::div_up(max_read_size, stick_size_padded_aligned), 1u);
 }
 
-std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime_args_rm(
-    const Tensor& input_tensor,
-    Tensor& output_tensor,
-    const ttnn::Shape& input_tensor_start,
-    const std::vector<CoreCoord>& cores_in_order,
-    const CoreRangeSet& core_group_1,
-    uint32_t num_w_sticks_per_core_group_1,
-    const CoreRangeSet& core_group_2,
-    uint32_t num_w_sticks_per_core_group_2,
-    uint32_t num_input_pages_in_row,
-    uint32_t num_output_pages_in_row,
-    uint32_t stick_size_padded_aligned) {
-    auto* input_buffer = input_tensor.buffer();
-    auto* output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.padded_shape();
-    auto output_shape = output_tensor.padded_shape();
-
-    uint32_t H = input_shape[2], C = input_shape[1], N = input_shape[0];
-
-    uint32_t H_padded = output_shape[2], C_padded = output_shape[1];
-
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
-    std::vector<uint32_t> start_dim_offset(num_dims, 0);
-
-    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(cores_in_order.size());
-
-    const auto& front_pad = input_tensor_start;
-    uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
-    for (uint32_t i = 0, curr_sticks_read = 0, curr_sticks_write = 0; i < cores_in_order.size(); i++) {
-        CoreCoord core = cores_in_order[i];
-
-        uint32_t num_sticks_per_core;
-        if (core_group_1.contains(core)) {
-            num_sticks_per_core = num_w_sticks_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_sticks_per_core = num_w_sticks_per_core_group_2;
-        } else {
-            // no-op
-            num_sticks_per_core = 0;
-        }
-
-        uint32_t num_sticks_per_barrier = get_num_stick_per_barrier(stick_size_padded_aligned);
-        // reader
-        std::vector<uint32_t> reader_runtime_args = {
-            input_buffer->address(),
-            num_sticks_per_core,
-            num_sticks_per_barrier,
-            curr_sticks_read * num_input_pages_in_row,
-            front_pad[-4],
-            front_pad[-3],
-            front_pad[-2],
-        };
-        reader_runtime_args.insert(reader_runtime_args.end(), start_dim_offset.begin(), start_dim_offset.end());
-
-        // writer
-        std::vector<uint32_t> writer_runtime_args = {
-            output_buffer->address(),
-            num_sticks_per_core,
-            num_sticks_per_barrier,
-            curr_sticks_write * num_output_pages_in_row};
-
-        ret_val[i] = {reader_runtime_args, writer_runtime_args};
-
-        curr_sticks_write += num_sticks_per_core;
-
-        for (uint32_t i = 0; i < num_sticks_per_core; ++i) {
-            if ((curr_h >= front_pad[-2] and curr_h < (H + front_pad[-2])) and
-                (curr_c >= front_pad[-3] and curr_c < (C + front_pad[-3])) and
-                (curr_n >= front_pad[-4] and curr_n < (N + front_pad[-4]))) {
-                curr_sticks_read++;
-            }
-
-            curr_h++;
-            if (curr_h == H_padded) {
-                curr_c++;
-                curr_h = 0;
-                if (curr_c == C_padded) {
-                    curr_n++;
-                    curr_c = 0;
-                }
-            }
-        }
-
-        start_dim_offset = {0, curr_h, curr_c, curr_n};
-    }
-
-    return ret_val;
-}
 }  // namespace
 
-PadRmReaderWriterMultiCoreDefaultProgramFactory::cached_program_t
-PadRmReaderWriterMultiCoreDefaultProgramFactory::create(
+ProgramDescriptor PadRmReaderWriterMultiCoreDefaultProgramFactory::create_descriptor(
     const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output) {
     const auto& a = tensor_args.input;
     const auto& pad_value = operation_attributes.pad_value;
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
     const auto& input_tensor_start = operation_attributes.input_tensor_start;
-    Program program{};
 
     const auto& a_shape = a.logical_shape();
     uint32_t W = a_shape[3], H = a_shape[2], C = a_shape[1], N = a_shape[0];
@@ -187,21 +99,6 @@ PadRmReaderWriterMultiCoreDefaultProgramFactory::create(
     // construct const buffer with the pad_value
     bool not_pad_by_zero = pad_value != 0;
 
-    uint32_t src1_cb_index = tt::CBIndex::c_1;
-    tt::tt_metal::CircularBufferConfig cb_src1_config =
-        tt::tt_metal::CircularBufferConfig(stick_size_padded_DRAM_aligned, {{src1_cb_index, cb_data_format}})
-            .set_page_size(src1_cb_index, stick_size_padded_DRAM_aligned);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
-
-    bool unaligned = stick_size_padded_aligned % hal::get_dram_alignment() != 0;
-    if (stick_size_padded_front != 0 || unaligned) {
-        uint32_t src2_cb_index = tt::CBIndex::c_2;
-        tt::tt_metal::CircularBufferConfig cb_src2_config =
-            tt::tt_metal::CircularBufferConfig(stick_size_padded_DRAM_aligned, {{src2_cb_index, cb_data_format}})
-                .set_page_size(src2_cb_index, stick_size_padded_DRAM_aligned);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src2_config);
-    }
-
     Buffer* src0_buffer = a.buffer();
     Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
@@ -213,6 +110,34 @@ PadRmReaderWriterMultiCoreDefaultProgramFactory::create(
         packed_pad_value = pack_two_uint16_into_uint32({float_to_uint16(pad_value), float_to_uint16(pad_value)});
     } else {
         packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});
+    }
+
+    ProgramDescriptor desc;
+
+    // c_1 reused for pad-value scratch on every dispatch.
+    uint32_t src1_cb_index = tt::CBIndex::c_1;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = stick_size_padded_DRAM_aligned,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src1_cb_index),
+            .data_format = cb_data_format,
+            .page_size = stick_size_padded_DRAM_aligned,
+        }}},
+    });
+
+    bool unaligned = stick_size_padded_aligned % hal::get_dram_alignment() != 0;
+    if (stick_size_padded_front != 0 || unaligned) {
+        uint32_t src2_cb_index = tt::CBIndex::c_2;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = stick_size_padded_DRAM_aligned,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(src2_cb_index),
+                .data_format = cb_data_format,
+                .page_size = stick_size_padded_DRAM_aligned,
+            }}},
+        });
     }
 
     std::vector<uint32_t> reader_ct_args = {
@@ -250,121 +175,115 @@ PadRmReaderWriterMultiCoreDefaultProgramFactory::create(
         (std::uint32_t)size_of_valid_data_in_last_output_page_in_row};
     TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
 
-    KernelHandle reader_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
-    KernelHandle writer_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved_v2.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    auto all_runtime_args = get_runtime_args_rm(
-        a,
-        output,
-        input_tensor_start,
-        cores_in_order,
-        core_group_1,
-        num_sticks_padded_per_core_group_1,
-        core_group_2,
-        num_sticks_padded_per_core_group_2,
-        num_input_pages_in_row,
-        num_output_pages_in_row,
-        stick_size_padded_aligned);
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved_v2.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    for (uint32_t i = 0; i < cores_in_order.size(); i++) {
-        CoreCoord core = cores_in_order[i];
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, all_runtime_args[i].first);
-        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, all_runtime_args[i].second);
+    // Build per-core runtime args inline (legacy path called get_runtime_args_rm()
+    // which produced the same data).  Slot 0 of both reader and writer is a raw
+    // buffer base address (no offset) — use Buffer* for BufferBinding so the
+    // framework patches addresses on cache hits.  Idle cores (num_sticks_per_core
+    // == 0) pass 0u to skip the binding since the kernel does nothing.
+    // The legacy helper used input_tensor.padded_shape() for the H/C/N bounds —
+    // mirror that here.  H_padded/C_padded already use the output padded shape.
+    auto input_padded_shape = a.padded_shape();
+    uint32_t H_in = input_padded_shape[2], C_in = input_padded_shape[1], N_in = input_padded_shape[0];
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_padded_shape.rank());
+    std::vector<uint32_t> start_dim_offset(num_dims, 0);
+
+    uint32_t num_sticks_per_barrier = get_num_stick_per_barrier(stick_size_padded_aligned);
+
+    uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
+    uint32_t curr_sticks_read = 0;
+    uint32_t curr_sticks_write = 0;
+    for (const auto& core : cores_in_order) {
+        uint32_t num_sticks_per_core;
+        if (core_group_1.contains(core)) {
+            num_sticks_per_core = num_sticks_padded_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_sticks_per_core = num_sticks_padded_per_core_group_2;
+        } else {
+            // no-op
+            num_sticks_per_core = 0;
+        }
+
+        KernelDescriptor::RTArgList reader_rt_args;
+        KernelDescriptor::RTArgList writer_rt_args;
+        if (num_sticks_per_core != 0) {
+            reader_rt_args.push_back(src0_buffer);
+            writer_rt_args.push_back(dst_buffer);
+        } else {
+            reader_rt_args.push_back(0u);
+            writer_rt_args.push_back(0u);
+        }
+        reader_rt_args.push_back(num_sticks_per_core);
+        reader_rt_args.push_back(num_sticks_per_barrier);
+        reader_rt_args.push_back(curr_sticks_read * num_input_pages_in_row);
+        reader_rt_args.push_back(static_cast<uint32_t>(front_pad[-4]));
+        reader_rt_args.push_back(static_cast<uint32_t>(front_pad[-3]));
+        reader_rt_args.push_back(static_cast<uint32_t>(front_pad[-2]));
+        for (uint32_t v : start_dim_offset) {
+            reader_rt_args.push_back(v);
+        }
+
+        writer_rt_args.push_back(num_sticks_per_core);
+        writer_rt_args.push_back(num_sticks_per_barrier);
+        writer_rt_args.push_back(curr_sticks_write * num_output_pages_in_row);
+
+        reader_desc.emplace_runtime_args(core, reader_rt_args);
+        writer_desc.emplace_runtime_args(core, writer_rt_args);
+
+        curr_sticks_write += num_sticks_per_core;
+
+        for (uint32_t k = 0; k < num_sticks_per_core; ++k) {
+            if ((curr_h >= front_pad[-2] and curr_h < (H_in + front_pad[-2])) and
+                (curr_c >= front_pad[-3] and curr_c < (C_in + front_pad[-3])) and
+                (curr_n >= front_pad[-4] and curr_n < (N_in + front_pad[-4]))) {
+                curr_sticks_read++;
+            }
+
+            curr_h++;
+            if (curr_h == H_padded) {
+                curr_c++;
+                curr_h = 0;
+                if (curr_c == C_padded) {
+                    curr_n++;
+                    curr_c = 0;
+                }
+            }
+        }
+
+        start_dim_offset = {0, curr_h, curr_c, curr_n};
     }
+
     uint32_t cb_npages = get_num_stick_per_barrier(stick_size_padded_aligned);
     const uint32_t buffer_reader_writer_async_factor = 16;
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(
-            buffer_reader_writer_async_factor * cb_npages * stick_size_padded_aligned,
-            {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, stick_size_padded_aligned);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = buffer_reader_writer_async_factor * cb_npages * stick_size_padded_aligned,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = stick_size_padded_aligned,
+        }}},
+    });
 
-    return cached_program_t{
-        std::move(program),
-        {reader_kernel_id,
-         writer_kernel_id,
-         compute_with_storage_grid_size,
-         input_tensor_start,
-         sub_core_grids,
-         std::move(cores_in_order)}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void PadRmReaderWriterMultiCoreDefaultProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const PadParams& operation_attributes,
-    const PadInputs& tensor_args,
-    Tensor& output) {
-    const auto& src_tensor = tensor_args.input;
-
-    auto dst_tensor = output;
-
-    const auto& sub_core_grids = cached_program.shared_variables.sub_core_grids;
-    const auto& compute_with_storage_grid_size = cached_program.shared_variables.compute_with_storage_grid_size;
-
-    auto output_tensor_shape = dst_tensor.logical_shape();
-    uint32_t H_padded = output_tensor_shape[2], C_padded = output_tensor_shape[1], N_padded = output_tensor_shape[0];
-    uint32_t NCH_padded = H_padded * C_padded * N_padded;
-
-    auto
-        [num_cores,
-         all_cores,
-         core_group_1,
-         core_group_2,
-         num_sticks_padded_per_core_group_1,
-         num_sticks_padded_per_core_group_2] =
-            sub_core_grids.has_value() ? tt::tt_metal::split_work_to_cores(sub_core_grids.value(), NCH_padded)
-                                       : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, NCH_padded);
-
-    const auto& cores_in_order = cached_program.shared_variables.cores_with_rtargs;
-
-    uint32_t num_input_pages_in_row = 1;
-    if (src_tensor.is_sharded()) {
-        uint32_t shard_width = src_tensor.shard_spec().has_value() ? src_tensor.shard_spec().value().shape[1]
-                                                                   : src_tensor.nd_shard_spec().value().shard_shape[-1];
-        num_input_pages_in_row = tt::div_up(src_tensor.logical_shape()[-1], shard_width);
-    }
-
-    uint32_t num_output_pages_in_row = 1;
-    if (dst_tensor.is_sharded()) {
-        uint32_t output_shard_width = dst_tensor.shard_spec().has_value()
-                                          ? dst_tensor.shard_spec().value().shape[1]
-                                          : dst_tensor.nd_shard_spec().value().shard_shape[-1];
-        num_output_pages_in_row = tt::div_up(operation_attributes.output_padded_shape[-1], output_shard_width);
-    }
-
-    uint32_t W_padded = operation_attributes.output_padded_shape[3];
-    auto stick_size_padded = W_padded * src_tensor.element_size();
-    uint32_t stick_size_padded_aligned = tt::align(stick_size_padded, hal::get_l1_alignment());
-
-    auto all_runtime_args = get_runtime_args_rm(
-        src_tensor,
-        dst_tensor,
-        cached_program.shared_variables.input_tensor_start,
-        cores_in_order,
-        core_group_1,
-        num_sticks_padded_per_core_group_1,
-        core_group_2,
-        num_sticks_padded_per_core_group_2,
-        num_input_pages_in_row,
-        num_output_pages_in_row,
-        stick_size_padded_aligned);
-
-    for (uint32_t i = 0; i < cores_in_order.size(); i++) {
-        CoreCoord core = cores_in_order[i];
-        SetRuntimeArgs(
-            cached_program.program, cached_program.shared_variables.reader_kernel_id, core, all_runtime_args[i].first);
-        SetRuntimeArgs(
-            cached_program.program, cached_program.shared_variables.writer_kernel_id, core, all_runtime_args[i].second);
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.hpp
@@ -5,31 +5,15 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 #include "ttnn/device_operation.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
-struct PadRmReaderWriterMultiCoreDefaultSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id{};
-    tt::tt_metal::KernelHandle writer_kernel_id{};
-    CoreCoord compute_with_storage_grid_size;
-    ttnn::Shape input_tensor_start{};
-    std::optional<CoreRangeSet> sub_core_grids;
-    std::vector<CoreCoord> cores_with_rtargs;
-};
-
 struct PadRmReaderWriterMultiCoreDefaultProgramFactory {
-    using shared_variables_t = PadRmReaderWriterMultiCoreDefaultSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const PadParams& operation_attributes,
-        const PadInputs& tensor_args,
-        Tensor& output);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "pad_rm_sharded_height_only_program_factory.hpp"
-#include "ttnn/operations/data_movement/common/common.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/work_split.hpp>
+#include "ttnn/operations/data_movement/common/common.hpp"
 
 using namespace tt::tt_metal;
 using namespace tt::constants;
@@ -37,9 +39,7 @@ inline std::vector<std::vector<uint32_t>> group_contiguous_and_repeated_values(s
     chunks.push_back(current_chunk);
     return chunks;
 }
-}  // namespace
 
-namespace {
 inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_pad_runtime_args_rm_sharded(
     const Tensor& input_tensor,
     Tensor& output_tensor,
@@ -92,7 +92,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
         std::vector<int> stick_ids_per_core;
         int front_pad_stick_id = -2;
         int pad_stick_id = -1;
-        for (uint32_t i = 0; i < num_sticks_per_core_padded; ++i) {
+        for (uint32_t j = 0; j < num_sticks_per_core_padded; ++j) {
             if ((curr_h >= front_pad[-2] and curr_h < (H + front_pad[-2])) and
                 (curr_c >= front_pad[-3] and curr_c < (C + front_pad[-3])) and
                 (curr_n >= front_pad[-4] and curr_n < (N + front_pad[-4]))) {
@@ -189,13 +189,13 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 }
 }  // namespace
 
-PadRmShardedHeightOnlyProgramFactory::cached_program_t PadRmShardedHeightOnlyProgramFactory::create(
-    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output) {
+ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
+    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.input;
+    Tensor& output = tensor_return_value;
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
     const auto& pad_value = operation_attributes.pad_value;
     const auto& input_tensor_start = operation_attributes.input_tensor_start;
-    Program program{};
 
     const auto& a_shape = a.logical_shape();
     uint32_t W = a_shape[3], H = a_shape[2], C = a_shape[1], N = a_shape[0];
@@ -267,29 +267,54 @@ PadRmShardedHeightOnlyProgramFactory::cached_program_t PadRmShardedHeightOnlyPro
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
 
-    uint32_t src0_cb_index = 0;
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(
-            shard_height_unpadded * stick_size_unpadded, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, stick_size_unpadded)
-            .set_globally_allocated_address(*a.buffer());
-    auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src0_config);
+    Buffer* src_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
 
+    ProgramDescriptor desc;
+
+    // Sharded input CB — globally allocated to the input buffer; framework patches
+    // the CB address on cache hits via cb.buffer.
+    uint32_t src0_cb_index = 0;
+    {
+        CBDescriptor cb_src0;
+        cb_src0.total_size = shard_height_unpadded * stick_size_unpadded;
+        cb_src0.core_ranges = total_cores;
+        cb_src0.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = stick_size_unpadded,
+        });
+        cb_src0.buffer = src_buffer;
+        desc.cbs.push_back(std::move(cb_src0));
+    }
+
+    // Sharded output CB — globally allocated to the output buffer.
     uint32_t output_cb_index = tt::CBIndex::c_16;
-    tt::tt_metal::CircularBufferConfig cb_output_config =
-        tt::tt_metal::CircularBufferConfig(
-            shard_height_padded * stick_size_padded, {{output_cb_index, dst_cb_data_format}})
-            .set_page_size(output_cb_index, stick_size_padded)
-            .set_globally_allocated_address(*output.buffer());
-    auto cb_output = tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_output_config);
+    {
+        CBDescriptor cb_output;
+        cb_output.total_size = shard_height_padded * stick_size_padded;
+        cb_output.core_ranges = total_cores;
+        cb_output.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = dst_cb_data_format,
+            .page_size = stick_size_padded,
+        });
+        cb_output.buffer = dst_buffer;
+        desc.cbs.push_back(std::move(cb_output));
+    }
 
     // construct const buffer with the pad_value
     bool not_pad_by_zero = pad_value != 0;
     uint32_t src1_cb_index = 1;
-    tt::tt_metal::CircularBufferConfig cb_src1_config =
-        tt::tt_metal::CircularBufferConfig(stick_size_padded, {{src1_cb_index, cb_data_format}})
-            .set_page_size(src1_cb_index, stick_size_padded);
-    tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src1_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = stick_size_padded,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src1_cb_index),
+            .data_format = cb_data_format,
+            .page_size = stick_size_padded,
+        }}},
+    });
 
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
@@ -317,17 +342,21 @@ PadRmShardedHeightOnlyProgramFactory::cached_program_t PadRmShardedHeightOnlyPro
         (std::uint32_t)row_major_min_bytes,
         (std::uint32_t)(stick_size_padded / row_major_min_bytes)};
 
-    KernelHandle reader_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp",
-        all_cores_padded,
-        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores_padded;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    KernelHandle writer_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp",
-        all_cores_padded,
-        tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores_padded;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     auto all_runtime_args = get_pad_runtime_args_rm_sharded(
         a,
@@ -342,6 +371,9 @@ PadRmShardedHeightOnlyProgramFactory::cached_program_t PadRmShardedHeightOnlyPro
         num_cores_x_unpadded,
         num_cores_y_unpadded);
 
+    // Sharded readers/writers consume only constant uint32_t per-core args; no
+    // BufferBinding is needed because the CBs themselves carry the buffer
+    // addresses (via cb.buffer).
     for (uint32_t i = 0; i < num_cores_padded; i++) {
         CoreCoord core;
         if (row_major) {
@@ -349,23 +381,24 @@ PadRmShardedHeightOnlyProgramFactory::cached_program_t PadRmShardedHeightOnlyPro
         } else {
             core = {i / num_cores_y_padded, i % num_cores_y_padded};
         }
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, all_runtime_args[i].first);
-        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, all_runtime_args[i].second);
+        KernelDescriptor::RTArgList reader_rt_args;
+        reader_rt_args.reserve(all_runtime_args[i].first.size());
+        for (uint32_t v : all_runtime_args[i].first) {
+            reader_rt_args.push_back(v);
+        }
+        KernelDescriptor::RTArgList writer_rt_args;
+        writer_rt_args.reserve(all_runtime_args[i].second.size());
+        for (uint32_t v : all_runtime_args[i].second) {
+            writer_rt_args.push_back(v);
+        }
+        reader_desc.emplace_runtime_args(core, reader_rt_args);
+        writer_desc.emplace_runtime_args(core, writer_rt_args);
     }
 
-    return cached_program_t{std::move(program), {cb_src0, cb_output}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void PadRmShardedHeightOnlyProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const PadParams& /*operation_attributes*/,
-    const PadInputs& tensor_args,
-    Tensor& tensor_return_value) {
-    auto* src_buffer_a = tensor_args.input.buffer();
-    auto* dst_buffer = tensor_return_value.buffer();
-
-    UpdateDynamicCircularBufferAddress(cached_program.program, cached_program.shared_variables.cb_src0, *src_buffer_a);
-    UpdateDynamicCircularBufferAddress(cached_program.program, cached_program.shared_variables.cb_output, *dst_buffer);
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.hpp
@@ -5,27 +5,15 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 #include "ttnn/device_operation.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
-struct PadRmShardedHeightOnlySharedVariables {
-    tt::tt_metal::CBHandle cb_src0{};
-    tt::tt_metal::CBHandle cb_output{};
-};
-
 struct PadRmShardedHeightOnlyProgramFactory {
-    using shared_variables_t = PadRmShardedHeightOnlySharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const PadParams& operation_attributes,
-        const PadInputs& tensor_args,
-        Tensor& tensor_return_value);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.cpp
@@ -5,6 +5,8 @@
 #include "pad_rm_sharded_width_only_program_factory.hpp"
 
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 
@@ -15,13 +17,13 @@ namespace ttnn::prim {
 using ttnn::operations::data_movement::float_to_uint16;
 using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 
-PadRmShardedWidthOnlyProgramFactory::cached_program_t PadRmShardedWidthOnlyProgramFactory::create(
-    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output) {
+ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
+    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& input_tensor = tensor_args.input;
+    Tensor& output = tensor_return_value;
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
     const auto& pad_value = operation_attributes.pad_value;
     const auto& input_tensor_start = operation_attributes.input_tensor_start;
-    Program program{};
 
     TT_ASSERT(
         output.shard_spec().has_value() and output.shard_spec()->shape[1] == output_padded_shape[-1],
@@ -52,31 +54,56 @@ PadRmShardedWidthOnlyProgramFactory::cached_program_t PadRmShardedWidthOnlyProgr
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
 
+    Buffer* input_buffer = input_tensor.buffer();
+    Buffer* output_buffer = output.buffer();
+
+    ProgramDescriptor desc;
+
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t input_shard_cb_index = tt::CBIndex::c_0;
-    tt::tt_metal::CircularBufferConfig input_shard_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            shard_height_unpadded * unpadded_stick_bytes, {{input_shard_cb_index, input_cb_data_format}})
-            .set_page_size(input_shard_cb_index, unpadded_stick_bytes)
-            .set_globally_allocated_address(*input_tensor.buffer());
-    auto input_shard_cb = tt::tt_metal::CreateCircularBuffer(program, total_cores, input_shard_cb_config);
+    {
+        // Sharded input CB — globally allocated to the input buffer; framework
+        // patches the CB address on cache hits via cb.buffer.
+        CBDescriptor cb_input;
+        cb_input.total_size = shard_height_unpadded * unpadded_stick_bytes;
+        cb_input.core_ranges = total_cores;
+        cb_input.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(input_shard_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = unpadded_stick_bytes,
+        });
+        cb_input.buffer = input_buffer;
+        desc.cbs.push_back(std::move(cb_input));
+    }
 
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t output_shard_cb_index = tt::CBIndex::c_16;
-    tt::tt_metal::CircularBufferConfig output_shard_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            shard_height_padded * padded_stick_bytes, {{output_shard_cb_index, output_cb_data_format}})
-            .set_page_size(output_shard_cb_index, padded_stick_bytes)
-            .set_globally_allocated_address(*output.buffer());
-    auto output_shard_cb = tt::tt_metal::CreateCircularBuffer(program, total_cores, output_shard_cb_config);
+    {
+        // Sharded output CB — globally allocated to the output buffer.
+        CBDescriptor cb_output;
+        cb_output.total_size = shard_height_padded * padded_stick_bytes;
+        cb_output.core_ranges = total_cores;
+        cb_output.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_shard_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = padded_stick_bytes,
+        });
+        cb_output.buffer = output_buffer;
+        desc.cbs.push_back(std::move(cb_output));
+    }
 
     // construct const buffer with the pad_value
     tt::DataFormat pad_val_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t pad_val_cb_index = tt::CBIndex::c_1;
-    tt::tt_metal::CircularBufferConfig cb_pad_val_config =
-        tt::tt_metal::CircularBufferConfig(padded_stick_bytes, {{pad_val_cb_index, pad_val_cb_data_format}})
-            .set_page_size(pad_val_cb_index, padded_stick_bytes);
-    tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_pad_val_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = padded_stick_bytes,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(pad_val_cb_index),
+            .data_format = pad_val_cb_data_format,
+            .page_size = padded_stick_bytes,
+        }}},
+    });
 
     uint32_t W_padding_front_bytes = input_tensor_start[-3] * input_tensor.element_size();
 
@@ -123,36 +150,35 @@ PadRmShardedWidthOnlyProgramFactory::cached_program_t PadRmShardedWidthOnlyProgr
         pad_val_cb_index,
         padded_stick_step};
 
-    KernelHandle reader_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded_stickwise.cpp",
-        all_cores_padded,
-        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded_stickwise.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores_padded;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    KernelHandle writer_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded_stickwise.cpp",
-        all_cores_padded,
-        tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded_stickwise.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores_padded;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, all_cores_padded, {});
-    tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, all_cores_padded, {});
+    // Sharded readers/writers don't consume per-core runtime args (legacy code
+    // called SetRuntimeArgs(..., {}) with empty arg lists).  CB addresses are
+    // patched via cb.buffer on cache hits.  Mirror the legacy behavior by
+    // emitting an empty rtarg list per active core so the kernel reserves slots.
+    for (const auto& core : ordered_cores_with_data) {
+        reader_desc.emplace_runtime_args(core, KernelDescriptor::RTArgList{});
+        writer_desc.emplace_runtime_args(core, KernelDescriptor::RTArgList{});
+    }
 
-    return cached_program_t{std::move(program), {input_shard_cb, output_shard_cb}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void PadRmShardedWidthOnlyProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const PadParams& /*operation_attributes*/,
-    const PadInputs& tensor_args,
-    Tensor& tensor_return_value) {
-    auto* input_buffer = tensor_args.input.buffer();
-    auto* output_buffer = tensor_return_value.buffer();
-
-    UpdateDynamicCircularBufferAddress(
-        cached_program.program, cached_program.shared_variables.input_shard_cb, *input_buffer);
-    UpdateDynamicCircularBufferAddress(
-        cached_program.program, cached_program.shared_variables.output_shard_cb, *output_buffer);
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.hpp
@@ -5,27 +5,15 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 #include "ttnn/device_operation.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
-struct PadRmShardedWidthOnlySharedVariables {
-    tt::tt_metal::CBHandle input_shard_cb{};
-    tt::tt_metal::CBHandle output_shard_cb{};
-};
-
 struct PadRmShardedWidthOnlyProgramFactory {
-    using shared_variables_t = PadRmShardedWidthOnlySharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const PadParams& operation_attributes,
-        const PadInputs& tensor_args,
-        Tensor& tensor_return_value);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "pad_tile_multicore_program_factory.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
@@ -26,12 +28,11 @@ static inline int advance_tensor_index(std::vector<uint32_t>& idx, const ttnn::S
     return 0;  // overflowed most-significant dim
 }
 
-PadTileMulticoreProgramFactory::cached_program_t PadTileMulticoreProgramFactory::create(
+ProgramDescriptor PadTileMulticoreProgramFactory::create_descriptor(
     const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output) {
     const auto& a = tensor_args.input;
     const auto& pad_value = operation_attributes.pad_value;
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
-    Program program{};
 
     const auto& a_shape = a.logical_shape();
     uint32_t num_pages = get_num_pages(output);
@@ -51,22 +52,40 @@ PadTileMulticoreProgramFactory::cached_program_t PadTileMulticoreProgramFactory:
     uint32_t page_size = output.buffer()->page_size();
     uint32_t multi_buffering_size = 2;
     uint32_t input_cb_index = tt::CBIndex::c_0;
-    tt::tt_metal::CircularBufferConfig input_cb_config =
-        tt::tt_metal::CircularBufferConfig(page_size * multi_buffering_size, {{input_cb_index, cb_data_format}})
-            .set_page_size(input_cb_index, page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, input_cb_config);
-
     uint32_t output_cb_index = tt::CBIndex::c_1;
-    tt::tt_metal::CircularBufferConfig output_cb_config =
-        tt::tt_metal::CircularBufferConfig(page_size * multi_buffering_size, {{output_cb_index, cb_data_format}})
-            .set_page_size(output_cb_index, page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
-
     uint32_t pad_val_cb_index = tt::CBIndex::c_2;
-    tt::tt_metal::CircularBufferConfig pad_val_cb_config =
-        tt::tt_metal::CircularBufferConfig(page_size, {{pad_val_cb_index, cb_data_format}})
-            .set_page_size(pad_val_cb_index, page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, pad_val_cb_config);
+
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = page_size * multi_buffering_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(input_cb_index),
+            .data_format = cb_data_format,
+            .page_size = page_size,
+        }}},
+    });
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = page_size * multi_buffering_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = page_size,
+        }}},
+    });
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(pad_val_cb_index),
+            .data_format = cb_data_format,
+            .page_size = page_size,
+        }}},
+    });
 
     Buffer* input_buffer = a.buffer();
     Buffer* output_buffer = output.buffer();
@@ -112,16 +131,21 @@ PadTileMulticoreProgramFactory::cached_program_t PadTileMulticoreProgramFactory:
     };
     TensorAccessorArgs(*output_buffer).append_to(writer_ct_args);
 
-    KernelHandle reader_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_tiled.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
-    KernelHandle writer_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_tiled.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_tiled.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_tiled.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     /*
     As an example, lets say we want to pad a [2, 1, 32, 32] tensor to [2, 3, 64, 64]
@@ -175,8 +199,6 @@ PadTileMulticoreProgramFactory::cached_program_t PadTileMulticoreProgramFactory:
     uint32_t input_page_offset = 0;
     uint32_t output_page_offset = 0;
 
-    std::vector<uint32_t> all_runtime_args;
-
     for (uint32_t i = 0; i < num_cores; i++) {
         CoreCoord core = cores_in_order[i];
 
@@ -189,26 +211,49 @@ PadTileMulticoreProgramFactory::cached_program_t PadTileMulticoreProgramFactory:
             num_pages_per_core = 0;  // no-op
         }
 
-        all_runtime_args = {
-            a.buffer()->address(),
-            num_pages_per_core,
-            input_page_offset,
-        };
+        // Slot 0 is a raw buffer base address (no offset).  Use Buffer* on active
+        // cores so the framework patches the address on cache hits.  Idle cores
+        // (num_pages_per_core == 0) pass 0u to skip BufferBinding registration —
+        // the kernel short-circuits and never dereferences the address.
+        KernelDescriptor::RTArgList reader_runtime_args;
+        KernelDescriptor::RTArgList writer_runtime_args;
 
-        // Every core should get the same input and output tile shapes
-        all_runtime_args.insert(all_runtime_args.end(), input_page_shape.cbegin(), input_page_shape.cend());
-        all_runtime_args.insert(all_runtime_args.end(), output_page_shape.cbegin(), output_page_shape.cend());
+        if (num_pages_per_core != 0) {
+            reader_runtime_args.push_back(input_buffer);
+            writer_runtime_args.push_back(output_buffer);
+        } else {
+            reader_runtime_args.push_back(0u);
+            writer_runtime_args.push_back(0u);
+        }
 
-        // As well as where the core should start writing in the output tensor
-        all_runtime_args.insert(all_runtime_args.end(), input_id_per_dim.begin(), input_id_per_dim.end());
-        all_runtime_args.insert(all_runtime_args.end(), output_id_per_dim.begin(), output_id_per_dim.end());
+        reader_runtime_args.push_back(num_pages_per_core);
+        reader_runtime_args.push_back(input_page_offset);
 
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, all_runtime_args);
-        all_runtime_args[0] = output.buffer()->address();  // change input addr to output addr before setting writer
-                                                           // args
-        all_runtime_args[2] =
-            output_page_offset;  // change input page offset to output page offset before setting writer args
-        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, all_runtime_args);
+        writer_runtime_args.push_back(num_pages_per_core);
+        writer_runtime_args.push_back(output_page_offset);
+
+        // Every core should get the same input and output tile shapes.
+        for (auto v : input_page_shape) {
+            reader_runtime_args.push_back(v);
+            writer_runtime_args.push_back(v);
+        }
+        for (auto v : output_page_shape) {
+            reader_runtime_args.push_back(v);
+            writer_runtime_args.push_back(v);
+        }
+
+        // As well as where the core should start writing in the output tensor.
+        for (uint32_t v : input_id_per_dim) {
+            reader_runtime_args.push_back(v);
+            writer_runtime_args.push_back(v);
+        }
+        for (uint32_t v : output_id_per_dim) {
+            reader_runtime_args.push_back(v);
+            writer_runtime_args.push_back(v);
+        }
+
+        reader_desc.emplace_runtime_args(core, reader_runtime_args);
+        writer_desc.emplace_runtime_args(core, writer_runtime_args);
 
         // We now need to increment the input and output id_per_dims by the number of pages this core is processing
         // Similarly to in the kernel, we only increment the input id_per_dim if we are within the input region
@@ -230,40 +275,10 @@ PadTileMulticoreProgramFactory::cached_program_t PadTileMulticoreProgramFactory:
         // The input and output id_per_dim should now be set correctly for the next core
     }
 
-    return cached_program_t{
-        std::move(program),
-        {reader_kernel_id,
-         writer_kernel_id,
-         compute_with_storage_grid_size,
-         sub_core_grids,
-         std::move(cores_in_order)}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void PadTileMulticoreProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const PadParams& /*operation_attributes*/,
-    const PadInputs& tensor_args,
-    Tensor& output) {
-    auto* src_buffer = tensor_args.input.buffer();
-    auto* dst_buffer = output.buffer();
-
-    const auto& cores = cached_program.shared_variables.cores_with_rtargs;
-
-    for (const auto& core : cores) {
-        // Update reader kernel runtime args
-        {
-            auto& runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.reader_kernel_id, core);
-            runtime_args[0] = src_buffer->address();
-        }
-
-        // Update writer kernel runtime args
-        {
-            auto& runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.writer_kernel_id, core);
-            runtime_args[0] = dst_buffer->address();
-        }
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.hpp
@@ -5,30 +5,15 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 #include "ttnn/device_operation.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
-struct PadTileMulticoreSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id{};
-    tt::tt_metal::KernelHandle writer_kernel_id{};
-    CoreCoord compute_with_storage_grid_size;
-    std::optional<CoreRangeSet> sub_core_grids;
-    std::vector<CoreCoord> cores_with_rtargs;
-};
-
 struct PadTileMulticoreProgramFactory {
-    using shared_variables_t = PadTileMulticoreSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const PadParams& operation_attributes,
-        const PadInputs& tensor_args,
-        Tensor& output);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.cpp
@@ -6,6 +6,7 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
@@ -14,22 +15,21 @@ namespace ttnn::prim {
 using ttnn::operations::data_movement::float_to_uint16;
 using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 
-PadTileCoreProgramFactory::cached_program_t PadTileCoreProgramFactory::create(
-    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output) {
+ProgramDescriptor PadTileCoreProgramFactory::create_descriptor(
+    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.input;
+    Tensor& output = tensor_return_value;
     const auto& pad_value = operation_attributes.pad_value;
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
-    tt::tt_metal::Program program{};
 
-    CoreRange core({0, 0}, {0, 0});
+    const CoreRangeSet core_ranges{CoreRange{{0, 0}, {0, 0}}};
 
     // This should allocate a DRAM buffer on the device
 
-    auto output_shape = output_padded_shape;
+    const auto& output_shape = output_padded_shape;
 
-    tt::tt_metal::Buffer* src0_buffer = a.buffer();
-
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    Buffer* src0_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
@@ -42,19 +42,31 @@ PadTileCoreProgramFactory::cached_program_t PadTileCoreProgramFactory::create(
     log_debug(tt::LogOp, "input_tensor_start: {}", operation_attributes.input_tensor_start);
     log_debug(tt::LogOp, "pad_value: {}", pad_value);
 
-    uint32_t src0_cb_index = 0;
-    uint32_t num_input_tiles = 2;
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
+    ProgramDescriptor desc;
 
-    uint32_t src1_cb_index = 1;  // For pad buffer
-    uint32_t num_pad_tiles = 1;
-    tt::tt_metal::CircularBufferConfig cb_src1_config =
-        tt::tt_metal::CircularBufferConfig(num_pad_tiles * single_tile_size, {{src1_cb_index, cb_data_format}})
-            .set_page_size(src1_cb_index, single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
+    const uint32_t src0_cb_index = 0;
+    const uint32_t num_input_tiles = 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
+
+    const uint32_t src1_cb_index = 1;  // For pad buffer
+    const uint32_t num_pad_tiles = 1;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_pad_tiles * single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src1_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
 
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
@@ -80,71 +92,52 @@ PadTileCoreProgramFactory::cached_program_t PadTileCoreProgramFactory::create(
 
     uint32_t num_unpadded_tiles = a.physical_volume() / TILE_HW;
 
-    const std::array reader_kernel_args = {
-        src0_buffer->address(),
-        num_unpadded_tiles,
-        std::uint32_t{0},
-    };
-    const std::array writer_kernel_args = {
-        dst_buffer->address(),
-        num_unpadded_W,
-        num_padded_Wt,
-        num_unpadded_Z,
-        num_padded_Zt,
-        num_unpadded_Yt,
-        num_padded_Yt,
-        num_unpadded_Xt,
-        num_padded_Xt,
-        packed_pad_value,
-    };
-
     // Reader compile-time args
     // Data is 32 byte aligned
     std::vector<uint32_t> reader_compile_time_args;
-    tt::tt_metal::TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
     std::vector<uint32_t> writer_compile_time_args = {src0_cb_index, src1_cb_index};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+
     // Tilized reader
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp",
-        core,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core_ranges;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp",
-        core,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = core_ranges;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_kernel_args);
+    // Slot 0 of both kernels is a raw buffer base address (no offset).  Use Buffer*
+    // for BufferBinding so the framework patches addresses on cache hits without
+    // rebuilding the descriptor.
+    reader_desc.emplace_runtime_args(CoreCoord{0, 0}, {src0_buffer, num_unpadded_tiles, std::uint32_t{0}});
 
-    tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_kernel_args);
+    writer_desc.emplace_runtime_args(
+        CoreCoord{0, 0},
+        {dst_buffer,
+         num_unpadded_W,
+         num_padded_Wt,
+         num_unpadded_Z,
+         num_padded_Zt,
+         num_unpadded_Yt,
+         num_padded_Yt,
+         num_unpadded_Xt,
+         num_padded_Xt,
+         packed_pad_value});
 
-    return cached_program_t{std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void PadTileCoreProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const PadParams& /*operation_attributes*/,
-    const PadInputs& tensor_args,
-    Tensor& tensor_return_value) {
-    auto* src_dram_buffer = tensor_args.input.buffer();
-    auto* dst_dram_buffer = tensor_return_value.buffer();
-
-    CoreCoord core = {0, 0};
-
-    {
-        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(
-            cached_program.program, cached_program.shared_variables.unary_reader_kernel_id, core);
-        runtime_args[0] = src_dram_buffer->address();
-    }
-
-    {
-        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(
-            cached_program.program, cached_program.shared_variables.unary_writer_kernel_id, core);
-        runtime_args[0] = dst_dram_buffer->address();
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.hpp
@@ -5,27 +5,15 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 #include "ttnn/device_operation.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
-struct PadTileCoreSharedVariables {
-    tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-    tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-};
-
 struct PadTileCoreProgramFactory {
-    using shared_variables_t = PadTileCoreSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const PadParams& operation_attributes,
-        const PadInputs& tensor_args,
-        Tensor& tensor_return_value);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_common.hpp
@@ -4,15 +4,10 @@
 
 #pragma once
 
-#include <tt-metalium/core_coord.hpp>
+#include <cstdint>
 
 namespace ttnn::prim {
 
 inline constexpr uint32_t READ_ALIGNMENT = 64;
-
-struct RepeatSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id{};
-    tt::tt_metal::CoreRange total_cores{tt::tt_metal::CoreCoord{0, 0}};
-};
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.cpp
@@ -1,98 +1,120 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-#include <cmath>
-#include <optional>
-#include <variant>
-
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-
-#include "ttnn/core.hpp"
-#include "ttnn/device_operation.hpp"
-#include "ttnn/operations/cb_utils.hpp"
-#include "ttnn/operations/math.hpp"
-#include "ttnn/operation.hpp"
-#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
-#include "ttnn/tensor/tensor.hpp"
-#include "ttnn/types.hpp"
 
 #include "ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.hpp"
 
+#include <cstdint>
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "ttnn/operations/data_movement/repeat/device/repeat_program_factory_common.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
 namespace ttnn::prim {
 
-RepeatProgramFactoryHigherDim::cached_program_t RepeatProgramFactoryHigherDim::create(
+using namespace tt::tt_metal;
+
+ProgramDescriptor RepeatProgramFactoryHigherDim::create_descriptor(
     const RepeatParams& operation_attributes, const RepeatInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input;
     const auto& output = tensor_return_value;
     const uint32_t num_repeats = operation_attributes.m_num_repeats;
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
     // get datum size
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
     const uint32_t data_size = input.element_size();
-    tt::tt_metal::IDevice* device = input.device();
+    IDevice* device = input.device();
     // Multi device pre-computation
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    uint32_t num_cores_total = num_cores_x * num_cores_y;
-    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    const uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    const uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    const uint32_t num_cores_total = num_cores_x * num_cores_y;
+    const CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    const CoreRangeSet total_core_ranges{total_cores};
 
     ttnn::Shape input_log_shape = ttnn::Shape(input.logical_shape().view());
     ttnn::Shape output_log_shape = ttnn::Shape(output.logical_shape().view());
-    uint32_t page_size_bytes = input_log_shape[3] * data_size;
+    const uint32_t page_size_bytes = input_log_shape[3] * data_size;
     TT_FATAL(
         page_size_bytes == output_log_shape[3] * data_size,
         "Data size of output does not match requirement for repeat last dim");
     uint32_t read_start_page = 0;
-    tt::tt_metal::Buffer* src_buffer = input.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    Buffer* src_buffer = input.buffer();
+    Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
     // Find how many input pages each core is responsible for so that we always start at the beginning of a read and
     // write page Since the logical volumes match, we are guaranteed that the very last page is aligned
-    uint32_t number_of_higher_pages = input_log_shape[0];
-    uint32_t number_of_lower_pages = input_log_shape[2];
-    uint32_t number_of_rep_dim_pages = input_log_shape[1];
-    uint32_t cb_size_bytes = (READ_ALIGNMENT * 2) + page_size_bytes;
-    uint32_t src0_cb_index = 0;
-    uint32_t src1_cb_index = 1;
+    const uint32_t number_of_higher_pages = input_log_shape[0];
+    const uint32_t number_of_lower_pages = input_log_shape[2];
+    const uint32_t number_of_rep_dim_pages = input_log_shape[1];
+    const uint32_t cb_size_bytes = (READ_ALIGNMENT * 2) + page_size_bytes;
+    constexpr uint32_t src0_cb_index = 0;
+    constexpr uint32_t src1_cb_index = 1;
 
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(cb_size_bytes, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, cb_size_bytes);
-    tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src0_config);
+    ProgramDescriptor desc;
 
-    tt::tt_metal::CircularBufferConfig cb_src1_config =
-        tt::tt_metal::CircularBufferConfig(cb_size_bytes, {{src1_cb_index, cb_data_format}})
-            .set_page_size(src1_cb_index, cb_size_bytes);
-    tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src1_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_size_bytes,
+        .core_ranges = total_core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = cb_data_format,
+            .page_size = cb_size_bytes,
+        }}},
+    });
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_size_bytes,
+        .core_ranges = total_core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src1_cb_index,
+            .data_format = cb_data_format,
+            .page_size = cb_size_bytes,
+        }}},
+    });
 
     std::vector<uint32_t> compile_time_args = {
         (std::uint32_t)page_size_bytes, src0_cb_index, src1_cb_index, number_of_lower_pages, number_of_rep_dim_pages};
-    tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*dst_buffer).append_to(compile_time_args);
 
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm.cpp",
-        total_cores,
-        tt::tt_metal::ReaderDataMovementConfig(compile_time_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = total_core_ranges;
+    reader_desc.compile_time_args = std::move(compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
     uint32_t done = 0;
     // Determine runtime arguments
-    bool divide_on_higher = number_of_higher_pages > number_of_lower_pages;
+    const bool divide_on_higher = number_of_higher_pages > number_of_lower_pages;
 
-    uint32_t responsibility_chunk =
+    const uint32_t responsibility_chunk =
         (divide_on_higher ? number_of_higher_pages : number_of_lower_pages) / num_cores_total;
-    uint32_t responsibility_mod = (divide_on_higher ? number_of_higher_pages : number_of_lower_pages) % num_cores_total;
+    const uint32_t responsibility_mod =
+        (divide_on_higher ? number_of_higher_pages : number_of_lower_pages) % num_cores_total;
     uint32_t core_count = 0;
-    for (int core_x = 0; core_x < num_cores_x; core_x++) {
-        for (int core_y = 0; core_y < num_cores_y; core_y++) {
-            uint32_t responsibility =
+    for (uint32_t core_x = 0; core_x < num_cores_x; core_x++) {
+        for (uint32_t core_y = 0; core_y < num_cores_y; core_y++) {
+            const uint32_t responsibility =
                 core_count++ < responsibility_mod ? responsibility_chunk + 1 : responsibility_chunk;
-            CoreCoord core = {core_x, core_y};
+            const CoreCoord core = {core_x, core_y};
             if (done == 1) {
-                const std::vector<uint32_t> reader_runtime_args = {0, 0, 0, 0, 0, 0, 0, 1};
-                tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+                // Idle cores: zero pages, with the trailing flag set to terminate the kernel early.
+                // Pass scalar zeros instead of buffers so the kernel sees the same arg count.
+                reader_desc.emplace_runtime_args(
+                    core,
+                    {uint32_t{0},
+                     uint32_t{0},
+                     uint32_t{0},
+                     uint32_t{0},
+                     uint32_t{0},
+                     uint32_t{0},
+                     uint32_t{0},
+                     uint32_t{1}});
             } else if (divide_on_higher) {
                 // set the runtime args
                 // set the compile time args
@@ -100,18 +122,20 @@ RepeatProgramFactoryHigherDim::cached_program_t RepeatProgramFactoryHigherDim::c
                 uint32_t end_of_read = read_start_page + responsibility;
                 end_of_read = end_of_read < number_of_higher_pages ? end_of_read : number_of_higher_pages;
 
-                const std::vector<uint32_t> reader_runtime_args = {
-                    src_buffer->address(),
-                    dst_buffer->address(),
-                    start_of_read,
-                    end_of_read,
-                    0,
-                    number_of_lower_pages,
-                    num_repeats,
-                    0};
+                // Buffer* args trigger BufferBinding entries; the framework patches their
+                // addresses on cache hits without rebuilding the descriptor.
+                reader_desc.emplace_runtime_args(
+                    core,
+                    {src_buffer,
+                     dst_buffer,
+                     start_of_read,
+                     end_of_read,
+                     uint32_t{0},
+                     number_of_lower_pages,
+                     num_repeats,
+                     uint32_t{0}});
                 read_start_page = end_of_read;
                 done = (end_of_read == number_of_higher_pages) ? 1 : 0;
-                tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
             } else {
                 // set the runtime args
                 // set the compile time args
@@ -119,44 +143,25 @@ RepeatProgramFactoryHigherDim::cached_program_t RepeatProgramFactoryHigherDim::c
                 uint32_t end_of_read = read_start_page + responsibility;
                 end_of_read = end_of_read < number_of_lower_pages ? end_of_read : number_of_lower_pages;
 
-                const std::vector<uint32_t> reader_runtime_args = {
-                    src_buffer->address(),
-                    dst_buffer->address(),
-                    0,
-                    number_of_higher_pages,
-                    start_of_read,
-                    end_of_read,
-                    num_repeats,
-                    0};
+                reader_desc.emplace_runtime_args(
+                    core,
+                    {src_buffer,
+                     dst_buffer,
+                     uint32_t{0},
+                     number_of_higher_pages,
+                     start_of_read,
+                     end_of_read,
+                     num_repeats,
+                     uint32_t{0}});
                 read_start_page = end_of_read;
                 done = (end_of_read == number_of_lower_pages) ? 1 : 0;
-                tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
             }
         }
     }
-    return RepeatProgramFactoryHigherDim::cached_program_t{std::move(program), {reader_kernel_id, total_cores}};
-}
 
-void RepeatProgramFactoryHigherDim::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const RepeatParams& /*operation_attributes*/,
-    const RepeatInputs& tensor_args,
-    Tensor& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& shared_vars = cached_program.shared_variables;
+    desc.kernels.push_back(std::move(reader_desc));
 
-    auto& reader_kernel_id = shared_vars.reader_kernel_id;
-    auto& total_cores = shared_vars.total_cores;
-
-    const auto& input = tensor_args.input;
-    const auto& output = tensor_return_value;
-
-    auto& runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
-    for (const auto& core : total_cores) {
-        auto& runtime_args = runtime_args_by_core[core.x][core.y];
-        runtime_args.at(0) = input.buffer()->address();
-        runtime_args.at(1) = output.buffer()->address();
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.hpp
@@ -4,24 +4,16 @@
 
 #pragma once
 
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "ttnn/operations/data_movement/repeat/device/repeat_device_operation_types.hpp"
-#include "ttnn/operations/data_movement/repeat/device/repeat_program_factory_common.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
 struct RepeatProgramFactoryHigherDim {
-    using shared_variables_t = RepeatSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const RepeatParams& operation_attributes, const RepeatInputs& tensor_args, Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const RepeatParams& operation_attributes,
-        const RepeatInputs& tensor_args,
-        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.cpp
@@ -1,129 +1,122 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-#include <cmath>
-#include <optional>
-#include <variant>
-
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-
-#include "ttnn/core.hpp"
-#include "ttnn/device_operation.hpp"
-#include "ttnn/operations/cb_utils.hpp"
-#include "ttnn/operations/math.hpp"
-#include "ttnn/operation.hpp"
-#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
-#include "ttnn/tensor/tensor.hpp"
-#include "ttnn/types.hpp"
 
 #include "ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.hpp"
 
+#include <cstdint>
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "ttnn/operations/data_movement/repeat/device/repeat_program_factory_common.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
 namespace ttnn::prim {
 
-RepeatProgramFactoryLastDim::cached_program_t RepeatProgramFactoryLastDim::create(
+using namespace tt::tt_metal;
+
+ProgramDescriptor RepeatProgramFactoryLastDim::create_descriptor(
     const RepeatParams& operation_attributes, const RepeatInputs& tensor_args, Tensor& tensor_return_value) {
     // We are repeating the last dim on a 2D shape
     const auto& input = tensor_args.input;
     const auto& output = tensor_return_value;
     const uint32_t num_repeats = operation_attributes.m_num_repeats;
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
     // get datum size
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
     const uint32_t data_size = input.element_size();
-    tt::tt_metal::IDevice* device = input.device();
+    IDevice* device = input.device();
     // Multi device pre-computation
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    uint32_t num_cores_total = num_cores_x * num_cores_y;
-    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    const uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    const uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    const uint32_t num_cores_total = num_cores_x * num_cores_y;
+    const CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    const CoreRangeSet total_core_ranges{total_cores};
+
     ttnn::Shape input_log_shape = ttnn::Shape(input.logical_shape().view());
     ttnn::Shape output_log_shape = ttnn::Shape(output.logical_shape().view());
-    uint32_t source_page_size_bytes = input_log_shape[-1] * data_size;
-    uint32_t dest_page_size_bytes = source_page_size_bytes * num_repeats;
+    const uint32_t source_page_size_bytes = input_log_shape[-1] * data_size;
+    const uint32_t dest_page_size_bytes = source_page_size_bytes * num_repeats;
     TT_FATAL(
         dest_page_size_bytes == output_log_shape[-1] * data_size,
         "Data size of output does not match requirement for repeat last dim");
     uint32_t read_start_page = 0;
-    tt::tt_metal::Buffer* src_buffer = input.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    Buffer* src_buffer = input.buffer();
+    Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
     // Find how many input pages each core is responsible for so that we always start at the beginning of a read and
     // write page Since the logical volumes match, we are guaranteed that the very last page is aligned
-    uint32_t number_of_pages = input_log_shape[-2];
-    uint32_t responsibility = ((number_of_pages - 1) / num_cores_total) + 1;
-    uint32_t cb_size_bytes = READ_ALIGNMENT * 2 + (source_page_size_bytes & 0xF) == 0 ? source_page_size_bytes
-                             : (source_page_size_bytes & 0x7) == 0                    ? source_page_size_bytes * 2
-                             : (source_page_size_bytes & 0x3) == 0                    ? source_page_size_bytes * 4
-                             : (source_page_size_bytes & 0x1) == 0                    ? source_page_size_bytes * 8
-                                                                                      : source_page_size_bytes * 16;
-    uint32_t src0_cb_index = 0;
-    uint32_t src1_cb_index = 1;
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(cb_size_bytes, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, cb_size_bytes);
-    tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src0_config);
-    tt::tt_metal::CircularBufferConfig cb_src1_config =
-        tt::tt_metal::CircularBufferConfig(cb_size_bytes, {{src1_cb_index, cb_data_format}})
-            .set_page_size(src1_cb_index, cb_size_bytes);
-    tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src1_config);
+    const uint32_t number_of_pages = input_log_shape[-2];
+    const uint32_t responsibility = ((number_of_pages - 1) / num_cores_total) + 1;
+    const uint32_t cb_size_bytes = READ_ALIGNMENT * 2 + (source_page_size_bytes & 0xF) == 0 ? source_page_size_bytes
+                                   : (source_page_size_bytes & 0x7) == 0                    ? source_page_size_bytes * 2
+                                   : (source_page_size_bytes & 0x3) == 0                    ? source_page_size_bytes * 4
+                                   : (source_page_size_bytes & 0x1) == 0                    ? source_page_size_bytes * 8
+                                                                         : source_page_size_bytes * 16;
+    constexpr uint32_t src0_cb_index = 0;
+    constexpr uint32_t src1_cb_index = 1;
+
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_size_bytes,
+        .core_ranges = total_core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = cb_data_format,
+            .page_size = cb_size_bytes,
+        }}},
+    });
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_size_bytes,
+        .core_ranges = total_core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src1_cb_index,
+            .data_format = cb_data_format,
+            .page_size = cb_size_bytes,
+        }}},
+    });
+
     std::vector<uint32_t> compile_time_args = {
         (std::uint32_t)source_page_size_bytes, (std::uint32_t)num_repeats, src0_cb_index, src1_cb_index};
-    tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*dst_buffer).append_to(compile_time_args);
 
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm.cpp",
-        total_cores,
-        tt::tt_metal::ReaderDataMovementConfig(compile_time_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = total_core_ranges;
+    reader_desc.compile_time_args = std::move(compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
     uint32_t done = 0;
-    for (int core_x = 0; core_x < num_cores_x; core_x++) {
-        for (int core_y = 0; core_y < num_cores_y; core_y++) {
-            CoreCoord core = {core_x, core_y};
+    for (uint32_t core_x = 0; core_x < num_cores_x; core_x++) {
+        for (uint32_t core_y = 0; core_y < num_cores_y; core_y++) {
+            const CoreCoord core = {core_x, core_y};
             if (done == 1) {
-                const std::vector<uint32_t> reader_runtime_args = {
-                    src_buffer->address(), dst_buffer->address(), 0, 0, 1};
-                tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+                // Buffer* args trigger BufferBinding entries; the framework patches their
+                // addresses on cache hits without rebuilding the descriptor.
+                reader_desc.emplace_runtime_args(core, {src_buffer, dst_buffer, uint32_t{0}, uint32_t{0}, uint32_t{1}});
             } else {
                 const uint32_t start_of_read = read_start_page;
                 uint32_t end_of_read = read_start_page + responsibility;
                 end_of_read = end_of_read < number_of_pages ? end_of_read : number_of_pages;
 
-                const std::vector<uint32_t> reader_runtime_args = {
-                    src_buffer->address(), dst_buffer->address(), start_of_read, end_of_read, 0
-
-                };
+                reader_desc.emplace_runtime_args(
+                    core, {src_buffer, dst_buffer, start_of_read, end_of_read, uint32_t{0}});
                 read_start_page = end_of_read;
                 done = (end_of_read == input_log_shape[-2]) ? 1 : 0;
-                tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
             }
         }
     }
-    return RepeatProgramFactoryLastDim::cached_program_t{std::move(program), {reader_kernel_id, total_cores}};
-}
 
-void RepeatProgramFactoryLastDim::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const RepeatParams& /*operation_attributes*/,
-    const RepeatInputs& tensor_args,
-    Tensor& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& shared_vars = cached_program.shared_variables;
+    desc.kernels.push_back(std::move(reader_desc));
 
-    auto& reader_kernel_id = shared_vars.reader_kernel_id;
-    auto& total_cores = shared_vars.total_cores;
-
-    const auto& input = tensor_args.input;
-    const auto& output = tensor_return_value;
-
-    auto& runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
-    for (const auto& core : total_cores) {
-        auto& runtime_args = runtime_args_by_core[core.x][core.y];
-        runtime_args.at(0) = input.buffer()->address();
-        runtime_args.at(1) = output.buffer()->address();
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.hpp
@@ -4,24 +4,16 @@
 
 #pragma once
 
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "ttnn/operations/data_movement/repeat/device/repeat_device_operation_types.hpp"
-#include "ttnn/operations/data_movement/repeat/device/repeat_program_factory_common.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
 struct RepeatProgramFactoryLastDim {
-    using shared_variables_t = RepeatSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const RepeatParams& operation_attributes, const RepeatInputs& tensor_args, Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const RepeatParams& operation_attributes,
-        const RepeatInputs& tensor_args,
-        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_rm_program_factory.cpp
@@ -3,119 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "reshape_rm_program_factory.hpp"
-#include <tt-metalium/work_split.hpp>
-#include "ttnn/operations/math.hpp"
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/hal.hpp>
-#include <tt-metalium/constants.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include "ttnn/operation.hpp"
 
-using namespace tt::tt_metal;
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+
+#include "ttnn/operation.hpp"
+#include "ttnn/operations/math.hpp"
 
 namespace ttnn::prim {
 
-namespace {
-std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime_args_rm_multi_core(
-    const Tensor& input_tensor,
-    Tensor& output_tensor,
-    uint32_t num_cores_total,
-    uint32_t num_cores_y,
-    const CoreRangeSet& core_group_1,
-    uint32_t num_w_sticks_per_core_group_1,
-    const CoreRangeSet& core_group_2,
-    uint32_t num_w_sticks_per_core_group_2,
-    bool split_work_by_old_sticks) {
-    auto* input_buffer = input_tensor.buffer();
-    auto* output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.padded_shape();
-    auto output_shape = output_tensor.padded_shape();
+using namespace tt::tt_metal;
 
-    uint32_t old_stick_size = input_shape[3] * input_tensor.element_size();
-    uint32_t new_stick_size = output_shape[3] * output_tensor.element_size();
-
-    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores_total);
-
-    uint32_t max_read_size = 2048;
-    for (uint32_t i = 0, curr_sticks_read = 0, curr_sticks_write = 0; i < num_cores_total; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        uint32_t num_new_sticks_per_core = 0, num_old_sticks_per_core = 0;
-        if (split_work_by_old_sticks) {
-            if (core_group_1.contains(core)) {
-                num_old_sticks_per_core = num_w_sticks_per_core_group_1;
-            } else if (core_group_2.contains(core)) {
-                num_old_sticks_per_core = num_w_sticks_per_core_group_2;
-            }
-        } else {
-            if (core_group_1.contains(core)) {
-                num_new_sticks_per_core = num_w_sticks_per_core_group_1;
-            } else if (core_group_2.contains(core)) {
-                num_new_sticks_per_core = num_w_sticks_per_core_group_2;
-            }
-        }
-
-        uint32_t old_new_stick_size_ratio =
-            old_stick_size > new_stick_size ? (old_stick_size / new_stick_size) : (new_stick_size / old_stick_size);
-        if (split_work_by_old_sticks) {
-            num_new_sticks_per_core = num_old_sticks_per_core * old_new_stick_size_ratio;
-        } else {
-            num_old_sticks_per_core = num_new_sticks_per_core * old_new_stick_size_ratio;
-        }
-
-        // issue more reads before calling barrier
-        uint32_t num_old_sticks_per_core_read = 0, num_old_sticks_read_per_barrier = 0, num_old_sticks_per_cb_push = 0;
-        uint32_t num_new_sticks_per_core_read = 0, num_new_sticks_read_per_barrier = 0, num_new_sticks_per_cb_push = 0;
-        if (old_stick_size > new_stick_size) {
-            if (num_old_sticks_per_core != 0) {
-                num_old_sticks_per_core_read =
-                    tt::tt_metal::merge_num_sticks_to_read(num_old_sticks_per_core, old_stick_size, max_read_size);
-                num_old_sticks_read_per_barrier = num_old_sticks_per_core / num_old_sticks_per_core_read;
-                num_old_sticks_per_cb_push = num_old_sticks_read_per_barrier * old_new_stick_size_ratio;
-
-                num_new_sticks_per_cb_push = num_old_sticks_per_cb_push;
-                num_new_sticks_read_per_barrier = num_old_sticks_per_cb_push;
-                num_new_sticks_per_core_read = num_new_sticks_per_core / num_new_sticks_read_per_barrier;
-            }
-        } else {
-            if (num_new_sticks_per_core != 0) {
-                num_new_sticks_per_core_read =
-                    tt::tt_metal::merge_num_sticks_to_read(num_new_sticks_per_core, new_stick_size, max_read_size);
-                num_new_sticks_read_per_barrier = num_new_sticks_per_core / num_new_sticks_per_core_read;
-                num_new_sticks_per_cb_push = num_new_sticks_read_per_barrier;
-
-                num_old_sticks_per_cb_push = num_new_sticks_per_cb_push;
-                num_old_sticks_read_per_barrier = num_old_sticks_per_cb_push * old_new_stick_size_ratio;
-                num_old_sticks_per_core_read = num_old_sticks_per_core / num_old_sticks_read_per_barrier;
-            }
-        }
-
-        // reader
-        std::vector<uint32_t> reader_runtime_args = {
-            input_buffer->address(),
-            num_old_sticks_per_core_read,
-            num_old_sticks_read_per_barrier,
-            num_old_sticks_per_cb_push,
-            curr_sticks_read};
-
-        // writer
-        std::vector<uint32_t> writer_runtime_args = {
-            output_buffer->address(),
-            num_new_sticks_per_core_read,
-            num_new_sticks_read_per_barrier,
-            num_new_sticks_per_cb_push,
-            curr_sticks_write};
-
-        ret_val[i] = {reader_runtime_args, writer_runtime_args};
-
-        curr_sticks_read += num_old_sticks_per_core;
-        curr_sticks_write += num_new_sticks_per_core;
-    }
-
-    return ret_val;
-}
-}  // namespace
-
-ReshapeRMProgramFactory::cached_program_t ReshapeRMProgramFactory::create(
+ProgramDescriptor ReshapeRMProgramFactory::create_descriptor(
     const ttnn::prim::ReshapeOnDeviceParams& /*operation_attributes*/,
     const ttnn::prim::ReshapeOnDeviceInputs& tensor_args,
     tt::tt_metal::Tensor& output_tensor) {
@@ -126,15 +29,13 @@ ReshapeRMProgramFactory::cached_program_t ReshapeRMProgramFactory::create(
         input_tensor.dtype(),
         output_tensor.dtype());
 
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
-
-    tt::tt_metal::IDevice* device = input_tensor.device();
+    IDevice* device = input_tensor.device();
 
     auto output_shape = output_tensor.padded_shape();
-    tt::tt_metal::Buffer* src0_buffer = input_tensor.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output_tensor.buffer();
+    Buffer* src0_buffer = input_tensor.buffer();
+    Buffer* dst_buffer = output_tensor.buffer();
 
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
 
     uint32_t num_old_sticks =
         input_tensor.padded_shape()[0] * input_tensor.padded_shape()[1] * input_tensor.padded_shape()[2];
@@ -155,123 +56,169 @@ ReshapeRMProgramFactory::cached_program_t ReshapeRMProgramFactory::create(
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     uint32_t num_cores_total = num_cores_x * num_cores_y;
     CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    const CoreRangeSet total_core_ranges{total_cores};
 
     bool split_work_by_old_sticks = old_stick_size > new_stick_size;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] =
         tt::tt_metal::split_work_to_cores(
-            compute_with_storage_grid_size, old_stick_size > new_stick_size ? num_old_sticks : num_new_sticks);
+            compute_with_storage_grid_size, split_work_by_old_sticks ? num_old_sticks : num_new_sticks);
 
-    uint32_t src0_cb_index = 0;
+    constexpr uint32_t src0_cb_index = 0;
     auto num_pages = num_sticks_per_core_group_1 > num_sticks_per_core_group_2 ? num_sticks_per_core_group_1
                                                                                : num_sticks_per_core_group_2;
     auto max_page_size = old_stick_size > new_stick_size ? old_stick_size : new_stick_size;
     auto page_size = new_stick_size;
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(num_pages * max_page_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, page_size);
-    tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src0_config);
+
+    ProgramDescriptor desc;
+
+    // CB sized for the largest page across the whole grid; page_size set to new_stick_size
+    // so the writer drains output-sized chunks.
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_pages * max_page_size,
+        .core_ranges = total_core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = page_size,
+        }}},
+    });
 
     // Reader compile-time args
     std::vector<uint32_t> reader_ct_args = {old_stick_size};
-    tt::tt_metal::TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
+    TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
 
     // Writer compile-time args
     std::vector<uint32_t> writer_ct_args = {src0_cb_index, new_stick_size};
-    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
+    TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
 
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/"
-        "reader_unary_reshape_stick_layout_interleaved_multi_core.cpp",
-        total_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
+        "reader_unary_reshape_stick_layout_interleaved_multi_core.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = total_core_ranges;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/"
-        "writer_unary_reshape_stick_layout_interleaved_multi_core.cpp",
-        total_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
+        "writer_unary_reshape_stick_layout_interleaved_multi_core.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = total_core_ranges;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    auto all_runtime_args = get_runtime_args_rm_multi_core(
-        input_tensor,
-        output_tensor,
-        num_cores_total,
-        num_cores_y,
-        core_group_1,
-        num_sticks_per_core_group_1,
-        core_group_2,
-        num_sticks_per_core_group_2,
-        split_work_by_old_sticks);
-
+    constexpr uint32_t max_read_size = 2048;
+    uint32_t curr_sticks_read = 0;
+    uint32_t curr_sticks_write = 0;
     for (uint32_t i = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, all_runtime_args[i].first);
-
-        tt::tt_metal::SetRuntimeArgs(
-            program, writer_kernel_id, core, all_runtime_args[i].second
-
-        );
-    }
-
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, compute_with_storage_grid_size}};
-}
-
-void ReshapeRMProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const ttnn::prim::ReshapeOnDeviceParams& /*operation_attributes*/,
-    const ttnn::prim::ReshapeOnDeviceInputs& tensor_args,
-    tt::tt_metal::Tensor& output_tensor) {
-    const auto& src_tensor = tensor_args.input_tensor;
-    auto& dst_tensor = output_tensor;
-
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    auto& compute_with_storage_grid_size = cached_program.shared_variables.compute_with_storage_grid_size;
-
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-
-    uint32_t num_cores_total = num_cores_x * num_cores_y;
-
-    auto output_shape = dst_tensor.logical_shape();
-
-    uint32_t num_old_sticks =
-        src_tensor.padded_shape()[0] * src_tensor.padded_shape()[1] * src_tensor.padded_shape()[2];
-    uint32_t num_new_sticks = output_shape[0] * output_shape[1] * output_shape[2];
-
-    uint32_t old_stick_size = src_tensor.padded_shape()[3] * src_tensor.element_size();
-    uint32_t new_stick_size = output_shape[3] * dst_tensor.element_size();
-
-    bool split_work_by_old_sticks = old_stick_size > new_stick_size;
-
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] =
-        tt::tt_metal::split_work_to_cores(
-            compute_with_storage_grid_size, old_stick_size > new_stick_size ? num_old_sticks : num_new_sticks);
-    auto all_runtime_args = get_runtime_args_rm_multi_core(
-        src_tensor,
-        dst_tensor,
-        num_cores_total,
-        num_cores_y,
-        core_group_1,
-        num_sticks_per_core_group_1,
-        core_group_2,
-        num_sticks_per_core_group_2,
-        split_work_by_old_sticks);
-
-    for (uint32_t i = 0; i < num_cores_total; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-        {
-            SetRuntimeArgs(program, reader_kernel_id, core, all_runtime_args[i].first);
+        uint32_t num_new_sticks_per_core = 0;
+        uint32_t num_old_sticks_per_core = 0;
+        if (split_work_by_old_sticks) {
+            if (core_group_1.contains(core)) {
+                num_old_sticks_per_core = num_sticks_per_core_group_1;
+            } else if (core_group_2.contains(core)) {
+                num_old_sticks_per_core = num_sticks_per_core_group_2;
+            }
+        } else {
+            if (core_group_1.contains(core)) {
+                num_new_sticks_per_core = num_sticks_per_core_group_1;
+            } else if (core_group_2.contains(core)) {
+                num_new_sticks_per_core = num_sticks_per_core_group_2;
+            }
         }
 
-        {
-            SetRuntimeArgs(program, writer_kernel_id, core, all_runtime_args[i].second);
+        uint32_t old_new_stick_size_ratio =
+            old_stick_size > new_stick_size ? (old_stick_size / new_stick_size) : (new_stick_size / old_stick_size);
+        if (split_work_by_old_sticks) {
+            num_new_sticks_per_core = num_old_sticks_per_core * old_new_stick_size_ratio;
+        } else {
+            num_old_sticks_per_core = num_new_sticks_per_core * old_new_stick_size_ratio;
         }
+
+        // issue more reads before calling barrier
+        uint32_t num_old_sticks_per_core_read = 0;
+        uint32_t num_old_sticks_read_per_barrier = 0;
+        uint32_t num_old_sticks_per_cb_push = 0;
+        uint32_t num_new_sticks_per_core_read = 0;
+        uint32_t num_new_sticks_read_per_barrier = 0;
+        uint32_t num_new_sticks_per_cb_push = 0;
+        if (old_stick_size > new_stick_size) {
+            if (num_old_sticks_per_core != 0) {
+                num_old_sticks_per_core_read =
+                    tt::tt_metal::merge_num_sticks_to_read(num_old_sticks_per_core, old_stick_size, max_read_size);
+                num_old_sticks_read_per_barrier = num_old_sticks_per_core / num_old_sticks_per_core_read;
+                num_old_sticks_per_cb_push = num_old_sticks_read_per_barrier * old_new_stick_size_ratio;
+
+                num_new_sticks_per_cb_push = num_old_sticks_per_cb_push;
+                num_new_sticks_read_per_barrier = num_old_sticks_per_cb_push;
+                num_new_sticks_per_core_read = num_new_sticks_per_core / num_new_sticks_read_per_barrier;
+            }
+        } else {
+            if (num_new_sticks_per_core != 0) {
+                num_new_sticks_per_core_read =
+                    tt::tt_metal::merge_num_sticks_to_read(num_new_sticks_per_core, new_stick_size, max_read_size);
+                num_new_sticks_read_per_barrier = num_new_sticks_per_core / num_new_sticks_per_core_read;
+                num_new_sticks_per_cb_push = num_new_sticks_read_per_barrier;
+
+                num_old_sticks_per_cb_push = num_new_sticks_per_cb_push;
+                num_old_sticks_read_per_barrier = num_new_sticks_per_cb_push * old_new_stick_size_ratio;
+                num_old_sticks_per_core_read = num_old_sticks_per_core / num_old_sticks_read_per_barrier;
+            }
+        }
+
+        // Per-core runtime args. Slot 0 holds the buffer address; idle cores (no sticks
+        // scheduled) get 0u so we skip BufferBinding registration — the kernel short-circuits
+        // when its sticks-to-read count is zero and never dereferences the address.
+        const bool reader_idle = num_old_sticks_per_core == 0;
+        if (reader_idle) {
+            reader_desc.emplace_runtime_args(
+                core,
+                {0u,
+                 num_old_sticks_per_core_read,
+                 num_old_sticks_read_per_barrier,
+                 num_old_sticks_per_cb_push,
+                 curr_sticks_read});
+        } else {
+            reader_desc.emplace_runtime_args(
+                core,
+                {src0_buffer,
+                 num_old_sticks_per_core_read,
+                 num_old_sticks_read_per_barrier,
+                 num_old_sticks_per_cb_push,
+                 curr_sticks_read});
+        }
+
+        const bool writer_idle = num_new_sticks_per_core == 0;
+        if (writer_idle) {
+            writer_desc.emplace_runtime_args(
+                core,
+                {0u,
+                 num_new_sticks_per_core_read,
+                 num_new_sticks_read_per_barrier,
+                 num_new_sticks_per_cb_push,
+                 curr_sticks_write});
+        } else {
+            writer_desc.emplace_runtime_args(
+                core,
+                {dst_buffer,
+                 num_new_sticks_per_core_read,
+                 num_new_sticks_read_per_barrier,
+                 num_new_sticks_per_cb_push,
+                 curr_sticks_write});
+        }
+
+        curr_sticks_read += num_old_sticks_per_core;
+        curr_sticks_write += num_new_sticks_per_core;
     }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_rm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_rm_program_factory.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "ttnn/operation.hpp"
 #include "ttnn/device_operation.hpp"
 #include "reshape_device_operation_types.hpp"
@@ -11,21 +13,7 @@
 namespace ttnn::prim {
 
 struct ReshapeRMProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle reader_kernel_id{};
-        tt::tt_metal::KernelHandle writer_kernel_id{};
-        tt::tt_metal::CoreCoord compute_with_storage_grid_size;
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const ttnn::prim::ReshapeOnDeviceParams& operation_attributes,
-        const ttnn::prim::ReshapeOnDeviceInputs& tensor_args,
-        tt::tt_metal::Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const ttnn::prim::ReshapeOnDeviceParams& operation_attributes,
         const ttnn::prim::ReshapeOnDeviceInputs& tensor_args,
         tt::tt_metal::Tensor& output_tensor);

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_tile_program_factory.cpp
@@ -3,113 +3,119 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "reshape_tile_program_factory.hpp"
-#include <tt-metalium/work_split.hpp>
-#include "ttnn/operations/math.hpp"
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/hal.hpp>
+
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+
 #include "ttnn/operation.hpp"
+#include "ttnn/operations/math.hpp"
 
 namespace ttnn::prim {
 
-ReshapeTileProgramFactory::cached_program_t ReshapeTileProgramFactory::create(
+using namespace tt::tt_metal;
+
+ProgramDescriptor ReshapeTileProgramFactory::create_descriptor(
     const ttnn::prim::ReshapeOnDeviceParams& /*operation_attributes*/,
     const ttnn::prim::ReshapeOnDeviceInputs& tensor_args,
     tt::tt_metal::Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input_tensor;
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
-    CoreRange core({0, 0}, {0, 0});
+    const CoreRangeSet core_ranges{CoreRange{{0, 0}, {0, 0}}};
+    const CoreCoord core{0, 0};
 
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
 
-    tt::tt_metal::Buffer* src0_buffer = input_tensor.buffer();
+    Buffer* src0_buffer = input_tensor.buffer();
 
     uint32_t num_tiles = input_tensor.physical_volume() / tt::constants::TILE_HW;
 
     auto output_shape = output_tensor.padded_shape();
 
-    tt::tt_metal::Buffer* dst_buffer = output_tensor.buffer();
+    Buffer* dst_buffer = output_tensor.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    uint32_t src0_cb_index = 0;
-    uint32_t num_input_tiles = 2;
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
+    constexpr uint32_t src0_cb_index = 0;
+    constexpr uint32_t num_input_tiles = 2;
 
-    bool src0_is_dram = src0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    uint32_t alignment = src0_is_dram ? tt::tt_metal::hal::get_dram_alignment() : tt::tt_metal::hal::get_l1_alignment();
+    ProgramDescriptor desc;
+
+    // Primary input CB: holds tiles streamed from DRAM/L1 into the writer.
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
+
+    bool src0_is_dram = src0_buffer->buffer_type() == BufferType::DRAM;
+    uint32_t alignment = src0_is_dram ? hal::get_dram_alignment() : hal::get_l1_alignment();
 
     std::vector<uint32_t> reader_compile_time_args = {alignment};
-    tt::tt_metal::TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)src0_cb_index};
-    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(src0_cb_index)};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
+    // Wide-alignment scratch CB: only needed when DRAM/L1 alignment exceeds a face's
+    // worth of bytes (the reader uses it as a temporary aligned landing pad).
     if (alignment > (tt::constants::FACE_WIDTH * input_tensor.element_size())) {
-        uint32_t src1_cb_index = 1;
-        tt::tt_metal::CircularBufferConfig cb_src1_config =
-            tt::tt_metal::CircularBufferConfig(alignment, {{src1_cb_index, cb_data_format}})
-                .set_page_size(src1_cb_index, alignment);
-        tt::tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
+        constexpr uint32_t src1_cb_index = 1;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = alignment,
+            .core_ranges = core_ranges,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(src1_cb_index),
+                .data_format = cb_data_format,
+                .page_size = alignment,
+            }}},
+        });
     }
 
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/kernels/dataflow/"
-        "reader_unary_reshape_interleaved.cpp",
-        core,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+        "reader_unary_reshape_interleaved.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core_ranges;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
+    // Reader runtime arg slot 0: src buffer address. Buffer* registers a BufferBinding
+    // so the framework patches the address on cache hits without rebuilding the descriptor.
+    reader_desc.emplace_runtime_args(
         core,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
-
-    tt::tt_metal::SetRuntimeArgs(
-        program,
-        unary_reader_kernel_id,
-        core,
-        {src0_buffer->address(),
+        {src0_buffer,
          input_tensor.padded_shape()[3] / tt::constants::TILE_WIDTH,
-         (uint32_t)output_shape[0],
-         (uint32_t)output_shape[1],
-         (uint32_t)output_shape[2] / tt::constants::TILE_HEIGHT,
-         (uint32_t)output_shape[3] / tt::constants::TILE_WIDTH});
+         static_cast<uint32_t>(output_shape[0]),
+         static_cast<uint32_t>(output_shape[1]),
+         static_cast<uint32_t>(output_shape[2]) / tt::constants::TILE_HEIGHT,
+         static_cast<uint32_t>(output_shape[3]) / tt::constants::TILE_WIDTH});
 
-    tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, {dst_buffer->address(), num_tiles, 0});
+    desc.kernels.push_back(std::move(reader_desc));
 
-    return {std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id}};
-}
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = core_ranges;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
-void ReshapeTileProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const ttnn::prim::ReshapeOnDeviceParams& /*operation_attributes*/,
-    const ttnn::prim::ReshapeOnDeviceInputs& tensor_args,
-    tt::tt_metal::Tensor& output_tensor) {
-    auto* src_buffer = tensor_args.input_tensor.buffer();
-    auto* dst_buffer = output_tensor.buffer();
+    // Writer runtime arg slot 0: dst buffer address (Buffer* -> BufferBinding for cache-hit patching).
+    // Slot 1: total tile count, slot 2: start_id (always 0 here, single-core).
+    writer_desc.emplace_runtime_args(core, {dst_buffer, num_tiles, 0u});
 
-    CoreCoord core = {0, 0};
+    desc.kernels.push_back(std::move(writer_desc));
 
-    auto& program = cached_program.program;
-    auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-
-    {
-        auto& runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
-        runtime_args[0] = src_buffer->address();
-    }
-
-    {
-        auto& runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
-        runtime_args[0] = dst_buffer->address();
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_tile_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_tile_program_factory.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "ttnn/operation.hpp"
 #include "ttnn/device_operation.hpp"
 #include "reshape_device_operation_types.hpp"
@@ -11,20 +13,7 @@
 namespace ttnn::prim {
 
 struct ReshapeTileProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-        tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const ttnn::prim::ReshapeOnDeviceParams& operation_attributes,
-        const ttnn::prim::ReshapeOnDeviceInputs& tensor_args,
-        tt::tt_metal::Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const ttnn::prim::ReshapeOnDeviceParams& operation_attributes,
         const ttnn::prim::ReshapeOnDeviceInputs& tensor_args,
         tt::tt_metal::Tensor& output_tensor);

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_program_factory.cpp
@@ -5,6 +5,7 @@
 #include "ttnn/operations/data_movement/reshape_view/device/reshape_row_major_program_factory.hpp"
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 #define MASK_64 0xFFFFFFFFFFFFFFC0
@@ -12,17 +13,18 @@
 
 namespace ttnn::prim {
 
-ReshapeViewRMProgramFactory::cached_program_t ReshapeViewRMProgramFactory::create(
+using namespace tt::tt_metal;
+
+ProgramDescriptor ReshapeViewRMProgramFactory::create_descriptor(
     const ReshapeViewParams& operation_attributes, const ReshapeViewInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input;
     const auto& output = tensor_return_value;
     const auto& sub_core_grid = operation_attributes.sub_core_grid;
 
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
     // get datum size
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
     const uint32_t data_size = input.element_size();
-    tt::tt_metal::IDevice* device = input.device();
+    IDevice* device = input.device();
     // Multi device pre-computation
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
@@ -44,8 +46,8 @@ ReshapeViewRMProgramFactory::cached_program_t ReshapeViewRMProgramFactory::creat
     uint32_t source_read_size_bytes = ((source_page_size_bytes - 1) & MASK_64) + 128;
     uint32_t read_start_page = 0;
     uint32_t write_start_page = 0;
-    tt::tt_metal::Buffer* src_buffer = input.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    Buffer* src_buffer = input.buffer();
+    Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
     // Find how many input pages each core is responsible for so that we always start at the beginning of a read and
     // write page Since the logical volumes match, we are guaranteed that the very last page is aligned
@@ -59,16 +61,32 @@ ReshapeViewRMProgramFactory::cached_program_t ReshapeViewRMProgramFactory::creat
     bool can_use_dual_kernel =
         (source_page_size_bytes % dest_page_size_bytes == 0 || dest_page_size_bytes % source_page_size_bytes == 0);
 
-    uint32_t src0_cb_index = 0;
-    uint32_t src1_cb_index = 1;
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(cb_size0 * 2, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, cb_size0);
-    tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src0_config);
-    tt::tt_metal::CircularBufferConfig cb_src1_config =
-        tt::tt_metal::CircularBufferConfig(cb_size1, {{src1_cb_index, cb_data_format}})
-            .set_page_size(src1_cb_index, cb_size1);
-    tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src1_config);
+    constexpr uint32_t src0_cb_index = 0;
+    constexpr uint32_t src1_cb_index = 1;
+    constexpr uint32_t src2_cb_index = 2;
+    constexpr uint32_t src3_cb_index = 3;
+
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_size0 * 2,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = cb_data_format,
+            .page_size = cb_size0,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_size1,
+        .core_ranges = total_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src1_cb_index,
+            .data_format = cb_data_format,
+            .page_size = cb_size1,
+        }}},
+    });
+
     std::vector<uint32_t> compile_time_args = {
         (std::uint32_t)(source_page_size_bytes % 64 == 0) ? 1 : 0,
         (std::uint32_t)(source_page_size_bytes % 16 == 0) ? 1 : 0,
@@ -76,44 +94,62 @@ ReshapeViewRMProgramFactory::cached_program_t ReshapeViewRMProgramFactory::creat
         src1_cb_index,
         source_page_size_bytes,
         dest_page_size_bytes};
-    tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*dst_buffer).append_to(compile_time_args);
 
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/rm_reshape_interleaved.cpp",
-        total_cores,
-        tt::tt_metal::ReaderDataMovementConfig(compile_time_args));
-    uint32_t src2_cb_index = 2;
-    uint32_t src3_cb_index = 3;
-    tt::tt_metal::KernelHandle reader_kernel_id2 = 0;
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/rm_reshape_interleaved.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = total_cores;
+    reader_desc.compile_time_args = compile_time_args;
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    // Second kernel uses CBs 2/3 with otherwise identical compile-time args; build its
+    // dedicated arg vector so we don't alias reader_desc.compile_time_args.
+    std::vector<uint32_t> writer_compile_time_args;
+    KernelDescriptor writer_desc;
     if (can_use_dual_kernel) {
-        tt::tt_metal::CircularBufferConfig cb_src2_config =
-            tt::tt_metal::CircularBufferConfig(cb_size0 * 2, {{src2_cb_index, cb_data_format}})
-                .set_page_size(src2_cb_index, cb_size0);
-        tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src2_config);
-        tt::tt_metal::CircularBufferConfig cb_src3_config =
-            tt::tt_metal::CircularBufferConfig(cb_size1, {{src3_cb_index, cb_data_format}})
-                .set_page_size(src3_cb_index, cb_size1);
-        tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src3_config);
-        compile_time_args[2] = src2_cb_index;
-        compile_time_args[3] = src3_cb_index;
-        reader_kernel_id2 = tt::tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/rm_reshape_interleaved.cpp",
-            total_cores,
-            tt::tt_metal::WriterDataMovementConfig(compile_time_args));
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = cb_size0 * 2,
+            .core_ranges = total_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = src2_cb_index,
+                .data_format = cb_data_format,
+                .page_size = cb_size0,
+            }}},
+        });
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = cb_size1,
+            .core_ranges = total_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = src3_cb_index,
+                .data_format = cb_data_format,
+                .page_size = cb_size1,
+            }}},
+        });
+
+        writer_compile_time_args = compile_time_args;
+        writer_compile_time_args[2] = src2_cb_index;
+        writer_compile_time_args[3] = src3_cb_index;
+
+        writer_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/rm_reshape_interleaved.cpp";
+        writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        writer_desc.core_ranges = total_cores;
+        writer_desc.compile_time_args = std::move(writer_compile_time_args);
+        writer_desc.config = WriterConfigDescriptor{};
     }
+
     uint32_t done = 0;
     for (auto core : corerange_to_cores(total_cores, std::nullopt)) {
         if (done == 1) {
-            const std::vector<uint32_t> reader_runtime_args = {
-                src_buffer->address(), dst_buffer->address(), source_read_size_bytes, 0, 0, 0, 0, 1
-
-            };
-            tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+            // Idle core: skip BufferBinding registration by passing 0u for buffer slots —
+            // the kernel short-circuits when the "done" flag (last arg) is 1 and never
+            // dereferences the address.
+            reader_desc.emplace_runtime_args(core, {0u, 0u, source_read_size_bytes, 0u, 0u, 0u, 0u, 1u});
             if (can_use_dual_kernel) {
-                tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id2, core, reader_runtime_args);
+                writer_desc.emplace_runtime_args(core, {0u, 0u, source_read_size_bytes, 0u, 0u, 0u, 0u, 1u});
             }
         } else {
             // Create the circular buffers
@@ -143,35 +179,32 @@ ReshapeViewRMProgramFactory::cached_program_t ReshapeViewRMProgramFactory::creat
                     second_write_pos = write_start_page + half_output_pages;
                 }
 
-                std::vector<uint32_t> runtime_args = {
-                    src_buffer->address(),
-                    dst_buffer->address(),
-                    source_read_size_bytes,
-                    start_of_read,
-                    mid_read,
-                    write_start_page,
-                    0,
-                    0};
+                reader_desc.emplace_runtime_args(
+                    core,
+                    {src_buffer,
+                     dst_buffer,
+                     source_read_size_bytes,
+                     start_of_read,
+                     mid_read,
+                     write_start_page,
+                     0u,
+                     0u});
 
-                tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
-
-                runtime_args[3] = mid_read;
-                runtime_args[4] = end_of_read;
-                runtime_args[5] = second_write_pos;
-
-                tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id2, core, runtime_args);
+                writer_desc.emplace_runtime_args(
+                    core,
+                    {src_buffer, dst_buffer, source_read_size_bytes, mid_read, end_of_read, second_write_pos, 0u, 0u});
             } else {
                 // Original single kernel approach
-                const std::vector<uint32_t> reader_runtime_args = {
-                    src_buffer->address(),
-                    dst_buffer->address(),
-                    source_read_size_bytes,
-                    start_of_read,
-                    end_of_read,
-                    write_start_page,
-                    0,  // write_start_offset removed (always 0)
-                    done};
-                tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+                reader_desc.emplace_runtime_args(
+                    core,
+                    {src_buffer,
+                     dst_buffer,
+                     source_read_size_bytes,
+                     start_of_read,
+                     end_of_read,
+                     write_start_page,
+                     0u,  // write_start_offset removed (always 0)
+                     done});
             }
             write_start_page += write_jump;
             read_start_page = end_of_read;
@@ -179,46 +212,12 @@ ReshapeViewRMProgramFactory::cached_program_t ReshapeViewRMProgramFactory::creat
         }
     }
 
-    return {std::move(program), {reader_kernel_id, reader_kernel_id2, can_use_dual_kernel, num_cores_x, num_cores_y}};
-}
-
-void ReshapeViewRMProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const ReshapeViewParams& operation_attributes,
-    const ReshapeViewInputs& tensor_args,
-    Tensor& tensor_return_value) {
-    auto& shared_variables = cached_program.shared_variables;
-    const auto& reader_kernel_id = shared_variables.reader_kernel_id;
-    const auto& reader_kernel_id2 = shared_variables.reader_kernel_id2;
-    const auto& can_use_dual_kernel = shared_variables.can_use_dual_kernel;
-    const auto& num_cores_x = shared_variables.num_cores_x;
-    const auto& num_cores_y = shared_variables.num_cores_y;
-
-    tt::tt_metal::Buffer* src_buffer = tensor_args.input.buffer();
-    tt::tt_metal::Buffer* dst_buffer = tensor_return_value.buffer();
-
-    auto& program = cached_program.program;
-
-    CoreRange default_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
-    CoreRangeSet total_cores = operation_attributes.sub_core_grid.has_value()
-                                   ? operation_attributes.sub_core_grid.value()
-                                   : CoreRangeSet(default_cores);
-
-    for (auto core : corerange_to_cores(total_cores, std::nullopt)) {
-        // Update buffer addresses for primary kernel
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = src_buffer->address();  // src_buffer address
-            runtime_args[1] = dst_buffer->address();  // dst_buffer address
-        }
-
-        // Update buffer addresses for dual kernel if enabled
-        if (can_use_dual_kernel) {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id2, core);
-            runtime_args[0] = src_buffer->address();  // src_buffer address
-            runtime_args[1] = dst_buffer->address();  // dst_buffer address
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    if (can_use_dual_kernel) {
+        desc.kernels.push_back(std::move(writer_desc));
     }
+
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_row_major_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_row_major_program_factory.hpp
@@ -4,28 +4,15 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/reshape_view/device/reshape_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct ReshapeViewRMProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle reader_kernel_id{};
-        tt::tt_metal::KernelHandle reader_kernel_id2{};
-        bool can_use_dual_kernel{};
-        uint32_t num_cores_x{};
-        uint32_t num_cores_y{};
-    };
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const ReshapeViewParams& operation_attributes,
-        const ReshapeViewInputs& tensor_args,
-        Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const ReshapeViewParams& operation_attributes,
         const ReshapeViewInputs& tensor_args,
         Tensor& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_common.hpp
@@ -5,24 +5,21 @@
 #pragma once
 
 #include "scatter_device_operation_types.hpp"
-#include "tt-metalium/allocator.hpp"
-#include "tt-metalium/device.hpp"
 #include "common/common.hpp"  // Data movement common utilities
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+#include "ttnn/tensor/tensor.hpp"
+
+#include <cstdint>
 
 namespace ttnn::prim {
 
-using namespace tt;
-using namespace tt::tt_metal;
-
+// CB index assignments shared by both scatter program factories.
 enum class ScatterCB : std::underlying_type_t<tt::CBIndex> {
-    INPUT = CBIndex::c_0,
-    SRC = CBIndex::c_1,
-    INDEX = CBIndex::c_2,
-    DST = CBIndex::c_3,
-    FP32_TEMP = CBIndex::c_4,
+    INPUT = tt::CBIndex::c_0,
+    SRC = tt::CBIndex::c_1,
+    INDEX = tt::CBIndex::c_2,
+    DST = tt::CBIndex::c_3,
+    FP32_TEMP = tt::CBIndex::c_4,
 };
 
 constexpr uint32_t BIT_MASK_32 = 32 - 1;
@@ -37,37 +34,9 @@ inline uint64_t ceil32(const uint64_t& number) {
 // tensors)
 // ... divided by 4 to account for 4-byte datum sizes of each tensor (fp32, int32)
 // ... minimized by ~10% to account for reserved memory
-inline uint32_t calculate_optimal_chunk_size(const Tensor& input_tensor) {
+inline uint32_t calculate_optimal_chunk_size(const tt::tt_metal::Tensor& input_tensor) {
     uint32_t l1_per_chunk = (ttnn::operations::data_movement::get_max_l1_space(input_tensor) / 4) / 4;
     return ceil32((l1_per_chunk * 9 / 10) - 32);
-}
-
-inline CBHandle create_cb(
-    Program& program,
-    const DataType& dtype,
-    const ScatterCB& scatter_cb,
-    const CoreRangeSet& core_range_set,
-    const uint32_t& page_size_bytes) {
-    const uint32_t cb_id{static_cast<uint32_t>(scatter_cb)};
-    const auto cb_data_format{datatype_to_dataformat_converter(dtype)};
-    const auto cb_config{
-        CircularBufferConfig{page_size_bytes, {{cb_id, cb_data_format}}}.set_page_size(cb_id, page_size_bytes)};
-    return CreateCircularBuffer(program, core_range_set, cb_config);
-}
-
-inline KernelHandle create_kernel(
-    Program& program,
-    const char* kernel_path,
-    const CoreRangeSet& core_range_set,
-    const std::variant<DataMovementConfig, ComputeConfig>& config,
-    const std::vector<uint32_t>& runtime_args = {}) {
-    auto kernel_id{CreateKernel(program, kernel_path, core_range_set, config)};
-
-    if (!runtime_args.empty()) {
-        SetRuntimeArgs(program, kernel_id, core_range_set, runtime_args);
-    }
-
-    return kernel_id;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_program_factory.cpp
@@ -6,24 +6,17 @@
 
 #include "scatter_common.hpp"
 
-#include "scatter_device_operation_types.hpp"
-#include "tt-metalium/allocator.hpp"
-#include "tt-metalium/device.hpp"
-
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
 
 namespace ttnn::prim {
 
-using namespace tt;
 using namespace tt::tt_metal;
 
-ScatterProgramFactory::cached_program_t ScatterProgramFactory::create(
+ProgramDescriptor ScatterProgramFactory::create_descriptor(
     const ScatterParams& args, const ScatterInputs& tensor_args, Tensor& output_tensor) {
-    using namespace tt::tt_metal;
-
-    Program program{};
-
     const auto& input_tensor{tensor_args.input_tensor};
     const auto& input_shape{input_tensor.logical_shape()};
     const auto& index_tensor{tensor_args.index_tensor};
@@ -37,22 +30,22 @@ ScatterProgramFactory::cached_program_t ScatterProgramFactory::create(
     auto* src_buffer = src_tensor.buffer();
     auto* output_buffer = output_tensor.buffer();
 
-    const uint32_t& input_stick_size = input_shape[-1];
-    const uint32_t& index_stick_size = index_shape[-1];
-    const uint32_t& source_stick_size = src_shape[-1];
-    const uint32_t& output_stick_size = output_shape[-1];
+    const uint32_t input_stick_size = input_shape[-1];
+    const uint32_t index_stick_size = index_shape[-1];
+    const uint32_t source_stick_size = src_shape[-1];
+    const uint32_t output_stick_size = output_shape[-1];
 
     // input dtype byte sizes
-    const uint32_t& input_datum_size = input_tensor.element_size();
-    const uint32_t& index_datum_size = index_tensor.element_size();
-    const uint32_t& source_datum_size = src_tensor.element_size();
-    const uint32_t& output_datum_size = output_tensor.element_size();
+    const uint32_t input_datum_size = input_tensor.element_size();
+    const uint32_t index_datum_size = index_tensor.element_size();
+    const uint32_t source_datum_size = src_tensor.element_size();
+    const uint32_t output_datum_size = output_tensor.element_size();
 
     // input row byte sizes
-    const uint32_t& input_stick_size_bytes = input_stick_size * input_datum_size;
-    const uint32_t& index_stick_size_bytes = index_stick_size * index_datum_size;
-    const uint32_t& source_stick_size_bytes = source_stick_size * source_datum_size;
-    const uint32_t& output_stick_size_bytes = output_stick_size * output_datum_size;
+    const uint32_t input_stick_size_bytes = input_stick_size * input_datum_size;
+    const uint32_t index_stick_size_bytes = index_stick_size * index_datum_size;
+    const uint32_t source_stick_size_bytes = source_stick_size * source_datum_size;
+    const uint32_t output_stick_size_bytes = output_stick_size * output_datum_size;
 
     // maximal input/index/source/output chunk size, divisible by 32, calculated as follows:
     // BH available L1 mem size of nearly 1.5 MB...
@@ -82,10 +75,10 @@ ScatterProgramFactory::cached_program_t ScatterProgramFactory::create(
         "ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/writer_scatter.cpp";
 
     std::vector<uint32_t> compile_time_args{
-        input_tensor.buffer()->address(),
-        index_tensor.buffer()->address(),
-        src_tensor.buffer()->address(),
-        output_tensor.buffer()->address(),
+        input_buffer->address(),
+        index_buffer->address(),
+        src_buffer->address(),
+        output_buffer->address(),
         static_cast<uint32_t>(ScatterCB::INPUT),
         static_cast<uint32_t>(ScatterCB::INDEX),
         static_cast<uint32_t>(ScatterCB::SRC),
@@ -99,10 +92,10 @@ ScatterProgramFactory::cached_program_t ScatterProgramFactory::create(
         source_stick_size_bytes,
         output_stick_size_bytes,
         input_shape.rank()};
-    tt::tt_metal::TensorAccessorArgs(*input_buffer).append_to(compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*index_buffer).append_to(compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*output_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*input_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*index_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*output_buffer).append_to(compile_time_args);
 
     auto* device = input_tensor.device();
     const auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
@@ -116,17 +109,41 @@ ScatterProgramFactory::cached_program_t ScatterProgramFactory::create(
     const auto farthest_x_y =
         args.sub_core_grid.has_value() ? args.sub_core_grid->bounding_box().end_coord : compute_with_storage_grid_size;
     const uint32_t all_cores_in_bounding_box = (farthest_x_y.x + 1) * (farthest_x_y.y + 1);
-    create_cb(program, input_tensor.dtype(), ScatterCB::INPUT, all_cores, input_page_size_bytes);
-    create_cb(program, index_tensor.dtype(), ScatterCB::INDEX, all_cores, index_page_size_bytes);
-    create_cb(program, src_tensor.dtype(), ScatterCB::SRC, all_cores, source_page_size_bytes);
-    create_cb(program, output_tensor.dtype(), ScatterCB::DST, all_cores, output_page_size_bytes);
 
-    auto reader_kernel =
-        create_kernel(program, reader_kernel_path, all_cores, ReaderDataMovementConfig{compile_time_args});
-    auto writer_kernel =
-        create_kernel(program, writer_kernel_path, all_cores, WriterDataMovementConfig{compile_time_args});
+    ProgramDescriptor desc;
 
-    std::vector<CoreCoord> cores{};
+    auto add_cb = [&](ScatterCB scatter_cb, DataType dtype, uint32_t page_size_bytes) {
+        const uint32_t cb_id = static_cast<uint32_t>(scatter_cb);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = page_size_bytes,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_id),
+                .data_format = datatype_to_dataformat_converter(dtype),
+                .page_size = page_size_bytes,
+            }}},
+        });
+    };
+
+    add_cb(ScatterCB::INPUT, input_tensor.dtype(), input_page_size_bytes);
+    add_cb(ScatterCB::INDEX, index_tensor.dtype(), index_page_size_bytes);
+    add_cb(ScatterCB::SRC, src_tensor.dtype(), source_page_size_bytes);
+    add_cb(ScatterCB::DST, output_tensor.dtype(), output_page_size_bytes);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_path;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = compile_time_args;
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_path;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
     uint32_t stick_offset = 0;
     for (uint32_t i = 0; i < all_cores_in_bounding_box; ++i) {
         const CoreCoord core{i / (farthest_x_y.y + 1), i % (farthest_x_y.y + 1)};
@@ -138,60 +155,38 @@ ScatterProgramFactory::cached_program_t ScatterProgramFactory::create(
         } else {
             continue;
         }
-        cores.push_back(core);
 
-        std::vector<uint32_t> reader_runtime_args{
-            input_buffer->address(),
-            index_buffer->address(),
-            src_buffer->address(),
-            stick_offset,
-            sticks_per_core,
-            input_and_output_chunk_size,
-            index_chunk_size,
-            source_chunk_size,
-            static_cast<uint32_t>(args.opt_reduction)};
-        std::copy(input_shape.cbegin(), input_shape.cend() - 1, std::back_inserter(reader_runtime_args));
-        std::copy(index_shape.cbegin(), index_shape.cend() - 1, std::back_inserter(reader_runtime_args));
+        // Buffer* entries become BufferBinding slots; addresses are patched on cache hits
+        // without rebuilding the descriptor.
+        KernelDescriptor::RTArgList reader_runtime_args;
+        reader_runtime_args.reserve(9 + (input_shape.rank() - 1) + (index_shape.rank() - 1));
+        reader_runtime_args.push_back(input_buffer);
+        reader_runtime_args.push_back(index_buffer);
+        reader_runtime_args.push_back(src_buffer);
+        reader_runtime_args.push_back(stick_offset);
+        reader_runtime_args.push_back(sticks_per_core);
+        reader_runtime_args.push_back(input_and_output_chunk_size);
+        reader_runtime_args.push_back(index_chunk_size);
+        reader_runtime_args.push_back(source_chunk_size);
+        reader_runtime_args.push_back(static_cast<uint32_t>(args.opt_reduction));
+        for (const auto* it = input_shape.cbegin(); it != input_shape.cend() - 1; ++it) {
+            reader_runtime_args.push_back(static_cast<uint32_t>(*it));
+        }
+        for (const auto* it = index_shape.cbegin(); it != index_shape.cend() - 1; ++it) {
+            reader_runtime_args.push_back(static_cast<uint32_t>(*it));
+        }
+        reader_desc.emplace_runtime_args(core, reader_runtime_args);
 
-        SetRuntimeArgs(program, reader_kernel, core, reader_runtime_args);
-
-        std::vector<uint32_t> writer_runtime_args{
-            output_buffer->address(),
-            stick_offset,
-            sticks_per_core,
-            input_and_output_chunk_size,
-        };
-
-        SetRuntimeArgs(program, writer_kernel, core, writer_runtime_args);
+        writer_desc.emplace_runtime_args(
+            core, {output_buffer, stick_offset, sticks_per_core, input_and_output_chunk_size});
 
         stick_offset += sticks_per_core;
     }
 
-    return {std::move(program), {reader_kernel, writer_kernel, cores}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void ScatterProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const ScatterParams& /*args*/,
-    const ScatterInputs& tensor_args,
-    Tensor& output_tensor) {
-    const auto& program = cached_program.program;
-    const auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    const auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    const auto& cores = cached_program.shared_variables.cores;
-
-    auto input_buffer_address = tensor_args.input_tensor.buffer()->address();
-    auto index_buffer_address = tensor_args.index_tensor.buffer()->address();
-    auto source_buffer_address = tensor_args.src_tensor.buffer()->address();
-    auto output_buffer_address = output_tensor.buffer()->address();
-    for (const auto& core : cores) {
-        auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-        auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-        reader_runtime_args[0] = input_buffer_address;
-        reader_runtime_args[1] = index_buffer_address;
-        reader_runtime_args[2] = source_buffer_address;
-        writer_runtime_args[0] = output_buffer_address;
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_program_factory.hpp
@@ -4,30 +4,16 @@
 
 #pragma once
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 #include "scatter_device_operation_types.hpp"
-
-#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
-using namespace tt;
-using namespace tt::tt_metal;
-
 struct ScatterProgramFactory {
-    struct shared_variables_t {
-        KernelHandle reader_kernel_id{};
-        KernelHandle writer_kernel_id{};
-        std::vector<CoreCoord> cores;
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(const ScatterParams&, const ScatterInputs&, Tensor&);
-
-    static void override_runtime_arguments(cached_program_t&, const ScatterParams&, const ScatterInputs&, Tensor&);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ScatterParams& args, const ScatterInputs& tensor_args, Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_reduce_bfloat16_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_reduce_bfloat16_program_factory.cpp
@@ -6,23 +6,17 @@
 
 #include "scatter_common.hpp"
 
-#include "scatter_device_operation_types.hpp"
-#include "tt-metalium/device.hpp"
-
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
 
 namespace ttnn::prim {
 
-using namespace tt;
 using namespace tt::tt_metal;
 
-ScatterReduceBfloat16ProgramFactory::cached_program_t ScatterReduceBfloat16ProgramFactory::create(
+ProgramDescriptor ScatterReduceBfloat16ProgramFactory::create_descriptor(
     const ScatterParams& args, const ScatterInputs& tensor_args, Tensor& output_tensor) {
-    using namespace tt::tt_metal;
-
-    Program program{};
-
     const auto& input_tensor{tensor_args.input_tensor};
     const auto& input_shape{input_tensor.logical_shape()};
     const auto& index_tensor{tensor_args.index_tensor};
@@ -36,23 +30,23 @@ ScatterReduceBfloat16ProgramFactory::cached_program_t ScatterReduceBfloat16Progr
     auto* src_buffer = src_tensor.buffer();
     auto* output_buffer = output_tensor.buffer();
 
-    const uint32_t& input_stick_size = input_shape[-1];
-    const uint32_t& index_stick_size = index_shape[-1];
-    const uint32_t& source_stick_size = src_shape[-1];
-    const uint32_t& output_stick_size = output_shape[-1];
+    const uint32_t input_stick_size = input_shape[-1];
+    const uint32_t index_stick_size = index_shape[-1];
+    const uint32_t source_stick_size = src_shape[-1];
+    const uint32_t output_stick_size = output_shape[-1];
 
     // input dtype byte sizes
-    const uint32_t& input_datum_size = input_tensor.element_size();
-    const uint32_t& index_datum_size = index_tensor.element_size();
-    const uint32_t& source_datum_size = src_tensor.element_size();
-    const uint32_t& output_datum_size = output_tensor.element_size();
-    const uint32_t& fp32_temp_datum_size = sizeof(float);
+    const uint32_t input_datum_size = input_tensor.element_size();
+    const uint32_t index_datum_size = index_tensor.element_size();
+    const uint32_t source_datum_size = src_tensor.element_size();
+    const uint32_t output_datum_size = output_tensor.element_size();
+    const uint32_t fp32_temp_datum_size = sizeof(float);
 
     // input row byte sizes
-    const uint32_t& input_stick_size_bytes = input_stick_size * input_datum_size;
-    const uint32_t& index_stick_size_bytes = index_stick_size * index_datum_size;
-    const uint32_t& source_stick_size_bytes = source_stick_size * source_datum_size;
-    const uint32_t& output_stick_size_bytes = output_stick_size * output_datum_size;
+    const uint32_t input_stick_size_bytes = input_stick_size * input_datum_size;
+    const uint32_t index_stick_size_bytes = index_stick_size * index_datum_size;
+    const uint32_t source_stick_size_bytes = source_stick_size * source_datum_size;
+    const uint32_t output_stick_size_bytes = output_stick_size * output_datum_size;
 
     // maximal input/index/source/output chunk size, divisible by 32, calculated as follows:
     // BH available L1 mem size of nearly 1.5 MB...
@@ -83,10 +77,10 @@ ScatterReduceBfloat16ProgramFactory::cached_program_t ScatterReduceBfloat16Progr
         "ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/writer_bf16_reduction_scatter.cpp";
 
     std::vector<uint32_t> compile_time_args{
-        input_tensor.buffer()->address(),
-        index_tensor.buffer()->address(),
-        src_tensor.buffer()->address(),
-        output_tensor.buffer()->address(),
+        input_buffer->address(),
+        index_buffer->address(),
+        src_buffer->address(),
+        output_buffer->address(),
         static_cast<uint32_t>(ScatterCB::INPUT),
         static_cast<uint32_t>(ScatterCB::INDEX),
         static_cast<uint32_t>(ScatterCB::SRC),
@@ -101,10 +95,10 @@ ScatterReduceBfloat16ProgramFactory::cached_program_t ScatterReduceBfloat16Progr
         source_stick_size_bytes,
         output_stick_size_bytes,
         input_shape.rank()};
-    tt::tt_metal::TensorAccessorArgs(*input_buffer).append_to(compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*index_buffer).append_to(compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*output_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*input_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*index_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(*output_buffer).append_to(compile_time_args);
 
     auto* device = input_tensor.device();
     const auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
@@ -119,18 +113,41 @@ ScatterReduceBfloat16ProgramFactory::cached_program_t ScatterReduceBfloat16Progr
     const auto farthest_x_y =
         args.sub_core_grid.has_value() ? args.sub_core_grid->bounding_box().end_coord : compute_with_storage_grid_size;
     const uint32_t all_cores_in_bounding_box = (farthest_x_y.x + 1) * (farthest_x_y.y + 1);
-    create_cb(program, input_tensor.dtype(), ScatterCB::INPUT, all_cores, input_page_size_bytes);
-    create_cb(program, index_tensor.dtype(), ScatterCB::INDEX, all_cores, index_page_size_bytes);
-    create_cb(program, src_tensor.dtype(), ScatterCB::SRC, all_cores, source_page_size_bytes);
-    create_cb(program, output_tensor.dtype(), ScatterCB::DST, all_cores, output_page_size_bytes);
-    create_cb(program, fp32_temp_dtype, ScatterCB::FP32_TEMP, all_cores, fp32_temp_page_size_bytes);
 
-    auto reader_kernel =
-        create_kernel(program, reader_kernel_path, all_cores, ReaderDataMovementConfig{compile_time_args});
-    auto writer_kernel =
-        create_kernel(program, writer_kernel_path, all_cores, WriterDataMovementConfig{compile_time_args});
+    ProgramDescriptor desc;
 
-    std::vector<CoreCoord> cores{};
+    auto add_cb = [&](ScatterCB scatter_cb, DataType dtype, uint32_t page_size_bytes) {
+        const uint32_t cb_id = static_cast<uint32_t>(scatter_cb);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = page_size_bytes,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(cb_id),
+                .data_format = datatype_to_dataformat_converter(dtype),
+                .page_size = page_size_bytes,
+            }}},
+        });
+    };
+
+    add_cb(ScatterCB::INPUT, input_tensor.dtype(), input_page_size_bytes);
+    add_cb(ScatterCB::INDEX, index_tensor.dtype(), index_page_size_bytes);
+    add_cb(ScatterCB::SRC, src_tensor.dtype(), source_page_size_bytes);
+    add_cb(ScatterCB::DST, output_tensor.dtype(), output_page_size_bytes);
+    add_cb(ScatterCB::FP32_TEMP, fp32_temp_dtype, fp32_temp_page_size_bytes);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_path;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = compile_time_args;
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_path;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     uint32_t stick_offset = 0;
     for (uint32_t i = 0; i < all_cores_in_bounding_box; ++i) {
@@ -143,60 +160,38 @@ ScatterReduceBfloat16ProgramFactory::cached_program_t ScatterReduceBfloat16Progr
         } else {
             continue;
         }
-        cores.push_back(core);
 
-        std::vector<uint32_t> reader_runtime_args{
-            input_buffer->address(),
-            index_buffer->address(),
-            src_buffer->address(),
-            stick_offset,
-            sticks_per_core,
-            input_and_output_chunk_size,
-            index_chunk_size,
-            source_chunk_size,
-            static_cast<uint32_t>(args.opt_reduction)};
-        std::copy(input_shape.cbegin(), input_shape.cend() - 1, std::back_inserter(reader_runtime_args));
-        std::copy(index_shape.cbegin(), index_shape.cend() - 1, std::back_inserter(reader_runtime_args));
+        // Buffer* entries become BufferBinding slots; addresses are patched on cache hits
+        // without rebuilding the descriptor.
+        KernelDescriptor::RTArgList reader_runtime_args;
+        reader_runtime_args.reserve(9 + (input_shape.rank() - 1) + (index_shape.rank() - 1));
+        reader_runtime_args.push_back(input_buffer);
+        reader_runtime_args.push_back(index_buffer);
+        reader_runtime_args.push_back(src_buffer);
+        reader_runtime_args.push_back(stick_offset);
+        reader_runtime_args.push_back(sticks_per_core);
+        reader_runtime_args.push_back(input_and_output_chunk_size);
+        reader_runtime_args.push_back(index_chunk_size);
+        reader_runtime_args.push_back(source_chunk_size);
+        reader_runtime_args.push_back(static_cast<uint32_t>(args.opt_reduction));
+        for (const auto* it = input_shape.cbegin(); it != input_shape.cend() - 1; ++it) {
+            reader_runtime_args.push_back(static_cast<uint32_t>(*it));
+        }
+        for (const auto* it = index_shape.cbegin(); it != index_shape.cend() - 1; ++it) {
+            reader_runtime_args.push_back(static_cast<uint32_t>(*it));
+        }
+        reader_desc.emplace_runtime_args(core, reader_runtime_args);
 
-        SetRuntimeArgs(program, reader_kernel, core, reader_runtime_args);
-
-        std::vector<uint32_t> writer_runtime_args{
-            output_buffer->address(),
-            stick_offset,
-            sticks_per_core,
-            input_and_output_chunk_size,
-        };
-
-        SetRuntimeArgs(program, writer_kernel, core, writer_runtime_args);
+        writer_desc.emplace_runtime_args(
+            core, {output_buffer, stick_offset, sticks_per_core, input_and_output_chunk_size});
 
         stick_offset += sticks_per_core;
     }
 
-    return {std::move(program), {reader_kernel, writer_kernel, cores}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void ScatterReduceBfloat16ProgramFactory::override_runtime_arguments(
-    ScatterReduceBfloat16ProgramFactory::cached_program_t& cached_program,
-    const ScatterParams& /*args*/,
-    const ScatterInputs& tensor_args,
-    Tensor& output_tensor) {
-    const auto& program = cached_program.program;
-    const auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    const auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    const auto& cores = cached_program.shared_variables.cores;
-
-    auto input_buffer_address = tensor_args.input_tensor.buffer()->address();
-    auto index_buffer_address = tensor_args.index_tensor.buffer()->address();
-    auto source_buffer_address = tensor_args.src_tensor.buffer()->address();
-    auto output_buffer_address = output_tensor.buffer()->address();
-    for (const auto& core : cores) {
-        auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-        auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-        reader_runtime_args[0] = input_buffer_address;
-        reader_runtime_args[1] = index_buffer_address;
-        reader_runtime_args[2] = source_buffer_address;
-        writer_runtime_args[0] = output_buffer_address;
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_reduce_bfloat16_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_reduce_bfloat16_program_factory.hpp
@@ -4,30 +4,16 @@
 
 #pragma once
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 #include "scatter_device_operation_types.hpp"
-
-#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
-using namespace tt;
-using namespace tt::tt_metal;
-
 struct ScatterReduceBfloat16ProgramFactory {
-    struct shared_variables_t {
-        KernelHandle reader_kernel_id{};
-        KernelHandle writer_kernel_id{};
-        std::vector<CoreCoord> cores;
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(const ScatterParams&, const ScatterInputs&, Tensor&);
-
-    static void override_runtime_arguments(cached_program_t&, const ScatterParams&, const ScatterInputs&, Tensor&);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ScatterParams& args, const ScatterInputs& tensor_args, Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 #include "ttnn/operations/data_movement/sharded/sharded_common.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
@@ -23,14 +24,39 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
+namespace {
+
+// Anonymous-namespace helper unique to interleaved_to_sharded to avoid unity-build collisions.
+void push_i2s_cb_pair(
+    ProgramDescriptor& desc,
+    uint32_t cb_index,
+    tt::DataFormat data_format,
+    uint32_t total_size,
+    uint32_t page_size,
+    const CoreRangeSet& core_ranges,
+    Buffer* bound_buffer) {
+    CBDescriptor cb;
+    cb.total_size = total_size;
+    cb.core_ranges = core_ranges;
+    cb.format_descriptors.push_back(CBFormatDescriptor{
+        .buffer_index = static_cast<uint8_t>(cb_index),
+        .data_format = data_format,
+        .page_size = page_size,
+    });
+    cb.buffer = bound_buffer;
+    desc.cbs.push_back(std::move(cb));
+}
+
+}  // namespace
+
 // Hardcoded for non-partial interleaved_to_sharded operation
 // to keep backward compatibility after migration to new infra
 // https://github.com/tenstorrent/tt-metal/issues/32752
 constexpr uint32_t num_slices = 1;
 constexpr uint32_t slice_index = 0;
 
-InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgramFactory::create(
-    const InterleavedToShardedParams&  /*operation_attributes*/,
+ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
+    const InterleavedToShardedParams& /*operation_attributes*/,
     const InterleavedToShardedInputs& tensor_args,
     Tensor& output_tensor) {
     const auto& input = tensor_args.input_tensor;
@@ -38,11 +64,16 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
     // Keep explicit bool init to match legacy behavior which forced it true
     bool keep_l1_aligned = true;  // operation_attributes.keep_l1_aligned;
 
-    tt::tt_metal::Program program{};
-
-    uint32_t num_units_per_shard, input_unit_size, output_unit_size, num_units_per_shard_width,
-        num_units_per_shard_height, num_units_offset, num_units_per_row, num_units_per_shard_height_last,
-        num_units_per_shard_width_last, padded_offset_bytes;
+    uint32_t num_units_per_shard = 0;
+    uint32_t input_unit_size = 0;
+    uint32_t output_unit_size = 0;
+    uint32_t num_units_per_shard_width = 0;
+    uint32_t num_units_per_shard_height = 0;
+    uint32_t num_units_offset = 0;
+    uint32_t num_units_per_row = 0;
+    uint32_t num_units_per_shard_height_last = 0;
+    uint32_t num_units_per_shard_width_last = 0;
+    uint32_t padded_offset_bytes = 0;
 
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
@@ -77,7 +108,7 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
         num_units_per_row = input.padded_shape()[-1] / TILE_WIDTH;
         num_units_offset = num_units_per_row;
-        uint32_t num_units_height = (input.physical_volume() / input.padded_shape()[-1])/ TILE_HEIGHT;
+        uint32_t num_units_height = (input.physical_volume() / input.padded_shape()[-1]) / TILE_HEIGHT;
         num_units_per_shard_height_last =
             num_units_per_shard_height -
             (tt::round_up(num_units_height, num_units_per_shard_height) - num_units_height);
@@ -86,14 +117,14 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
             (tt::round_up(num_units_per_row, num_units_per_shard_width) - num_units_per_row);
         padded_offset_bytes = (num_units_per_shard_width - num_units_per_shard_width_last) * input_unit_size;
     } else {
-        input_unit_size = shard_spec.shape[1] * input.element_size();
-        output_unit_size = shard_spec.shape[1] * output.element_size();
+        input_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * input.element_size());
+        output_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * output.element_size());
         num_units_per_shard_height = shard_spec.shape[0];
         num_units_per_shard_width = 1;
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
-        num_units_per_row = input.logical_shape()[-1] * input.element_size();
+        num_units_per_row = static_cast<uint32_t>(input.logical_shape()[-1] * input.element_size());
         num_units_offset = 1;
-        uint32_t num_units_height = input.logical_volume() / input.logical_shape()[-1];
+        uint32_t num_units_height = static_cast<uint32_t>(input.logical_volume() / input.logical_shape()[-1]);
         num_units_per_shard_height_last =
             num_units_per_shard_height -
             (tt::round_up(num_units_height, num_units_per_shard_height) - num_units_height);
@@ -113,92 +144,108 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
     uint32_t out_cb_index = input_cb_index;
     uint32_t num_input_units = num_units_per_shard;
     uint32_t output_page_size = tt::align(output_unit_size, dst_buffer->alignment());
+
+    ProgramDescriptor desc;
+
     if (convert_df) {
         out_cb_index = tt::CBIndex::c_16;
         uint32_t input_page_size = tt::align(input_unit_size, src_buffer->alignment());
-        tt::tt_metal::CircularBufferConfig input_cb_out_config =
-            tt::tt_metal::CircularBufferConfig(
-                num_input_units * input_page_size, {{input_cb_index, input_cb_data_format}})
-                .set_page_size(input_cb_index, input_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, input_cb_out_config);
+        // Non-globally-allocated input CB (interleaved input streamed via reader).
+        push_i2s_cb_pair(
+            desc,
+            input_cb_index,
+            input_cb_data_format,
+            num_input_units * input_page_size,
+            input_page_size,
+            all_cores,
+            /*bound_buffer=*/nullptr);
     }
-    tt::tt_metal::CircularBufferConfig output_cb_out_config =
-        tt::tt_metal::CircularBufferConfig(num_input_units * output_page_size, {{out_cb_index, output_cb_data_format}})
-            .set_page_size(out_cb_index, output_page_size);
-    if (!dst_is_dram) {
-        output_cb_out_config = output_cb_out_config.set_globally_allocated_address(*output.buffer());
-    }
-    auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, output_cb_out_config);
+
+    // Output CB. When destination is sharded (non-DRAM) we bind it to the output buffer
+    // for dynamic-CB rebinding on cache hits via cb.buffer. When dst is DRAM, no binding.
+    push_i2s_cb_pair(
+        desc,
+        out_cb_index,
+        output_cb_data_format,
+        num_input_units * output_page_size,
+        output_page_size,
+        all_cores,
+        /*bound_buffer=*/dst_is_dram ? nullptr : dst_buffer);
+
     uint32_t dram_alignment = hal::get_dram_alignment();
     uint32_t l1_alignment = hal::get_l1_alignment();
     uint32_t num_trids = 4;
     if ((src_is_dram && (input_unit_size % dram_alignment != 0)) || is_blackhole || keep_l1_aligned) {
-        uint32_t scratch_cb_page_size;
         // scratchpad going to be used to align DRAM (64B) to L1 (16B)
-
         // This is done to mitigate the alignment issues.
         // See issue #34414.
-        scratch_cb_page_size = tt::align(input_unit_size + dram_alignment, dram_alignment);
-
-        tt::tt_metal::CircularBufferConfig scratch_cb_out_config =
-            tt::tt_metal::CircularBufferConfig(num_trids * scratch_cb_page_size, {{scratch_cb_index, input_cb_data_format}})
-                .set_page_size(scratch_cb_index, scratch_cb_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, scratch_cb_out_config);
+        uint32_t scratch_cb_page_size = tt::align(input_unit_size + dram_alignment, dram_alignment);
+        push_i2s_cb_pair(
+            desc,
+            scratch_cb_index,
+            input_cb_data_format,
+            num_trids * scratch_cb_page_size,
+            scratch_cb_page_size,
+            all_cores,
+            /*bound_buffer=*/nullptr);
     }
 
-    tt::tt_metal::KernelHandle unary_reader_kernel_id;
+    // Reader kernel.
+    KernelDescriptor reader_desc;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.config = ReaderConfigDescriptor{};
     if (input.layout() == Layout::TILE) {
         std::vector<uint32_t> reader_compile_time_args = {input_cb_index, all_cores.num_cores()};
         tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
-
-        unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-            program,
+        reader_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
-            "reader_unary_sharded_blocks_interleaved_start_id.cpp",
-            all_cores,
-            tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+            "reader_unary_sharded_blocks_interleaved_start_id.cpp";
+        reader_desc.compile_time_args = std::move(reader_compile_time_args);
     } else {
         std::vector<uint32_t> reader_compile_time_args = {input_cb_index, scratch_cb_index, num_trids};
         tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
-
-        unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-            program,
+        reader_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
-            "reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp",
-            all_cores,
-            tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+            "reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp";
+        reader_desc.compile_time_args = std::move(reader_compile_time_args);
     }
 
-    std::string writer_kernel;
+    // Writer kernel.
+    KernelDescriptor writer_desc;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.config = WriterConfigDescriptor{};
     std::vector<uint32_t> writer_compile_time_args = {out_cb_index};
     if (dst_is_dram) {
         if (input.layout() == Layout::TILE) {
-            writer_kernel = std::string(
+            writer_desc.kernel_source =
                 "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
-                "writer_unary_sharded_blocks_start_id.cpp");
+                "writer_unary_sharded_blocks_start_id.cpp";
         } else {
-            writer_kernel = std::string(
+            writer_desc.kernel_source =
                 "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
-                "writer_unary_sharded_stick_layout_start_id.cpp");
+                "writer_unary_sharded_stick_layout_start_id.cpp";
         }
         shard_builder::extend_sharding_compile_time_args(output, writer_compile_time_args);
     } else {
-        writer_kernel = std::string(
-            "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp");
+        writer_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp";
     }
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program, writer_kernel, all_cores, tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
 
-    tt::tt_metal::KernelHandle compute_kernel_id = 0;
+    // Optional compute kernel for data-format conversion.
+    KernelDescriptor compute_desc;
     if (convert_df) {
-        compute_kernel_id = tt::tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/compute/eltwise_copy.cpp",
-            all_cores,
-            tt::tt_metal::ComputeConfig{});
+        compute_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/compute/eltwise_copy.cpp";
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = all_cores;
+        compute_desc.config = ComputeConfigDescriptor{};
     }
 
-    uint32_t starting_idx_h = operations::data_movement::detail::calculate_starting_idx_h(input, num_slices, slice_index);
+    uint32_t starting_idx_h =
+        operations::data_movement::detail::calculate_starting_idx_h(input, num_slices, slice_index);
     uint32_t curr_idx_h = 0;
     uint32_t curr_idx_w = 0;
 
@@ -238,36 +285,37 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
             }
             curr_num_units_per_shard = shard_height * num_units_per_shard_width;
 
-            // Reader run-time args
-            std::vector<uint32_t> reader_run_time_args = {
-                src_buffer->address(),
-                shard_height,
-                shard_width,
-                padded_offset,
-                num_units_offset,
-                curr_num_units_per_shard,
-                curr_idx_h + curr_idx_w,
-                starting_idx_h};
-            tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_run_time_args);
+            // Reader run-time args: arg 0 is the source-buffer base address (binding).
+            KernelDescriptor::RTArgList reader_rt;
+            reader_rt.push_back(src_buffer);
+            reader_rt.push_back(shard_height);
+            reader_rt.push_back(shard_width);
+            reader_rt.push_back(padded_offset);
+            reader_rt.push_back(num_units_offset);
+            reader_rt.push_back(curr_num_units_per_shard);
+            reader_rt.push_back(curr_idx_h + curr_idx_w);
+            reader_rt.push_back(starting_idx_h);
+            reader_desc.emplace_runtime_args(core, reader_rt);
 
             // Writer run-time args
             uint32_t pad_offset = (num_units_per_shard_width - shard_width) * output_unit_size;
-            std::vector<uint32_t> writer_run_time_args;
             if (dst_is_dram) {
-                writer_run_time_args = {
-                    dst_buffer->address(),
-                    shard_height,
-                    shard_width,
-                    pad_offset,
-                    curr_num_units_per_shard,
-                    num_units_offset,
-                    curr_idx_h + curr_idx_w,
-                    starting_idx_h};
-                shard_builder::extend_sharding_run_time_args(output, writer_run_time_args);
+                KernelDescriptor::RTArgList writer_rt;
+                writer_rt.push_back(dst_buffer);
+                writer_rt.push_back(shard_height);
+                writer_rt.push_back(shard_width);
+                writer_rt.push_back(pad_offset);
+                writer_rt.push_back(curr_num_units_per_shard);
+                writer_rt.push_back(num_units_offset);
+                writer_rt.push_back(curr_idx_h + curr_idx_w);
+                writer_rt.push_back(starting_idx_h);
+                std::vector<uint32_t> extra;
+                shard_builder::extend_sharding_run_time_args(output, extra);
+                writer_rt.append(extra);
+                writer_desc.emplace_runtime_args(core, writer_rt);
             } else {
-                writer_run_time_args = {curr_num_units_per_shard};
+                writer_desc.emplace_runtime_args(core, {curr_num_units_per_shard});
             }
-            tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_run_time_args);
 
             // Update indexing
             curr_idx_w += num_units_per_shard_width;
@@ -307,7 +355,7 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
                 }
             }
 
-            bool aligned;
+            bool aligned = false;
             if (src_is_dram) {
                 aligned = (curr_idx_w % dram_alignment == 0) && (padded_offset_bytes % dram_alignment == 0);
             } else if (is_blackhole) {
@@ -315,7 +363,9 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
             } else {
                 aligned = true;
             }
-            uint32_t aligned_width_offset, aligned_shard_width, aligned_offset;
+            uint32_t aligned_width_offset = 0;
+            uint32_t aligned_shard_width = 0;
+            uint32_t aligned_offset = 0;
             if (!aligned) {
                 // TODO: is this right, leaving non BH case the same for now, should investigate
                 if (!is_blackhole) {
@@ -335,38 +385,39 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
                 aligned_offset = 0;
             }
 
-            // Reader run-time args
-            std::vector<uint32_t> reader_run_time_args = {
-                src_buffer->address(),
-                num_units_per_row,
-                shard_height,
-                shard_width,
-                padded_offset_bytes,
-                static_cast<uint32_t>(aligned),
-                aligned_width_offset,
-                aligned_shard_width,
-                aligned_offset,
-                curr_idx_h};
-            tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_run_time_args);
+            // Reader run-time args: arg 0 is the source-buffer base address (binding).
+            KernelDescriptor::RTArgList reader_rt;
+            reader_rt.push_back(src_buffer);
+            reader_rt.push_back(num_units_per_row);
+            reader_rt.push_back(shard_height);
+            reader_rt.push_back(shard_width);
+            reader_rt.push_back(padded_offset_bytes);
+            reader_rt.push_back(static_cast<uint32_t>(aligned));
+            reader_rt.push_back(aligned_width_offset);
+            reader_rt.push_back(aligned_shard_width);
+            reader_rt.push_back(aligned_offset);
+            reader_rt.push_back(curr_idx_h);
+            reader_desc.emplace_runtime_args(core, reader_rt);
 
             // Writer run-time args
-            std::vector<uint32_t> writer_run_time_args;
             if (dst_is_dram) {
                 uint32_t page_id_within_row = curr_idx_w / input_unit_size;
                 uint32_t output_width_in_pages = tt::div_up(num_units_per_row, input_unit_size);
                 uint32_t start_id = (curr_idx_h * output_width_in_pages) + page_id_within_row;
-                writer_run_time_args = {
-                    dst_buffer->address(),
-                    shard_height,
-                    shard_width,
-                    padded_offset_bytes,
-                    start_id,
-                    output_width_in_pages};
-                shard_builder::extend_sharding_run_time_args(output, writer_run_time_args);
+                KernelDescriptor::RTArgList writer_rt;
+                writer_rt.push_back(dst_buffer);
+                writer_rt.push_back(shard_height);
+                writer_rt.push_back(shard_width);
+                writer_rt.push_back(padded_offset_bytes);
+                writer_rt.push_back(start_id);
+                writer_rt.push_back(output_width_in_pages);
+                std::vector<uint32_t> extra;
+                shard_builder::extend_sharding_run_time_args(output, extra);
+                writer_rt.append(extra);
+                writer_desc.emplace_runtime_args(core, writer_rt);
             } else {
-                writer_run_time_args = {curr_num_units_per_shard};
+                writer_desc.emplace_runtime_args(core, {curr_num_units_per_shard});
             }
-            tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_run_time_args);
 
             // Update indexing
             curr_idx_w += input_unit_size;
@@ -376,45 +427,17 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
             }
         }
         if (convert_df) {
-            tt::tt_metal::SetRuntimeArgs(program, compute_kernel_id, core, {curr_num_units_per_shard});
+            compute_desc.emplace_runtime_args(core, {curr_num_units_per_shard});
         }
     }
 
-    return {std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id, cb_output, cores, num_slices}};
-}
-
-void InterleavedToShardedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const InterleavedToShardedParams&  /*operation_attributes*/,
-    const InterleavedToShardedInputs& tensor_args,
-    Tensor& output_tensor) {
-    auto* src_buffer = tensor_args.input_tensor.buffer();
-    auto* dst_buffer = output_tensor.buffer();
-
-    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-
-    auto& shared_variables = cached_program.shared_variables;
-    auto& program = cached_program.program;
-    auto unary_reader_kernel_id = shared_variables.unary_reader_kernel_id;
-    auto unary_writer_kernel_id = shared_variables.unary_writer_kernel_id;
-    auto cb_output = shared_variables.cb_output;
-    const auto& cores = shared_variables.cores;
-
-    auto& runtime_args_by_core = GetRuntimeArgs(program, unary_reader_kernel_id);
-    for (const auto& core : cores) {
-        auto& runtime_args = runtime_args_by_core[core.x][core.y];
-        runtime_args[0] = src_buffer->address();
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    if (convert_df) {
+        desc.kernels.push_back(std::move(compute_desc));
     }
 
-    if (dst_is_dram) {
-        auto& runtime_args_by_core = GetRuntimeArgs(program, unary_writer_kernel_id);
-        for (const auto& core : cores) {
-            auto& runtime_args = runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = dst_buffer->address();
-        }
-    } else {
-        UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.hpp
@@ -4,29 +4,14 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/device_operation.hpp"
 #include "interleaved_to_sharded_op_types.hpp"
 
 namespace ttnn::prim {
 
 struct InterleavedToShardedProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-        tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-        tt::tt_metal::CBHandle cb_output{};
-        std::vector<tt::tt_metal::CoreCoord> cores;
-        uint32_t num_slices{};
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const InterleavedToShardedParams& operation_attributes,
-        const InterleavedToShardedInputs& tensor_args,
-        Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const InterleavedToShardedParams& operation_attributes,
         const InterleavedToShardedInputs& tensor_args,
         Tensor& output_tensor);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_local.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_local.cpp
@@ -5,6 +5,7 @@
 #include "ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_local.hpp"
 
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include "tt-metalium/host_api.hpp"
 
 using namespace tt::tt_metal;
@@ -12,7 +13,7 @@ using namespace tt::tt_metal;
 namespace ttnn::prim {
 
 template <bool local_is_input>
-NdReshardCopyLocalShardFactory<local_is_input>::cached_program_t NdReshardCopyLocalShardFactory<local_is_input>::create(
+ProgramDescriptor NdReshardCopyLocalShardFactory<local_is_input>::create_descriptor(
     const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
     const auto& input = tensor_args.input;
     auto& output = output_tensor;
@@ -23,27 +24,25 @@ NdReshardCopyLocalShardFactory<local_is_input>::cached_program_t NdReshardCopyLo
     const auto input_accessor_args = TensorAccessorArgs(*input_buffer);
     const auto output_accessor_args = TensorAccessorArgs(*output_buffer);
 
-    // Choose buffer and aligned page size based on is_reader flag
+    // Choose buffer and aligned page size based on local_is_input flag
     auto* local_buffer = local_is_input ? input_buffer : output_buffer;
     auto aligned_page_size = local_buffer->aligned_page_size();
     auto other_aligned_page_size =
         local_is_input ? output_buffer->aligned_page_size() : input_buffer->aligned_page_size();
 
-    // Create Program + Grid
-    auto program = CreateProgram();
-
     // This implementation assumes that input and output grids are the same.
     auto cores_vec = local_buffer->buffer_distribution_spec()->cores_with_data();
     auto grid = CoreRangeSet(cores_vec);
 
-    auto num_shards = local_buffer->buffer_distribution_spec()->num_shards();
+    uint32_t num_shards = static_cast<uint32_t>(local_buffer->buffer_distribution_spec()->num_shards());
 
     // num cores with data * 2 because we have two kernels
-    auto shard_id_stride = local_buffer->buffer_distribution_spec()->num_cores_with_data() * 2;
+    uint32_t shard_id_stride =
+        static_cast<uint32_t>(local_buffer->buffer_distribution_spec()->num_cores_with_data()) * 2u;
 
     // Prepare compile time arguments
     auto logical_size = input.logical_shape();
-    uint32_t logical_width = logical_size[-1] * input.element_size();
+    uint32_t logical_width = static_cast<uint32_t>(logical_size[-1] * input.element_size());
     uint32_t source_width = logical_width;
     uint32_t destination_width = logical_width;
     uint32_t base_page_size = aligned_page_size;
@@ -71,129 +70,67 @@ NdReshardCopyLocalShardFactory<local_is_input>::cached_program_t NdReshardCopyLo
             output_num_shard_cores = output_shard_grid.x == 1 ? output_shard_grid.y : output_shard_grid.x;
         }
 
-        source_width = input_buffer->shard_spec().shape()[1] * input.element_size() * input_num_shard_cores;
-        destination_width = output_buffer->shard_spec().shape()[1] * output.element_size() * output_num_shard_cores;
+        source_width =
+            static_cast<uint32_t>(input_buffer->shard_spec().shape()[1] * input.element_size() * input_num_shard_cores);
+        destination_width = static_cast<uint32_t>(
+            output_buffer->shard_spec().shape()[1] * output.element_size() * output_num_shard_cores);
         uint32_t input_page_size = input_buffer->page_size();
         uint32_t output_page_size = output_buffer->page_size();
         base_page_size = std::gcd(input_page_size, output_page_size);
     }
-    auto compile_time_args_reader = input_accessor_args.get_compile_time_args();
-    output_accessor_args.append_to(compile_time_args_reader);
-    compile_time_args_reader.push_back(aligned_page_size);
-    compile_time_args_reader.push_back(other_aligned_page_size);
-    compile_time_args_reader.push_back(local_is_input);
-    compile_time_args_reader.push_back(logical_width);
-    compile_time_args_reader.push_back(source_width);
-    compile_time_args_reader.push_back(destination_width);
-    compile_time_args_reader.push_back(base_page_size);
+    auto compile_time_args = input_accessor_args.get_compile_time_args();
+    output_accessor_args.append_to(compile_time_args);
+    compile_time_args.push_back(aligned_page_size);
+    compile_time_args.push_back(other_aligned_page_size);
+    compile_time_args.push_back(static_cast<uint32_t>(local_is_input));
+    compile_time_args.push_back(logical_width);
+    compile_time_args.push_back(source_width);
+    compile_time_args.push_back(destination_width);
+    compile_time_args.push_back(base_page_size);
 
-    // Create kernels
-    KernelHandle brisc_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_local_shards.cpp",
-        grid,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = compile_time_args_reader,
-        });
+    ProgramDescriptor desc;
 
-    KernelHandle ncrisc_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_local_shards.cpp",
-        grid,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = NOC::RISCV_1_default,
-            .compile_args = compile_time_args_reader,
-        });
+    KernelDescriptor brisc_desc;
+    brisc_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    brisc_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_local_shards.cpp";
+    brisc_desc.core_ranges = grid;
+    brisc_desc.config = DataMovementConfigDescriptor{
+        .processor = DataMovementProcessor::RISCV_0,
+        .noc = NOC::RISCV_0_default,
+    };
+    brisc_desc.compile_time_args = compile_time_args;
 
-    std::vector<uint32_t> common_runtime_args = {
-        input.buffer()->address(), output.buffer()->address(), num_shards, shard_id_stride};
-    SetCommonRuntimeArgs(program, brisc_kernel_id, common_runtime_args);
-    SetCommonRuntimeArgs(program, ncrisc_kernel_id, common_runtime_args);
+    KernelDescriptor ncrisc_desc;
+    ncrisc_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    ncrisc_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_local_shards.cpp";
+    ncrisc_desc.core_ranges = grid;
+    ncrisc_desc.config = DataMovementConfigDescriptor{
+        .processor = DataMovementProcessor::RISCV_1,
+        .noc = NOC::RISCV_1_default,
+    };
+    ncrisc_desc.compile_time_args = std::move(compile_time_args);
 
-    // Set unique runtime arguments to 0, and call
-    for (const auto& core : cores_vec) {
-        SetRuntimeArgs(program, brisc_kernel_id, core, {0});
-        SetRuntimeArgs(program, ncrisc_kernel_id, core, {0});
-    }
+    // Common runtime args: [input_addr, output_addr, num_shards, shard_id_stride]
+    // arg 0 / arg 1 are the buffer base addresses (binding via Buffer*).
+    brisc_desc.emplace_common_runtime_args({input_buffer, output_buffer, num_shards, shard_id_stride});
+    ncrisc_desc.emplace_common_runtime_args({input_buffer, output_buffer, num_shards, shard_id_stride});
 
-    auto cached_program = NdReshardCopyLocalShardFactory::cached_program_t{
-        std::move(program),
-        {.brisc_kernel_id = brisc_kernel_id, .ncrisc_kernel_id = ncrisc_kernel_id, .grid = grid, .cores = cores_vec}};
-
-    // For now, directly set runtime args
-    {
-        const auto& input = tensor_args.input;
-        const auto& output = output_tensor;
-        auto* local_buffer = local_is_input ? input.buffer() : output.buffer();
-        auto num_shards = local_buffer->buffer_distribution_spec()->num_shards();
-        auto shard_id_stride = local_buffer->buffer_distribution_spec()->num_cores_with_data() * 2;
-
-        std::vector<uint32_t> common_runtime_args = {
-            input.buffer()->address(), output.buffer()->address(), num_shards, shard_id_stride};
-        auto& common_runtime_args_brisc = GetCommonRuntimeArgs(cached_program.program, brisc_kernel_id);
-        auto& common_runtime_args_ncrisc = GetCommonRuntimeArgs(cached_program.program, ncrisc_kernel_id);
-        for (size_t i = 0; i < common_runtime_args.size(); i++) {
-            common_runtime_args_brisc[i] = common_runtime_args[i];
-            common_runtime_args_ncrisc[i] = common_runtime_args[i];
-        }
-
-        auto& runtime_args_by_core_brisc = GetRuntimeArgs(cached_program.program, brisc_kernel_id);
-        auto& runtime_args_by_core_ncrisc = GetRuntimeArgs(cached_program.program, ncrisc_kernel_id);
-
-        auto start_shard_id = 0;
-        for (const auto& core : cores_vec) {
-            runtime_args_by_core_brisc[core.x][core.y][0] = start_shard_id;
-            runtime_args_by_core_ncrisc[core.x][core.y][0] = start_shard_id + shard_id_stride / 2;
-            ++start_shard_id;
-        }
-    }
-
-    return cached_program;
-}
-
-template <bool is_reader>
-void NdReshardCopyLocalShardFactory<is_reader>::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const ReshardParams& /*operation_attributes*/,
-    const ReshardInputs& tensor_args,
-    Tensor& output_tensor) {
-    const auto& input = tensor_args.input;
-    const auto& output = output_tensor;
-
-    auto& program = cached_program.program;
-    const auto& brisc_kernel_id = cached_program.shared_variables.brisc_kernel_id;
-    const auto& ncrisc_kernel_id = cached_program.shared_variables.ncrisc_kernel_id;
-    const auto& cores = cached_program.shared_variables.cores;
-
-    // Choose buffer for distribution spec based on is_reader flag
-    auto* local_buffer = is_reader ? input.buffer() : output.buffer();
-    auto num_shards = local_buffer->buffer_distribution_spec()->num_shards();
-    auto shard_id_stride = local_buffer->buffer_distribution_spec()->num_cores_with_data() * 2;
-
-    std::vector<uint32_t> common_runtime_args = {
-        input.buffer()->address(), output.buffer()->address(), num_shards, shard_id_stride};
-    auto& common_runtime_args_brisc = GetCommonRuntimeArgs(program, brisc_kernel_id);
-    auto& common_runtime_args_ncrisc = GetCommonRuntimeArgs(program, ncrisc_kernel_id);
-    for (size_t i = 0; i < common_runtime_args.size(); i++) {
-        common_runtime_args_brisc[i] = common_runtime_args[i];
-        common_runtime_args_ncrisc[i] = common_runtime_args[i];
-    }
-
-    auto& runtime_args_by_core_brisc = GetRuntimeArgs(program, brisc_kernel_id);
-    auto& runtime_args_by_core_ncrisc = GetRuntimeArgs(program, ncrisc_kernel_id);
-
-    auto start_shard_id = 0;
-
+    // Per-core unique runtime args: [start_shard_id]
     // brisc copies shards [0, num_data_cores*2, num_data_cores*4, num_data_cores*6, ...]
     // ncrisc copies shards [num_data_cores, num_data_cores*3, num_data_cores*5, num_data_cores*7, ...]
-    for (const auto& core : cores) {
-        runtime_args_by_core_brisc[core.x][core.y][0] = start_shard_id;
-        runtime_args_by_core_ncrisc[core.x][core.y][0] = start_shard_id + shard_id_stride / 2;
+    uint32_t start_shard_id = 0;
+    for (const auto& core : cores_vec) {
+        brisc_desc.emplace_runtime_args(core, {start_shard_id});
+        ncrisc_desc.emplace_runtime_args(core, {start_shard_id + shard_id_stride / 2});
         ++start_shard_id;
     }
+
+    desc.kernels.push_back(std::move(brisc_desc));
+    desc.kernels.push_back(std::move(ncrisc_desc));
+
+    return desc;
 }
 
 // Explicit template instantiations

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_local.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_local.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "ttnn/device_operation.hpp"
 #include "reshard_device_operation_types.hpp"
 
@@ -12,24 +14,8 @@ namespace ttnn::prim {
 // Factory for L1<->DRAM or L1->L1 nd reshard (read into local pages in L1)
 template <bool local_is_input>
 struct NdReshardCopyLocalShardFactory {
-    struct NdReshardCopyLocalShardSharedVariables {
-        tt::tt_metal::KernelHandle brisc_kernel_id{};
-        tt::tt_metal::KernelHandle ncrisc_kernel_id{};
-        CoreRangeSet grid;
-        std::vector<CoreCoord> cores;
-    };
-
-    using shared_variables_t = NdReshardCopyLocalShardSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const ReshardParams& operation_attributes, const ReshardInputs& tensor_args, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const ReshardParams& operation_attributes,
-        const ReshardInputs& tensor_args,
-        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_pages.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_pages.cpp
@@ -5,14 +5,39 @@
 #include "ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_pages.hpp"
 
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include "tt-metalium/host_api.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-NdReshardCopyPagesFactory::cached_program_t NdReshardCopyPagesFactory::create(
-    const ReshardParams& operation_attributes, const ReshardInputs& tensor_args, Tensor& output_tensor) {
+namespace {
+
+// Anonymous-namespace helper unique to nd_reshard_copy_pages to avoid unity-build collisions.
+void push_reshard_copy_pages_cb(
+    ProgramDescriptor& desc,
+    uint32_t cb_index,
+    tt::DataFormat data_format,
+    uint32_t total_size,
+    uint32_t page_size,
+    const CoreRangeSet& core_ranges) {
+    CBDescriptor cb;
+    cb.total_size = total_size;
+    cb.core_ranges = core_ranges;
+    cb.format_descriptors.push_back(CBFormatDescriptor{
+        .buffer_index = static_cast<uint8_t>(cb_index),
+        .data_format = data_format,
+        .page_size = page_size,
+    });
+    cb.buffer = nullptr;
+    desc.cbs.push_back(std::move(cb));
+}
+
+}  // namespace
+
+ProgramDescriptor NdReshardCopyPagesFactory::create_descriptor(
+    const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
     const auto& input = tensor_args.input;
     auto& output = output_tensor;
 
@@ -26,19 +51,19 @@ NdReshardCopyPagesFactory::cached_program_t NdReshardCopyPagesFactory::create(
 
     auto aligned_page_size = input_buffer->aligned_page_size();
 
-    // Create Program + Grid
-    auto program = CreateProgram();
+    // Create grid + cores
     auto grid_size = input.device()->compute_with_storage_grid_size();
     auto grid = CoreRangeSet({CoreRange(CoreCoord(0, 0), CoreCoord(grid_size.x - 1, grid_size.y - 1))});
     auto cores = corerange_to_cores(grid, std::nullopt, input_nd_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
 
     // Create Circular Buffer
     const auto data_format = datatype_to_dataformat_converter(input.dtype());
-    constexpr auto num_tiles_in_cb = 1;  // TODO: Try double buffering
-    CBHandle cb_in0_idx = tt::CBIndex::c_0;
-    auto c_in0_config = CircularBufferConfig(aligned_page_size * num_tiles_in_cb, {{cb_in0_idx, data_format}})
-                            .set_page_size(cb_in0_idx, aligned_page_size);
-    CreateCircularBuffer(program, grid, c_in0_config);
+    constexpr uint32_t num_tiles_in_cb = 1;  // TODO: Try double buffering
+    constexpr uint32_t cb_in0_idx = tt::CBIndex::c_0;
+
+    ProgramDescriptor desc;
+    push_reshard_copy_pages_cb(
+        desc, cb_in0_idx, data_format, aligned_page_size * num_tiles_in_cb, aligned_page_size, grid);
 
     // Prepare compile time arguments
     auto compile_time_args_reader = input_accessor_args.get_compile_time_args();
@@ -50,69 +75,34 @@ NdReshardCopyPagesFactory::cached_program_t NdReshardCopyPagesFactory::create(
     compile_time_args_writer.push_back(aligned_page_size);
 
     // Create kernels
-    KernelHandle reader_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_reader.cpp",
-        grid,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = compile_time_args_reader,
-        });
+    KernelDescriptor reader_desc;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_reader.cpp";
+    reader_desc.core_ranges = grid;
+    reader_desc.config = ReaderConfigDescriptor{};
+    reader_desc.compile_time_args = std::move(compile_time_args_reader);
 
-    KernelHandle writer_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_writer.cpp",
-        grid,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = NOC::RISCV_1_default,
-            .compile_args = compile_time_args_writer,
-        });
+    KernelDescriptor writer_desc;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_writer.cpp";
+    writer_desc.core_ranges = grid;
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.compile_time_args = std::move(compile_time_args_writer);
 
-    SetCommonRuntimeArgs(program, reader_kernel_id, {input.buffer()->address()});
-    SetCommonRuntimeArgs(program, writer_kernel_id, {output.buffer()->address()});
+    // Common runtime args: arg 0 is the buffer base address (binding via Buffer*).
+    // emplace_common_runtime_args registers a CommonBufferBinding for the framework
+    // fast cache-hit path.
+    reader_desc.emplace_common_runtime_args({input_buffer});
+    writer_desc.emplace_common_runtime_args({output_buffer});
 
-    for (const auto& core : cores) {
-        SetRuntimeArgs(program, reader_kernel_id, core, {0, 0});
-        SetRuntimeArgs(program, writer_kernel_id, core, {0, 0});
-    }
-
-    auto cached_program = cached_program_t{
-        std::move(program),
-        {.reader_kernel_id = reader_kernel_id, .writer_kernel_id = writer_kernel_id, .grid = grid, .cores = cores}};
-
-    // Set initial runtime arguments
-    override_runtime_arguments(cached_program, operation_attributes, tensor_args, output_tensor);
-
-    return cached_program;
-}
-
-void NdReshardCopyPagesFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const ReshardParams& /*operation_attributes*/,
-    const ReshardInputs& tensor_args,
-    Tensor& output_tensor) {
-    const auto& input = tensor_args.input;
-    const auto& output = output_tensor;
-
-    auto& program = cached_program.program;
-    const auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    const auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    const auto& cores = cached_program.shared_variables.cores;
-
-    auto& common_runtime_args_reader = GetCommonRuntimeArgs(program, reader_kernel_id);
-    auto& common_runtime_args_writer = GetCommonRuntimeArgs(program, writer_kernel_id);
-    common_runtime_args_reader[0] = input.buffer()->address();
-    common_runtime_args_writer[0] = output.buffer()->address();
-
-    auto& runtime_args_by_core_reader = GetRuntimeArgs(program, reader_kernel_id);
-    auto& runtime_args_by_core_writer = GetRuntimeArgs(program, writer_kernel_id);
-
+    // Per-core unique runtime args: [start_page, end_page]
     uint32_t start_page = 0;
-    uint32_t num_dev_pages = input.buffer()->buffer_distribution_spec()->tensor_shape_in_pages().volume();
-    uint32_t n_pages_per_core = num_dev_pages / cores.size();
-    uint32_t remainder = num_dev_pages % cores.size();
+    uint32_t num_dev_pages =
+        static_cast<uint32_t>(input_buffer->buffer_distribution_spec()->tensor_shape_in_pages().volume());
+    uint32_t n_pages_per_core = num_dev_pages / static_cast<uint32_t>(cores.size());
+    uint32_t remainder = num_dev_pages % static_cast<uint32_t>(cores.size());
 
     for (const auto& core : cores) {
         uint32_t num_pages_for_core = n_pages_per_core;
@@ -120,12 +110,15 @@ void NdReshardCopyPagesFactory::override_runtime_arguments(
             num_pages_for_core++;
             remainder--;
         }
-        runtime_args_by_core_reader[core.x][core.y][0] = start_page;
-        runtime_args_by_core_reader[core.x][core.y][1] = start_page + num_pages_for_core;
-        runtime_args_by_core_writer[core.x][core.y][0] = start_page;
-        runtime_args_by_core_writer[core.x][core.y][1] = start_page + num_pages_for_core;
+        reader_desc.emplace_runtime_args(core, {start_page, start_page + num_pages_for_core});
+        writer_desc.emplace_runtime_args(core, {start_page, start_page + num_pages_for_core});
         start_page += num_pages_for_core;
     }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_pages.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_pages.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "ttnn/device_operation.hpp"
 #include "reshard_device_operation_types.hpp"
 
@@ -11,24 +13,8 @@ namespace ttnn::prim {
 
 // Factory for DRAM->DRAM nd reshard (simple page by page copy)
 struct NdReshardCopyPagesFactory {
-    struct NdReshardCopyPagesSharedVariables {
-        tt::tt_metal::KernelHandle reader_kernel_id{};
-        tt::tt_metal::KernelHandle writer_kernel_id{};
-        CoreRangeSet grid;
-        std::vector<CoreCoord> cores;
-    };
-
-    using shared_variables_t = NdReshardCopyPagesSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const ReshardParams& operation_attributes, const ReshardInputs& tensor_args, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const ReshardParams& operation_attributes,
-        const ReshardInputs& tensor_args,
-        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
@@ -6,12 +6,38 @@
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/tensor/tensor_utils.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
+
+namespace {
+
+// Anonymous-namespace helper unique to reshard generic to avoid unity-build collisions.
+void push_reshard_generic_cb_pair(
+    ProgramDescriptor& desc,
+    uint32_t cb_index,
+    tt::DataFormat data_format,
+    uint32_t total_size,
+    uint32_t page_size,
+    const CoreRangeSet& core_ranges,
+    Buffer* bound_buffer) {
+    CBDescriptor cb;
+    cb.total_size = total_size;
+    cb.core_ranges = core_ranges;
+    cb.format_descriptors.push_back(CBFormatDescriptor{
+        .buffer_index = static_cast<uint8_t>(cb_index),
+        .data_format = data_format,
+        .page_size = page_size,
+    });
+    cb.buffer = bound_buffer;
+    desc.cbs.push_back(std::move(cb));
+}
+
+}  // namespace
 
 namespace detail {
 // start is inclusive, end is exclusive
@@ -623,66 +649,77 @@ std::vector<uint32_t> get_runtime_args_for_given_ranges(
 
 }  // namespace detail
 
-ReshardGenericFactory::cached_program_t ReshardGenericFactory::create(
+ProgramDescriptor ReshardGenericFactory::create_descriptor(
     const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
     const auto& input = tensor_args.input;
     auto& output = output_tensor;
 
     auto* device = input.device();
+    auto* input_buffer = input.buffer();
+    auto* output_buffer = output.buffer();
 
-    tt::tt_metal::Program program{};
-
-    auto input_shard_spec = input.shard_spec().value();
-    auto output_shard_spec = output.shard_spec().value();
-    auto grid = input.buffer()->buffer_type() == BufferType::DRAM ? device->dram_grid_size()
-                                                                  : device->compute_with_storage_grid_size();
-    auto input_core_type = input.buffer()->core_type();
+    auto grid = input_buffer->buffer_type() == BufferType::DRAM ? device->dram_grid_size()
+                                                                : device->compute_with_storage_grid_size();
+    auto input_core_type = input_buffer->core_type();
     uint32_t dst_cb_index = 16;
     auto cores = get_optimal_worker_cores_for_sharded_tensor(output);
     auto all_cores = CoreRangeSet(ttsl::Span<const CoreCoord>(cores));
 
-    uint32_t total_size, page_size, unit_size;
-    auto output_shard_shape = output_shard_spec.shape;
+    uint32_t total_size = 0;
+    uint32_t page_size = 0;
+    uint32_t unit_size = 0;
+    auto output_shard_shape = output.shard_spec().value().shape;
     auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
 
     if (input.layout() == Layout::TILE) {
         page_size = tt::tile_size(data_format);
         unit_size = page_size;
-        total_size = output_shard_spec.numel() / TILE_HW * unit_size;
+        total_size = static_cast<uint32_t>(output.shard_spec().value().numel() / TILE_HW) * unit_size;
     } else {
         // For ROW_MAJOR, use base page size from GCD calculation
-        uint32_t input_page_size = input.buffer()->page_size();
-        uint32_t output_page_size = output.buffer()->page_size();
+        uint32_t input_page_size = input_buffer->page_size();
+        uint32_t output_page_size = output_buffer->page_size();
         uint32_t base_page_size = std::gcd(input_page_size, output_page_size);
 
         unit_size = base_page_size;
         page_size = base_page_size;
-        total_size = output_shard_shape[0] * output_shard_shape[1] * output.element_size();
+        total_size = static_cast<uint32_t>(output_shard_shape[0] * output_shard_shape[1] * output.element_size());
     }
 
-    tt::tt_metal::KernelHandle kernel_id_0 = tt::tt_metal::CreateKernel(
-        program,
-        input.buffer()->page_size() != output.buffer()->page_size()
-            ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_reader_diff_width.cpp"
-            : "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_reader.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(
-            {dst_cb_index, (uint32_t)grid.x, (uint32_t)grid.y, page_size, unit_size}));
+    ProgramDescriptor desc;
 
-    tt::tt_metal::KernelHandle kernel_id_1 = tt::tt_metal::CreateKernel(
-        program,
-        input.buffer()->page_size() != output.buffer()->page_size()
-            ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_reader_diff_width.cpp"
-            : "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_reader.cpp",
+    // Output sharded CB. Bind to output buffer for dynamic-CB rebinding on cache hits via cb.buffer.
+    push_reshard_generic_cb_pair(
+        desc,
+        dst_cb_index,
+        data_format,
+        total_size,
+        output_buffer->page_size(),
         all_cores,
-        tt::tt_metal::WriterDataMovementConfig(
-            {dst_cb_index, (uint32_t)grid.x, (uint32_t)grid.y, page_size, unit_size}));
+        /*bound_buffer=*/output_buffer);
 
-    tt::tt_metal::CircularBufferConfig cb_dst_config =
-        tt::tt_metal::CircularBufferConfig(total_size, {{dst_cb_index, data_format}})
-            .set_page_size(dst_cb_index, output.buffer()->page_size())
-            .set_globally_allocated_address(*output.buffer());
-    auto cb_dst0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_dst_config);
+    const std::string kernel_source = input_buffer->page_size() != output_buffer->page_size()
+                                          ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
+                                            "reshard_reader_diff_width.cpp"
+                                          : "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
+                                            "reshard_reader.cpp";
+
+    std::vector<uint32_t> compile_args = {
+        dst_cb_index, static_cast<uint32_t>(grid.x), static_cast<uint32_t>(grid.y), page_size, unit_size};
+
+    KernelDescriptor kernel_desc_0;
+    kernel_desc_0.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    kernel_desc_0.kernel_source = kernel_source;
+    kernel_desc_0.core_ranges = all_cores;
+    kernel_desc_0.config = ReaderConfigDescriptor{};
+    kernel_desc_0.compile_time_args = compile_args;
+
+    KernelDescriptor kernel_desc_1;
+    kernel_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    kernel_desc_1.kernel_source = kernel_source;
+    kernel_desc_1.core_ranges = all_cores;
+    kernel_desc_1.config = WriterConfigDescriptor{};
+    kernel_desc_1.compile_time_args = std::move(compile_args);
 
     std::vector<uint32_t> physical_core_coords;
     physical_core_coords.reserve(grid.x * grid.y);
@@ -698,35 +735,35 @@ ReshardGenericFactory::cached_program_t ReshardGenericFactory::create(
     for (const auto& core : cores) {
         std::vector<uint32_t> runtime_args_0;
         std::vector<uint32_t> runtime_args_1;
-        if (input.buffer()->page_size() != output.buffer()->page_size()) {
+        if (input_buffer->page_size() != output_buffer->page_size()) {
             auto output_core_to_page_range_pair =
-                detail::get_core_page_ranges_diff_width(input.buffer(), output.buffer(), input);
+                detail::get_core_page_ranges_diff_width(input_buffer, output_buffer, input);
             const auto& page_stride_vector = output_core_to_page_range_pair.at(core);
             runtime_args_0 = detail::get_runtime_args_for_given_ranges_diff_width(
                 physical_core_coords,
                 page_stride_vector,
                 0,
-                input.buffer()->address(),
+                input_buffer->address(),
                 0,
-                tt::div_up(page_stride_vector.size(), 2));
+                tt::div_up(static_cast<uint32_t>(page_stride_vector.size()), 2u));
             auto output_page_offset = runtime_args_0[physical_core_coords.size() + 1];
             runtime_args_1 = detail::get_runtime_args_for_given_ranges_diff_width(
                 physical_core_coords,
                 page_stride_vector,
                 output_page_offset,
-                input.buffer()->address(),
-                tt::div_up(page_stride_vector.size(), 2),
+                input_buffer->address(),
+                tt::div_up(static_cast<uint32_t>(page_stride_vector.size()), 2u),
                 page_stride_vector.size());
         } else {
-            auto output_core_to_page_range_pair = detail::get_core_page_ranges(input.buffer(), output.buffer());
+            auto output_core_to_page_range_pair = detail::get_core_page_ranges(input_buffer, output_buffer);
             const auto& page_stride_vector = output_core_to_page_range_pair.at(core);
             runtime_args_0 = detail::get_runtime_args_for_given_ranges(
                 physical_core_coords,
                 page_stride_vector,
                 0,
-                input.buffer()->address(),
+                input_buffer->address(),
                 0,
-                tt::div_up(page_stride_vector.size(), 2));
+                tt::div_up(static_cast<uint32_t>(page_stride_vector.size()), 2u));
             auto output_page_offset =
                 runtime_args_0[physical_core_coords.size() + 1];  // offset is equivalent to number of pages output in
                                                                   // previous risc core
@@ -734,39 +771,40 @@ ReshardGenericFactory::cached_program_t ReshardGenericFactory::create(
                 physical_core_coords,
                 page_stride_vector,
                 output_page_offset,
-                input.buffer()->address(),
-                tt::div_up(page_stride_vector.size(), 2),
+                input_buffer->address(),
+                tt::div_up(static_cast<uint32_t>(page_stride_vector.size()), 2u),
                 page_stride_vector.size());
-        };
+        }
 
-        tt::tt_metal::SetRuntimeArgs(program, kernel_id_0, core, runtime_args_0);
-        tt::tt_metal::SetRuntimeArgs(program, kernel_id_1, core, runtime_args_1);
+        // Patch arg index (grid.x + grid.y) to bind the input-buffer base address.
+        // The detail helpers already pre-compute physical_core_coords (size grid.x+grid.y) followed by input addr.
+        KernelDescriptor::RTArgList rt_args_0;
+        rt_args_0.reserve(runtime_args_0.size());
+        for (size_t i = 0; i < runtime_args_0.size(); ++i) {
+            if (i == grid.x + grid.y) {
+                rt_args_0.push_back(input_buffer);
+            } else {
+                rt_args_0.push_back(runtime_args_0[i]);
+            }
+        }
+        KernelDescriptor::RTArgList rt_args_1;
+        rt_args_1.reserve(runtime_args_1.size());
+        for (size_t i = 0; i < runtime_args_1.size(); ++i) {
+            if (i == grid.x + grid.y) {
+                rt_args_1.push_back(input_buffer);
+            } else {
+                rt_args_1.push_back(runtime_args_1[i]);
+            }
+        }
+
+        kernel_desc_0.emplace_runtime_args(core, rt_args_0);
+        kernel_desc_1.emplace_runtime_args(core, rt_args_1);
     }
 
-    return cached_program_t{
-        std::move(program),
-        {.kernel_id_0 = kernel_id_0, .kernel_id_1 = kernel_id_1, .cb_dst0 = cb_dst0, .grid = grid, .cores = cores}};
-}
+    desc.kernels.push_back(std::move(kernel_desc_0));
+    desc.kernels.push_back(std::move(kernel_desc_1));
 
-void ReshardGenericFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const ReshardParams& /*operation_attributes*/,
-    const ReshardInputs& tensor_args,
-    Tensor& output_tensor) {
-    const auto& input = tensor_args.input;
-    const auto& output = output_tensor;
-    uint32_t input_addr = input.buffer()->address();
-    auto& runtime_args_0_by_core = GetRuntimeArgs(cached_program.program, cached_program.shared_variables.kernel_id_0);
-    auto& runtime_args_1_by_core = GetRuntimeArgs(cached_program.program, cached_program.shared_variables.kernel_id_1);
-    auto& grid = cached_program.shared_variables.grid;
-    for (auto core : cached_program.shared_variables.cores) {
-        auto& runtime_args_0 = runtime_args_0_by_core[core.x][core.y];
-        auto& runtime_args_1 = runtime_args_1_by_core[core.x][core.y];
-        runtime_args_0[grid.x + grid.y] = input_addr;
-        runtime_args_1[grid.x + grid.y] = input_addr;
-    }
-    UpdateDynamicCircularBufferAddress(
-        cached_program.program, cached_program.shared_variables.cb_dst0, *output.buffer());
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.hpp
@@ -4,31 +4,16 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
 
 namespace ttnn::prim {
 
 struct ReshardGenericFactory {
-    struct ReshardGenericSharedVariables {
-        tt::tt_metal::KernelHandle kernel_id_0{};
-        tt::tt_metal::KernelHandle kernel_id_1{};
-        tt::tt_metal::CBHandle cb_dst0{};
-        CoreCoord grid;
-        std::vector<CoreCoord> cores;
-    };
-
-    using shared_variables_t = ReshardGenericSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const ReshardParams& operation_attributes, const ReshardInputs& tensor_args, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const ReshardParams& operation_attributes,
-        const ReshardInputs& tensor_args,
-        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_height.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_height.cpp
@@ -8,14 +8,40 @@
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
+namespace {
+
+// Anonymous-namespace helper unique to reshard same-height to avoid unity-build collisions.
+void push_reshard_same_height_cb_pair(
+    ProgramDescriptor& desc,
+    uint32_t cb_index,
+    tt::DataFormat data_format,
+    uint32_t total_size,
+    uint32_t page_size,
+    const CoreRangeSet& core_ranges,
+    Buffer* bound_buffer) {
+    CBDescriptor cb;
+    cb.total_size = total_size;
+    cb.core_ranges = core_ranges;
+    cb.format_descriptors.push_back(CBFormatDescriptor{
+        .buffer_index = static_cast<uint8_t>(cb_index),
+        .data_format = data_format,
+        .page_size = page_size,
+    });
+    cb.buffer = bound_buffer;
+    desc.cbs.push_back(std::move(cb));
+}
+
+}  // namespace
+
 template <bool local_is_output>
-ReshardSameHeightFactory<local_is_output>::cached_program_t ReshardSameHeightFactory<local_is_output>::create(
+ProgramDescriptor ReshardSameHeightFactory<local_is_output>::create_descriptor(
     const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
     const auto& input = tensor_args.input;
     const auto& output = output_tensor;
@@ -25,7 +51,6 @@ ReshardSameHeightFactory<local_is_output>::cached_program_t ReshardSameHeightFac
     const auto remote_shard_spec = remote_tensor.shard_spec().value();
 
     auto* device = input.device();
-    tt::tt_metal::Program program{};
 
     const auto remote_core_type = remote_tensor.buffer()->core_type();
     bool interface_with_dram = (remote_core_type == tt::CoreType::DRAM);
@@ -37,30 +62,42 @@ ReshardSameHeightFactory<local_is_output>::cached_program_t ReshardSameHeightFac
     const uint32_t element_size = tt::datum_size(data_format);
 
     TT_FATAL(local_tensor.layout() == Layout::ROW_MAJOR, "Expected row major tensor");
-    const uint32_t unit_size = local_shard_spec.shape[1] * local_tensor.element_size();  // width * element size
+    const uint32_t unit_size =
+        static_cast<uint32_t>(local_shard_spec.shape[1] * local_tensor.element_size());  // width * element size
     const uint32_t remote_units_per_shard = remote_shard_spec.shape[0];                  // height
     const uint32_t total_size = remote_units_per_shard * unit_size;
 
     constexpr uint32_t cb_index = tt::CBIndex::c_0;
-    tt::tt_metal::CircularBufferConfig cb_config =
-        tt::tt_metal::CircularBufferConfig(total_size, {{cb_index, data_format}})
-            .set_page_size(cb_index, unit_size)
-            .set_globally_allocated_address(*local_tensor.buffer());
-    auto cb_0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_config);
+
+    auto* local_buffer = local_tensor.buffer();
+    auto* remote_buffer = remote_tensor.buffer();
+
+    ProgramDescriptor desc;
+
+    // Local sharded CB. Bind to local buffer for dynamic-CB rebinding on cache hits via cb.buffer.
+    push_reshard_same_height_cb_pair(
+        desc, cb_index, data_format, total_size, unit_size, all_cores, /*bound_buffer=*/local_buffer);
 
     const std::string kernel_name =
         local_is_output
             ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_height_reader.cpp"
             : "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_height_writer.cpp";
 
-    tt::tt_metal::KernelHandle kernel_id_0 = tt::tt_metal::CreateKernel(
-        program, kernel_name, all_cores, tt::tt_metal::ReaderDataMovementConfig({cb_index, interface_with_dram}));
+    KernelDescriptor reader_desc;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.kernel_source = kernel_name;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.config = ReaderConfigDescriptor{};
+    reader_desc.compile_time_args = {cb_index, static_cast<uint32_t>(interface_with_dram)};
 
-    tt::tt_metal::KernelHandle kernel_id_1 = tt::tt_metal::CreateKernel(
-        program, kernel_name, all_cores, tt::tt_metal::WriterDataMovementConfig({cb_index, interface_with_dram}));
+    KernelDescriptor writer_desc;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.kernel_source = kernel_name;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.compile_time_args = {cb_index, static_cast<uint32_t>(interface_with_dram)};
 
-    uint32_t remote_address = remote_tensor.buffer()->address();
-    auto remote_buffer_type = remote_tensor.buffer()->buffer_type();
+    auto remote_buffer_type = remote_buffer->buffer_type();
 
     // Generate all read/write offsets for each core
     auto [runtime_args_for_each_core, total_num_sticks, local_stride_bytes, remote_stride_bytes] =
@@ -81,60 +118,46 @@ ReshardSameHeightFactory<local_is_output>::cached_program_t ReshardSameHeightFac
     // Here all we do is convert pre-computed offsets into vectors so they can be passed as runtime arguments
     for (uint32_t core_idx = 0; core_idx < local_cores.size(); core_idx++) {
         const auto& args_for_all_segments = runtime_args_for_each_core[core_idx];
-        std::vector<uint32_t> runtime_args_0 = {
-            total_num_sticks_kernel_0,
-            local_stride_bytes,
-            remote_stride_bytes,
-            remote_address,
-            args_for_all_segments.size()};
-        std::vector<uint32_t> runtime_args_1 = {
-            total_num_sticks_kernel_1,
-            local_stride_bytes,
-            remote_stride_bytes,
-            remote_address,
-            args_for_all_segments.size()};
+
+        // arg 3 is remote-buffer base address (binding via Buffer*).
+        KernelDescriptor::RTArgList runtime_args_0;
+        runtime_args_0.push_back(total_num_sticks_kernel_0);
+        runtime_args_0.push_back(local_stride_bytes);
+        runtime_args_0.push_back(remote_stride_bytes);
+        runtime_args_0.push_back(remote_buffer);
+        runtime_args_0.push_back(static_cast<uint32_t>(args_for_all_segments.size()));
+
+        KernelDescriptor::RTArgList runtime_args_1;
+        runtime_args_1.push_back(total_num_sticks_kernel_1);
+        runtime_args_1.push_back(local_stride_bytes);
+        runtime_args_1.push_back(remote_stride_bytes);
+        runtime_args_1.push_back(remote_buffer);
+        runtime_args_1.push_back(static_cast<uint32_t>(args_for_all_segments.size()));
+
         for (const auto& args : args_for_all_segments) {
-            const std::vector<uint32_t> segment_kernel_0 = {
-                args.write_size, args.read_offset, args.bank_id, args.write_offset};
-            runtime_args_0.insert(runtime_args_0.end(), segment_kernel_0.begin(), segment_kernel_0.end());
+            runtime_args_0.push_back(args.write_size);
+            runtime_args_0.push_back(args.read_offset);
+            runtime_args_0.push_back(args.bank_id);
+            runtime_args_0.push_back(args.write_offset);
 
             // Adjust read and write offsets to the correct stick address because we are splitting work across 2 kernels
             const uint32_t adjusted_read_offset = args.read_offset + (total_num_sticks_kernel_0 * local_stride_bytes);
             const uint32_t adjusted_write_offset =
                 args.write_offset + (total_num_sticks_kernel_0 * remote_stride_bytes);
 
-            const std::vector<uint32_t> segment_kernel_1 = {
-                args.write_size, adjusted_read_offset, args.bank_id, adjusted_write_offset};
-            runtime_args_1.insert(runtime_args_1.end(), segment_kernel_1.begin(), segment_kernel_1.end());
+            runtime_args_1.push_back(args.write_size);
+            runtime_args_1.push_back(adjusted_read_offset);
+            runtime_args_1.push_back(args.bank_id);
+            runtime_args_1.push_back(adjusted_write_offset);
         }
-        SetRuntimeArgs(program, kernel_id_0, local_cores[core_idx], runtime_args_0);
-        SetRuntimeArgs(program, kernel_id_1, local_cores[core_idx], runtime_args_1);
+        reader_desc.emplace_runtime_args(local_cores[core_idx], runtime_args_0);
+        writer_desc.emplace_runtime_args(local_cores[core_idx], runtime_args_1);
     }
 
-    return {std::move(program), {kernel_id_0, kernel_id_1, cb_0, local_cores}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-template <bool is_reader>
-void ReshardSameHeightFactory<is_reader>::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const ReshardParams& /*operation_attributes*/,
-    const ReshardInputs& tensor_args,
-    Tensor& output_tensor) {
-    const auto& input = tensor_args.input;
-    const auto& output = output_tensor;
-    const auto& local_tensor = is_reader ? output : input;
-    const auto& remote_tensor = is_reader ? input : output;
-    uint32_t remote_address = remote_tensor.buffer()->address();
-    auto& runtime_args_0_by_core = GetRuntimeArgs(cached_program.program, cached_program.shared_variables.kernel_id_0);
-    auto& runtime_args_1_by_core = GetRuntimeArgs(cached_program.program, cached_program.shared_variables.kernel_id_1);
-    for (auto core : cached_program.shared_variables.local_cores) {
-        auto& runtime_args_0 = runtime_args_0_by_core[core.x][core.y];
-        auto& runtime_args_1 = runtime_args_1_by_core[core.x][core.y];
-        runtime_args_0[3] = remote_address;
-        runtime_args_1[3] = remote_address;
-    }
-    UpdateDynamicCircularBufferAddress(
-        cached_program.program, cached_program.shared_variables.cb_0, *local_tensor.buffer());
+    return desc;
 }
 
 // Explicit template instantiations

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_height.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_height.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
 
@@ -12,24 +14,8 @@ namespace ttnn::prim {
 // WIDTH_SHARDED -> WIDTH_SHARDED reshard
 template <bool local_is_output>
 struct ReshardSameHeightFactory {
-    struct ReshardSameHeightSharedVariables {
-        tt::tt_metal::KernelHandle kernel_id_0{};
-        tt::tt_metal::KernelHandle kernel_id_1{};
-        tt::tt_metal::CBHandle cb_0{};
-        std::vector<CoreCoord> local_cores;
-    };
-
-    using shared_variables_t = ReshardSameHeightSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const ReshardParams& operation_attributes, const ReshardInputs& tensor_args, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const ReshardParams& operation_attributes,
-        const ReshardInputs& tensor_args,
-        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/tt_align.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/tensor/tensor_utils.hpp"
 
 using namespace tt::constants;
@@ -15,8 +16,33 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
+namespace {
+
+// Anonymous-namespace helper unique to reshard same-width to avoid unity-build collisions.
+void push_reshard_same_width_cb_pair(
+    ProgramDescriptor& desc,
+    uint32_t cb_index,
+    tt::DataFormat data_format,
+    uint32_t total_size,
+    uint32_t page_size,
+    const CoreRangeSet& core_ranges,
+    Buffer* bound_buffer) {
+    CBDescriptor cb;
+    cb.total_size = total_size;
+    cb.core_ranges = core_ranges;
+    cb.format_descriptors.push_back(CBFormatDescriptor{
+        .buffer_index = static_cast<uint8_t>(cb_index),
+        .data_format = data_format,
+        .page_size = page_size,
+    });
+    cb.buffer = bound_buffer;
+    desc.cbs.push_back(std::move(cb));
+}
+
+}  // namespace
+
 template <bool local_is_output>
-ReshardSameWidthFactory<local_is_output>::cached_program_t ReshardSameWidthFactory<local_is_output>::create(
+ProgramDescriptor ReshardSameWidthFactory<local_is_output>::create_descriptor(
     const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
     const auto& input = tensor_args.input;
     const auto& output = output_tensor;
@@ -24,7 +50,6 @@ ReshardSameWidthFactory<local_is_output>::cached_program_t ReshardSameWidthFacto
     const auto& remote_tensor = local_is_output ? input : output;
 
     auto* device = input.device();
-    tt::tt_metal::Program program{};
 
     const auto local_shard_spec = local_tensor.shard_spec().value();
     const auto remote_shard_spec = remote_tensor.shard_spec().value();
@@ -36,7 +61,9 @@ ReshardSameWidthFactory<local_is_output>::cached_program_t ReshardSameWidthFacto
     auto all_cores = CoreRangeSet(ttsl::Span<const CoreCoord>(local_cores));
     auto remote_cores = remote_tensor.buffer()->buffer_distribution_spec().value().cores_with_data();
 
-    uint32_t unit_size, local_units_per_shard, remote_units_per_shard;
+    uint32_t unit_size = 0;
+    uint32_t local_units_per_shard = 0;
+    uint32_t remote_units_per_shard = 0;
     auto data_format = tt::tt_metal::datatype_to_dataformat_converter(local_tensor.dtype());
 
     uint32_t num_units = local_tensor.buffer()->num_pages();
@@ -45,7 +72,7 @@ ReshardSameWidthFactory<local_is_output>::cached_program_t ReshardSameWidthFacto
         local_units_per_shard = local_shard_spec.numel() / TILE_HW;
         remote_units_per_shard = remote_shard_spec.numel() / TILE_HW;
     } else {
-        unit_size = local_shard_spec.shape[1] * local_tensor.element_size();
+        unit_size = static_cast<uint32_t>(local_shard_spec.shape[1] * local_tensor.element_size());
         local_units_per_shard = local_shard_spec.shape[0];
         remote_units_per_shard = remote_shard_spec.shape[0];
     }
@@ -62,62 +89,73 @@ ReshardSameWidthFactory<local_is_output>::cached_program_t ReshardSameWidthFacto
             : "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_writer.cpp";
 
     bool interface_with_dram = (remote_core_type == tt::CoreType::DRAM);
-    tt::tt_metal::KernelHandle kernel_id_0 = tt::tt_metal::CreateKernel(
-        program,
-        kernel_name,
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(
-            {cb_index,
-             interface_with_dram,
-             unaligned,
-             unit_size,
-             local_unit_size_padded,
-             remote_unit_size_padded,
-             cb_scratch_index}));
+    auto* local_buffer = local_tensor.buffer();
+    auto* remote_buffer = remote_tensor.buffer();
+    auto remote_buffer_type = remote_buffer->buffer_type();
 
-    tt::tt_metal::KernelHandle kernel_id_1 = tt::tt_metal::CreateKernel(
-        program,
-        kernel_name,
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(
-            {cb_index,
-             interface_with_dram,
-             unaligned,
-             unit_size,
-             local_unit_size_padded,
-             remote_unit_size_padded,
-             cb_scratch_index}));
+    ProgramDescriptor desc;
 
-    tt::tt_metal::CircularBufferConfig cb_config =
-        tt::tt_metal::CircularBufferConfig(total_size, {{cb_index, data_format}})
-            .set_page_size(cb_index, unit_size)
-            .set_globally_allocated_address(*local_tensor.buffer());
-    auto cb_0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_config);
+    // Local sharded CB. Bind to local buffer for dynamic-CB rebinding on cache hits via cb.buffer.
+    push_reshard_same_width_cb_pair(
+        desc, cb_index, data_format, total_size, unit_size, all_cores, /*bound_buffer=*/local_buffer);
 
     if (unaligned) {
-        tt::tt_metal::CircularBufferConfig cb_scratch_config =
-            tt::tt_metal::CircularBufferConfig(
-                remote_units_per_shard * remote_unit_size_padded, {{cb_scratch_index, data_format}})
-                .set_page_size(cb_scratch_index, unit_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_scratch_config);
+        // Scratch CB used by kernels when local/remote alignments differ.
+        push_reshard_same_width_cb_pair(
+            desc,
+            cb_scratch_index,
+            data_format,
+            remote_units_per_shard * remote_unit_size_padded,
+            unit_size,
+            all_cores,
+            /*bound_buffer=*/nullptr);
     }
+
+    // Reader/writer kernels share the same source and compile-time args.
+    std::vector<uint32_t> compile_args = {
+        cb_index,
+        static_cast<uint32_t>(interface_with_dram),
+        static_cast<uint32_t>(unaligned),
+        unit_size,
+        local_unit_size_padded,
+        remote_unit_size_padded,
+        cb_scratch_index};
+
+    KernelDescriptor reader_desc;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.kernel_source = kernel_name;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.config = ReaderConfigDescriptor{};
+    reader_desc.compile_time_args = compile_args;
+
+    KernelDescriptor writer_desc;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.kernel_source = kernel_name;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.compile_time_args = std::move(compile_args);
 
     uint32_t remote_core_idx = 0;
     uint32_t remote_core_units_rem = remote_units_per_shard;
-    uint32_t remote_address = remote_tensor.buffer()->address();
-    auto remote_buffer_type = remote_tensor.buffer()->buffer_type();
     auto bank_id =
         device->allocator()->get_bank_ids_from_logical_core(remote_buffer_type, remote_cores[remote_core_idx])[0];
 
-    std::array<tt::tt_metal::KernelHandle, 2> kernels = {kernel_id_0, kernel_id_1};
+    std::array<KernelDescriptor*, 2> kernels = {&reader_desc, &writer_desc};
     uint32_t local_units_left = num_units;
     for (const auto& core : local_cores) {
         uint32_t local_units_per_core = std::min(local_units_left, local_units_per_shard);
         local_units_left -= local_units_per_core;
-        uint32_t local_units_per_kernel = tt::div_up(local_units_per_core, kernels.size());
+        uint32_t local_units_per_kernel = tt::div_up(local_units_per_core, static_cast<uint32_t>(kernels.size()));
         uint32_t local_start_offset = 0;
-        for (const auto& kernel_id : kernels) {
-            std::vector<uint32_t> kernel_args = {remote_address, 0, 0};
+        for (auto* kernel : kernels) {
+            // arg 0 is remote-buffer base address (binding via Buffer*).
+            // RTArgList doesn't expose operator[] for back-patching, so we build
+            // a std::vector<variant> here and pass via the vector overload of
+            // emplace_runtime_args.
+            std::vector<std::variant<uint32_t, Buffer*>> kernel_args;
+            kernel_args.emplace_back(remote_buffer);
+            kernel_args.emplace_back(uint32_t{0});
+            kernel_args.emplace_back(uint32_t{0});
             uint32_t local_units_to_transfer = std::min(local_units_per_core, local_units_per_kernel);
             if (local_units_to_transfer != 0) {
                 uint32_t num_transfers = 0;
@@ -133,11 +171,10 @@ ReshardSameWidthFactory<local_is_output>::cached_program_t ReshardSameWidthFacto
                     uint32_t units_to_transfer = std::min(remote_core_units_rem, local_units_to_transfer);
                     bank_id = device->allocator()->get_bank_ids_from_logical_core(
                         remote_buffer_type, remote_cores[remote_core_idx])[0];
-                    kernel_args.insert(
-                        kernel_args.end(),
-                        {bank_id,
-                         (remote_units_per_shard - remote_core_units_rem) * remote_unit_size_padded,
-                         units_to_transfer});
+                    kernel_args.emplace_back(bank_id);
+                    kernel_args.emplace_back(
+                        (remote_units_per_shard - remote_core_units_rem) * remote_unit_size_padded);
+                    kernel_args.emplace_back(units_to_transfer);
                     local_units_per_core -= units_to_transfer;
                     local_units_to_transfer -= units_to_transfer;
                     remote_core_units_rem -= units_to_transfer;
@@ -145,33 +182,14 @@ ReshardSameWidthFactory<local_is_output>::cached_program_t ReshardSameWidthFacto
                 }
                 kernel_args[2] = num_transfers;
             }
-            SetRuntimeArgs(program, kernel_id, core, kernel_args);
+            kernel->emplace_runtime_args(core, kernel_args);
         }
     }
-    return {std::move(program), {kernel_id_0, kernel_id_1, cb_0, local_cores}};
-}
 
-template <bool is_reader>
-void ReshardSameWidthFactory<is_reader>::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const ReshardParams& /*operation_attributes*/,
-    const ReshardInputs& tensor_args,
-    Tensor& output_tensor) {
-    const auto& input = tensor_args.input;
-    const auto& output = output_tensor;
-    const auto& local_tensor = is_reader ? output : input;
-    const auto& remote_tensor = is_reader ? input : output;
-    uint32_t remote_addr = remote_tensor.buffer()->address();
-    auto& runtime_args_0_by_core = GetRuntimeArgs(cached_program.program, cached_program.shared_variables.kernel_id_0);
-    auto& runtime_args_1_by_core = GetRuntimeArgs(cached_program.program, cached_program.shared_variables.kernel_id_1);
-    for (auto core : cached_program.shared_variables.local_cores) {
-        auto& runtime_args_0 = runtime_args_0_by_core[core.x][core.y];
-        auto& runtime_args_1 = runtime_args_1_by_core[core.x][core.y];
-        runtime_args_0[0] = remote_addr;
-        runtime_args_1[0] = remote_addr;
-    }
-    UpdateDynamicCircularBufferAddress(
-        cached_program.program, cached_program.shared_variables.cb_0, *local_tensor.buffer());
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
 }
 
 // Explicit template instantiations

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
 
@@ -12,24 +14,8 @@ namespace ttnn::prim {
 // HEIGHT_SHARDED -> HEIGHT_SHARDED reshard
 template <bool local_is_output>
 struct ReshardSameWidthFactory {
-    struct ReshardSameWidthSharedVariables {
-        tt::tt_metal::KernelHandle kernel_id_0{};
-        tt::tt_metal::KernelHandle kernel_id_1{};
-        tt::tt_metal::CBHandle cb_0{};
-        std::vector<CoreCoord> local_cores;
-    };
-
-    using shared_variables_t = ReshardSameWidthSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const ReshardParams& operation_attributes, const ReshardInputs& tensor_args, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const ReshardParams& operation_attributes,
-        const ReshardInputs& tensor_args,
-        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/operations/data_movement/sharded/sharded_common.hpp"
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/tt_align.hpp>
@@ -18,7 +19,32 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-ShardedToInterleavedProgramFactory::cached_program_t ShardedToInterleavedProgramFactory::create(
+namespace {
+
+// Anonymous-namespace helper unique to sharded_to_interleaved to avoid unity-build collisions.
+void push_s2i_cb_pair(
+    ProgramDescriptor& desc,
+    uint32_t cb_index,
+    tt::DataFormat data_format,
+    uint32_t total_size,
+    uint32_t page_size,
+    const CoreRangeSet& core_ranges,
+    Buffer* bound_buffer) {
+    CBDescriptor cb;
+    cb.total_size = total_size;
+    cb.core_ranges = core_ranges;
+    cb.format_descriptors.push_back(CBFormatDescriptor{
+        .buffer_index = static_cast<uint8_t>(cb_index),
+        .data_format = data_format,
+        .page_size = page_size,
+    });
+    cb.buffer = bound_buffer;
+    desc.cbs.push_back(std::move(cb));
+}
+
+}  // namespace
+
+ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
     const ShardedToInterleavedParams& operation_attributes,
     const ShardedToInterleavedInputs& tensor_args,
     Tensor& output_tensor) {
@@ -28,10 +54,16 @@ ShardedToInterleavedProgramFactory::cached_program_t ShardedToInterleavedProgram
     const uint32_t slice_index = operation_attributes.slice_index;
     const bool is_l1_aligned = true;
 
-    tt_metal::Program program{};
-    uint32_t num_units_per_shard, input_unit_size, output_unit_size, num_units_per_shard_width,
-        num_units_per_shard_height, num_units_offset, num_units_per_row, num_units_height,
-        num_units_per_shard_height_last, num_units_per_shard_width_last;
+    uint32_t num_units_per_shard = 0;
+    uint32_t input_unit_size = 0;
+    uint32_t output_unit_size = 0;
+    uint32_t num_units_per_shard_width = 0;
+    uint32_t num_units_per_shard_height = 0;
+    uint32_t num_units_offset = 0;
+    uint32_t num_units_per_row = 0;
+    uint32_t num_units_height = 0;
+    uint32_t num_units_per_shard_height_last = 0;
+    uint32_t num_units_per_shard_width_last = 0;
 
     tt::DataFormat input_cb_data_format = tt_metal::datatype_to_dataformat_converter(input.dtype());
     tt::DataFormat output_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
@@ -54,20 +86,20 @@ ShardedToInterleavedProgramFactory::cached_program_t ShardedToInterleavedProgram
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
         num_units_per_row = input.padded_shape()[-1] / TILE_WIDTH;
         num_units_offset = num_units_per_row;
-        num_units_height = (input.physical_volume() / input.padded_shape()[-1])/ TILE_HEIGHT;
+        num_units_height = (input.physical_volume() / input.padded_shape()[-1]) / TILE_HEIGHT;
         num_units_per_shard_height_last =
             num_units_per_shard_height - (round_up(num_units_height, num_units_per_shard_height) - num_units_height);
         num_units_per_shard_width_last =
             num_units_per_shard_width - (round_up(num_units_per_row, num_units_per_shard_width) - num_units_per_row);
     } else {
-        input_unit_size = shard_spec.shape[1] * input.element_size();
-        output_unit_size = shard_spec.shape[1] * output.element_size();
+        input_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * input.element_size());
+        output_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * output.element_size());
         num_units_per_shard_height = shard_spec.shape[0];
         num_units_per_shard_width = 1;
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
-        num_units_per_row = input.logical_shape()[-1] * input.element_size();
+        num_units_per_row = static_cast<uint32_t>(input.logical_shape()[-1] * input.element_size());
         num_units_offset = 1;
-        num_units_height = input.logical_volume() / input.logical_shape()[-1];
+        num_units_height = static_cast<uint32_t>(input.logical_volume() / input.logical_shape()[-1]);
         num_units_per_shard_height_last =
             num_units_per_shard_height - (round_up(num_units_height, num_units_per_shard_height) - num_units_height);
         num_units_per_shard_width_last =
@@ -96,69 +128,82 @@ ShardedToInterleavedProgramFactory::cached_program_t ShardedToInterleavedProgram
     uint32_t src0_cb_index = CBIndex::c_0;
     uint32_t out_cb_index = src0_cb_index;
     uint32_t num_input_units = num_units_per_shard;
-    uint32_t input_page_size = align(input_unit_size, input.buffer()->alignment());
-    tt_metal::CircularBufferConfig cb_src0_config =
-        tt_metal::CircularBufferConfig(num_input_units * input_page_size, {{src0_cb_index, input_cb_data_format}})
-            .set_page_size(src0_cb_index, input_page_size)
-            .set_globally_allocated_address(*input.buffer());
-    auto cb_src0 = tt_metal::CreateCircularBuffer(program, used_cores, cb_src0_config);
-    if (convert_df) {
-        out_cb_index = CBIndex::c_16;
-        uint32_t output_page_size = align(output_unit_size, output.buffer()->alignment());
-        tt_metal::CircularBufferConfig output_cb_out_config =
-            tt_metal::CircularBufferConfig(num_input_units * output_page_size, {{out_cb_index, output_cb_data_format}})
-                .set_page_size(out_cb_index, output_page_size);
-        tt_metal::CreateCircularBuffer(program, used_cores, output_cb_out_config);
-    }
-
+    auto* src_buffer = input.buffer();
     auto* dst_buffer = output.buffer();
-
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)src0_cb_index};
-
-    tt_metal::KernelHandle unary_reader_kernel_id = tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp",
-        used_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
-
+    uint32_t input_page_size = tt::align(input_unit_size, src_buffer->alignment());
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     bool is_blackhole = (input.device()->arch() == tt::ARCH::BLACKHOLE);
 
-    tt_metal::KernelHandle unary_writer_kernel_id;
-    if (input.layout() == Layout::TILE) {
-        std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)out_cb_index};
-        TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    ProgramDescriptor desc;
 
-        unary_writer_kernel_id = tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
-            "writer_unary_sharded_blocks_interleaved_start_id.cpp",
-            used_cores,
-            tt_metal::WriterDataMovementConfig(writer_compile_time_args));
-    } else {
-        std::vector<uint32_t> writer_compile_time_args = {out_cb_index};
-        TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    // Sharded input CB. Bind to src buffer for dynamic-CB rebinding on cache hits via cb.buffer.
+    push_s2i_cb_pair(
+        desc,
+        src0_cb_index,
+        input_cb_data_format,
+        num_input_units * input_page_size,
+        input_page_size,
+        used_cores,
+        /*bound_buffer=*/src_buffer);
 
-        unary_writer_kernel_id = tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
-            "writer_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp",
-            used_cores,
-            tt_metal::WriterDataMovementConfig(writer_compile_time_args));
-    }
     if (convert_df) {
-        std::vector<uint32_t> compute_kernel_args = {num_units_per_shard};
-
-        tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/kernel/compute/eltwise_copy.cpp",
+        out_cb_index = CBIndex::c_16;
+        uint32_t output_page_size = tt::align(output_unit_size, dst_buffer->alignment());
+        push_s2i_cb_pair(
+            desc,
+            out_cb_index,
+            output_cb_data_format,
+            num_input_units * output_page_size,
+            output_page_size,
             used_cores,
-            tt_metal::ComputeConfig{.compile_args = compute_kernel_args});
+            /*bound_buffer=*/nullptr);
     }
 
-    tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, used_cores, {num_units_per_shard});
+    // Reader kernel (sharded input streamed in via globally-allocated CB).
+    KernelDescriptor reader_desc;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = used_cores;
+    reader_desc.config = ReaderConfigDescriptor{};
+    reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
+    reader_desc.compile_time_args = {src0_cb_index};
 
-    uint32_t starting_idx_h = operations::data_movement::detail::calculate_starting_idx_h(output, num_slices, slice_index);
+    // Writer kernel (writes interleaved output to DRAM).
+    KernelDescriptor writer_desc;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = used_cores;
+    writer_desc.config = WriterConfigDescriptor{};
+    std::vector<uint32_t> writer_compile_time_args = {out_cb_index};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    if (input.layout() == Layout::TILE) {
+        writer_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
+            "writer_unary_sharded_blocks_interleaved_start_id.cpp";
+    } else {
+        writer_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
+            "writer_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp";
+    }
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+
+    // Optional compute kernel for data-format conversion.
+    KernelDescriptor compute_desc;
+    if (convert_df) {
+        compute_desc.kernel_source = "ttnn/cpp/ttnn/kernel/compute/eltwise_copy.cpp";
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = used_cores;
+        compute_desc.config = ComputeConfigDescriptor{};
+        compute_desc.compile_time_args = {num_units_per_shard};
+    }
+
+    // Reader runtime args: identical on every used core.
+    for (const auto& core_range : used_cores.ranges()) {
+        for (const auto& core : core_range) {
+            reader_desc.emplace_runtime_args(core, {num_units_per_shard});
+        }
+    }
+
+    uint32_t starting_idx_h =
+        operations::data_movement::detail::calculate_starting_idx_h(output, num_slices, slice_index);
     uint32_t curr_idx_h = 0;
     uint32_t curr_idx_w = 0;
 
@@ -192,19 +237,19 @@ ShardedToInterleavedProgramFactory::cached_program_t ShardedToInterleavedProgram
                     }
                 }
             }
-            tt_metal::SetRuntimeArgs(
-                program,
-                unary_writer_kernel_id,
-                core,
-                {dst_buffer->address(),
-                 num_units_per_shard_height,
-                 num_units_per_shard_width,
-                 shard_height,
-                 shard_width,
-                 num_units_offset,
-                 num_units_per_shard,
-                 curr_idx_h + curr_idx_w,
-                 starting_idx_h});
+            // Writer run-time args: arg 0 is the destination-buffer base address (binding via Buffer*).
+            KernelDescriptor::RTArgList writer_rt;
+            writer_rt.push_back(dst_buffer);
+            writer_rt.push_back(num_units_per_shard_height);
+            writer_rt.push_back(num_units_per_shard_width);
+            writer_rt.push_back(shard_height);
+            writer_rt.push_back(shard_width);
+            writer_rt.push_back(num_units_offset);
+            writer_rt.push_back(num_units_per_shard);
+            writer_rt.push_back(curr_idx_h + curr_idx_w);
+            writer_rt.push_back(starting_idx_h);
+            writer_desc.emplace_runtime_args(core, writer_rt);
+
             curr_idx_w += num_units_per_shard_width;
             if (curr_idx_w >= num_units_per_row) {
                 curr_idx_w = 0;
@@ -237,23 +282,23 @@ ShardedToInterleavedProgramFactory::cached_program_t ShardedToInterleavedProgram
                 }
             }
             uint32_t l1_alignment = hal::get_l1_alignment();
-            uint32_t padded_shard_width = align(output_unit_size, dst_buffer->alignment());
+            uint32_t padded_shard_width = tt::align(output_unit_size, dst_buffer->alignment());
             if (is_blackhole or is_l1_aligned) {
                 if (!dst_is_dram or is_l1_aligned) {
-                    padded_shard_width = align(output_unit_size, l1_alignment);
+                    padded_shard_width = tt::align(output_unit_size, l1_alignment);
                 }
             }
-            tt_metal::SetRuntimeArgs(
-                program,
-                unary_writer_kernel_id,
-                core,
-                {dst_buffer->address(),
-                 num_units_per_row,
-                 shard_height,
-                 shard_width,
-                 padded_shard_width,
-                 curr_idx_w,
-                 curr_idx_h});
+            // Writer run-time args: arg 0 is the destination-buffer base address (binding via Buffer*).
+            KernelDescriptor::RTArgList writer_rt;
+            writer_rt.push_back(dst_buffer);
+            writer_rt.push_back(num_units_per_row);
+            writer_rt.push_back(shard_height);
+            writer_rt.push_back(shard_width);
+            writer_rt.push_back(padded_shard_width);
+            writer_rt.push_back(curr_idx_w);
+            writer_rt.push_back(curr_idx_h);
+            writer_desc.emplace_runtime_args(core, writer_rt);
+
             curr_idx_w += output_unit_size;
             if (curr_idx_w >= num_units_per_row) {
                 curr_idx_w = 0;
@@ -262,47 +307,13 @@ ShardedToInterleavedProgramFactory::cached_program_t ShardedToInterleavedProgram
         }
     }
 
-    return cached_program_t{
-        std::move(program),
-        shared_variables_t{
-            .unary_reader_kernel_id = unary_reader_kernel_id,
-            .unary_writer_kernel_id = unary_writer_kernel_id,
-            .cb_src0 = cb_src0,
-            .cores = cores,
-            .num_slices = num_slices,
-            .num_cores_unpadded = num_cores_unpadded,
-        }};
-}
-
-void ShardedToInterleavedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const ShardedToInterleavedParams& operation_attributes,
-    const ShardedToInterleavedInputs& tensor_args,
-    Tensor& output_tensor) {
-    const auto& output = output_tensor;
-    auto& program = cached_program.program;
-    auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& cb_src0 = cached_program.shared_variables.cb_src0;
-    const auto& cores = cached_program.shared_variables.cores;
-    const uint32_t num_slices = cached_program.shared_variables.num_slices;
-    const uint32_t num_cores_unpadded = cached_program.shared_variables.num_cores_unpadded;
-
-    auto* src_buffer = tensor_args.input_tensor.buffer();
-    auto* dst_buffer = output.buffer();
-
-    // Calculate starting_idx_h if partial operation
-    uint32_t starting_idx_h = operations::data_movement::detail::calculate_starting_idx_h(output, num_slices, operation_attributes.slice_index);
-
-    auto& runtime_args_by_core = GetRuntimeArgs(program, unary_writer_kernel_id);
-    for (uint32_t core_idx = 0; core_idx < num_cores_unpadded; core_idx++) {
-        const auto& core = cores[core_idx];
-        auto& runtime_args = runtime_args_by_core[core.x][core.y];
-        runtime_args[0] = dst_buffer->address();
-        if (num_slices > 1) {
-            runtime_args[8] = starting_idx_h;
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    if (convert_df) {
+        desc.kernels.push_back(std::move(compute_desc));
     }
-    UpdateDynamicCircularBufferAddress(program, cb_src0, *src_buffer);
+
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.hpp
@@ -4,31 +4,15 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
 
 namespace ttnn::prim {
 
-struct ShardedToInterleavedSharedVariables {
-    tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-    tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-    tt::tt_metal::CBHandle cb_src0{};
-    std::vector<CoreCoord> cores;
-    uint32_t num_slices{};
-    uint32_t num_cores_unpadded{};
-};
-
 struct ShardedToInterleavedProgramFactory {
-    using shared_variables_t = ShardedToInterleavedSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const ShardedToInterleavedParams& operation_attributes,
-        const ShardedToInterleavedInputs& tensor_args,
-        Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const ShardedToInterleavedParams& operation_attributes,
         const ShardedToInterleavedInputs& tensor_args,
         Tensor& output_tensor);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 #include "ttnn/operations/data_movement/sharded/sharded_common.hpp"
 
@@ -22,7 +23,32 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-InterleavedToShardedPartialProgramFactory::cached_program_t InterleavedToShardedPartialProgramFactory::create(
+namespace {
+
+// Anonymous-namespace helper unique to interleaved_to_sharded_partial to avoid unity-build collisions.
+void push_i2s_partial_cb_pair(
+    ProgramDescriptor& desc,
+    uint32_t cb_index,
+    tt::DataFormat data_format,
+    uint32_t total_size,
+    uint32_t page_size,
+    const CoreRangeSet& core_ranges,
+    Buffer* bound_buffer) {
+    CBDescriptor cb;
+    cb.total_size = total_size;
+    cb.core_ranges = core_ranges;
+    cb.format_descriptors.push_back(CBFormatDescriptor{
+        .buffer_index = static_cast<uint8_t>(cb_index),
+        .data_format = data_format,
+        .page_size = page_size,
+    });
+    cb.buffer = bound_buffer;
+    desc.cbs.push_back(std::move(cb));
+}
+
+}  // namespace
+
+ProgramDescriptor InterleavedToShardedPartialProgramFactory::create_descriptor(
     const InterleavedToShardedPartialParams& params, const Tensor& input, Tensor& output) {
     // Partial op behavior
     bool keep_l1_aligned = false;
@@ -30,11 +56,16 @@ InterleavedToShardedPartialProgramFactory::cached_program_t InterleavedToSharded
     uint32_t num_slices = params.num_slices;
     uint32_t slice_index = params.slice_index;
 
-    tt::tt_metal::Program program{};
-
-    uint32_t num_units_per_shard, input_unit_size, output_unit_size, num_units_per_shard_width,
-        num_units_per_shard_height, num_units_offset, num_units_per_row, num_units_per_shard_height_last,
-        num_units_per_shard_width_last, padded_offset_bytes;
+    uint32_t num_units_per_shard = 0;
+    uint32_t input_unit_size = 0;
+    uint32_t output_unit_size = 0;
+    uint32_t num_units_per_shard_width = 0;
+    uint32_t num_units_per_shard_height = 0;
+    uint32_t num_units_offset = 0;
+    uint32_t num_units_per_row = 0;
+    uint32_t num_units_per_shard_height_last = 0;
+    uint32_t num_units_per_shard_width_last = 0;
+    uint32_t padded_offset_bytes = 0;
 
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
@@ -67,7 +98,8 @@ InterleavedToShardedPartialProgramFactory::cached_program_t InterleavedToSharded
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
         num_units_per_row = input.padded_shape()[-1] / TILE_WIDTH;
         num_units_offset = num_units_per_row;
-        uint32_t num_units_height = input.physical_volume() / input.padded_shape()[-1] / TILE_HEIGHT / num_slices;
+        uint32_t num_units_height =
+            static_cast<uint32_t>(input.physical_volume() / input.padded_shape()[-1] / TILE_HEIGHT / num_slices);
         num_units_per_shard_height_last =
             num_units_per_shard_height -
             (tt::round_up(num_units_height, num_units_per_shard_height) - num_units_height);
@@ -76,14 +108,14 @@ InterleavedToShardedPartialProgramFactory::cached_program_t InterleavedToSharded
             (tt::round_up(num_units_per_row, num_units_per_shard_width) - num_units_per_row);
         padded_offset_bytes = (num_units_per_shard_width - num_units_per_shard_width_last) * input_unit_size;
     } else {
-        input_unit_size = shard_spec.shape[1] * input.element_size();
-        output_unit_size = shard_spec.shape[1] * output.element_size();
+        input_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * input.element_size());
+        output_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * output.element_size());
         num_units_per_shard_height = shard_spec.shape[0];
         num_units_per_shard_width = 1;
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
-        num_units_per_row = input.padded_shape()[-1] * input.element_size();
+        num_units_per_row = static_cast<uint32_t>(input.padded_shape()[-1] * input.element_size());
         num_units_offset = 1;
-        uint32_t num_units_height = input.physical_volume() / input.padded_shape()[-1];
+        uint32_t num_units_height = static_cast<uint32_t>(input.physical_volume() / input.padded_shape()[-1]);
         num_units_per_shard_height_last =
             num_units_per_shard_height -
             (tt::round_up(num_units_height, num_units_per_shard_height) - num_units_height);
@@ -104,89 +136,104 @@ InterleavedToShardedPartialProgramFactory::cached_program_t InterleavedToSharded
     uint32_t out_cb_index = input_cb_index;
     uint32_t num_input_units = num_units_per_shard;
     uint32_t output_page_size = tt::align(output_unit_size, dst_buffer->alignment());
+
+    ProgramDescriptor desc;
+
     if (convert_df) {
         out_cb_index = tt::CBIndex::c_16;
         uint32_t input_page_size = tt::align(input_unit_size, src_buffer->alignment());
-        tt::tt_metal::CircularBufferConfig input_cb_out_config =
-            tt::tt_metal::CircularBufferConfig(
-                num_input_units * input_page_size, {{input_cb_index, input_cb_data_format}})
-                .set_page_size(input_cb_index, input_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, input_cb_out_config);
+        // Non-globally-allocated input CB (interleaved input streamed via reader).
+        push_i2s_partial_cb_pair(
+            desc,
+            input_cb_index,
+            input_cb_data_format,
+            num_input_units * input_page_size,
+            input_page_size,
+            all_cores,
+            /*bound_buffer=*/nullptr);
     }
-    tt::tt_metal::CircularBufferConfig output_cb_out_config =
-        tt::tt_metal::CircularBufferConfig(num_input_units * output_page_size, {{out_cb_index, output_cb_data_format}})
-            .set_page_size(out_cb_index, output_page_size);
-    if (!dst_is_dram) {
-        output_cb_out_config = output_cb_out_config.set_globally_allocated_address(*output.buffer());
-    }
-    auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, output_cb_out_config);
+
+    // Output CB. When destination is sharded (non-DRAM) we bind it to the output buffer
+    // for dynamic-CB rebinding on cache hits via cb.buffer. When dst is DRAM, no binding.
+    push_i2s_partial_cb_pair(
+        desc,
+        out_cb_index,
+        output_cb_data_format,
+        num_input_units * output_page_size,
+        output_page_size,
+        all_cores,
+        /*bound_buffer=*/dst_is_dram ? nullptr : dst_buffer);
+
     uint32_t dram_alignment = hal::get_dram_alignment();
+    uint32_t l1_alignment = hal::get_l1_alignment();
     uint32_t num_trids = 4;
     if ((src_is_dram && (input_unit_size % dram_alignment != 0)) || is_blackhole || keep_l1_aligned) {
-        uint32_t scratch_cb_page_size;
         // scratchpad going to be used to align DRAM (64B) to L1 (16B)
-
         // This is done to mitigate the alignment issues.
         // See issue #34414.
-        scratch_cb_page_size = tt::align(input_unit_size + dram_alignment, dram_alignment);
-
-        tt::tt_metal::CircularBufferConfig scratch_cb_out_config =
-            tt::tt_metal::CircularBufferConfig(
-                num_trids * scratch_cb_page_size, {{scratch_cb_index, input_cb_data_format}})
-                .set_page_size(scratch_cb_index, scratch_cb_page_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, scratch_cb_out_config);
+        uint32_t scratch_cb_page_size = tt::align(input_unit_size + dram_alignment, dram_alignment);
+        push_i2s_partial_cb_pair(
+            desc,
+            scratch_cb_index,
+            input_cb_data_format,
+            num_trids * scratch_cb_page_size,
+            scratch_cb_page_size,
+            all_cores,
+            /*bound_buffer=*/nullptr);
     }
 
-    tt::tt_metal::KernelHandle unary_reader_kernel_id;
+    // Reader kernel.
+    KernelDescriptor reader_desc;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.config = ReaderConfigDescriptor{};
     if (input.layout() == Layout::TILE) {
         std::vector<uint32_t> reader_compile_time_args = {input_cb_index, all_cores.num_cores()};
         tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
-
-        unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-            program,
+        reader_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
-            "reader_unary_sharded_blocks_interleaved_start_id.cpp",
-            all_cores,
-            tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+            "reader_unary_sharded_blocks_interleaved_start_id.cpp";
+        reader_desc.compile_time_args = std::move(reader_compile_time_args);
     } else {
         std::vector<uint32_t> reader_compile_time_args = {input_cb_index, scratch_cb_index, num_trids};
         tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
-
-        unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-            program,
+        reader_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
-            "reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp",
-            all_cores,
-            tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+            "reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp";
+        reader_desc.compile_time_args = std::move(reader_compile_time_args);
     }
 
-    std::string writer_kernel;
+    // Writer kernel.
+    KernelDescriptor writer_desc;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.config = WriterConfigDescriptor{};
     std::vector<uint32_t> writer_compile_time_args = {out_cb_index};
     if (dst_is_dram) {
         if (input.layout() == Layout::TILE) {
-            writer_kernel = std::string(
+            writer_desc.kernel_source =
                 "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
-                "writer_unary_sharded_blocks_start_id.cpp");
+                "writer_unary_sharded_blocks_start_id.cpp";
         } else {
-            writer_kernel = std::string(
+            writer_desc.kernel_source =
                 "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
-                "writer_unary_sharded_stick_layout_start_id.cpp");
+                "writer_unary_sharded_stick_layout_start_id.cpp";
         }
         shard_builder::extend_sharding_compile_time_args(output, writer_compile_time_args);
     } else {
-        writer_kernel = std::string(
-            "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp");
+        writer_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp";
     }
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program, writer_kernel, all_cores, tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
 
-    tt::tt_metal::KernelHandle compute_kernel_id = 0;
+    // Optional compute kernel for data-format conversion.
+    KernelDescriptor compute_desc;
     if (convert_df) {
-        compute_kernel_id = tt::tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/compute/eltwise_copy.cpp",
-            all_cores,
-            tt::tt_metal::ComputeConfig{});
+        compute_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/compute/eltwise_copy.cpp";
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = all_cores;
+        compute_desc.config = ComputeConfigDescriptor{};
     }
 
     uint32_t starting_idx_h =
@@ -231,36 +278,37 @@ InterleavedToShardedPartialProgramFactory::cached_program_t InterleavedToSharded
             }
             curr_num_units_per_shard = shard_height * num_units_per_shard_width;
 
-            // Reader run-time args
-            std::vector<uint32_t> reader_run_time_args = {
-                src_buffer->address(),
-                shard_height,
-                shard_width,
-                padded_offset,
-                num_units_offset,
-                curr_num_units_per_shard,
-                curr_idx_h + curr_idx_w,
-                starting_idx_h};
-            tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_run_time_args);
+            // Reader run-time args: arg 0 is the source-buffer base address (binding).
+            KernelDescriptor::RTArgList reader_rt;
+            reader_rt.push_back(src_buffer);
+            reader_rt.push_back(shard_height);
+            reader_rt.push_back(shard_width);
+            reader_rt.push_back(padded_offset);
+            reader_rt.push_back(num_units_offset);
+            reader_rt.push_back(curr_num_units_per_shard);
+            reader_rt.push_back(curr_idx_h + curr_idx_w);
+            reader_rt.push_back(starting_idx_h);
+            reader_desc.emplace_runtime_args(core, reader_rt);
 
             // Writer run-time args
             uint32_t pad_offset = (num_units_per_shard_width - shard_width) * output_unit_size;
-            std::vector<uint32_t> writer_run_time_args;
             if (dst_is_dram) {
-                writer_run_time_args = {
-                    dst_buffer->address(),
-                    shard_height,
-                    shard_width,
-                    pad_offset,
-                    curr_num_units_per_shard,
-                    num_units_offset,
-                    curr_idx_h + curr_idx_w,
-                    starting_idx_h};
-                shard_builder::extend_sharding_run_time_args(output, writer_run_time_args);
+                KernelDescriptor::RTArgList writer_rt;
+                writer_rt.push_back(dst_buffer);
+                writer_rt.push_back(shard_height);
+                writer_rt.push_back(shard_width);
+                writer_rt.push_back(pad_offset);
+                writer_rt.push_back(curr_num_units_per_shard);
+                writer_rt.push_back(num_units_offset);
+                writer_rt.push_back(curr_idx_h + curr_idx_w);
+                writer_rt.push_back(starting_idx_h);
+                std::vector<uint32_t> extra;
+                shard_builder::extend_sharding_run_time_args(output, extra);
+                writer_rt.append(extra);
+                writer_desc.emplace_runtime_args(core, writer_rt);
             } else {
-                writer_run_time_args = {curr_num_units_per_shard};
+                writer_desc.emplace_runtime_args(core, {curr_num_units_per_shard});
             }
-            tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_run_time_args);
 
             // Update indexing
             curr_idx_w += num_units_per_shard_width;
@@ -300,14 +348,14 @@ InterleavedToShardedPartialProgramFactory::cached_program_t InterleavedToSharded
                 }
             }
 
-            uint32_t dram_alignment = hal::get_dram_alignment();
-            uint32_t l1_alignment = hal::get_l1_alignment();
             bool aligned =
                 (src_is_dram ? (curr_idx_w % dram_alignment == 0) && (padded_offset_bytes % dram_alignment == 0)
                              : true);
             // for blackhole and keep_l1_aligned cases, always enforce unaligned kernel call
             aligned = aligned and !(is_blackhole);
-            uint32_t aligned_width_offset, aligned_shard_width, aligned_offset;
+            uint32_t aligned_width_offset = 0;
+            uint32_t aligned_shard_width = 0;
+            uint32_t aligned_offset = 0;
             if (!aligned) {
                 // TODO: is this right, leaving non BH case the same for now, should investigate
                 if (!is_blackhole) {
@@ -327,38 +375,39 @@ InterleavedToShardedPartialProgramFactory::cached_program_t InterleavedToSharded
                 aligned_offset = 0;
             }
 
-            // Reader run-time args
-            std::vector<uint32_t> reader_run_time_args = {
-                src_buffer->address(),
-                num_units_per_row,
-                shard_height,
-                shard_width,
-                padded_offset_bytes,
-                static_cast<uint32_t>(aligned),
-                aligned_width_offset,
-                aligned_shard_width,
-                aligned_offset,
-                curr_idx_h};
-            tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_run_time_args);
+            // Reader run-time args: arg 0 is the source-buffer base address (binding).
+            KernelDescriptor::RTArgList reader_rt;
+            reader_rt.push_back(src_buffer);
+            reader_rt.push_back(num_units_per_row);
+            reader_rt.push_back(shard_height);
+            reader_rt.push_back(shard_width);
+            reader_rt.push_back(padded_offset_bytes);
+            reader_rt.push_back(static_cast<uint32_t>(aligned));
+            reader_rt.push_back(aligned_width_offset);
+            reader_rt.push_back(aligned_shard_width);
+            reader_rt.push_back(aligned_offset);
+            reader_rt.push_back(curr_idx_h);
+            reader_desc.emplace_runtime_args(core, reader_rt);
 
             // Writer run-time args
-            std::vector<uint32_t> writer_run_time_args;
             if (dst_is_dram) {
                 uint32_t page_id_within_row = curr_idx_w / input_unit_size;
                 uint32_t output_width_in_pages = tt::div_up(num_units_per_row, input_unit_size);
                 uint32_t start_id = (curr_idx_h * output_width_in_pages) + page_id_within_row;
-                writer_run_time_args = {
-                    dst_buffer->address(),
-                    shard_height,
-                    shard_width,
-                    padded_offset_bytes,
-                    start_id,
-                    output_width_in_pages};
-                shard_builder::extend_sharding_run_time_args(output, writer_run_time_args);
+                KernelDescriptor::RTArgList writer_rt;
+                writer_rt.push_back(dst_buffer);
+                writer_rt.push_back(shard_height);
+                writer_rt.push_back(shard_width);
+                writer_rt.push_back(padded_offset_bytes);
+                writer_rt.push_back(start_id);
+                writer_rt.push_back(output_width_in_pages);
+                std::vector<uint32_t> extra;
+                shard_builder::extend_sharding_run_time_args(output, extra);
+                writer_rt.append(extra);
+                writer_desc.emplace_runtime_args(core, writer_rt);
             } else {
-                writer_run_time_args = {curr_num_units_per_shard};
+                writer_desc.emplace_runtime_args(core, {curr_num_units_per_shard});
             }
-            tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_run_time_args);
 
             // Update indexing
             curr_idx_w += input_unit_size;
@@ -368,58 +417,17 @@ InterleavedToShardedPartialProgramFactory::cached_program_t InterleavedToSharded
             }
         }
         if (convert_df) {
-            tt::tt_metal::SetRuntimeArgs(program, compute_kernel_id, core, {curr_num_units_per_shard});
+            compute_desc.emplace_runtime_args(core, {curr_num_units_per_shard});
         }
     }
 
-    return {std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id, cb_output, cores, num_slices}};
-}
-
-void InterleavedToShardedPartialProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const InterleavedToShardedPartialParams& params,
-    const Tensor& input_tensor,
-    Tensor& output_tensor) {
-    auto* src_buffer = input_tensor.buffer();
-    auto* dst_buffer = output_tensor.buffer();
-
-    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-
-    uint32_t num_slices = params.num_slices;
-    uint32_t slice_index = params.slice_index;
-    bool partial_op = num_slices > 1;
-    uint32_t starting_idx_h = 0;
-    if (partial_op) {
-        uint32_t runtime_slice_index = slice_index;
-        starting_idx_h =
-            operations::data_movement::detail::calculate_starting_idx_h(input_tensor, num_slices, runtime_slice_index);
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    if (convert_df) {
+        desc.kernels.push_back(std::move(compute_desc));
     }
 
-    auto& shared_variables = cached_program.shared_variables;
-    auto& program = cached_program.program;
-    auto unary_reader_kernel_id = shared_variables.unary_reader_kernel_id;
-    auto unary_writer_kernel_id = shared_variables.unary_writer_kernel_id;
-    auto cb_output = shared_variables.cb_output;
-    const auto& cores = shared_variables.cores;
-
-    auto& runtime_args_by_core = GetRuntimeArgs(program, unary_reader_kernel_id);
-    for (const auto& core : cores) {
-        auto& runtime_args = runtime_args_by_core[core.x][core.y];
-        runtime_args[0] = src_buffer->address();
-        if (partial_op) {
-            runtime_args[7] = starting_idx_h;
-        }
-    }
-
-    if (dst_is_dram) {
-        auto& runtime_args_by_core = GetRuntimeArgs(program, unary_writer_kernel_id);
-        for (const auto& core : cores) {
-            auto& runtime_args = runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = dst_buffer->address();
-        }
-    } else {
-        UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/operation.hpp"
 #include "ttnn/device_operation.hpp"
 #include "interleaved_to_sharded_partial_op_types.hpp"
@@ -11,24 +12,8 @@
 namespace ttnn::prim {
 
 struct InterleavedToShardedPartialProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-        tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-        tt::tt_metal::CBHandle cb_output{};
-        std::vector<tt::tt_metal::CoreCoord> cores;
-        uint32_t num_slices{};
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const InterleavedToShardedPartialParams& params, const Tensor& input_tensor, Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const InterleavedToShardedPartialParams& params,
-        const Tensor& input_tensor,
-        Tensor& output_tensor);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const InterleavedToShardedPartialParams& params, const Tensor& input, Tensor& output);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_program_factory.cpp
@@ -4,50 +4,317 @@
 
 #include "ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_program_factory.hpp"
 
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/operations/data_movement/sharded/sharded_common.hpp"
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/tt_align.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+using namespace tt;
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
 namespace ttnn::prim {
 
-ShardedToInterleavedPartialProgramFactory::cached_program_t ShardedToInterleavedPartialProgramFactory::create(
-    const ShardedToInterleavedPartialParams& params,
-    const ShardedToInterleavedPartialInputs& tensor_args,
-    Tensor& output_tensor) {
-    // Convert partial types to shared types
-    ShardedToInterleavedParams shared_attrs{
-        .output_mem_config = params.output_mem_config,
-        .output_dtype = params.output_dtype,
-        .num_slices = params.num_slices,
-        .slice_index = params.slice_index,
-    };
+namespace {
 
-    ShardedToInterleavedInputs shared_tensor_args{
-        .input_tensor = tensor_args.input_tensor,
-        .preallocated_output = tensor_args.cache_tensor,
-    };
-
-    // Delegates to shared to interleaved factory
-    return ShardedToInterleavedProgramFactory::create(shared_attrs, shared_tensor_args, output_tensor);
+// Anonymous-namespace helper unique to sharded_to_interleaved_partial to avoid unity-build collisions.
+void push_s2i_partial_cb_pair(
+    ProgramDescriptor& desc,
+    uint32_t cb_index,
+    tt::DataFormat data_format,
+    uint32_t total_size,
+    uint32_t page_size,
+    const CoreRangeSet& core_ranges,
+    Buffer* bound_buffer) {
+    CBDescriptor cb;
+    cb.total_size = total_size;
+    cb.core_ranges = core_ranges;
+    cb.format_descriptors.push_back(CBFormatDescriptor{
+        .buffer_index = static_cast<uint8_t>(cb_index),
+        .data_format = data_format,
+        .page_size = page_size,
+    });
+    cb.buffer = bound_buffer;
+    desc.cbs.push_back(std::move(cb));
 }
 
-void ShardedToInterleavedPartialProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const ShardedToInterleavedPartialParams& params,
+}  // namespace
+
+ProgramDescriptor ShardedToInterleavedPartialProgramFactory::create_descriptor(
+    const ShardedToInterleavedPartialParams& operation_attributes,
     const ShardedToInterleavedPartialInputs& tensor_args,
     Tensor& output_tensor) {
-    // Convert partial types to shared types
-    ShardedToInterleavedParams shared_attrs{
-        .output_mem_config = params.output_mem_config,
-        .output_dtype = params.output_dtype,
-        .num_slices = params.num_slices,
-        .slice_index = params.slice_index,
-    };
+    const auto& input = tensor_args.input_tensor;
+    const auto& output = output_tensor;
+    const uint32_t num_slices = operation_attributes.num_slices;
+    const uint32_t slice_index = operation_attributes.slice_index;
+    const bool is_l1_aligned = true;
 
-    ShardedToInterleavedInputs shared_tensor_args{
-        .input_tensor = tensor_args.input_tensor,
-        .preallocated_output = tensor_args.cache_tensor,
-    };
+    uint32_t num_units_per_shard = 0;
+    uint32_t input_unit_size = 0;
+    uint32_t output_unit_size = 0;
+    uint32_t num_units_per_shard_width = 0;
+    uint32_t num_units_per_shard_height = 0;
+    uint32_t num_units_offset = 0;
+    uint32_t num_units_per_row = 0;
+    uint32_t num_units_height = 0;
+    uint32_t num_units_per_shard_height_last = 0;
+    uint32_t num_units_per_shard_width_last = 0;
 
-    // Delegates to shared to interleaved factory
-    ShardedToInterleavedProgramFactory::override_runtime_arguments(
-        cached_program, shared_attrs, shared_tensor_args, output_tensor);
+    tt::DataFormat input_cb_data_format = tt_metal::datatype_to_dataformat_converter(input.dtype());
+    tt::DataFormat output_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
+
+    auto shard_spec = input.shard_spec().value();
+    auto shard_strategy = input.memory_config().memory_layout();
+
+    bool rm_orientation = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+    auto& all_cores = shard_spec.grid;
+    uint32_t num_cores = all_cores.num_cores();
+    uint32_t num_cores_unpadded = num_cores;
+    const auto cores = corerange_to_cores(all_cores, std::nullopt, rm_orientation);
+
+    CoreCoord end_core = cores[num_cores - 1];
+    if (output.layout() == Layout::TILE) {
+        input_unit_size = tt::tile_size(input_cb_data_format);
+        output_unit_size = tt::tile_size(output_cb_data_format);
+        num_units_per_shard_height = shard_spec.shape[0] / TILE_HEIGHT;
+        num_units_per_shard_width = shard_spec.shape[1] / TILE_WIDTH;
+        num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
+        num_units_per_row = input.padded_shape()[-1] / TILE_WIDTH;
+        num_units_offset = num_units_per_row;
+        num_units_height = (input.physical_volume() / input.padded_shape()[-1]) / TILE_HEIGHT;
+        num_units_per_shard_height_last =
+            num_units_per_shard_height - (round_up(num_units_height, num_units_per_shard_height) - num_units_height);
+        num_units_per_shard_width_last =
+            num_units_per_shard_width - (round_up(num_units_per_row, num_units_per_shard_width) - num_units_per_row);
+    } else {
+        input_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * input.element_size());
+        output_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * output.element_size());
+        num_units_per_shard_height = shard_spec.shape[0];
+        num_units_per_shard_width = 1;
+        num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
+        num_units_per_row = static_cast<uint32_t>(input.logical_shape()[-1] * input.element_size());
+        num_units_offset = 1;
+        num_units_height = static_cast<uint32_t>(input.logical_volume() / input.logical_shape()[-1]);
+        num_units_per_shard_height_last =
+            num_units_per_shard_height - (round_up(num_units_height, num_units_per_shard_height) - num_units_height);
+        num_units_per_shard_width_last =
+            output_unit_size - (round_up(num_units_per_row, output_unit_size) - num_units_per_row);
+    }
+
+    // re-calculate end_core in the case shard grid is larger than used grid
+    if (shard_strategy == TensorMemoryLayout::HEIGHT_SHARDED) {
+        num_cores_unpadded = div_up(num_units_height, num_units_per_shard_height);
+    } else if (shard_strategy == TensorMemoryLayout::WIDTH_SHARDED) {
+        if (output.layout() == Layout::TILE) {
+            num_cores_unpadded = div_up(num_units_per_row, num_units_per_shard_width);
+        } else {
+            num_cores_unpadded = div_up(num_units_per_row, output_unit_size);
+        }
+    }
+    end_core = cores[num_cores_unpadded - 1];
+
+    // Create CoreRangeSet for only the cores that will be used (fixes NOC error when grid > data)
+    CoreRangeSet used_cores = num_cores_unpadded < num_cores
+                                  ? select_from_corerangeset(all_cores, 0, num_cores_unpadded - 1, rm_orientation)
+                                  : all_cores;
+
+    bool convert_df = input_cb_data_format != output_cb_data_format;
+
+    uint32_t src0_cb_index = CBIndex::c_0;
+    uint32_t out_cb_index = src0_cb_index;
+    uint32_t num_input_units = num_units_per_shard;
+    auto* src_buffer = input.buffer();
+    auto* dst_buffer = output.buffer();
+    uint32_t input_page_size = tt::align(input_unit_size, src_buffer->alignment());
+    bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+    bool is_blackhole = (input.device()->arch() == tt::ARCH::BLACKHOLE);
+
+    ProgramDescriptor desc;
+
+    // Sharded input CB. Bind to src buffer for dynamic-CB rebinding on cache hits via cb.buffer.
+    push_s2i_partial_cb_pair(
+        desc,
+        src0_cb_index,
+        input_cb_data_format,
+        num_input_units * input_page_size,
+        input_page_size,
+        used_cores,
+        /*bound_buffer=*/src_buffer);
+
+    if (convert_df) {
+        out_cb_index = CBIndex::c_16;
+        uint32_t output_page_size = tt::align(output_unit_size, dst_buffer->alignment());
+        push_s2i_partial_cb_pair(
+            desc,
+            out_cb_index,
+            output_cb_data_format,
+            num_input_units * output_page_size,
+            output_page_size,
+            used_cores,
+            /*bound_buffer=*/nullptr);
+    }
+
+    // Reader kernel (sharded input streamed in via globally-allocated CB).
+    KernelDescriptor reader_desc;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = used_cores;
+    reader_desc.config = ReaderConfigDescriptor{};
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
+    reader_desc.compile_time_args = {src0_cb_index};
+
+    // Writer kernel (writes interleaved output to DRAM).
+    KernelDescriptor writer_desc;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = used_cores;
+    writer_desc.config = WriterConfigDescriptor{};
+    std::vector<uint32_t> writer_compile_time_args = {out_cb_index};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    if (input.layout() == Layout::TILE) {
+        writer_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
+            "writer_unary_sharded_blocks_interleaved_start_id.cpp";
+    } else {
+        writer_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
+            "writer_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp";
+    }
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+
+    // Optional compute kernel for data-format conversion.
+    KernelDescriptor compute_desc;
+    if (convert_df) {
+        compute_desc.kernel_source = "ttnn/cpp/ttnn/kernel/compute/eltwise_copy.cpp";
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = used_cores;
+        compute_desc.config = ComputeConfigDescriptor{};
+        compute_desc.compile_time_args = {num_units_per_shard};
+    }
+
+    // Reader runtime args: identical on every used core.
+    for (const auto& core_range : used_cores.ranges()) {
+        for (const auto& core : core_range) {
+            reader_desc.emplace_runtime_args(core, {num_units_per_shard});
+        }
+    }
+
+    uint32_t starting_idx_h =
+        operations::data_movement::detail::calculate_starting_idx_h(output, num_slices, slice_index);
+    uint32_t curr_idx_h = 0;
+    uint32_t curr_idx_w = 0;
+
+    for (uint32_t core_idx = 0; core_idx < num_cores_unpadded; core_idx++) {
+        const auto& core = cores[core_idx];
+        uint32_t shard_height = num_units_per_shard_height;
+        uint32_t shard_width = input.layout() == Layout::TILE ? num_units_per_shard_width : output_unit_size;
+        if (input.layout() == Layout::TILE) {
+            if (shard_strategy == TensorMemoryLayout::HEIGHT_SHARDED) {
+                if (core.x == end_core.x && core.y == end_core.y) {
+                    shard_height = num_units_per_shard_height_last;
+                }
+            } else if (shard_strategy == TensorMemoryLayout::WIDTH_SHARDED) {
+                if (core.x == end_core.x && core.y == end_core.y) {
+                    shard_width = num_units_per_shard_width_last;
+                }
+            } else if (shard_strategy == TensorMemoryLayout::BLOCK_SHARDED) {
+                if (rm_orientation) {
+                    if (core.x == end_core.x) {
+                        shard_width = num_units_per_shard_width_last;
+                    }
+                    if (core.y == end_core.y) {
+                        shard_height = num_units_per_shard_height_last;
+                    }
+                } else {
+                    if (core.y == end_core.y) {
+                        shard_width = num_units_per_shard_width_last;
+                    }
+                    if (core.x == end_core.x) {
+                        shard_height = num_units_per_shard_height_last;
+                    }
+                }
+            }
+            // Writer run-time args: arg 0 is the destination-buffer base address (binding via Buffer*).
+            KernelDescriptor::RTArgList writer_rt;
+            writer_rt.push_back(dst_buffer);
+            writer_rt.push_back(num_units_per_shard_height);
+            writer_rt.push_back(num_units_per_shard_width);
+            writer_rt.push_back(shard_height);
+            writer_rt.push_back(shard_width);
+            writer_rt.push_back(num_units_offset);
+            writer_rt.push_back(num_units_per_shard);
+            writer_rt.push_back(curr_idx_h + curr_idx_w);
+            writer_rt.push_back(starting_idx_h);
+            writer_desc.emplace_runtime_args(core, writer_rt);
+
+            curr_idx_w += num_units_per_shard_width;
+            if (curr_idx_w >= num_units_per_row) {
+                curr_idx_w = 0;
+                curr_idx_h += num_units_per_row * num_units_per_shard_height;
+            }
+        } else {
+            if (shard_strategy == TensorMemoryLayout::HEIGHT_SHARDED) {
+                if (core.x == end_core.x && core.y == end_core.y) {
+                    shard_height = num_units_per_shard_height_last;
+                }
+            } else if (shard_strategy == TensorMemoryLayout::WIDTH_SHARDED) {
+                if (core.x == end_core.x && core.y == end_core.y) {
+                    shard_width = num_units_per_shard_width_last;
+                }
+            } else if (shard_strategy == TensorMemoryLayout::BLOCK_SHARDED) {
+                if (rm_orientation) {
+                    if (core.x == end_core.x) {
+                        shard_width = num_units_per_shard_width_last;
+                    }
+                    if (core.y == end_core.y) {
+                        shard_height = num_units_per_shard_height_last;
+                    }
+                } else {
+                    if (core.y == end_core.y) {
+                        shard_width = num_units_per_shard_width_last;
+                    }
+                    if (core.x == end_core.x) {
+                        shard_height = num_units_per_shard_height_last;
+                    }
+                }
+            }
+            uint32_t l1_alignment = hal::get_l1_alignment();
+            uint32_t padded_shard_width = tt::align(output_unit_size, dst_buffer->alignment());
+            if (is_blackhole or is_l1_aligned) {
+                if (!dst_is_dram or is_l1_aligned) {
+                    padded_shard_width = tt::align(output_unit_size, l1_alignment);
+                }
+            }
+            // Writer run-time args: arg 0 is the destination-buffer base address (binding via Buffer*).
+            KernelDescriptor::RTArgList writer_rt;
+            writer_rt.push_back(dst_buffer);
+            writer_rt.push_back(num_units_per_row);
+            writer_rt.push_back(shard_height);
+            writer_rt.push_back(shard_width);
+            writer_rt.push_back(padded_shard_width);
+            writer_rt.push_back(curr_idx_w);
+            writer_rt.push_back(curr_idx_h);
+            writer_desc.emplace_runtime_args(core, writer_rt);
+
+            curr_idx_w += output_unit_size;
+            if (curr_idx_w >= num_units_per_row) {
+                curr_idx_w = 0;
+                curr_idx_h += num_units_per_shard_height;
+            }
+        }
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    if (convert_df) {
+        desc.kernels.push_back(std::move(compute_desc));
+    }
+
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_program_factory.hpp
@@ -4,25 +4,16 @@
 
 #pragma once
 
-#include "ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
 
 namespace ttnn::prim {
 
-// Adapter factory that wraps the shared factory
 struct ShardedToInterleavedPartialProgramFactory {
-    using shared_variables_t = ShardedToInterleavedSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const ShardedToInterleavedPartialParams& params,
-        const ShardedToInterleavedPartialInputs& tensor_args,
-        Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const ShardedToInterleavedPartialParams& params,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ShardedToInterleavedPartialParams& operation_attributes,
         const ShardedToInterleavedPartialInputs& tensor_args,
         Tensor& output_tensor);
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
@@ -6,19 +6,20 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
+#include <bit>
 #include <cmath>
 #include <cstdint>
 
 namespace ttnn::prim {
 
-// Single row - single core
-SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingleRowSingleCore::create(
-    const SortParams& attributes, const SortInputs& tensor_args, std::vector<Tensor>& output_tensors) {
-    // Program config
-    tt::tt_metal::Program program{};
+using namespace tt::tt_metal;
 
+// Single row - single core
+ProgramDescriptor SortProgramFactorySingleRowSingleCore::create_descriptor(
+    const SortParams& attributes, const SortInputs& tensor_args, std::vector<Tensor>& output_tensors) {
     const tt::DataFormat input_tensor_cb_data_format =
         tt::tt_metal::datatype_to_dataformat_converter(tensor_args.input_tensor.dtype());
     const tt::DataFormat value_tensor_cb_data_format =
@@ -98,55 +99,86 @@ SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingle
         }
     }
 
+    ProgramDescriptor desc;
+
     // Circular buffers
     constexpr uint32_t input_tensor_cb_index = tt::CBIndex::c_0;
-    const tt::tt_metal::CircularBufferConfig input_tensor_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            cb_in_units * input_tensor_tile_size, {{input_tensor_cb_index, input_tensor_cb_data_format}})
-            .set_page_size(input_tensor_cb_index, input_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, input_tensor_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_in_units * input_tensor_tile_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(input_tensor_cb_index),
+            .data_format = input_tensor_cb_data_format,
+            .page_size = input_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t index_tensor_cb_index = tt::CBIndex::c_1;
-    const tt::tt_metal::CircularBufferConfig index_tensor_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            cb_in_units * index_tensor_tile_size, {{index_tensor_cb_index, index_tensor_cb_data_format}})
-            .set_page_size(index_tensor_cb_index, index_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, index_tensor_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_in_units * index_tensor_tile_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(index_tensor_cb_index),
+            .data_format = index_tensor_cb_data_format,
+            .page_size = index_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t input_tensor_transposed_cb_index = tt::CBIndex::c_2;
-    const tt::tt_metal::CircularBufferConfig input_tensor_transposed_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            Wt * input_tensor_tile_size, {{input_tensor_transposed_cb_index, input_tensor_cb_data_format}})
-            .set_page_size(input_tensor_transposed_cb_index, input_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, input_tensor_transposed_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = Wt * input_tensor_tile_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(input_tensor_transposed_cb_index),
+            .data_format = input_tensor_cb_data_format,
+            .page_size = input_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t index_tensor_transposed_cb_index = tt::CBIndex::c_3;
-    const tt::tt_metal::CircularBufferConfig index_tensor_transposed_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            Wt * index_tensor_tile_size, {{index_tensor_transposed_cb_index, index_tensor_cb_data_format}})
-            .set_page_size(index_tensor_transposed_cb_index, index_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, index_tensor_transposed_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = Wt * index_tensor_tile_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(index_tensor_transposed_cb_index),
+            .data_format = index_tensor_cb_data_format,
+            .page_size = index_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t value_tensor_cb_index = tt::CBIndex::c_4;
-    const tt::tt_metal::CircularBufferConfig value_tensor_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_cb_unit * value_tensor_tile_size, {{value_tensor_cb_index, value_tensor_cb_data_format}})
-            .set_page_size(value_tensor_cb_index, value_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, value_tensor_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cb_unit * value_tensor_tile_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(value_tensor_cb_index),
+            .data_format = value_tensor_cb_data_format,
+            .page_size = value_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t index_tensor_output_cb_index = tt::CBIndex::c_5;
-    const tt::tt_metal::CircularBufferConfig index_tensor_output_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_cb_unit * index_tensor_tile_size, {{index_tensor_output_cb_index, index_tensor_cb_data_format}})
-            .set_page_size(index_tensor_output_cb_index, index_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, index_tensor_output_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cb_unit * index_tensor_tile_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(index_tensor_output_cb_index),
+            .data_format = index_tensor_cb_data_format,
+            .page_size = index_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t synchronization_cb_index = tt::CBIndex::c_6;
     constexpr uint32_t synchronization_cb_size = tt::constants::TILE_HW * sizeof(uint8_t);
-    const tt::tt_metal::CircularBufferConfig synchronization_cb_config =
-        tt::tt_metal::CircularBufferConfig(synchronization_cb_size, {{synchronization_cb_index, tt::DataFormat::UInt8}})
-            .set_page_size(synchronization_cb_index, synchronization_cb_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, synchronization_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = synchronization_cb_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(synchronization_cb_index),
+            .data_format = tt::DataFormat::UInt8,
+            .page_size = synchronization_cb_size,
+        }}},
+    });
 
     // Kernels
     std::vector<uint32_t> reader_compile_time_args = {
@@ -159,17 +191,14 @@ SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingle
         compute_with_storage_grid_size.y};
     TensorAccessorArgs(*input_buffer).append_to(reader_compile_time_args);
     TensorAccessorArgs(*index_buffer).append_to(reader_compile_time_args);
-    const std::string reader_kernel_path =
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_single_core.cpp";
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program, reader_kernel_path, core_range, tt::tt_metal::ReaderDataMovementConfig{reader_compile_time_args});
-    SetRuntimeArgs(
-        program,
-        reader_kernel_id,
-        core_range,
-        {input_buffer->address(),
-         index_buffer->address(),
-         all_core_utilization_loop_count ? all_core_utilization_loop_count : 1});
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core_range;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
     std::vector<uint32_t> writer_compile_time_args = {
         value_tensor_cb_index,
@@ -181,17 +210,16 @@ SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingle
         compute_with_storage_grid_size.y,
         static_cast<uint32_t>(is_32_bit_index)};
     TensorAccessorArgs(*value_buffer).append_to(writer_compile_time_args);
-    const std::string writer_kernel_path =
-        "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_single_core.cpp";
-    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
-        program, writer_kernel_path, core_range, tt::tt_metal::WriterDataMovementConfig{writer_compile_time_args});
-    SetRuntimeArgs(
-        program,
-        writer_kernel_id,
-        core_range,
-        {value_buffer->address(), all_core_utilization_loop_count ? all_core_utilization_loop_count : 1});
 
-    const std::vector<uint32_t> compute_compile_time_args = {
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_single_core.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = core_range;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    std::vector<uint32_t> compute_compile_time_args = {
         input_tensor_cb_index,
         index_tensor_cb_index,
         input_tensor_transposed_cb_index,
@@ -202,157 +230,70 @@ SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingle
         static_cast<uint32_t>(attributes.descending),
         static_cast<uint32_t>(attributes.stable),
         synchronization_cb_index};
-    const std::string compute_kernel_path =
-        "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_single_row_single_core.cpp";
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode_vector(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode_vector(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
     if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
         unpack_to_dest_mode_vector[input_tensor_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
         unpack_to_dest_mode_vector[input_tensor_transposed_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
         unpack_to_dest_mode_vector[value_tensor_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
-    tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        compute_kernel_path,
-        core_range,
-        tt::tt_metal::ComputeConfig{
-            .fp32_dest_acc_en = is_32_bit_data,
-            .unpack_to_dest_mode = unpack_to_dest_mode_vector,
-            .compile_args = compute_compile_time_args});
-    SetRuntimeArgs(
-        program,
-        compute_kernel_id,
-        core_range,
-        {all_core_utilization_loop_count ? all_core_utilization_loop_count : 1});
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_single_row_single_core.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = core_range;
+    compute_desc.compile_time_args = std::move(compute_compile_time_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = is_32_bit_data,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode_vector),
+    };
 
-    if (all_core_utilization_loop_residuum != 0 && all_core_utilization_loop_count != 0) {
-        uint32_t residuum_count = 0;
-        for (uint32_t core_y = 0; core_y < compute_with_storage_grid_size.y; core_y++) {
-            for (uint32_t core_x = 0; core_x < compute_with_storage_grid_size.x; core_x++) {
-                const uint32_t new_loop_count = all_core_utilization_loop_count + 1;
-                const CoreCoord core = {core_x, core_y};
-
-                SetRuntimeArgs(
-                    program,
-                    reader_kernel_id,
-                    core,
-                    {input_buffer->address(), index_buffer->address(), new_loop_count});
-
-                SetRuntimeArgs(program, writer_kernel_id, core, {value_buffer->address(), new_loop_count});
-
-                SetRuntimeArgs(program, compute_kernel_id, core, {new_loop_count});
-
-                residuum_count++;
-                if (residuum_count >= all_core_utilization_loop_residuum) {
-                    core_y = compute_with_storage_grid_size.y;  // Break outer loop
-                    break;
-                }
-            }  // core_x loop
-        }  // core_y loop
-    }
-
-    return {
-        std::move(program), {reader_kernel_id, compute_kernel_id, writer_kernel_id, compute_with_storage_grid_size}};
-}
-
-void SortProgramFactorySingleRowSingleCore::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const SortParams& /*attributes*/,
-    const SortInputs& tensor_args,
-    std::vector<Tensor>& output_tensors) {
-    auto* input_tensor_buffer = tensor_args.input_tensor.buffer();
-    auto* value_tensor_buffer = output_tensors.at(0).buffer();
-    auto* index_tensor_buffer = output_tensors.at(1).buffer();
-
-    const auto input_shape = tensor_args.input_tensor.padded_shape();
-    const uint32_t Ht = (input_shape[0] * input_shape[1] * input_shape[2]) / tt::constants::TILE_HEIGHT;
-    const uint32_t total_number_of_cores =
-        cached_program.shared_variables.storage_grid_size.x * cached_program.shared_variables.storage_grid_size.y;
-
-    // Calculate the number of cores utilized based on the input tensor shape
-    const uint32_t all_core_utilization_loop_count = Ht / total_number_of_cores;
-    const uint32_t all_core_utilization_loop_residuum = Ht % total_number_of_cores;
-
-    uint32_t residuum_count = 0;
-    for (uint32_t core_y = 0; core_y < cached_program.shared_variables.storage_grid_size.y; core_y++) {
-        for (uint32_t core_x = 0; core_x < cached_program.shared_variables.storage_grid_size.x; core_x++) {
+    // Per-core runtime args.  Buffer* slots register BufferBindings so the framework
+    // patches addresses on cache hits.  When work doesn't divide evenly, the first
+    // `residuum` cores in row-major order get one extra loop iteration to absorb the
+    // remainder — matching the legacy implementation.
+    const uint32_t default_loop_count = all_core_utilization_loop_count ? all_core_utilization_loop_count : 1;
+    const bool has_residuum = (all_core_utilization_loop_residuum != 0) && (all_core_utilization_loop_count != 0);
+    uint32_t residuum_used = 0;
+    for (uint32_t core_y = 0; core_y < compute_with_storage_grid_size.y; core_y++) {
+        for (uint32_t core_x = 0; core_x < compute_with_storage_grid_size.x; core_x++) {
             const CoreCoord core = {core_x, core_y};
-            auto& reader_runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.reader_kernel_id, core);
-            reader_runtime_args[0] = input_tensor_buffer->address();
-            reader_runtime_args[1] = index_tensor_buffer->address();
-
-            auto& writer_runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.writer_kernel_id, core);
-            writer_runtime_args[0] = value_tensor_buffer->address();
-
-            if (all_core_utilization_loop_count < 1 && all_core_utilization_loop_residuum != 0) {
-                residuum_count++;
-                if (residuum_count >= all_core_utilization_loop_residuum) {
-                    core_y = cached_program.shared_variables.storage_grid_size.y;  // Break outer loop
-                    break;
-                }
+            if (!core_range.contains(core)) {
+                continue;
             }
+            uint32_t core_loop_count = default_loop_count;
+            if (has_residuum && residuum_used < all_core_utilization_loop_residuum) {
+                core_loop_count = all_core_utilization_loop_count + 1;
+                residuum_used++;
+            }
+            reader_desc.emplace_runtime_args(core, {input_buffer, index_buffer, core_loop_count});
+            writer_desc.emplace_runtime_args(core, {value_buffer, core_loop_count});
+            compute_desc.emplace_runtime_args(core, {core_loop_count});
         }
     }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
 }
 
 // SortProgramFactoryCrossCoreDataExchange - single row, multi core with processing multiple tiles on one core with
 // cross core data exchange
-SortProgramFactoryCrossCoreDataExchange::cached_program_t SortProgramFactoryCrossCoreDataExchange::create(
-    const SortParams& attributes, const SortInputs& tensor_args, std::vector<Tensor>& output_tensors) {
-    // Program config
-    tt::tt_metal::Program program{};
+//
+// The lookup-table tensor uploaded to DRAM here must outlive the program build so
+// its base address can be patched into reader runtime args on cache hits.  We
+// allocate it via prepare_resources(); the framework reflects through Resources
+// to register the tensor's buffer for binding alongside user tensors.
 
-    const tt::DataFormat input_tensor_cb_data_format =
-        tt::tt_metal::datatype_to_dataformat_converter(tensor_args.input_tensor.dtype());
-    const tt::DataFormat value_tensor_cb_data_format =
-        tt::tt_metal::datatype_to_dataformat_converter(output_tensors.at(0).dtype());
-    const tt::DataFormat index_tensor_cb_data_format =
-        tt::tt_metal::datatype_to_dataformat_converter(output_tensors.at(1).dtype());
-    const tt::DataFormat packer_unpacker_sync_cb_data_format = tt::DataFormat::Float16_b;
+namespace {
 
-    const uint32_t input_tensor_tile_size = tile_size(input_tensor_cb_data_format);
-    const uint32_t value_tensor_tile_size = tile_size(value_tensor_cb_data_format);
-    const uint32_t index_tensor_tile_size = tile_size(index_tensor_cb_data_format);
-    const uint32_t packer_unpacker_sync_tile_size = tile_size(packer_unpacker_sync_cb_data_format);
-
-    auto* input_buffer = tensor_args.input_tensor.buffer();
-    auto* value_buffer = output_tensors.at(0).buffer();
-    auto* index_buffer = output_tensors.at(1).buffer();
-
-    const auto tile_width = tensor_args.input_tensor.tensor_spec().tile().get_width();
-    const auto tile_height = tensor_args.input_tensor.tensor_spec().tile().get_height();
-
-    const auto input_shape = tensor_args.input_tensor.padded_shape();
-    const uint32_t Ht = (input_shape[0] * input_shape[1] * input_shape[2]) / tile_height;
-    const uint32_t Wt = input_shape[3] / tile_width;
-
-    // Calculate the number of cores available for computation
-    auto* const device = tensor_args.input_tensor.device();
-    const auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    const uint32_t total_number_of_cores_physical = compute_with_storage_grid_size.y * compute_with_storage_grid_size.x;
-    const uint32_t total_number_of_cores_virtual = rounddown_pow2(total_number_of_cores_physical);
-    uint32_t number_of_tiles_per_core = get_number_of_tiles_per_core(
-        total_number_of_cores_virtual,
-        Wt,
-        tensor_args.input_tensor.dtype(),
-        output_tensors.at(1).dtype(),
-        CrossCoreDataExchangeSortSlicingStrategy::USE_AS_MANY_CORES);
-    number_of_tiles_per_core = std::min(number_of_tiles_per_core, Wt);
-
-    // Calculate the number of cores utilized based on the input tensor shape
-    const uint32_t all_core_utilization_count = (Wt + number_of_tiles_per_core - 1) / number_of_tiles_per_core;
-
-    TT_FATAL(
-        all_core_utilization_count <= total_number_of_cores_virtual,
-        "All core utilization count exceeds total number of cores. Utilized cores: {}, Total cores: {}",
-        all_core_utilization_count,
-        total_number_of_cores_virtual);
-
-    // uint32 index tensor support
-    const bool is_32_bit_index = index_tensor_cb_data_format == tt::DataFormat::UInt32;
-    const bool is_32_bit_data = is_32_bit_index || input_tensor_cb_data_format == tt::DataFormat::Float32;
-
+CoreRangeSet compute_cross_core_range(
+    uint32_t all_core_utilization_count,
+    uint32_t total_number_of_cores_physical,
+    uint32_t total_number_of_cores_virtual,
+    const CoreCoord& compute_with_storage_grid_size) {
     /**
      * Calculates the core range based on the number of work units (all_core_utilization_count) and the total number of
      * available cores in the device's compute grid. The core range determines which cores will be utilized for
@@ -414,10 +355,75 @@ SortProgramFactoryCrossCoreDataExchange::cached_program_t SortProgramFactoryCros
             }
         }
     }
+    return core_range;
+}
 
-    // Lookup tensor data with physical core coordinates
+// Mirrors the legacy create() compute of all_core_utilization_count so prepare_resources()
+// and create_descriptor() agree on the worker grid layout used to populate the lookup table.
+struct CrossCoreLayout {
+    CoreRangeSet core_range;
+    uint32_t all_core_utilization_count;
+    uint32_t total_number_of_cores_physical;
+    uint32_t total_number_of_cores_virtual;
+    uint32_t number_of_tiles_per_core;
+    CoreCoord compute_with_storage_grid_size;
+    uint32_t Ht;
+    uint32_t Wt;
+};
+
+CrossCoreLayout compute_cross_core_layout(const SortInputs& tensor_args, const std::vector<Tensor>& output_tensors) {
+    CrossCoreLayout layout{};
+    auto* const device = tensor_args.input_tensor.device();
+    layout.compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    layout.total_number_of_cores_physical =
+        layout.compute_with_storage_grid_size.y * layout.compute_with_storage_grid_size.x;
+    layout.total_number_of_cores_virtual =
+        SortProgramFactoryCrossCoreDataExchange::rounddown_pow2(layout.total_number_of_cores_physical);
+
+    const auto tile_width = tensor_args.input_tensor.tensor_spec().tile().get_width();
+    const auto tile_height = tensor_args.input_tensor.tensor_spec().tile().get_height();
+    const auto input_shape = tensor_args.input_tensor.padded_shape();
+    layout.Ht = (input_shape[0] * input_shape[1] * input_shape[2]) / tile_height;
+    layout.Wt = input_shape[3] / tile_width;
+
+    uint32_t number_of_tiles_per_core = SortProgramFactoryCrossCoreDataExchange::get_number_of_tiles_per_core(
+        layout.total_number_of_cores_virtual,
+        layout.Wt,
+        tensor_args.input_tensor.dtype(),
+        output_tensors.at(1).dtype(),
+        SortProgramFactoryCrossCoreDataExchange::CrossCoreDataExchangeSortSlicingStrategy::USE_AS_MANY_CORES);
+    layout.number_of_tiles_per_core = std::min(number_of_tiles_per_core, layout.Wt);
+
+    layout.all_core_utilization_count =
+        (layout.Wt + layout.number_of_tiles_per_core - 1) / layout.number_of_tiles_per_core;
+
+    layout.core_range = compute_cross_core_range(
+        layout.all_core_utilization_count,
+        layout.total_number_of_cores_physical,
+        layout.total_number_of_cores_virtual,
+        layout.compute_with_storage_grid_size);
+
+    return layout;
+}
+
+}  // namespace
+
+namespace {
+
+// Build the workload-scoped physical-core lookup table tensor.
+// Pulled out so create_workload_descriptor() can allocate it once on cache
+// miss and park it on the returned WorkloadDescriptor::buffers, where it
+// outlives the cached workload (program-cache lifetime).
+Tensor build_physical_core_lookup_table_tensor(const SortInputs& tensor_args, std::vector<Tensor>& output_tensors) {
+    auto* const device = tensor_args.input_tensor.device();
+    const auto layout = compute_cross_core_layout(tensor_args, output_tensors);
+
+    // Lookup tensor data with physical core coordinates.  This is the same data the legacy
+    // override_runtime_arguments() rebuilt on every dispatch — we now build it once on
+    // cache miss; the framework keeps the tensor (and its buffer) alive for cache hits
+    // and patches its base address into the reader runtime args via BufferBinding.
     std::vector<uint32_t> physical_core_lookup_table_data;
-    for (const auto& core_range : core_range.ranges()) {
+    for (const auto& core_range : layout.core_range.ranges()) {
         for (const auto& core_coord : core_range) {
             const auto physical_core = device->worker_core_from_logical_core(core_coord);
             physical_core_lookup_table_data.emplace_back(physical_core.x);
@@ -429,108 +435,223 @@ SortProgramFactoryCrossCoreDataExchange::cached_program_t SortProgramFactoryCros
         TensorLayout{DataType::UINT32, PageConfig{Layout::ROW_MAJOR}, MemoryConfig()});
     Tensor physical_core_lookup_table_tensor =
         Tensor::from_vector(std::move(physical_core_lookup_table_data), physical_core_lookup_table_spec);
-    physical_core_lookup_table_tensor = physical_core_lookup_table_tensor.to_device(device);
-    auto* const physical_core_lookup_table_tensor_buffer = physical_core_lookup_table_tensor.buffer();
-    const tt::DataFormat physical_core_lookup_table_cb_data_format =
-        tt::tt_metal::datatype_to_dataformat_converter(physical_core_lookup_table_tensor.dtype());
+    return physical_core_lookup_table_tensor.to_device(device);
+}
+
+// Build the per-coord ProgramDescriptor for the cross-core-data-exchange sort.
+// Takes the helper Buffer* directly so the caller (create_workload_descriptor)
+// can own the lookup-table Tensor lifetime via WorkloadDescriptor::buffers.
+ProgramDescriptor build_cross_core_program_descriptor(
+    const SortParams& attributes,
+    const SortInputs& tensor_args,
+    std::vector<Tensor>& output_tensors,
+    Buffer* physical_core_lookup_table_tensor_buffer,
+    tt::DataFormat physical_core_lookup_table_cb_data_format) {
+    const tt::DataFormat input_tensor_cb_data_format =
+        tt::tt_metal::datatype_to_dataformat_converter(tensor_args.input_tensor.dtype());
+    const tt::DataFormat value_tensor_cb_data_format =
+        tt::tt_metal::datatype_to_dataformat_converter(output_tensors.at(0).dtype());
+    const tt::DataFormat index_tensor_cb_data_format =
+        tt::tt_metal::datatype_to_dataformat_converter(output_tensors.at(1).dtype());
+    const tt::DataFormat packer_unpacker_sync_cb_data_format = tt::DataFormat::Float16_b;
+
+    const uint32_t input_tensor_tile_size = tile_size(input_tensor_cb_data_format);
+    const uint32_t value_tensor_tile_size = tile_size(value_tensor_cb_data_format);
+    const uint32_t index_tensor_tile_size = tile_size(index_tensor_cb_data_format);
+    const uint32_t packer_unpacker_sync_tile_size = tile_size(packer_unpacker_sync_cb_data_format);
+
+    auto* input_buffer = tensor_args.input_tensor.buffer();
+    auto* value_buffer = output_tensors.at(0).buffer();
+    auto* index_buffer = output_tensors.at(1).buffer();
+
+    const auto layout = compute_cross_core_layout(tensor_args, output_tensors);
+    const auto& core_range = layout.core_range;
+    const uint32_t Ht = layout.Ht;
+    const uint32_t Wt = layout.Wt;
+    const uint32_t number_of_tiles_per_core = layout.number_of_tiles_per_core;
+    const uint32_t all_core_utilization_count = layout.all_core_utilization_count;
+    const uint32_t total_number_of_cores_virtual = layout.total_number_of_cores_virtual;
+    const auto& compute_with_storage_grid_size = layout.compute_with_storage_grid_size;
+
+    TT_FATAL(
+        all_core_utilization_count <= total_number_of_cores_virtual,
+        "All core utilization count exceeds total number of cores. Utilized cores: {}, Total cores: {}",
+        all_core_utilization_count,
+        total_number_of_cores_virtual);
+
+    // uint32 index tensor support
+    const bool is_32_bit_index = index_tensor_cb_data_format == tt::DataFormat::UInt32;
+    const bool is_32_bit_data = is_32_bit_index || input_tensor_cb_data_format == tt::DataFormat::Float32;
+
+    TT_FATAL(
+        physical_core_lookup_table_tensor_buffer != nullptr,
+        "physical_core_lookup_table_tensor_buffer must be provided by create_workload_descriptor");
     const uint32_t physical_core_lookup_table_tile_size = tile_size(physical_core_lookup_table_cb_data_format);
+
+    ProgramDescriptor desc;
 
     // Circular buffers
     constexpr uint32_t cb_scale_factor = 2;
 
     constexpr uint32_t input_tensor_cb_index = tt::CBIndex::c_0;
-    const tt::tt_metal::CircularBufferConfig input_tensor_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            cb_scale_factor * input_tensor_tile_size, {{input_tensor_cb_index, input_tensor_cb_data_format}})
-            .set_page_size(input_tensor_cb_index, input_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, input_tensor_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_scale_factor * input_tensor_tile_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(input_tensor_cb_index),
+            .data_format = input_tensor_cb_data_format,
+            .page_size = input_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t index_tensor_cb_index = tt::CBIndex::c_1;
-    const tt::tt_metal::CircularBufferConfig index_tensor_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            cb_scale_factor * index_tensor_tile_size, {{index_tensor_cb_index, index_tensor_cb_data_format}})
-            .set_page_size(index_tensor_cb_index, index_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, index_tensor_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_scale_factor * index_tensor_tile_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(index_tensor_cb_index),
+            .data_format = index_tensor_cb_data_format,
+            .page_size = index_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t input_tensor_transposed_cb_index = tt::CBIndex::c_2;
-    const tt::tt_metal::CircularBufferConfig input_tensor_transposed_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            number_of_tiles_per_core * input_tensor_tile_size,
-            {{input_tensor_transposed_cb_index, input_tensor_cb_data_format}})
-            .set_page_size(input_tensor_transposed_cb_index, input_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, input_tensor_transposed_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = number_of_tiles_per_core * input_tensor_tile_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(input_tensor_transposed_cb_index),
+            .data_format = input_tensor_cb_data_format,
+            .page_size = input_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t index_tensor_transposed_cb_index = tt::CBIndex::c_3;
-    const tt::tt_metal::CircularBufferConfig index_tensor_transposed_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            number_of_tiles_per_core * index_tensor_tile_size,
-            {{index_tensor_transposed_cb_index, index_tensor_cb_data_format}})
-            .set_page_size(index_tensor_transposed_cb_index, index_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, index_tensor_transposed_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = number_of_tiles_per_core * index_tensor_tile_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(index_tensor_transposed_cb_index),
+            .data_format = index_tensor_cb_data_format,
+            .page_size = index_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t value_tensor_cb_index = tt::CBIndex::c_4;
-    const tt::tt_metal::CircularBufferConfig value_tensor_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            cb_scale_factor * value_tensor_tile_size, {{value_tensor_cb_index, value_tensor_cb_data_format}})
-            .set_page_size(value_tensor_cb_index, value_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, value_tensor_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_scale_factor * value_tensor_tile_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(value_tensor_cb_index),
+            .data_format = value_tensor_cb_data_format,
+            .page_size = value_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t index_tensor_output_cb_index = tt::CBIndex::c_5;
-    const tt::tt_metal::CircularBufferConfig index_tensor_output_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            cb_scale_factor * index_tensor_tile_size, {{index_tensor_output_cb_index, index_tensor_cb_data_format}})
-            .set_page_size(index_tensor_output_cb_index, index_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, index_tensor_output_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_scale_factor * index_tensor_tile_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(index_tensor_output_cb_index),
+            .data_format = index_tensor_cb_data_format,
+            .page_size = index_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t value_tensor_intermediate_cb_index = tt::CBIndex::c_6;
-    const tt::tt_metal::CircularBufferConfig value_tensor_intermediate_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            cb_scale_factor * value_tensor_tile_size,
-            {{value_tensor_intermediate_cb_index, value_tensor_cb_data_format}})
-            .set_page_size(value_tensor_intermediate_cb_index, index_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, value_tensor_intermediate_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_scale_factor * value_tensor_tile_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(value_tensor_intermediate_cb_index),
+            .data_format = value_tensor_cb_data_format,
+            // Note: legacy code paged at index_tensor_tile_size here.  Preserved verbatim.
+            .page_size = index_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t index_tensor_intermediate_cb_index = tt::CBIndex::c_7;
-    const tt::tt_metal::CircularBufferConfig index_tensor_intermediate_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            cb_scale_factor * index_tensor_tile_size,
-            {{index_tensor_intermediate_cb_index, index_tensor_cb_data_format}})
-            .set_page_size(index_tensor_intermediate_cb_index, index_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, index_tensor_intermediate_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_scale_factor * index_tensor_tile_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(index_tensor_intermediate_cb_index),
+            .data_format = index_tensor_cb_data_format,
+            .page_size = index_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t value_tensor_peer_cb_index = tt::CBIndex::c_8;
-    const tt::tt_metal::CircularBufferConfig value_tensor_peer_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            cb_scale_factor * value_tensor_tile_size, {{value_tensor_peer_cb_index, value_tensor_cb_data_format}})
-            .set_page_size(value_tensor_peer_cb_index, index_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, value_tensor_peer_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_scale_factor * value_tensor_tile_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(value_tensor_peer_cb_index),
+            .data_format = value_tensor_cb_data_format,
+            // Note: legacy code paged at index_tensor_tile_size here.  Preserved verbatim.
+            .page_size = index_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t index_tensor_peer_cb_index = tt::CBIndex::c_9;
-    const tt::tt_metal::CircularBufferConfig index_tensor_peer_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            cb_scale_factor * index_tensor_tile_size, {{index_tensor_peer_cb_index, index_tensor_cb_data_format}})
-            .set_page_size(index_tensor_peer_cb_index, index_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, index_tensor_peer_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_scale_factor * index_tensor_tile_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(index_tensor_peer_cb_index),
+            .data_format = index_tensor_cb_data_format,
+            // Note: legacy code paged at index_tensor_tile_size here.  Preserved verbatim.
+            .page_size = index_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t physical_core_lookup_table_cb_index = tt::CBIndex::c_10;
-    const tt::tt_metal::CircularBufferConfig physical_core_lookup_table_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            physical_core_lookup_table_tile_size,
-            {{physical_core_lookup_table_cb_index, physical_core_lookup_table_cb_data_format}})
-            .set_page_size(physical_core_lookup_table_cb_index, physical_core_lookup_table_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, physical_core_lookup_table_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = physical_core_lookup_table_tile_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(physical_core_lookup_table_cb_index),
+            .data_format = physical_core_lookup_table_cb_data_format,
+            .page_size = physical_core_lookup_table_tile_size,
+        }}},
+    });
 
     constexpr uint32_t packer_unpacker_sync_cb_index = tt::CBIndex::c_11;
-    const tt::tt_metal::CircularBufferConfig packer_unpacker_sync_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            packer_unpacker_sync_tile_size, {{packer_unpacker_sync_cb_index, packer_unpacker_sync_cb_data_format}})
-            .set_page_size(packer_unpacker_sync_cb_index, packer_unpacker_sync_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, packer_unpacker_sync_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = packer_unpacker_sync_tile_size,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(packer_unpacker_sync_cb_index),
+            .data_format = packer_unpacker_sync_cb_data_format,
+            .page_size = packer_unpacker_sync_tile_size,
+        }}},
+    });
 
-    // Semaphores
-    const uint32_t semaphore_exchange_readers = CreateSemaphore(program, core_range, 0);
-    CreateSemaphore(program, core_range, 0);
-    const uint32_t semaphore_barrier = CreateSemaphore(program, core_range, 0);
+    // Semaphores.  Three legacy CreateSemaphore calls — the middle one was unused
+    // by the kernels but still allocated to keep the next id stable, so we
+    // reserve a slot here too via a placeholder semaphore.
+    constexpr uint32_t semaphore_exchange_readers = 0;
+    constexpr uint32_t semaphore_unused = 1;
+    constexpr uint32_t semaphore_barrier = 2;
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = semaphore_exchange_readers,
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = core_range,
+        .initial_value = 0,
+    });
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = semaphore_unused,
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = core_range,
+        .initial_value = 0,
+    });
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = semaphore_barrier,
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = core_range,
+        .initial_value = 0,
+    });
 
     // Kernels
     std::vector<uint32_t> reader_compile_time_args = {
@@ -554,15 +675,14 @@ SortProgramFactoryCrossCoreDataExchange::cached_program_t SortProgramFactoryCros
     TensorAccessorArgs(*input_buffer).append_to(reader_compile_time_args);
     TensorAccessorArgs(*index_buffer).append_to(reader_compile_time_args);
     TensorAccessorArgs(*physical_core_lookup_table_tensor_buffer).append_to(reader_compile_time_args);
-    const std::string reader_kernel_path =
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_cross_core_data_exchange.cpp";
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program, reader_kernel_path, core_range, tt::tt_metal::ReaderDataMovementConfig{reader_compile_time_args});
-    SetRuntimeArgs(
-        program,
-        reader_kernel_id,
-        core_range,
-        {input_buffer->address(), index_buffer->address(), physical_core_lookup_table_tensor_buffer->address()});
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core_range;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
     std::vector<uint32_t> writer_compile_time_args = {
         compute_with_storage_grid_size.x,
@@ -578,13 +698,26 @@ SortProgramFactoryCrossCoreDataExchange::cached_program_t SortProgramFactoryCros
         semaphore_exchange_readers,
         static_cast<uint32_t>(is_32_bit_index)};
     TensorAccessorArgs(*value_buffer).append_to(writer_compile_time_args);
-    const std::string writer_kernel_path =
-        "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_cross_core_data_exchange.cpp";
-    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
-        program, writer_kernel_path, core_range, tt::tt_metal::WriterDataMovementConfig{writer_compile_time_args});
-    SetRuntimeArgs(program, writer_kernel_id, core_range, {value_buffer->address()});
 
-    const std::vector<uint32_t> compute_compile_time_args = {
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_cross_core_data_exchange.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = core_range;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // Per-core runtime args.  Buffer* slots auto-register as BufferBindings so
+    // the framework patches addresses on cache hits without rebuilding.
+    for (const auto& cr : core_range.ranges()) {
+        for (const auto& core_coord : cr) {
+            reader_desc.emplace_runtime_args(
+                core_coord, {input_buffer, index_buffer, physical_core_lookup_table_tensor_buffer});
+            writer_desc.emplace_runtime_args(core_coord, {value_buffer});
+        }
+    }
+
+    std::vector<uint32_t> compute_compile_time_args = {
         compute_with_storage_grid_size.x,
         compute_with_storage_grid_size.y,
         Ht,
@@ -604,68 +737,67 @@ SortProgramFactoryCrossCoreDataExchange::cached_program_t SortProgramFactoryCros
         index_tensor_peer_cb_index,
         packer_unpacker_sync_cb_index,
     };
-    const std::string compute_kernel_path =
-        "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_cross_core_data_exchange.cpp";
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode_vector(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode_vector(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
     if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
         unpack_to_dest_mode_vector[input_tensor_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
         unpack_to_dest_mode_vector[input_tensor_transposed_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
         unpack_to_dest_mode_vector[value_tensor_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
-        unpack_to_dest_mode_vector[value_tensor_intermediate_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode_vector[value_tensor_intermediate_cb_index] =
+            tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
         unpack_to_dest_mode_vector[value_tensor_peer_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
-    tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        compute_kernel_path,
-        core_range,
-        tt::tt_metal::ComputeConfig{
-            .fp32_dest_acc_en = is_32_bit_data,
-            .unpack_to_dest_mode = unpack_to_dest_mode_vector,
-            .compile_args = compute_compile_time_args});
 
-    return {std::move(program), {reader_kernel_id, compute_kernel_id, writer_kernel_id, core_range}};
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_cross_core_data_exchange.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = core_range;
+    compute_desc.compile_time_args = std::move(compute_compile_time_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = is_32_bit_data,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode_vector),
+    };
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
 }
 
-void SortProgramFactoryCrossCoreDataExchange::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const SortParams& /*attributes*/,
+}  // namespace
+
+tt::tt_metal::WorkloadDescriptor SortProgramFactoryCrossCoreDataExchange::create_workload_descriptor(
+    const SortParams& attributes,
     const SortInputs& tensor_args,
-    std::vector<Tensor>& output_tensors) {
-    auto* const input_tensor_buffer = tensor_args.input_tensor.buffer();
-    auto* const value_tensor_buffer = output_tensors.at(0).buffer();
-    auto* const index_tensor_buffer = output_tensors.at(1).buffer();
-    auto* const device = tensor_args.input_tensor.device();
+    std::vector<Tensor>& output_tensors,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor wd;
 
-    // Lookup tensor data with physical core coordinates
-    std::vector<uint32_t> physical_core_lookup_table_data;
-    for (const auto& core_range : cached_program.shared_variables.core_range_set.ranges()) {
-        for (const auto& core_coord : core_range) {
-            const auto physical_core = device->worker_core_from_logical_core(core_coord);
-            physical_core_lookup_table_data.emplace_back(physical_core.x);
-            physical_core_lookup_table_data.emplace_back(physical_core.y);
-        }
+    // Build and park the physical-core lookup tensor on the WorkloadDescriptor.
+    // Wrapping the Tensor in a shared_ptr held by WorkloadBuffer.owner defers
+    // ~Tensor until the cached workload itself is evicted; holding only a
+    // shared_ptr<MeshBuffer> would let DeviceStorage::deallocate force-free
+    // the device memory when the local Tensor goes out of scope here
+    // (see is_sole_owner_of_device_memory).
+    Tensor lookup_tensor = build_physical_core_lookup_table_tensor(tensor_args, output_tensors);
+    const tt::DataFormat lookup_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(lookup_tensor.dtype());
+    auto lookup_owner = std::make_shared<Tensor>(std::move(lookup_tensor));
+    tt::tt_metal::Buffer* lookup_buffer = lookup_owner->buffer();
+    wd.buffers.push_back({lookup_owner, lookup_buffer});
+
+    auto desc = build_cross_core_program_descriptor(
+        attributes, tensor_args, output_tensors, lookup_buffer, lookup_cb_data_format);
+
+    auto ranges = tensor_coords.ranges();
+    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
+        wd.programs.push_back({ranges[i], desc});
     }
-    const TensorSpec physical_core_lookup_table_spec(
-        ttnn::Shape{1, physical_core_lookup_table_data.size()},
-        TensorLayout{DataType::UINT32, PageConfig{Layout::ROW_MAJOR}, MemoryConfig()});
-    Tensor physical_core_lookup_table_tensor =
-        Tensor::from_vector(std::move(physical_core_lookup_table_data), physical_core_lookup_table_spec);
-    physical_core_lookup_table_tensor = physical_core_lookup_table_tensor.to_device(device);
-
-    // Update runtime args
-    for (const auto& core_range : cached_program.shared_variables.core_range_set.ranges()) {
-        for (const auto& core_coord : core_range) {
-            auto& reader_runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.reader_kernel_id, core_coord);
-            reader_runtime_args[0] = input_tensor_buffer->address();
-            reader_runtime_args[1] = index_tensor_buffer->address();
-            reader_runtime_args[2] = physical_core_lookup_table_tensor.buffer()->address();
-
-            auto& writer_runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.writer_kernel_id, core_coord);
-            writer_runtime_args[0] = value_tensor_buffer->address();
-        }  // core_coord loop
-    }  // core_range loop
+    if (!ranges.empty()) {
+        wd.programs.push_back({ranges.back(), std::move(desc)});
+    }
+    return wd;
 }
 
 uint32_t SortProgramFactoryCrossCoreDataExchange::get_number_of_tiles_per_core(
@@ -706,11 +838,8 @@ uint32_t SortProgramFactoryCrossCoreDataExchange::rounddown_pow2(uint32_t n) {
 }
 
 // Single row - multi core
-SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleRowMultiCore::create(
+ProgramDescriptor SortProgramFactorySingleRowMultiCore::create_descriptor(
     const SortParams& attributes, const SortInputs& tensor_args, std::vector<Tensor>& output_tensors) {
-    // Program config
-    tt::tt_metal::Program program{};
-
     const tt::DataFormat input_tensor_cb_data_format =
         tt::tt_metal::datatype_to_dataformat_converter(tensor_args.input_tensor.dtype());
     const tt::DataFormat value_tensor_cb_data_format =
@@ -805,56 +934,93 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
     CoreRangeSet all_core_set({CoreRange(coordinator_core)});
     all_core_set = all_core_set.merge<CoreRangeSet>(core_range);
 
+    ProgramDescriptor desc;
+
     // Circular buffers
     constexpr uint32_t buffer_scale_factor = 2;
 
     constexpr uint32_t input_tensor_cb_index = tt::CBIndex::c_0;
-    const tt::tt_metal::CircularBufferConfig input_tensor_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            buffer_scale_factor * input_tensor_tile_size, {{input_tensor_cb_index, input_tensor_cb_data_format}})
-            .set_page_size(input_tensor_cb_index, input_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_core_set, input_tensor_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = buffer_scale_factor * input_tensor_tile_size,
+        .core_ranges = all_core_set,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(input_tensor_cb_index),
+            .data_format = input_tensor_cb_data_format,
+            .page_size = input_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t index_tensor_cb_index = tt::CBIndex::c_1;
-    const tt::tt_metal::CircularBufferConfig index_tensor_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            buffer_scale_factor * index_tensor_tile_size, {{index_tensor_cb_index, index_tensor_cb_data_format}})
-            .set_page_size(index_tensor_cb_index, index_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_core_set, index_tensor_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = buffer_scale_factor * index_tensor_tile_size,
+        .core_ranges = all_core_set,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(index_tensor_cb_index),
+            .data_format = index_tensor_cb_data_format,
+            .page_size = index_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t input_tensor_transposed_cb_index = tt::CBIndex::c_2;
-    const tt::tt_metal::CircularBufferConfig input_tensor_transposed_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            buffer_scale_factor * input_tensor_tile_size,
-            {{input_tensor_transposed_cb_index, input_tensor_cb_data_format}})
-            .set_page_size(input_tensor_transposed_cb_index, input_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_core_set, input_tensor_transposed_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = buffer_scale_factor * input_tensor_tile_size,
+        .core_ranges = all_core_set,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(input_tensor_transposed_cb_index),
+            .data_format = input_tensor_cb_data_format,
+            .page_size = input_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t index_tensor_transposed_cb_index = tt::CBIndex::c_3;
-    const tt::tt_metal::CircularBufferConfig index_tensor_transposed_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            buffer_scale_factor * index_tensor_tile_size,
-            {{index_tensor_transposed_cb_index, index_tensor_cb_data_format}})
-            .set_page_size(index_tensor_transposed_cb_index, index_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_core_set, index_tensor_transposed_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = buffer_scale_factor * index_tensor_tile_size,
+        .core_ranges = all_core_set,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(index_tensor_transposed_cb_index),
+            .data_format = index_tensor_cb_data_format,
+            .page_size = index_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t input_tensor_output_cb_index = tt::CBIndex::c_4;
-    const tt::tt_metal::CircularBufferConfig input_tensor_output_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            buffer_scale_factor * value_tensor_tile_size, {{input_tensor_output_cb_index, value_tensor_cb_data_format}})
-            .set_page_size(input_tensor_output_cb_index, value_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_core_set, input_tensor_output_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = buffer_scale_factor * value_tensor_tile_size,
+        .core_ranges = all_core_set,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(input_tensor_output_cb_index),
+            .data_format = value_tensor_cb_data_format,
+            .page_size = value_tensor_tile_size,
+        }}},
+    });
 
     constexpr uint32_t index_tensor_output_cb_index = tt::CBIndex::c_5;
-    const tt::tt_metal::CircularBufferConfig index_tensor_output_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            buffer_scale_factor * index_tensor_tile_size, {{index_tensor_output_cb_index, index_tensor_cb_data_format}})
-            .set_page_size(index_tensor_output_cb_index, index_tensor_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_core_set, index_tensor_output_cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = buffer_scale_factor * index_tensor_tile_size,
+        .core_ranges = all_core_set,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(index_tensor_output_cb_index),
+            .data_format = index_tensor_cb_data_format,
+            .page_size = index_tensor_tile_size,
+        }}},
+    });
 
     // Semaphores
-    const uint32_t coordinator_to_cores_semaphore_id = CreateSemaphore(program, all_core_set, 0);
-    const uint32_t cores_to_coordinator_semaphore_id = CreateSemaphore(program, all_core_set, 0);
+    constexpr uint32_t coordinator_to_cores_semaphore_id = 0;
+    constexpr uint32_t cores_to_coordinator_semaphore_id = 1;
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = coordinator_to_cores_semaphore_id,
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = all_core_set,
+        .initial_value = 0,
+    });
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = cores_to_coordinator_semaphore_id,
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = all_core_set,
+        .initial_value = 0,
+    });
+
     const auto coordinator_core_physical_coord = device->worker_core_from_logical_core(coordinator_core);
 
     const auto start_core_logical = core_range.ranges()[0].start_coord;
@@ -874,27 +1040,26 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
     TensorAccessorArgs(*input_buffer).append_to(coordinator_compile_time_args);
     TensorAccessorArgs(*value_buffer).append_to(coordinator_compile_time_args);
     TensorAccessorArgs(*index_buffer).append_to(coordinator_compile_time_args);
-    const std::string coordinator_kernel_path =
+
+    KernelDescriptor coordinator_desc;
+    coordinator_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp";
-    tt::tt_metal::KernelHandle coordinator_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        coordinator_kernel_path,
+    coordinator_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    coordinator_desc.core_ranges = CoreRangeSet(CoreRange(coordinator_core));
+    coordinator_desc.compile_time_args = std::move(coordinator_compile_time_args);
+    coordinator_desc.config = ReaderConfigDescriptor{};
+    coordinator_desc.emplace_runtime_args(
         coordinator_core,
-        tt::tt_metal::ReaderDataMovementConfig{coordinator_compile_time_args});
-    SetRuntimeArgs(
-        program,
-        coordinator_kernel_id,
-        coordinator_core,
-        {start_core_physical_coord.x,
-         start_core_physical_coord.y,
-         end_core_physical_coord.x,
-         end_core_physical_coord.y,
+        {static_cast<uint32_t>(start_core_physical_coord.x),
+         static_cast<uint32_t>(start_core_physical_coord.y),
+         static_cast<uint32_t>(end_core_physical_coord.x),
+         static_cast<uint32_t>(end_core_physical_coord.y),
          coordinator_to_cores_semaphore_id,
          cores_to_coordinator_semaphore_id,
-         core_range.num_cores(),
-         input_buffer->address(),
-         value_buffer->address(),
-         index_buffer->address()});
+         static_cast<uint32_t>(core_range.num_cores()),
+         input_buffer,
+         value_buffer,
+         index_buffer});
 
     std::vector<uint32_t> reader_compile_time_args = {
         input_tensor_cb_index,
@@ -907,20 +1072,14 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
         number_of_available_cores};
     TensorAccessorArgs(*value_buffer).append_to(reader_compile_time_args);
     TensorAccessorArgs(*index_buffer).append_to(reader_compile_time_args);
-    const std::string reader_kernel_path =
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_multi_core.cpp";
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program, reader_kernel_path, core_range, tt::tt_metal::ReaderDataMovementConfig{reader_compile_time_args});
-    SetRuntimeArgs(
-        program,
-        reader_kernel_id,
-        core_range,
-        {value_buffer->address(),
-         index_buffer->address(),
-         coordinator_core_physical_coord.x,
-         coordinator_core_physical_coord.y,
-         coordinator_to_cores_semaphore_id,
-         cores_to_coordinator_semaphore_id});
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core_range;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
     std::vector<uint32_t> writer_compile_time_args = {
         input_tensor_output_cb_index,
@@ -933,22 +1092,39 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
         number_of_available_cores};
     TensorAccessorArgs(*value_buffer).append_to(writer_compile_time_args);
     TensorAccessorArgs(*index_buffer).append_to(writer_compile_time_args);
-    const std::string writer_kernel_path =
-        "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_multi_core.cpp";
-    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
-        program, writer_kernel_path, core_range, tt::tt_metal::WriterDataMovementConfig{writer_compile_time_args});
-    SetRuntimeArgs(
-        program,
-        writer_kernel_id,
-        core_range,
-        {value_buffer->address(),
-         index_buffer->address(),
-         coordinator_core_physical_coord.x,
-         coordinator_core_physical_coord.y,
-         coordinator_to_cores_semaphore_id,
-         cores_to_coordinator_semaphore_id});
 
-    const std::vector<uint32_t> compute_compile_time_args = {
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_multi_core.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = core_range;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // Worker per-core runtime args.  The coordinator core is excluded — its args
+    // are emplaced separately above on the coordinator kernel.
+    for (const auto& cr : core_range.ranges()) {
+        for (const auto& core : cr) {
+            reader_desc.emplace_runtime_args(
+                core,
+                {value_buffer,
+                 index_buffer,
+                 static_cast<uint32_t>(coordinator_core_physical_coord.x),
+                 static_cast<uint32_t>(coordinator_core_physical_coord.y),
+                 coordinator_to_cores_semaphore_id,
+                 cores_to_coordinator_semaphore_id});
+            writer_desc.emplace_runtime_args(
+                core,
+                {value_buffer,
+                 index_buffer,
+                 static_cast<uint32_t>(coordinator_core_physical_coord.x),
+                 static_cast<uint32_t>(coordinator_core_physical_coord.y),
+                 coordinator_to_cores_semaphore_id,
+                 cores_to_coordinator_semaphore_id});
+        }
+    }
+
+    std::vector<uint32_t> compute_compile_time_args = {
         input_tensor_cb_index,
         index_tensor_cb_index,
         input_tensor_transposed_cb_index,
@@ -963,57 +1139,31 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
         static_cast<uint32_t>(attributes.descending),
         static_cast<uint32_t>(attributes.stable),
         log2Wt};
-    const std::string compute_kernel_path =
-        "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_single_row_multi_core.cpp";
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode_vector(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode_vector(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
     if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
         unpack_to_dest_mode_vector[input_tensor_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
         unpack_to_dest_mode_vector[input_tensor_transposed_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
         unpack_to_dest_mode_vector[input_tensor_output_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
-    tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        compute_kernel_path,
-        core_range,
-        tt::tt_metal::ComputeConfig{
-            .fp32_dest_acc_en = is_32_bit_data,
-            .unpack_to_dest_mode = unpack_to_dest_mode_vector,
-            .compile_args = compute_compile_time_args});
 
-    return {
-        std::move(program),
-        {coordinator_kernel_id, reader_kernel_id, compute_kernel_id, writer_kernel_id, coordinator_core, core_range}};
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_single_row_multi_core.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = core_range;
+    compute_desc.compile_time_args = std::move(compute_compile_time_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = is_32_bit_data,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode_vector),
+    };
+
+    desc.kernels.push_back(std::move(coordinator_desc));
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
 }
 
-void SortProgramFactorySingleRowMultiCore::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const SortParams& /*attributes*/,
-    const SortInputs& tensor_args,
-    std::vector<Tensor>& output_tensors) {
-    auto* const input_tensor_buffer = tensor_args.input_tensor.buffer();
-    auto* const value_tensor_buffer = output_tensors.at(0).buffer();
-    auto* const index_tensor_buffer = output_tensors.at(1).buffer();
-
-    auto& coordinator_core_runtime_args = GetRuntimeArgs(
-        cached_program.program,
-        cached_program.shared_variables.coordinator_kernel_id,
-        cached_program.shared_variables.coordinator_core);
-    coordinator_core_runtime_args[7] = input_tensor_buffer->address();
-    coordinator_core_runtime_args[8] = value_tensor_buffer->address();
-    coordinator_core_runtime_args[9] = index_tensor_buffer->address();
-
-    for (const auto& core_range : cached_program.shared_variables.worker_core_range.ranges()) {
-        for (const auto& core : core_range) {
-            auto& reader_runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.reader_kernel_id, core);
-            reader_runtime_args[0] = value_tensor_buffer->address();
-            reader_runtime_args[1] = index_tensor_buffer->address();
-
-            auto& writer_runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.writer_kernel_id, core);
-            writer_runtime_args[0] = value_tensor_buffer->address();
-            writer_runtime_args[1] = index_tensor_buffer->address();
-        }  // core loop
-    }  // core_range loop
-}
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.hpp
@@ -7,43 +7,36 @@
 #include "sort_device_operation_types.hpp"
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/work_split.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
+#include "ttnn/distributed/types.hpp"
 #include "ttnn/device_operation.hpp"
 
 #include <cstdint>
 
 namespace ttnn::prim {
 using namespace tt::tt_metal;
+
 // Single row - single core
 struct SortProgramFactorySingleRowSingleCore {
-    struct shared_variables_t {
-        KernelHandle reader_kernel_id{};
-        KernelHandle compute_kernel_id{};
-        KernelHandle writer_kernel_id{};
-        CoreCoord storage_grid_size;
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(const SortParams&, const SortInputs&, std::vector<Tensor>&);
-    static void override_runtime_arguments(
-        cached_program_t&, const SortParams&, const SortInputs&, std::vector<Tensor>&);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const SortParams& attributes, const SortInputs& tensor_args, std::vector<Tensor>& output_tensors);
 };
 
 // SortProgramFactoryCrossCoreDataExchange - single row, multi core with processing multiple tiles on one core with
 // cross core data exchange
 struct SortProgramFactoryCrossCoreDataExchange {
-    struct shared_variables_t {
-        KernelHandle reader_kernel_id{};
-        KernelHandle compute_kernel_id{};
-        KernelHandle writer_kernel_id{};
-        CoreRangeSet core_range_set;
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-    static cached_program_t create(const SortParams&, const SortInputs&, std::vector<Tensor>&);
-    static void override_runtime_arguments(
-        cached_program_t&, const SortParams&, const SortInputs&, std::vector<Tensor>&);
+    // Workload-scoped helper tensor (physical-core lookup table) is allocated once
+    // on cache miss inside create_workload_descriptor() and parked on the returned
+    // WorkloadDescriptor::buffers so it outlives the cached workload via the
+    // program cache.  emplace_runtime_args() with Buffer* lets the framework patch
+    // the buffer address on cache hits without re-running this factory.
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
+        const SortParams& attributes,
+        const SortInputs& tensor_args,
+        std::vector<Tensor>& output_tensors,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 
     /**
      * @brief Strategies for slicing work across cores in cross-core data exchange sort.
@@ -66,20 +59,8 @@ struct SortProgramFactoryCrossCoreDataExchange {
 
 // Single row - multi core
 struct SortProgramFactorySingleRowMultiCore {
-    struct shared_variables_t {
-        KernelHandle coordinator_kernel_id{};
-        KernelHandle reader_kernel_id{};
-        KernelHandle compute_kernel_id{};
-        KernelHandle writer_kernel_id{};
-        CoreCoord coordinator_core;
-        CoreRangeSet worker_core_range;
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(const SortParams&, const SortInputs&, std::vector<Tensor>&);
-    static void override_runtime_arguments(
-        cached_program_t&, const SortParams&, const SortInputs&, std::vector<Tensor>&);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const SortParams& attributes, const SortInputs& tensor_args, std::vector<Tensor>& output_tensors);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/data_movement/split/device/split_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/split/device/split_program_factory.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
@@ -3,30 +3,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/data_movement/split/device/split_program_factory.hpp"
-#include <tt-metalium/work_split.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/constants.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 
-using namespace tt::tt_metal;
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
 
 namespace ttnn::prim {
+
+using namespace tt::tt_metal;
 
 namespace {
 
 void setup_runtime(
-    const Program& program,
+    KernelDescriptor& reader_desc,
+    KernelDescriptor& writer_desc,
     const uint32_t& num_cores_c,
     const uint32_t& z,
     const uint32_t& num_cores_x,
     const uint32_t& per_core_tiles_y,
     const uint32_t& per_core_tiles_x,
     const uint32_t& num_tiles_per_z,
-    tt::tt_metal::Buffer* in0_buffer,
-    tt::tt_metal::Buffer* out0_buffer,
-    tt::tt_metal::Buffer* out1_buffer,
-    tt::tt_metal::KernelHandle reader_kernel_id,
-    tt::tt_metal::KernelHandle writer_kernel_id) {
+    Buffer* in0_buffer,
+    Buffer* out0_buffer,
+    Buffer* out1_buffer) {
     uint32_t start_core_x = 0;
     uint32_t start_core_y = 0;
 
@@ -55,11 +56,6 @@ void setup_runtime(
                     uint32_t reader_core_id = id_c * per_core_tiles_y;
                     reader_core_id += id_r_reader;
 
-                    const std::array reader_runtime_args = {
-                        (std::uint32_t)reader_core_id,
-                        (std::uint32_t)(in0_buffer->address()),  // in0_tensor_addr
-                        (std::uint32_t)0                         // split on last dim
-                    };
                     bool out0_only = false;
                     bool out1_only = false;
                     if (num_cores_c > 1) {
@@ -69,14 +65,18 @@ void setup_runtime(
 
                     uint32_t writer_core_id = (id_c_inner * per_core_tiles_y) + (id_r_writer);
 
-                    const std::array writer_runtime_args = {
-                        writer_core_id,
-                        (std::uint32_t)out0_buffer->address(),  // first base addr
-                        (std::uint32_t)out1_buffer->address(),  // second base addr
-                        (std::uint32_t)out0_only,
-                        (std::uint32_t)out1_only};
-                    tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-                    tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+                    // Buffer* entries register binding slots so the framework patches their
+                    // addresses on cache hits without rebuilding the descriptor.
+                    reader_desc.emplace_runtime_args(
+                        core, {(std::uint32_t)reader_core_id, in0_buffer, (std::uint32_t)0});  // split on last dim
+
+                    writer_desc.emplace_runtime_args(
+                        core,
+                        {writer_core_id,
+                         out0_buffer,  // first base addr
+                         out1_buffer,  // second base addr
+                         (std::uint32_t)out0_only,
+                         (std::uint32_t)out1_only});
                 }
             }
         }
@@ -85,38 +85,35 @@ void setup_runtime(
 
 }  // namespace
 
-SplitProgramFactory::cached_program_t SplitProgramFactory::create(
-    const ttnn::prim::SplitParams& operation_attributes,
-    const ttnn::prim::SplitInputs& tensor_args,
-    std::vector<Tensor>& output_tensors) {
+ProgramDescriptor SplitProgramFactory::create_descriptor(
+    const SplitParams& operation_attributes, const SplitInputs& tensor_args, std::vector<Tensor>& tensor_return_value) {
     const auto& input_tensor = tensor_args.input;
     const uint32_t num_chunks = operation_attributes.num_splits;
 
     auto input_shape = input_tensor.padded_shape();
 
-    Program program{};
-    tt::tt_metal::IDevice* device = input_tensor.device();
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    IDevice* device = input_tensor.device();
+    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
 
     ////////////////////////////////////////////////////////////////////////////
     //                 Buffer Setup
     ////////////////////////////////////////////////////////////////////////////
 
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
-    tt::tt_metal::Buffer* in0_buffer = input_tensor.buffer();
+    Buffer* in0_buffer = input_tensor.buffer();
 
     // Output buffers
     TT_FATAL(
-        output_tensors.size() == num_chunks,
+        tensor_return_value.size() == num_chunks,
         "Number of output tensors ({}) must equal number of chunks ({})",
-        output_tensors.size(),
+        tensor_return_value.size(),
         num_chunks);
-    tt::tt_metal::Tensor& out0 = output_tensors[0];
-    tt::tt_metal::Tensor& out1 = output_tensors[1];
+    Tensor& out0 = tensor_return_value[0];
+    Tensor& out1 = tensor_return_value[1];
 
-    tt::tt_metal::Buffer* out0_buffer = out0.buffer();
+    Buffer* out0_buffer = out0.buffer();
     TT_FATAL(out0_buffer != nullptr, "Output 0 buffer should be allocated on device!");
-    tt::tt_metal::Buffer* out1_buffer = out1.buffer();
+    Buffer* out1_buffer = out1.buffer();
     TT_FATAL(out1_buffer != nullptr, "Output 1 buffer should be allocated on device!");
 
     ////////////////////////////////////////////////////////////////////////////
@@ -133,12 +130,12 @@ SplitProgramFactory::cached_program_t SplitProgramFactory::create(
     auto num_cores_z = z;
 
     // parallelize y
-    auto [num_cores_y, per_core_tiles_y] = tt::tt_metal::get_max_cores_divisible_by_tiles_per_core_tiles(
+    auto [num_cores_y, per_core_tiles_y] = get_max_cores_divisible_by_tiles_per_core_tiles(
         num_tiles_dim_3, num_cores_y_limit, /*request_even=*/(num_tiles_dim_3 > 1));
 
     // parallelize x
     auto [num_cores_x, per_core_tiles_x] =
-        tt::tt_metal::get_max_cores_divisible_by_tiles_per_core_tiles(num_tiles_dim_2, num_cores_x_limit / num_cores_z);
+        get_max_cores_divisible_by_tiles_per_core_tiles(num_tiles_dim_2, num_cores_x_limit / num_cores_z);
 
     uint32_t start_core_x = 0;
     uint32_t start_core_y = 0;
@@ -178,29 +175,42 @@ SplitProgramFactory::cached_program_t SplitProgramFactory::create(
     TensorAccessorArgs(*out0_buffer).append_to(writer_compile_time_args);
     TensorAccessorArgs(*out1_buffer).append_to(writer_compile_time_args);
 
-    auto reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/"
-        "reader_tm_tile_layout_split_two_chunks.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    ProgramDescriptor desc;
 
-    auto writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/"
-        "writer_tm_tile_layout_split_two_chunks.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    // Circular buffer for input tile staging.
+    constexpr uint32_t src0_cb_index = 0;
+    constexpr uint32_t num_input_tiles = 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * single_tile_size,
+        .core_ranges = CoreRangeSet{all_cores},
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
 
-    uint32_t src0_cb_index = 0;
-    uint32_t num_input_tiles = 2;
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/"
+        "reader_tm_tile_layout_split_two_chunks.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = CoreRangeSet{all_cores};
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/"
+        "writer_tm_tile_layout_split_two_chunks.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = CoreRangeSet{all_cores};
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     setup_runtime(
-        program,
+        reader_desc,
+        writer_desc,
         num_cores_c,
         num_cores_z,
         num_cores_x,
@@ -209,47 +219,12 @@ SplitProgramFactory::cached_program_t SplitProgramFactory::create(
         num_tiles_per_z,
         in0_buffer,
         out0_buffer,
-        out1_buffer,
-        reader_kernel_id,
-        writer_kernel_id);
+        out1_buffer);
 
-    return {
-        std::move(program), {reader_kernel_id, writer_kernel_id, num_cores_r, num_cores_c, start_core_x, start_core_y}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void SplitProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const ttnn::prim::SplitParams& /*operation_attributes*/,
-    const ttnn::prim::SplitInputs& tensor_args,
-    std::vector<Tensor>& output_tensors) {
-    auto& program = cached_program.program;
-    const auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    const auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    const auto& num_cores_r = cached_program.shared_variables.num_cores_r;
-    const auto& num_cores_c = cached_program.shared_variables.num_cores_c;
-    const auto& start_core_x = cached_program.shared_variables.start_core_x;
-    const auto& start_core_y = cached_program.shared_variables.start_core_y;
-
-    auto* src_dram_buffer = tensor_args.input.buffer();
-    auto* dst_0_dram_buffer = output_tensors.at(0).buffer();
-    auto* dst_1_dram_buffer = output_tensors.at(1).buffer();
-
-    for (int core_idx_y = 0; core_idx_y < num_cores_c; core_idx_y++) {
-        for (int core_idx_x = 0; core_idx_x < num_cores_r; core_idx_x++) {
-            CoreCoord core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
-
-            {
-                auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[1] = src_dram_buffer->address();
-            }
-
-            {
-                auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[1] = dst_0_dram_buffer->address();
-                runtime_args[2] = dst_1_dram_buffer->address();
-            }
-        }
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.hpp
@@ -4,34 +4,17 @@
 
 #pragma once
 
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/operations/data_movement/split/device/split_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
-struct SplitSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id;
-    tt::tt_metal::KernelHandle writer_kernel_id;
-    uint32_t num_cores_r;
-    uint32_t num_cores_c;
-    uint32_t start_core_x;
-    uint32_t start_core_y;
-};
-
 struct SplitProgramFactory {
-    using shared_variables_t = SplitSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const ttnn::prim::SplitParams& operation_attributes,
-        const ttnn::prim::SplitInputs& tensor_args,
-        std::vector<Tensor>& output_tensors);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const ttnn::prim::SplitParams& operation_attributes,
-        const ttnn::prim::SplitInputs& tensor_args,
-        std::vector<Tensor>& output_tensors);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const SplitParams& operation_attributes,
+        const SplitInputs& tensor_args,
+        std::vector<Tensor>& tensor_return_value);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation_types.hpp
@@ -24,13 +24,4 @@ struct TilizeInputs {
     std::optional<Tensor> optional_input_tensor;
 };
 
-struct MultiCoreSharedVariables {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-        tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-        std::vector<CoreCoord> cores;
-        uint32_t ncores{};
-    };
-};
-
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
@@ -3,29 +3,63 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tilize_multi_core_block_program_factory.hpp"
-#include "ttnn/operations/cb_utils.hpp"
+
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
+
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
-TilizeMultiCoreBlockProgramFactory::cached_program_t TilizeMultiCoreBlockProgramFactory::create(
-    const ttnn::prim::TilizeParams& operation_attributes,
-    const ttnn::prim::TilizeInputs& tensor_args,
-    const Tensor& output_tensor) {
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
-    auto a = tensor_args.input_tensor;
-    const auto& output = output_tensor;
-    auto sub_core_grids = operation_attributes.sub_core_grids;
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+
+namespace {
+
+// Helper: append a paired (input, output) CBDescriptor for a given core range.
+void push_cb_pair(
+    ProgramDescriptor& desc,
+    const CoreRangeSet& core_ranges,
+    uint32_t input_single_tile_size,
+    uint32_t output_single_tile_size,
+    uint32_t num_tiles,
+    tt::DataFormat input_cb_data_format,
+    tt::DataFormat output_cb_data_format) {
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * input_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_0),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * output_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_16),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
+}
+
+}  // namespace
+
+ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
+    const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value) {
+    const auto& a = tensor_args.input_tensor;
+    const Tensor& output = tensor_return_value;
+    const auto& sub_core_grids = operation_attributes.sub_core_grids;
+
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
     bool fp32_llk_acc = a.dtype() == DataType::FLOAT32;
@@ -71,75 +105,52 @@ TilizeMultiCoreBlockProgramFactory::cached_program_t TilizeMultiCoreBlockProgram
 
     uint32_t row_size_bytes = a.padded_shape()[-1] * a.element_size();  // Assuming bfloat16 dataformat
 
-    if (!core_range.empty()) {
-        create_cb(
-            tt::CBIndex::c_0, program, core_range, input_single_tile_size, single_sub_block_size, input_cb_data_format);
-
-        create_cb(
-            tt::CBIndex::c_16,
-            program,
-            core_range,
-            output_single_tile_size,
-            single_sub_block_size,
-            output_cb_data_format);
-    }
-    if (has_cliff_col && has_cliff_row) {
-        create_cb(
-            tt::CBIndex::c_0,
-            program,
-            cliff_col_row_core_range,
-            input_single_tile_size,
-            single_block_size_cliff_row,
-            input_cb_data_format);
-
-        create_cb(
-            tt::CBIndex::c_16,
-            program,
-            cliff_col_row_core_range,
-            output_single_tile_size,
-            single_block_size_cliff_row,
-            output_cb_data_format);
-    }
-
-    if (has_cliff_row) {
-        create_cb(
-            tt::CBIndex::c_0,
-            program,
-            cliff_row_core_range,
-            input_single_tile_size,
-            single_block_size_cliff_row,
-            input_cb_data_format);
-
-        create_cb(
-            tt::CBIndex::c_16,
-            program,
-            cliff_row_core_range,
-            output_single_tile_size,
-            single_block_size_cliff_row,
-            output_cb_data_format);
-    }
-
-    if (has_cliff_col) {
-        create_cb(
-            tt::CBIndex::c_0,
-            program,
-            cliff_col_core_range,
-            input_single_tile_size,
-            single_sub_block_size,
-            input_cb_data_format);
-
-        create_cb(
-            tt::CBIndex::c_16,
-            program,
-            cliff_col_core_range,
-            output_single_tile_size,
-            single_sub_block_size,
-            output_cb_data_format);
-    }
-
     Buffer* src0_buffer = a.buffer();
     Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    ProgramDescriptor desc;
+
+    if (!core_range.empty()) {
+        push_cb_pair(
+            desc,
+            core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_sub_block_size,
+            input_cb_data_format,
+            output_cb_data_format);
+    }
+    if (has_cliff_col && has_cliff_row) {
+        push_cb_pair(
+            desc,
+            cliff_col_row_core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_block_size_cliff_row,
+            input_cb_data_format,
+            output_cb_data_format);
+    }
+    if (has_cliff_row) {
+        push_cb_pair(
+            desc,
+            cliff_row_core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_block_size_cliff_row,
+            input_cb_data_format,
+            output_cb_data_format);
+    }
+    if (has_cliff_col) {
+        push_cb_pair(
+            desc,
+            cliff_col_core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_sub_block_size,
+            input_cb_data_format,
+            output_cb_data_format);
+    }
 
     // reader
     uint32_t num_tiles_2d = output.padded_shape()[-1] * output.padded_shape()[-2] / TILE_HW;
@@ -163,76 +174,69 @@ TilizeMultiCoreBlockProgramFactory::cached_program_t TilizeMultiCoreBlockProgram
     std::vector<uint32_t> reader_compile_time_args = {
         total_num_rows, third_dim, tile_height, a.element_size(), row_size_bytes};
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    KernelHandle unary_reader_kernel_id = CreateKernel(
-        program,
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/"
-        "reader_unary_pad_multicore_both_dims.cpp",
-        all_cores,
-        ReaderDataMovementConfig(reader_compile_time_args));
+        "reader_unary_pad_multicore_both_dims.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
     // writer
-
     std::vector<uint32_t> writer_compile_time_args = {tt::CBIndex::c_16, num_tiles_2d, third_dim, total_tiles_per_row};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-    KernelHandle unary_writer_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id_wh.cpp",
-        all_cores,
-        WriterDataMovementConfig(writer_compile_time_args));
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id_wh.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     // compute
     uint32_t single_sub_block_wh = single_block_size * single_block_size / single_sub_block_size;
     uint32_t single_sub_block_cliff_col_wh = single_block_size_cliff_col * single_block_size / single_sub_block_size;
 
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_llk_acc) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
     }
 
+    const std::string compute_kernel_path =
+        "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp";
+
+    auto make_compute_kernel = [&](const CoreRangeSet& cores, std::vector<uint32_t> compile_args) {
+        KernelDescriptor cd;
+        cd.kernel_source = compute_kernel_path;
+        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cd.core_ranges = cores;
+        cd.compile_time_args = std::move(compile_args);
+        cd.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_llk_acc,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+        };
+        return cd;
+    };
+
+    std::vector<KernelDescriptor> compute_kernels;
     if (!core_range.empty()) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp",
-            core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_llk_acc,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {single_sub_block_wh, single_sub_block_size, third_dim},
-            });
+        compute_kernels.push_back(
+            make_compute_kernel(core_range, {single_sub_block_wh, single_sub_block_size, third_dim}));
     }
     if (has_cliff_col && has_cliff_row) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp",
-            cliff_col_row_core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_llk_acc,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {single_block_size_cliff_col, single_block_size_cliff_row, third_dim},
-            });
+        compute_kernels.push_back(make_compute_kernel(
+            cliff_col_row_core_range, {single_block_size_cliff_col, single_block_size_cliff_row, third_dim}));
     }
     if (has_cliff_row) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp",
-            cliff_row_core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_llk_acc,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {single_block_size, single_block_size_cliff_row, third_dim},
-            });
+        compute_kernels.push_back(
+            make_compute_kernel(cliff_row_core_range, {single_block_size, single_block_size_cliff_row, third_dim}));
     }
-
     if (has_cliff_col) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp",
-            cliff_col_core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_llk_acc,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {single_sub_block_cliff_col_wh, single_sub_block_size, third_dim},
-            });
+        compute_kernels.push_back(make_compute_kernel(
+            cliff_col_core_range, {single_sub_block_cliff_col_wh, single_sub_block_size, third_dim}));
     }
 
     // RUNTIME ARGS
@@ -272,25 +276,23 @@ TilizeMultiCoreBlockProgramFactory::cached_program_t TilizeMultiCoreBlockProgram
             single_sub_block_size_row_arg = single_sub_block_size;
         }
 
-        //  reader runtime args
-        std::vector<uint32_t> reader_rt_args = {
-            src0_buffer->address(),
-            0,
-            TILE_WIDTH * a.element_size() * single_block_size_row_arg,
-            start_row_id,
-            start_column_id,
-            single_block_size_row_arg,
-            single_block_size_col_arg,
-            TILE_WIDTH * a.element_size() * single_sub_block_size_row_arg,
-            single_sub_block_size_row_arg,
-        };
+        // reader runtime args — Buffer* slot auto-registers as a BufferBinding so the
+        // framework patches addresses on cache hits.
+        reader_desc.emplace_runtime_args(
+            core,
+            {src0_buffer,
+             std::uint32_t{0},
+             TILE_WIDTH * a.element_size() * single_block_size_row_arg,
+             start_row_id,
+             start_column_id,
+             single_block_size_row_arg,
+             single_block_size_col_arg,
+             TILE_WIDTH * a.element_size() * single_sub_block_size_row_arg,
+             single_sub_block_size_row_arg});
 
         // writer runtime args
-        const std::array writer_rt_args = {
-            dst_buffer->address(), tile_start_id, single_block_size_row_arg, single_block_size_col_arg};
-
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
+        writer_desc.emplace_runtime_args(
+            core, {dst_buffer, tile_start_id, single_block_size_row_arg, single_block_size_col_arg});
 
         uint32_t end_column_id = start_column_id + (single_block_size_row_arg * TILE_WIDTH * a.element_size());
         start_column_id = end_column_id % row_size_bytes;
@@ -306,33 +308,12 @@ TilizeMultiCoreBlockProgramFactory::cached_program_t TilizeMultiCoreBlockProgram
         }
     }
 
-    return cached_program_t{std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id, cores, ncores}};
-}
-
-void TilizeMultiCoreBlockProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const ttnn::prim::TilizeParams& /*operation_attributes*/,
-    const ttnn::prim::TilizeInputs& tensor_args,
-    const Tensor& output_tensor) {
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& cores = cached_program.shared_variables.cores;
-    auto* src_buffer = tensor_args.input_tensor.buffer();
-    auto* dst_buffer = output_tensor.buffer();
-    auto& program = cached_program.program;
-    auto ncores = cached_program.shared_variables.ncores;
-    auto& reader_runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
-    auto& writer_runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
-    for (uint32_t i = 0; i < ncores; ++i) {
-        const auto& core = cores[i];
-        {
-            auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = src_buffer->address();
-        }
-        {
-            auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = dst_buffer->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    for (auto& cd : compute_kernels) {
+        desc.kernels.push_back(std::move(cd));
     }
+
+    return desc;
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.hpp
@@ -4,26 +4,14 @@
 
 #pragma once
 
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include "tilize_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
 struct TilizeMultiCoreBlockProgramFactory {
-    using shared_variables_t = ttnn::prim::MultiCoreSharedVariables::shared_variables_t;
-    using cached_program_t =
-        ttnn::device_operation::CachedProgram<TilizeMultiCoreBlockProgramFactory::shared_variables_t>;
-    using operation_attributes_t = ttnn::prim::TilizeParams;
-
-    static cached_program_t create(
-        const ttnn::prim::TilizeParams& operation_attributes,
-        const ttnn::prim::TilizeInputs& tensor_args,
-        const Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const ttnn::prim::TilizeParams& operation_attributes,
-        const ttnn::prim::TilizeInputs& tensor_args,
-        const Tensor& output_tensor);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_default_program_factory.cpp
@@ -3,12 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tilize_multi_core_default_program_factory.hpp"
-#include "tilize_multi_core_block_program_factory.hpp"
-#include "ttnn/operations/cb_utils.hpp"
+
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt::constants;
@@ -16,14 +17,12 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-TilizeMultiCoreDefaultProgramFactory::cached_program_t TilizeMultiCoreDefaultProgramFactory::create(
-    const ttnn::prim::TilizeParams& operation_attributes,
-    const ttnn::prim::TilizeInputs& tensor_args,
-    const Tensor& output_tensor) {
-    auto a = tensor_args.input_tensor;
-    const auto& output = output_tensor;
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
-    auto sub_core_grids = operation_attributes.sub_core_grids;
+ProgramDescriptor TilizeMultiCoreDefaultProgramFactory::create_descriptor(
+    const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value) {
+    const auto& a = tensor_args.input_tensor;
+    const Tensor& output = tensor_return_value;
+    const auto& sub_core_grids = operation_attributes.sub_core_grids;
+
     tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
     tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
@@ -48,10 +47,30 @@ TilizeMultiCoreDefaultProgramFactory::cached_program_t TilizeMultiCoreDefaultPro
     auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
         ttnn::split_blocks_for_tilize(available_grid, nblocks);
 
-    create_cb(tt::CBIndex::c_0, program, all_cores, input_single_tile_size, ntiles_per_block, input_cb_data_format);
+    const uint32_t src0_cb_index = tt::CBIndex::c_0;
+    const uint32_t output_cb_index = tt::CBIndex::c_16;
 
-    auto [output_cb_index, _] = create_cb(
-        tt::CBIndex::c_16, program, all_cores, output_single_tile_size, ntiles_per_block, output_cb_data_format);
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = ntiles_per_block * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = ntiles_per_block * output_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
 
     /** reader
      */
@@ -72,54 +91,65 @@ TilizeMultiCoreDefaultProgramFactory::cached_program_t TilizeMultiCoreDefaultPro
     std::vector<uint32_t> reader_ct_args = {
         aligned_page_size, num_pages_in_row, size_of_valid_data_in_last_page_in_row};
     TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
-    KernelHandle unary_reader_kernel_id = CreateKernel(
-        program,
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/"
-        "reader_unary_stick_layout_split_rows_multicore.cpp",
-        all_cores,
-        ReaderDataMovementConfig(reader_ct_args));
+        "reader_unary_stick_layout_split_rows_multicore.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
     /** writer
      */
     std::vector<uint32_t> writer_ct_args = {output_cb_index};
-    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
-    KernelHandle unary_writer_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
-        all_cores,
-        WriterDataMovementConfig(writer_ct_args));
+    TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     /** compute
      */
     std::vector<uint32_t> compute_args = {nblocks_per_core, ntiles_per_block};
     std::vector<uint32_t> compute_args_cliff = {nblocks_per_core_cliff, ntiles_per_block};
 
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_llk_acc) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
     }
 
+    std::optional<KernelDescriptor> compute_desc;
     if (!core_range.ranges().empty()) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/kernel/compute/tilize.cpp",
-            core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_llk_acc,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = compute_args,
-            });
+        KernelDescriptor cd;
+        cd.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
+        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cd.core_ranges = core_range;
+        cd.compile_time_args = std::move(compute_args);
+        cd.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_llk_acc,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+        };
+        compute_desc = std::move(cd);
     }
+
+    std::optional<KernelDescriptor> compute_cliff_desc;
     if (!core_range_cliff.empty()) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/kernel/compute/tilize.cpp",
-            core_range_cliff,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_llk_acc,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = compute_args_cliff,
-            });
+        KernelDescriptor cd;
+        cd.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
+        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cd.core_ranges = core_range_cliff;
+        cd.compile_time_args = std::move(compute_args_cliff);
+        cd.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_llk_acc,
+            .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+        };
+        compute_cliff_desc = std::move(cd);
     }
 
     // 1D distribution of blocks across cores
@@ -132,27 +162,26 @@ TilizeMultiCoreDefaultProgramFactory::cached_program_t TilizeMultiCoreDefaultPro
     for (uint32_t i = 0; i < ncores_full; ++i) {
         const CoreCoord& core = cores[i];
 
-        // reader runtime args
-        const std::array reader_rt_args = {
-            src0_buffer->address(),
-            nblocks_per_core * TILE_HEIGHT,
-            page_size,
-            ntiles_per_block,
-            page_size,
-            std::uint32_t{1},  // full blocks in row
-            std::uint32_t{0},  // num leftover tiles
-            std::uint32_t{0},  // leftover width in row
-            page_start_id};
+        // reader runtime args — Buffer* slots auto-register as BufferBindings so the
+        // framework patches addresses on cache hits.
+        reader_desc.emplace_runtime_args(
+            core,
+            {src0_buffer,
+             nblocks_per_core * TILE_HEIGHT,
+             page_size,
+             ntiles_per_block,
+             page_size,
+             std::uint32_t{1},  // full blocks in row
+             std::uint32_t{0},  // num leftover tiles
+             std::uint32_t{0},  // leftover width in row
+             page_start_id});
 
         // writer runtime args
-        const std::array writer_rt_args = {
-            dst_buffer->address(),
-            ntiles_per_block * nblocks_per_core,  // ntiles per core
-            tile_start_id                         // start id
-        };
-
-        SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
-        SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
+        writer_desc.emplace_runtime_args(
+            core,
+            {dst_buffer,
+             ntiles_per_block * nblocks_per_core,  // ntiles per core
+             tile_start_id});                      // start id
 
         tile_start_id += ntiles_per_block * nblocks_per_core;
         page_start_id += TILE_HEIGHT * nblocks_per_core * num_pages_in_row;
@@ -162,58 +191,36 @@ TilizeMultiCoreDefaultProgramFactory::cached_program_t TilizeMultiCoreDefaultPro
         const CoreCoord& core = cores[ncores_full];
 
         // reader runtime args
-        const std::array reader_rt_args = {
-            src0_buffer->address(),
-            nblocks_per_core_cliff * TILE_HEIGHT,
-            page_size,
-            ntiles_per_block,
-            page_size,
-            std::uint32_t{1},  // full blocks in row
-            std::uint32_t{0},  // num leftover tiles
-            std::uint32_t{0},  // leftover width in row
-            page_start_id};
+        reader_desc.emplace_runtime_args(
+            core,
+            {src0_buffer,
+             nblocks_per_core_cliff * TILE_HEIGHT,
+             page_size,
+             ntiles_per_block,
+             page_size,
+             std::uint32_t{1},  // full blocks in row
+             std::uint32_t{0},  // num leftover tiles
+             std::uint32_t{0},  // leftover width in row
+             page_start_id});
 
         // writer runtime args
-        const std::array writer_rt_args = {
-            dst_buffer->address(),
-            ntiles_per_block * nblocks_per_core_cliff,  // ntiles per core
-            tile_start_id                               // start id
-        };
-
-        SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
-        SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
+        writer_desc.emplace_runtime_args(
+            core,
+            {dst_buffer,
+             ntiles_per_block * nblocks_per_core_cliff,  // ntiles per core
+             tile_start_id});                            // start id
     }
 
-    shared_variables_t shared_vars{unary_reader_kernel_id, unary_writer_kernel_id, cores, ncores};
-    return cached_program_t{std::move(program), std::move(shared_vars)};
-}
-
-void TilizeMultiCoreDefaultProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const ttnn::prim::TilizeParams& /*operation_attributes*/,
-    const ttnn::prim::TilizeInputs& tensor_args,
-    const Tensor& output_tensor) {
-    auto* src_buffer = tensor_args.input_tensor.buffer();
-    auto* dst_buffer = output_tensor.buffer();
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& cores = cached_program.shared_variables.cores;
-    auto ncores = cached_program.shared_variables.ncores;
-
-    auto& reader_runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
-    auto& writer_runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
-    for (uint32_t i = 0; i < ncores; ++i) {
-        const CoreCoord& core = cores[i];
-        {
-            auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = src_buffer->address();
-        }
-        {
-            auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = dst_buffer->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    if (compute_desc.has_value()) {
+        desc.kernels.push_back(std::move(*compute_desc));
     }
+    if (compute_cliff_desc.has_value()) {
+        desc.kernels.push_back(std::move(*compute_cliff_desc));
+    }
+
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_default_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_default_program_factory.hpp
@@ -4,25 +4,14 @@
 
 #pragma once
 
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include "tilize_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
 struct TilizeMultiCoreDefaultProgramFactory {
-    using shared_variables_t = ttnn::prim::MultiCoreSharedVariables::shared_variables_t;
-    using cached_program_t =
-        ttnn::device_operation::CachedProgram<ttnn::prim::MultiCoreSharedVariables::shared_variables_t>;
-
-    static cached_program_t create(
-        const ttnn::prim::TilizeParams& operation_attributes,
-        const ttnn::prim::TilizeInputs& tensor_args,
-        const Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const ttnn::prim::TilizeParams& operation_attributes,
-        const ttnn::prim::TilizeInputs& tensor_args,
-        const Tensor& output_tensor);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_sharded_program_factory.cpp
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tilize_multi_core_sharded_program_factory.hpp"
-#include "ttnn/operations/cb_utils.hpp"
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt::constants;
@@ -15,92 +15,107 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-TilizeMultiCoreShardedProgramFactory::cached_program_t TilizeMultiCoreShardedProgramFactory::create(
-    const ttnn::prim::TilizeParams& /*operation_attributes*/,
-    const ttnn::prim::TilizeInputs& tensor_args,
-    const Tensor& output_tensor) {
-    tt::tt_metal::Program program{};
-    auto input = tensor_args.input_tensor;
-    const auto& output = output_tensor;
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+ProgramDescriptor TilizeMultiCoreShardedProgramFactory::create_descriptor(
+    const TilizeParams& /*operation_attributes*/, const TilizeInputs& tensor_args, Tensor& tensor_return_value) {
+    const auto& input = tensor_args.input_tensor;
+    const Tensor& output = tensor_return_value;
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(input.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
     bool fp32_llk_acc = input.dtype() == DataType::FLOAT32;
 
     auto shard_spec = input.shard_spec().value();
     uint32_t num_tiles_per_shard = shard_spec.shape[0] * shard_spec.shape[1] / TILE_HW;
     uint32_t num_tiles_per_row = shard_spec.shape[1] / TILE_WIDTH;
-    auto all_cores = shard_spec.grid;
+    const CoreRangeSet& all_cores = shard_spec.grid;
 
-    auto [src0_cb_index, cb_src0] = create_cb(
-        tt::CBIndex::c_0,
-        program,
-        all_cores,
-        input_single_tile_size,
-        num_tiles_per_shard,
-        input_cb_data_format,
-        input.buffer());
+    const uint32_t src0_cb_index = tt::CBIndex::c_0;
+    const uint32_t output_cb_index = tt::CBIndex::c_16;
 
-    auto [output_cb_index, cb_output] = create_cb(
-        tt::CBIndex::c_16,
-        program,
-        all_cores,
-        output_single_tile_size,
-        num_tiles_per_shard,
-        output_cb_data_format,
-        output.buffer());
+    Buffer* src_buffer = input.buffer();
+    Buffer* dst_buffer = output.buffer();
 
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)src0_cb_index};
+    ProgramDescriptor desc;
 
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
+    // Sharded input CB — globally allocated to the input buffer; framework patches
+    // the CB address on cache hits via cb.buffer.
+    {
+        CBDescriptor cb_src0;
+        cb_src0.total_size = num_tiles_per_shard * input_single_tile_size;
+        cb_src0.core_ranges = all_cores;
+        cb_src0.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        });
+        cb_src0.buffer = src_buffer;
+        desc.cbs.push_back(std::move(cb_src0));
+    }
 
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    // Sharded output CB — globally allocated to the output buffer.
+    {
+        CBDescriptor cb_output;
+        cb_output.total_size = num_tiles_per_shard * output_single_tile_size;
+        cb_output.core_ranges = all_cores;
+        cb_output.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        });
+        cb_output.buffer = dst_buffer;
+        desc.cbs.push_back(std::move(cb_output));
+    }
 
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    std::vector<uint32_t> reader_compile_time_args = {src0_cb_index};
+    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // Sharded readers/writers consume only the (constant per-launch) num_tiles_per_shard
+    // count; no Buffer* slot is needed because the CB itself carries the buffer binding.
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        reader_desc.emplace_runtime_args(core, {num_tiles_per_shard});
+        writer_desc.emplace_runtime_args(core, {num_tiles_per_shard});
+    }
 
     std::vector<uint32_t> compute_args = {
         uint32_t(num_tiles_per_shard / num_tiles_per_row), uint32_t(num_tiles_per_row)};
 
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_llk_acc) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
     }
 
-    tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/kernel/compute/tilize.cpp",
-        all_cores,
-        tt::tt_metal::ComputeConfig{
-            .fp32_dest_acc_en = fp32_llk_acc,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .compile_args = compute_args,
-        });
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = std::move(compute_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_llk_acc,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
 
-    tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, all_cores, {num_tiles_per_shard});
-    tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, all_cores, {num_tiles_per_shard});
-    return TilizeMultiCoreShardedProgramFactory::cached_program_t{
-        std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id, cb_src0, cb_output}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
 }
 
-void TilizeMultiCoreShardedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const ttnn::prim::TilizeParams& /*operation_attributes*/,
-    const ttnn::prim::TilizeInputs& tensor_args,
-    const Tensor& output_tensor) {
-    auto* src_buffer = tensor_args.input_tensor.buffer();
-    auto* dst_buffer = output_tensor.buffer();
-    UpdateDynamicCircularBufferAddress(
-        cached_program.program, cached_program.shared_variables.input_cb_handle, *src_buffer);
-    UpdateDynamicCircularBufferAddress(
-        cached_program.program, cached_program.shared_variables.output_cb_handle, *dst_buffer);
-}
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_sharded_program_factory.hpp
@@ -4,29 +4,14 @@
 
 #pragma once
 
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include "tilize_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
 struct TilizeMultiCoreShardedProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-        tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-        tt::tt_metal::CBHandle input_cb_handle{};
-        tt::tt_metal::CBHandle output_cb_handle{};
-    };
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const ttnn::prim::TilizeParams& operation_attributes,
-        const ttnn::prim::TilizeInputs& tensor_args,
-        const Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const ttnn::prim::TilizeParams& operation_attributes,
-        const ttnn::prim::TilizeInputs& tensor_args,
-        const Tensor& output_tensor);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_width_sharded_program_factory.cpp
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tilize_multi_core_width_sharded_program_factory.hpp"
-#include "ttnn/operations/cb_utils.hpp"
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt::constants;
@@ -15,95 +15,108 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-TilizeMultiCoreWidthShardedProgramFactory::cached_program_t TilizeMultiCoreWidthShardedProgramFactory::create(
-    const ttnn::prim::TilizeParams& /*operation_attributes*/,
-    const ttnn::prim::TilizeInputs& tensor_args,
-    const Tensor& output_tensor) {
-    tt::tt_metal::Program program{};
+ProgramDescriptor TilizeMultiCoreWidthShardedProgramFactory::create_descriptor(
+    const TilizeParams& /*operation_attributes*/, const TilizeInputs& tensor_args, Tensor& tensor_return_value) {
+    const auto& input = tensor_args.input_tensor;
+    const Tensor& output = tensor_return_value;
 
-    auto input = tensor_args.input_tensor;
-    const auto& output = output_tensor;
-
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(input.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
     bool fp32_llk_acc = input.dtype() == DataType::FLOAT32;
 
     auto shard_spec = input.shard_spec().value();
     uint32_t num_tiles_per_shard = shard_spec.shape[0] * shard_spec.shape[1] / TILE_HW;
     uint32_t num_tiles_per_row = shard_spec.shape[1] / TILE_WIDTH;
-    auto all_cores = shard_spec.grid;
+    const CoreRangeSet& all_cores = shard_spec.grid;
 
-    auto [src0_cb_index, cb_src0] = create_cb(
-        tt::CBIndex::c_0,
-        program,
-        all_cores,
-        input_single_tile_size,
-        num_tiles_per_shard,
-        input_cb_data_format,
-        input.buffer());
+    const uint32_t src0_cb_index = tt::CBIndex::c_0;
+    const uint32_t output_cb_index = tt::CBIndex::c_16;
 
-    auto [output_cb_index, cb_output] = create_cb(
-        tt::CBIndex::c_16,
-        program,
-        all_cores,
-        output_single_tile_size,
-        num_tiles_per_shard,
-        output_cb_data_format,
-        output.buffer());
+    Buffer* src_buffer = input.buffer();
+    Buffer* dst_buffer = output.buffer();
 
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)src0_cb_index};
+    ProgramDescriptor desc;
 
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
+    // Sharded input CB — globally allocated to the input buffer; framework patches
+    // the CB address on cache hits via cb.buffer.
+    {
+        CBDescriptor cb_src0;
+        cb_src0.total_size = num_tiles_per_shard * input_single_tile_size;
+        cb_src0.core_ranges = all_cores;
+        cb_src0.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        });
+        cb_src0.buffer = src_buffer;
+        desc.cbs.push_back(std::move(cb_src0));
+    }
 
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    // Sharded output CB — globally allocated to the output buffer.
+    {
+        CBDescriptor cb_output;
+        cb_output.total_size = num_tiles_per_shard * output_single_tile_size;
+        cb_output.core_ranges = all_cores;
+        cb_output.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        });
+        cb_output.buffer = dst_buffer;
+        desc.cbs.push_back(std::move(cb_output));
+    }
 
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    std::vector<uint32_t> reader_compile_time_args = {src0_cb_index};
+    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // Sharded readers/writers consume only num_tiles_per_shard (constant per launch);
+    // the CB itself carries the buffer binding.
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        reader_desc.emplace_runtime_args(core, {num_tiles_per_shard});
+        writer_desc.emplace_runtime_args(core, {num_tiles_per_shard});
+    }
 
     std::vector<uint32_t> compute_args = {
         uint32_t(num_tiles_per_shard / num_tiles_per_row), uint32_t(num_tiles_per_row)};
 
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_llk_acc) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
     }
 
-    tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/kernel/compute/tilize.cpp",
-        all_cores,
-        tt::tt_metal::ComputeConfig{
-            .fp32_dest_acc_en = fp32_llk_acc,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .compile_args = compute_args,
-        });
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = std::move(compute_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_llk_acc,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
 
-    tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, all_cores, {num_tiles_per_shard});
-    tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, all_cores, {num_tiles_per_shard});
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-    return TilizeMultiCoreWidthShardedProgramFactory::cached_program_t{
-        std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id, cb_src0, cb_output}};
+    return desc;
 }
 
-void TilizeMultiCoreWidthShardedProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const ttnn::prim::TilizeParams& /*operation_attributes*/,
-    const ttnn::prim::TilizeInputs& tensor_args,
-    const Tensor& output_tensor) {
-    auto* src_buffer = tensor_args.input_tensor.buffer();
-    auto* dst_buffer = output_tensor.buffer();
-    UpdateDynamicCircularBufferAddress(
-        cached_program.program, cached_program.shared_variables.input_cb_handle, *src_buffer);
-    UpdateDynamicCircularBufferAddress(
-        cached_program.program, cached_program.shared_variables.output_cb_handle, *dst_buffer);
-}
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_width_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_width_sharded_program_factory.hpp
@@ -4,29 +4,14 @@
 
 #pragma once
 
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include "tilize_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
 struct TilizeMultiCoreWidthShardedProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-        tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-        tt::tt_metal::CBHandle input_cb_handle{};
-        tt::tt_metal::CBHandle output_cb_handle{};
-    };
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const ttnn::prim::TilizeParams& operation_attributes,
-        const ttnn::prim::TilizeInputs& tensor_args,
-        const Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const ttnn::prim::TilizeParams& operation_attributes,
-        const ttnn::prim::TilizeInputs& tensor_args,
-        const Tensor& output_tensor);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_single_core_program_factory.cpp
@@ -3,39 +3,39 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tilize_single_core_program_factory.hpp"
+
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
-TilizeSingleCoreProgramFactory::cached_program_t TilizeSingleCoreProgramFactory::create(
-    const ttnn::prim::TilizeParams& operation_attributes,
-    const ttnn::prim::TilizeInputs& tensor_args,
-    const Tensor& output_tensor) {
-    tt::tt_metal::Program program{};
 
-    auto a = tensor_args.input_tensor;
-    const auto& output = output_tensor;
-    auto sub_core_grids = operation_attributes.sub_core_grids;
+ProgramDescriptor TilizeSingleCoreProgramFactory::create_descriptor(
+    const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value) {
+    const auto& a = tensor_args.input_tensor;
+    const Tensor& output = tensor_return_value;
+    const auto& sub_core_grids = operation_attributes.sub_core_grids;
 
     CoreRange default_core({0, 0}, {0, 0});
     CoreRange core = sub_core_grids.has_value() ? corerange_to_cores(sub_core_grids.value()).at(0) : default_core;
+    CoreRangeSet core_ranges{core};
 
-    tt::tt_metal::Buffer* src0_buffer = a.buffer();
+    Buffer* src0_buffer = a.buffer();
 
     // This should allocate a DRAM buffer on the device
 
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
 
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
     bool fp32_llk_acc = a.dtype() == DataType::FLOAT32;
@@ -73,100 +73,98 @@ TilizeSingleCoreProgramFactory::cached_program_t TilizeSingleCoreProgramFactory:
     uint32_t num_leftover_tiles = num_tiles_in_row % num_tiles_per_block;
     uint32_t leftover_width_in_row = num_leftover_tiles * a.element_size();
 
-    uint32_t src0_cb_index = 0;
-    uint32_t num_input_tiles = num_tiles_per_block;
+    const uint32_t src0_cb_index = 0;
+    const uint32_t output_cb_index = tt::CBIndex::c_16;
+    const uint32_t num_input_tiles = num_tiles_per_block;
+    const uint32_t num_output_tiles = num_tiles_per_block;
 
-    auto src0_cb_config = tt::tt_metal::CircularBufferConfig(
-                              num_input_tiles * input_single_tile_size, {{src0_cb_index, input_cb_data_format}})
-                              .set_page_size(src0_cb_index, input_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core, src0_cb_config);
+    ProgramDescriptor desc;
 
-    uint32_t output_cb_index = tt::CBIndex::c_16;
-    uint32_t num_output_tiles = num_tiles_per_block;
-    auto cb_output_config = tt::tt_metal::CircularBufferConfig(
-                                num_output_tiles * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
-                                .set_page_size(output_cb_index, output_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core, cb_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
-    const std::array reader_kernel_args = {
-        src0_buffer->address(),
-        num_sticks,
-        stick_size,
-        num_tiles_per_block,
-        block_width_size,
-        num_full_blocks_in_row,
-        num_leftover_tiles,
-        leftover_width_in_row,
-        std::uint32_t{0},  // row_start_id
-    };
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
 
     // Reader compile-time args
     std::vector<uint32_t> reader_compile_time_args = {stick_size};
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
-    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     // Tilized reader
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/"
-        "reader_unary_stick_layout_split_rows_singlecore.cpp",
-        core,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+        "reader_unary_stick_layout_split_rows_singlecore.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core_ranges;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    // Buffer* slots register BufferBindings so the framework patches addresses on cache hits.
+    reader_desc.emplace_runtime_args(
+        core.start_coord,
+        {src0_buffer,
+         num_sticks,
+         stick_size,
+         num_tiles_per_block,
+         block_width_size,
+         num_full_blocks_in_row,
+         num_leftover_tiles,
+         leftover_width_in_row,
+         std::uint32_t{0}});  // row_start_id
 
     // Tilized writer
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
-        core,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = core_ranges;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.emplace_runtime_args(core.start_coord, {dst_buffer, num_tiles, std::uint32_t{0}});
 
     std::vector<uint32_t> compute_args = {
         num_tiles / num_tiles_per_block,  // per_core_block_cnt
         num_tiles_per_block               // per_core_block_tile_cnt
     };
 
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_llk_acc) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
     }
 
-    tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/kernel/compute/tilize.cpp",
-        core,
-        tt::tt_metal::ComputeConfig{
-            .fp32_dest_acc_en = fp32_llk_acc,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .compile_args = compute_args,
-        });
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = core_ranges;
+    compute_desc.compile_time_args = std::move(compute_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_llk_acc,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
 
-    tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_kernel_args);
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-    tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, {dst_buffer->address(), num_tiles, 0});
-    return cached_program_t{std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id, core}};
+    return desc;
 }
 
-void TilizeSingleCoreProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const ttnn::prim::TilizeParams& /*operation_attributes*/,
-    const ttnn::prim::TilizeInputs& tensor_args,
-    const Tensor& output_tensor) {
-    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto& core = cached_program.shared_variables.core;
-    auto* src_buffer = tensor_args.input_tensor.buffer();
-    auto& program = cached_program.program;
-    auto* dst_buffer = output_tensor.buffer();
-    CoreCoord core_0 = corerange_to_cores(core).at(0);
-    {
-        auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core_0);
-        runtime_args[0] = src_buffer->address();
-    }
-    {
-        auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core_0);
-        runtime_args[0] = dst_buffer->address();
-    }
-}
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_single_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_single_core_program_factory.hpp
@@ -4,27 +4,13 @@
 
 #pragma once
 
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include "tilize_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 struct TilizeSingleCoreProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-        tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-        tt::tt_metal::CoreRange core{tt::tt_metal::CoreCoord{0, 0}};
-    };
-    using cached_program_t = ttnn::device_operation::CachedProgram<TilizeSingleCoreProgramFactory::shared_variables_t>;
-
-    static cached_program_t create(
-        const ttnn::prim::TilizeParams& operation_attributes,
-        const ttnn::prim::TilizeInputs& tensor_args,
-        const Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const ttnn::prim::TilizeParams& operation_attributes,
-        const ttnn::prim::TilizeInputs& tensor_args,
-        const Tensor& output_tensor);
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.cpp
@@ -6,12 +6,12 @@
 
 #include <cmath>
 
-#include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.hpp"
@@ -21,18 +21,48 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-TilizeWithValPaddingMultiCoreBlockInterleavedFactory::cached_program_t
-TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create(
-    const operation_attributes_t& operation_attributes, const Tensor& input_tensor, const Tensor& output_tensor) {
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+namespace {
 
+// Helper: append a paired (input, output) CBDescriptor for a given core range.
+void push_padded_cb_pair(
+    ProgramDescriptor& desc,
+    const CoreRangeSet& core_ranges,
+    uint32_t input_single_tile_size,
+    uint32_t output_single_tile_size,
+    uint32_t num_tiles,
+    tt::DataFormat input_cb_data_format,
+    tt::DataFormat output_cb_data_format) {
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * input_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_0),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * output_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_16),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
+}
+
+}  // namespace
+
+ProgramDescriptor TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create_descriptor(
+    const TilizeWithValPaddingParams& operation_attributes, const Tensor& input_tensor, Tensor& tensor_return_value) {
     const Tensor& a = input_tensor;
-    const Tensor& output = output_tensor;
+    const Tensor& output = tensor_return_value;
     const auto& sub_core_grids = operation_attributes.sub_core_grids;
 
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
     bool fp32_llk_acc = a.dtype() == DataType::FLOAT32;
@@ -78,75 +108,52 @@ TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create(
     uint32_t unpadded_row_size_bytes = a.padded_shape()[-1] * a.element_size();     // Assuming bfloat16 dataformat
     uint32_t padded_row_size_bytes = output.padded_shape()[-1] * a.element_size();  // Assuming bfloat16 dataformat
 
-    if (!core_range.empty()) {
-        create_cb(
-            tt::CBIndex::c_0, program, core_range, input_single_tile_size, single_sub_block_size, input_cb_data_format);
-
-        create_cb(
-            tt::CBIndex::c_16,
-            program,
-            core_range,
-            output_single_tile_size,
-            single_sub_block_size,
-            output_cb_data_format);
-    }
-    if (has_cliff_col && has_cliff_row) {
-        create_cb(
-            tt::CBIndex::c_0,
-            program,
-            cliff_col_row_core_range,
-            input_single_tile_size,
-            single_block_size_cliff_row,
-            input_cb_data_format);
-
-        create_cb(
-            tt::CBIndex::c_16,
-            program,
-            cliff_col_row_core_range,
-            output_single_tile_size,
-            single_block_size_cliff_row,
-            output_cb_data_format);
-    }
-
-    if (has_cliff_row) {
-        create_cb(
-            tt::CBIndex::c_0,
-            program,
-            cliff_row_core_range,
-            input_single_tile_size,
-            single_block_size_cliff_row,
-            input_cb_data_format);
-
-        create_cb(
-            tt::CBIndex::c_16,
-            program,
-            cliff_row_core_range,
-            output_single_tile_size,
-            single_block_size_cliff_row,
-            output_cb_data_format);
-    }
-
-    if (has_cliff_col) {
-        create_cb(
-            tt::CBIndex::c_0,
-            program,
-            cliff_col_core_range,
-            input_single_tile_size,
-            single_sub_block_size,
-            input_cb_data_format);
-
-        create_cb(
-            tt::CBIndex::c_16,
-            program,
-            cliff_col_core_range,
-            output_single_tile_size,
-            single_sub_block_size,
-            output_cb_data_format);
-    }
-
     Buffer* src0_buffer = a.buffer();
     Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    ProgramDescriptor desc;
+
+    if (!core_range.empty()) {
+        push_padded_cb_pair(
+            desc,
+            core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_sub_block_size,
+            input_cb_data_format,
+            output_cb_data_format);
+    }
+    if (has_cliff_col && has_cliff_row) {
+        push_padded_cb_pair(
+            desc,
+            cliff_col_row_core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_block_size_cliff_row,
+            input_cb_data_format,
+            output_cb_data_format);
+    }
+    if (has_cliff_row) {
+        push_padded_cb_pair(
+            desc,
+            cliff_row_core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_block_size_cliff_row,
+            input_cb_data_format,
+            output_cb_data_format);
+    }
+    if (has_cliff_col) {
+        push_padded_cb_pair(
+            desc,
+            cliff_col_core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_sub_block_size,
+            input_cb_data_format,
+            output_cb_data_format);
+    }
 
     // reader
     uint32_t packed_pad_value = detail::get_packed_value(a, operation_attributes.pad_value);
@@ -174,71 +181,68 @@ TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create(
         total_num_rows, third_dim, tile_height, a.element_size(), unpadded_row_size_bytes};
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
-    KernelHandle unary_reader_kernel_id = CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/"
-        "reader_unary_pad_multicore_both_dims.cpp",
-        all_cores,
-        ReaderDataMovementConfig(reader_compile_time_args));
+        "reader_unary_pad_multicore_both_dims.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
     // writer
     std::vector<uint32_t> writer_compile_time_args = {tt::CBIndex::c_16, num_tiles_2d, third_dim, total_tiles_per_row};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-    KernelHandle unary_writer_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id_wh.cpp",
-        all_cores,
-        WriterDataMovementConfig(writer_compile_time_args));
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id_wh.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     // compute
     uint32_t single_sub_block_wh = single_block_size * single_block_size / single_sub_block_size;
     uint32_t single_sub_block_cliff_col_wh = single_block_size_cliff_col * single_block_size / single_sub_block_size;
 
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_llk_acc) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
     }
 
+    const std::string compute_kernel_path =
+        "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp";
+
+    auto make_compute_kernel = [&](const CoreRangeSet& cores, std::vector<uint32_t> compile_args) {
+        KernelDescriptor cd;
+        cd.kernel_source = compute_kernel_path;
+        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cd.core_ranges = cores;
+        cd.compile_time_args = std::move(compile_args);
+        cd.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_llk_acc,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+        };
+        return cd;
+    };
+
+    std::vector<KernelDescriptor> compute_kernels;
     if (!core_range.empty()) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp",
-            core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_llk_acc,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {single_sub_block_wh, single_sub_block_size, third_dim}});
+        compute_kernels.push_back(
+            make_compute_kernel(core_range, {single_sub_block_wh, single_sub_block_size, third_dim}));
     }
     if (has_cliff_col && has_cliff_row) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp",
-            cliff_col_row_core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_llk_acc,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {single_block_size_cliff_col, single_block_size_cliff_row, third_dim}});
+        compute_kernels.push_back(make_compute_kernel(
+            cliff_col_row_core_range, {single_block_size_cliff_col, single_block_size_cliff_row, third_dim}));
     }
     if (has_cliff_row) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp",
-            cliff_row_core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_llk_acc,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {single_block_size, single_block_size_cliff_row, third_dim}});
+        compute_kernels.push_back(
+            make_compute_kernel(cliff_row_core_range, {single_block_size, single_block_size_cliff_row, third_dim}));
     }
-
     if (has_cliff_col) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp",
-            cliff_col_core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_llk_acc,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {single_sub_block_cliff_col_wh, single_sub_block_size, third_dim}});
+        compute_kernels.push_back(make_compute_kernel(
+            cliff_col_core_range, {single_sub_block_cliff_col_wh, single_sub_block_size, third_dim}));
     }
 
     // RUNTIME ARGS
@@ -278,24 +282,23 @@ TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create(
             single_sub_block_size_row_arg = single_sub_block_size;
         }
 
-        //  reader runtime args
-        std::vector<uint32_t> reader_rt_args = {
-            src0_buffer->address(),
-            packed_pad_value,
-            TILE_WIDTH * a.element_size() * single_block_size_row_arg,
-            start_row_id,
-            start_column_id,
-            single_block_size_row_arg,
-            single_block_size_col_arg,
-            TILE_WIDTH * a.element_size() * single_sub_block_size_row_arg,
-            single_sub_block_size_row_arg};
+        // reader runtime args — Buffer* slot auto-registers as a BufferBinding so the
+        // framework patches addresses on cache hits.
+        reader_desc.emplace_runtime_args(
+            core,
+            {src0_buffer,
+             packed_pad_value,
+             TILE_WIDTH * a.element_size() * single_block_size_row_arg,
+             start_row_id,
+             start_column_id,
+             single_block_size_row_arg,
+             single_block_size_col_arg,
+             TILE_WIDTH * a.element_size() * single_sub_block_size_row_arg,
+             single_sub_block_size_row_arg});
 
         // writer runtime args
-        const std::array writer_rt_args = {
-            dst_buffer->address(), tile_start_id, single_block_size_row_arg, single_block_size_col_arg};
-
-        SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
-        SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
+        writer_desc.emplace_runtime_args(
+            core, {dst_buffer, tile_start_id, single_block_size_row_arg, single_block_size_col_arg});
 
         uint32_t end_column_id = start_column_id + (single_block_size_row_arg * TILE_WIDTH * a.element_size());
         start_column_id = end_column_id % padded_row_size_bytes;
@@ -311,39 +314,13 @@ TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create(
         }
     }
 
-    shared_variables_t shared_variables{
-        .reader_kernel_id = unary_reader_kernel_id,
-        .writer_kernel_id = unary_writer_kernel_id,
-        .cores = cores,
-        .ncores = ncores};
-    return cached_program_t(std::move(program), std::move(shared_variables));
-}
-
-void TilizeWithValPaddingMultiCoreBlockInterleavedFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const Tensor& input_tensor,
-    const Tensor& output_tensor) {
-    auto& program = cached_program.program;
-    auto& shared_variables = cached_program.shared_variables;
-    const auto& ncores = shared_variables.ncores;
-    const auto& cores = shared_variables.cores;
-    auto* src_buffer = input_tensor.buffer();
-    auto* dst_buffer = output_tensor.buffer();
-
-    auto& reader_runtime_args_by_core = GetRuntimeArgs(program, shared_variables.reader_kernel_id);
-    auto& writer_runtime_args_by_core = GetRuntimeArgs(program, shared_variables.writer_kernel_id);
-    for (uint32_t i = 0; i < ncores; ++i) {
-        const auto& core = cores[i];
-        {
-            auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = src_buffer->address();
-        }
-        {
-            auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = dst_buffer->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    for (auto& cd : compute_kernels) {
+        desc.kernels.push_back(std::move(cd));
     }
+
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.hpp
@@ -4,28 +4,17 @@
 
 #pragma once
 
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation_types.hpp"
-#include "ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_shared_variables.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
 struct TilizeWithValPaddingMultiCoreBlockInterleavedFactory {
-    using shared_variables_t = shared_variables_interleaved;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    using operation_attributes_t = ttnn::prim::TilizeWithValPaddingParams;
-    using tensor_args_t = Tensor;
-    using tensor_return_value_t = Tensor;
-
-    static cached_program_t create(
-        const operation_attributes_t& operation_attributes, const Tensor& input_tensor, const Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const operation_attributes_t& operation_attributes,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TilizeWithValPaddingParams& operation_attributes,
         const Tensor& input_tensor,
-        const Tensor& output_tensor);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_default_program_factory.cpp
@@ -6,29 +6,27 @@
 
 #include <cmath>
 
-#include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.hpp"
-#include "ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-TilizeWithValPaddingMultiCoreDefaultFactory::cached_program_t TilizeWithValPaddingMultiCoreDefaultFactory::create(
-    const operation_attributes_t& operation_attributes, const Tensor& input_tensor, const Tensor& output_tensor) {
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+ProgramDescriptor TilizeWithValPaddingMultiCoreDefaultFactory::create_descriptor(
+    const TilizeWithValPaddingParams& operation_attributes, const Tensor& input_tensor, Tensor& tensor_return_value) {
     const Tensor& a = input_tensor;
-    const Tensor& output = output_tensor;
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    const Tensor& output = tensor_return_value;
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
     bool fp32_llk_acc = a.dtype() == DataType::FLOAT32;
@@ -52,14 +50,34 @@ TilizeWithValPaddingMultiCoreDefaultFactory::cached_program_t TilizeWithValPaddi
     uint32_t unpadded_row_size_bytes = a.logical_shape()[-1] * a.element_size();    // Assuming bfloat16 dataformat
     uint32_t padded_row_size_bytes = output.padded_shape()[-1] * a.element_size();  // Assuming bfloat16 dataformat
 
-    create_cb(tt::CBIndex::c_0, program, all_cores, input_single_tile_size, num_tiles_per_row, input_cb_data_format);
-
-    auto [output_cb_index, cb_output] = create_cb(
-        tt::CBIndex::c_16, program, all_cores, output_single_tile_size, num_tiles_per_row, output_cb_data_format);
-
     Buffer* src0_buffer = a.buffer();
     Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    const uint32_t src0_cb_index = tt::CBIndex::c_0;
+    const uint32_t output_cb_index = tt::CBIndex::c_16;
+
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles_per_row * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles_per_row * output_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
 
     /** reader
      */
@@ -83,7 +101,7 @@ TilizeWithValPaddingMultiCoreDefaultFactory::cached_program_t TilizeWithValPaddi
         size_of_valid_data_in_last_page_in_row = unpadded_row_size_bytes - (num_pages_in_row - 1) * page_size;
     }
 
-    std::vector<uint32_t> reader_compile_time_args = {
+    std::vector<uint32_t> reader_ct_args = {
         shift_bits,
         unpadded_row_size_bytes,
         elem_size,
@@ -91,50 +109,63 @@ TilizeWithValPaddingMultiCoreDefaultFactory::cached_program_t TilizeWithValPaddi
         page_size,
         aligned_page_size,
         size_of_valid_data_in_last_page_in_row};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    KernelHandle unary_reader_kernel_id = CreateKernel(
-        program,
+    TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/"
-        "reader_unary_pad_dims_split_rows_multicore.cpp",
-        all_cores,
-        ReaderDataMovementConfig(reader_compile_time_args));
+        "reader_unary_pad_dims_split_rows_multicore.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
     /** writer
      */
-    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
-    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-    KernelHandle unary_writer_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
-        all_cores,
-        WriterDataMovementConfig(writer_compile_time_args));
+    std::vector<uint32_t> writer_ct_args = {output_cb_index};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     /** compute
      */
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_llk_acc) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
     }
 
+    std::optional<KernelDescriptor> compute_desc;
     if (!core_range.empty()) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/kernel/compute/tilize.cpp",
-            core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_llk_acc,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {nblocks_per_core, num_tiles_per_row}});
+        KernelDescriptor cd;
+        cd.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
+        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cd.core_ranges = core_range;
+        cd.compile_time_args = {nblocks_per_core, num_tiles_per_row};
+        cd.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_llk_acc,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+        };
+        compute_desc = std::move(cd);
     }
+
+    std::optional<KernelDescriptor> compute_cliff_desc;
     if (has_cliff) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/kernel/compute/tilize.cpp",
-            core_range_cliff,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_llk_acc,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {nblocks_per_core_cliff, num_tiles_per_row}});
+        KernelDescriptor cd;
+        cd.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
+        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cd.core_ranges = core_range_cliff;
+        cd.compile_time_args = {nblocks_per_core_cliff, num_tiles_per_row};
+        cd.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_llk_acc,
+            .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+        };
+        compute_cliff_desc = std::move(cd);
     }
 
     /* RUNTIME ARGS */
@@ -156,20 +187,21 @@ TilizeWithValPaddingMultiCoreDefaultFactory::cached_program_t TilizeWithValPaddi
         const auto& core = cores[i];
         const std::vector<BlockRep>& assignment = core_assignments.at(i);
 
-        // reader runtime args
-        std::vector<uint32_t> reader_rt_args = {
-            src0_buffer->address(),
-            padded_row_size_bytes,
-            packed_pad_value,
-            start_page_id,
-            static_cast<unsigned int>(assignment.size()),
-        };
+        // reader runtime args — Buffer* slot auto-registers as a BufferBinding so the
+        // framework patches addresses on cache hits.
+        KernelDescriptor::RTArgList reader_rt_args;
+        reader_rt_args.reserve(5 + assignment.size() * 5);
+        reader_rt_args.push_back(src0_buffer);
+        reader_rt_args.push_back(padded_row_size_bytes);
+        reader_rt_args.push_back(packed_pad_value);
+        reader_rt_args.push_back(start_page_id);
+        reader_rt_args.push_back(static_cast<uint32_t>(assignment.size()));
 
-        uint32_t nblocks_per_core = 0;
+        uint32_t nblocks_per_core_local = 0;
         BlockRep ref_el = assignment[0];
         uint32_t count_repeated = 0;  // will be incremented in first iteration of the loop
         for (const auto& el : assignment) {
-            nblocks_per_core += el.block_count();
+            nblocks_per_core_local += el.block_count();
             start_page_id += el.data_row_count() * num_pages_in_row;
             if (compare_assignments(ref_el, el)) {
                 count_repeated++;
@@ -191,50 +223,26 @@ TilizeWithValPaddingMultiCoreDefaultFactory::cached_program_t TilizeWithValPaddi
         reader_rt_args.push_back(ref_el.times);
         reader_rt_args.push_back(count_repeated);
 
-        uint32_t num_tiles_per_core = num_tiles_per_row * nblocks_per_core;
+        uint32_t num_tiles_per_core = num_tiles_per_row * nblocks_per_core_local;
+
+        reader_desc.emplace_runtime_args(core, reader_rt_args);
 
         // writer runtime args
-        const std::array writer_rt_args = {dst_buffer->address(), num_tiles_per_core, tile_start_id};
-
-        SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
-        SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
+        writer_desc.emplace_runtime_args(core, {dst_buffer, num_tiles_per_core, tile_start_id});
 
         tile_start_id += num_tiles_per_core;
     }
 
-    shared_variables_t shared_variables{
-        .reader_kernel_id = unary_reader_kernel_id,
-        .writer_kernel_id = unary_writer_kernel_id,
-        .cores = cores,
-        .ncores = ncores};
-    return cached_program_t(std::move(program), std::move(shared_variables));
-}
-
-void TilizeWithValPaddingMultiCoreDefaultFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const Tensor& input_tensor,
-    const Tensor& output_tensor) {
-    auto& program = cached_program.program;
-    auto& shared_variables = cached_program.shared_variables;
-    const auto& ncores = shared_variables.ncores;
-    const auto& cores = shared_variables.cores;
-    auto* src_buffer = input_tensor.buffer();
-    auto* dst_buffer = output_tensor.buffer();
-
-    auto& reader_runtime_args_by_core = GetRuntimeArgs(program, shared_variables.reader_kernel_id);
-    auto& writer_runtime_args_by_core = GetRuntimeArgs(program, shared_variables.writer_kernel_id);
-    for (uint32_t i = 0; i < ncores; ++i) {
-        const CoreCoord& core = cores[i];
-        {
-            auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = src_buffer->address();
-        }
-        {
-            auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = dst_buffer->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    if (compute_desc.has_value()) {
+        desc.kernels.push_back(std::move(*compute_desc));
     }
+    if (compute_cliff_desc.has_value()) {
+        desc.kernels.push_back(std::move(*compute_cliff_desc));
+    }
+
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_default_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_default_program_factory.hpp
@@ -4,28 +4,17 @@
 
 #pragma once
 
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation_types.hpp"
-#include "ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_shared_variables.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
 struct TilizeWithValPaddingMultiCoreDefaultFactory {
-    using shared_variables_t = shared_variables_interleaved;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    using operation_attributes_t = ttnn::prim::TilizeWithValPaddingParams;
-    using tensor_args_t = Tensor;
-    using tensor_return_value_t = Tensor;
-
-    static cached_program_t create(
-        const operation_attributes_t& operation_attributes, const Tensor& input_tensor, const Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const operation_attributes_t& operation_attributes,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TilizeWithValPaddingParams& operation_attributes,
         const Tensor& input_tensor,
-        const Tensor& output_tensor);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_sharded_program_factory.cpp
@@ -6,10 +6,10 @@
 
 #include <cmath>
 
-#include "ttnn/operations/cb_utils.hpp"
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.hpp"
@@ -19,19 +19,17 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-TilizeWithValPaddingMultiCoreShardedFactory::cached_program_t TilizeWithValPaddingMultiCoreShardedFactory::create(
-    const operation_attributes_t& operation_attributes, const Tensor& input_tensor, const Tensor& output_tensor) {
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
-
+ProgramDescriptor TilizeWithValPaddingMultiCoreShardedFactory::create_descriptor(
+    const TilizeWithValPaddingParams& operation_attributes, const Tensor& input_tensor, Tensor& tensor_return_value) {
     const Tensor& a = input_tensor;
-    const Tensor& output = output_tensor;
+    const Tensor& output = tensor_return_value;
     auto pad_value = operation_attributes.pad_value;
     bool src_sharded = a.memory_config().is_sharded();
     bool out_sharded = output.memory_config().is_sharded();
 
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
     bool fp32_llk_acc = a.dtype() == DataType::FLOAT32;
@@ -51,119 +49,141 @@ TilizeWithValPaddingMultiCoreShardedFactory::cached_program_t TilizeWithValPaddi
     uint32_t nblocks_per_core = output_shard_spec.shape[0] / TILE_HEIGHT;
     uint32_t num_padded_rows = output.padded_shape()[-2] - a.padded_shape()[-2];
 
-    auto [src0_cb_index, cb_src0] = create_cb(
-        tt::CBIndex::c_1,
-        program,
-        all_cores,
-        input_shard_width_bytes,
-        num_input_rows,
-        input_cb_data_format,
-        src_sharded ? a.buffer() : nullptr);
-
-    auto [src1_cb_index, cb_src1] = create_cb(
-        tt::CBIndex::c_0, program, all_cores, input_single_tile_size, ntiles_per_batch * 2, input_cb_data_format);
-
-    auto [src2_cb_index, cb_src2] =
-        create_cb(tt::CBIndex::c_2, program, all_cores, input_shard_width_bytes, 1, input_cb_data_format);
-
-    auto [output_cb_index, cb_output] = create_cb(
-        tt::CBIndex::c_16,
-        program,
-        all_cores,
-        output_single_tile_size,
-        ntiles_per_core,
-        output_cb_data_format,
-        out_sharded ? output.buffer() : nullptr);
-
     Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
+    const uint32_t src0_cb_index = tt::CBIndex::c_1;
+    const uint32_t src1_cb_index = tt::CBIndex::c_0;
+    const uint32_t src2_cb_index = tt::CBIndex::c_2;
+    const uint32_t output_cb_index = tt::CBIndex::c_16;
+
+    ProgramDescriptor desc;
+
+    // Sharded input CB — globally allocated to the input buffer; framework patches
+    // the CB address on cache hits via cb.buffer.
+    {
+        CBDescriptor cb_src0;
+        cb_src0.total_size = num_input_rows * input_shard_width_bytes;
+        cb_src0.core_ranges = all_cores;
+        cb_src0.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_shard_width_bytes,
+        });
+        if (src_sharded) {
+            cb_src0.buffer = a.buffer();
+        }
+        desc.cbs.push_back(std::move(cb_src0));
+    }
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = ntiles_per_batch * 2 * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src1_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = input_shard_width_bytes,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src2_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_shard_width_bytes,
+        }}},
+    });
+
+    // Sharded output CB — globally allocated to the output buffer.
+    {
+        CBDescriptor cb_output;
+        cb_output.total_size = ntiles_per_core * output_single_tile_size;
+        cb_output.core_ranges = all_cores;
+        cb_output.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        });
+        if (out_sharded) {
+            cb_output.buffer = dst_buffer;
+        }
+        desc.cbs.push_back(std::move(cb_output));
+    }
+
     /** reader
      */
-    KernelHandle unary_reader_kernel_id;
     std::vector<uint32_t> reader_ct_args = {
-        (std::uint32_t)src0_cb_index,
-        (std::uint32_t)src1_cb_index,
-        (std::uint32_t)src2_cb_index,
+        static_cast<uint32_t>(src0_cb_index),
+        static_cast<uint32_t>(src1_cb_index),
+        static_cast<uint32_t>(src2_cb_index),
     };
 
-    unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/"
-        "reader_unary_pad_height_width_sharded.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
+        "reader_unary_pad_height_width_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
     /** writer
      */
-    KernelHandle unary_writer_kernel_id;
-    std::vector<uint32_t> writer_ct_args = {
-        output_cb_index,
-    };
-    unary_writer_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp",
-        all_cores,
-        WriterDataMovementConfig(writer_ct_args));
+    std::vector<uint32_t> writer_ct_args = {output_cb_index};
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     /** compute
      */
     std::vector<uint32_t> compute_args = {
-        (uint32_t)nblocks_per_core,  // per_core_block_cnt
-        (uint32_t)ntiles_per_block,  // per_block_ntiles
+        static_cast<uint32_t>(nblocks_per_core),  // per_core_block_cnt
+        static_cast<uint32_t>(ntiles_per_block),  // per_block_ntiles
     };
 
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_llk_acc) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
     }
 
-    CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/kernel/compute/tilize.cpp",
-        all_cores,
-        ComputeConfig{
-            .fp32_dest_acc_en = fp32_llk_acc,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .compile_args = compute_args});
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = std::move(compute_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_llk_acc,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
 
     uint32_t packed_pad_value = detail::get_packed_value(a, pad_value);
 
-    const std::array reader_rt_args = {
-        num_input_rows,
-        input_shard_width_bytes,
-        (num_input_rows / num_batches) * input_shard_width_bytes,
-        ntiles_per_batch,
-        num_padded_rows,
-        num_batches,
-        packed_pad_value};
-    tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, all_cores, reader_rt_args);
+    // Sharded readers/writers: the CBs themselves carry the buffer bindings, so no
+    // Buffer* slot is needed in runtime args.
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        reader_desc.emplace_runtime_args(
+            core,
+            {num_input_rows,
+             input_shard_width_bytes,
+             (num_input_rows / num_batches) * input_shard_width_bytes,
+             ntiles_per_batch,
+             num_padded_rows,
+             num_batches,
+             packed_pad_value});
+        writer_desc.emplace_runtime_args(core, {ntiles_per_core});
+    }
 
-    const std::array writer_rt_args = {ntiles_per_core};
-    tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, all_cores, writer_rt_args);
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-    return cached_program_t(
-        std::move(program),
-        shared_variables_t{
-            .reader_kernel_id = unary_reader_kernel_id,
-            .writer_kernel_id = unary_writer_kernel_id,
-            .cb_src0 = cb_src0,
-            .cb_output = cb_output});
-}
-
-void TilizeWithValPaddingMultiCoreShardedFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const Tensor& input_tensor,
-    const Tensor& output_tensor) {
-    auto& program = cached_program.program;
-    auto& shared_variables = cached_program.shared_variables;
-
-    auto* src_buffer = input_tensor.buffer();
-    auto* dst_buffer = output_tensor.buffer();
-
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_src0, *src_buffer);
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_output, *dst_buffer);
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_sharded_program_factory.hpp
@@ -4,33 +4,17 @@
 
 #pragma once
 
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
 struct TilizeWithValPaddingMultiCoreShardedFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle reader_kernel_id{};
-        tt::tt_metal::KernelHandle writer_kernel_id{};
-        tt::tt_metal::CBHandle cb_src0{};
-        tt::tt_metal::CBHandle cb_output{};
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    using operation_attributes_t = ttnn::prim::TilizeWithValPaddingParams;
-    using tensor_args_t = Tensor;
-    using tensor_return_value_t = Tensor;
-
-    static cached_program_t create(
-        const operation_attributes_t& operation_attributes, const Tensor& input_tensor, const Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const operation_attributes_t& operation_attributes,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TilizeWithValPaddingParams& operation_attributes,
         const Tensor& input_tensor,
-        const Tensor& output_tensor);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_single_core_program_factory.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.hpp"
@@ -18,24 +19,23 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-TilizeWithValPaddingSingleCoreFactory::cached_program_t TilizeWithValPaddingSingleCoreFactory::create(
-    const operation_attributes_t& operation_attributes, const Tensor& input_tensor, const Tensor& output_tensor) {
-    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
-
+ProgramDescriptor TilizeWithValPaddingSingleCoreFactory::create_descriptor(
+    const TilizeWithValPaddingParams& operation_attributes, const Tensor& input_tensor, Tensor& tensor_return_value) {
     const Tensor& a = input_tensor;
-    const Tensor& output = output_tensor;
+    const Tensor& output = tensor_return_value;
     const auto& sub_core_grids = operation_attributes.sub_core_grids;
     CoreRange default_core({0, 0}, {0, 0});
     CoreRange core = sub_core_grids.has_value() ? corerange_to_cores(sub_core_grids.value()).at(0) : default_core;
+    CoreRangeSet core_ranges{core};
 
     // This should allocate a DRAM buffer on the device
 
-    tt::tt_metal::Buffer* src0_buffer = a.buffer();
+    Buffer* src0_buffer = a.buffer();
 
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
 
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
     bool fp32_llk_acc = a.dtype() == DataType::FLOAT32;
@@ -98,120 +98,112 @@ TilizeWithValPaddingSingleCoreFactory::cached_program_t TilizeWithValPaddingSing
         (output_w - input_w) * output_z * output_y / TILE_HEIGHT * num_blocks_w_output;
     const uint32_t num_leftover_Y = input_y - (input_y / TILE_HEIGHT * TILE_HEIGHT);
 
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    uint32_t src0_cb_index = 0;
-    uint32_t num_input_tiles = num_tiles_per_block;
+    const uint32_t src0_cb_index = 0;
+    const uint32_t output_cb_index = tt::CBIndex::c_16;
+    const uint32_t num_input_tiles = num_tiles_per_block;
     assert(num_input_tiles > 0);
-    tt::tt_metal::CircularBufferConfig src0_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_input_tiles * input_single_tile_size, {{src0_cb_index, input_cb_data_format}})
-            .set_page_size(src0_cb_index, input_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core, src0_cb_config);
+    const uint32_t num_output_tiles = num_tiles_per_block;
 
-    uint32_t output_cb_index = tt::CBIndex::c_16;
-    uint32_t num_output_tiles = num_tiles_per_block;
-    tt::tt_metal::CircularBufferConfig cb_output_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_output_tiles * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
-            .set_page_size(output_cb_index, output_single_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core, cb_output_config);
+    ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
 
     uint32_t packed_pad_value = detail::get_packed_value(a, operation_attributes.pad_value);
     uint32_t tile_row_size_bytes = a.element_size() * TILE_HEIGHT;
-
-    const std::array reader_kernel_args = {
-        src0_buffer->address(),
-        input_w,
-        padded_W_diff_blocks,
-        input_z,
-        padded_Z_diff_blocks,
-        input_y,
-        padded_Y_diff_blocks,
-        num_leftover_Y,
-        input_x,
-        padded_row_size_bytes,
-        packed_pad_value,
-        num_blocks_w_input,
-        num_blocks_w_output,
-        num_blocks_w_diff,
-        block_row_size,
-        block_row_leftover_size};
 
     // Reader compile-time args
     std::vector<uint32_t> reader_compile_time_args = {tile_row_size_bytes, unpadded_row_size_bytes};
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
     // Tilized reader
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/"
-        "reader_unary_pad_dims_split_rows.cpp",
-        core,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+        "reader_unary_pad_dims_split_rows.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core_ranges;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    // Buffer* slot auto-registers as a BufferBinding so the framework patches
+    // addresses on cache hits.
+    reader_desc.emplace_runtime_args(
+        core.start_coord,
+        {src0_buffer,
+         input_w,
+         padded_W_diff_blocks,
+         input_z,
+         padded_Z_diff_blocks,
+         input_y,
+         padded_Y_diff_blocks,
+         num_leftover_Y,
+         input_x,
+         padded_row_size_bytes,
+         packed_pad_value,
+         num_blocks_w_input,
+         num_blocks_w_output,
+         num_blocks_w_diff,
+         block_row_size,
+         block_row_leftover_size});
 
     // Tilized writer
     std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
-    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
-        core,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = core_ranges;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+    writer_desc.emplace_runtime_args(
+        core.start_coord, {dst_buffer, static_cast<uint32_t>(num_tiles), std::uint32_t{0}});
 
     std::vector<uint32_t> compute_kernel_args = {
-        uint32_t(num_tiles / num_tiles_per_block), uint32_t(num_tiles_per_block)};
+        static_cast<uint32_t>(num_tiles / num_tiles_per_block), static_cast<uint32_t>(num_tiles_per_block)};
 
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_llk_acc) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
     }
 
-    tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/kernel/compute/tilize.cpp",
-        core,
-        tt::tt_metal::ComputeConfig{
-            .fp32_dest_acc_en = fp32_llk_acc,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .compile_args = compute_kernel_args,
-        });
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = core_ranges;
+    compute_desc.compile_time_args = std::move(compute_kernel_args);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_llk_acc,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
 
-    tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_kernel_args);
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
 
-    tt::tt_metal::SetRuntimeArgs(
-        program, unary_writer_kernel_id, core, {dst_buffer->address(), (uint32_t)num_tiles, 0});
-
-    return cached_program_t(
-        std::move(program),
-        shared_variables_t{
-            .reader_kernel_id = unary_reader_kernel_id, .writer_kernel_id = unary_writer_kernel_id, .core = core});
-}
-
-void TilizeWithValPaddingSingleCoreFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& /*operation_attributes*/,
-    const Tensor& input_tensor,
-    const Tensor& output_tensor) {
-    auto& program = cached_program.program;
-    auto& shared_variables = cached_program.shared_variables;
-    const auto& core = shared_variables.core;
-
-    auto* src_buffer = input_tensor.buffer();
-    auto* dst_buffer = output_tensor.buffer();
-
-    CoreCoord core_0 = corerange_to_cores(core).at(0);
-
-    {
-        auto& runtime_args = GetRuntimeArgs(program, shared_variables.reader_kernel_id, core_0);
-        runtime_args[0] = src_buffer->address();
-    }
-
-    {
-        auto& runtime_args = GetRuntimeArgs(program, shared_variables.writer_kernel_id, core_0);
-        runtime_args[0] = dst_buffer->address();
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_single_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_single_core_program_factory.hpp
@@ -4,32 +4,17 @@
 
 #pragma once
 
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
 struct TilizeWithValPaddingSingleCoreFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle reader_kernel_id{};
-        tt::tt_metal::KernelHandle writer_kernel_id{};
-        tt::tt_metal::CoreRange core{{0, 0}, {0, 0}};
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    using operation_attributes_t = ttnn::prim::TilizeWithValPaddingParams;
-    using tensor_args_t = Tensor;
-    using tensor_return_value_t = Tensor;
-
-    static cached_program_t create(
-        const operation_attributes_t& operation_attributes, const Tensor& input_tensor, const Tensor& output_tensor);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const operation_attributes_t& operation_attributes,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const TilizeWithValPaddingParams& operation_attributes,
         const Tensor& input_tensor,
-        const Tensor& output_tensor);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_block_program_factory.cpp
@@ -2,35 +2,65 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
-#include "ttnn/operations/cb_utils.hpp"
-#include "ttnn/operations/math.hpp"
+#include "untilize_multi_core_block_program_factory.hpp"
+
 #include "ttnn/common/constants.hpp"
-#include "ttnn/operation.hpp"
-#include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
+
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include "untilize_multi_core_block_program_factory.hpp"
+#include <tt-metalium/work_split.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-UntilizeMultiCoreBlockProgramFactory::cached_program_t UntilizeMultiCoreBlockProgramFactory::create(
+namespace {
+
+// Helper: append a paired (input, output) CBDescriptor for a given core range.
+void push_cb_pair(
+    ProgramDescriptor& desc,
+    const CoreRangeSet& core_ranges,
+    uint32_t input_single_tile_size,
+    uint32_t output_single_tile_size,
+    uint32_t num_tiles,
+    tt::DataFormat input_cb_data_format,
+    tt::DataFormat output_cb_data_format) {
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * input_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_0),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * output_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_16),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
+}
+
+}  // namespace
+
+ProgramDescriptor UntilizeMultiCoreBlockProgramFactory::create_descriptor(
     const UntilizeOperationAttributes& operation_attributes,
     const UntilizeTensorArgs& tensor_args,
-    const UntilizeTensorReturnValue& tensor_return_value) {
-    tt::tt_metal::Program program{};
+    UntilizeTensorReturnValue& tensor_return_value) {
     const auto& a = tensor_args.input;
-    const auto& output = tensor_return_value;
+    const Tensor& output = tensor_return_value;
     const auto& fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
     tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
@@ -86,79 +116,54 @@ UntilizeMultiCoreBlockProgramFactory::cached_program_t UntilizeMultiCoreBlockPro
         row_size_bytes = input_shape[-1] * a.element_size();
     }
 
-    if (!core_range.empty()) {
-        create_cb(
-            tt::CBIndex::c_0, program, core_range, input_single_tile_size, single_sub_block_size, input_cb_data_format);
-
-        create_cb(
-            tt::CBIndex::c_16,
-            program,
-            core_range,
-            output_single_tile_size,
-            single_sub_block_size,
-            output_cb_data_format);
-    }
-
-    if (has_cliff_col && has_cliff_row) {
-        create_cb(
-            tt::CBIndex::c_0,
-            program,
-            cliff_col_row_core_range,
-            input_single_tile_size,
-            single_block_size_cliff_row,
-            input_cb_data_format);
-
-        create_cb(
-            tt::CBIndex::c_16,
-            program,
-            cliff_col_row_core_range,
-            output_single_tile_size,
-            single_block_size_cliff_row,
-            output_cb_data_format);
-    }
-
-    if (has_cliff_row) {
-        create_cb(
-            tt::CBIndex::c_0,
-            program,
-            cliff_row_core_range,
-            input_single_tile_size,
-            single_block_size_cliff_row,
-            input_cb_data_format);
-
-        create_cb(
-            tt::CBIndex::c_16,
-            program,
-            cliff_row_core_range,
-            output_single_tile_size,
-            single_block_size_cliff_row,
-            output_cb_data_format);
-    }
-
-    if (has_cliff_col) {
-        create_cb(
-            tt::CBIndex::c_0,
-            program,
-            cliff_col_core_range,
-            input_single_tile_size,
-            single_sub_block_size,
-            input_cb_data_format);
-
-        create_cb(
-            tt::CBIndex::c_16,
-            program,
-            cliff_col_core_range,
-            output_single_tile_size,
-            single_sub_block_size,
-            output_cb_data_format);
-    }
-
     Buffer* src0_buffer = a.buffer();
     Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    // reader
+    ProgramDescriptor desc;
 
+    if (!core_range.empty()) {
+        push_cb_pair(
+            desc,
+            core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_sub_block_size,
+            input_cb_data_format,
+            output_cb_data_format);
+    }
+    if (has_cliff_col && has_cliff_row) {
+        push_cb_pair(
+            desc,
+            cliff_col_row_core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_block_size_cliff_row,
+            input_cb_data_format,
+            output_cb_data_format);
+    }
+    if (has_cliff_row) {
+        push_cb_pair(
+            desc,
+            cliff_row_core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_block_size_cliff_row,
+            input_cb_data_format,
+            output_cb_data_format);
+    }
+    if (has_cliff_col) {
+        push_cb_pair(
+            desc,
+            cliff_col_core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_sub_block_size,
+            input_cb_data_format,
+            output_cb_data_format);
+    }
+
+    // reader
     uint32_t num_tiles_2d = a.padded_shape()[-1] * a.padded_shape()[-2] / TILE_HW;
 
     auto log_shape = output.logical_shape();
@@ -171,81 +176,77 @@ UntilizeMultiCoreBlockProgramFactory::cached_program_t UntilizeMultiCoreBlockPro
 
     std::vector<uint32_t> reader_compile_time_args = {num_tiles_2d, third_dim, total_tiles_per_row};
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    KernelHandle unary_reader_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_wh_multicore.cpp",
-        all_cores,
-        ReaderDataMovementConfig(reader_compile_time_args));
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_wh_multicore.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
     // writer
     uint32_t total_num_rows = output.logical_shape()[-2];
     std::vector<uint32_t> writer_ct_args = {total_num_rows, third_dim, TILE_HEIGHT, row_size_bytes};
     TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
-    KernelHandle unary_writer_kernel_id = CreateKernel(
-        program,
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
-        "writer_unary_stick_layout_wh_multicore.cpp",
-        all_cores,
-        WriterDataMovementConfig(writer_ct_args));
+        "writer_unary_stick_layout_wh_multicore.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     // compute
     uint32_t single_sub_block_size_wh = single_block_size * single_block_size / single_sub_block_size;
     uint32_t single_sub_block_size_cliff_col_wh =
         single_block_size_cliff_col * single_block_size / single_sub_block_size;
 
-    std::map<std::string, std::string> compute_kernel_defines;
+    std::vector<std::pair<std::string, std::string>> compute_kernel_defines;
     if (input_cb_data_format == tt::DataFormat::Int32 || input_cb_data_format == tt::DataFormat::UInt32 ||
         input_cb_data_format == tt::DataFormat::Float32) {
-        compute_kernel_defines["DST_ACCUM_MODE"] = "1";
+        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
     }
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_dest_acc_en) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
-    }
-    if (!core_range.empty()) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh.cpp",
-            core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {single_sub_block_size_wh, single_sub_block_size, third_dim},
-                .defines = compute_kernel_defines});
-    }
-    if (has_cliff_col && has_cliff_row) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh.cpp",
-            cliff_col_row_core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {single_block_size_cliff_col, single_block_size_cliff_row, third_dim},
-                .defines = compute_kernel_defines});
-    }
-    if (has_cliff_row) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh.cpp",
-            cliff_row_core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {single_block_size, single_block_size_cliff_row, third_dim},
-                .defines = compute_kernel_defines});
+        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
     }
 
+    const std::string compute_kernel_path =
+        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh.cpp";
+
+    auto make_compute_kernel = [&](const CoreRangeSet& cores, std::vector<uint32_t> compile_args) {
+        KernelDescriptor cd;
+        cd.kernel_source = compute_kernel_path;
+        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cd.core_ranges = cores;
+        cd.compile_time_args = std::move(compile_args);
+        cd.defines = compute_kernel_defines;
+        cd.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+        };
+        return cd;
+    };
+
+    std::vector<KernelDescriptor> compute_kernels;
+    if (!core_range.empty()) {
+        compute_kernels.push_back(
+            make_compute_kernel(core_range, {single_sub_block_size_wh, single_sub_block_size, third_dim}));
+    }
+    if (has_cliff_col && has_cliff_row) {
+        compute_kernels.push_back(make_compute_kernel(
+            cliff_col_row_core_range, {single_block_size_cliff_col, single_block_size_cliff_row, third_dim}));
+    }
+    if (has_cliff_row) {
+        compute_kernels.push_back(
+            make_compute_kernel(cliff_row_core_range, {single_block_size, single_block_size_cliff_row, third_dim}));
+    }
     if (has_cliff_col) {
-        CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh.cpp",
-            cliff_col_core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = {single_sub_block_size_cliff_col_wh, single_sub_block_size, third_dim},
-                .defines = compute_kernel_defines});
+        compute_kernels.push_back(make_compute_kernel(
+            cliff_col_core_range, {single_sub_block_size_cliff_col_wh, single_sub_block_size, third_dim}));
     }
 
     // RUNTIME ARGS
@@ -287,23 +288,22 @@ UntilizeMultiCoreBlockProgramFactory::cached_program_t UntilizeMultiCoreBlockPro
             single_sub_block_size_row_arg = single_sub_block_size;
         }
 
-        //  writer runtime args
-        std::vector<uint32_t> writer_rt_args = {
-            dst_buffer->address(),
-            TILE_WIDTH * el_size * single_block_size_row_arg,
-            start_row_id,
-            start_column_id,
-            single_block_size_row_arg,
-            single_block_size_col_arg,
-            TILE_WIDTH * el_size * single_sub_block_size_row_arg,
-            single_sub_block_size_row_arg,
-        };
+        // reader runtime args — Buffer* slot auto-registers as a BufferBinding so the
+        // framework patches addresses on cache hits.
+        reader_desc.emplace_runtime_args(
+            core, {src0_buffer, tile_start_id, single_block_size_row_arg, single_block_size_col_arg});
 
-        // reader runtime args
-        const std::array reader_rt_args = {
-            src0_buffer->address(), tile_start_id, single_block_size_row_arg, single_block_size_col_arg};
-        SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
-        SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
+        // writer runtime args
+        writer_desc.emplace_runtime_args(
+            core,
+            {dst_buffer,
+             TILE_WIDTH * el_size * single_block_size_row_arg,
+             start_row_id,
+             start_column_id,
+             single_block_size_row_arg,
+             single_block_size_col_arg,
+             TILE_WIDTH * el_size * single_sub_block_size_row_arg,
+             single_sub_block_size_row_arg});
 
         uint32_t end_column_id = start_column_id + (single_block_size_row_arg * TILE_WIDTH * el_size);
         start_column_id = end_column_id % row_size_bytes;
@@ -319,37 +319,13 @@ UntilizeMultiCoreBlockProgramFactory::cached_program_t UntilizeMultiCoreBlockPro
         }
     }
 
-    return UntilizeMultiCoreBlockProgramFactory::cached_program_t{
-        std::move(program),
-        UntilizeMultiCoreBlockProgramFactory::shared_variables_t{
-            .reader_kernel_id = unary_reader_kernel_id,
-            .writer_kernel_id = unary_writer_kernel_id,
-            .cores_with_runtime_args = cores}};
-}
-
-void UntilizeMultiCoreBlockProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const UntilizeOperationAttributes& /*operation_attributes*/,
-    const UntilizeTensorArgs& tensor_args,
-    const UntilizeTensorReturnValue& tensor_return_value) {
-    auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    auto& cores = cached_program.shared_variables.cores_with_runtime_args;
-    auto* src_buffer = tensor_args.input.buffer();
-    auto* dst_buffer = tensor_return_value.buffer();
-
-    auto& reader_runtime_args_by_core = tt::tt_metal::GetRuntimeArgs(cached_program.program, reader_kernel_id);
-    auto& writer_runtime_args_by_core = tt::tt_metal::GetRuntimeArgs(cached_program.program, writer_kernel_id);
-
-    for (const auto& core : cores) {
-        {
-            auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = src_buffer->address();
-        }
-        {
-            auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = dst_buffer->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    for (auto& cd : compute_kernels) {
+        desc.kernels.push_back(std::move(cd));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_block_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_block_program_factory.hpp
@@ -4,25 +4,16 @@
 
 #pragma once
 
-#include "ttnn/operation.hpp"
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/data_movement/untilize/device/untilize_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct UntilizeMultiCoreBlockProgramFactory {
-    using shared_variables_t = UntilizeSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<UntilizeSharedVariables>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const UntilizeOperationAttributes& operation_attributes,
         const UntilizeTensorArgs& tensor_args,
-        const UntilizeTensorReturnValue& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const UntilizeOperationAttributes& operation_attributes,
-        const UntilizeTensorArgs& tensor_args,
-        const UntilizeTensorReturnValue& tensor_return_value);
+        UntilizeTensorReturnValue& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.cpp
@@ -2,43 +2,36 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
-#include "ttnn/operations/cb_utils.hpp"
-#include "ttnn/operations/math.hpp"
+#include "untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.hpp"
+
 #include "ttnn/common/constants.hpp"
-#include "ttnn/operation.hpp"
-#include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
-#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+
+#include <tt-metalium/buffer_distribution_spec.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/buffer_distribution_spec.hpp>
-#include "untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
-UntilizeMultiCoreInputAndOutputNDShardTypeAndShardSpecIdenticalProgramFactory::cached_program_t
-UntilizeMultiCoreInputAndOutputNDShardTypeAndShardSpecIdenticalProgramFactory::create(
+
+ProgramDescriptor UntilizeMultiCoreInputAndOutputNDShardTypeAndShardSpecIdenticalProgramFactory::create_descriptor(
     const UntilizeOperationAttributes& operation_attributes,
     const UntilizeTensorArgs& tensor_args,
-    const UntilizeTensorReturnValue& tensor_return_value) {
-    tt::tt_metal::Program program{};
-
+    UntilizeTensorReturnValue& tensor_return_value) {
     const auto& a = tensor_args.input;
-    const auto& output = tensor_return_value;
+    const Tensor& output = tensor_return_value;
     const auto& fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
 
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
-    tt::tt_metal::Buffer* src0_buffer = a.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    Buffer* src0_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     const auto& tile_shape = a.tensor_spec().tile().get_tile_shape();
@@ -69,75 +62,86 @@ UntilizeMultiCoreInputAndOutputNDShardTypeAndShardSpecIdenticalProgramFactory::c
         num_cores,
         num_shards_per_core);
 
-    // Input CB
-    auto [src0_cb_index, cb_src0] = create_cb(
-        tt::CBIndex::c_0,
-        program,
-        grid,
-        input_single_tile_size,
-        num_tiles_per_shard * num_shards_per_core,
-        input_cb_data_format,
-        src0_buffer);
+    const uint32_t src0_cb_index = tt::CBIndex::c_0;
+    const uint32_t output_cb_index = tt::CBIndex::c_16;
 
-    // Output CB
-    auto [output_cb_index, cb_output] = create_cb(
-        tt::CBIndex::c_16,
-        program,
-        grid,
-        output_single_tile_size,
-        num_tiles_per_shard * num_shards_per_core,
-        output_cb_data_format,
-        dst_buffer);
+    ProgramDescriptor desc;
 
-    // Reader compile-time args
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_cb_index};
+    // Sharded input CB — globally allocated to the input buffer; framework patches
+    // the CB address on cache hits via cb.buffer.
+    {
+        CBDescriptor cb_src0;
+        cb_src0.total_size = num_tiles_per_shard * num_shards_per_core * input_single_tile_size;
+        cb_src0.core_ranges = grid;
+        cb_src0.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        });
+        cb_src0.buffer = src0_buffer;
+        desc.cbs.push_back(std::move(cb_src0));
+    }
 
-    // Reader kernel
-    KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp",
-        grid,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    // Sharded output CB — globally allocated to the output buffer.
+    {
+        CBDescriptor cb_output;
+        cb_output.total_size = num_tiles_per_shard * num_shards_per_core * output_single_tile_size;
+        cb_output.core_ranges = grid;
+        cb_output.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        });
+        cb_output.buffer = dst_buffer;
+        desc.cbs.push_back(std::move(cb_output));
+    }
 
-    // Writer compile-time args
+    std::vector<uint32_t> reader_compile_time_args = {src0_cb_index};
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = grid;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
     std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = grid;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    // Writer kernel
-    KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp",
-        grid,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
-
-    // Compute compile-time args
     std::vector<uint32_t> compute_compile_time_args = {num_tiles_per_block, src0_cb_index, output_cb_index};
 
-    // Compute kernel
-    std::map<std::string, std::string> compute_kernel_defines;
+    std::vector<std::pair<std::string, std::string>> compute_kernel_defines;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32 || a.dtype() == DataType::FLOAT32) {
-        compute_kernel_defines["DST_ACCUM_MODE"] = "1";
+        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
     }
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_dest_acc_en) {
-        unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
     }
-    std::string compute_kernel(
-        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp");
-    KernelHandle untilize_kernel_id = CreateKernel(
-        program,
-        compute_kernel,
-        grid,
-        ComputeConfig{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .compile_args = compute_compile_time_args,
-            .defines = compute_kernel_defines});
+
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = grid;
+    compute_desc.compile_time_args = std::move(compute_compile_time_args);
+    compute_desc.defines = std::move(compute_kernel_defines);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
 
     // Run-time args
     auto cores = corerange_to_cores(grid, std::nullopt, orientation == ShardOrientation::ROW_MAJOR);
     auto page_mapping = distribution_spec.compute_page_mapping();
     const auto& mapped_cores = page_mapping.all_cores;
-    for (auto core : cores) {
+    for (const auto& core : cores) {
         auto core_it = std::find(mapped_cores.begin(), mapped_cores.end(), core);
         uint32_t num_blocks_to_process = 0;
         uint32_t num_tiles_to_process = 0;
@@ -148,36 +152,18 @@ UntilizeMultiCoreInputAndOutputNDShardTypeAndShardSpecIdenticalProgramFactory::c
             num_tiles_to_process = num_tiles_per_block * num_blocks_to_process;
         }
 
-        // Reader run-time args
-        std::vector<uint32_t> reader_run_time_args = {num_tiles_to_process};
-
-        // Writer run-time args
-        std::vector<uint32_t> writer_run_time_args = {num_tiles_to_process};
-
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_run_time_args);
-
-        // Compute run-time args
-        std::vector<uint32_t> compute_run_time_args = {num_blocks_to_process};
-        tt::tt_metal::SetRuntimeArgs(program, untilize_kernel_id, core, compute_run_time_args);
-
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_run_time_args);
+        // Sharded readers/writers consume only the (per-launch) tile count; no Buffer* slot is
+        // needed because the CB itself carries the buffer binding.
+        reader_desc.emplace_runtime_args(core, {num_tiles_to_process});
+        compute_desc.emplace_runtime_args(core, {num_blocks_to_process});
+        writer_desc.emplace_runtime_args(core, {num_tiles_to_process});
     }
 
-    return cached_program_t{std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id, cb_src0, cb_output}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
 }
 
-void UntilizeMultiCoreInputAndOutputNDShardTypeAndShardSpecIdenticalProgramFactory::override_runtime_arguments(
-    UntilizeMultiCoreInputAndOutputNDShardTypeAndShardSpecIdenticalProgramFactory::cached_program_t& cached_program,
-    const UntilizeOperationAttributes& /*operation_attributes*/,
-    const UntilizeTensorArgs& tensor_args,
-    const UntilizeTensorReturnValue& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& cb_src0 = cached_program.shared_variables.cb_src0;
-    auto& cb_output = cached_program.shared_variables.cb_output;
-    auto* src_buffer = tensor_args.input.buffer();
-    auto* dst_buffer = tensor_return_value.buffer();
-
-    UpdateDynamicCircularBufferAddress(program, cb_src0, *src_buffer);
-    UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
-}
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.hpp
@@ -4,31 +4,16 @@
 
 #pragma once
 
-#include "ttnn/operation.hpp"
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/data_movement/untilize/device/untilize_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct UntilizeMultiCoreInputAndOutputNDShardTypeAndShardSpecIdenticalProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-        tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-        tt::tt_metal::CBHandle cb_src0{};
-        tt::tt_metal::CBHandle cb_output{};
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const UntilizeOperationAttributes& operation_attributes,
         const UntilizeTensorArgs& tensor_args,
-        const UntilizeTensorReturnValue& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const UntilizeOperationAttributes& operation_attributes,
-        const UntilizeTensorArgs& tensor_args,
-        const UntilizeTensorReturnValue& tensor_return_value);
+        UntilizeTensorReturnValue& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.cpp
@@ -2,42 +2,35 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
-#include "ttnn/operations/cb_utils.hpp"
-#include "ttnn/operations/math.hpp"
+#include "untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.hpp"
+
 #include "ttnn/common/constants.hpp"
-#include "ttnn/operation.hpp"
-#include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
-#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include "untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
-UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory::cached_program_t
-UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory::create(
+
+ProgramDescriptor UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory::create_descriptor(
     const UntilizeOperationAttributes& operation_attributes,
     const UntilizeTensorArgs& tensor_args,
-    const UntilizeTensorReturnValue& tensor_return_value) {
-    tt::tt_metal::Program program{};
-
+    UntilizeTensorReturnValue& tensor_return_value) {
     const auto& a = tensor_args.input;
-    const auto& output = tensor_return_value;
+    const Tensor& output = tensor_return_value;
     const auto& fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
 
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
-    tt::tt_metal::Buffer* src0_buffer = a.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    Buffer* src0_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     const auto& tile_shape = a.tensor_spec().tile().get_tile_shape();
@@ -52,105 +45,99 @@ UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory::cre
     uint32_t num_blocks_per_core = shard_height / tile_height;
     uint32_t num_tiles_per_shard = num_tiles_per_block * num_blocks_per_core;
 
-    // Input CB
-    auto [src0_cb_index, cb_src0] = create_cb(
-        tt::CBIndex::c_0,
-        program,
-        shard_spec.grid,
-        input_single_tile_size,
-        num_tiles_per_shard,
-        input_cb_data_format,
-        src0_buffer);
+    const uint32_t src0_cb_index = tt::CBIndex::c_0;
+    const uint32_t output_cb_index = tt::CBIndex::c_16;
 
-    // Output CB
-    auto [output_cb_index, cb_output] = create_cb(
-        tt::CBIndex::c_16,
-        program,
-        shard_spec.grid,
-        output_single_tile_size,
-        num_tiles_per_shard,
-        output_cb_data_format,
-        dst_buffer);
+    ProgramDescriptor desc;
 
-    // Reader compile-time args
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_cb_index};
+    // Sharded input CB — globally allocated to the input buffer; framework patches
+    // the CB address on cache hits via cb.buffer.
+    {
+        CBDescriptor cb_src0;
+        cb_src0.total_size = num_tiles_per_shard * input_single_tile_size;
+        cb_src0.core_ranges = shard_spec.grid;
+        cb_src0.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        });
+        cb_src0.buffer = src0_buffer;
+        desc.cbs.push_back(std::move(cb_src0));
+    }
 
-    // Reader kernel
-    KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp",
-        shard_spec.grid,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    // Sharded output CB — globally allocated to the output buffer.
+    {
+        CBDescriptor cb_output;
+        cb_output.total_size = num_tiles_per_shard * output_single_tile_size;
+        cb_output.core_ranges = shard_spec.grid;
+        cb_output.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        });
+        cb_output.buffer = dst_buffer;
+        desc.cbs.push_back(std::move(cb_output));
+    }
 
-    // Writer compile-time args
-    std::vector<uint32_t> writer_compile_time_args = {(uint32_t)output_cb_index};
+    std::vector<uint32_t> reader_compile_time_args = {src0_cb_index};
 
-    // Writer kernel
-    KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp",
-        shard_spec.grid,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = shard_spec.grid;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
-    // Compute compile-time args
+    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = shard_spec.grid;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
     std::vector<uint32_t> compute_compile_time_args = {
-        (uint32_t)num_blocks_per_core,
-        (uint32_t)num_tiles_per_block,
-        (uint32_t)src0_cb_index,
-        (uint32_t)output_cb_index};
+        num_blocks_per_core, num_tiles_per_block, src0_cb_index, output_cb_index};
 
-    // Compute kernel
-    std::map<std::string, std::string> compute_kernel_defines;
+    std::vector<std::pair<std::string, std::string>> compute_kernel_defines;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32 || a.dtype() == DataType::FLOAT32) {
-        compute_kernel_defines["DST_ACCUM_MODE"] = "1";
+        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
     }
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_dest_acc_en) {
-        unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
     }
-    std::string compute_kernel("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
-    CreateKernel(
-        program,
-        compute_kernel,
-        shard_spec.grid,
-        ComputeConfig{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-            .compile_args = compute_compile_time_args,
-            .defines = compute_kernel_defines});
 
-    // Run-time args
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = shard_spec.grid;
+    compute_desc.compile_time_args = std::move(compute_compile_time_args);
+    compute_desc.defines = std::move(compute_kernel_defines);
+    compute_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    };
+
+    // Sharded readers/writers consume only the (constant per-launch) num_tiles_per_shard
+    // count; no Buffer* slot is needed because the CB itself carries the buffer binding.
     auto cores =
         corerange_to_cores(shard_spec.grid, std::nullopt, shard_spec.orientation == ShardOrientation::ROW_MAJOR);
-    for (auto core : cores) {
-        // Reader run-time args
+    for (const auto& core : cores) {
         uint32_t num_tiles_to_read = num_tiles_per_block * num_blocks_per_core;
-        std::vector<uint32_t> reader_run_time_args = {num_tiles_to_read};
-
-        // Writer run-time args
         uint32_t num_tiles_to_write = num_tiles_per_block * num_blocks_per_core;
-        std::vector<uint32_t> writer_run_time_args = {num_tiles_to_write};
-
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_run_time_args);
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_run_time_args);
+        reader_desc.emplace_runtime_args(core, {num_tiles_to_read});
+        writer_desc.emplace_runtime_args(core, {num_tiles_to_write});
     }
 
-    return UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory::cached_program_t{
-        std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id, cb_src0, cb_output}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
 }
 
-void UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory::override_runtime_arguments(
-    UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory::cached_program_t& cached_program,
-    const UntilizeOperationAttributes& /*operation_attributes*/,
-    const UntilizeTensorArgs& tensor_args,
-    const UntilizeTensorReturnValue& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& cb_src0 = cached_program.shared_variables.cb_src0;
-    auto& cb_output = cached_program.shared_variables.cb_output;
-    auto* src_buffer = tensor_args.input.buffer();
-    auto* dst_buffer = tensor_return_value.buffer();
-
-    UpdateDynamicCircularBufferAddress(program, cb_src0, *src_buffer);
-    UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
-}
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.hpp
@@ -4,31 +4,16 @@
 
 #pragma once
 
-#include "ttnn/operation.hpp"
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/data_movement/untilize/device/untilize_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory {
-    struct shared_variables_t {
-        tt::tt_metal::KernelHandle unary_reader_kernel_id{};
-        tt::tt_metal::KernelHandle unary_writer_kernel_id{};
-        tt::tt_metal::CBHandle cb_src0{};
-        tt::tt_metal::CBHandle cb_output{};
-    };
-
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const UntilizeOperationAttributes& operation_attributes,
         const UntilizeTensorArgs& tensor_args,
-        const UntilizeTensorReturnValue& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const UntilizeOperationAttributes& operation_attributes,
-        const UntilizeTensorArgs& tensor_args,
-        const UntilizeTensorReturnValue& tensor_return_value);
+        UntilizeTensorReturnValue& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
@@ -2,42 +2,40 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/operation.hpp"
-#include "ttnn/operations/cb_utils.hpp"
-#include "ttnn/operations/math.hpp"
+#include "untilize_multi_core_nd_shard_input_program_factory.hpp"
+
 #include "ttnn/common/constants.hpp"
-#include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+#include "ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
+
+#include <tt-metalium/buffer_distribution_spec.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/buffer_distribution_spec.hpp>
-#include "untilize_multi_core_nd_shard_input_program_factory.hpp"
-#include "ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp"
+#include <tt-metalium/work_split.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-UntilizeMultiCoreNDShardInputProgramFactory::cached_program_t UntilizeMultiCoreNDShardInputProgramFactory::create(
+ProgramDescriptor UntilizeMultiCoreNDShardInputProgramFactory::create_descriptor(
     const UntilizeOperationAttributes& operation_attributes,
     const UntilizeTensorArgs& tensor_args,
-    const UntilizeTensorReturnValue& output) {
-    tt::tt_metal::Program program{};
-
+    UntilizeTensorReturnValue& tensor_return_value) {
     const auto& a = tensor_args.input;
+    const Tensor& output = tensor_return_value;
     const auto& fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
-    tt::tt_metal::Buffer* src0_buffer = a.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    Buffer* src0_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     uint32_t tensor_width = a.padded_shape()[-1];
@@ -77,6 +75,11 @@ UntilizeMultiCoreNDShardInputProgramFactory::cached_program_t UntilizeMultiCoreN
     uint32_t num_blocks_per_shard = num_planes_per_shard * num_blocks_per_shard_plane;
     uint32_t num_input_blocks_per_full_core = groups.num_shards_per_core_in_group_1 * num_blocks_per_shard;
 
+    const uint32_t src0_cb_index = tt::CBIndex::c_0;
+    const uint32_t output_cb_index = tt::CBIndex::c_16;
+
+    ProgramDescriptor desc;
+
     // Input CB
     uint32_t input_cb_num_tiles;
     if (num_input_blocks_per_full_core == 1) {
@@ -84,13 +87,15 @@ UntilizeMultiCoreNDShardInputProgramFactory::cached_program_t UntilizeMultiCoreN
     } else {
         input_cb_num_tiles = num_tiles_per_input_block * 2;
     }
-    auto [src0_cb_index, cb_src0] = create_cb(
-        tt::CBIndex::c_0,
-        program,
-        compute_core_range,
-        input_single_tile_size,
-        input_cb_num_tiles,
-        input_cb_data_format);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = input_cb_num_tiles * input_single_tile_size,
+        .core_ranges = compute_core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
 
     // Output CB
     uint32_t output_cb_num_tiles;
@@ -101,27 +106,28 @@ UntilizeMultiCoreNDShardInputProgramFactory::cached_program_t UntilizeMultiCoreN
         // Double buffer if the core is processing 2+ blocks
         output_cb_num_tiles = num_tiles_per_input_block * 2;
     }
-    auto [output_cb_index, cb_output] = create_cb(
-        tt::CBIndex::c_16,
-        program,
-        compute_core_range,
-        output_single_tile_size,
-        output_cb_num_tiles,
-        output_cb_data_format);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = output_cb_num_tiles * output_single_tile_size,
+        .core_ranges = compute_core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
 
     // Reader compile-time args and kernel
-    KernelHandle unary_reader_kernel_id;
     std::vector<uint32_t> reader_compile_time_args = {
-        (uint32_t)src0_cb_index,
-        (uint32_t)num_tiles_per_input_block,
-        (uint32_t)num_shards,
-        (uint32_t)num_compute_cores};
+        src0_cb_index, num_tiles_per_input_block, num_shards, num_compute_cores};
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    unary_reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_nd_sharded_blocks.cpp",
-        compute_core_range,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_nd_sharded_blocks.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = compute_core_range;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
     // Writer compile-time args
     uint32_t output_element_size = output.element_size();
@@ -143,67 +149,62 @@ UntilizeMultiCoreNDShardInputProgramFactory::cached_program_t UntilizeMultiCoreN
     uint32_t num_cols_per_output_block = output_page_width;
     uint32_t output_stick_size = num_cols_per_output_block * output_element_size;
     std::vector<uint32_t> writer_compile_time_args = {
-        (uint32_t)output_cb_index,
-        (uint32_t)output_stick_size,
-        (uint32_t)tile_height,
-        (uint32_t)num_tiles_per_input_block,
-        (uint32_t)output_num_blocks_across_width,
-        (uint32_t)output_element_size,
-        (uint32_t)num_cols_per_input_block,
-        (uint32_t)num_cols_per_output_block,
-        (uint32_t)input_single_tile_size,
-        (uint32_t)num_shards,
-        (uint32_t)num_compute_cores,
-        (uint32_t)num_tiles_per_input_row,
-        (uint32_t)tile_width,
-        (uint32_t)output_tensor_width,
-        (uint32_t)output_tensor_height,
+        output_cb_index,
+        output_stick_size,
+        tile_height,
+        num_tiles_per_input_block,
+        output_num_blocks_across_width,
+        output_element_size,
+        num_cols_per_input_block,
+        num_cols_per_output_block,
+        input_single_tile_size,
+        num_shards,
+        num_compute_cores,
+        num_tiles_per_input_row,
+        tile_width,
+        output_tensor_width,
+        output_tensor_height,
     };
 
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-
     TensorAccessorArgs(*src0_buffer)
         .append_to(writer_compile_time_args);  // For ND sharded input, we need info on the input buffer distribution
 
-    // Writer kernel
-    std::string writer_kernel_file =
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/"
         "writer_unary_stick_layout_split_rows_multi_core_nd_shard.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = compute_core_range;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
-    KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        writer_kernel_file,
-        compute_core_range,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
-
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_dest_acc_en) {
-        unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
     }
 
-    // Compute kernel file
-    std::string compute_kernel(
-        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp");
-
-    // Compute compile-time args and kernel
+    // Compute kernel
     // Note: This condition is always true for sharded input
-    KernelHandle untilize_kernel_id = 0;
-    std::map<std::string, std::string> compute_kernel_defines;
+    std::vector<std::pair<std::string, std::string>> compute_kernel_defines;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32 || a.dtype() == DataType::FLOAT32) {
-        compute_kernel_defines["DST_ACCUM_MODE"] = "1";
+        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
     }
+    std::optional<KernelDescriptor> compute_desc;
     if (!compute_core_range.ranges().empty()) {
-        std::vector<uint32_t> compute_compile_time_args = {
-            (uint32_t)num_tiles_per_input_block, (uint32_t)src0_cb_index, (uint32_t)output_cb_index};
-        untilize_kernel_id = CreateKernel(
-            program,
-            compute_kernel,
-            compute_core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = compute_compile_time_args,
-                .defines = compute_kernel_defines});
+        std::vector<uint32_t> compute_compile_time_args = {num_tiles_per_input_block, src0_cb_index, output_cb_index};
+        KernelDescriptor cd;
+        cd.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp";
+        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cd.core_ranges = compute_core_range;
+        cd.compile_time_args = std::move(compute_compile_time_args);
+        cd.defines = std::move(compute_kernel_defines);
+        cd.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+        };
+        compute_desc = std::move(cd);
     }
 
     // Run-time args
@@ -215,7 +216,7 @@ UntilizeMultiCoreNDShardInputProgramFactory::cached_program_t UntilizeMultiCoreN
     // page_mapping.core_host_page_indices[core_id] contains host page indices for all device pages on that core,
     // with UncompressedBufferPageMapping::PADDING indicating padding pages
     uint32_t start_shard_id = 0;
-    for (auto core : ordered_cores_with_data) {
+    for (const auto& core : ordered_cores_with_data) {
         auto core_it = std::find(mapped_cores.begin(), mapped_cores.end(), core);
         uint32_t num_input_blocks_to_process = 0;
 
@@ -239,48 +240,28 @@ UntilizeMultiCoreNDShardInputProgramFactory::cached_program_t UntilizeMultiCoreN
                 page_offset += num_tiles_per_input_block;
             }
         }
-        // Reader run-time args
-        std::vector<uint32_t> reader_run_time_args = {src0_buffer->address(), start_shard_id};
 
-        // Writer run-time args
-        std::vector<uint32_t> writer_run_time_args = {dst_buffer->address(), src0_buffer->address(), start_shard_id};
+        // Reader run-time args — Buffer* slot auto-registers as a BufferBinding so the
+        // framework patches addresses on cache hits.
+        reader_desc.emplace_runtime_args(core, {src0_buffer, start_shard_id});
+
+        // Writer run-time args (writer reads from input buffer too for ND sharded info)
+        writer_desc.emplace_runtime_args(core, {dst_buffer, src0_buffer, start_shard_id});
         start_shard_id++;
 
         // Compute run-time args
-        std::vector<uint32_t> compute_run_time_args = {num_input_blocks_to_process};
-        // Set run-time arg
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_run_time_args);
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_run_time_args);
-        tt::tt_metal::SetRuntimeArgs(program, untilize_kernel_id, core, compute_run_time_args);
+        if (compute_desc.has_value()) {
+            compute_desc->emplace_runtime_args(core, {num_input_blocks_to_process});
+        }
     }
 
-    return cached_program_t{
-        std::move(program),
-        {unary_reader_kernel_id, unary_writer_kernel_id, cb_src0, cb_output, ordered_cores_with_data}};
-}
-
-void UntilizeMultiCoreNDShardInputProgramFactory::override_runtime_arguments(
-    UntilizeMultiCoreNDShardInputProgramFactory::cached_program_t& cached_program,
-    const UntilizeOperationAttributes& /*operation_attributes*/,
-    const UntilizeTensorArgs& tensor_args,
-    const UntilizeTensorReturnValue& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    auto& cores_with_runtime_args = cached_program.shared_variables.cores_with_runtime_args;
-
-    auto* src_buffer = tensor_args.input.buffer();
-    auto* dst_buffer = tensor_return_value.buffer();
-
-    // Reader and Writer update buffer addresses
-    auto& runtime_args_by_core_reader = GetRuntimeArgs(program, reader_kernel_id);
-    auto& runtime_args_by_core_writer = GetRuntimeArgs(program, writer_kernel_id);
-    for (const CoreCoord& core : cores_with_runtime_args) {
-        auto& runtime_args_reader = runtime_args_by_core_reader[core.x][core.y];
-        runtime_args_reader[0] = src_buffer->address();
-        auto& runtime_args_writer = runtime_args_by_core_writer[core.x][core.y];
-        runtime_args_writer[0] = dst_buffer->address();
-        runtime_args_writer[1] = src_buffer->address();
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    if (compute_desc.has_value()) {
+        desc.kernels.push_back(std::move(*compute_desc));
     }
+
+    return desc;
 }
+
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.hpp
@@ -4,25 +4,16 @@
 
 #pragma once
 
-#include "ttnn/operation.hpp"
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/tensor/tensor.hpp"
 #include "../untilize_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct UntilizeMultiCoreNDShardInputProgramFactory {
-    using shared_variables_t = UntilizeSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const UntilizeOperationAttributes& operation_attributes,
         const UntilizeTensorArgs& tensor_args,
-        const UntilizeTensorReturnValue& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const UntilizeOperationAttributes& operation_attributes,
-        const UntilizeTensorArgs& tensor_args,
-        const UntilizeTensorReturnValue& tensor_return_value);
+        UntilizeTensorReturnValue& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_parallelize_column_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_parallelize_column_program_factory.cpp
@@ -2,60 +2,50 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/reflection.hpp>
-#include "ttnn/operations/cb_utils.hpp"
-#include "ttnn/operations/math.hpp"
+#include "untilize_multi_core_parallelize_column_program_factory.hpp"
+
 #include "ttnn/common/constants.hpp"
-#include "ttnn/operation.hpp"
-#include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include "untilize_multi_core_parallelize_column_program_factory.hpp"
+#include <tt-metalium/work_split.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-UntilizeMultiCoreParallelizeColumnProgramFactory::cached_program_t
-UntilizeMultiCoreParallelizeColumnProgramFactory::create(
+ProgramDescriptor UntilizeMultiCoreParallelizeColumnProgramFactory::create_descriptor(
     const UntilizeOperationAttributes& operation_attributes,
     const UntilizeTensorArgs& tensor_args,
-    const UntilizeTensorReturnValue& tensor_return_value) {
-    tt::tt_metal::Program program{};
-
+    UntilizeTensorReturnValue& tensor_return_value) {
     const auto& a = tensor_args.input;
-    const auto& output = tensor_return_value;
+    const Tensor& output = tensor_return_value;
     const auto& fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
     IDevice* device = a.device();
-
     auto grid_size = device->compute_with_storage_grid_size();
 
     uint32_t ntiles = a.physical_volume() / TILE_HW;
     uint32_t ncores_x = grid_size.x;
     uint32_t ncores_y = grid_size.y;
-    // uint32_t ncores_x = 2;
 
     ncores_x = untilize_helper::get_largest_divisor(ntiles, ncores_x);
-    // uint32_t ncores_y = 1;
     ncores_y = untilize_helper::get_largest_divisor(ntiles, ncores_y, ncores_x);
 
     TT_ASSERT(ntiles % (ncores_x * ncores_y) == 0);
     uint32_t ntiles_per_block = ntiles / (ncores_x * ncores_y);
 
     // TODO increase block size to increase untilize performance, currently each untilize block is a single tile
-    // uint32_t max_l1_size = a.device()->l1_size_per_core() / 2 -
-    // a.device()->allocator()->get_base_allocator_addr(HalMemType::L1); uint32_t max_tiles =
-    // (max_l1_size / (input_single_tile_size + output_single_tile_size))/2;  // 2 CBs, double buffering each
     uint32_t max_tiles = 1;
 
     uint32_t stick_s = a.padded_shape()[-1];
@@ -77,86 +67,112 @@ UntilizeMultiCoreParallelizeColumnProgramFactory::create(
         ttnn::split_blocks_for_tilize(CoreCoord(ncores_x, ncores_y), nblocks);
 
     bool row_major = true;
-    std::vector<CoreCoord> cores_with_rtargs;
-
-    uint32_t num_input_tiles = ntiles_per_block * 2;
-    auto [src0_cb_index, cb_src0] = create_cb(
-        tt::CBIndex::c_0, program, all_cores, input_single_tile_size, num_input_tiles, input_cb_data_format, nullptr);
-
-    uint32_t num_output_tiles = ntiles_per_block * 2;
-    auto [output_cb_index, cb_output] = create_cb(
-        tt::CBIndex::c_16,
-        program,
-        all_cores,
-        output_single_tile_size,
-        num_output_tiles,
-        output_cb_data_format,
-        nullptr);
 
     Buffer* src0_buffer = a.buffer();
     Buffer* dst_buffer = output.buffer();
+
+    const uint32_t src0_cb_index = tt::CBIndex::c_0;
+    const uint32_t output_cb_index = tt::CBIndex::c_16;
+
+    ProgramDescriptor desc;
+
+    uint32_t num_input_tiles = ntiles_per_block * 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * input_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+
+    uint32_t num_output_tiles = ntiles_per_block * 2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_output_tiles * output_single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
+
     std::vector<uint32_t> reader_ct_args;
     TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
 
-    auto unary_reader_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp",
-        all_cores,
-        ReaderDataMovementConfig(reader_ct_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
     std::vector<uint32_t> writer_ct_args = {stick_size};
     TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
 
-    auto unary_writer_kernel_id = CreateKernel(
-        program,
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/"
-        "writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp",
-        all_cores,
-        WriterDataMovementConfig(writer_ct_args));
+        "writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     /** compute
      */
     std::vector<uint32_t> compute_args = {
-        (uint32_t)nblocks_per_core,  // per_core_block_cnt
-        (uint32_t)ntiles_per_block,  // per_block_ntiles
-        (uint32_t)src0_cb_index,
-        (uint32_t)output_cb_index};
+        nblocks_per_core,  // per_core_block_cnt
+        ntiles_per_block,  // per_block_ntiles
+        src0_cb_index,
+        output_cb_index};
     std::vector<uint32_t> compute_args_cliff = {
-        (uint32_t)nblocks_per_core_cliff,
-        (uint32_t)ntiles_per_block,  // per_block_ntiles
-        (uint32_t)src0_cb_index,
-        (uint32_t)output_cb_index};
+        nblocks_per_core_cliff,
+        ntiles_per_block,  // per_block_ntiles
+        src0_cb_index,
+        output_cb_index};
 
-    std::map<std::string, std::string> compute_kernel_defines;
+    std::vector<std::pair<std::string, std::string>> compute_kernel_defines;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32 || a.dtype() == DataType::FLOAT32) {
-        compute_kernel_defines["DST_ACCUM_MODE"] = "1";
+        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
     }
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_dest_acc_en) {
-        unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
     }
-    std::string compute_kernel("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
+
+    const std::string compute_kernel_path =
+        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp";
+
+    std::optional<KernelDescriptor> compute_desc;
     if (!core_range.ranges().empty()) {
-        CreateKernel(
-            program,
-            compute_kernel,
-            core_range,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = compute_args,
-                .defines = compute_kernel_defines});
+        KernelDescriptor cd;
+        cd.kernel_source = compute_kernel_path;
+        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cd.core_ranges = core_range;
+        cd.compile_time_args = std::move(compute_args);
+        cd.defines = compute_kernel_defines;
+        cd.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+        };
+        compute_desc = std::move(cd);
     }
+    std::optional<KernelDescriptor> compute_cliff_desc;
     if (!core_range_cliff.ranges().empty()) {
-        CreateKernel(
-            program,
-            compute_kernel,
-            core_range_cliff,
-            ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .unpack_to_dest_mode = unpack_to_dest_mode,
-                .compile_args = compute_args_cliff,
-                .defines = compute_kernel_defines});
+        KernelDescriptor cd;
+        cd.kernel_source = compute_kernel_path;
+        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cd.core_ranges = core_range_cliff;
+        cd.compile_time_args = std::move(compute_args_cliff);
+        cd.defines = std::move(compute_kernel_defines);
+        cd.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+        };
+        compute_cliff_desc = std::move(cd);
     }
 
     uint32_t ncores_full = ncores;
@@ -172,29 +188,28 @@ UntilizeMultiCoreParallelizeColumnProgramFactory::create(
 
     auto nsticks_per_core = ntiles_per_column * TILE_HEIGHT;
 
-    for (auto core : cores) {
+    for (const auto& core : cores) {
         if (!full_cores.contains(core)) {
             continue;
         }
-        // reader runtime args
-        auto ntiles_per_core = ntiles_per_block * nblocks_per_core;
-        const std::array reader_rt_args = {
-            src0_buffer->address(),  // src_addr
-            ntiles_per_core,         // ntiles
-            tile_start_id            // start_id
-        };
+        // reader runtime args — Buffer* slot auto-registers as a BufferBinding so the
+        // framework patches addresses on cache hits.
+        uint32_t ntiles_per_core = ntiles_per_block * nblocks_per_core;
+        reader_desc.emplace_runtime_args(
+            core,
+            {src0_buffer,      // src_addr
+             ntiles_per_core,  // ntiles
+             tile_start_id});  // start_id
 
-        const std::array writer_rt_args = {
-            dst_buffer->address(),               // dst_addr
-            nsticks_per_core,                    // nsticks
-            ntiles_per_core,                     // ntiles_per_core
-            TILE_WIDTH * output.element_size(),  // tile_width_size
-            std::uint32_t{0},                    // start stick id = 0, since parallelizing on height
-            offset_within_stick};
+        writer_desc.emplace_runtime_args(
+            core,
+            {dst_buffer,                                                 // dst_addr
+             nsticks_per_core,                                           // nsticks
+             ntiles_per_core,                                            // ntiles_per_core
+             static_cast<uint32_t>(TILE_WIDTH * output.element_size()),  // tile_width_size
+             std::uint32_t{0},                                           // start stick id = 0
+             offset_within_stick});
 
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
-        cores_with_rtargs.push_back(core);
         tile_start_id += ntiles_per_core;
         offset_within_stick += ntiles_per_core * TILE_WIDTH * output.element_size();
     }
@@ -202,56 +217,34 @@ UntilizeMultiCoreParallelizeColumnProgramFactory::create(
         // last core is the cliff core with nblocks_per_core_cliff blocks
         CoreCoord core = row_major ? CoreCoord{ncores_full % ncores_x, ncores_full / ncores_x}
                                    : CoreCoord{ncores_full / ncores_y, ncores_full % ncores_y};
-        // reader runtime args
-        auto ntiles_per_core_cliff = ntiles_per_block * nblocks_per_core_cliff;
-        const std::array reader_rt_args = {
-            src0_buffer->address(),  // src_addr
-            ntiles_per_core_cliff,   // ntiles
-            tile_start_id            // start_id
-        };
+        uint32_t ntiles_per_core_cliff = ntiles_per_block * nblocks_per_core_cliff;
+        reader_desc.emplace_runtime_args(
+            core,
+            {src0_buffer,            // src_addr
+             ntiles_per_core_cliff,  // ntiles
+             tile_start_id});        // start_id
 
-        const std::array writer_rt_args = {
-            dst_buffer->address(),               // dst_addr
-            nsticks_per_core,                    // nsticks
-            stick_size,                          // block_size_nbytes
-            ntiles_per_core_cliff,               // ntiles_per_core
-            TILE_WIDTH * output.element_size(),  // tile_width_size
-            std::uint32_t{0},                    // start stick id = 0, since parallelizing on height
-            offset_within_stick};
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
+        writer_desc.emplace_runtime_args(
+            core,
+            {dst_buffer,                                                 // dst_addr
+             nsticks_per_core,                                           // nsticks
+             stick_size,                                                 // block_size_nbytes
+             ntiles_per_core_cliff,                                      // ntiles_per_core
+             static_cast<uint32_t>(TILE_WIDTH * output.element_size()),  // tile_width_size
+             std::uint32_t{0},                                           // start stick id = 0
+             offset_within_stick});
     }
 
-    return UntilizeMultiCoreParallelizeColumnProgramFactory::cached_program_t{
-        std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id, cb_src0, cb_output, cores_with_rtargs}};
-}
-
-void UntilizeMultiCoreParallelizeColumnProgramFactory::override_runtime_arguments(
-    UntilizeMultiCoreParallelizeColumnProgramFactory::cached_program_t& cached_program,
-    const UntilizeOperationAttributes& /*operation_attributes*/,
-    const UntilizeTensorArgs& tensor_args,
-    const UntilizeTensorReturnValue& tensor_return_value) {
-    auto& program = cached_program.program;
-    auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-    auto& cores_with_rtargs = cached_program.shared_variables.cores_with_runtime_args;
-    auto* src_buffer = tensor_args.input.buffer();
-    auto* dst_buffer = tensor_return_value.buffer();
-    {
-        auto& runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
-        for (const CoreCoord& core : cores_with_rtargs) {
-            auto& runtime_args = runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = src_buffer->address();
-        }
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    if (compute_desc.has_value()) {
+        desc.kernels.push_back(std::move(*compute_desc));
+    }
+    if (compute_cliff_desc.has_value()) {
+        desc.kernels.push_back(std::move(*compute_cliff_desc));
     }
 
-    {
-        auto& runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
-        for (const CoreCoord& core : cores_with_rtargs) {
-            auto& runtime_args = runtime_args_by_core[core.x][core.y];
-            runtime_args[0] = dst_buffer->address();
-        }
-    }
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_parallelize_column_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_parallelize_column_program_factory.hpp
@@ -4,25 +4,16 @@
 
 #pragma once
 
-#include "ttnn/operation.hpp"
-#include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/data_movement/untilize/device/untilize_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct UntilizeMultiCoreParallelizeColumnProgramFactory {
-    using shared_variables_t = UntilizeSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const UntilizeOperationAttributes& operation_attributes,
         const UntilizeTensorArgs& tensor_args,
-        const UntilizeTensorReturnValue& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const UntilizeOperationAttributes& operation_attributes,
-        const UntilizeTensorArgs& tensor_args,
-        const UntilizeTensorReturnValue& tensor_return_value);
+        UntilizeTensorReturnValue& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation_types.hpp
@@ -35,13 +35,4 @@ using UntilizeTensorReturnValue = Tensor;
 using UntilizeSpecReturnValue = ttnn::TensorSpec;
 using UntilizeShapeReturnValue = ttnn::Shape;
 
-struct UntilizeSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id{};
-    tt::tt_metal::KernelHandle writer_kernel_id{};
-    tt::tt_metal::CBHandle cb_src0{};
-    tt::tt_metal::CBHandle cb_output{};
-    std::vector<CoreCoord> cores_with_runtime_args;
-    bool has_uneven_sharding = false;
-};
-
 }  // namespace ttnn::prim


### PR DESCRIPTION
## Summary

Migrates 25 data_movement sub-ops to ProgramDescriptor.

Each Factory now exposes a single `static create_descriptor(...)` returning `ProgramDescriptor`; `cached_program_t` / `shared_variables_t` / `create()` / `override_runtime_arguments()` are dropped. Buffer-address patching on cache hits is handled by the framework via BufferBinding (`emplace_runtime_args(core, {Buffer*, ...})`) and dynamic CB binding (`CBDescriptor::buffer = tensor.buffer()` on sharded factories).

## Ops migrated

- **fill**: fill_rm, fill_pad
- **moe**: moe_routing_remap, moe_expert_token_remap
- **core**: gather, scatter, split, repeat, fold, move, sort, indexed_fill, non_zero_indices, pad
- **layout**: tilize, untilize, tilize_with_val_padding, untilize_with_unpadding, reshape_view, reshape_on_device
- **sharded**: interleaved_to_sharded, sharded_to_interleaved, reshard (5 sub-factories), interleaved_to_sharded_partial, sharded_to_interleaved_partial

Excluded:
- clone — in #42477
- slice, permute, transpose — assigned to mouliraj-mcw
- bcast, concat, copy — assigned to ctr-martemovTT

## Framework features used

- BufferBinding fast cache-hit patching (#42992)
- `prepare_resources` hook (#43675) — first real consumers: sort cross-core (lookup table) and reshape_view tiled (mapping tensor)
- Per-mesh-coord `create_descriptor` overload — moe_routing_remap, moe_expert_token_remap (per-coord compile-time args)

## Perf

Host-side dispatch, `n=2000` iter, `500` warmup, fresh process per op, 5 paired rounds, warmup outlier dropped, trimmed mean across stable runs:

| Op | Legacy | Migrated | Δ % |
|---|---|---|---|
| indexed_fill[2,1,32,32] | 20.57 us | 15.93 us | **−23%** |
| tilize[1,1,32,32] | 15.87 us | 16.16 us | +2% |
| move[1,1,32,32] | 3.50 us | 3.56 us | +2% |
| fill_rm[1,1,32,32] | 13.49 us | 14.25 us | +6% |
| fill_pad[17,17] | 6.33 us | 7.11 us | +12% |
| **average** | **11.95 us** | **11.40 us** | **−5%** |

Two methodology notes:
- `PYTHONPATH=<worktree>/ttnn` (note `/ttnn` suffix) is required for Python to actually load the worktree's `ttnn`. Without it, both legacy and migrated benches load `/home/diego/tt-metal`'s build and the comparison is meaningless.
- tilize bench is bimodal on this hardware (~15us / ~21us); a single paired sample can show ±17% noise. Multi-round paired averages collapse to ~flat.

## Tests

2,556 unit tests passing across 18 of 26 ops with single-device pytest coverage. moe_* require mesh-device CI.

## Framework-level changes carried with this PR

Three sub-microsecond cache-hit-path improvements squashed onto the framework-fast-path branch:
- Sort `rt_args` by `(is_common, kernel_idx, core, arg_idx)` in `resolve_bindings`; cache the live `RuntimeArgsData&` across consecutive same-`(kernel,core)` bindings in `apply_resolved_bindings`. Avoids redundant `GetRuntimeArgs` lookups when an op has multiple `Buffer*` slots per core.
- `collect_tensor_buffers` returns `ttsl::SmallVector<Buffer*, 16>` instead of heap `std::vector`; resolve/apply take `std::span<Buffer* const>`. Removes one heap alloc per cache hit.
- Typed `extract_tensor_buffers_t<T>` replaces the lambda + `visit_object_of_type<Tensor>` chain in `collect_tensor_buffers`. The compiler emits a straight-line walk of `tensor_args`'s Tensor fields per device-op type, no runtime visit indirection. Binary size delta: −0.04%.

Tracked in #43838. They are committed on `dgomez/descriptor-framework-fast-path-extensions`.

## Depends on
- #43675 (descriptor framework fast-path extensions). Will rebase off main once that merges.


- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/migrate-data-movement-batch1-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/migrate-data-movement-batch1-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/migrate-data-movement-batch1-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/migrate-data-movement-batch1-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/migrate-data-movement-batch1-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/migrate-data-movement-batch1-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/migrate-data-movement-batch1-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/migrate-data-movement-batch1-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/migrate-data-movement-batch1-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/migrate-data-movement-batch1-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/migrate-data-movement-batch1-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/migrate-data-movement-batch1-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/migrate-data-movement-batch1-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/migrate-data-movement-batch1-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/migrate-data-movement-batch1-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/migrate-data-movement-batch1-v2)

## Performance

data-movement family — 121 files migrated. Representative ops measured on WH B0 single device (N=20, 5 trials, warm cache):
- pad 1x1x32x32 → 1x1x64x64 bfloat16: 27034 ns ± 840 ns vs main 26772 ns ± 89 ns (+1.0%, noise)
- tilize 1x1x32x32 bfloat16: 18785 ns ± 791 ns vs main 19767 ns ± 2223 ns (−5.0%)
- fold 1x16x16x32 stride=2 bfloat16: 23940 ns ± 422 ns vs main 27458 ns ± 3809 ns (−12.8%) — fast cache-hit patching via emplace_runtime_args(Buffer*)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/migrate-data-movement-batch1-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/migrate-data-movement-batch1-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/migrate-data-movement-batch1-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/migrate-data-movement-batch1-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/migrate-data-movement-batch1-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/migrate-data-movement-batch1-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/migrate-data-movement-batch1-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/migrate-data-movement-batch1-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/migrate-data-movement-batch1-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/migrate-data-movement-batch1-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/migrate-data-movement-batch1-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/migrate-data-movement-batch1-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/migrate-data-movement-batch1-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/migrate-data-movement-batch1-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/migrate-data-movement-batch1-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/migrate-data-movement-batch1-v2)

