### PR TITLE
[Bug fix] Draft fix for movb2d enforce fp32 error (low16 bits zeroed in ttsim)

### DIFF
--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -30,14 +30,13 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/eltwise/test_typecast_int.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary.py
 
-  # Numeric mismatches, not root caused
-  # https://github.com/tenstorrent/tt-metal/issues/41530
-  - tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
-  - tests/ttnn/unit_tests/operations/fused/test_layer_norm_sharded.py
-  - tests/ttnn/unit_tests/operations/fused/test_softmax.py
+  # Residual ttsim-only failures originally tagged under #41530; LLK root cause fixed by
+  # tt-llk reduce_row_perform_transpose change, but these suites still surface separate
+  # ttsim limitations that are out of scope for #41530:
+  # - test_moe.py: ttsim UnsupportedFunctionality on tensix_execute_gmpool with src_b!=1.0f
+  # - test_reduction.py: ttsim failure on test_2d_topk[dim2=8128] (large-topk path)
   - tests/ttnn/unit_tests/operations/reduce/test_moe.py
   - tests/ttnn/unit_tests/operations/reduce/test_reduction.py
-  - tests/ttnn/unit_tests/operations/reduce/test_sum.py
 
   # ERROR: UndefinedBehavior: tensix_execute_pacr: intermediate_format=5 mismatches late_from_format=0
   # https://github.com/tenstorrent/tt-metal/issues/42525
@@ -87,9 +86,10 @@ blackhole:
   - tests/ttnn/unit_tests/operations/eltwise/test_typecast_int.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary.py
 
-  # Numeric mismatches, not root caused
-  # https://github.com/tenstorrent/tt-metal/issues/41530
+  # Residual ttsim-only failures originally tagged under #41530; LLK root cause fixed by
+  # tt-llk reduce_row_perform_transpose change, but these suites still surface separate
+  # ttsim limitations that are out of scope for #41530:
+  # - test_moe.py: ttsim UnsupportedFunctionality on tensix_execute_gmpool with src_b!=1.0f
+  # - test_reduction.py: ttsim failure on test_2d_topk[dim2=8128] (large-topk path)
   - tests/ttnn/unit_tests/operations/reduce/test_moe.py
   - tests/ttnn/unit_tests/operations/reduce/test_reduction.py
-  - tests/ttnn/unit_tests/operations/reduce/test_reduction_program_cache.py
-  - tests/ttnn/unit_tests/operations/reduce/test_sum.py

--- a/tests/ttnn/unit_tests/operations/fused/test_rms_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_rms_norm.py
@@ -10,8 +10,6 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
-import os
-
 TEST_PADDING_VALUE = -42
 pytestmark = pytest.mark.use_module_device
 
@@ -84,25 +82,14 @@ def test_rms_norm_row_major(device, batch_size, h, w, math_fidelity, math_approx
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    # Higher frobenius_threshold for ttsim due to issue #41530
-    if os.environ.get("TT_METAL_SIMULATOR"):
-        assert_numeric_metrics(
-            torch_output_tensor,
-            output_tensor,
-            pcc_threshold=0.999,
-            rtol=0.091,
-            atol=0.129,
-            frobenius_threshold=0.09,
-        )
-    else:
-        assert_numeric_metrics(
-            torch_output_tensor,
-            output_tensor,
-            pcc_threshold=0.999,
-            rtol=0.091,
-            atol=0.129,
-            frobenius_threshold=0.052,
-        )
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.091,
+        atol=0.129,
+        frobenius_threshold=0.052,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1])

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
@@ -28,9 +28,19 @@ inline void reduce_row_perform_transpose()
 {
     if (enforce_fp32_accumulation)
     {
+        // tt-metal#41530 / tt-llk#1512: MOVB2D and MOVA2D with UseDst32bLo=0 (DEST_NORM)
+        // are permitted by the ISA to leave the lo16 of dst32b in an unspecified state;
+        // BH HW deterministically zeros it. The previous implementation read lo16 from
+        // dst AFTER the hi16 MOVB2D writes, so the lo16 reads observed zeros. Fix: stage
+        // the transposed hi16 in srcA, finish the lo16 round-trip while dst lo16 is
+        // still intact, then write hi16 first (lo16 corruption is overwritten by the
+        // lo16 MOVB2D in the next 4 instructions). Same pattern as the is_32bit
+        // !transpose_of_faces branch in llk_math_transpose_dest.h. SrcA scratch is safe:
+        // last consumed by reduce_pool_op<...,CLR_NONE> immediately above and re-supplied
+        // by the unpacker before any subsequent GAPOOL/MVMUL.
+
         // needs to be disabled for MOVD2B/B2D on BH (Issue ##449)
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(0);
-        // move back to B and transpose in 2 parts, first hi16 bits then lo16 bits
 
         // move hi16 bits D2B
         // we avoid clobbering weights in src B by moving to rows 16 - 31
@@ -40,24 +50,30 @@ inline void reduce_row_perform_transpose()
         // move row D2B again for cases of reducing across multiple tiles
         TTI_MOVD2B(p_mov::DEST_NORM, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
 
-        // move hi16 bits B2D
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 4);
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 8);
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+        // save the post-transpose hi16 face from srcB rows 16..31 to srcA rows 0..15
+        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 0, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 0);
+        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 4, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 4);
+        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 8, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 8);
+        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 12, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 12);
 
-        // move lo16 bits D2B
+        // move lo16 bits D2B - dst lo16 is still intact because no MOVB2D has run yet
         TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
         // transpose face
         TTI_TRNSPSRCB;
         // move row again for cases of reducing multiple tiles
         TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
 
-        // move lo16 bits B2D
+        // write hi16 first from srcA scratch. MOVA2D(DEST_NORM) zeros dst lo16 on BH,
+        // but the lo16 MOVB2D writes immediately below restore it.
+        TTI_MOVA2D(p_mov::DEST_NORM, p_movb2a::SRCA_ZERO_OFFSET + 0, ADDR_MOD_0, p_mova2d::MOV_8_ROWS, 0);
+        TTI_MOVA2D(p_mov::DEST_NORM, p_movb2a::SRCA_ZERO_OFFSET + 8, ADDR_MOD_0, p_mova2d::MOV_8_ROWS, 8);
+
+        // move lo16 bits B2D - per ISA, MOVB2D(DEST_32B_LOW) preserves dst hi16
         TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 0);
         TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 4);
         TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 8);
         TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(1);
     }
     else

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
@@ -28,7 +28,16 @@ inline void reduce_row_perform_transpose()
 {
     if constexpr (enforce_fp32_accumulation)
     {
-        // Move back to B and transpose in 2 parts, first hi16 bits then lo16 bits
+        // tt-metal#41530 / tt-llk#1512: MOVB2D and MOVA2D with UseDst32bLo=0 (DEST_NORM)
+        // are permitted by the ISA to leave the lo16 of dst32b in an unspecified state.
+        // The previous implementation read lo16 from dst AFTER the hi16 MOVB2D writes,
+        // observing zeros on architectures that deterministically clear lo16 (BH, ttsim).
+        // Fix: stage the transposed hi16 in srcA so the lo16 round-trip can finish with
+        // dst lo16 still intact, then write hi16 first (any lo16 corruption is overwritten
+        // by the lo16 MOVB2D in the next 4 instructions). Same pattern as the is_32bit
+        // !transpose_of_faces branch in llk_math_transpose_dest.h. SrcA scratch is safe:
+        // it was last consumed by reduce_pool_op<...,CLR_NONE> immediately above and is
+        // re-supplied by the unpacker before any subsequent GAPOOL/MVMUL.
 
         // move hi16 bits D2B
         // we avoid clobbering weights in src B by moving to rows 16 - 31
@@ -38,20 +47,25 @@ inline void reduce_row_perform_transpose()
         // move row D2B again for cases of reducing across multiple tiles
         TTI_MOVD2B(p_mov::DEST_NORM, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
 
-        // move hi16 bits B2D
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 4);
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 8);
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+        // save the post-transpose hi16 face from srcB rows 16..31 to srcA rows 0..15
+        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 0, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 0);
+        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 4, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 4);
+        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 8, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 8);
+        TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 12, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 12);
 
-        // move lo16 bits D2B
+        // move lo16 bits D2B - dst lo16 is still intact because no MOVB2D has run yet
         TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
         // transpose face
         TTI_TRNSPSRCB;
         // move row again for cases of reducing multiple tiles
         TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
 
-        // move lo16 bits B2D
+        // write hi16 first from srcA scratch. MOVA2D(DEST_NORM) may leave dst lo16 in an
+        // unspecified state, but the lo16 MOVB2D writes immediately below restore it.
+        TTI_MOVA2D(p_mov::DEST_NORM, p_movb2a::SRCA_ZERO_OFFSET + 0, ADDR_MOD_0, p_mova2d::MOV_8_ROWS, 0);
+        TTI_MOVA2D(p_mov::DEST_NORM, p_movb2a::SRCA_ZERO_OFFSET + 8, ADDR_MOD_0, p_mova2d::MOV_8_ROWS, 8);
+
+        // move lo16 bits B2D - per ISA, MOVB2D(DEST_32B_LOW) preserves dst hi16
         TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 0);
         TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 4);
         TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 8);


### PR DESCRIPTION
### PR Category
Fix for part of test failures in: https://github.com/tenstorrent/tt-metal/issues/41530

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/norm-movb2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/norm-movb2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/norm-movb2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/norm-movb2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/norm-movb2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/norm-movb2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/norm-movb2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/norm-movb2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/norm-movb2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/norm-movb2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/norm-movb2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/norm-movb2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/norm-movb2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/norm-movb2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/norm-movb2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/norm-movb2d)