### PR TITLE
[skip ci] Models e2e: bump T3K e2e timeouts for Qwen2.5-{32B,Coder-32B} and Llama-3.2-90B-Vision

### DIFF
--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -101,7 +101,7 @@
   model: llama3.2-90b-vision
   skus:
     wh_llmbox_perf:
-      timeout: 30
+      timeout: 25
       tier: 2
   owner_id: U07RY6B5FLJ # Gongyu Wang
   team: models
@@ -210,7 +210,7 @@
   model: qwen2.5-coder-32b
   skus:
     wh_llmbox_perf:
-      timeout: 20
+      timeout: 18
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -97,11 +97,11 @@
 - name: Llama 3.2-90B-Vision e2e tests
   cmd: |
     export HF_MODEL=meta-llama/Llama-3.2-90B-Vision-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.2-90B-Vision-Instruct MESH_DEVICE=T3K
-    pytest --timeout 1000 models/tt_transformers/demo/simple_vision_demo.py -k "batch1-trace"
+    pytest --timeout 1500 models/tt_transformers/demo/simple_vision_demo.py -k "batch1-trace"
   model: llama3.2-90b-vision
   skus:
     wh_llmbox_perf:
-      timeout: 25
+      timeout: 30
       tier: 2
   owner_id: U07RY6B5FLJ # Gongyu Wang
   team: models
@@ -192,12 +192,12 @@
 - name: Qwen2.5-32B e2e tests
   cmd: |
     export HF_MODEL=Qwen/Qwen2.5-32B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen2.5-32B-Instruct
-    pytest --timeout 420 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching"
+    pytest --timeout 1500 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching"
     pytest --timeout 1800 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-eval-32"
   model: qwen2.5-32b
   skus:
     wh_llmbox_perf:
-      timeout: 10
+      timeout: 20
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
@@ -205,12 +205,12 @@
 - name: Qwen2.5-Coder-32B e2e tests
   cmd: |
     export HF_MODEL=Qwen/Qwen2.5-Coder-32B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen2.5-Coder-32B-Instruct
-    pytest --timeout 420 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching"
+    pytest --timeout 1500 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching"
     pytest --timeout 1800 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-eval-32"
   model: qwen2.5-coder-32b
   skus:
     wh_llmbox_perf:
-      timeout: 10
+      timeout: 20
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models


### PR DESCRIPTION
## Summary
Three Tier 2 e2e tests on `wh_llmbox_perf` were failing on the nightly schedule with `pytest-timeout` killing them mid-test. This PR raises both the per-test pytest timeout and the job-level timeout to give them room to complete, then tightens the job-level allocation based on the observed runtimes from a confirmation run.

## Changes

| Model | pytest `--timeout` (s) | Job-level (min) |
|---|---|---|
| Qwen2.5-32B | 420 → **1500** | 10 → **20** |
| Qwen2.5-Coder-32B | 420 → **1500** | 10 → **18** |
| Llama-3.2-90B-Vision | 1000 → **1500** | 25 → **25** (was bumped to 30 mid-PR, then trimmed back) |

These match the more generous timeouts already used by the comparable Qwen3-32B Tier 2 e2e entry. Total `wh_llmbox_perf` e2e budget (312 min) has plenty of headroom.

## Confirmation runs (on this branch)

Dispatched via `all-model-tests` filtered to each model:

| Model | Run | Conclusion | Exec time | Outcome |
|---|---|---|---|---|
| Qwen2.5-32B | [25559667736](https://github.com/tenstorrent/tt-metal/actions/runs/25559667736) | failure | 17m 31s | Real numerical regression (`Batch32 repeat batch outputs … 1/64 consistency checks failed`) — **not** a timeout kill |
| Qwen2.5-Coder-32B | [25559669749](https://github.com/tenstorrent/tt-metal/actions/runs/25559669749) | ✅ success | 13m 34s | Passes cleanly with the new budget |
| Llama-3.2-90B-Vision | [25559672170](https://github.com/tenstorrent/tt-metal/actions/runs/25559672170) | failure | 20m 25s | Real perf-target drift (`Performance regression detected. Failing fast`) — **not** a timeout kill |

So the timeout bumps did their job — the two remaining failures are genuine model-level regressions to be chased separately (existing tracking: #37724 for Qwen2.5-32B LB, #37725 for Llama-3.2-90B-VL LB).

## Final job-level timeouts in this PR

After tightening based on observed exec times:
- Qwen2.5-32B: **20 min** (observed 17m 31s — ~2.5 min slack)
- Qwen2.5-Coder-32B: **18 min** (observed 13m 34s — ~4.5 min slack)
- Llama-3.2-90B-Vision: **25 min** (observed 20m 25s — ~4.5 min slack)
