### PR TITLE
ttnn/concat: fall back to single-buffered CB when depth=2 exceeds L1

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
@@ -447,3 +447,22 @@ def test_concat_sub_core_grids(device, layout, dim, input_shapes, sub_core_grids
     output = ttnn.to_torch(output)
 
     assert_equal(torch_output_tensor, output)
+
+
+@pytest.mark.parametrize(
+    "shapes, dim",
+    [
+        ([[217413, 1]] * 4, 1),
+    ],
+)
+def test_concat_large_page_l1_budget(device, shapes, dim):
+    torch_inputs = [torch.rand(*shape, dtype=torch.float32) for shape in shapes]
+    torch_output_tensor = torch.concat(torch_inputs, dim=dim)
+
+    input_tensors = [
+        ttnn.from_torch(t, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.float32) for t in torch_inputs
+    ]
+    output = ttnn.concat(input_tensors, dim=dim)
+    output = ttnn.to_torch(output)
+
+    assert_with_pcc(torch_output_tensor, output)

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
@@ -108,7 +108,21 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     const uint32_t src0_cb_index = 0;
-    const uint32_t num_input_pages = 2;
+    // Depth=2 is a prefetch optimization; fall back to depth=1 when it would overflow L1.
+    const uint32_t l1_budget =
+        (device->l1_size_per_core() / 2) - device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t l1_capacity =
+        device->l1_size_per_core() - device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    TT_FATAL(
+        single_page_size <= l1_capacity,
+        "ttnn.concat: required CB page size ({} B) exceeds per-core L1 capacity ({} B); "
+        "op cannot fit on this device.",
+        single_page_size,
+        l1_capacity);
+    uint32_t num_input_pages = 2;
+    if (num_input_pages * single_page_size > l1_budget) {
+        num_input_pages = 1;
+    }
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_input_pages * single_page_size,
         .core_ranges = all_cores,


### PR DESCRIPTION
### Ticket

fixes https://github.com/tenstorrent/tt-metal/issues/43893

### Problem description

`ttnn.concat` fails with `TT_THROW: Statically allocated circular buffers ... grow to 1843072 B which is beyond max L1 size of 1499136 B` on tile-layout tensors whose post-massage row width is large (e.g. four `(217413, 1)` f32 tensors on `dim=1`).

**Root cause:** `ConcatProgramFactory::create` hard-codes the input CB depth at `num_input_pages = 2` (prefetch double-buffer). When `untilize_rm_retilize_concat` + `non_aligned_last_dim_concat` rewrite the op into a row-major concat on a non-last dim, `single_page_size` becomes one full output row (~870 KB for the repro), so `2 × single_page_size ≈ 1.74 MB` exceeds per-core L1. The reader kernel only reserves one page at a time (`cb_in.reserve_back(1)`), so depth=2 is a perf optimization, not a correctness requirement.

## What's changed

**Fix (`concat_program_factory.cpp`)** — fall back to depth=1 when the depth-2 CB would not fit in L1, mirroring the budgeting in `untilize`/`tilize`/`copy` factories:

```diff
- const uint32_t num_input_pages = 2;
+ const uint32_t l1_budget =
+     (device->l1_size_per_core() / 2) - device->allocator()->get_base_allocator_addr(HalMemType::L1);
+ uint32_t num_input_pages = 2;
+ if (num_input_pages * single_page_size > l1_budget) {
+     num_input_pages = 1;
+ }
```

### Checklist

- [x] Nightly tt-metal L2 tests - https://github.com/tenstorrent/tt-metal/actions/runs/25558543278
- [x] Sanity tests - https://github.com/tenstorrent/tt-metal/actions/runs/25558426789/attempts/1

**Note:** Nightly & sanity test failures on my branch also occur in main ([run 25594359343](https://github.com/tenstorrent/tt-metal/actions/runs/25594359343), [run 25592896430](https://github.com/tenstorrent/tt-metal/actions/runs/25592896430)), confirming this change introduces no regression.
