### PR TITLE
Support head_dim=32 in ttnn.experimental.rotary_embedding_hf via dedicated Wt == 1 paths

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_hf.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_hf.py
@@ -22,8 +22,9 @@ Layout mapping from the legacy rotary tests (``[W, Z, Y, X]`` with cos/sin ``[1,
   (different users at different cached steps) are what ``is_decode_mode=True`` and ``[1, batch, …]`` cos/sin fix
   relative to the legacy op (see ``test_rotary_embedding_hf_decode_per_batch_position``).
 
-The HF op requires TILE layout and ``head_dim`` divisible by ``2 * ttnn.TILE_SIZE``; ``test_rotary_embedding_hf_row_major`` skips
-because row-major inputs are rejected by validation.
+The HF op requires TILE layout and padded ``head_dim`` equal to ``ttnn.TILE_SIZE`` or divisible by
+``2 * ttnn.TILE_SIZE``; ``test_rotary_embedding_hf_row_major`` skips because row-major inputs are
+rejected by validation.
 
 See ``ttnn/cpp/.../rotary_embedding_hf/device/rotary_embedding_hf_device_operation.cpp`` for shape rules.
 """
@@ -183,7 +184,7 @@ def _decode_hf_cos_sin_sharded(device, batch: int, head_dim: int, cos_torch, sin
 
 @pytest.mark.parametrize(
     "W, Z, Y, X",
-    ([1, 1, 128, 64], [1, 71, 128, 64], [32, 1, 32, 64], [32, 71, 32, 64]),
+    ([1, 1, 128, 64], [1, 71, 128, 64], [32, 1, 32, 64], [32, 71, 32, 64], [1, 1, 128, 32], [1, 32, 32, 32]),
 )
 @pytest.mark.parametrize("cache_size", [2048])
 @pytest.mark.parametrize("in_sharded", [True, False])
@@ -264,7 +265,8 @@ def test_rotary_embedding_hf_prefill(
     assert p
 
 
-def test_rotary_embedding_hf_decode_per_batch_position(device):
+@pytest.mark.parametrize("head_dim", [32, 128])
+def test_rotary_embedding_hf_decode_per_batch_position(device, head_dim):
     """Decode mode: each batch row uses a different cached position (legacy op could not do this).
 
     ``cos_cache`` / ``sin_cache`` are ``[1, batch, 1, head_dim]`` with one row per user; positions are taken
@@ -276,7 +278,6 @@ def test_rotary_embedding_hf_decode_per_batch_position(device):
 
     batch = 32
     num_heads = 8
-    head_dim = 128
     cache_size = 2048
     dtype = ttnn.bfloat16
 
@@ -340,7 +341,8 @@ def test_rotary_embedding_hf_decode_per_batch_position(device):
     ttnn.deallocate(sin_tt)
 
 
-def test_rotary_embedding_hf_decode_batch_per_core_gt_one(device):
+@pytest.mark.parametrize("head_dim", [32, 128])
+def test_rotary_embedding_hf_decode_batch_per_core_gt_one(device, head_dim):
     """Decode mode regression: force ``batch_per_core > 1`` and verify per-batch cos/sin rows are honored."""
     torch.manual_seed(0)
 
@@ -348,7 +350,6 @@ def test_rotary_embedding_hf_decode_batch_per_core_gt_one(device):
     num_cores = core_grid.x * core_grid.y
     batch = num_cores * 2  # Forces batch_per_core = 2 with exact height-shard packing.
     num_heads = 8
-    head_dim = 128
     cache_size = max(2048, batch * 4)
     dtype = ttnn.bfloat16
 
@@ -443,7 +444,16 @@ def test_rotary_embedding_hf_decode_batch_per_core_gt_one(device):
 
 @pytest.mark.parametrize(
     "W, Z, Y, X",
-    ([1, 1, 32, 64], [1, 71, 32, 64], [1, 1, 64, 64], [1, 71, 64, 64], [1, 32, 32, 64], [1, 2, 32, 64]),
+    (
+        [1, 1, 32, 64],
+        [1, 71, 32, 64],
+        [1, 1, 64, 64],
+        [1, 71, 64, 64],
+        [1, 32, 32, 64],
+        [1, 2, 32, 64],
+        [1, 1, 32, 32],
+        [1, 2, 32, 32],
+    ),
 )
 @pytest.mark.parametrize("cache_size", [2048])
 @pytest.mark.parametrize("token_idx", [0, 128, 129, 1024, 1025])
@@ -528,7 +538,7 @@ def test_rotary_embedding_hf_decode(
     assert p
 
 
-@pytest.mark.parametrize("W, Z, Y, X", [(1, 1, 128, 64)])
+@pytest.mark.parametrize("W, Z, Y, X", [(1, 1, 128, 32), (1, 1, 128, 64)])
 @pytest.mark.parametrize("cache_size", [2048])
 @pytest.mark.parametrize("in_sharded", [True])
 @pytest.mark.parametrize("out_sharded", [True])
@@ -608,7 +618,7 @@ def test_rotary_embedding_hf_prefill_fp32(
     assert p
 
 
-@pytest.mark.parametrize("W, Z, Y, X", [(1, 1, 32, 64)])
+@pytest.mark.parametrize("W, Z, Y, X", [(1, 1, 32, 32), (1, 1, 32, 64)])
 @pytest.mark.parametrize("cache_size", [2048])
 @pytest.mark.parametrize("token_idx", [0, 128])
 @pytest.mark.parametrize("in_sharded", [True])

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/rotary_embedding_hf_single_tile_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/rotary_embedding_hf_single_tile_sharded.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/rotary_embedding_hf_single_tile_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/rotary_embedding_hf_single_tile_sharded.cpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "api/compute/bcast.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/matmul.h"
+
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
+
+void kernel_main() {
+    constexpr uint32_t onetile = 1;
+
+    constexpr uint32_t in_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t cos_cb = get_compile_time_arg_val(1);
+    constexpr uint32_t sin_cb = get_compile_time_arg_val(2);
+    constexpr uint32_t trans_mat_cb = get_compile_time_arg_val(3);
+    constexpr uint32_t rotated_in_interm_cb = get_compile_time_arg_val(4);
+    constexpr uint32_t cos_interm_cb = get_compile_time_arg_val(5);
+    constexpr uint32_t sin_interm_cb = get_compile_time_arg_val(6);
+    constexpr uint32_t out_cb = get_compile_time_arg_val(7);
+    constexpr uint32_t heads_per_batch_t = get_compile_time_arg_val(8);
+    constexpr uint32_t batch_per_core = get_compile_time_arg_val(9);
+
+    cb_wait_front(trans_mat_cb, onetile);
+    mm_init(in_cb, trans_mat_cb, rotated_in_interm_cb);
+    binary_op_init_common(rotated_in_interm_cb, sin_cb, sin_interm_cb);
+
+    for (uint32_t batch_idx = 0; batch_idx < batch_per_core; ++batch_idx) {
+        cb_reserve_back(sin_cb, onetile);
+        cb_reserve_back(cos_cb, onetile);
+        cb_push_back(sin_cb, onetile);
+        cb_push_back(cos_cb, onetile);
+
+        for (uint32_t ht = 0; ht < heads_per_batch_t; ++ht) {
+            cb_reserve_back(rotated_in_interm_cb, onetile);
+            cb_reserve_back(sin_interm_cb, onetile);
+            cb_reserve_back(cos_interm_cb, onetile);
+            cb_reserve_back(out_cb, onetile);
+
+            cb_reserve_back(in_cb, onetile);
+            cb_push_back(in_cb, onetile);
+            cb_wait_front(in_cb, onetile);
+
+            reconfig_data_format(in_cb, trans_mat_cb);
+            pack_reconfig_data_format(rotated_in_interm_cb);
+            mm_init_short(in_cb, trans_mat_cb);
+            ACQ();
+            matmul_tiles(in_cb, trans_mat_cb, 0, 0, 0);
+            pack_tile(0, rotated_in_interm_cb);
+            REL();
+            cb_push_back(rotated_in_interm_cb, onetile);
+
+            cb_wait_front(rotated_in_interm_cb, onetile);
+            cb_wait_front(sin_cb, onetile);
+            reconfig_data_format(rotated_in_interm_cb, sin_cb);
+            pack_reconfig_data_format(sin_interm_cb);
+            ACQ();
+            mul_bcast_rows_init_short(rotated_in_interm_cb, sin_cb);
+            mul_tiles_bcast_rows(rotated_in_interm_cb, sin_cb, 0, 0, 0);
+            pack_tile(0, sin_interm_cb);
+            REL();
+            cb_push_back(sin_interm_cb, onetile);
+            cb_pop_front(rotated_in_interm_cb, onetile);
+
+            cb_wait_front(cos_cb, onetile);
+            reconfig_data_format(in_cb, cos_cb);
+            pack_reconfig_data_format(cos_interm_cb);
+            ACQ();
+            mul_bcast_rows_init_short(in_cb, cos_cb);
+            mul_tiles_bcast_rows(in_cb, cos_cb, 0, 0, 0);
+            pack_tile(0, cos_interm_cb);
+            REL();
+            cb_push_back(cos_interm_cb, onetile);
+            cb_pop_front(in_cb, onetile);
+
+            cb_wait_front(cos_interm_cb, onetile);
+            cb_wait_front(sin_interm_cb, onetile);
+            reconfig_data_format(cos_interm_cb, sin_interm_cb);
+            pack_reconfig_data_format(out_cb);
+            add_tiles_init(cos_interm_cb, sin_interm_cb);
+            ACQ();
+            add_tiles(cos_interm_cb, sin_interm_cb, 0, 0, 0);
+            pack_tile(0, out_cb);
+            REL();
+            cb_push_back(out_cb, onetile);
+            cb_pop_front(cos_interm_cb, onetile);
+            cb_pop_front(sin_interm_cb, onetile);
+        }
+
+        cb_pop_front(sin_cb, onetile);
+        cb_pop_front(cos_cb, onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/rotary_embedding_hf_single_tile_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/rotary_embedding_hf_single_tile_sharded.cpp
@@ -9,9 +9,6 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/matmul.h"
 
-ALWI void ACQ() { acquire_dst(); }
-ALWI void REL() { release_dst(); }
-
 void kernel_main() {
     constexpr uint32_t onetile = 1;
 
@@ -49,32 +46,38 @@ void kernel_main() {
             reconfig_data_format(in_cb, trans_mat_cb);
             pack_reconfig_data_format(rotated_in_interm_cb);
             mm_init_short(in_cb, trans_mat_cb);
-            ACQ();
+            tile_regs_acquire();
             matmul_tiles(in_cb, trans_mat_cb, 0, 0, 0);
+            tile_regs_commit();
+            tile_regs_wait();
             pack_tile(0, rotated_in_interm_cb);
-            REL();
+            tile_regs_release();
             cb_push_back(rotated_in_interm_cb, onetile);
 
             cb_wait_front(rotated_in_interm_cb, onetile);
             cb_wait_front(sin_cb, onetile);
             reconfig_data_format(rotated_in_interm_cb, sin_cb);
             pack_reconfig_data_format(sin_interm_cb);
-            ACQ();
+            tile_regs_acquire();
             mul_bcast_rows_init_short(rotated_in_interm_cb, sin_cb);
             mul_tiles_bcast_rows(rotated_in_interm_cb, sin_cb, 0, 0, 0);
+            tile_regs_commit();
+            tile_regs_wait();
             pack_tile(0, sin_interm_cb);
-            REL();
+            tile_regs_release();
             cb_push_back(sin_interm_cb, onetile);
             cb_pop_front(rotated_in_interm_cb, onetile);
 
             cb_wait_front(cos_cb, onetile);
             reconfig_data_format(in_cb, cos_cb);
             pack_reconfig_data_format(cos_interm_cb);
-            ACQ();
+            tile_regs_acquire();
             mul_bcast_rows_init_short(in_cb, cos_cb);
             mul_tiles_bcast_rows(in_cb, cos_cb, 0, 0, 0);
+            tile_regs_commit();
+            tile_regs_wait();
             pack_tile(0, cos_interm_cb);
-            REL();
+            tile_regs_release();
             cb_push_back(cos_interm_cb, onetile);
             cb_pop_front(in_cb, onetile);
 
@@ -83,10 +86,12 @@ void kernel_main() {
             reconfig_data_format(cos_interm_cb, sin_interm_cb);
             pack_reconfig_data_format(out_cb);
             add_tiles_init(cos_interm_cb, sin_interm_cb);
-            ACQ();
+            tile_regs_acquire();
             add_tiles(cos_interm_cb, sin_interm_cb, 0, 0, 0);
+            tile_regs_commit();
+            tile_regs_wait();
             pack_tile(0, out_cb);
-            REL();
+            tile_regs_release();
             cb_push_back(out_cb, onetile);
             cb_pop_front(cos_interm_cb, onetile);
             cb_pop_front(sin_interm_cb, onetile);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id.cpp
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+inline void fill_rotate_half_trans_mat_bfp8(uint32_t cb_id) {
+    constexpr uint32_t onetile = 1;
+    cb_reserve_back(cb_id, onetile);
+    volatile tt_l1_ptr uint8_t* p = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(get_write_ptr(cb_id));
+    for (uint32_t i = 0; i < 1088; ++i) {
+        p[i] = 0;
+    }
+    for (uint32_t r = 0; r < 16; ++r) {
+        p[16 + r] = 127;
+        p[320 + r * 16 + r] = 0x40;
+    }
+    for (uint32_t r = 0; r < 16; ++r) {
+        p[32 + r] = 127;
+        p[576 + r * 16 + r] = 0xC0;
+    }
+    cb_push_back(cb_id, onetile);
+}
+
+inline void fill_rotate_half_trans_mat_bf16(uint32_t cb_id) {
+    constexpr uint32_t onetile = 1;
+    constexpr uint16_t one_bf16 = 0x3F80;
+    constexpr uint16_t neg_one_bf16 = 0xBF80;
+    constexpr uint32_t face_elems = 16 * 16;
+
+    cb_reserve_back(cb_id, onetile);
+    volatile tt_l1_ptr uint16_t* tile = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id));
+    for (uint32_t i = 0; i < 4 * face_elems; ++i) {
+        tile[i] = 0;
+    }
+    for (uint32_t r = 0; r < 16; ++r) {
+        tile[1 * face_elems + r * 16 + r] = one_bf16;
+    }
+    for (uint32_t r = 0; r < 16; ++r) {
+        tile[2 * face_elems + r * 16 + r] = neg_one_bf16;
+    }
+    cb_push_back(cb_id, onetile);
+}
+
+inline void fill_rotate_half_trans_mat_fp32(uint32_t cb_id) {
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t one_fp32 = 0x3F800000;
+    constexpr uint32_t neg_one_fp32 = 0xBF800000;
+    constexpr uint32_t face_elems = 16 * 16;
+
+    cb_reserve_back(cb_id, onetile);
+    volatile tt_l1_ptr uint32_t* tile = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+    for (uint32_t i = 0; i < 4 * face_elems; ++i) {
+        tile[i] = 0;
+    }
+    for (uint32_t r = 0; r < 16; ++r) {
+        tile[1 * face_elems + r * 16 + r] = one_fp32;
+    }
+    for (uint32_t r = 0; r < 16; ++r) {
+        tile[2 * face_elems + r * 16 + r] = neg_one_fp32;
+    }
+    cb_push_back(cb_id, onetile);
+}
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t cos_addr = get_arg_val<uint32_t>(1);
+    uint32_t sin_addr = get_arg_val<uint32_t>(2);
+    uint32_t num_rows = get_arg_val<uint32_t>(3);
+    uint32_t start_id = get_arg_val<uint32_t>(4);
+    uint32_t start_row_id = get_arg_val<uint32_t>(5);
+    uint32_t cos_sin_start_id = get_arg_val<uint32_t>(6);
+
+    constexpr uint32_t input_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t cos_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t sin_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t trans_mat_cb_id = get_compile_time_arg_val(3);
+    constexpr uint32_t Ht = get_compile_time_arg_val(4);
+    constexpr uint32_t HtWt = get_compile_time_arg_val(5);
+    constexpr auto src_args = TensorAccessorArgs<6>();
+    constexpr auto cos_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+    constexpr auto sin_args = TensorAccessorArgs<cos_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t onetile = 1;
+    const uint32_t input_tile_bytes = get_tile_size(input_cb_id);
+    const auto s0 = TensorAccessor(src_args, src_addr, input_tile_bytes);
+
+    const uint32_t cos_tile_bytes = get_tile_size(cos_cb_id);
+    const auto s1 = TensorAccessor(cos_args, cos_addr, cos_tile_bytes);
+
+    const uint32_t sin_tile_bytes = get_tile_size(sin_cb_id);
+    const auto s2 = TensorAccessor(sin_args, sin_addr, sin_tile_bytes);
+
+    const uint32_t trans_mat_tile_size = get_tile_size(trans_mat_cb_id);
+    if (trans_mat_tile_size == 4096) {
+        fill_rotate_half_trans_mat_fp32(trans_mat_cb_id);
+    } else if (trans_mat_tile_size == 2048) {
+        fill_rotate_half_trans_mat_bf16(trans_mat_cb_id);
+    } else {
+        fill_rotate_half_trans_mat_bfp8(trans_mat_cb_id);
+    }
+
+    uint32_t input_curr_id = start_id;
+    uint32_t cos_sin_curr_id = cos_sin_start_id;
+    uint32_t ht = start_row_id;
+
+    for (uint32_t i = 0; i < num_rows; ++i) {
+        cb_reserve_back(input_cb_id, onetile);
+        uint32_t input_l1_write_addr = get_write_ptr(input_cb_id);
+        noc_async_read_tile(input_curr_id, s0, input_l1_write_addr);
+        noc_async_read_barrier();
+        cb_push_back(input_cb_id, onetile);
+        input_curr_id++;
+
+        cb_reserve_back(sin_cb_id, onetile);
+        {
+            uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
+            noc_async_read_tile(cos_sin_curr_id, s2, sin_l1_write_addr);
+            noc_async_read_barrier();
+        }
+        cb_push_back(sin_cb_id, onetile);
+
+        cb_reserve_back(cos_cb_id, onetile);
+        {
+            uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
+            noc_async_read_tile(cos_sin_curr_id, s1, cos_l1_write_addr);
+            noc_async_read_barrier();
+        }
+        cb_push_back(cos_cb_id, onetile);
+        cos_sin_curr_id++;
+
+        ht++;
+        if (ht == Ht) {
+            ht = 0;
+            cos_sin_curr_id -= HtWt;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id_sharded.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id_sharded.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+inline void fill_rotate_half_trans_mat_bfp8(uint32_t cb_id) {
+    constexpr uint32_t onetile = 1;
+    cb_reserve_back(cb_id, onetile);
+    volatile tt_l1_ptr uint8_t* p = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(get_write_ptr(cb_id));
+    for (uint32_t i = 0; i < 1088; ++i) {
+        p[i] = 0;
+    }
+    for (uint32_t r = 0; r < 16; ++r) {
+        p[16 + r] = 127;
+        p[320 + r * 16 + r] = 0x40;
+    }
+    for (uint32_t r = 0; r < 16; ++r) {
+        p[32 + r] = 127;
+        p[576 + r * 16 + r] = 0xC0;
+    }
+    cb_push_back(cb_id, onetile);
+}
+
+inline void fill_rotate_half_trans_mat_bf16(uint32_t cb_id) {
+    constexpr uint32_t onetile = 1;
+    constexpr uint16_t one_bf16 = 0x3F80;
+    constexpr uint16_t neg_one_bf16 = 0xBF80;
+    constexpr uint32_t face_elems = 16 * 16;
+
+    cb_reserve_back(cb_id, onetile);
+    volatile tt_l1_ptr uint16_t* tile = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id));
+    for (uint32_t i = 0; i < 4 * face_elems; ++i) {
+        tile[i] = 0;
+    }
+    for (uint32_t r = 0; r < 16; ++r) {
+        tile[1 * face_elems + r * 16 + r] = one_bf16;
+    }
+    for (uint32_t r = 0; r < 16; ++r) {
+        tile[2 * face_elems + r * 16 + r] = neg_one_bf16;
+    }
+    cb_push_back(cb_id, onetile);
+}
+
+inline void fill_rotate_half_trans_mat_fp32(uint32_t cb_id) {
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t one_fp32 = 0x3F800000;
+    constexpr uint32_t neg_one_fp32 = 0xBF800000;
+    constexpr uint32_t face_elems = 16 * 16;
+
+    cb_reserve_back(cb_id, onetile);
+    volatile tt_l1_ptr uint32_t* tile = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+    for (uint32_t i = 0; i < 4 * face_elems; ++i) {
+        tile[i] = 0;
+    }
+    for (uint32_t r = 0; r < 16; ++r) {
+        tile[1 * face_elems + r * 16 + r] = one_fp32;
+    }
+    for (uint32_t r = 0; r < 16; ++r) {
+        tile[2 * face_elems + r * 16 + r] = neg_one_fp32;
+    }
+    cb_push_back(cb_id, onetile);
+}
+
+void kernel_main() {
+    uint32_t cos_addr = get_arg_val<uint32_t>(0);
+    uint32_t sin_addr = get_arg_val<uint32_t>(1);
+    uint32_t num_rows = get_arg_val<uint32_t>(2);
+    uint32_t start_row_id = get_arg_val<uint32_t>(3);
+    uint32_t cos_sin_start_id = get_arg_val<uint32_t>(4);
+
+    constexpr uint32_t input_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t cos_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t sin_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t trans_mat_cb_id = get_compile_time_arg_val(3);
+    constexpr uint32_t Ht = get_compile_time_arg_val(4);
+    constexpr uint32_t HtWt = get_compile_time_arg_val(5);
+    constexpr auto cos_args = TensorAccessorArgs<6>();
+    constexpr auto sin_args = TensorAccessorArgs<cos_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t onetile = 1;
+
+    cb_reserve_back(input_cb_id, num_rows);
+    cb_push_back(input_cb_id, num_rows);
+
+    const uint32_t cos_tile_bytes = get_tile_size(cos_cb_id);
+    const auto s1 = TensorAccessor(cos_args, cos_addr, cos_tile_bytes);
+
+    const uint32_t sin_tile_bytes = get_tile_size(sin_cb_id);
+    const auto s2 = TensorAccessor(sin_args, sin_addr, sin_tile_bytes);
+
+    const uint32_t trans_mat_tile_size = get_tile_size(trans_mat_cb_id);
+    if (trans_mat_tile_size == 4096) {
+        fill_rotate_half_trans_mat_fp32(trans_mat_cb_id);
+    } else if (trans_mat_tile_size == 2048) {
+        fill_rotate_half_trans_mat_bf16(trans_mat_cb_id);
+    } else {
+        fill_rotate_half_trans_mat_bfp8(trans_mat_cb_id);
+    }
+
+    uint32_t cos_sin_curr_id = cos_sin_start_id;
+    uint32_t ht = start_row_id;
+    for (uint32_t i = 0; i < num_rows; ++i) {
+        cb_reserve_back(sin_cb_id, onetile);
+        {
+            uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
+            noc_async_read_tile(cos_sin_curr_id, s2, sin_l1_write_addr);
+            noc_async_read_barrier();
+        }
+        cb_push_back(sin_cb_id, onetile);
+
+        cb_reserve_back(cos_cb_id, onetile);
+        {
+            uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
+            noc_async_read_tile(cos_sin_curr_id, s1, cos_l1_write_addr);
+            noc_async_read_barrier();
+        }
+        cb_push_back(cos_cb_id, onetile);
+        cos_sin_curr_id++;
+
+        ht++;
+        if (ht == Ht) {
+            ht = 0;
+            cos_sin_curr_id -= HtWt;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_sharded.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_sharded.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+inline void fill_rotate_half_trans_mat_bfp8(uint32_t cb_id) {
+    constexpr uint32_t onetile = 1;
+    cb_reserve_back(cb_id, onetile);
+    volatile tt_l1_ptr uint8_t* p = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(get_write_ptr(cb_id));
+    for (uint32_t i = 0; i < 1088; ++i) {
+        p[i] = 0;
+    }
+    for (uint32_t r = 0; r < 16; ++r) {
+        p[16 + r] = 127;
+        p[320 + r * 16 + r] = 0x40;
+    }
+    for (uint32_t r = 0; r < 16; ++r) {
+        p[32 + r] = 127;
+        p[576 + r * 16 + r] = 0xC0;
+    }
+    cb_push_back(cb_id, onetile);
+}
+
+inline void fill_rotate_half_trans_mat_bf16(uint32_t cb_id) {
+    constexpr uint32_t onetile = 1;
+    constexpr uint16_t one_bf16 = 0x3F80;
+    constexpr uint16_t neg_one_bf16 = 0xBF80;
+    constexpr uint32_t face_elems = 16 * 16;
+
+    cb_reserve_back(cb_id, onetile);
+    volatile tt_l1_ptr uint16_t* tile = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id));
+    for (uint32_t i = 0; i < 4 * face_elems; ++i) {
+        tile[i] = 0;
+    }
+    for (uint32_t r = 0; r < 16; ++r) {
+        tile[1 * face_elems + r * 16 + r] = one_bf16;
+    }
+    for (uint32_t r = 0; r < 16; ++r) {
+        tile[2 * face_elems + r * 16 + r] = neg_one_bf16;
+    }
+    cb_push_back(cb_id, onetile);
+}
+
+inline void fill_rotate_half_trans_mat_fp32(uint32_t cb_id) {
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t one_fp32 = 0x3F800000;
+    constexpr uint32_t neg_one_fp32 = 0xBF800000;
+    constexpr uint32_t face_elems = 16 * 16;
+
+    cb_reserve_back(cb_id, onetile);
+    volatile tt_l1_ptr uint32_t* tile = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+    for (uint32_t i = 0; i < 4 * face_elems; ++i) {
+        tile[i] = 0;
+    }
+    for (uint32_t r = 0; r < 16; ++r) {
+        tile[1 * face_elems + r * 16 + r] = one_fp32;
+    }
+    for (uint32_t r = 0; r < 16; ++r) {
+        tile[2 * face_elems + r * 16 + r] = neg_one_fp32;
+    }
+    cb_push_back(cb_id, onetile);
+}
+
+void kernel_main() {
+    constexpr uint32_t trans_mat_cb_id = get_compile_time_arg_val(0);
+
+    const uint32_t trans_mat_tile_size = get_tile_size(trans_mat_cb_id);
+    if (trans_mat_tile_size == 4096) {
+        fill_rotate_half_trans_mat_fp32(trans_mat_cb_id);
+    } else if (trans_mat_tile_size == 2048) {
+        fill_rotate_half_trans_mat_bf16(trans_mat_cb_id);
+    } else {
+        fill_rotate_half_trans_mat_bfp8(trans_mat_cb_id);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation.cpp
@@ -40,7 +40,13 @@ void RotaryEmbeddingHfDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(cos.layout() == tt::tt_metal::Layout::TILE, "Cos must be tilized");
     TT_FATAL(sin.layout() == tt::tt_metal::Layout::TILE, "Sin must be tilized");
 
-    TT_FATAL(input_tensor.padded_shape()[-1] % (TILE_WIDTH * 2) == 0, "Input X dim must be divisible by 64");
+    TT_FATAL(
+        input_tensor.padded_shape()[-1] == TILE_WIDTH || input_tensor.padded_shape()[-1] % (TILE_WIDTH * 2) == 0,
+        "Input X dim ({}) must be either {} (single tile) or divisible by {} (rotate_half midpoint must align with "
+        "a tile boundary).",
+        input_tensor.padded_shape()[-1],
+        TILE_WIDTH,
+        TILE_WIDTH * 2);
     uint32_t X = input_tensor.padded_shape()[-1];
     TT_FATAL(cos.dtype() == sin.dtype(), "Cos and Sin dtypes must match");
     TT_FATAL(cos.padded_shape() == sin.padded_shape(), "Cos and Sin shapes must match");

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_multi_core_program_factory.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "rotary_embedding_hf_multi_core_program_factory.hpp"
+#include <bit>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
@@ -12,11 +13,297 @@ namespace ttnn::experimental::prim {
 
 using namespace tt::constants;
 
+namespace {
+
+RotaryEmbeddingHfMultiCore::cached_program_t create_single_tile_prefill(
+    const RotaryEmbeddingHfParams& operation_attributes, const RotaryEmbeddingHfInputs& tensor_args, Tensor& output) {
+    using namespace tt::tt_metal;
+
+    const auto& input = tensor_args.input_tensor;
+    const auto& cos = tensor_args.cos_cache;
+    const auto& sin = tensor_args.sin_cache;
+
+    Program program{};
+
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
+
+    tt::DataFormat cos_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(cos.dtype());
+    uint32_t cos_single_tile_size = tt::tile_size(cos_cb_data_format);
+
+    tt::DataFormat sin_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(sin.dtype());
+    uint32_t sin_single_tile_size = tt::tile_size(sin_cb_data_format);
+
+    tt::DataFormat trans_mat_cb_data_format = input_cb_data_format == tt::DataFormat::Bfp8_b
+                                                  ? tt::DataFormat::Bfp8_b
+                                              : input_cb_data_format == tt::DataFormat::Float32
+                                                  ? tt::DataFormat::Float32
+                                                  : tt::DataFormat::Float16_b;
+    uint32_t trans_mat_single_tile_size = tt::tile_size(trans_mat_cb_data_format);
+
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
+
+    constexpr uint32_t Wt = 1;
+    uint32_t num_rows = input.physical_volume() / input.padded_shape()[-1] / TILE_HEIGHT;
+    uint32_t Ht = input.padded_shape()[-2] / TILE_HEIGHT;
+    uint32_t HtWt = Ht * Wt;
+
+    tt::tt_metal::IDevice* device = input.device();
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    bool row_major;
+    uint32_t num_cores, num_rows_per_core_group_1, num_rows_per_core_group_2;
+    CoreRangeSet all_cores, core_group_1, core_group_2;
+
+    bool in_sharded = input.shard_spec().has_value();
+    bool out_sharded = output.shard_spec().has_value();
+    std::optional<ShardSpec> shard_spec = in_sharded ? input.shard_spec() : output.shard_spec();
+
+    uint32_t num_input_tiles, num_output_tiles;
+
+    if (shard_spec.has_value()) {
+        row_major = shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
+        all_cores = shard_spec.value().grid;
+        num_cores = all_cores.num_cores();
+        core_group_1 = all_cores;
+        core_group_2 = CoreRangeSet();
+        num_rows_per_core_group_1 = shard_spec.value().shape[0] / TILE_HEIGHT;
+        num_rows_per_core_group_2 = 0;
+        num_input_tiles = in_sharded ? shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW : 2 * Wt;
+        num_output_tiles = out_sharded ? shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW : 2 * Wt;
+        auto bbox = all_cores.bounding_box();
+        num_cores_x = bbox.end_coord.x + 1;
+        num_cores_y = bbox.end_coord.y + 1;
+    } else {
+        row_major = true;
+        std::tie(
+            num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_rows, row_major);
+        num_input_tiles = 2 * Wt;
+        num_output_tiles = num_input_tiles;
+    }
+
+    uint32_t input_cb_index = tt::CBIndex::c_0;
+    tt::tt_metal::CircularBufferConfig cb_input_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_input_tiles * input_single_tile_size, {{input_cb_index, input_cb_data_format}})
+            .set_page_size(input_cb_index, input_single_tile_size);
+    if (in_sharded) {
+        cb_input_config = cb_input_config.set_globally_allocated_address(*input.buffer());
+    }
+    auto cb_input = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_input_config);
+
+    uint32_t trans_mat_cb_index = tt::CBIndex::c_1;
+    tt::tt_metal::CircularBufferConfig cb_trans_mat_config =
+        tt::tt_metal::CircularBufferConfig(trans_mat_single_tile_size, {{trans_mat_cb_index, trans_mat_cb_data_format}})
+            .set_page_size(trans_mat_cb_index, trans_mat_single_tile_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_trans_mat_config);
+
+    uint32_t cos_cb_index = tt::CBIndex::c_2;
+    tt::tt_metal::CircularBufferConfig cb_cos_config =
+        tt::tt_metal::CircularBufferConfig(cos_single_tile_size, {{cos_cb_index, cos_cb_data_format}})
+            .set_page_size(cos_cb_index, cos_single_tile_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_config);
+
+    uint32_t sin_cb_index = tt::CBIndex::c_3;
+    tt::tt_metal::CircularBufferConfig cb_sin_config =
+        tt::tt_metal::CircularBufferConfig(sin_single_tile_size, {{sin_cb_index, sin_cb_data_format}})
+            .set_page_size(sin_cb_index, sin_single_tile_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_config);
+
+    uint32_t num_interm_tiles = 1;
+    uint32_t rotated_input_interm_cb_index = tt::CBIndex::c_24;
+    tt::tt_metal::CircularBufferConfig cb_rotated_input_interm_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_interm_tiles * input_single_tile_size, {{rotated_input_interm_cb_index, input_cb_data_format}})
+            .set_page_size(rotated_input_interm_cb_index, input_single_tile_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_rotated_input_interm_config);
+
+    uint32_t cos_interm_cb_index = tt::CBIndex::c_25;
+    tt::tt_metal::CircularBufferConfig cb_cos_interm_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_interm_tiles * input_single_tile_size, {{cos_interm_cb_index, input_cb_data_format}})
+            .set_page_size(cos_interm_cb_index, input_single_tile_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_interm_config);
+
+    uint32_t sin_interm_cb_index = tt::CBIndex::c_26;
+    tt::tt_metal::CircularBufferConfig cb_sin_interm_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_interm_tiles * input_single_tile_size, {{sin_interm_cb_index, input_cb_data_format}})
+            .set_page_size(sin_interm_cb_index, input_single_tile_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_interm_config);
+
+    uint32_t output_cb_index = tt::CBIndex::c_16;
+    tt::tt_metal::CircularBufferConfig cb_output_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_output_tiles * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
+            .set_page_size(output_cb_index, output_single_tile_size);
+    if (out_sharded) {
+        cb_output_config = cb_output_config.set_globally_allocated_address(*output.buffer());
+    }
+    auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+
+    auto* src_buffer = input.buffer();
+    auto* cos_buffer = cos.buffer();
+    auto* sin_buffer = sin.buffer();
+    auto* dst_buffer = output.buffer();
+
+    std::vector<uint32_t> reader_compile_time_args;
+    if (in_sharded) {
+        reader_compile_time_args = {
+            (std::uint32_t)input_cb_index,
+            (std::uint32_t)cos_cb_index,
+            (std::uint32_t)sin_cb_index,
+            (std::uint32_t)trans_mat_cb_index,
+            (std::uint32_t)Ht,
+            (std::uint32_t)HtWt,
+        };
+        tt::tt_metal::TensorAccessorArgs(cos_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(sin_buffer).append_to(reader_compile_time_args);
+    } else {
+        reader_compile_time_args = {
+            (std::uint32_t)input_cb_index,
+            (std::uint32_t)cos_cb_index,
+            (std::uint32_t)sin_cb_index,
+            (std::uint32_t)trans_mat_cb_index,
+            (std::uint32_t)Ht,
+            (std::uint32_t)HtWt,
+        };
+        tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(cos_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(sin_buffer).append_to(reader_compile_time_args);
+    }
+
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
+    tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_args);
+
+    std::map<std::string, std::string> writer_kernel_defines;
+    if (out_sharded) {
+        writer_kernel_defines["OUT_SHARDED"] = "1";
+    }
+
+    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        in_sharded ? "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/"
+                     "dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id_sharded.cpp"
+                   : "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/"
+                     "dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id.cpp",
+        all_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/"
+        "writer_rotary_embedding_hf_interleaved.cpp",
+        all_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, writer_kernel_defines));
+
+    std::vector<uint32_t> compute_kernel_args = {
+        (std::uint32_t)input_cb_index,
+        (std::uint32_t)cos_cb_index,
+        (std::uint32_t)sin_cb_index,
+        (std::uint32_t)trans_mat_cb_index,
+        (std::uint32_t)rotated_input_interm_cb_index,
+        (std::uint32_t)cos_interm_cb_index,
+        (std::uint32_t)sin_interm_cb_index,
+        (std::uint32_t)output_cb_index,
+        (std::uint32_t)num_rows_per_core_group_1,
+    };
+
+    tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/"
+        "rotary_embedding_single_tile.cpp",
+        core_group_1,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .compile_args = compute_kernel_args});
+    if (!core_group_2.ranges().empty()) {
+        compute_kernel_args[8] = num_rows_per_core_group_2;
+        tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/"
+            "rotary_embedding_single_tile.cpp",
+            core_group_2,
+            tt::tt_metal::ComputeConfig{
+                .math_fidelity = math_fidelity,
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+                .compile_args = compute_kernel_args});
+    }
+
+    uint32_t g1_numcores = core_group_1.num_cores();
+    const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
+
+    for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; ++i) {
+        const CoreCoord& core = cores.at(i);
+        uint32_t num_rows_per_core = i < g1_numcores ? num_rows_per_core_group_1 : num_rows_per_core_group_2;
+        uint32_t cos_sin_start_id = num_tiles_written % HtWt;
+
+        std::vector<uint32_t> reader_rt_args;
+        if (in_sharded) {
+            reader_rt_args = {
+                cos_buffer->address(),
+                sin_buffer->address(),
+                num_rows_per_core,
+                num_tiles_written / Wt % Ht,
+                cos_sin_start_id,
+            };
+        } else {
+            reader_rt_args = {
+                src_buffer->address(),
+                cos_buffer->address(),
+                sin_buffer->address(),
+                num_rows_per_core,
+                num_tiles_written,
+                num_tiles_written / Wt % Ht,
+                cos_sin_start_id,
+            };
+        }
+        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
+
+        tt::tt_metal::SetRuntimeArgs(
+            program, unary_writer_kernel_id, core, {dst_buffer->address(), num_rows_per_core * Wt, num_tiles_written});
+        num_tiles_written += num_rows_per_core * Wt;
+    }
+
+    RotaryEmbeddingHfMultiCore::shared_variables_t shared_variables{
+        .unary_reader_kernel_id = unary_reader_kernel_id,
+        .unary_writer_kernel_id = unary_writer_kernel_id,
+        .cb_input = cb_input,
+        .cb_output = cb_output,
+        .cores = cores,
+        .g1_numcores = g1_numcores,
+        .num_rows_per_core_group_1 = num_rows_per_core_group_1,
+        .num_rows_per_core_group_2 = num_rows_per_core_group_2,
+        .Wt = Wt,
+        .Ht = Ht,
+        .HtWt = HtWt,
+        .single_tile = true,
+        .single_tile_reader_uses_sharded_args = in_sharded,
+    };
+
+    return RotaryEmbeddingHfMultiCore::cached_program_t{std::move(program), std::move(shared_variables)};
+}
+
+}  // namespace
+
 RotaryEmbeddingHfMultiCore::cached_program_t RotaryEmbeddingHfMultiCore::create(
     const RotaryEmbeddingHfParams& operation_attributes, const RotaryEmbeddingHfInputs& tensor_args, Tensor& output) {
     using namespace tt::tt_metal;
 
     const auto& input = tensor_args.input_tensor;
+    if (input.padded_shape()[-1] / TILE_WIDTH == 1) {
+        return create_single_tile_prefill(operation_attributes, tensor_args, output);
+    }
+
     const auto& cos = tensor_args.cos_cache;
     const auto& sin = tensor_args.sin_cache;
 
@@ -118,7 +405,6 @@ RotaryEmbeddingHfMultiCore::cached_program_t RotaryEmbeddingHfMultiCore::create(
             .set_page_size(sin_cb_index, sin_single_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_config);
 
-    // Used for bcast scalar (-1)
     uint32_t src_scalar_cb_index = tt::CBIndex::c_4;
     uint32_t num_scalar_tiles = 1;
     tt::tt_metal::CircularBufferConfig cb_src1_config =
@@ -149,7 +435,7 @@ RotaryEmbeddingHfMultiCore::cached_program_t RotaryEmbeddingHfMultiCore::create(
             .set_page_size(sin_interm_cb_index, sin_single_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_interm_config);
 
-    uint32_t output_cb_index = tt::CBIndex::c_16;  // output operands start at index 16
+    uint32_t output_cb_index = tt::CBIndex::c_16;
     tt::tt_metal::CircularBufferConfig cb_output_config =
         tt::tt_metal::CircularBufferConfig(
             num_output_tiles * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
@@ -166,9 +452,7 @@ RotaryEmbeddingHfMultiCore::cached_program_t RotaryEmbeddingHfMultiCore::create(
     auto* sin_buffer = sin.buffer();
     auto* dst_buffer = output.buffer();
 
-    std::vector<uint32_t> reader_compile_time_args;
-
-    reader_compile_time_args = {
+    std::vector<uint32_t> reader_compile_time_args = {
         (std::uint32_t)input_cb_index,
         (std::uint32_t)rotated_input_cb_index,
         (std::uint32_t)cos_cb_index,
@@ -243,22 +527,13 @@ RotaryEmbeddingHfMultiCore::cached_program_t RotaryEmbeddingHfMultiCore::create(
     }
 
     uint32_t g1_numcores = core_group_1.num_cores();
-
     const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
 
     for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; ++i) {
         const CoreCoord& core = cores.at(i);
-        uint32_t num_rows_per_core = 0;
-        if (i < g1_numcores) {
-            num_rows_per_core = num_rows_per_core_group_1;
-        } else {
-            num_rows_per_core = num_rows_per_core_group_2;
-        }
-
+        uint32_t num_rows_per_core = i < g1_numcores ? num_rows_per_core_group_1 : num_rows_per_core_group_2;
         uint32_t cos_sin_start_id = num_tiles_written % HtWt;
 
-        // reader_rotary_embedding_hf_interleaved.cpp expects:
-        // 0 src, 1 cos, 2 sin, 3 num_rows, 4 start_id, 5 start_row_id, 6 cos_sin_start_id
         std::vector<uint32_t> reader_rt_args = {
             src_buffer->address(),
             cos_buffer->address(),
@@ -285,7 +560,10 @@ RotaryEmbeddingHfMultiCore::cached_program_t RotaryEmbeddingHfMultiCore::create(
         .num_rows_per_core_group_2 = num_rows_per_core_group_2,
         .Wt = Wt,
         .Ht = Ht,
-        .HtWt = HtWt};
+        .HtWt = HtWt,
+        .single_tile = false,
+        .single_tile_reader_uses_sharded_args = false,
+    };
 
     return cached_program_t{std::move(program), std::move(shared_variables)};
 }
@@ -318,6 +596,9 @@ void RotaryEmbeddingHfMultiCore::override_runtime_arguments(
     const auto& num_rows_per_core_group_2 = cached_program.shared_variables.num_rows_per_core_group_2;
     const auto& Wt = cached_program.shared_variables.Wt;
     const auto& HtWt = cached_program.shared_variables.HtWt;
+    const auto& single_tile = cached_program.shared_variables.single_tile;
+    const auto& single_tile_reader_uses_sharded_args =
+        cached_program.shared_variables.single_tile_reader_uses_sharded_args;
 
     if (in_sharded) {
         UpdateDynamicCircularBufferAddress(program, cb_input, *src_buffer);
@@ -329,21 +610,21 @@ void RotaryEmbeddingHfMultiCore::override_runtime_arguments(
 
     for (uint32_t i = 0, num_tiles_written = 0; i < cores.size(); ++i) {
         const CoreCoord& core = cores.at(i);
-        uint32_t num_rows_per_core = 0;
-        if (i < g1_numcores) {
-            num_rows_per_core = num_rows_per_core_group_1;
-        } else {
-            num_rows_per_core = num_rows_per_core_group_2;
-        }
-
+        uint32_t num_rows_per_core = i < g1_numcores ? num_rows_per_core_group_1 : num_rows_per_core_group_2;
         uint32_t cos_sin_start_id = num_tiles_written % HtWt;
 
         {
             auto& runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
-            runtime_args[0] = src_buffer->address();
-            runtime_args[1] = cos_buffer->address();
-            runtime_args[2] = sin_buffer->address();
-            runtime_args[6] = cos_sin_start_id;
+            if (single_tile && single_tile_reader_uses_sharded_args) {
+                runtime_args[0] = cos_buffer->address();
+                runtime_args[1] = sin_buffer->address();
+                runtime_args[4] = cos_sin_start_id;
+            } else {
+                runtime_args[0] = src_buffer->address();
+                runtime_args[1] = cos_buffer->address();
+                runtime_args[2] = sin_buffer->address();
+                runtime_args[6] = cos_sin_start_id;
+            }
         }
 
         {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_multi_core_program_factory.hpp
@@ -25,6 +25,8 @@ struct RotaryEmbeddingHfMultiCore {
         uint32_t Wt;
         uint32_t Ht;
         uint32_t HtWt;
+        bool single_tile;
+        bool single_tile_reader_uses_sharded_args;
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_sharded_program_factory.cpp
@@ -11,6 +11,170 @@
 
 namespace ttnn::experimental::prim {
 
+namespace {
+
+RotaryEmbeddingHfMultiCoreSharded::cached_program_t create_single_tile_decode(
+    const RotaryEmbeddingHfParams& operation_attributes, const RotaryEmbeddingHfInputs& tensor_args, Tensor& output) {
+    using namespace tt::constants;
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    const auto& input = tensor_args.input_tensor;
+    const auto& cos = tensor_args.cos_cache;
+    const auto& sin = tensor_args.sin_cache;
+
+    Program program{};
+
+    const tt::DataFormat input_cb_data_format = tt_metal::datatype_to_dataformat_converter(input.dtype());
+    const uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
+
+    const tt::DataFormat cos_cb_data_format = tt_metal::datatype_to_dataformat_converter(cos.dtype());
+    const uint32_t cos_single_tile_size = tt::tile_size(cos_cb_data_format);
+
+    const tt::DataFormat sin_cb_data_format = tt_metal::datatype_to_dataformat_converter(sin.dtype());
+    const uint32_t sin_single_tile_size = tt::tile_size(sin_cb_data_format);
+
+    const tt::DataFormat trans_mat_cb_data_format = input_cb_data_format == tt::DataFormat::Bfp8_b
+                                                        ? tt::DataFormat::Bfp8_b
+                                                    : input_cb_data_format == tt::DataFormat::Float32
+                                                        ? tt::DataFormat::Float32
+                                                        : tt::DataFormat::Float16_b;
+    const uint32_t trans_mat_single_tile_size = tt::tile_size(trans_mat_cb_data_format);
+
+    const tt::DataFormat output_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
+    const uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
+
+    bool in_sharded = input.shard_spec().has_value();
+    std::optional<ShardSpec> shard_spec = in_sharded ? input.shard_spec() : output.shard_spec();
+
+    const uint32_t batch = input.padded_shape()[1];
+    const uint32_t n_heads_t = shard_spec->shape[0] / constants::TILE_HEIGHT;
+    const uint32_t n_heads_per_batch_t = input.padded_shape()[2] / constants::TILE_HEIGHT;
+    constexpr uint32_t head_dim_t = 1;
+
+    tt_metal::IDevice* device = input.device();
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
+
+    CoreRange all_cores = shard_spec->grid.bounding_box();
+    uint32_t num_cores_x = all_cores.grid_size().x;
+    uint32_t num_cores_y = all_cores.grid_size().y;
+
+    const uint32_t num_input_tiles = n_heads_t * head_dim_t;
+    const uint32_t num_output_tiles = num_input_tiles;
+
+    const uint32_t num_cores = num_cores_x * num_cores_y;
+    const uint32_t batch_parallel_factor = std::min(batch, num_cores);
+    const uint32_t batch_per_core = (batch + batch_parallel_factor - 1) / batch_parallel_factor;
+    const uint32_t num_cos_sin_tiles = head_dim_t * batch_per_core;
+
+    auto* src_buffer = input.buffer();
+    auto* cos_buffer = cos.buffer();
+    auto* sin_buffer = sin.buffer();
+    auto* dst_buffer = output.buffer();
+
+    uint32_t input_cb_index = CBIndex::c_0;
+    tt_metal::CircularBufferConfig cb_input_config =
+        tt_metal::CircularBufferConfig(
+            num_input_tiles * input_single_tile_size, {{input_cb_index, input_cb_data_format}})
+            .set_page_size(input_cb_index, input_single_tile_size)
+            .set_globally_allocated_address(*src_buffer);
+    auto cb_input = tt_metal::CreateCircularBuffer(program, all_cores, cb_input_config);
+
+    uint32_t cos_cb_index = CBIndex::c_1;
+    tt_metal::CircularBufferConfig cb_cos_config =
+        tt_metal::CircularBufferConfig(num_cos_sin_tiles * cos_single_tile_size, {{cos_cb_index, cos_cb_data_format}})
+            .set_page_size(cos_cb_index, cos_single_tile_size)
+            .set_globally_allocated_address(*cos_buffer);
+    auto cb_cos = tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_config);
+
+    uint32_t sin_cb_index = CBIndex::c_2;
+    tt_metal::CircularBufferConfig cb_sin_config =
+        tt_metal::CircularBufferConfig(num_cos_sin_tiles * sin_single_tile_size, {{sin_cb_index, sin_cb_data_format}})
+            .set_page_size(sin_cb_index, sin_single_tile_size)
+            .set_globally_allocated_address(*sin_buffer);
+    auto cb_sin = tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_config);
+
+    uint32_t trans_mat_cb_index = CBIndex::c_3;
+    tt_metal::CircularBufferConfig cb_trans_mat_config =
+        tt_metal::CircularBufferConfig(trans_mat_single_tile_size, {{trans_mat_cb_index, trans_mat_cb_data_format}})
+            .set_page_size(trans_mat_cb_index, trans_mat_single_tile_size);
+    tt_metal::CreateCircularBuffer(program, all_cores, cb_trans_mat_config);
+
+    uint32_t num_interm_tiles = head_dim_t;
+    uint32_t rotated_input_interm_cb_index = CBIndex::c_24;
+    tt_metal::CircularBufferConfig cb_rotated_input_interm_config =
+        tt_metal::CircularBufferConfig(
+            num_interm_tiles * input_single_tile_size, {{rotated_input_interm_cb_index, input_cb_data_format}})
+            .set_page_size(rotated_input_interm_cb_index, input_single_tile_size);
+    tt_metal::CreateCircularBuffer(program, all_cores, cb_rotated_input_interm_config);
+
+    uint32_t cos_interm_cb_index = CBIndex::c_25;
+    tt_metal::CircularBufferConfig cb_cos_interm_config =
+        tt_metal::CircularBufferConfig(
+            num_interm_tiles * input_single_tile_size, {{cos_interm_cb_index, input_cb_data_format}})
+            .set_page_size(cos_interm_cb_index, input_single_tile_size);
+    tt_metal::CreateCircularBuffer(program, all_cores, cb_cos_interm_config);
+
+    uint32_t sin_interm_cb_index = CBIndex::c_26;
+    tt_metal::CircularBufferConfig cb_sin_interm_config =
+        tt_metal::CircularBufferConfig(
+            num_interm_tiles * input_single_tile_size, {{sin_interm_cb_index, input_cb_data_format}})
+            .set_page_size(sin_interm_cb_index, input_single_tile_size);
+    tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_interm_config);
+
+    uint32_t output_cb_index = CBIndex::c_16;
+    tt_metal::CircularBufferConfig cb_output_config =
+        tt_metal::CircularBufferConfig(
+            num_output_tiles * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
+            .set_page_size(output_cb_index, output_single_tile_size)
+            .set_globally_allocated_address(*dst_buffer);
+    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+
+    std::vector<uint32_t> compute_kernel_args = {
+        (std::uint32_t)input_cb_index,
+        (std::uint32_t)cos_cb_index,
+        (std::uint32_t)sin_cb_index,
+        (std::uint32_t)trans_mat_cb_index,
+        (std::uint32_t)rotated_input_interm_cb_index,
+        (std::uint32_t)cos_interm_cb_index,
+        (std::uint32_t)sin_interm_cb_index,
+        (std::uint32_t)output_cb_index,
+        (std::uint32_t)n_heads_per_batch_t,
+        (std::uint32_t)batch_per_core,
+    };
+
+    tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/"
+        "rotary_embedding_hf_single_tile_sharded.cpp",
+        all_cores,
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_kernel_args});
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        (std::uint32_t)trans_mat_cb_index,
+    };
+    tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/"
+        "reader_rotary_embedding_hf_single_tile_sharded.cpp",
+        all_cores,
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    return RotaryEmbeddingHfMultiCoreSharded::cached_program_t{
+        std::move(program),
+        RotaryEmbeddingHfMultiCoreSharded::shared_variables_t{
+            cb_input,
+            cb_cos,
+            cb_sin,
+            cb_output,
+        }};
+}
+
+}  // namespace
+
 RotaryEmbeddingHfMultiCoreSharded::cached_program_t RotaryEmbeddingHfMultiCoreSharded::create(
     const RotaryEmbeddingHfParams& operation_attributes, const RotaryEmbeddingHfInputs& tensor_args, Tensor& output) {
     using namespace tt::constants;
@@ -18,6 +182,10 @@ RotaryEmbeddingHfMultiCoreSharded::cached_program_t RotaryEmbeddingHfMultiCoreSh
     using namespace tt::tt_metal;
 
     const auto& input = tensor_args.input_tensor;
+    if (input.padded_shape()[-1] / TILE_WIDTH == 1) {
+        return create_single_tile_decode(operation_attributes, tensor_args, output);
+    }
+
     const auto& cos = tensor_args.cos_cache;
     const auto& sin = tensor_args.sin_cache;
 
@@ -58,7 +226,6 @@ RotaryEmbeddingHfMultiCoreSharded::cached_program_t RotaryEmbeddingHfMultiCoreSh
     const uint32_t num_input_tiles = n_heads_t * head_dim_t;
     const uint32_t num_output_tiles = num_input_tiles;
 
-    // Parallelization
     const uint32_t num_cores = num_cores_x * num_cores_y;
     const uint32_t batch_parallel_factor = std::min(batch, num_cores);
     const uint32_t batch_per_core = (batch + batch_parallel_factor - 1) / batch_parallel_factor;
@@ -66,7 +233,6 @@ RotaryEmbeddingHfMultiCoreSharded::cached_program_t RotaryEmbeddingHfMultiCoreSh
     const uint32_t num_sin_cos_rows_per_core = batch_per_core;
     uint32_t num_cos_sin_tiles = head_dim_t * num_sin_cos_rows_per_core;
 
-    // Set up the CBs
     auto* src_buffer = input.buffer();
     auto* cos_buffer = cos.buffer();
     auto* sin_buffer = sin.buffer();
@@ -94,7 +260,6 @@ RotaryEmbeddingHfMultiCoreSharded::cached_program_t RotaryEmbeddingHfMultiCoreSh
             .set_globally_allocated_address(*sin_buffer);
     auto cb_sin = tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_config);
 
-    // Used for bcast scalar (-1)
     uint32_t src_scalar_cb_index = CBIndex::c_3;
     uint32_t num_scalar_tiles = 1;
     tt_metal::CircularBufferConfig cb_src_scalar_config =
@@ -125,7 +290,7 @@ RotaryEmbeddingHfMultiCoreSharded::cached_program_t RotaryEmbeddingHfMultiCoreSh
             .set_page_size(sin_interm_cb_index, sin_single_tile_size);
     tt_metal::CreateCircularBuffer(program, all_cores, cb_sin_interm_config);
 
-    uint32_t output_cb_index = CBIndex::c_16;  // output operands start at index 16
+    uint32_t output_cb_index = CBIndex::c_16;
     tt_metal::CircularBufferConfig cb_output_config =
         tt_metal::CircularBufferConfig(
             num_output_tiles * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
@@ -133,7 +298,6 @@ RotaryEmbeddingHfMultiCoreSharded::cached_program_t RotaryEmbeddingHfMultiCoreSh
             .set_globally_allocated_address(*dst_buffer);
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
 
-    // Set up the kernel
     std::vector<uint32_t> compute_kernel_args = {
         (std::uint32_t)input_cb_index,
         (std::uint32_t)cos_cb_index,
@@ -157,10 +321,6 @@ RotaryEmbeddingHfMultiCoreSharded::cached_program_t RotaryEmbeddingHfMultiCoreSh
         tt_metal::ComputeConfig{
             .math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_kernel_args});
 
-    // Reader kernel: writes -1.0 (bfloat16) into the scalar CB so the compute
-    // kernel can use it for the rotate-half negation.  No NOC transfers needed —
-    // all tensor data is in globally-allocated L1 CBs — so this is the only job
-    // of the reader on the sharded decode path.
     const uint16_t bfloat16_neg_one = std::bit_cast<uint16_t>(bfloat16(-1.0f));
     std::vector<uint32_t> reader_compile_time_args = {
         (std::uint32_t)src_scalar_cb_index,
@@ -188,9 +348,6 @@ void RotaryEmbeddingHfMultiCoreSharded::override_runtime_arguments(
     const RotaryEmbeddingHfParams& /*operation_attributes*/,
     const RotaryEmbeddingHfInputs& tensor_args,
     Tensor& output) {
-    using namespace tt::constants;
-    using namespace tt::tt_metal;
-
     auto& program = cached_program.program;
     auto& shared_variables = cached_program.shared_variables;
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/rotary_embedding_hf_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/rotary_embedding_hf_nanobind.cpp
@@ -28,8 +28,9 @@ void bind_rotary_embedding_hf(nb::module_& mod) {
 
         ``input_tensor``, ``cos_cache``, and ``sin_cache`` must be **device** tensors (host tensors
         are rejected). Tensors must use TILE layout. The padded ``head_dim`` (last dimension of
-        ``input_tensor``, ``cos_cache``, and ``sin_cache``) must be divisible by ``2 * ttnn.TILE_SIZE``
-        (typically ``TILE_SIZE`` is 32, so ``head_dim`` is a multiple of 64).
+        ``input_tensor``, ``cos_cache``, and ``sin_cache``) must be either ``ttnn.TILE_SIZE`` or
+        divisible by ``2 * ttnn.TILE_SIZE`` (typically ``TILE_SIZE`` is 32, so supported values are
+        ``32`` or multiples of ``64``).
 
         Args:
             input_tensor (ttnn.Tensor): Input tensor to apply rotation to (on device)


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Feature


### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Relates to #39266

Following #42442, this PR adds head_dim=32 support to `ttnn.experimental.rotary_embedding_hf`.
I need to make the RoPE operator support a single TILE_SIZE.
The current implementation does not affect the original behavior of the `rotary_embedding_hf` operator.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
All tests were PASS.
<img width="1886" height="1067" alt="83697525395105284c836b5bfa2733f" src="https://github.com/user-attachments/assets/cb76103d-282c-4b43-92b9-e228299db54f" />
<img width="1920" height="907" alt="cd87ce26bebe5b481449dfce23435e5" src="https://github.com/user-attachments/assets/779d2b8d-3e04-4502-9f4f-125e9e178e07" />
<img width="1921" height="305" alt="c2fc9c90b1c8ad9e32d3016352548ce" src="https://github.com/user-attachments/assets/2e3b8b28-0754-4b47-9477-6d49177ed5a7" />
<img width="1920" height="125" alt="f0bb4054dead67101d70406f031a307" src="https://github.com/user-attachments/assets/896dfe44-dac5-46d3-91cf-293525b7748a" />
<img width="1931" height="144" alt="786cb7624b5b0e88b928acc076358eb" src="https://github.com/user-attachments/assets/ad60ca56-211e-4113-912e-c023b12f263e" />

