### PR TITLE
validate_perf_targets: warn (don't fail) on missing centralized target

### DIFF
--- a/.github/scripts/utils/validate_perf_targets.py
+++ b/.github/scripts/utils/validate_perf_targets.py
@@ -317,15 +317,21 @@ def _validate_gap_coverage(
     tests_yaml_path: Path,
     targets_yaml: dict[str, Any],
 ) -> list[str]:
-    """Ensure each active model/SKU combo has centralized target coverage."""
-    errors: list[str] = []
+    """Report active e2e model/SKU combos missing from the centralized targets.
+
+    Returns a list of human-readable messages — these are surfaced as
+    warnings (not errors) so a missing target does not fail CI. The
+    intent is to nudge owners to add the entry, not to block landing.
+    Only `models_e2e_tests.yaml` is walked here by design.
+    """
+    warnings: list[str] = []
     for model, sku in _collect_active_test_combos(tests_yaml_path):
         if not _has_model_sku_coverage(targets_yaml, model_name=model, sku=sku):
-            errors.append(
+            warnings.append(
                 f"Active test combo model={model}, sku={sku} is missing in centralized targets "
-                "(must be active entry or explicit TODO in models/model_targets.yaml)"
+                "(add an active entry or explicit TODO in models/model_targets.yaml)"
             )
-    return errors
+    return warnings
 
 
 def parse_args() -> argparse.Namespace:
@@ -377,11 +383,9 @@ def main() -> int:
             print(f"::error::{error}")
         return 1
 
-    gap_errors = _validate_gap_coverage(tests_yaml_path, targets_yaml)
-    if gap_errors:
-        for error in gap_errors:
-            print(f"::error::{error}")
-        return 1
+    gap_warnings = _validate_gap_coverage(tests_yaml_path, targets_yaml)
+    for warning in gap_warnings:
+        print(f"::warning::{warning}")
 
     benchmark_files = _benchmark_files(benchmark_dir)
     if not benchmark_files:


### PR DESCRIPTION
## Summary
A model registered in `tests/pipeline_reorg/models_e2e_tests.yaml` without a matching entry in `models/model_targets.yaml` currently **fails** the perf-target validator (`::error::` + `exit 1`). The centralized targets system is still being populated — most entries today are placeholder TODOs — so a missing target should **nudge** the owner, not block the merge.

This PR switches gap-coverage from error-on-missing to warning-on-missing:
- `_validate_gap_coverage` now returns warning messages (variable + docstring renamed for intent).
- `main()` prints them as `::warning::` and no longer returns 1 for gap misses.
- Schema validation continues to fail hard — a malformed targets file is a real bug, not a coverage gap.
- Scope is intentionally e2e-only (matches existing `_collect_active_test_combos` behaviour).

## Test plan
- [ ] Add a temp e2e entry referencing a non-existent model — validator now exits 0, prints a warning annotation in the PR.
- [ ] Introduce a schema error in `model_targets.yaml` — validator still exits 1.
- [ ] Existing CI green on all currently-covered combos (32 today, all resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/gap-coverage-warn-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/gap-coverage-warn-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/gap-coverage-warn-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/gap-coverage-warn-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/gap-coverage-warn-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/gap-coverage-warn-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/gap-coverage-warn-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/gap-coverage-warn-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/gap-coverage-warn-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/gap-coverage-warn-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/gap-coverage-warn-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/gap-coverage-warn-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/gap-coverage-warn-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/gap-coverage-warn-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/gap-coverage-warn-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/gap-coverage-warn-only)