### PR TITLE
Switch blackhole channel 0 DRAM endpoint usage.

### DIFF
--- a/tt_metal/soc_descriptors/blackhole_140_arch.yaml
+++ b/tt_metal/soc_descriptors/blackhole_140_arch.yaml
@@ -27,8 +27,8 @@ dram_views:
   [
     {
       channel: 0,
-      eth_endpoint: [2, 1],
-      worker_endpoint: [2, 1],
+      eth_endpoint: [2, 0],
+      worker_endpoint: [2, 0],
       address_offset: 0
     },
     {

--- a/tt_metal/soc_descriptors/blackhole_140_arch.yaml
+++ b/tt_metal/soc_descriptors/blackhole_140_arch.yaml
@@ -22,13 +22,13 @@ dram:
 
 # Eth and worker dram endpoints represent subchannel id from dram array for each noc.
 # For example, a dram view where channel is 0 and worker_endpoint is [1, 2] would resolve to dram core at position [0,2] for noc1 which is 0-11.
-# Endpoint assignment for noc0 needs to be the same endpoint used by CMFW to read DRAM telemetry to avoid SYS-1419.
+# Endpoint assignment for noc0 needs to be the same endpoint used by CMFW to read DRAM telemetry to avoid SYS-1419. 
 dram_views:
   [
     {
       channel: 0,
-      eth_endpoint: [2, 0],
-      worker_endpoint: [2, 0],
+      eth_endpoint: [0, 1],
+      worker_endpoint: [0, 1],
       address_offset: 0
     },
     {


### PR DESCRIPTION
### PR Category
Bug fix.

### Summary
We're trying to enable using DRAM RISC V cores for some workloads. Syseng already uses one RISC V per DRAM bank to run power management code, so we want to leave that core alone and avoid trying to run code on it. For our purposes it only makes sense to run RISC V code on the endpoints that aren't used for normal DRAM NoC traffic, since to initiate NoC traffic from the RISC core we need to have it in a mode where it can't be used for normal DRAM traffic.

There are a total of 3 endpoints per DRAM bank, each with a RISC V core. One endpoint will be used by NoC 0 DRAM traffic, a different one will be used by NoC 1 DRAM traffic, and  the final one should run our RISC V firmware. Therefore, we need to ensure that the cores used by syseng are selected as worker/dram endpoints so we have a core available for us to run RISC V code on - the RISC V syseng code doesn't need to use the NoC, so it's fine to run on a core that's servicing normal DRAM requests.

For most DRAM channels that's already the case, except on channel 0, where (17, 12) (subchannel 0) is used by syseng but not by metal. We can  switch NoC 1 to use that endpoint - NoC 0 must remain the same, as the syseng firmware uses NoC to access that endpoint and we want to be sure that it uses the same endpoint for that as we do.

Side note: the syseng firmware uses the bottom endpoint for DRAM on the left column, and the top for DRAM on the right column.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/switchdramendpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/switchdramendpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/switchdramendpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/switchdramendpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/switchdramendpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/switchdramendpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/switchdramendpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/switchdramendpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/switchdramendpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/switchdramendpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/switchdramendpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/switchdramendpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/switchdramendpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/switchdramendpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/switchdramendpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/switchdramendpoint)