### PR TITLE
gpt-oss MoE: pad short prefill seqs up to seq_len_per_chip and slice back

### DIFF
--- a/models/demos/gpt_oss/tt/experts_throughput/__init__.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/__init__.py
@@ -361,10 +361,12 @@ class ThroughputExperts:
             # routing). Instead, slice a pad_len-sized chunk from the
             # precomputed round-robin index tensor (built at init) and concat.
             # This keeps the forward path host-write-free for trace capture.
-            assert self._round_robin_pad_indices is not None, (
-                "ThroughputExperts._round_robin_pad_indices was not initialized; "
-                "did the prefill_config get set after __init__?"
-            )
+            if self._round_robin_pad_indices is None:
+                raise RuntimeError(
+                    "ThroughputExperts._round_robin_pad_indices was not "
+                    "initialized; did the prefill_config get set after "
+                    "__init__?"
+                )
             pad_idx_slice = ttnn.slice(
                 self._round_robin_pad_indices,
                 [0, 0, 0, 0],
@@ -376,6 +378,11 @@ class ThroughputExperts:
             target_shape = list(topk_expert_indices.shape)
             target_shape[0] = pad_len
             pad_idx_slice = ttnn.reshape(pad_idx_slice, target_shape)
+            # ttnn.concat requires matching layouts; the cached round-robin
+            # tensor is ROW_MAJOR but runtime topk indices may be TILE
+            # (depending on the upstream router output). Align before concat.
+            if pad_idx_slice.layout != topk_expert_indices.layout:
+                pad_idx_slice = ttnn.to_layout(pad_idx_slice, topk_expert_indices.layout)
             topk_expert_indices = ttnn.concat([topk_expert_indices, pad_idx_slice], dim=0)
             # Convert to TILE_LAYOUT to match what ttnn.topk normally produces.
             # The chunk function does "idx_for_routing = to_layout(topk_expert_indices,

--- a/models/demos/gpt_oss/tt/experts_throughput/__init__.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/__init__.py
@@ -199,6 +199,32 @@ class ThroughputExperts:
         self.hidden_size = config.hidden_size
         self.num_experts_per_device = config.num_experts_per_device
 
+        # Precompute a chunk-sized round-robin index tensor used to pad short
+        # warmup seqs (e.g. seq=128) up to seq_len_per_chip. Built once at init
+        # so forward_prefill stays trace-compatible — no ttnn.from_torch host
+        # writes are allowed once trace capture starts.
+        self._round_robin_pad_indices = None
+        prefill_cfg = getattr(self, "prefill_config", None)
+        if prefill_cfg is not None:
+            import torch as _torch
+
+            chunk_init = prefill_cfg.seq_len_per_chip
+            num_experts_init = config.num_experts
+            num_experts_per_tok_init = config.num_experts_per_tok
+            positions_init = _torch.arange(chunk_init, dtype=_torch.int32).view(chunk_init, 1, 1, 1)
+            ks_init = _torch.arange(num_experts_per_tok_init, dtype=_torch.int32).view(
+                1, 1, 1, num_experts_per_tok_init
+            )
+            rr_torch = ((positions_init + ks_init) % num_experts_init).to(_torch.int32).contiguous()
+            # uint16 matches ttnn.topk output dtype (see prefill.py dispatch).
+            # num_experts (128) fits comfortably in uint16.
+            self._round_robin_pad_indices = ttnn.from_torch(
+                rr_torch.to(_torch.int32),  # ttnn.from_torch needs int32 source for uint16
+                device=mesh_device,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                dtype=ttnn.uint16,
+            )
+
     def __call__(
         self,
         hidden_states: ttnn.Tensor,
@@ -307,6 +333,80 @@ class ThroughputExperts:
         # DeepSeek-style chunked prefill is the only supported path; the legacy
         # chunked fallback was removed when DeepSeek prefill was bundled into
         # use_throughput_experts.
+        #
+        # The DeepSeek prefill path is hardcoded for seq_len_per_chip (kernels,
+        # CB sizes, dispatch tables all baked at config init). For seq shorter
+        # than that (e.g. vLLM warmup at seq_len=128), pad up to seq_len_per_chip
+        # with zeros + expert_id=0 + weight=0, then slice the output back.
+        chunk = self.prefill_config.seq_len_per_chip
+        seq_per_device = hidden_states.shape[2] if len(hidden_states.shape) >= 3 else hidden_states.shape[0]
+        if seq_per_device < chunk:
+            pad_len = chunk - seq_per_device
+
+            # Pad along seq axis only; build spec sized to each tensor's rank
+            # to avoid "padding len can't be larger than input tensor rank".
+            def _pad_seq(t, seq_axis, value):
+                rank = len(t.shape)
+                spec = [(0, 0)] * rank
+                spec[seq_axis] = (0, pad_len)
+                return ttnn.pad(t, spec, value=value)
+
+            # hidden_states is [..., S, H] — seq is axis 2 if rank>=3 else axis 0
+            h_seq_axis = 2 if len(hidden_states.shape) >= 3 else 0
+            hidden_states = _pad_seq(hidden_states, h_seq_axis, value=0.0)
+
+            # topk_expert_indices: padding all positions with expert_id=0 would
+            # route every padding token to expert 0 and overflow the dispatch
+            # buffer (max_dispatched_tokens_per_expert is sized for balanced
+            # routing). Instead, slice a pad_len-sized chunk from the
+            # precomputed round-robin index tensor (built at init) and concat.
+            # This keeps the forward path host-write-free for trace capture.
+            assert self._round_robin_pad_indices is not None, (
+                "ThroughputExperts._round_robin_pad_indices was not initialized; "
+                "did the prefill_config get set after __init__?"
+            )
+            pad_idx_slice = ttnn.slice(
+                self._round_robin_pad_indices,
+                [0, 0, 0, 0],
+                [pad_len, 1, 1, self.config.num_experts_per_tok],
+            )
+            # Cached tensor is 4D [chunk, 1, 1, K]; runtime indices may be 2D
+            # [N, K] (from topk_router) or 4D. Reshape slice to match runtime
+            # rank/shape (with seq dim replaced by pad_len) before concat.
+            target_shape = list(topk_expert_indices.shape)
+            target_shape[0] = pad_len
+            pad_idx_slice = ttnn.reshape(pad_idx_slice, target_shape)
+            topk_expert_indices = ttnn.concat([topk_expert_indices, pad_idx_slice], dim=0)
+            # Convert to TILE_LAYOUT to match what ttnn.topk normally produces.
+            # The chunk function does "idx_for_routing = to_layout(topk_expert_indices,
+            # ROW_MAJOR_LAYOUT); ... deallocate(idx_for_routing)". When the input is
+            # already ROW_MAJOR, to_layout aliases instead of creating a new buffer,
+            # so the deallocate kills topk_expert_indices itself, leading to
+            # "Tensor is not allocated" on the next use. By passing TILE here, the
+            # chunk function's ROW_MAJOR conversion is a real copy, no alias.
+            topk_expert_indices = ttnn.to_layout(topk_expert_indices, ttnn.TILE_LAYOUT)
+
+            # weights: pad with zeros — combine multiplies expert outputs by these,
+            # so padding contributions are zeroed regardless of which expert ran them.
+            topk_expert_weights = _pad_seq(topk_expert_weights, 0, value=0.0)
+            out = forward_prefill_deepseek(
+                hidden_states=hidden_states,
+                topk_expert_indices=topk_expert_indices,
+                topk_expert_weights=topk_expert_weights,
+                config=self.config,
+                prefill_config=self.prefill_config,
+                mesh_device=self.mesh_device,
+                mesh_config=self.mesh_config,
+                ccl_manager=self.ccl_manager,
+                weights=self.weights,
+                program_config=self.program_config,
+            )
+            return ttnn.slice(
+                out,
+                [0, 0, 0, 0],
+                [out.shape[0], out.shape[1], seq_per_device, out.shape[3]],
+            )
+
         return forward_prefill_deepseek(
             hidden_states=hidden_states,
             topk_expert_indices=topk_expert_indices,


### PR DESCRIPTION
## Summary

`ThroughputExperts.forward_prefill` (the DeepSeek prefill MoE path on GPT-OSS) is hardcoded for `seq_len_per_chip` — kernels, CB sizes, and dispatch tables are baked at config init. Sequences shorter than `seq_len_per_chip` (e.g. the vLLM warmup batch at seq=128) cannot run through it as-is.

The previous workaround was changing `tt_transformers/tt/common.py:get_padded_prefill_len` to skip its `<=128` branch, but that helper is shared across many models (llama70B, qwen, vision models, …), so a global change wastes attention/RMSNorm/embedding compute on every model.

This PR moves the pad/slice **inside the MoE layer**:

- `__init__`: precompute a `(seq_len_per_chip × num_experts_per_tok)` round-robin expert-index tensor on device, once. Built at init so `forward_prefill` stays trace-compatible (no `ttnn.from_torch` host writes once trace capture starts).
- `forward_prefill`: when `seq_per_device < seq_len_per_chip`:
  - pad `hidden_states` with zeros along seq axis
  - slice `pad_len` rows from the precomputed round-robin index tensor for `topk_expert_indices` (round-robin spreads padding across experts so the dispatch buffer doesn't overflow — `max_dispatched_tokens_per_expert` is sized for balanced routing)
  - pad `topk_expert_weights` with zeros (so padding contributions are zeroed in the combine, regardless of which expert ran them)
  - call `forward_prefill_deepseek` with padded tensors
  - `ttnn.slice` the output back to `seq_per_device`

Scope: only `models/demos/gpt_oss/tt/experts_throughput/__init__.py`. No shared infrastructure touched. No behavior change for `seq_per_device >= seq_len_per_chip` (the existing fast path).

## Test plan

- [x] vLLM warmup (seq=128) runs through DeepSeek prefill without dispatch-buffer overflow
- [x] AIME25 end-to-end on gpt-oss-120b, Galaxy 4x8, `data_parallel_size=4` — eval completes (matches behavior of the global `get_padded_prefill_len` workaround, but without the cross-model side effects)
- [x] Trace capture compatible (no host writes during forward; round-robin indices precomputed at init)

## Notes

- File is unchanged between the e65cf58 release commit (where DeepSeek prefill MoE landed) and current main. Patch applies cleanly to either.
- Helper for `get_padded_prefill_len` in `tt_transformers/tt/common.py` is left untouched — production callers continue to behave as before.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sraizada/gpt-oss-moe-pad-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sraizada/gpt-oss-moe-pad-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sraizada/gpt-oss-moe-pad-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sraizada/gpt-oss-moe-pad-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sraizada/gpt-oss-moe-pad-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sraizada/gpt-oss-moe-pad-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sraizada/gpt-oss-moe-pad-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sraizada/gpt-oss-moe-pad-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sraizada/gpt-oss-moe-pad-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sraizada/gpt-oss-moe-pad-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sraizada/gpt-oss-moe-pad-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sraizada/gpt-oss-moe-pad-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sraizada/gpt-oss-moe-pad-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sraizada/gpt-oss-moe-pad-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sraizada/gpt-oss-moe-pad-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sraizada/gpt-oss-moe-pad-slice)