### PR TITLE
#42240: Remove dead transpose_utils helpers superseded by #45071

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
@@ -6,7 +6,6 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::data_movement::transpose {
 
@@ -169,35 +168,6 @@ ShardSpec generate_transpose_shard_spec(
     }
     log_debug(tt::LogOp, "Transpose: generated shard spec over full compute grid ({} cores)", num_cores);
     return ShardSpec(all_cores, shard_shape, ShardOrientation::ROW_MAJOR);
-}
-
-// Skip refresh when the buffer carries no common runtime args (interleaved case).
-// Only sharded buffers populate RuntimeTensorShape; the strict size check below
-// applies to them.
-void copy_transpose_common_runtime_args(const Buffer& buffer, std::span<std::uint32_t> dst) {
-    const auto src =
-        TensorAccessorArgs(buffer, tensor_accessor::ArgConfig::RuntimeTensorShape).get_common_runtime_args();
-    if (src.empty()) {
-        return;
-    }
-    TT_FATAL(
-        dst.size() == src.size(),
-        "copy_transpose_common_runtime_args: destination span ({} elems) must match common args ({} elems).",
-        dst.size(),
-        src.size());
-    std::copy(src.begin(), src.end(), dst.begin());
-}
-
-void refresh_transpose_common_runtime_args(
-    Program& program,
-    KernelHandle reader_kernel_id,
-    KernelHandle writer_kernel_id,
-    const Buffer& input_buffer,
-    const Buffer& output_buffer) {
-    auto& reader_args = GetCommonRuntimeArgs(program, reader_kernel_id);
-    auto& writer_args = GetCommonRuntimeArgs(program, writer_kernel_id);
-    copy_transpose_common_runtime_args(input_buffer, std::span<std::uint32_t>(reader_args.data(), reader_args.size()));
-    copy_transpose_common_runtime_args(output_buffer, std::span<std::uint32_t>(writer_args.data(), writer_args.size()));
 }
 
 }  // namespace ttnn::operations::data_movement::transpose

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.hpp
@@ -5,11 +5,6 @@
 
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/tensor/tensor.hpp"
-#include <tt-metalium/kernel_types.hpp>
-#include <tt-metalium/program.hpp>
-#include <cstdint>
-#include <optional>
-#include <span>
 
 namespace ttnn::operations::data_movement::transpose {
 
@@ -24,16 +19,5 @@ std::optional<tt::tt_metal::ShardSpec> adjust_shard_spec_to_shape(
 
 tt::tt_metal::ShardSpec generate_transpose_shard_spec(
     const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, tt::tt_metal::TensorMemoryLayout memory_layout);
-
-// Copy RuntimeTensorShape common args for `buffer` into `dst` (size-checked).
-void copy_transpose_common_runtime_args(const tt::tt_metal::Buffer& buffer, std::span<std::uint32_t> dst);
-
-// Refresh reader/writer common args on program-cache hits.
-void refresh_transpose_common_runtime_args(
-    tt::tt_metal::Program& program,
-    tt::tt_metal::KernelHandle reader_kernel_id,
-    tt::tt_metal::KernelHandle writer_kernel_id,
-    const tt::tt_metal::Buffer& input_buffer,
-    const tt::tt_metal::Buffer& output_buffer);
 
 }  // namespace ttnn::operations::data_movement::transpose


### PR DESCRIPTION
### Ticket
Closes #42240. Part of #42199.

### Problem
The `ProgramDescriptor` migration for `ttnn::transpose` was completed in #45071, which removed every call site of the legacy `override_runtime_arguments`-style helpers in `transpose_utils`. Two functions and several unused includes were left behind as dead code:

- `copy_transpose_common_runtime_args(...)` — 14 lines in `.cpp`, 1 declaration + comment in `.hpp`
- `refresh_transpose_common_runtime_args(...)` — 11 lines in `.cpp`, 8 declarations + comment in `.hpp`
- `#include <tt-metalium/tensor_accessor_args.hpp>` in `.cpp` (only used by the deleted helpers)
- `#include <tt-metalium/kernel_types.hpp>`, `#include <tt-metalium/program.hpp>`, `<cstdint>`, `<optional>`, `<span>` in `.hpp` (only used by the deleted declarations; `<optional>` is still transitively pulled in via `tensor.hpp`)

### What this PR does
Removes that dead code. `git grep` for both function names returns no remaining references anywhere in the tree.

**Diff:** 2 files changed, 0 insertions, 46 deletions.

- `ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp` — 30 lines removed
- `ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.hpp` — 16 lines removed

No behavior change. The remaining `transpose_utils` API (`adjust_shard_spec_to_shape`, `generate_transpose_shard_spec`) is unchanged.

### Tests
All run on Wormhole B0 against the rebased branch. These cover every transpose program factory and explicitly hit the post-migration cache-hit path that replaced `override_runtime_arguments`:

- `tests/ttnn/unit_tests/base_functionality/test_reshape_transpose.py` — 1/1 PASSED
- `tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py`:
  - `test_transpose_hc_unit` — 3/3 PASSED (`TransposeHCTiledInterleavedProgramFactory`)
  - `test_transpose_wh_uint16`, `test_transpose_wh_bfp4` — 2/2 PASSED (`TransposeWHProgramFactory`)
  - `test_transpose_hc_program_cache` — 3/3 PASSED
  - `test_transpose_cn_program_cache` — 3/3 PASSED (`TransposeCNProgramFactory`)
  - `test_transpose_wh_program_cache` — 4/4 PASSED
  - `test_transpose_wh_sharded_program_cache` — 3/3 PASSED (`TransposeWHShardedProgramFactory`)
  - `test_transpose_hw_rm_with_program_cache` — 1/1 PASSED
  - `test_transpose_hw_sharded_rm_with_program_cache` — 1/1 PASSED (`TransposeWHShardedRMProgramFactory`)
  - `test_transpose_hc_rm_with_program_cache` — 1/1 PASSED (`TransposeHCRMProgramFactory`)
  - `test_transpose_hc_sharded_with_program_cache` — 9/9 PASSED (`TransposeHCShardedProgramFactory`)

**Total: 31 passed, 0 failed.**

### Notes for Reviewers
- This branch originally carried the full `ProgramDescriptor` migration of all eight transpose factories. #45071 landed first and superseded that work; the branch was rebased onto `main`, and the only valuable change left was this dead-code cleanup. All 16 factory `.cpp`/`.hpp` files in this branch were dropped in favor of `main`'s merged versions.
- No external consumers of the removed symbols (`git grep` of `copy_transpose_common_runtime_args` / `refresh_transpose_common_runtime_args` returns no hits).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/transpose_descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/transpose_descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/transpose_descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/transpose_descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/transpose_descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/transpose_descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/transpose_descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/transpose_descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/transpose_descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/transpose_descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/transpose_descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/transpose_descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/transpose_descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/transpose_descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/transpose_descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/transpose_descriptor)
