### PR TITLE
[Bug fix] ttnn.embedding: fix partial trailing chunk in chunked tilize path

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
@@ -541,3 +541,51 @@ def test_embedding_oom(
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_equal(torch_output_tensor, output_tensor)
+
+
+# Regression for the chunked-tilize embedding path with non-multiple-of-cap
+# tile counts (i.e. partial trailing chunk). The chunked reader/compute path
+# previously assumed each chunk had the same tile count and read
+# `weight_block_size / num_chunks` bytes (integer division) per row, which
+# left the last chunk's CB slot partially uninitialised when
+# `num_tiles_per_block` did not evenly divide. Each entry below is a
+# previously failing (D, tile_count) pair drawn from the wider sweep,
+# including a prime tile count to exercise the worst-case partial chunk.
+@pytest.mark.parametrize(
+    "hidden_embedding_dim",
+    [
+        8224,  # tile_count = 257 — prime, tiny last chunk
+        8320,  # tile_count = 260 — smallest known failing chunked config
+        10752,  # tile_count = 336 — Gemma-4 per-layer embedding
+        15488,  # tile_count = 484
+    ],
+)
+@pytest.mark.parametrize("batch_size", [1])
+@pytest.mark.parametrize("sentence_size", [64])
+@pytest.mark.parametrize("vocabulary_size", [256])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("input_mem_config", [ttnn.DRAM_MEMORY_CONFIG])
+@pytest.mark.parametrize("output_mem_config", [ttnn.DRAM_MEMORY_CONFIG])
+def test_embedding_chunked_partial_last_chunk(
+    device,
+    hidden_embedding_dim,
+    batch_size,
+    sentence_size,
+    vocabulary_size,
+    dtype,
+    input_mem_config,
+    output_mem_config,
+):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randint(0, vocabulary_size, (batch_size, sentence_size))
+    torch_weights = torch_random((vocabulary_size, hidden_embedding_dim), -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.nn.functional.embedding(torch_input_tensor, torch_weights)
+
+    input_tensor = ttnn.to_device(ttnn.from_torch(torch_input_tensor), device, memory_config=input_mem_config)
+    weights = ttnn.to_device(ttnn.from_torch(torch_weights, dtype=dtype), device, memory_config=input_mem_config)
+
+    output_tensor = ttnn.embedding(input_tensor, weights, memory_config=output_mem_config, layout=ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_equal(torch_output_tensor, output_tensor)

--- a/ttnn/cpp/ttnn/operations/embedding/device/embeddings_fused_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embeddings_fused_program_factory.cpp
@@ -103,16 +103,22 @@ EmbeddingsFusedProgramFactory::cached_program_t EmbeddingsFusedProgramFactory::c
     // For very large embeddings, use chunked processing
     uint32_t tiles_per_chunk;
     uint32_t num_chunks;
+    uint32_t last_chunk_tiles;
     uint32_t buffering;
 
     if (use_chunked_processing) {
+        // Keep tiles_per_chunk near the cap and let the last chunk be partial.
+        // Reader/compute kernels handle the partial trailing chunk explicitly
+        // via last_chunk_tiles.
         tiles_per_chunk = std::min(max_tiles_per_chunk, max_double_buffer_tiles);
         num_chunks = (num_tiles_per_block + tiles_per_chunk - 1) / tiles_per_chunk;
+        last_chunk_tiles = num_tiles_per_block - (num_chunks - 1) * tiles_per_chunk;
         buffering = tiles_per_chunk > max_double_buffer_tiles ? 1 : 2;
     } else {
         // Use original non-chunked approach for smaller embeddings
         tiles_per_chunk = num_tiles_per_block;
         num_chunks = 1;
+        last_chunk_tiles = num_tiles_per_block;
         buffering = num_tiles_per_block > max_double_buffer_tiles ? 1 : 2;
     }
 
@@ -179,7 +185,8 @@ EmbeddingsFusedProgramFactory::cached_program_t EmbeddingsFusedProgramFactory::c
         (std::uint32_t)weight_block_size,
         (std::uint32_t)tiles_per_chunk,
         (std::uint32_t)input_block_size_bytes,
-        (std::uint32_t)num_chunks};
+        (std::uint32_t)num_chunks,
+        (std::uint32_t)last_chunk_tiles};
     tt::tt_metal::TensorAccessorArgs(*a.buffer()).append_to(embedding_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(*weights.buffer()).append_to(embedding_compile_time_args);
 
@@ -198,7 +205,8 @@ EmbeddingsFusedProgramFactory::cached_program_t EmbeddingsFusedProgramFactory::c
             uint32_t(output_cb_index),              // output_cb_index
             uint32_t(num_blocks_per_core_group_1),  // per_core_block_cnt
             uint32_t(tiles_per_chunk),              // tiles_per_chunk
-            uint32_t(num_chunks)                    // num_chunks per block
+            uint32_t(num_chunks),                   // num_chunks per block
+            uint32_t(last_chunk_tiles)              // last_chunk_tiles
         };
         tt::tt_metal::CreateKernel(
             program,
@@ -214,7 +222,8 @@ EmbeddingsFusedProgramFactory::cached_program_t EmbeddingsFusedProgramFactory::c
             uint32_t(output_cb_index),              // output_cb_index
             uint32_t(num_blocks_per_core_group_2),  // per_core_block_cnt
             uint32_t(tiles_per_chunk),              // tiles_per_chunk
-            uint32_t(num_chunks)                    // num_chunks per block
+            uint32_t(num_chunks),                   // num_chunks per block
+            uint32_t(last_chunk_tiles)              // last_chunk_tiles
         };
         tt::tt_metal::CreateKernel(
             program,

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/compute/tilize_chunked.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/compute/tilize_chunked.cpp
@@ -13,15 +13,41 @@ void kernel_main() {
     constexpr uint32_t per_core_block_cnt = get_compile_time_arg_val(2);
     constexpr uint32_t tiles_per_chunk = get_compile_time_arg_val(3);
     constexpr uint32_t num_chunks = get_compile_time_arg_val(4);
+    constexpr uint32_t last_chunk_tiles = get_compile_time_arg_val(5);
 
     compute_kernel_hw_startup(cb_id_in0, cb_id_out0);
-    // Process the block in chunks to fit within L1 memory limits
-    compute_kernel_lib::tilize<
-        tiles_per_chunk,
-        cb_id_in0,
-        cb_id_out0,
-        compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
-        compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
-        compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(
-        per_core_block_cnt * num_chunks);
+    // Process the block in chunks to fit within L1 memory limits.
+    // When num_tiles_per_block divides evenly (last_chunk_tiles ==
+    // tiles_per_chunk), use the original single-call path. Otherwise the
+    // last chunk is partial and is tilized separately with its own template
+    // tile count.
+    if constexpr (last_chunk_tiles == tiles_per_chunk) {
+        compute_kernel_lib::tilize<
+            tiles_per_chunk,
+            cb_id_in0,
+            cb_id_out0,
+            compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
+            compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
+            compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(
+            per_core_block_cnt * num_chunks);
+    } else {
+        for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
+            if constexpr (num_chunks > 1) {
+                compute_kernel_lib::tilize<
+                    tiles_per_chunk,
+                    cb_id_in0,
+                    cb_id_out0,
+                    compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
+                    compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
+                    compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(num_chunks - 1);
+            }
+            compute_kernel_lib::tilize<
+                last_chunk_tiles,
+                cb_id_in0,
+                cb_id_out0,
+                compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
+                compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
+                compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(1);
+        }
+    }
 }

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_tilize.cpp
@@ -28,8 +28,9 @@ void kernel_main() {
     constexpr uint32_t tiles_per_chunk = get_compile_time_arg_val(6);
     constexpr uint32_t input_block_size_bytes = get_compile_time_arg_val(7);
     constexpr uint32_t num_chunks = get_compile_time_arg_val(8);
+    constexpr uint32_t last_chunk_tiles = get_compile_time_arg_val(9);
 
-    constexpr auto input_args = TensorAccessorArgs<9>();
+    constexpr auto input_args = TensorAccessorArgs<10>();
     constexpr auto weights_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
     auto input = TensorAccessor(input_args, input_buffer_src_addr);
     auto weights = TensorAccessor(weights_args, weight_buffer_src_addr + weight_offset);
@@ -44,6 +45,12 @@ void kernel_main() {
 
     volatile tt_l1_ptr input_token_t* input_l1_ptr = reinterpret_cast<volatile tt_l1_ptr input_token_t*>(input_l1_addr);
 
+    // Per-row byte counts for the full and (possibly partial) last chunk.
+    constexpr uint32_t num_tiles_per_block = (num_chunks - 1) * tiles_per_chunk + last_chunk_tiles;
+    constexpr uint32_t bytes_per_tile_row = weight_block_size / num_tiles_per_block;
+    constexpr uint32_t full_chunk_bytes = tiles_per_chunk * bytes_per_tile_row;
+    constexpr uint32_t last_chunk_bytes = last_chunk_tiles * bytes_per_tile_row;
+
     uint32_t curr_row = input_start_id;
     uint32_t offset = input_start_offset;
     for (uint32_t i = 0; i < num_blocks; ++i) {
@@ -56,12 +63,13 @@ void kernel_main() {
         noc.async_read_barrier();
 
         for (uint32_t chunk = 0; chunk < num_chunks; ++chunk) {
-            cb_in0.reserve_back(tiles_per_chunk);
-            uint32_t l1_write_addr = cb_in0.get_write_ptr();
+            const bool is_last = (chunk + 1 == num_chunks);
+            const uint32_t this_chunk_tiles = is_last ? last_chunk_tiles : tiles_per_chunk;
+            const uint32_t weight_chunk_size = is_last ? last_chunk_bytes : full_chunk_bytes;
+            const uint32_t weight_chunk_offset = chunk * full_chunk_bytes;
 
-            // Calculate the chunk size and offset within the embedding vector
-            uint32_t weight_chunk_size = weight_block_size / num_chunks;
-            uint32_t weight_chunk_offset = chunk * weight_chunk_size;
+            cb_in0.reserve_back(this_chunk_tiles);
+            uint32_t l1_write_addr = cb_in0.get_write_ptr();
 
             for (uint32_t k = 0; k < tile_height; ++k) {
                 input_token_t token = input_l1_ptr[k];
@@ -69,7 +77,7 @@ void kernel_main() {
                 l1_write_addr += weight_chunk_size;
             }
             noc.async_read_barrier();
-            cb_in0.push_back(tiles_per_chunk);
+            cb_in0.push_back(this_chunk_tiles);
         }
 
         offset += input_block_size_bytes;


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug Fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
The reader computed per-chunk byte size as `weight_block_size / num_chunks` (integer division). When `num_tiles_per_block` was not a multiple of `tiles_per_chunk`, the last chunk wrote fewer bytes than the CB slot reserved, and the compute kernel tilized uninitialised data (PCC ~0.02). Bump `num_chunks` past the cap-implied minimum until it divides `num_tiles_per_block` evenly.

Adds a regression test covering D=8320/10752/15488 — previously failing chunked configs whose tile counts are not multiples of 64.


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
N/A

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sshon/pr-embedding-pcc-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sshon/pr-embedding-pcc-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sshon/pr-embedding-pcc-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sshon/pr-embedding-pcc-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sshon/pr-embedding-pcc-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sshon/pr-embedding-pcc-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sshon/pr-embedding-pcc-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sshon/pr-embedding-pcc-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sshon/pr-embedding-pcc-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sshon/pr-embedding-pcc-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sshon/pr-embedding-pcc-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sshon/pr-embedding-pcc-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sshon/pr-embedding-pcc-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sshon/pr-embedding-pcc-issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sshon/pr-embedding-pcc-issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sshon/pr-embedding-pcc-issue)