### PR TITLE
[Feature] Metal 2.0 support for UpdateTensorArgs

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -40,6 +40,8 @@
 #include <tt-metalium/experimental/context/metal_env.hpp>
 #include <tt-metalium/experimental/mock_device.hpp>
 
+#include "impl/kernels/kernel.hpp"
+#include "impl/program/program_impl.hpp"
 #include "test_helpers.hpp"
 
 namespace tt::tt_metal::experimental::metal2_host_api {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -1109,5 +1109,270 @@ TEST_F(ProgramRunParamsTestGen1, TensorSpecMismatchFails) {
             "TensorArg for binding 'input_tensor' supplied a MeshTensor whose TensorSpec does not match")));
 }
 
+// ============================================================================
+// SECTION: UpdateTensorArgs Tests (Gen1 / WH)
+// ============================================================================
+// UpdateTensorArgs is the partial-update fast path: it patches only the tensor binding
+// address slots in the per-kernel CRTA buffer, leaving everything else (named CRTAs,
+// vararg CRTAs, all RTAs) statefully unchanged from the most recent SetProgramRunParameters
+// call.
+
+// Helper: allocate a MeshTensor matching the given TensorParameter's spec.
+inline MeshTensor AllocateTensorForBinding(distributed::MeshDevice& mesh_device, const TensorParameter& binding) {
+    return MeshTensor::allocate_on_device(mesh_device, binding.spec, TensorTopology{});
+}
+
+// Helper: read the patched tensor binding address out of a kernel's CRTA buffer.
+// Mirrors the offset arithmetic UpdateTensorArgs uses internally, so a regression in either
+// site shows up as a test failure.
+inline uint32_t ReadBindingAddressFromCRTA(
+    const Program& program, const KernelSpecName& kernel_name, const std::string& tensor_parameter_name) {
+    auto kernel = program.impl().get_kernel_by_spec_name(kernel_name);
+    for (const auto& handle : kernel->tensor_binding_handles()) {
+        if (handle.tensor_parameter_name == tensor_parameter_name) {
+            const uint32_t word_index = handle.addr_crta_offset / sizeof(uint32_t);
+            return kernel->common_runtime_args_data().data()[word_index];
+        }
+    }
+    ADD_FAILURE() << "No binding handle for '" << tensor_parameter_name << "' on kernel '" << kernel_name << "'";
+    return 0;
+}
+
+TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_BeforeSetProgramRunParametersFails) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto binding = MakeMinimalTensorParameter("input_tensor");
+    spec.tensor_parameters = {binding};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    MeshTensor tensor = AllocateTensorForBinding(*mesh_device_, binding);
+    std::vector<ProgramRunParams::TensorArg> tensor_args{
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    };
+
+    // No SetProgramRunParameters call before the partial update.
+    EXPECT_THAT(
+        [&] { UpdateTensorArgs(program, tensor_args); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("UpdateTensorArgs called on Program before SetProgramRunParameters")));
+}
+
+TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_MissingTensorArgFails) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto binding = MakeMinimalTensorParameter("input_tensor");
+    spec.tensor_parameters = {binding};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    // Establish baseline state.
+    MeshTensor tensor = AllocateTensorForBinding(*mesh_device_, binding);
+    auto params = MakeRunParamsForMinimalSpec(node, {}, {});
+    params.tensor_args = {
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    };
+    SetProgramRunParameters(program, params);
+
+    // Empty tensor_args fails the completeness check.
+    std::vector<ProgramRunParams::TensorArg> empty;
+    EXPECT_THAT(
+        [&] { UpdateTensorArgs(program, empty); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
+            "TensorParameter 'input_tensor' is declared in the Program but has no TensorArg entry")));
+}
+
+TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_DuplicateTensorArgFails) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto binding = MakeMinimalTensorParameter("input_tensor");
+    spec.tensor_parameters = {binding};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    MeshTensor tensor = AllocateTensorForBinding(*mesh_device_, binding);
+    auto params = MakeRunParamsForMinimalSpec(node, {}, {});
+    params.tensor_args = {
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    };
+    SetProgramRunParameters(program, params);
+
+    std::vector<ProgramRunParams::TensorArg> tensor_args{
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    };
+    EXPECT_THAT(
+        [&] { UpdateTensorArgs(program, tensor_args); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("Duplicate tensor_parameter_name 'input_tensor'")));
+}
+
+TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_UnknownTensorParameterFails) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto binding = MakeMinimalTensorParameter("input_tensor");
+    spec.tensor_parameters = {binding};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    MeshTensor tensor = AllocateTensorForBinding(*mesh_device_, binding);
+    auto params = MakeRunParamsForMinimalSpec(node, {}, {});
+    params.tensor_args = {
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    };
+    SetProgramRunParameters(program, params);
+
+    std::vector<ProgramRunParams::TensorArg> tensor_args{
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "ghost_tensor", .tensor = std::cref(tensor)},
+    };
+    EXPECT_THAT(
+        [&] { UpdateTensorArgs(program, tensor_args); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("TensorArg references unknown TensorParameter 'ghost_tensor'")));
+}
+
+TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_TensorSpecMismatchFails) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto binding = MakeMinimalTensorParameter("input_tensor");  // shape {1, 32}
+    spec.tensor_parameters = {binding};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    MeshTensor tensor = AllocateTensorForBinding(*mesh_device_, binding);
+    auto params = MakeRunParamsForMinimalSpec(node, {}, {});
+    params.tensor_args = {
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor)},
+    };
+    SetProgramRunParameters(program, params);
+
+    // Different shape: {1, 64} instead of declared {1, 32}.
+    auto page_config = tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR);
+    auto memory_config =
+        tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
+    auto tensor_layout = tt::tt_metal::TensorLayout(tt::tt_metal::DataType::BFLOAT16, page_config, memory_config);
+    auto wrong_spec = tt::tt_metal::TensorSpec(tt::tt_metal::Shape{1, 64}, tensor_layout);
+    MeshTensor wrong_tensor = MeshTensor::allocate_on_device(*mesh_device_, wrong_spec, TensorTopology{});
+
+    std::vector<ProgramRunParams::TensorArg> tensor_args{
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(wrong_tensor)},
+    };
+    EXPECT_THAT(
+        [&] { UpdateTensorArgs(program, tensor_args); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
+            "TensorArg for binding 'input_tensor' supplied a MeshTensor whose TensorSpec does not match")));
+}
+
+TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_PatchesBindingAddress) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto binding = MakeMinimalTensorParameter("input_tensor");
+    spec.tensor_parameters = {binding};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    // First enqueue: full SetProgramRunParameters with tensor T1.
+    MeshTensor tensor1 = AllocateTensorForBinding(*mesh_device_, binding);
+    auto params = MakeRunParamsForMinimalSpec(node, {}, {});
+    params.tensor_args = {
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor1)},
+    };
+    SetProgramRunParameters(program, params);
+    ASSERT_EQ(
+        ReadBindingAddressFromCRTA(program, "dm_kernel", "input_tensor"), static_cast<uint32_t>(tensor1.address()));
+
+    // Second enqueue: partial update to tensor T2.
+    MeshTensor tensor2 = AllocateTensorForBinding(*mesh_device_, binding);
+    ASSERT_NE(tensor1.address(), tensor2.address())
+        << "Test pre-condition: two separate allocations should yield distinct addresses";
+
+    std::vector<ProgramRunParams::TensorArg> tensor_args{
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor2)},
+    };
+    EXPECT_NO_THROW(UpdateTensorArgs(program, tensor_args));
+
+    EXPECT_EQ(
+        ReadBindingAddressFromCRTA(program, "dm_kernel", "input_tensor"), static_cast<uint32_t>(tensor2.address()));
+}
+
+TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_LeavesNamedCRTAsUnchanged) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto binding = MakeMinimalTensorParameter("input_tensor");
+    spec.tensor_parameters = {binding};
+    // Schema with a named CRTA preceding the binding-address section.
+    spec.kernels[0].runtime_arguments_schema.named_common_runtime_args = {"tile_count"};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    MeshTensor tensor1 = AllocateTensorForBinding(*mesh_device_, binding);
+    constexpr uint32_t kNamedCRTAValue = 0xABCD1234;
+    ProgramRunParams params;
+    params.kernel_run_params.push_back({
+        .kernel_spec_name = "dm_kernel",
+        .named_common_runtime_args = {{"tile_count", kNamedCRTAValue}},
+    });
+    params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
+    params.tensor_args = {
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor1)},
+    };
+    SetProgramRunParameters(program, params);
+
+    // Capture the named CRTA's slot value before the partial update.
+    auto dm_kernel = program.impl().get_kernel_by_spec_name("dm_kernel");
+    const auto* crta_data_before = dm_kernel->common_runtime_args_data().data();
+    ASSERT_EQ(crta_data_before[0], kNamedCRTAValue) << "named CRTA should occupy slot 0 of the CRTA buffer";
+
+    // Partial update.
+    MeshTensor tensor2 = AllocateTensorForBinding(*mesh_device_, binding);
+    std::vector<ProgramRunParams::TensorArg> tensor_args{
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "input_tensor", .tensor = std::cref(tensor2)},
+    };
+    UpdateTensorArgs(program, tensor_args);
+
+    // Named CRTA preserved; binding address patched.
+    const auto* crta_data_after = dm_kernel->common_runtime_args_data().data();
+    EXPECT_EQ(crta_data_after[0], kNamedCRTAValue) << "named CRTA must be untouched by UpdateTensorArgs";
+    EXPECT_EQ(
+        ReadBindingAddressFromCRTA(program, "dm_kernel", "input_tensor"), static_cast<uint32_t>(tensor2.address()));
+}
+
+TEST_F(ProgramRunParamsTestGen1, UpdateTensorArgs_PatchesAllKernelsBoundToSameTensor) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto binding = MakeMinimalTensorParameter("shared_tensor");
+    spec.tensor_parameters = {binding};
+    // Bind the same TensorParameter on both kernels.
+    BindTensorParameterToKernel(spec.kernels[0], "shared_tensor", "shared_ta_dm");
+    BindTensorParameterToKernel(spec.kernels[1], "shared_tensor", "shared_ta_compute");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    MeshTensor tensor1 = AllocateTensorForBinding(*mesh_device_, binding);
+    auto params = MakeRunParamsForMinimalSpec(node, {}, {});
+    params.tensor_args = {
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "shared_tensor", .tensor = std::cref(tensor1)},
+    };
+    SetProgramRunParameters(program, params);
+
+    MeshTensor tensor2 = AllocateTensorForBinding(*mesh_device_, binding);
+    std::vector<ProgramRunParams::TensorArg> tensor_args{
+        ProgramRunParams::TensorArg{.tensor_parameter_name = "shared_tensor", .tensor = std::cref(tensor2)},
+    };
+    UpdateTensorArgs(program, tensor_args);
+
+    EXPECT_EQ(
+        ReadBindingAddressFromCRTA(program, "dm_kernel", "shared_tensor"), static_cast<uint32_t>(tensor2.address()));
+    EXPECT_EQ(
+        ReadBindingAddressFromCRTA(program, "compute_kernel", "shared_tensor"),
+        static_cast<uint32_t>(tensor2.address()));
+}
+
 }  // namespace
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <span>
+
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
@@ -28,14 +30,28 @@ Program MakeProgramFromSpec(
 // COMPLETENESS: You must specify runtime args (named and vararg alike) for every
 // (kernel, node) pair that requires runtime arguments. Missing entries will cause an error.
 //
-// For high-performance inner loops, prefer the in-place power user API below.
-// If stateful behavior of parameters is required, use the power user API.
+// For high-performance inner loops, prefer the power user APIs below.
+// If stateful behavior of parameters is required, use the power user APIs.
 void SetProgramRunParameters(Program& program, const ProgramRunParams& params);
+
+// Fast-path partial update: refresh ONLY the TensorArgs of an existing Program.
+// All other ProgramRunParams (named/vararg RTAs and CRTAs, DFB params) retain their values
+// from the most recent SetProgramRunParameters call.
+//
+// PRE-CONDITION: SetProgramRunParameters must have been called previously.
+//
+// COMPLETENESS: A TensorArg must be specified for every TensorParameter declared in the
+// ProgramSpec, exactly once. The supplied MeshTensor's TensorSpec must match the
+// TensorParameter's declared spec.
+//
+// USE CASE: Program re-enqueue loops where the only per-enqueue ProgramRunParams variation
+// is in the tensors args (i.e. which specific MeshTensorsare operated on by the Program).
+void UpdateTensorArgs(Program& program, std::span<const ProgramRunParams::TensorArg> tensor_args);
 
 // Power-user API for updating the mutable parameters of a Program in-place.
 // ProgramRunParamsView is a non-owning view into the Program's command buffers,
 // enabling in-place modification of mutable Program parameters.
-// (Sketch only; not yet implemented)
+// (Sketch only; not yet implemented. TBD if needed at all.)
 ProgramRunParamsView& GetProgramRunParamsView(Program& program);
 
 // Useful? Might want to expose a const view for debug/test use?

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
@@ -45,7 +45,7 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params);
 // TensorParameter's declared spec.
 //
 // USE CASE: Program re-enqueue loops where the only per-enqueue ProgramRunParams variation
-// is in the tensors args (i.e. which specific MeshTensorsare operated on by the Program).
+// is in the tensor args (i.e. which specific MeshTensors are operated on by the Program).
 void UpdateTensorArgs(Program& program, std::span<const ProgramRunParams::TensorArg> tensor_args);
 
 // Power-user API for updating the mutable parameters of a Program in-place.

--- a/tt_metal/impl/metal2_host_api/program_run_params.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_params.cpp
@@ -4,6 +4,7 @@
 
 #include <cstring>
 #include <limits>
+#include <span>
 #include <unordered_set>
 
 #include <tt-logger/tt-logger.hpp>
@@ -16,11 +17,50 @@
 namespace tt::tt_metal::experimental::metal2_host_api {
 
 // ============================================================================
-// Validation Helper
+// Validation Helpers
 // ============================================================================
 
 // Type alias for readability
 using KernelRTASchema = detail::ProgramImpl::KernelRTASchema;
+
+// Internal validation function - validates a TensorArg list against the Program's TensorParameters.
+// Shared by SetProgramRunParameters (full path) and UpdateTensorArgs (partial path).
+//   - No duplicate tensor_parameter_name entries
+//   - Every entry references a TensorParameter declared in the ProgramSpec
+//   - The supplied MeshTensor's TensorSpec equals the binding's expected TensorSpec
+//     (full equality is required, for now. This will be loosened to layout-compatible-modulo-shape
+//     in a follow-up PR that adds RuntimeTensorShape as a mutable parameter).
+//   - Every declared TensorParameter must be set
+void ValidateTensorArgs(const Program& program, std::span<const ProgramRunParams::TensorArg> tensor_args) {
+    const detail::ProgramImpl& program_impl = program.impl();
+
+    std::unordered_set<std::string> tensor_parameters_with_params;
+    for (const auto& tensor_params : tensor_args) {
+        auto [it, inserted] = tensor_parameters_with_params.insert(tensor_params.tensor_parameter_name);
+        TT_FATAL(
+            inserted,
+            "Duplicate tensor_parameter_name '{}' in tensor_args. Each TensorParameter must appear at most once.",
+            tensor_params.tensor_parameter_name);
+        const TensorSpec* expected_spec = program_impl.get_tensor_parameter_layout(tensor_params.tensor_parameter_name);
+        TT_FATAL(
+            expected_spec != nullptr,
+            "TensorArg references unknown TensorParameter '{}'.",
+            tensor_params.tensor_parameter_name);
+        const TensorSpec& runtime_spec = tensor_params.tensor.get().tensor_spec();
+        TT_FATAL(
+            runtime_spec == *expected_spec,
+            "TensorArg for binding '{}' supplied a MeshTensor whose TensorSpec does not match the binding's "
+            "declared spec. The binding declaration in ProgramSpec is the single source of truth for layout; the "
+            "supplied tensor must conform to it.",
+            tensor_params.tensor_parameter_name);
+    }
+    for (const std::string& declared : program_impl.get_registered_tensor_parameter_names()) {
+        TT_FATAL(
+            tensor_parameters_with_params.contains(declared),
+            "TensorParameter '{}' is declared in the Program but has no TensorArg entry.",
+            declared);
+    }
+}
 
 // Internal validation function - validates ProgramRunParams against the Program's schema.
 //
@@ -194,44 +234,12 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
     // Unlike kernels, DFBs don't require DFBRunParams.
     // It is only required for DFBs built on borrowed memory. (Which is not yet supported.)
 
-    // Validate tensor runtime parameters:
-    //   - No duplicate tensor_parameter_name entries
-    //   - Every entry references a TensorParameter declared in the ProgramSpec
-    //   - The supplied MeshTensor's TensorSpec equals the binding's expected TensorSpec
-    //     (full equality is required, for now. This will be loosened to layout-compatible-modulo-shape
-    //     in a follow-up PR that adds RuntimeTensorShape as a mutable parameter).
-    //   - Every declared TensorParameter must be set
-    std::unordered_set<std::string> tensor_parameters_with_params;
-    for (const auto& tensor_params : params.tensor_args) {
-        auto [it, inserted] = tensor_parameters_with_params.insert(tensor_params.tensor_parameter_name);
-        TT_FATAL(
-            inserted,
-            "Duplicate tensor_parameter_name '{}' in ProgramRunParams.tensor_args. Each TensorParameter must appear "
-            "at most once.",
-            tensor_params.tensor_parameter_name);
-        const TensorSpec* expected_spec = program_impl.get_tensor_parameter_layout(tensor_params.tensor_parameter_name);
-        TT_FATAL(
-            expected_spec != nullptr,
-            "TensorArg references unknown TensorParameter '{}'.",
-            tensor_params.tensor_parameter_name);
-        const TensorSpec& runtime_spec = tensor_params.tensor.get().tensor_spec();
-        TT_FATAL(
-            runtime_spec == *expected_spec,
-            "TensorArg for binding '{}' supplied a MeshTensor whose TensorSpec does not match the binding's "
-            "declared spec. The binding declaration in ProgramSpec is the single source of truth for layout; the "
-            "supplied tensor must conform to it.",
-            tensor_params.tensor_parameter_name);
-    }
-    for (const std::string& declared : program_impl.get_registered_tensor_parameter_names()) {
-        TT_FATAL(
-            tensor_parameters_with_params.contains(declared),
-            "TensorParameter '{}' is declared in the Program but has no TensorArg entry.",
-            declared);
-    }
+    // Validate tensor runtime parameters (delegated to shared helper).
+    ValidateTensorArgs(program, params.tensor_args);
 }
 
 // ============================================================================
-// PUBLIC ENTRY POINTS: SetProgramRunParameters + GetProgramRunParamsView
+// PUBLIC ENTRY POINTS: SetProgramRunParameters + UpdateTensorArgs + GetProgramRunParamsView
 // ============================================================================
 
 void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
@@ -383,6 +391,64 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
 
     // Process DFB runtime parameters
     // (Not yet supported)
+}
+
+void UpdateTensorArgs(Program& program, std::span<const ProgramRunParams::TensorArg> tensor_args) {
+    log_debug(tt::LogMetal, "Updating tensor args (partial fast-path)");
+
+    // Validate the TensorArg list (shared with the full-path validator).
+    ValidateTensorArgs(program, tensor_args);
+
+    detail::ProgramImpl& program_impl = program.impl();
+
+    // Build a tensor_parameter_name -> base address lookup.
+    // As in SetProgramRunParameters, this assumes lockstep mesh allocation:
+    // a single device-independent uint32_t address per binding.
+    std::unordered_map<std::string, uint32_t> ta_binding_addresses;
+    ta_binding_addresses.reserve(tensor_args.size());
+    for (const auto& tensor_params : tensor_args) {
+        const auto address = tensor_params.tensor.get().address();
+        TT_FATAL(
+            address <= std::numeric_limits<uint32_t>::max(),
+            "TensorParameter '{}' base address {} exceeds uint32_t max",
+            tensor_params.tensor_parameter_name,
+            address);
+        ta_binding_addresses.emplace(tensor_params.tensor_parameter_name, static_cast<uint32_t>(address));
+    }
+
+    // For every kernel with tensor bindings, patch the binding-address slots in its CRTA buffer
+    // in place. The rest of the buffer (named CRTAs, vararg CRTAs) is left untouched and retains
+    // the values installed by the most recent SetProgramRunParameters call.
+    // The kernel's RTA buffer is left untouched (tensor binding addresses live in CRTAs only).
+    for (const KernelSpecName& kernel_name : program_impl.get_registered_kernel_names()) {
+        std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_name);
+        const auto& binding_handles = kernel->tensor_binding_handles();
+        if (binding_handles.empty()) {
+            continue;
+        }
+
+        // Pre-condition: SetProgramRunParameters must have been called previously to size and
+        // populate this kernel's CRTA buffer. Without it, there is no buffer to patch into.
+        TT_FATAL(
+            !kernel->common_runtime_args().empty(),
+            "UpdateTensorArgs called on Program before SetProgramRunParameters: kernel '{}' has tensor "
+            "bindings but its CRTA buffer has not been allocated. Call SetProgramRunParameters at least "
+            "once first.",
+            kernel_name);
+
+        RuntimeArgsData& crta = kernel->common_runtime_args_data();
+        for (const auto& handle : binding_handles) {
+            auto addr_it = ta_binding_addresses.find(handle.tensor_parameter_name);
+            TT_FATAL(
+                addr_it != ta_binding_addresses.end(),
+                "Internal error: tensor binding '{}' has no resolved base address (validation should have "
+                "caught this).",
+                handle.tensor_parameter_name);
+            // addr_crta_offset is a byte offset; data() is uint32_t*.
+            const uint32_t word_index = handle.addr_crta_offset / sizeof(uint32_t);
+            crta.data()[word_index] = addr_it->second;
+        }
+    }
 }
 
 ProgramRunParamsView& GetProgramRunParamsView(Program& program) {

--- a/tt_metal/impl/metal2_host_api/program_run_params.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_params.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <limits>
 #include <span>
+#include <unordered_map>
 #include <unordered_set>
 
 #include <tt-logger/tt-logger.hpp>


### PR DESCRIPTION
### PR Category
Feature

### Summary
Metal 2.0 uses explicit, `Program`-level tensor binding semantics to pass tensor arguments to kernels. (see https://github.com/tenstorrent/tt-metal/pull/43687/).

When updating a `Program`'s mutable parameters for re-enqueue, a common use-case is to update only the tensor arguments, leaving the rest of the mutable Program params intact (i.e. kernel RTAs, CRTAs, other advanced features).

This PR provides a "fast path" API for updating _only_ the tensor arguments for a `Program`. The rest of the mutable params preserve their state from the previous enqueue. This "stateful arguments" behavior is for power users only, but can be helpful in performance-sensitive tight loops.

(See https://github.com/tenstorrent/tt-metal/pull/42992 for the `ProgramDescritor`-based shim version of the same API concept.)

### Notes for reviewers
The only interesting file is `experimental/program.hpp`. That's the new API. 
The rest is plumbing + unit tests.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/update-tensor-args-fastpath)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/update-tensor-args-fastpath)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/update-tensor-args-fastpath)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/update-tensor-args-fastpath)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/update-tensor-args-fastpath)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/update-tensor-args-fastpath)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/update-tensor-args-fastpath)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/update-tensor-args-fastpath)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/update-tensor-args-fastpath)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/update-tensor-args-fastpath)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/update-tensor-args-fastpath)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/update-tensor-args-fastpath)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/update-tensor-args-fastpath)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/update-tensor-args-fastpath)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/update-tensor-args-fastpath)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/update-tensor-args-fastpath)