### PR TITLE
[codex] Fix quad-ring MoE expert ownership

### DIFF
--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_optimized_moe_decode_block.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_optimized_moe_decode_block.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import comp_allclose, comp_pcc
+from models.demos.deepseek_v3.tt.moe_expert_mapping import get_expert_owner_linearized_mesh_coord
 from tests.nightly.tg.ccl.moe.test_moe_compute_6U import prepare_w0_w1_tensor, prepare_w2_tensor
 
 
@@ -29,13 +30,10 @@ def tt_to_torch_dtype(tt_dtype):
 
 def get_linearized_mesh_coord(num_replicated_devices, cluster_axis, expert_id, experts_per_cluster, experts_per_device):
     if cluster_axis == 0:
-        cluster_id = expert_id // experts_per_cluster
-        expert_id_within_cluster = expert_id % experts_per_cluster
-        device_id_within_cluster = expert_id_within_cluster // experts_per_device
-
-        return device_id_within_cluster * num_replicated_devices + cluster_id
+        mesh_shape = (experts_per_cluster // experts_per_device, num_replicated_devices)
     else:
-        return expert_id // experts_per_device
+        mesh_shape = (num_replicated_devices, experts_per_cluster // experts_per_device)
+    return get_expert_owner_linearized_mesh_coord(mesh_shape, cluster_axis, expert_id, experts_per_device)
 
 
 def create_torch_w0_tensors(L, E, H, N):

--- a/models/demos/deepseek_v3/tests/test_moe_expert_mapping.py
+++ b/models/demos/deepseek_v3/tests/test_moe_expert_mapping.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+from models.demos.deepseek_v3.tt.moe_expert_mapping import (
+    create_expert_mapping_tensor,
+    get_expert_owner_linearized_mesh_coord,
+)
+
+
+def test_cluster_axis_zero_maps_experts_along_columns():
+    mesh_shape = (16, 8)
+    experts_per_device = 2
+
+    assert get_expert_owner_linearized_mesh_coord(mesh_shape, 0, 0, experts_per_device) == 0
+    assert get_expert_owner_linearized_mesh_coord(mesh_shape, 0, 1, experts_per_device) == 0
+    assert get_expert_owner_linearized_mesh_coord(mesh_shape, 0, 2, experts_per_device) == 8
+    assert get_expert_owner_linearized_mesh_coord(mesh_shape, 0, 31, experts_per_device) == 120
+    assert get_expert_owner_linearized_mesh_coord(mesh_shape, 0, 32, experts_per_device) == 1
+    assert get_expert_owner_linearized_mesh_coord(mesh_shape, 0, 255, experts_per_device) == 127
+
+
+def test_cluster_axis_one_matches_row_major_expert_ownership():
+    mesh_shape = (16, 8)
+    experts_per_device = 2
+
+    for expert_id in range(256):
+        assert (
+            get_expert_owner_linearized_mesh_coord(mesh_shape, 1, expert_id, experts_per_device)
+            == expert_id // experts_per_device
+        )
+
+
+def test_create_expert_mapping_tensor_replicates_axis_aware_mapping():
+    mapping = create_expert_mapping_tensor((16, 8), 0, 256, 2)
+
+    assert mapping.shape == (128, 256)
+    assert mapping.dtype == torch.uint16
+    assert torch.equal(mapping[0], mapping[-1])
+    assert mapping[0, 2].item() == 8
+    assert mapping[0, 32].item() == 1

--- a/models/demos/deepseek_v3/tt/experts.py
+++ b/models/demos/deepseek_v3/tt/experts.py
@@ -10,6 +10,10 @@ from loguru import logger
 from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
+from models.demos.deepseek_v3.tt.moe_expert_mapping import (
+    OPTIMIZED_MOE_CLUSTER_AXIS,
+    get_expert_owner_linearized_mesh_coord,
+)
 from models.demos.deepseek_v3.utils.abstract_module import AbstractModule
 from models.demos.deepseek_v3.utils.config_dataclass import FromWeightConfig, LinearConfig, MeshDeviceStub, MulConfig
 from models.demos.deepseek_v3.utils.config_helpers import (
@@ -133,8 +137,8 @@ class Experts(AbstractModule):
         matmul_N = w0.shape[-1]
         ring2cores, compute_matmul_dram_core_range_set = determine_compute_matmul_cores(mesh_device)
 
-        prepared_w0_w1 = []
-        prepared_w2 = []
+        prepared_w0_w1 = [None] * mesh_device.get_num_devices()
+        prepared_w2 = [None] * mesh_device.get_num_devices()
         for i in range(0, num_routed_experts, num_experts_per_device):
             prepared_w0_w1_tensor = prepare_w0_w1_tensor(
                 w0[:, i : i + num_experts_per_device, :, :],
@@ -154,8 +158,17 @@ class Experts(AbstractModule):
                 ring2cores,
             )
 
-            prepared_w0_w1.append(prepared_w0_w1_tensor)
-            prepared_w2.append(prepared_w2_tensor)
+            linearized_mesh_coord = get_expert_owner_linearized_mesh_coord(
+                mesh_device.shape,
+                OPTIMIZED_MOE_CLUSTER_AXIS,
+                i,
+                num_experts_per_device,
+            )
+            prepared_w0_w1[linearized_mesh_coord] = prepared_w0_w1_tensor
+            prepared_w2[linearized_mesh_coord] = prepared_w2_tensor
+
+        if any(tensor is None for tensor in prepared_w0_w1) or any(tensor is None for tensor in prepared_w2):
+            raise RuntimeError("Optimized MoE expert weight placement did not assign every mesh device")
 
         prepared_w0_w1 = torch.cat(prepared_w0_w1, dim=2)
         prepared_w2 = torch.cat(prepared_w2, dim=2)

--- a/models/demos/deepseek_v3/tt/moe_expert_mapping.py
+++ b/models/demos/deepseek_v3/tt/moe_expert_mapping.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Sequence
+
+OPTIMIZED_MOE_CLUSTER_AXIS = 0
+
+
+def get_expert_owner_linearized_mesh_coord(
+    mesh_shape: Sequence[int],
+    cluster_axis: int,
+    expert_id: int,
+    experts_per_device: int,
+) -> int:
+    """Map a global expert id to the owning device for optimized MoE routing."""
+    if len(mesh_shape) != 2:
+        raise ValueError(f"Expected a 2D mesh shape, got {tuple(mesh_shape)}")
+    if cluster_axis not in (0, 1):
+        raise ValueError(f"Expected cluster_axis 0 or 1, got {cluster_axis}")
+    if experts_per_device <= 0:
+        raise ValueError(f"experts_per_device must be positive, got {experts_per_device}")
+
+    rows, cols = (int(mesh_shape[0]), int(mesh_shape[1]))
+    devices_per_cluster = rows if cluster_axis == 0 else cols
+    num_clusters = cols if cluster_axis == 0 else rows
+    experts_per_cluster = devices_per_cluster * experts_per_device
+
+    cluster_id = expert_id // experts_per_cluster
+    if cluster_id >= num_clusters:
+        raise ValueError(
+            f"Expert {expert_id} is outside mesh capacity for mesh_shape={tuple(mesh_shape)}, "
+            f"cluster_axis={cluster_axis}, experts_per_device={experts_per_device}"
+        )
+
+    expert_id_within_cluster = expert_id % experts_per_cluster
+    device_id_within_cluster = expert_id_within_cluster // experts_per_device
+
+    if cluster_axis == 0:
+        row = device_id_within_cluster
+        col = cluster_id
+    else:
+        row = cluster_id
+        col = device_id_within_cluster
+
+    return row * cols + col
+
+
+def create_expert_mapping_tensor(
+    mesh_shape: Sequence[int],
+    cluster_axis: int,
+    num_experts: int,
+    experts_per_device: int,
+    dtype=None,
+):
+    """Create the replicated expert-to-owner mapping tensor consumed by optimized MoE kernels."""
+    import torch
+
+    if dtype is None:
+        dtype = torch.uint16
+
+    rows, cols = (int(mesh_shape[0]), int(mesh_shape[1]))
+    num_devices = rows * cols
+    expert_mapping = torch.empty((1, num_experts), dtype=dtype)
+    for expert_id in range(num_experts):
+        expert_mapping[0, expert_id] = get_expert_owner_linearized_mesh_coord(
+            mesh_shape,
+            cluster_axis,
+            expert_id,
+            experts_per_device,
+        )
+    return expert_mapping.repeat(num_devices, 1)

--- a/models/demos/deepseek_v3/tt/moe_optimized.py
+++ b/models/demos/deepseek_v3/tt/moe_optimized.py
@@ -10,6 +10,7 @@ from transformers.configuration_utils import PretrainedConfig
 import ttnn
 from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.experts import Experts as MoEExperts
+from models.demos.deepseek_v3.tt.moe_expert_mapping import OPTIMIZED_MOE_CLUSTER_AXIS, create_expert_mapping_tensor
 from models.demos.deepseek_v3.tt.moe_gate import MoEGate
 from models.demos.deepseek_v3.utils.abstract_module import AbstractModule
 from models.demos.deepseek_v3.utils.config_dataclass import (
@@ -123,8 +124,11 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
         )
 
         num_experts = num_devices * num_experts_per_device
-        torch_expert_mapping_tensor = (
-            (torch.arange(num_experts) // num_experts_per_device).unsqueeze(0).repeat(num_devices, 1)
+        torch_expert_mapping_tensor = create_expert_mapping_tensor(
+            mesh_device.shape,
+            OPTIMIZED_MOE_CLUSTER_AXIS,
+            num_experts,
+            num_experts_per_device,
         )
         expert_mapping_tensor = ttnn.from_torch(
             torch_expert_mapping_tensor,
@@ -267,7 +271,7 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
             worker_mode=ttnn.WorkerMode.DIRECT,
             dispatch_algorithm=ttnn.DispatchAlgorithm.SPARSE_MCAST_SHORTEST_PATH,
             drain_sync_tilizer_core=(6, 9),
-            cluster_axis=0,
+            cluster_axis=OPTIMIZED_MOE_CLUSTER_AXIS,
             num_links=4,
             cross_device_semaphore=None,
         )
@@ -287,7 +291,7 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
         config["quad_ring_moe_compute"] = MoEComputeConfig(
             output_height_shard_dim=4,
             output_width_shard_dim=4,
-            cluster_axis=0,
+            cluster_axis=OPTIMIZED_MOE_CLUSTER_AXIS,
         )
         config["quad_ring_selective_reduce_combine"] = SelectiveReduceCombineConfig(
             hidden_size=hf_config.hidden_size,
@@ -295,7 +299,7 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
             seq_size=seq_len,
             select_experts_k=hf_config.num_experts_per_tok,
             experts=hf_config.n_routed_experts,
-            cluster_axis=0,
+            cluster_axis=OPTIMIZED_MOE_CLUSTER_AXIS,
             token_parallel_core_dim=4,
             data_parallel_core_dim=4,
             worker_cores=ttnn.experimental.get_moe_combine_cores(mesh_device),


### PR DESCRIPTION
**Note:** speculative AI fix. Not tested yet (no local quad).

## Summary
- Fix optimized DeepSeek-V3 quad-ring MoE expert ownership so `cluster_axis=0` uses column-local expert placement instead of row-major placement.
- Share the owner mapping helper between production and the fused optimized MoE test so the test and runtime cannot drift again.
- Add a small unit test for the 16x8 expert-owner mapping.

## Issue
Refs #42712

cc @kpaigwar @yalrawwashTT @pprajapatiTT

## Root Cause
The optimized MoE dispatch/compute path is configured with `cluster_axis=0`, so the C++ routing only sends within a mesh column. Production was assigning experts in row-major order (`expert // experts_per_device`) and placing optimized expert weights in the same row-major order. On 16x8 with 2 experts/device, expert 2 was mapped to device 1, but same-column routing from device 0 can reach device 8, not device 1.

## Testing
- `python -m compileall models/demos/deepseek_v3/tt/moe_expert_mapping.py models/demos/deepseek_v3/tt/moe_optimized.py models/demos/deepseek_v3/tt/experts.py models/demos/deepseek_v3/tests/test_moe_expert_mapping.py models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_optimized_moe_decode_block.py`
- Pure Python assertion script for the 16x8 cluster-axis mapping passed.
- Commit hooks passed with `validate-metalium-deprecation` skipped; that hook reports unrelated existing deprecation state when this ds-rc1 branch is compared to `origin/main`.
- Triggered `(Galaxy) DeepSeek tests` with `test-type=all` on the PR branch: https://github.com/tenstorrent/tt-metal/actions/runs/25556963541
- Not run locally: `pytest models/demos/deepseek_v3/tests/test_moe_expert_mapping.py -q` because this local Python environment does not have `pytest` or `torch` installed.

## Hardware Validation
Not run locally. Please try branch `codex/fix-ds-rc1-quad-moe-expert-mapping` on the affected QUAD/ring DeepSeek run.

## CI Badge
[![(Galaxy) DeepSeek tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=codex%2Ffix-ds-rc1-quad-moe-expert-mapping)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml?query=branch%3Acodex%2Ffix-ds-rc1-quad-moe-expert-mapping)
