### PR TITLE
[Fix] Pick globally free semaphore ID for multi-range CoreRangeSets

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_semaphores.cpp
@@ -221,4 +221,25 @@ TEST_F(MeshDeviceFixture, TensixCreateMultipleSemaphoresOnSameCore) {
     EXPECT_EQ(sem6_id, 0);
 }
 
+TEST_F(MeshDeviceFixture, TensixCreateSemaphoreOnMultipleRanges) {
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    tt_metal::Program program = tt_metal::CreateProgram();
+    workload.add_program(device_range, std::move(program));
+    auto& program_ = workload.get_programs().at(device_range);
+
+    CoreCoord core_a(0, 0);
+    CoreCoord core_b(2, 0);
+    CoreCoord core_c(4, 0);
+
+    CoreRangeSet ac_set(std::set<CoreRange>{CoreRange(core_a), CoreRange(core_c)});
+    CoreRangeSet bc_set(std::set<CoreRange>{CoreRange(core_b), CoreRange(core_c)});
+    CoreRangeSet ab_set(std::set<CoreRange>{CoreRange(core_a), CoreRange(core_b)});
+
+    EXPECT_EQ(tt_metal::CreateSemaphore(program_, ac_set, 0), 0u);
+    EXPECT_EQ(tt_metal::CreateSemaphore(program_, bc_set, 0), 1u);
+    EXPECT_EQ(tt_metal::CreateSemaphore(program_, ab_set, 0), 2u);
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1471,11 +1471,9 @@ uint32_t detail::ProgramImpl::create_semaphore(const CoreRangeSet& crs, uint32_t
         MetalContext::instance().is_coord_in_range(crs.ranges().back().end_coord, core_type),
         "Coordinates out of range");
 
-    // The allocated ID must be free on every core in crs. Find the max ID that's free on each
-    // range (they each return the smallest free ID on their cores) and use that everywhere.
     std::optional<uint32_t> semaphore_id;
+    std::bitset<NUM_SEMAPHORES> used_semaphore_ids;
     for (const auto& core_range : crs.ranges()) {
-        std::vector<uint32_t> semaphore_histogram(NUM_SEMAPHORES, 0);
         for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
             for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                 CoreCoord logical_core(x, y);
@@ -1487,21 +1485,22 @@ uint32_t detail::ProgramImpl::create_semaphore(const CoreRangeSet& crs, uint32_t
                         NUM_SEMAPHORES);
                 }
                 for (const auto& semaphore : existing) {
-                    semaphore_histogram[semaphore.get().id()]++;
+                    used_semaphore_ids.set(semaphore.get().id());
                 }
             }
         }
-        std::optional<uint32_t> candidate;
-        for (uint32_t sem_id = 0; sem_id < semaphore_histogram.size(); sem_id++) {
-            if (semaphore_histogram[sem_id] == 0) {
-                candidate = sem_id;
-                break;
-            }
-        }
-        TT_FATAL(candidate.has_value(), "Unable to initialize semaphores on core range {}", core_range.str());
-        semaphore_id = semaphore_id.has_value() ? std::max(*semaphore_id, *candidate) : candidate;
     }
-    TT_FATAL(semaphore_id.has_value(), "Unable to initialize Semaphore!");
+    for (uint32_t sem_id = 0; sem_id < NUM_SEMAPHORES; sem_id++) {
+        if (!used_semaphore_ids.test(sem_id)) {
+            semaphore_id = sem_id;
+            break;
+        }
+    }
+    TT_FATAL(
+        semaphore_id.has_value(),
+        "Unable to initialize semaphore on CoreRangeSet {}: all {} IDs are in use",
+        crs.str(),
+        NUM_SEMAPHORES);
 
     this->add_semaphore(crs, *semaphore_id, initial_value, core_type);
     return *semaphore_id;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
For a `CoreRangeSet` spanning multiple ranges, `create_semaphore` could pick an ID already in use on one of the target cores, causing the call to fail even though an ID free on all target cores was available. We now track semaphore ID usage across the whole set and pick the smallest ID that's free everywhere.

Fixes #43105.

### Notes for reviewers
- Adds a regression test covering the affected multi-range allocation case.
- The exhaustion error now reports the `CoreRangeSet` and semaphore-count cap.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ybashi/fix-multirange-semaphore-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ybashi/fix-multirange-semaphore-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ybashi/fix-multirange-semaphore-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ybashi/fix-multirange-semaphore-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ybashi/fix-multirange-semaphore-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ybashi/fix-multirange-semaphore-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ybashi/fix-multirange-semaphore-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ybashi/fix-multirange-semaphore-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ybashi/fix-multirange-semaphore-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ybashi/fix-multirange-semaphore-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ybashi/fix-multirange-semaphore-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ybashi/fix-multirange-semaphore-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ybashi/fix-multirange-semaphore-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ybashi/fix-multirange-semaphore-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ybashi/fix-multirange-semaphore-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ybashi/fix-multirange-semaphore-id)