### PR TITLE
Remove typecast for dispatched_buffer from DeepSeek V3 Prefill MoE

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -464,19 +464,17 @@ class TtMoe(LightweightModule):
         # Squeeze the first two dimensions
 
         # Convert dispatched_buffer to TILE_LAYOUT for routed experts
-        dispatched_buffer = ttnn.to_layout(
-            ttnn.squeeze(ttnn.squeeze(dispatched_buffer, dim=0), dim=0), ttnn.TILE_LAYOUT
+        dispatched_buffer_tiled = ttnn.to_layout(
+            ttnn.squeeze(ttnn.squeeze(dispatched_buffer, dim=0), dim=0),
+            ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat8_b,
         )
-        logger.debug(f"[TtMoe.forward] dispatched_buffer_tiled shape: {dispatched_buffer.shape}")
+        logger.debug(f"[TtMoe.forward] dispatched_buffer_tiled shape: {dispatched_buffer_tiled.shape}")
 
-        expert_outputs = self.routed_expert(dispatched_buffer, tt_expert_token_counts, tt_expert_region_offsets)
+        expert_outputs = self.routed_expert(dispatched_buffer_tiled, tt_expert_token_counts, tt_expert_region_offsets)
 
         if not return_intermediates:
             dispatched_buffer = ttnn.deallocate(dispatched_buffer)
-        else:
-            # add squeezed dimenisions back for intermediates to match original dispatch output shape
-            dispatched_buffer = ttnn.unsqueeze(dispatched_buffer, dim=0)
-            dispatched_buffer = ttnn.unsqueeze(dispatched_buffer, dim=0)
 
         logger.debug(f"[TtMoe.forward] expert_outputs shape: {expert_outputs.shape}")
 

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -467,15 +467,18 @@ class TtMoe(LightweightModule):
         dispatched_buffer_tiled = ttnn.to_layout(
             ttnn.squeeze(ttnn.squeeze(dispatched_buffer, dim=0), dim=0),
             ttnn.TILE_LAYOUT,
-            dtype=ttnn.bfloat8_b,
+            dtype=self.routed_expert.activations_dtype,
         )
-        logger.debug(f"[TtMoe.forward] dispatched_buffer_tiled shape: {dispatched_buffer_tiled.shape}")
 
-        expert_outputs = self.routed_expert(dispatched_buffer_tiled, tt_expert_token_counts, tt_expert_region_offsets)
-
+        # Free the original ROW_MAJOR DRAM buffer before entering routed_expert for clear state.
+        # When return_intermediates=True, keep it so the PCC check can compare against the
+        # bfloat16 torch reference (the tiled buffer may be bfloat8_b).
         if not return_intermediates:
             dispatched_buffer = ttnn.deallocate(dispatched_buffer)
 
+        logger.debug(f"[TtMoe.forward] dispatched_buffer_tiled shape: {dispatched_buffer_tiled.shape}")
+
+        expert_outputs = self.routed_expert(dispatched_buffer_tiled, tt_expert_token_counts, tt_expert_region_offsets)
         logger.debug(f"[TtMoe.forward] expert_outputs shape: {expert_outputs.shape}")
 
         # Add back the batch dimensions for combine

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -478,6 +478,12 @@ class TtMoe(LightweightModule):
 
         logger.debug(f"[TtMoe.forward] dispatched_buffer_tiled shape: {dispatched_buffer_tiled.shape}")
 
+        # NOTE: expert_outputs aliases dispatched_buffer_tiled — TtRoutedExpert.forward sets
+        # expert_outputs = dispatched_buffer and then writes per-expert FFN results back
+        # in-place via deepseek_prefill.insert. The two names point at the same device buffer.
+        # Therefore we must NOT call ttnn.deallocate(dispatched_buffer_tiled) here; doing so
+        # would free the storage that expert_outputs still depends on, and the subsequent
+        # ttnn.unsqueeze / combine_module calls would raise "Tensor is not allocated".
         expert_outputs = self.routed_expert(dispatched_buffer_tiled, tt_expert_token_counts, tt_expert_region_offsets)
         logger.debug(f"[TtMoe.forward] expert_outputs shape: {expert_outputs.shape}")
 


### PR DESCRIPTION
### Problem description
Unnecessary typecast from `BFLOAT16 TILE_LAYOUT` to `BFLOAT8_B TILE_LAYOUT`.

### What's changed
- Changed `ttnn.to_layout` to tilize `BFLOAT16 ROW_MAJOR` to `BFLAOT8_B TILE_LAYOUT`.

### Performance measurements on **test_ttnn_moe** bh-lb harvested 2-link


### DeepSeek CI

- [x] [![(T3K) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pmilojevic/typecast-dispatch-remove)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pmilojevic/typecast-dispatch-remove)
- [x] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pmilojevic/typecast-dispatch-remove)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pmilojevic/typecast-dispatch-remove)
- [x] [![Demo SP
Release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=pmilojevic/typecast-dispatch-remove)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:pmilojevic/typecast-dispatch-remove)
- [x] [![(Galaxy) DeepSeek Prefill
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=pmilojevic/typecast-dispatch-remove)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:pmilojevic/typecast-dispatch-remove)

### Performance measurements done on `test_ttnn_moe.py`

Mesh Config | Shape of input | Branch | Tilization | Typecast | Together
-- | -- | -- | -- | -- | --
linear-8-2link | (3200, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE, 256, 8, 5, GateComputeMode.DEVICE) | main | 9,219 µs | 6,356 µs | 15,575 us
mesh-4x2-2link | (3200, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE, 256, 8, 5, GateComputeMode.DEVICE) | main | 4,669 µs | 3,182 µs | 7,851 us
linear-8-2link | (1600, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE, 64, 8, 5, GateComputeMode.HOST_ALL) | main | 4,676 µs | 3,187 µs | 7,863 us
mesh-4x2-2link | (1600, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE, 64, 8, 5, GateComputeMode.HOST_ALL) | main | 2,384 µs | 1,597 µs | 3,981 us
linear-8-2link | (3200, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE, 256, 8, 5, GateComputeMode.DEVICE) | typecast removed | 6,641 µs | 0us | 6,641 µs
mesh-4x2-2link | (3200, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE, 256, 8, 5, GateComputeMode.DEVICE) | typecast removed | 3,318 µs | 0us | 3,318 µs
linear-8-2link | (1600, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE, 64, 8, 5, GateComputeMode.HOST_ALL) | typecast removed | 3,336 µs | 0us | 3,336 µs
mesh-4x2-2link | (1600, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE, 64, 8, 5, GateComputeMode.HOST_ALL) | typecast removed | 1,633 µs | 0us | 1,633 µs

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilojevic/typecast-dispatch-remove)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilojevic/typecast-dispatch-remove)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilojevic/typecast-dispatch-remove)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilojevic/typecast-dispatch-remove)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pmilojevic/typecast-dispatch-remove)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pmilojevic/typecast-dispatch-remove)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/typecast-dispatch-remove)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/typecast-dispatch-remove)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilojevic/typecast-dispatch-remove)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilojevic/typecast-dispatch-remove)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilojevic/typecast-dispatch-remove)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilojevic/typecast-dispatch-remove)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilojevic/typecast-dispatch-remove)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilojevic/typecast-dispatch-remove)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilojevic/typecast-dispatch-remove)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilojevic/typecast-dispatch-remove)