### PR TITLE
#43911: fix bug in prod nc test

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_nc.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_nc.py
@@ -73,9 +73,7 @@ def test_prod_dims(input_shape, dims, device):
     torch_output = torch.prod(torch_input, dims[0], True)
 
     cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    tt_output_cpu = (
-        ttnn.prod(tt_input, tt_output, dims=dims).cpu().to(cpu_layout).unpad_from_tile(output_shape).to_torch()
-    )
+    tt_output_cpu = ttnn.prod(tt_input, tt_output, dims=dims).cpu().to(cpu_layout).to_torch()
 
     rtol = atol = 0.1
     passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Closes #43911 

There was a bug in a nightly pytest that was exposed after some checks were changed from assert to fatal. This PR fixes this bug.

Why the test was wrong: .cpu().to(ROW_MAJOR_LAYOUT) goes through ttnn::to_layout (to_layout_op.cpp:214-223), which already calls
unpad_from_tile(tensor.logical_shape()) internally when requires_padding_change is true. The instrumented run confirmed:
after to(ROW_MAJOR): logical=[1,3,191,223], padded=[1,3,191,223]
So padded == logical (NOT tile-aligned), and the test's subsequent .unpad_from_tile(output_shape) was both redundant and now invalid.

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-43911_prod_nc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-43911_prod_nc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-43911_prod_nc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-43911_prod_nc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-43911_prod_nc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-43911_prod_nc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-43911_prod_nc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-43911_prod_nc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-43911_prod_nc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-43911_prod_nc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-43911_prod_nc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-43911_prod_nc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-43911_prod_nc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-43911_prod_nc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-43911_prod_nc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-43911_prod_nc_fix)