### PR TITLE
Only disallow SD push in FD runs after RT profiler is also init

### DIFF
--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -43,6 +43,7 @@
 #include <tracy/TracyTTDevice.hpp>
 
 #include "context/metal_context.hpp"
+#include "device/device_manager.hpp"
 #include "dispatch/command_queue_common.hpp"
 #include "dispatch/dispatch_core_manager.hpp"
 #include "dispatch/dispatch_mem_map.hpp"
@@ -336,6 +337,7 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
 
         auto eligibility = evaluate_realtime_profiler_eligibility(device);
         if (!eligibility.enabled) {
+            MetalContext::instance().device_manager()->mark_rt_profiler_device_init_complete(device_id);
             continue;
         }
         CoreCoord realtime_profiler_core = eligibility.core;
@@ -387,6 +389,7 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
                 "profiler on this device.",
                 device_id,
                 e.what());
+            MetalContext::instance().device_manager()->mark_rt_profiler_device_init_complete(device_id);
             continue;
         }
 
@@ -564,6 +567,7 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
                 config_buffer_addr);
         }
 
+        MetalContext::instance().device_manager()->mark_rt_profiler_device_init_complete(device_id);
         devices_.push_back(std::move(dev_state));
     }
 

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -639,6 +639,21 @@ bool DeviceManager::is_dispatch_firmware_active() const {
     return it != initializers_.end() && it->second->is_initialized();
 }
 
+bool DeviceManager::is_rt_profiler_device_init_complete(ChipId chip_id) const {
+    std::lock_guard<std::mutex> lock(lock_);
+    return rt_profiler_device_init_complete_.contains(chip_id);
+}
+
+void DeviceManager::mark_rt_profiler_device_init_complete(ChipId chip_id) {
+    std::lock_guard<std::mutex> lock(lock_);
+    rt_profiler_device_init_complete_.insert(chip_id);
+}
+
+void DeviceManager::clear_rt_profiler_device_init_complete(ChipId chip_id) {
+    std::lock_guard<std::mutex> lock(lock_);
+    rt_profiler_device_init_complete_.erase(chip_id);
+}
+
 bool DeviceManager::close_device(ChipId device_id) {
     // Sync and close one device
     // Currently can only call this on mmio chips, once we split dispatch kernel shutdown
@@ -722,6 +737,7 @@ bool DeviceManager::close_devices(const std::vector<IDevice*>& devices, bool /*s
 
     bool pass = true;
     for (const auto& dev_id : devices_to_close) {
+        clear_rt_profiler_device_init_complete(dev_id);
         auto* dev = this->get_active_device(dev_id);
         pass &= dev->close();
     }
@@ -732,6 +748,7 @@ bool DeviceManager::close_devices(const std::vector<IDevice*>& devices, bool /*s
 DeviceManager::~DeviceManager() {
     for (const auto& dev : this->devices_) {
         if (dev != nullptr and dev->is_initialized()) {
+            clear_rt_profiler_device_init_complete(dev->id());
             // TODO: #13876, Was encountering issues with the DispatchMemMap being destroyed before the DeviceManager
             // destructor, which leads to device->close() hitting asserts. We need to move the ownership of
             // DispatchMemMap to the device, so it doesn't go out of scope before the device is closed.

--- a/tt_metal/impl/device/device_manager.hpp
+++ b/tt_metal/impl/device/device_manager.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <tt_stl/span.hpp>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <hostdevcommon/common_values.hpp>
 #include "umd/device/types/cluster_descriptor_types.hpp"
@@ -61,6 +62,12 @@ public:
     const std::unordered_set<CoreCoord>& get_virtual_dispatch_cores(ChipId dev_id) const;
     const std::unordered_set<CoreCoord>& get_virtual_dispatch_routing_cores(ChipId dev_id) const;
 
+    // Per-chip: mesh RT-profiler init pass finished for this chip (ineligible skip, socket skip, or kernels launched).
+    // Cleared when the device is closed via DeviceManager. Used so low-level code can query without MeshDevice.
+    bool is_rt_profiler_device_init_complete(ChipId chip_id) const;
+    void mark_rt_profiler_device_init_complete(ChipId chip_id);
+    void clear_rt_profiler_device_init_complete(ChipId chip_id);
+
 private:
     MetalEnv& env_;
     MetalEnvImpl& env_impl_;
@@ -87,6 +94,7 @@ private:
     // Determine which CPU cores the worker threads need to be placed on for each device
     std::unordered_map<uint32_t, uint32_t> worker_thread_to_cpu_core_map_;
     std::unordered_map<uint32_t, uint32_t> completion_queue_reader_to_cpu_core_map_;
+    std::unordered_set<ChipId> rt_profiler_device_init_complete_;
     void init_firmware_on_active_devices();
     void activate_device(ChipId id);
     Device* get_active_device_internal(ChipId device_id) const;

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -824,7 +824,13 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
         if (!force_slow_dispatch) {
             detail::DispatchStateCheck(false);
         } else {
-            TT_ASSERT(!MetalContext::instance().device_manager()->is_dispatch_firmware_active());
+            auto& dm = MetalContext::instance().device_manager();
+            const bool fd_active = dm->is_dispatch_firmware_active();
+            const bool rt_done = dm->is_rt_profiler_device_init_complete(device->id());
+            TT_ASSERT(
+                !(fd_active && rt_done),
+                "Cannot force slow dispatch while fast dispatch firmware is active and real-time profiler init has "
+                "completed on this device.");
         }
 
 #ifdef TT_METAL_USE_EMULE


### PR DESCRIPTION
### PR Category
Bug fix for debug builds

### Summary
Realtime profiler needs to dispatch its kernel after FD kernels are 
Fixes this issue: https://github.com/tenstorrent/tt-metal/issues/43914

### CI Status
Previously failing debug CIs
https://github.com/tenstorrent/tt-metal/actions/runs/25569294441
https://github.com/tenstorrent/tt-metal/actions/runs/25569204145

Merge gate:
https://github.com/tenstorrent/tt-metal/actions/runs/25569204145

Profiler CI:
https://github.com/tenstorrent/tt-metal/actions/runs/25569365399