### PR TITLE
Fix SFPU sqrt/rsqrt signed zero handling

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_sqrt_rsqrt_signed_zero.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_sqrt_rsqrt_signed_zero.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from helpers.format_config import DataFormat, InputOutputFormat
+from helpers.golden_generators import TILE_DIMENSIONS
+from helpers.llk_params import (
+    ApproximationMode,
+    BlocksCalculationAlgorithm,
+    DestAccumulation,
+    FastMode,
+    MathOperation,
+)
+from helpers.param_config import get_num_blocks_and_num_tiles_in_block
+from helpers.stimuli_config import StimuliConfig
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    APPROX_MODE,
+    CLAMP_NEGATIVE,
+    FAST_MODE,
+    MATH_OP,
+    NUM_BLOCKS,
+    NUM_TILES_IN_BLOCK,
+    TILE_COUNT,
+    DestSync,
+    generate_input_dim,
+)
+
+SPECIAL_VALUES = torch.tensor(
+    [-0.0, 0.0, -1.0, -float("inf"), float("inf")],
+    dtype=torch.float32,
+)
+
+
+def _hex_bits(tensor):
+    return [f"0x{int(v) & 0xffffffff:08x}" for v in tensor.view(torch.int32)]
+
+
+@pytest.mark.parametrize("mathop", [MathOperation.Sqrt, MathOperation.Rsqrt])
+@pytest.mark.parametrize("approx_mode", [ApproximationMode.No, ApproximationMode.Yes])
+def test_sqrt_rsqrt_signed_zero_specials_float32(mathop, approx_mode):
+    input_dimensions = [32, 32]
+    num_elements = input_dimensions[0] * input_dimensions[1]
+    src_a = SPECIAL_VALUES.repeat(num_elements // SPECIAL_VALUES.numel() + 1)[
+        :num_elements
+    ]
+    src_b = torch.zeros_like(src_a)
+    tile_count = 1
+    sample_count = SPECIAL_VALUES.numel()
+
+    formats = InputOutputFormat(DataFormat.Float32, DataFormat.Float32)
+    dest_acc = DestAccumulation.Yes
+    expected = torch.sqrt(src_a) if mathop == MathOperation.Sqrt else torch.rsqrt(src_a)
+
+    num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
+        DestSync.Half,
+        dest_acc,
+        formats,
+        input_dimensions,
+        TILE_DIMENSIONS,
+        BlocksCalculationAlgorithm.Standard,
+    )
+
+    configuration = TestConfig(
+        "sources/eltwise_unary_sfpu_test.cpp",
+        formats,
+        templates=[
+            generate_input_dim(input_dimensions, input_dimensions),
+            APPROX_MODE(approx_mode),
+            FAST_MODE(FastMode.No),
+            CLAMP_NEGATIVE(True),
+            MATH_OP(mathop=mathop),
+        ],
+        runtimes=[
+            TILE_COUNT(tile_count),
+            NUM_BLOCKS(num_blocks),
+            NUM_TILES_IN_BLOCK(num_tiles_in_block),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_a,
+            formats.input_format,
+            src_b,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_count,
+            tile_count_B=tile_count,
+            tile_count_res=tile_count,
+        ),
+        dest_acc=dest_acc,
+        unpack_to_dest=True,
+    )
+
+    actual = torch.tensor(configuration.run().result, dtype=torch.float32)
+
+    actual_bits = actual.view(torch.int32)
+    expected_bits = expected.view(torch.int32)
+    same_bits = actual_bits == expected_bits
+    both_nan = torch.isnan(actual) & torch.isnan(expected)
+    same = same_bits | both_nan
+
+    assert torch.all(same), (
+        f"{mathop.name} {approx_mode.name} special-value mismatch\n"
+        f"input first {sample_count}:    {SPECIAL_VALUES.tolist()}\n"
+        f"expected first {sample_count}: {expected[:sample_count].tolist()} "
+        f"{_hex_bits(expected[:sample_count])}\n"
+        f"actual first {sample_count}:   {actual[:sample_count].tolist()} "
+        f"{_hex_bits(actual[:sample_count])}\n"
+        f"bad indices:      {torch.nonzero(~same).flatten()[:32].tolist()}"
+    )

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -35,9 +35,10 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
         if constexpr (RECIPROCAL)
         {
             sfpi::vInt x_bits                = sfpi::reinterpret<sfpi::vInt>(x);
+            sfpi::vInt x_abs_bits            = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(x, 0));
             sfpi::vInt infinity_minus_x_bits = infinity_bits - x_bits;
             // If x != inf and x != 0.
-            v_if (infinity_minus_x_bits != 0 && x_bits != 0)
+            v_if (x_abs_bits != infinity_bits && x_abs_bits != 0)
             {
                 y = y * t;
             }
@@ -76,9 +77,10 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
         {
             sfpi::vFloat half_y              = sfpi::addexp(y, -1);
             sfpi::vInt x_bits                = sfpi::reinterpret<sfpi::vInt>(x);
+            sfpi::vInt x_abs_bits            = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(x, 0));
             sfpi::vInt infinity_minus_x_bits = infinity_bits - x_bits;
             // If x != inf and x != 0.
-            v_if (infinity_minus_x_bits != 0 && x_bits != 0)
+            v_if (x_abs_bits != infinity_bits && x_abs_bits != 0)
             {
                 y = one_minus_xyy * half_y + y;
             }
@@ -103,7 +105,16 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
 
     if constexpr (!FAST_APPROX)
     {
-        v_if (x < 0.0f)
+        sfpi::vInt x_abs_bits = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(x, 0));
+        if constexpr (!RECIPROCAL)
+        {
+            v_if (x_abs_bits == 0)
+            {
+                y = x;
+            }
+            v_endif;
+        }
+        v_if (x < 0.0f && x_abs_bits != 0)
         {
             y = std::numeric_limits<float>::quiet_NaN();
         }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -35,9 +35,10 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
         if constexpr (RECIPROCAL)
         {
             sfpi::vInt x_bits                = sfpi::reinterpret<sfpi::vInt>(x);
+            sfpi::vInt x_abs_bits            = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(x, 0));
             sfpi::vInt infinity_minus_x_bits = infinity_bits - x_bits;
             // If x != inf and x != 0.
-            v_if (infinity_minus_x_bits != 0 && x_bits != 0)
+            v_if (x_abs_bits != infinity_bits && x_abs_bits != 0)
             {
                 y = y * t;
             }
@@ -76,9 +77,10 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
         {
             sfpi::vFloat half_y              = sfpi::addexp(y, -1);
             sfpi::vInt x_bits                = sfpi::reinterpret<sfpi::vInt>(x);
+            sfpi::vInt x_abs_bits            = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(x, 0));
             sfpi::vInt infinity_minus_x_bits = infinity_bits - x_bits;
             // If x != inf and x != 0.
-            v_if (infinity_minus_x_bits != 0 && x_bits != 0)
+            v_if (x_abs_bits != infinity_bits && x_abs_bits != 0)
             {
                 y = one_minus_xyy * half_y + y;
             }
@@ -102,7 +104,16 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
     }
     if constexpr (!FAST_APPROX)
     {
-        v_if (x < 0.0F)
+        sfpi::vInt x_abs_bits = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(x, 0));
+        if constexpr (!RECIPROCAL)
+        {
+            v_if (x_abs_bits == 0)
+            {
+                y = x;
+            }
+            v_endif;
+        }
+        v_if (x < 0.0F && x_abs_bits != 0)
         {
             y = std::numeric_limits<float>::quiet_NaN(); // returns nan for fp32 and inf for bf16
         }


### PR DESCRIPTION
### Problem description

`v_if (x < 0.0f)` treats `-0.0f` as negative in this SFPI path. In the non-fast sqrt/rsqrt implementation that changes two signed-zero cases:

- `sqrt(-0.0f)` returns `NaN`; expected `-0.0f`
- `rsqrt(-0.0f)` returns `NaN`; expected `-inf`

### What's changed

- For reciprocal sqrt zero/inf handling, compare absolute-value bits so `-0.0f` and `-inf` take the existing special-case path.
- For sqrt, preserve signed zero before the finite-negative NaN guard.
- Keep finite negative inputs returning NaN.
- Add a focused LLK regression test for `sqrt` and `rsqrt` special values in exact and approximate modes.

### Testing

```bash
docker exec -e TT_METAL_SIMULATOR=/tmp/lib.so -e TT_METAL_HOME=/work -e TT_METAL_DISABLE_SFPLOADMACRO=1 tt-metal-hunt-run bash -lc 'rm -rf /tmp/tt-llk-build/sources/eltwise_unary_sfpu_test.cpp; cd /work/tt_metal/tt-llk/tests/python_tests && python3 -m pytest -q --run-simulator --timeout=300 test_sfpu_sqrt_rsqrt_signed_zero.py -vv --tb=short'
```

Result: `4 passed` on the available Blackhole ttsim setup.

Exact-mode generated `math.elf` delta from local measurement:

- `sqrt`: 355 -> 360 instructions, text 1420 -> 1440 bytes
- `rsqrt`: 359 -> 363 instructions, text 1436 -> 1452 bytes
