### PR TITLE
[Bug fix] LLK: preserve UInt16 datums whose low byte is zero across SrcA/SrcB reconfig (#37571)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -167,8 +167,6 @@ inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
     llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srca_new_operand);
     llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srcb_new_operand);
-    _llk_unpack_reconfig_zero_src_flag_(
-        unpack_dst_format[get_operand_id(srca_new_operand)], unpack_dst_format[get_operand_id(srcb_new_operand)]);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
@@ -182,8 +180,6 @@ inline void llk_unpack_reconfig_data_format(
         srca_old_operand, srca_new_operand);
     llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
         srcb_old_operand, srcb_new_operand);
-    _llk_unpack_reconfig_zero_src_flag_(
-        unpack_dst_format[get_operand_id(srca_new_operand)], unpack_dst_format[get_operand_id(srcb_new_operand)]);
 }
 
 // TODO NC: Remove as a part of tt-metal#36411

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -178,8 +178,6 @@ inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
     llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srca_new_operand);
     llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srcb_new_operand);
-    _llk_unpack_reconfig_zero_src_flag_(
-        unpack_dst_format[get_operand_id(srca_new_operand)], unpack_dst_format[get_operand_id(srcb_new_operand)]);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
@@ -193,8 +191,6 @@ inline void llk_unpack_reconfig_data_format(
         srca_old_operand, srca_new_operand);
     llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
         srcb_old_operand, srcb_new_operand);
-    _llk_unpack_reconfig_zero_src_flag_(
-        unpack_dst_format[get_operand_id(srca_new_operand)], unpack_dst_format[get_operand_id(srcb_new_operand)]);
 }
 
 // TODO NC: Remove as a part of tt-metal#36411

--- a/tt_metal/tt-llk/tests/python_tests/test_sort.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sort.py
@@ -1,0 +1,269 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+LLK regression for the metal `sort_single_row_single_core` algorithm
+(local_sort + merge, no rebuild).
+
+Per tile-row: first half = bf16 value tiles, second half = uint16 index
+tiles encoding [0, Wt*32). Asserts result indices form a valid permutation
+per row; duplicates / missing values (especially multiples of 256) signal
+the tt-metal#37571 class of corruption.
+"""
+
+from collections import Counter
+
+import torch
+from helpers.format_config import DataFormat, InputOutputFormat
+from helpers.golden_generators import (
+    ELEMENTS_PER_TILE,
+    TilizeGolden,
+    TransposeGolden,
+    UntilizeGolden,
+    get_golden_generator,
+)
+from helpers.llk_params import DestAccumulation, TopKSortDirection, format_dict
+from helpers.logger import logger
+from helpers.param_config import input_output_formats, parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    DEST_SYNC,
+    INPUT_DIMENSIONS,
+    TILE_COUNT,
+    TOPK,
+)
+
+NUM_STAGES = 2  # Values and Indices halves of the row.
+
+
+def prepare_input_tensor_for_sort(src_A, formats, input_dimensions):
+    """Identical to test_topk.prepare_input_tensor_for_topk.  Encodes
+    arange(0, Wt*32) as uint16 in the index half of every row, then tilizes."""
+    num_rows_tensor, num_cols_tensor = input_dimensions
+    num_tiles_in_input = (num_rows_tensor * num_cols_tensor) // ELEMENTS_PER_TILE
+
+    if num_tiles_in_input < NUM_STAGES * 2:
+        raise ValueError(
+            f"Expected at least 4 tiles (2 value + 2 index), got {num_tiles_in_input}."
+        )
+
+    src_A = src_A.clone()
+    half = num_cols_tensor // NUM_STAGES
+
+    for row in range(num_rows_tensor):
+        indices_start_idx = row * num_cols_tensor + half
+        indices_end_idx = indices_start_idx + half
+
+        uint16_indices = torch.arange(0, half, dtype=torch.int16).to(torch.uint16)
+        src_A[indices_start_idx:indices_end_idx] = uint16_indices.view(src_A.dtype)
+
+    src_tilizer = get_golden_generator(TilizeGolden)
+    src_A = src_tilizer(src_A, input_dimensions, formats.input_format)
+    return src_A
+
+
+def transform_result_tensor_to_right_form(res_tensor, formats, input_dimensions):
+    """Same approach as test_topk.transform_result_tensor_to_right_form, but
+    operating on the FULL-sort output (Wt value tiles + Wt index tiles per row)."""
+    num_rows_tensor, num_cols_tensor = input_dimensions
+    res_tensor = res_tensor[0 : num_rows_tensor * num_cols_tensor]
+
+    num_tiles = (num_rows_tensor * num_cols_tensor) // ELEMENTS_PER_TILE
+
+    transpose_util = get_golden_generator(TransposeGolden)
+    res_tensor = transpose_util.transpose_faces_multi_tile(
+        res_tensor,
+        formats.output_format,
+        num_tiles=num_tiles,
+        tilize=False,
+        untilize=False,
+        input_dimensions=[num_rows_tensor, num_cols_tensor],
+    )
+    res_tensor = transpose_util.transpose_within_faces_multi_tile(
+        res_tensor,
+        formats.output_format,
+        num_tiles=num_tiles,
+        tilize=False,
+        untilize=False,
+        input_dimensions=[num_rows_tensor, num_cols_tensor],
+    )
+    return res_tensor
+
+
+def validate_sort_permutation(
+    res_tensor, original_input_tensor, formats, input_dimensions, atol=0.02
+):
+    """Validate the LLK sort output:
+      1. indices form a valid permutation of [0, Wt*32) per row
+      2. each result index points to the matching value in the original input
+
+    On failure, log the corruption pattern (duplicates, missing values,
+    multiples of 256 missing) so we can diagnose #37571.
+    """
+    num_rows_tensor, num_cols_tensor = input_dimensions
+    half = num_cols_tensor // NUM_STAGES  # number of values per row
+    indices_offset = half
+
+    untilizer = get_golden_generator(UntilizeGolden)
+    res_untilized = untilizer(res_tensor, formats.output_format, input_dimensions)
+    original_untilized = untilizer(
+        original_input_tensor, formats.input_format, input_dimensions
+    )
+
+    all_ok = True
+    first_failure_row = None
+
+    for row_idx in range(num_rows_tensor):
+        # Extract uint16 indices for this row.
+        row_indices = []
+        row_values = []
+        for k in range(half):
+            value_idx = row_idx * num_cols_tensor + k
+            index_idx = row_idx * num_cols_tensor + indices_offset + k
+            row_values.append(res_untilized[value_idx].item())
+            idx_uint16 = (
+                res_untilized[index_idx : index_idx + 1].view(torch.uint16).item()
+            )
+            row_indices.append(idx_uint16)
+
+        # Permutation check.
+        idx_counter = Counter(row_indices)
+        expected = set(range(half))
+        present = set(row_indices)
+        missing = sorted(expected - present)
+        duplicates = sorted(
+            [(v, c) for v, c in idx_counter.items() if c > 1], key=lambda x: x[0]
+        )
+
+        if missing or duplicates:
+            all_ok = False
+            if first_failure_row is None:
+                first_failure_row = row_idx
+                missing_mod_256 = [v for v in missing if v % 256 == 0]
+                dup0_count = idx_counter.get(0, 0)
+                logger.error(
+                    "[#37571 reproducer] Row {} indices are NOT a valid permutation of [0, {}):\n"
+                    "  missing count   = {}  (first 16: {})\n"
+                    "  missing %256==0 = {}\n"
+                    "  duplicates      = {}  (count of 0 = {})",
+                    row_idx,
+                    half,
+                    len(missing),
+                    missing[:16],
+                    missing_mod_256[:16],
+                    duplicates[:16],
+                    dup0_count,
+                )
+            continue
+
+        # Index -> value pointer check.
+        for k in range(half):
+            result_index = row_indices[k]
+            result_value = row_values[k]
+            original_value_at_idx = original_untilized[
+                row_idx * num_cols_tensor + result_index
+            ].item()
+            if not torch.isclose(
+                torch.tensor(result_value),
+                torch.tensor(original_value_at_idx),
+                atol=atol,
+            ):
+                if first_failure_row is None:
+                    first_failure_row = row_idx
+                    logger.error(
+                        "[#37571 reproducer] Row {}, datum {}: index {} "
+                        "points to {} in input, but result has {}",
+                        row_idx,
+                        k,
+                        result_index,
+                        original_value_at_idx,
+                        result_value,
+                    )
+                all_ok = False
+                break
+
+    return all_ok
+
+
+def _wt_to_input_dim(Wt: int) -> list:
+    """Wt is the number of value tiles per row.  Total tiles per row is
+    2*Wt (Wt values + Wt indices), so the per-row column count is 2*Wt*32.
+    We only test a single tile-row for speed."""
+    return [32, 2 * Wt * 32]
+
+
+@parametrize(
+    formats=input_output_formats([DataFormat.Float16_b]),
+    Wt=[8, 16, 32],
+)
+def test_sort_sfpu(formats: InputOutputFormat, Wt: int):
+    """Reproducer for tt-metal issue #37571.
+
+    Wt = 8  -> 256 elements per row -> EXPECTED TO PASS (no merge stages, only local_sort).
+    Wt = 16 -> 512 elements per row -> EXPECTED TO FAIL (4-stage merge, the broken path).
+    Wt = 32 -> 1024 elements per row -> EXPECTED TO FAIL (5-stage merge, sibling failure).
+    """
+    input_dimensions = _wt_to_input_dim(Wt)
+    K = Wt * 32  # for the TOPK template params: makes log2(K) = log2(Wt*32)
+    # so TOPK_NUM_ITERATIONS = log2(Wt) - matches our STAGES.
+    sort_direction = TopKSortDirection.Ascending
+
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        sfpu=False,
+    )
+
+    src_A = prepare_input_tensor_for_sort(src_A, formats, input_dimensions)
+
+    configuration = TestConfig(
+        test_name="sources/sort_test.cpp",
+        formats=formats,
+        templates=[
+            DEST_SYNC(),
+            TOPK(
+                topk_k=K,
+                topk_matrix_width=input_dimensions[1],
+                topk_sort_direction=sort_direction,
+                topk_stable_sort=False,
+            ),
+        ],
+        runtimes=[
+            INPUT_DIMENSIONS(input_dimensions[0] // 32, input_dimensions[1] // 32),
+            TILE_COUNT(tile_cnt_A),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_B,
+            tile_count_res=tile_cnt_A,
+        ),
+        dest_acc=DestAccumulation.No,
+        unpack_to_dest=False,
+    )
+
+    res_from_L1 = configuration.run().result
+    res_tensor = torch.tensor(res_from_L1, dtype=format_dict[formats.output_format])
+
+    res_tensor = transform_result_tensor_to_right_form(
+        res_tensor, formats, input_dimensions
+    )
+
+    assert len(res_tensor) == input_dimensions[0] * input_dimensions[1], (
+        f"Result tensor length {len(res_tensor)} != expected "
+        f"{input_dimensions[0] * input_dimensions[1]}"
+    )
+
+    ok = validate_sort_permutation(res_tensor, src_A, formats, input_dimensions)
+    assert ok, (
+        f"Sort permutation invalid for Wt={Wt} (input_dimensions={input_dimensions}). "
+        "See stderr for the corruption pattern."
+    )

--- a/tt_metal/tt-llk/tests/sources/sort_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sort_test.cpp
@@ -1,0 +1,588 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+//
+// LLK regression for ttnn.sort's bitonic-merge algorithm. Mirrors
+//   ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_single_row_single_core.cpp
+//   ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_common.hpp
+// at the LLK level — local_sort + merge ONLY (no rebuild), which is the path
+// that fails in tt-metal#37571 (topk_test.cpp covers the rebuild path).
+//
+// buffer_A per tile-row: [0..Wt-1] = value tiles, [Wt..2*Wt-1] = uint16 index tiles.
+
+#include <algorithm>
+#include <cstdint>
+#include <type_traits>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "params.h"
+
+// Globals required by the test framework.
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+
+// Stage indices: 0 = Values, 1 = Indices.
+constexpr int NUM_STAGES = 2;
+
+// DEST register layout (matches metal sort kernel):
+//   DEST[0] = value tile low,  DEST[1] = value tile high
+//   DEST[2] = index tile low,  DEST[3] = index tile high
+constexpr int input_dest_start = 0;
+constexpr int input_dest_end   = 1;
+constexpr int index_dest_start = 2;
+constexpr int index_dest_end   = 3;
+
+// Same hard-coded constants as the metal sort kernel.
+constexpr int SORT_K         = 64;
+constexpr int SORT_END_PHASE = 5; // log2(64)-1
+
+// Sort direction (this LLK reproducer always sorts ascending).
+constexpr bool ASCENDING = true;
+
+// Helper: count log2 of a power-of-2 integer.
+static constexpr std::uint32_t ilog2_ce(std::uint32_t n)
+{
+    std::uint32_t r = 0;
+    while ((1u << r) < n)
+    {
+        ++r;
+    }
+    return r;
+}
+
+// ============================================================================
+// UNPACK TRISC
+// ============================================================================
+
+#ifdef LLK_TRISC_UNPACK
+#include "llk_unpack_A.h"
+#include "llk_unpack_common.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t FULL_CT_DIM = params.FULL_CT_DIM;
+    const std::uint32_t Wt          = FULL_CT_DIM / NUM_STAGES;
+    const std::uint32_t NUM_ROWS    = params.FULL_RT_DIM;
+    const std::uint32_t STAGES      = ilog2_ce(Wt);
+
+    const std::uint32_t unpack_src_data_types[NUM_STAGES] = {formats.unpack_A_src, ckernel::to_underlying(DataFormat::UInt16)};
+    const std::uint32_t unpack_dst_data_types[NUM_STAGES] = {formats.unpack_A_dst, ckernel::to_underlying(DataFormat::UInt16)};
+
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        unpack_src_data_types[0],
+        unpack_src_data_types[0],
+        unpack_dst_data_types[0],
+        unpack_dst_data_types[0],
+        /*unpA_face_r_dim=*/FACE_R_DIM,
+        /*unpB_face_r_dim=*/FACE_R_DIM,
+        /*unpA_num_faces=*/4,
+        /*unpB_num_faces=*/4);
+
+    for (std::uint32_t row = 0; row < NUM_ROWS; ++row)
+    {
+        const std::uint32_t row_offset = row * FULL_CT_DIM;
+
+        // ----- 1. Bitonic-sequence formation -----
+        for (std::uint32_t wt = 0; wt < Wt; wt += 2)
+        {
+            // Values pair (wt, wt+1) - face-level transpose.
+            _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false>(
+                unpack_src_data_types[0], unpack_dst_data_types[0], /*tile_size=*/16 * 16 * 4);
+            _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                /*transpose_of_faces=*/1, /*within_face_16x16_transpose=*/1, FACE_R_DIM, /*num_faces=*/4, unpack_src_data_types[0], unpack_dst_data_types[0]);
+            _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                L1_ADDRESS(params.buffer_A[row_offset + wt]), unpack_src_data_types[0], unpack_dst_data_types[0]);
+            _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                L1_ADDRESS(params.buffer_A[row_offset + wt + 1]), unpack_src_data_types[0], unpack_dst_data_types[0]);
+
+            // Indices pair (Wt+wt, Wt+wt+1) - face-level transpose.
+            _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false>(
+                unpack_src_data_types[1], unpack_dst_data_types[1], /*tile_size=*/16 * 16 * 4);
+            _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                /*transpose_of_faces=*/1, /*within_face_16x16_transpose=*/1, FACE_R_DIM, /*num_faces=*/4, unpack_src_data_types[1], unpack_dst_data_types[1]);
+            _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                L1_ADDRESS(params.buffer_A[row_offset + Wt + wt]), unpack_src_data_types[1], unpack_dst_data_types[1]);
+            _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                L1_ADDRESS(params.buffer_A[row_offset + Wt + wt + 1]), unpack_src_data_types[1], unpack_dst_data_types[1]);
+        }
+
+        // ----- 2. Bitonic merge stages -----
+        for (std::uint32_t stage = 2; stage <= STAGES; ++stage)
+        {
+            for (std::uint32_t sub = stage; sub > 0; --sub)
+            {
+                const std::uint32_t sub_dist = 1u << (sub - 1);
+                for (std::uint32_t i = 0; i < Wt; ++i)
+                {
+                    const std::uint32_t j = i ^ sub_dist;
+                    if (j > i)
+                    {
+                        // Values - no face transpose (data already column-wise after local_sort).
+                        _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false>(
+                            unpack_src_data_types[0], unpack_dst_data_types[0], /*tile_size=*/16 * 16 * 4);
+                        _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                            /*transpose_of_faces=*/0,
+                            /*within_face_16x16_transpose=*/0,
+                            FACE_R_DIM,
+                            /*num_faces=*/4,
+                            unpack_src_data_types[0],
+                            unpack_dst_data_types[0]);
+                        _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                            L1_ADDRESS(params.buffer_A[row_offset + i]), unpack_src_data_types[0], unpack_dst_data_types[0]);
+                        _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                            L1_ADDRESS(params.buffer_A[row_offset + j]), unpack_src_data_types[0], unpack_dst_data_types[0]);
+
+                        // Indices - no face transpose.
+                        _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false>(
+                            unpack_src_data_types[1], unpack_dst_data_types[1], /*tile_size=*/16 * 16 * 4);
+                        _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                            /*transpose_of_faces=*/0,
+                            /*within_face_16x16_transpose=*/0,
+                            FACE_R_DIM,
+                            /*num_faces=*/4,
+                            unpack_src_data_types[1],
+                            unpack_dst_data_types[1]);
+                        _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                            L1_ADDRESS(params.buffer_A[row_offset + Wt + i]), unpack_src_data_types[1], unpack_dst_data_types[1]);
+                        _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                            L1_ADDRESS(params.buffer_A[row_offset + Wt + j]), unpack_src_data_types[1], unpack_dst_data_types[1]);
+                    }
+                }
+            }
+        }
+
+        // ----- 3. Final result-copy pass: unpack each tile (no transpose) -----
+        for (std::uint32_t t = 0; t < FULL_CT_DIM; ++t)
+        {
+            const std::uint32_t stage_idx = (t < Wt) ? 0u : 1u;
+            _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false>(
+                unpack_src_data_types[stage_idx], unpack_dst_data_types[stage_idx], /*tile_size=*/16 * 16 * 4);
+            _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                /*transpose_of_faces=*/0,
+                /*within_face_16x16_transpose=*/0,
+                FACE_R_DIM,
+                /*num_faces=*/4,
+                unpack_src_data_types[stage_idx],
+                unpack_dst_data_types[stage_idx]);
+            _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                L1_ADDRESS(params.buffer_A[row_offset + t]), unpack_src_data_types[stage_idx], unpack_dst_data_types[stage_idx]);
+        }
+    }
+}
+#endif // LLK_TRISC_UNPACK
+
+// ============================================================================
+// MATH TRISC
+// ============================================================================
+
+#ifdef LLK_TRISC_MATH
+#include "ckernel_sfpu.h"
+#include "llk_math_common.h"
+#include "llk_math_eltwise_unary_datacopy.h"
+
+using namespace ckernel;
+
+#define DST_SYNC_MODE  dest_sync
+#define DST_ACCUM_MODE is_fp32_dest_acc_en
+#include "llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h"
+#undef DST_SYNC_MODE
+#undef DST_ACCUM_MODE
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t FULL_CT_DIM = params.FULL_CT_DIM;
+    const std::uint32_t Wt          = FULL_CT_DIM / NUM_STAGES;
+    const std::uint32_t NUM_ROWS    = params.FULL_RT_DIM;
+    const std::uint32_t STAGES      = ilog2_ce(Wt);
+
+    constexpr bool APPROX             = false;
+    constexpr std::uint32_t dst_index = 0;
+    constexpr int vector_mode         = (int)VectorMode::RC_custom;
+    constexpr int start_phase         = 0;
+    constexpr int end_step            = 0;
+    constexpr int start_step          = 0;
+
+    const std::uint32_t math_data_types[NUM_STAGES] = {formats.math, ckernel::to_underlying(DataFormat::UInt16)};
+
+    _llk_math_pack_sync_init_<dest_sync, is_fp32_dest_acc_en>();
+    _llk_math_eltwise_unary_sfpu_init_<SfpuType::topk_local_sort>();
+    ckernel::sfpu::_init_topk();
+
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(math_data_types[0], math_data_types[0]);
+
+    for (std::uint32_t row = 0; row < NUM_ROWS; ++row)
+    {
+        // ----- 1. Bitonic-sequence formation -----
+        bool ascending_local = ASCENDING;
+        for (std::uint32_t wt = 0; wt < Wt; wt += 2)
+        {
+            _llk_math_wait_for_dest_available_<dest_sync>();
+
+            // Values reconfig + datacopy.
+            _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, false>(math_data_types[0]);
+#ifdef ARCH_BLACKHOLE
+            _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false, PackMode::Default>(
+                /*num_faces=*/4, /*dst_format=*/math_data_types[0]);
+#else
+            _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false>(
+                /*num_faces=*/4, /*dst_format=*/math_data_types[0]);
+#endif
+            _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                input_dest_start, math_data_types[0], math_data_types[0]);
+            _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                input_dest_end, math_data_types[0], math_data_types[0]);
+
+            // Indices reconfig + datacopy.
+            _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, false>(math_data_types[1]);
+#ifdef ARCH_BLACKHOLE
+            _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false, PackMode::Default>(
+                /*num_faces=*/4, /*dst_format=*/math_data_types[1]);
+#else
+            _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false>(
+                /*num_faces=*/4, /*dst_format=*/math_data_types[1]);
+#endif
+            _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                index_dest_start, math_data_types[1], math_data_types[1]);
+            _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                index_dest_end, math_data_types[1], math_data_types[1]);
+
+            _llk_math_eltwise_unary_sfpu_params_(
+                ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROX, is_fp32_dest_acc_en, /*STABLE=*/false>,
+                dst_index,
+                vector_mode,
+                /*idir=*/(int)ascending_local,
+                SORT_END_PHASE,
+                start_phase,
+                end_step,
+                start_step);
+
+            _llk_math_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
+            ascending_local = !ascending_local;
+        }
+
+        // ----- 2. Bitonic merge stages -----
+        for (std::uint32_t stage = 2; stage <= STAGES; ++stage)
+        {
+            const std::uint32_t m_iter = stage - 1;
+            for (std::uint32_t sub = stage; sub > 0; --sub)
+            {
+                const std::uint32_t sub_dist = 1u << (sub - 1);
+                for (std::uint32_t i = 0; i < Wt; ++i)
+                {
+                    const std::uint32_t j = i ^ sub_dist;
+                    if (j > i)
+                    {
+                        const bool ascending_block = ((i >> stage) & 1) == 0;
+                        const bool dir             = (ascending_block == ASCENDING);
+
+                        _llk_math_wait_for_dest_available_<dest_sync>();
+
+                        // Values reconfig + datacopy.
+                        _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, false>(math_data_types[0]);
+#ifdef ARCH_BLACKHOLE
+                        _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false, PackMode::Default>(
+                            /*num_faces=*/4, /*dst_format=*/math_data_types[0]);
+#else
+                        _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false>(
+                            /*num_faces=*/4, /*dst_format=*/math_data_types[0]);
+#endif
+                        _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                            input_dest_start, math_data_types[0], math_data_types[0]);
+                        _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                            input_dest_end, math_data_types[0], math_data_types[0]);
+
+                        // Indices reconfig + datacopy.
+                        _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, false>(math_data_types[1]);
+#ifdef ARCH_BLACKHOLE
+                        _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false, PackMode::Default>(
+                            /*num_faces=*/4, /*dst_format=*/math_data_types[1]);
+#else
+                        _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false>(
+                            /*num_faces=*/4, /*dst_format=*/math_data_types[1]);
+#endif
+                        _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                            index_dest_start, math_data_types[1], math_data_types[1]);
+                        _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                            index_dest_end, math_data_types[1], math_data_types[1]);
+
+                        if (sub == 1)
+                        {
+                            _llk_math_eltwise_unary_sfpu_params_(
+                                ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROX, is_fp32_dest_acc_en, /*STABLE=*/false>,
+                                dst_index,
+                                vector_mode,
+                                /*idir=*/(int)dir,
+                                SORT_END_PHASE,
+                                start_phase,
+                                end_step,
+                                start_step);
+                        }
+                        else
+                        {
+                            // top_min = false (compile-time), matching metal kernel (default idir=false).
+                            _llk_math_eltwise_unary_sfpu_params_(
+                                ckernel::sfpu::calculate_bitonic_topk_merge<APPROX, is_fp32_dest_acc_en, /*top_min=*/false, /*STABLE=*/false>,
+                                dst_index,
+                                vector_mode,
+                                m_iter,
+                                SORT_K);
+                        }
+
+                        _llk_math_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
+                    }
+                }
+            }
+        }
+
+        // ----- 3. Final result-copy pass: datacopy each tile to DEST[0] -----
+        for (std::uint32_t t = 0; t < FULL_CT_DIM; ++t)
+        {
+            const std::uint32_t stage_idx = (t < Wt) ? 0u : 1u;
+            _llk_math_wait_for_dest_available_<dest_sync>();
+            _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, false>(math_data_types[stage_idx]);
+#ifdef ARCH_BLACKHOLE
+            _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false, PackMode::Default>(
+                /*num_faces=*/4, /*dst_format=*/math_data_types[stage_idx]);
+#else
+            _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false>(
+                /*num_faces=*/4, /*dst_format=*/math_data_types[stage_idx]);
+#endif
+            _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                /*dst_index=*/0, math_data_types[stage_idx], math_data_types[stage_idx]);
+            _llk_math_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
+        }
+    }
+}
+#endif // LLK_TRISC_MATH
+
+// ============================================================================
+// PACK TRISC
+// ============================================================================
+
+#ifdef LLK_TRISC_PACK
+#include "llk_lib_pack_wrappers.h"
+#include "llk_pack.h"
+#include "llk_pack_common.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t FULL_CT_DIM = params.FULL_CT_DIM;
+    const std::uint32_t Wt          = FULL_CT_DIM / NUM_STAGES;
+    const std::uint32_t NUM_ROWS    = params.FULL_RT_DIM;
+    const std::uint32_t STAGES      = ilog2_ce(Wt);
+
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();
+#else
+    _llk_pack_dest_init_<dest_sync, false, PackMode::Default>();
+#endif
+
+    const std::uint32_t pack_src_data_types[NUM_STAGES] = {formats.pack_src, ckernel::to_underlying(DataFormat::UInt16)};
+    const std::uint32_t pack_dst_data_types[NUM_STAGES] = {formats.pack_dst, ckernel::to_underlying(DataFormat::UInt16)};
+
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(pack_src_data_types[0], pack_dst_data_types[0], /*tile_size=*/16 * 16 * 4);
+    _llk_pack_init_wrapper_</*pack_mode=*/PackMode::Default, /*zero_output=*/false>(pack_dst_data_types[0]);
+
+    for (std::uint32_t row = 0; row < NUM_ROWS; ++row)
+    {
+        const std::uint32_t row_offset = row * FULL_CT_DIM;
+
+        // ----- 1. Bitonic-sequence formation -----
+        for (std::uint32_t wt = 0; wt < Wt; wt += 2)
+        {
+            _llk_packer_wait_for_math_done_();
+
+            // Values reconfig + pack.
+#ifdef ARCH_BLACKHOLE
+            _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
+                pack_src_data_types[0],
+                pack_dst_data_types[0],
+                /*tile_size=*/16 * 16 * 4,
+                FACE_R_DIM,
+                TILE_C_DIM,
+                /*num_faces=*/4,
+                /*partial_face=*/false);
+#else
+            _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
+                pack_src_data_types[0],
+                pack_dst_data_types[0],
+                /*tile_size=*/16 * 16 * 4,
+                FACE_R_DIM,
+                /*num_faces=*/4,
+                /*partial_face=*/false,
+                /*narrow_tile=*/false);
+#endif
+            _llk_pack_init_wrapper_</*pack_mode=*/PackMode::Default, /*zero_output=*/false>(pack_dst_data_types[0]);
+            _llk_pack_<dest_sync, is_fp32_dest_acc_en, PackMode::Default>(input_dest_start, L1_ADDRESS(params.buffer_A[row_offset + wt]));
+            _llk_pack_<dest_sync, is_fp32_dest_acc_en, PackMode::Default>(input_dest_end, L1_ADDRESS(params.buffer_A[row_offset + wt + 1]));
+
+            // Indices reconfig + pack.
+#ifdef ARCH_BLACKHOLE
+            _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
+                pack_src_data_types[1],
+                pack_dst_data_types[1],
+                /*tile_size=*/16 * 16 * 4,
+                FACE_R_DIM,
+                TILE_C_DIM,
+                /*num_faces=*/4,
+                /*partial_face=*/false);
+#else
+            _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
+                pack_src_data_types[1],
+                pack_dst_data_types[1],
+                /*tile_size=*/16 * 16 * 4,
+                FACE_R_DIM,
+                /*num_faces=*/4,
+                /*partial_face=*/false,
+                /*narrow_tile=*/false);
+#endif
+            _llk_pack_init_wrapper_</*pack_mode=*/PackMode::Default, /*zero_output=*/false>(pack_dst_data_types[1]);
+            _llk_pack_<dest_sync, is_fp32_dest_acc_en, PackMode::Default>(index_dest_start, L1_ADDRESS(params.buffer_A[row_offset + Wt + wt]));
+            _llk_pack_<dest_sync, is_fp32_dest_acc_en, PackMode::Default>(index_dest_end, L1_ADDRESS(params.buffer_A[row_offset + Wt + wt + 1]));
+
+            _llk_pack_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
+        }
+
+        // ----- 2. Bitonic merge stages -----
+        for (std::uint32_t stage = 2; stage <= STAGES; ++stage)
+        {
+            for (std::uint32_t sub = stage; sub > 0; --sub)
+            {
+                const std::uint32_t sub_dist = 1u << (sub - 1);
+                for (std::uint32_t i = 0; i < Wt; ++i)
+                {
+                    const std::uint32_t j = i ^ sub_dist;
+                    if (j > i)
+                    {
+                        const bool ascending_block = ((i >> stage) & 1) == 0;
+                        const bool dir             = (ascending_block == ASCENDING);
+
+                        // Direction handling: for sub != 1 (merge with top_min=false),
+                        // DEST[0] holds the SMALLER value and DEST[1] holds the LARGER.
+                        // - dir == true (ascending): low tile id (i) gets smaller -> DEST[0],
+                        //   high tile id (j) gets larger -> DEST[1].  But the metal code shows
+                        //   the OPPOSITE swap: when dir, swap so tile_input_low = input_dest_end (1).
+                        //   Reading the metal kernel carefully:
+                        //     "topk_merge puts smallest values in DEST[0] and largest in DEST[1]"
+                        //     "We swap their indices when using descending order"
+                        //   But the code is:  if (dir) { swap; }   and `dir` is computed as
+                        //   `dir = ascending_block == ascending` where ascending=true means
+                        //   the global request is ascending.  So `dir==true` means ASCENDING.
+                        //   The comment says "swap when descending" but the code swaps when `dir==true`.
+                        //   This is consistent if we read it as: top_min=false means DEST[0]=largest
+                        //   and DEST[1]=smallest (top-K of largest values goes to DEST[0]).
+                        //   In ascending order, smaller goes left -> we want DEST[1] in left, hence swap.
+                        //   We faithfully mirror the metal code's behaviour.
+                        int v_low_dst, v_high_dst, x_low_dst, x_high_dst;
+                        if (sub != 1 && dir)
+                        {
+                            v_low_dst  = input_dest_end;
+                            v_high_dst = input_dest_start;
+                            x_low_dst  = index_dest_end;
+                            x_high_dst = index_dest_start;
+                        }
+                        else
+                        {
+                            v_low_dst  = input_dest_start;
+                            v_high_dst = input_dest_end;
+                            x_low_dst  = index_dest_start;
+                            x_high_dst = index_dest_end;
+                        }
+
+                        _llk_packer_wait_for_math_done_();
+
+                        // Values reconfig + pack.
+#ifdef ARCH_BLACKHOLE
+                        _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
+                            pack_src_data_types[0],
+                            pack_dst_data_types[0],
+                            /*tile_size=*/16 * 16 * 4,
+                            FACE_R_DIM,
+                            TILE_C_DIM,
+                            /*num_faces=*/4,
+                            /*partial_face=*/false);
+#else
+                        _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
+                            pack_src_data_types[0],
+                            pack_dst_data_types[0],
+                            /*tile_size=*/16 * 16 * 4,
+                            FACE_R_DIM,
+                            /*num_faces=*/4,
+                            /*partial_face=*/false,
+                            /*narrow_tile=*/false);
+#endif
+                        _llk_pack_init_wrapper_</*pack_mode=*/PackMode::Default, /*zero_output=*/false>(pack_dst_data_types[0]);
+                        _llk_pack_<dest_sync, is_fp32_dest_acc_en, PackMode::Default>(v_low_dst, L1_ADDRESS(params.buffer_A[row_offset + i]));
+                        _llk_pack_<dest_sync, is_fp32_dest_acc_en, PackMode::Default>(v_high_dst, L1_ADDRESS(params.buffer_A[row_offset + j]));
+
+                        // Indices reconfig + pack.
+#ifdef ARCH_BLACKHOLE
+                        _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
+                            pack_src_data_types[1],
+                            pack_dst_data_types[1],
+                            /*tile_size=*/16 * 16 * 4,
+                            FACE_R_DIM,
+                            TILE_C_DIM,
+                            /*num_faces=*/4,
+                            /*partial_face=*/false);
+#else
+                        _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
+                            pack_src_data_types[1],
+                            pack_dst_data_types[1],
+                            /*tile_size=*/16 * 16 * 4,
+                            FACE_R_DIM,
+                            /*num_faces=*/4,
+                            /*partial_face=*/false,
+                            /*narrow_tile=*/false);
+#endif
+                        _llk_pack_init_wrapper_</*pack_mode=*/PackMode::Default, /*zero_output=*/false>(pack_dst_data_types[1]);
+                        _llk_pack_<dest_sync, is_fp32_dest_acc_en, PackMode::Default>(x_low_dst, L1_ADDRESS(params.buffer_A[row_offset + Wt + i]));
+                        _llk_pack_<dest_sync, is_fp32_dest_acc_en, PackMode::Default>(x_high_dst, L1_ADDRESS(params.buffer_A[row_offset + Wt + j]));
+
+                        _llk_pack_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
+                    }
+                }
+            }
+        }
+
+        // ----- 3. Final result-copy pass: pack each tile from DEST[0] to buffer_Res -----
+        for (std::uint32_t t = 0; t < FULL_CT_DIM; ++t)
+        {
+            const std::uint32_t stage_idx = (t < Wt) ? 0u : 1u;
+            _llk_packer_wait_for_math_done_();
+#ifdef ARCH_BLACKHOLE
+            _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
+                pack_src_data_types[stage_idx],
+                pack_dst_data_types[stage_idx],
+                /*tile_size=*/16 * 16 * 4,
+                FACE_R_DIM,
+                TILE_C_DIM,
+                /*num_faces=*/4,
+                /*partial_face=*/false);
+#else
+            _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
+                pack_src_data_types[stage_idx],
+                pack_dst_data_types[stage_idx],
+                /*tile_size=*/16 * 16 * 4,
+                FACE_R_DIM,
+                /*num_faces=*/4,
+                /*partial_face=*/false,
+                /*narrow_tile=*/false);
+#endif
+            _llk_pack_init_wrapper_</*pack_mode=*/PackMode::Default, /*zero_output=*/false>(pack_dst_data_types[stage_idx]);
+            _llk_pack_<dest_sync, is_fp32_dest_acc_en, PackMode::Default>(/*tile_index=*/0, L1_ADDRESS(params.buffer_Res[row_offset + t]));
+            _llk_pack_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
+        }
+    }
+}
+#endif // LLK_TRISC_PACK

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -125,6 +125,12 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
 
         TT_SETADCXX(p_setadc::UNP_A, (unpack_face_r_dim << 4) - 1, 0x0);
     }
+
+    // Disable zero-src flag: any UInt16 with low byte 0x00 (256, 0x8000, ...) shares the bf16 -0 pattern and would be zeroed.
+    if (unpack_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16))
+    {
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
@@ -173,15 +179,22 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
 
         TT_SETADCXX(p_setadc::UNP_B, (unpack_face_r_dim << 4) - 1, 0x0);
     }
+
+    // Disable zero-src flag: any UInt16 with low byte 0x00 (256, 0x8000, ...) shares the bf16 -0 pattern and would be zeroed.
+    if (unpack_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16))
+    {
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
 }
 
 // Update ALU_ACC_CTRL_Zero_Flag_disabled_src after a data-format reconfig.
 //
-// The zero-src flag causes the hardware to substitute 0 for values whose bit
-// pattern matches -0.0f in bfloat16 (e.g. 0x8000).  configure_unpack_AB
-// disables the flag whenever either dest format is uint16, because 0x8000 is a
-// valid uint16 value (32768) that must not be zeroed.  The same adjustment is
-// needed every time formats are reconfigured.
+// The zero-src flag (when enabled) makes the hardware zero any 16-bit SrcA/B
+// datum whose low byte is 0x00 (predicate: !(SrcVal & 0xff)).
+// The substitution is meant to flush bf16 denormals/-0, but it also
+// clobbers valid UInt16 values such as 256 (0x0100), 512 (0x0200), 0x8000, etc.
+// configure_unpack_AB disables the flag whenever either dest format is uint16;
+// the same adjustment is needed every time formats are reconfigured.
 //
 // Only disable the flag (write 1) when transitioning TO uint16.  Do NOT
 // re-enable it (write 0) for non-uint16 transitions: other LLK operations

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -123,6 +123,12 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
 
         TT_SETADCXX(p_setadc::UNP_A, (unpack_face_r_dim << 4) - 1, 0x0);
     }
+
+    // Disable zero-src flag: any UInt16 with low byte 0x00 (256, 0x8000, ...) shares the bf16 -0 pattern and would be zeroed.
+    if (unpack_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16))
+    {
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
@@ -168,15 +174,22 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
 
         TT_SETADCXX(p_setadc::UNP_B, (unpack_face_r_dim << 4) - 1, 0x0);
     }
+
+    // Disable zero-src flag: any UInt16 with low byte 0x00 (256, 0x8000, ...) shares the bf16 -0 pattern and would be zeroed.
+    if (unpack_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16))
+    {
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
 }
 
 // Update ALU_ACC_CTRL_Zero_Flag_disabled_src after a data-format reconfig.
 //
-// The zero-src flag causes the hardware to substitute 0 for values whose bit
-// pattern matches -0.0f in bfloat16 (e.g. 0x8000).  configure_unpack_AB
-// disables the flag whenever either dest format is uint16, because 0x8000 is a
-// valid uint16 value (32768) that must not be zeroed.  The same adjustment is
-// needed every time formats are reconfigured.
+// The zero-src flag (when enabled) makes the hardware zero any 16-bit SrcA/B
+// datum whose low byte is 0x00 (predicate: !(SrcVal & 0xff)).
+// The substitution is meant to flush bf16 denormals/-0, but it also
+// clobbers valid UInt16 values such as 256 (0x0100), 512 (0x0200), 0x8000, etc.
+// configure_unpack_AB disables the flag whenever either dest format is uint16;
+// the same adjustment is needed every time formats are reconfigured.
 //
 // Only disable the flag (write 1) when transitioning TO uint16.  Do NOT
 // re-enable it (write 0) for non-uint16 transitions: other LLK operations


### PR DESCRIPTION

### PR Category

Bug fix

### Summary

Fixes #37571.

`ttnn.sort` returned non-permutation indices for last-dim > 256 elements on Wormhole B0 (and Blackhole). The corruption was data-independent: index `0` duplicated, multiples of 256 (`256, 512, 768, …`) missing.

**Root cause** is in the LLK unpacker reconfig path:

1. `configure_unpack_AB` (called from the first `_llk_unpack_hw_configure_`) explicitly sets `ALU_ACC_CTRL_Zero_Flag_disabled_src` based on the *initial* dst format.
2. `ttnn.sort`'s compute kernel boots with bf16 (values), so the flag is set to **0** (flush ON).
3. The kernel later reconfigs SrcA to UInt16 to handle index tiles via `_llk_unpack_reconfig_data_format_srca_impl_`. That path **never updated the zero-flag**.
4. With the flag still at 0, `MOVA2D` (used by the math TRISC's datacopy) applies its bf16-denormal-flush rule `(SrcAVal & 0xFF) == 0 → 0` to UInt16 *index* data, eating any value with a zero low byte.

The LLK already documents this concern in `llk_unpack_common.h:173-191` and ships the helper `_llk_unpack_reconfig_zero_src_flag_`, but it was only wired into `configure_unpack_AB` — not into the runtime SrcA/SrcB reconfig functions. This PR closes that gap.

**Fix:** at the end of `_llk_unpack_reconfig_data_format_srca_impl_` and `_srcb_impl_` (both WH B0 and BH), re-assert `ALU_ACC_CTRL_Zero_Flag_disabled_src = 1` whenever the new dst format is `UInt16`. The write is sticky and only sets to 1 — never re-enables the flag — matching `_llk_unpack_reconfig_zero_src_flag_`'s documented semantics.

**Verification (Wormhole B0):**

- Issue's verbatim minimal repro: `Unique indices: 512/512`, `Index 0 count: 1`, `Index 256 count: 1` — was `511/512`, `2`, `0` before fix.
- All four scenarios from the issue's table pass: widths 256, 288, 512, 1024 — every index in `range(width)` appears exactly once.
- New LLK regression test `tests/sources/sort_test.cpp` + `tests/python_tests/test_sort.py` reproduces the exact #37571 signature pre-fix (Wt=8 PASS, Wt=16 missing `[256]`, Wt=32 missing `[256, 512, 768]`) and passes post-fix.

### Notes for reviewers

- Behavior change is conditional and monotonic: only writes when `dst_format == UInt16`, only ever writes `1`. For all other format reconfigs the change is a pure no-op (one extra compare + not-taken branch in a cold init function).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/issue-37571-fix-uint16-zero-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/issue-37571-fix-uint16-zero-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstamatovic/issue-37571-fix-uint16-zero-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstamatovic/issue-37571-fix-uint16-zero-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nstamatovic/issue-37571-fix-uint16-zero-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nstamatovic/issue-37571-fix-uint16-zero-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/issue-37571-fix-uint16-zero-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/issue-37571-fix-uint16-zero-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstamatovic/issue-37571-fix-uint16-zero-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstamatovic/issue-37571-fix-uint16-zero-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/issue-37571-fix-uint16-zero-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/issue-37571-fix-uint16-zero-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/issue-37571-fix-uint16-zero-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/issue-37571-fix-uint16-zero-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/issue-37571-fix-uint16-zero-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/issue-37571-fix-uint16-zero-flag)