### PR TITLE
Test Only: Fix tt-smi path in SP multihost demo pipeline recovery

### DIFF
--- a/tests/pipeline_reorg/demo_sp_multihost_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_multihost_tests.yaml
@@ -73,7 +73,7 @@
       echo "=== Recovery attempt $attempt of $MAX_RECOVERY_ATTEMPTS ==="
 
       echo "--- Resetting cards with tt-smi ---"
-      if ! mpirun --pernode --tag-output /opt/venv/bin/tt-smi -glx_reset; then
+      if ! mpirun --pernode --tag-output /usr/local/bin/tt-smi -glx_reset; then
         echo "WARNING: Reset failed on attempt $attempt"
         if [ "$attempt" -eq "$MAX_RECOVERY_ATTEMPTS" ]; then
           echo "ERROR: Reset failed on final attempt"


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Multihost Blaze SP demo pipeline recovery resets cards via `tt-smi -glx_reset`. Developers use`tt-smi` at `/usr/local/bin/tt-smi`, not under `/opt/venv/bin/`. This updates `tests/pipeline_reorg/demo_sp_multihost_tests.yaml` so the reset step invokes the correct binary and recovery can run when a step fails.

### Notes for reviewers
Single-line path change; no product/runtime code. Confirm this matches the standard location on the SP4 / multihost CI images you care about.

Verified this `tt-smi` works manually on one of the CI machines:
```
gwang@bh-glx-120-a04u02:~$ which tt-smi
/usr/local/bin/tt-smi
gwang@bh-glx-120-a04u02:~$ tt-smi -glx_reset
 Hint: tt-smi -r is now supported on Galaxy 6U.
 Resetting WH Galaxy trays with reset command...
 Issuing USER_RESET on 32 devices before IPMI reset...
2026-05-07 23:04:33.346 | info     |             UMD | Starting reset. Executing command: sudo ipmitool raw 0x30 0x8b 0xf 0xff 0x0 0xf (warm_reset.cpp:352)

2026-05-07 23:04:33.809 | info     |             UMD | Reset successfully completed. Exit code: 0 (warm_reset.cpp:380)
Waiting for 30 seconds: 30
All 32 chips found in "/dev/tenstorrent"
 Issuing POST_RESET on 32 devices after IPMI reset...
 Re-initializing boards after reset....
 Detected Chips: 32
 Re-initialized 32 boards after reset. Exiting...
```

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gongyu/blaze_sp4_ci_tt_smi)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gongyu/blaze_sp4_ci_tt_smi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gongyu/blaze_sp4_ci_tt_smi)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gongyu/blaze_sp4_ci_tt_smi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gongyu/blaze_sp4_ci_tt_smi)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gongyu/blaze_sp4_ci_tt_smi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gongyu/blaze_sp4_ci_tt_smi)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gongyu/blaze_sp4_ci_tt_smi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=gongyu/blaze_sp4_ci_tt_smi)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:gongyu/blaze_sp4_ci_tt_smi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gongyu/blaze_sp4_ci_tt_smi)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gongyu/blaze_sp4_ci_tt_smi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gongyu/blaze_sp4_ci_tt_smi)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gongyu/blaze_sp4_ci_tt_smi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gongyu/blaze_sp4_ci_tt_smi)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gongyu/blaze_sp4_ci_tt_smi)