### PR TITLE
[Bug Fix] Fix runtime integration tests pipeline

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -317,7 +317,7 @@ def eltwise_rsqrt(
         t0 = t0.to(ttnn.TILE_LAYOUT)
         t0 = t0.to(device)
         t1 = ttnn.rsqrt(t0, memory_config=output_mem_config)
-        t1 = t1.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(input_shape)
+        t1 = t1.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
 
     return tt2torch_tensor(t1)
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -312,7 +312,6 @@ def eltwise_rsqrt(
     else:
         # this case is for test_eltwise_rsqrt_in_depth.py with shape (3, 11, 92, 100) RM
         # either use this format or move the test to non-working as ttnn does not use run_with_autoformat
-        input_shape = t0.shape
         t0 = t0.cpu().pad_to_tile(0)
         t0 = t0.to(ttnn.TILE_LAYOUT)
         t0 = t0.to(device)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_average_pool.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_average_pool.py
@@ -49,8 +49,6 @@ def test_run_average_pool(act_shape, dtype, device):
     out = out.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
     out_shape = [batch_size, 1, 1, channels]
     out_shape_padded = shape_padded(out_shape)
-    if out_shape != out_shape_padded:
-        out = out.unpad_from_tile(out_shape)
 
     out_pytorch = out.to_torch()
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_average_pool.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_average_pool.py
@@ -47,8 +47,6 @@ def test_run_average_pool(act_shape, dtype, device):
     out = ttnn.global_avg_pool2d(ttact)
 
     out = out.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-    out_shape = [batch_size, 1, 1, channels]
-    out_shape_padded = shape_padded(out_shape)
 
     out_pytorch = out.to_torch()
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_padding_test.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_padding_test.py
@@ -281,9 +281,8 @@ def test_run_tile_padding_and_add_test(input_tensor_shape, pad_value, device):
     out_dev = ttnn.add(a_dev, b_dev)
     out_pad = out_dev.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
 
-    # Unpad out to get result
-    out = out_pad.unpad_from_tile(input_tensor_shape)
-    out_pt = out.to_torch().to(torch.float32)
+    # to(ROW_MAJOR_LAYOUT) already unpadded; use directly.
+    out_pt = out_pad.to_torch().to(torch.float32)
 
     out_ref = inp + ones
 


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug Fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Yesterday #43568, which hardens the `unpad_from_tile` precondition check, was merged.
It broke [runtime integration pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/25478730878/job/74759069808).

This is because `unpad_from_tile` expectes padded shape to be in alignment with a typical tile dimension.
However, it is called after a `to(ROW_MAJOR_LAYOUT)` transformation, which performs the unpadding, making padded shape the same as logical shape, which violates the precondition checks.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Verification run: https://github.com/tenstorrent/tt-metal/actions/runs/25537531503

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/fix-unpad-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/fix-unpad-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/fix-unpad-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/fix-unpad-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/fix-unpad-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/fix-unpad-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/fix-unpad-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/fix-unpad-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/fix-unpad-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/fix-unpad-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/fix-unpad-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/fix-unpad-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/fix-unpad-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/fix-unpad-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/fix-unpad-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/fix-unpad-fatal)