### PR TITLE
fix(program-patching): handle duplicate Buffer* in tensor_buffers; re-enable muon test

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
+++ b/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
@@ -366,6 +366,38 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_CbOnlyBuffers_Return
     EXPECT_TRUE(resolved.empty());
 }
 
+// Regression: when tensor_buffers contains the same Buffer* more than once
+// (e.g. matmul(X, X) in newton-schulz, or an output that aliases an input),
+// resolve_bindings cannot disambiguate which binding maps to which slot from
+// Buffer* alone.  std::find would silently return the first occurrence for
+// every binding, causing apply_resolved_bindings to write the same address to
+// every slot and producing wrong results on a future cache hit with two
+// distinct tensors.
+//
+// The fix bails out and returns an empty ResolvedBindings, forcing the
+// adapter onto the slow path (rebuild the descriptor) for that cache hit.
+TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_DuplicateBuffer_ReturnsEmpty) {
+    auto buf_a = MakeDramBuffer(device());
+
+    KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
+    // Two bindings for the same Buffer*, simulating an op that takes the same
+    // tensor at two distinct positional slots.
+    kd.emplace_runtime_args({0, 0}, {buf_a.get(), buf_a.get()});
+
+    ProgramDescriptor desc;
+    desc.kernels = {kd};
+
+    Program program{desc};
+    // tensor_buffers reflects "X used twice" — the same Buffer* appears at
+    // both slots.  resolve_bindings must report empty so the adapter takes
+    // the slow path.
+    ResolvedBindings resolved = resolve_bindings(program, desc, {buf_a.get(), buf_a.get()});
+
+    EXPECT_TRUE(resolved.empty());
+    EXPECT_TRUE(resolved.rt_args.empty());
+    EXPECT_TRUE(resolved.cbs.empty());
+}
+
 // resolve_bindings fires TT_FATAL when a binding buffer is not in tensor_buffers.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_BufferNotInTensorList_Throws) {
     auto buf_a = MakeDramBuffer(device());

--- a/tt-train/tests/optimizers/muon_composite_test.cpp
+++ b/tt-train/tests/optimizers/muon_composite_test.cpp
@@ -94,10 +94,6 @@ TEST_P(MuonCorrectnessTest, DeviceMatchesCPU) {
     using namespace ttml;
     const auto& tc = GetParam();
 
-    if (tc.name == "Square_3_step" && autograd::ctx().get_device().arch() == tt::ARCH::WORMHOLE_B0) {
-        GTEST_SKIP() << "Skipped on WORMHOLE_B0 due to https://github.com/tenstorrent/tt-metal/issues/43861";
-    }
-
     xt::xarray<float> w0 = ttml::test_utils::make_uniform_xarray<float>(tc.shape, -1.0F, 1.0F, 42U);
     xt::xarray<float> g0 = ttml::test_utils::make_uniform_xarray<float>(tc.shape, -1.0F, 1.0F, 43U);
 

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -37,6 +37,7 @@ ResolvedBindings resolve_bindings(
     // so we fall back to the slow path (rebuild the descriptor) when this happens.
     {
         std::unordered_set<Buffer*> seen;
+        seen.reserve(tensor_buffers.size());
         for (Buffer* buf : tensor_buffers) {
             if (buf && !seen.insert(buf).second) {
                 return ResolvedBindings{};

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <string_view>
+#include <unordered_set>
 #include <vector>
 
 namespace tt::tt_metal {
@@ -24,6 +25,24 @@ namespace tt::tt_metal {
 ResolvedBindings resolve_bindings(
     Program& program, const ProgramDescriptor& desc, const std::vector<Buffer*>& tensor_buffers) {
     ResolvedBindings result;
+
+    // If the same Buffer* appears in tensor_buffers more than once (e.g. matmul(X, X),
+    // or an output that aliases an input), every binding for that buffer would map to
+    // the first occurrence via std::find below.  At cache hit, all of those bindings
+    // would be patched with current_buffers[first_slot].address(), so the second
+    // tensor's address would never get written.  The result is silent miscompute when
+    // a future call uses distinct tensors at the same shape/dtype.
+    //
+    // We can't disambiguate which binding corresponds to which slot from Buffer* alone,
+    // so we fall back to the slow path (rebuild the descriptor) when this happens.
+    {
+        std::unordered_set<Buffer*> seen;
+        for (Buffer* buf : tensor_buffers) {
+            if (buf && !seen.insert(buf).second) {
+                return ResolvedBindings{};
+            }
+        }
+    }
 
     // Map each Buffer* to its index in tensor_buffers.  Every binding Buffer* must be
     // present; TT_FATAL fires if a factory used a non-tensor buffer in emplace_runtime_args.


### PR DESCRIPTION
## Summary

Fixes the `MuonCorrectness/MuonCorrectnessTest.DeviceMatchesCPU/Square_3_step` failure on Wormhole B0 (issue #43861) and re-enables the test that was skipped in #43883.

### Root cause

`resolve_bindings` in `program_descriptor_patching.cpp` uses `std::find` to map each binding's `Buffer*` to its position in `tensor_buffers`. When the same `Buffer*` appears multiple times (e.g. `matmul(X, X)` in newton-schulz, or an output that aliases an input), `std::find` always returns the **first** occurrence. On a cache hit, every binding for that buffer gets patched with `current_buffers[first_slot].address()`, so the second tensor's address is never written. A subsequent call with two distinct tensors at the same shape/dtype hits this cached entry and silently produces wrong results.

### Fix

Detect duplicate `Buffer*` entries in `tensor_buffers` up front in `resolve_bindings` and return an empty `ResolvedBindings`. The adapter then falls back to the slow path (rebuild the descriptor) for that cache hit.

We can't disambiguate which binding corresponds to which slot from `Buffer*` alone without a broader API change to carry tensor identity into `BufferBinding`. Silently miscomputing is far worse than paying the slow-path cost (~2x for a 128x128 matmul measured locally) for the small set of ops that bind the same buffer twice.

### Re-enable Muon test

PR #43883 added a `GTEST_SKIP()` for the `Square_3_step` parameterization on WORMHOLE_B0 with a pointer to issue #43861. With the patching fix in place, all 3 `MuonCorrectness` cases (`Wide`, `Tall_2_step`, `Square_3_step`) pass on N300. The skip is removed.

Closes #43861.

## Test plan

- [x] Build `ttml_tests` cleanly on top of latest main
- [x] `MuonCorrectness/MuonCorrectnessTest.DeviceMatchesCPU/*` passes locally on N300 (`Wide`, `Tall_2_step`, `Square_3_step` all PASSED)
- [ ] CI: tt-train C++ unit tests (sanity-tests pipeline) — exercises this codepath via the muon test on Wormhole

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rmillerTT/fix_muon_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rmillerTT/fix_muon_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rmillerTT/fix_muon_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rmillerTT/fix_muon_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rmillerTT/fix_muon_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rmillerTT/fix_muon_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rmillerTT/fix_muon_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/fix_muon_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rmillerTT/fix_muon_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rmillerTT/fix_muon_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rmillerTT/fix_muon_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/fix_muon_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rmillerTT/fix_muon_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/fix_muon_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rmillerTT/fix_muon_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/fix_muon_test)