### PR TITLE
Conv3D: L1-aware auto-shrink for ViT-style patch-embed shapes

### DIFF
--- a/tests/ttnn/unit_tests/operations/qwen_2_5_vl_conv3d/test_qwen_2_5_vl_conv3d_oom.py
+++ b/tests/ttnn/unit_tests/operations/qwen_2_5_vl_conv3d/test_qwen_2_5_vl_conv3d_oom.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Regression test for the Qwen 2.5-VL vision patch-embed Conv3D shape.
+
+Before the L1-aware auto-shrink in `conv3d_program_factory.cpp`, the default
+`Conv3dConfig` (and the values currently emitted by tt-mlir's lowering)
+produced per-core circular buffers that exceeded Wormhole's L1 budget:
+
+    Statically allocated circular buffers on core range [0-0 - 7-7]
+    grow to 1738528 B which is beyond max L1 size of 1499136 B
+
+The Qwen 2.5-VL-3B-Instruct vision encoder begins with:
+
+    nn.Conv3d(in_channels=3, out_channels=1280,
+              kernel_size=[2, 14, 14], stride=[2, 14, 14], bias=False)
+
+which has matmul K = kT*kH*kW*C_in_block = 2*14*14*32 = 12544 — large
+enough that the weight + vol2col CBs blow L1 with the default `C_in_block`.
+The auto-shrink picks a smaller `(C_in_block, C_out_block)` pair that fits
+(for this shape: `C_in_block=16`).
+
+This test pins the failing config and asserts the op runs to completion
+with PCC ≥ 0.99 against torch CPU reference. If a future change reverts
+or breaks the auto-shrink, this test will fail — either with an OOM or
+with a PCC drop.
+"""
+
+from loguru import logger
+import pytest
+import torch
+import torch.nn as nn
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+
+
+ALIGNMENT = 32  # L1 alignment for Wormhole and Blackhole.
+
+
+def _out_size(in_size, pad, stride, k, dilation):
+    effective_k = (dilation * (k - 1)) + 1
+    return (in_size + 2 * pad - effective_k) // stride + 1
+
+
+def _prepare_input_tensor(input_tensor, C, device, alignment=ALIGNMENT, dtype=ttnn.DataType.BFLOAT16):
+    """Permute (N,C,D,H,W) -> (N,D,H,W,C) and right-pad C to `alignment`."""
+    tt_input = input_tensor.permute(0, 2, 3, 4, 1)
+    if C % alignment != 0:
+        align_pad = alignment - C % alignment
+        tt_input = torch.nn.functional.pad(tt_input, (0, align_pad))
+    return ttnn.from_torch(tt_input, device=device, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+
+@pytest.mark.parametrize("N", [64], ids=["N_64"])
+def test_qwen_2_5_vl_patch_embed_conv3d(device, N):
+    """Default `Conv3dConfig` must fit L1 for the Qwen patch-embed shape."""
+    torch.manual_seed(42)
+
+    # Qwen 2.5-VL-3B-Instruct vision-config patch-embed parameters.
+    C_in = 3
+    out_channels = 1280
+    kernel_size = (2, 14, 14)
+    stride = (2, 14, 14)
+    padding = (0, 0, 0)
+    dilation = (1, 1, 1)
+    groups = 1
+    padding_mode = "zeros"
+    dtype = ttnn.DataType.BFLOAT16
+
+    D, H, W = 2, 14, 14
+    input_shape = (N, C_in, D, H, W)
+    D_out = _out_size(D, padding[0], stride[0], kernel_size[0], dilation[0])
+    H_out = _out_size(H, padding[1], stride[1], kernel_size[1], dilation[1])
+    W_out = _out_size(W, padding[2], stride[2], kernel_size[2], dilation[2])
+
+    input_tensor = torch.randn(*input_shape, dtype=torch.float32)
+    conv3d_module = nn.Conv3d(
+        C_in,
+        out_channels,
+        groups=groups,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        bias=False,  # Qwen patch embed has bias=False.
+        padding_mode=padding_mode,
+    )
+    gt_output = conv3d_module(input_tensor)
+
+    tt_input = _prepare_input_tensor(input_tensor, C_in, device, dtype=dtype)
+
+    # Match the compute config emitted by tt-mlir's lowering for this op.
+    kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
+
+    # `C_out_block=0` and `C_in_block=ALIGNMENT` (=32) is the case that
+    # used to TT_THROW with "grow to 1738528 B" before the auto-shrink.
+    grid_size = device.compute_with_storage_grid_size()
+    config = ttnn.Conv3dConfig(
+        weights_dtype=dtype,
+        output_layout=ttnn.ROW_MAJOR_LAYOUT,
+        T_out_block=1,
+        W_out_block=1,
+        H_out_block=1,
+        C_out_block=0,
+        C_in_block=ALIGNMENT,
+        dilation=dilation,
+        compute_with_storage_grid_size=grid_size,
+    )
+
+    # Pass weight as a rank-5 host tensor so conv3d.cpp prepares it AFTER the
+    # L1-aware auto-shrink resolves the final C_in_block. This is the same
+    # path tt-mlir's lowering uses. Pre-preparing weights via
+    # `prepare_conv3d_weights` with a fixed C_in_block (as
+    # `tests/ttnn/unit_tests/operations/conv/test_conv3d.py` does) bypasses
+    # the auto-shrink and locks the layout to the user's C_in_block — only
+    # safe when that value already fits L1.
+    w_host = ttnn.from_torch(conv3d_module.weight.data, dtype=dtype, pad_value=0)
+
+    tt_output = ttnn.experimental.conv3d(
+        input_tensor=tt_input,
+        weight_tensor=w_host,
+        device=device,
+        bias_tensor=None,
+        dtype=dtype,
+        output_channels=out_channels,
+        kernel_size=kernel_size,
+        stride=stride,
+        groups=groups,
+        padding=padding,
+        dilation=dilation,
+        padding_mode=padding_mode,
+        config=config,
+        compute_kernel_config=kernel_config,
+    )
+
+    tt_output = ttnn.to_torch(tt_output, device=device, dtype=torch.float32)
+    tt_output = tt_output.reshape(N, D_out, H_out, W_out, out_channels)
+    tt_output = tt_output.permute(0, 4, 1, 2, 3)
+
+    assert tt_output.shape == gt_output.shape, f"shape mismatch: tt={tt_output.shape} gt={gt_output.shape}"
+
+    pcc_passed, pcc_message = check_with_pcc(gt_output, tt_output, pcc=0.99)
+    logger.info("conv3d torch vs ttnn: {}", pcc_message)
+    assert pcc_passed, pcc_message

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.cpp
@@ -6,6 +6,8 @@
 #include "device/conv3d_device_operation.hpp"
 #include "ttnn/operations/experimental/conv3d/prepare_conv3d_weights.hpp"
 #include <tt-metalium/math.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "ttnn/common/constants.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
@@ -13,6 +15,188 @@
 using namespace tt::tt_metal;
 
 namespace ttnn::experimental {
+
+namespace {
+
+// Largest divisor of n that is <= cap. Mirrors the helper in
+// `device/conv3d_program_factory.cpp` (kept in sync).
+uint32_t largest_divisor_up_to(uint32_t n, uint32_t cap) {
+    for (uint32_t d = std::min(n, cap); d >= 1; --d) {
+        if (n % d == 0) {
+            return d;
+        }
+    }
+    return 1;
+}
+
+// Project the per-core circular-buffer byte allocation for the Conv3D op
+// given a candidate (C_in_block, C_out_block). Mirrors the `create_cb`
+// allocations in `device/conv3d_program_factory.cpp` — keep this in sync
+// when CB sizing in the program factory changes.
+uint64_t project_conv3d_cb_bytes(
+    uint32_t C_in,
+    uint32_t cib,
+    uint32_t cob,
+    uint32_t num_patches,
+    uint32_t kT,
+    uint32_t kH,
+    uint32_t kW,
+    uint32_t dtype_bytes,
+    uint32_t tile_size,
+    tt::DataFormat data_format,
+    bool fp32_dest_acc_en,
+    bool use_bias,
+    tt::ARCH arch) {
+    uint32_t patch_size_p = kT * kH * kW * cib;
+    uint32_t padded_patch_size_p = tt::round_up(patch_size_p, tt::constants::TILE_WIDTH);
+    uint32_t C_in_num_blocks_p = tt::div_up(C_in, cib);
+    uint32_t matmul_K_t_p = tt::div_up(patch_size_p, tt::constants::TILE_WIDTH);
+    uint32_t matmul_M_t_p = tt::div_up(num_patches, tt::constants::TILE_HEIGHT);
+    uint32_t matmul_N_t_p = tt::div_up(cob, tt::constants::TILE_WIDTH);
+    uint32_t padded_patch_size_bytes_p = padded_patch_size_p * dtype_bytes;
+    uint32_t vol2col_rm_pages_p = (num_patches % tt::constants::TILE_HEIGHT == 0)
+                                      ? std::min(num_patches, (uint32_t)tt::constants::TILE_HEIGHT)
+                                      : std::min(num_patches, 2 * tt::constants::TILE_HEIGHT);
+    const uint32_t dst_size_p = fp32_dest_acc_en ? 4 : 8;
+    const uint32_t out_subblock_w_p = std::min(matmul_N_t_p, dst_size_p);
+    const bool scale_subblock_h_p = arch == tt::ARCH::WORMHOLE_B0 && out_subblock_w_p == matmul_N_t_p;
+    const uint32_t out_subblock_h_p =
+        scale_subblock_h_p ? largest_divisor_up_to(matmul_M_t_p, dst_size_p / out_subblock_w_p) : 1;
+    const bool use_fp32_partials_p = fp32_dest_acc_en && C_in_num_blocks_p > 1;
+    const auto partial_data_format_p = use_fp32_partials_p ? tt::DataFormat::Float32 : data_format;
+    const uint32_t partial_tile_size_p = tt::tile_size(partial_data_format_p);
+    uint64_t bytes =
+        (uint64_t)padded_patch_size_bytes_p * vol2col_rm_pages_p +
+        (uint64_t)tile_size * out_subblock_h_p * matmul_K_t_p + (uint64_t)tile_size * matmul_K_t_p * matmul_N_t_p +
+        (uint64_t)partial_tile_size_p * matmul_M_t_p * matmul_N_t_p + (uint64_t)tile_size * matmul_M_t_p * matmul_N_t_p;
+    if (C_in_num_blocks_p > 1) {
+        bytes += (uint64_t)partial_tile_size_p * matmul_M_t_p * matmul_N_t_p;
+        bytes += tile_size;
+    }
+    if (use_fp32_partials_p) {
+        bytes += tile_size;
+    }
+    if (use_bias) {
+        bytes += (uint64_t)tile_size * matmul_N_t_p;
+    }
+    return bytes;
+}
+
+// L1-aware block-size resolution. The defaults — or the values supplied
+// by frontends like tt-mlir — can overflow per-core L1 for ViT-style
+// patch-embed shapes (large spatial kernel × small C_in × big C_out),
+// where matmul K = kT*kH*kW*C_in_block is huge and the weight + vol2col
+// CBs blow the L1 budget. This helper picks the largest valid
+// (C_in_block, C_out_block) pair ≤ initial values that fits L1.
+//
+// Returns (resolved_C_in_block, resolved_C_out_block). TT_FATALs if no
+// valid pair fits.
+//
+// Must be called BEFORE `prepare_conv3d_weights` because the weight
+// layout depends on `C_in_block`. If `freeze_C_in_block` is true (e.g.
+// the caller passed a pre-prepared rank-2 weight whose layout is fixed
+// to `initial_C_in_block`), the resolver only shrinks `C_out_block`.
+// `C_out_block` does not affect the weight layout, so it can always
+// be auto-shrunk.
+std::pair<uint32_t, uint32_t> resolve_block_sizes_for_l1(
+    uint32_t initial_C_in_block,
+    uint32_t initial_C_out_block,
+    uint32_t C_in,
+    uint32_t padded_C_out,
+    uint32_t num_patches,
+    uint32_t kT,
+    uint32_t kH,
+    uint32_t kW,
+    uint32_t dtype_bytes,
+    uint32_t tile_size,
+    tt::DataFormat data_format,
+    bool fp32_dest_acc_en,
+    bool use_bias,
+    bool freeze_C_in_block) {
+    const tt::ARCH arch = tt::tt_metal::hal::get_arch();
+    // Match the kernel-code reserve used in `conv3d_program_factory.cpp` for
+    // prefetch-buffer sizing so the resolver and the runtime CB validator
+    // agree on the L1 budget.
+    constexpr uint32_t L1_KERNEL_CODE_RESERVE = 200 * 1024;
+    const uint64_t l1_budget = tt::tt_metal::hal::get_max_worker_l1_unreserved_size() - L1_KERNEL_CODE_RESERVE;
+
+    auto fits = [&](uint32_t cib, uint32_t cob) -> bool {
+        return project_conv3d_cb_bytes(
+                   C_in,
+                   cib,
+                   cob,
+                   num_patches,
+                   kT,
+                   kH,
+                   kW,
+                   dtype_bytes,
+                   tile_size,
+                   data_format,
+                   fp32_dest_acc_en,
+                   use_bias,
+                   arch) <= l1_budget;
+    };
+
+    uint32_t C_in_block = initial_C_in_block;
+    uint32_t C_out_block = initial_C_out_block;
+    if (fits(C_in_block, C_out_block)) {
+        return {C_in_block, C_out_block};
+    }
+
+    constexpr uint32_t C_IN_BLOCK_ALIGNMENT = 16;
+    const uint32_t C_OUT_BLOCK_ALIGNMENT = tt::constants::TILE_WIDTH;
+
+    // Prefer larger C_in_block (fewer reduction passes) over larger C_out_block.
+    // Outer loop: candidate C_in_block from initial down to alignment floor.
+    // Inner loop: largest C_out_block (≤ initial) that fits, given the C_in_block.
+    // When the caller has a pre-prepared weight, only shrink C_out_block.
+    bool found = false;
+    uint32_t resolved_cib = 0;
+    uint32_t resolved_cob = 0;
+    const uint32_t cib_min = freeze_C_in_block ? initial_C_in_block : C_IN_BLOCK_ALIGNMENT;
+    for (uint32_t cib = initial_C_in_block; cib >= cib_min && !found; cib -= C_IN_BLOCK_ALIGNMENT) {
+        if (C_in % cib != 0) {
+            continue;
+        }
+        for (uint32_t cob = initial_C_out_block; cob >= C_OUT_BLOCK_ALIGNMENT && !found; cob -= C_OUT_BLOCK_ALIGNMENT) {
+            if (padded_C_out % cob != 0) {
+                continue;
+            }
+            if (fits(cib, cob)) {
+                resolved_cib = cib;
+                resolved_cob = cob;
+                found = true;
+            }
+        }
+    }
+
+    TT_FATAL(
+        found,
+        "Conv3D circular buffers exceed L1 budget ({} B) for all valid block "
+        "sizes (initial C_in_block={}, C_out_block={}; C_in={}, padded_C_out={}). "
+        "{}"
+        "Reduce T_out_block / H_out_block / W_out_block, or use a different op.",
+        l1_budget,
+        initial_C_in_block,
+        initial_C_out_block,
+        C_in,
+        padded_C_out,
+        freeze_C_in_block ? "C_in_block was frozen at the user-supplied value because a pre-prepared "
+                            "(rank-2) weight tensor was passed; pass a rank-5 weight to allow auto-shrink. "
+                          : "");
+
+    log_info(
+        tt::LogOp,
+        "Conv3D auto-shrink: (C_in_block, C_out_block) {}/{} -> {}/{} to fit L1.",
+        initial_C_in_block,
+        initial_C_out_block,
+        resolved_cib,
+        resolved_cob);
+
+    return {resolved_cib, resolved_cob};
+}
+
+}  // namespace
 
 static Tensor prepare_and_check_weight_tensor(
     const Tensor& weight_tensor,
@@ -68,6 +252,66 @@ ttnn::Tensor conv3d(
         32,                                                      // alignment
         input_tensor.device()->compute_with_storage_grid_size()  // use full device grid
         ));
+
+    // Resolve (C_in_block, C_out_block) up-front so the weight preparation
+    // and the program factory agree on a layout that fits L1. Without this,
+    // ViT-style patch-embed shapes (e.g. Qwen 2.5-VL: kernel=[2,14,14],
+    // C_out=1280) produce a per-core CB allocation that exceeds Wormhole's
+    // L1, and the failure surfaces as a cryptic
+    //   `Bad StatusOr access: INTERNAL: Error code: 13`
+    // at program-launch time. The resolver shrinks the blocks if needed and
+    // fails early with an actionable message if no valid pair fits.
+    {
+        const auto& input_shape = input_tensor.logical_shape();
+        const uint32_t C_in = input_shape[input_shape.rank() - 1];
+        const uint32_t padded_C_out = tt::round_up(output_channels_, tt::constants::TILE_WIDTH);
+        const uint32_t initial_C_out_block = config.C_out_block > 0 ? config.C_out_block : padded_C_out;
+        const uint32_t initial_C_in_block = config.C_in_block > 0 ? config.C_in_block : C_in;
+
+        const auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+        const uint32_t dtype_bytes = input_tensor.element_size();
+        const uint32_t tile_size = tt::tile_size(data_format);
+        const uint32_t num_patches = config.T_out_block * config.H_out_block * config.W_out_block;
+
+        // Match the defaults used by `Conv3dDeviceOperation::validate_on_program_cache_miss`
+        // (see device/conv3d_device_operation.cpp call to init_device_compute_kernel_config)
+        // so the resolver and the program factory agree on `fp32_dest_acc_en`.
+        const auto compute_kernel_config_resolved = ttnn::init_device_compute_kernel_config(
+            input_tensor.device()->arch(),
+            compute_kernel_config,
+            tt::tt_metal::MathFidelity::HiFi2,  // default_fidelity
+            true,                               // default_approx_mode
+            false,                              // default_fp32_acc
+            false,                              // default_l1_acc
+            false                               // default_dst_full_sync_en
+        );
+        [[maybe_unused]] auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+            get_compute_kernel_config_args(input_tensor.device()->arch(), compute_kernel_config_resolved);
+
+        // If the weight is already prepared (rank 2), its physical layout is
+        // baked-in to the user-supplied C_in_block — auto-shrinking C_in_block
+        // here would silently produce garbage output. Freeze it.
+        const bool freeze_C_in_block = (weight_tensor.logical_shape().rank() == 2);
+
+        auto [resolved_C_in_block, resolved_C_out_block] = resolve_block_sizes_for_l1(
+            initial_C_in_block,
+            initial_C_out_block,
+            C_in,
+            padded_C_out,
+            num_patches,
+            kernel_size_[0],
+            kernel_size_[1],
+            kernel_size_[2],
+            dtype_bytes,
+            tile_size,
+            data_format,
+            fp32_dest_acc_en,
+            bias_tensor.has_value(),
+            freeze_C_in_block);
+
+        config.C_in_block = resolved_C_in_block;
+        config.C_out_block = resolved_C_out_block;
+    }
 
     Tensor prepared_weight_tensor = prepare_and_check_weight_tensor(weight_tensor, groups_, config, device);
     return ttnn::prim::conv3d(


### PR DESCRIPTION
### Issues 
[Link to GitHub issue](https://github.com/tenstorrent/tt-metal/issues/43873)

### PR Category                          
  Bug fix
                                                                                                                                                                                                
  ### Summary
  Fixes a per-core L1 overflow in `ttnn.experimental.conv3d` that surfaces as a                                                                                                                 
  cryptic `RuntimeError: Bad StatusOr access: INTERNAL: Error code: 13` from the                                                                                                                
  runtime CB validator at program-launch time, blocking Qwen 2.5-VL bringup                                                                                                                     
  through the PJRT plugin / tt-mlir lowering.                                                                                                                                                   
                                                                                                                                                                                                
  The failing shape is the model's vision patch embed:                                                                                                                                          
                                                                                                                                                                                                
  Conv3d(in_channels=3, out_channels=1280, kernel=[2,14,14], stride=[2,14,14], bias=False)                                                                                                      
                       
  The matmul K dimension is `kT*kH*kW*C_in_block = 12544`, so with the default                                                                                                                  
  `Conv3dConfig` the weight + vol2col CBs total ~1.7 MB per core — over the                                                                                                                     
  1.5 MB Wormhole L1 budget. Same pathology applies to any ViT-style 3D patch                                                                                                                   
  embed (huge spatial kernel × small `C_in` × big `C_out`).                                                                                                                                     
                                                                                                                                                                                                
  This PR adds an L1-aware resolver in `conv3d.cpp` that runs **before**                                                                                                                        
  `prepare_conv3d_weights` and picks the largest valid `(C_in_block, C_out_block)`                                                                                                              
  pair ≤ initial values that fits L1. For Qwen the resolver picks                                                                                                                               
  `(C_in_block, C_out_block) = (32, 1280) → (16, 64)`; the kernel then runs and                                                                                                                 
  matches torch reference at PCC = 0.99999.                                                                                                                                                     
                                                                                                                                                                                                
  If no valid pair fits, `TT_FATAL`s with an actionable message instead of the                                                                                                                  
  cryptic StatusOr error.                                                                                                                                                                       
                                                                                                                                                                                                
  Adds a regression test under
  `tests/ttnn/unit_tests/operations/qwen_2_5_vl_conv3d/` pinning the failing                                                                                                                    
  config.                                                                                                                                                                                       
   
  ### Notes for reviewers                                                                                                                                                                       
                  
  The diff is +396 LoC, all in one file. Three things worth a closer look:                                                                                                                      
                  
  1. **Duplicate byte accounting.** `project_conv3d_cb_bytes` in `conv3d.cpp`                                                                                                                   
     mirrors the `create_cb` allocations and `other_cbs_bytes` block in
     `device/conv3d_program_factory.cpp`. They have to stay in sync — comment                                                                                                                   
     flags this. Open to alternative refactors that share the logic (extract a                                                                                                                  
     shared header? expose the program factory's calculation as a static helper?).                                                                                                              
                                                                                                                                                                                                
  2. **`freeze_C_in_block` for rank-2 weights.** When the caller passes a                                                                                                                       
     pre-prepared (rank-2) weight, its physical layout is baked-in to the                                                                                                                       
     user-supplied `C_in_block`; auto-shrinking it would silently produce                                                                                                                       
     garbage output. The resolver detects rank-2 weights and shrinks only                                                                                                                       
     `C_out_block` in that case. The existing `tests/ttnn/unit_tests/operations/conv/test_conv3d.py`                                                                                            
     uses pre-prepared weights at "normal" shapes that already fit L1, so this                                                                                                                  
     path is exercised but never triggers the shrink. Worth confirming the                                                                                                                      
     semantic is right.                                                                                                                                                                         
                                                                                                                                                                                                
  3. **Compute-config defaulting consistency.** The resolver calls                                                                                                                              
     `init_device_compute_kernel_config` with the same defaults
     (`HiFi2`, `approx_mode=true`, `fp32_acc=false`, `l1_acc=false`) that                                                                                                                       
     `Conv3dDeviceOperation::validate_on_program_cache_miss` uses, so resolver                                                                                                                  
     and program factory agree on `fp32_dest_acc_en` (which affects projected                                                                                                                   
     bytes via the partials path). If the device-op defaults change, this                                                                                                                       
     resolver needs the same change.                                                                                                                                                            
                                                                                                                                                                                                
  **Verified on Wormhole B0:**                                                                                                                                                                  
  - Qwen patch-embed regression test: was `TT_THROW (1738528 B > L1)` → now
    `PASS, PCC=0.99999`.                                                                                                                                                                        
  - `tests/ttnn/unit_tests/operations/conv/test_conv3d.py -k kernel_111`:
    768 passed, 0 failed (no regressions in the existing suite).                                                                                                                                
  - Auto-shrink log line fires only when defaults overflow; existing call paths                                                                                                                 
    short-circuit at the top of the resolver and see no behavior change.                                                                                                                        
 
### Logs
Before Fix: [ttmetal_run.log](https://github.com/user-attachments/files/27516841/ttmetal_run.log)
After Fix: 
[ttmetal_run_after_fix2.log](https://github.com/user-attachments/files/27516860/ttmetal_run_after_fix2.log)
Regression logs, tested all conv3d tests after change : 
[conv3d_regression_v2.log](https://github.com/user-attachments/files/27516879/conv3d_regression_v2.log)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sai_arthi_raguram/qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sai_arthi_raguram/qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sai_arthi_raguram/qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sai_arthi_raguram/qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sai_arthi_raguram/qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sai_arthi_raguram/qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sai_arthi_raguram/qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sai_arthi_raguram/qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sai_arthi_raguram/qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sai_arthi_raguram/qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sai_arthi_raguram/qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sai_arthi_raguram/qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sai_arthi_raguram/qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sai_arthi_raguram/qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sai_arthi_raguram/qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sai_arthi_raguram/qwen)