### PR TITLE
#29047: add dram shard weight mm checks and test

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 import pytest
 import torch
 import ttnn
@@ -504,6 +505,97 @@ def test_matmul_m_direction_padding(device):
     assert_numeric_metrics(
         expected,
         output,
+        check_allclose=False,
+        check_frobenius=True,
+        frobenius_threshold=0.02,
+        pcc_threshold=0.999,
+        check_ulp=False,
+    )
+
+
+def test_dram_sharded_weight_mm(device):
+    torch.manual_seed(0)
+    seq_len = 2048
+    n = 3200
+    tile_w = 32
+    dram_cores = 12
+
+    # Pad N up to a per-bank-aligned boundary so shards are uniform and only
+    # the last bank may be partially padded (matmul rejects fully-padded shards past N).
+    padded_size = math.ceil(n / (tile_w * dram_cores)) * (tile_w * dram_cores)
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1),
+                )
+            }
+        ),
+        (1280, padded_size // dram_cores),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    # grid_x must divide N_tiles so that grid_x * per_core_N == N_tiles
+    # (required when in1 is width-sharded so the kernel produces exactly N tiles).
+    n_tiles = n // tile_w  # 100
+    grid_x = 5  # 100 / 5 = 20
+    per_core_N = n_tiles // grid_x
+
+    m_tiles = seq_len // tile_w  # 64
+    per_core_M = 8
+    grid_y = m_tiles // per_core_M  # 8
+
+    pc_1 = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=(grid_x, grid_y),
+        in0_block_w=1,
+        out_subblock_h=1,  # Must be divisible by per_core_M
+        out_subblock_w=1,  # Must be divisible by per_core_N, out_subblock_w * out_subblock_h <= 4
+        per_core_M=per_core_M,
+        per_core_N=per_core_N,
+        transpose_mcast=False,
+        fused_activation=None,
+        fuse_batch=seq_len <= 2048,
+    )
+
+    w1_torch = (2 * torch.randn(1, 1, 1280, 3200)) + 1
+    w1 = ttnn.from_torch(
+        w1_torch,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec),
+        dtype=ttnn.bfloat8_b,
+    )
+
+    torch_input = torch.randn(1, 1, seq_len, 1280)
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=device,
+        dtype=ttnn.bfloat8_b,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    tt_input = ttnn.reshape(tt_input, (1, seq_len // 1024, 1024, -1))
+
+    w1_out = ttnn.linear(
+        tt_input,
+        w1,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
+        ),
+        dtype=ttnn.bfloat8_b,
+        program_config=pc_1,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    ref_torch = torch_input @ w1_torch
+    tt_out_torch = ttnn.to_torch(w1_out).reshape(1, 1, seq_len, -1)
+    assert_numeric_metrics(
+        ref_torch,
+        tt_out_torch,
         check_allclose=False,
         check_frobenius=True,
         frobenius_threshold=0.02,

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
@@ -518,7 +518,9 @@ def test_dram_sharded_weight_mm(device):
     seq_len = 2048
     n = 3200
     tile_w = 32
-    dram_cores = 12
+    dram_cores = (
+        12  # Based on an example for a specific architecture, only used for easier to follow shape calculation.
+    )
 
     # Pad N up to a per-bank-aligned boundary so shards are uniform and only
     # the last bank may be partially padded (matmul rejects fully-padded shards past N).

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -930,6 +930,55 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                             "coordinates, got start: {} vs end: {}",
                             input_tensor_b.shard_spec()->grid.bounding_box().start_coord.y,
                             input_tensor_b.shard_spec()->grid.bounding_box().end_coord.y);
+
+                        // For WIDTH_SHARDED in1, the shard layout must align with N: shards must
+                        // cover N, and at most the last shard may be partially padded. Otherwise
+                        // the kernel reader fetches in1 tiles from fully-padded shards (garbage)
+                        // for any tile_id_n that the compute grid iterates past the last valid
+                        // shard, silently producing wrong results.
+                        const auto N_tiles = operations::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
+                        const auto& in1_shard_spec = input_tensor_b.shard_spec().value();
+                        const uint32_t shard_width_tiles = in1_shard_spec.shape[1] / in1_tile.get_width();
+                        const uint32_t num_banks = in1_shard_spec.grid.num_cores();
+                        TT_FATAL(
+                            shard_width_tiles > 0 && num_banks > 0,
+                            "WIDTH_SHARDED input B must have non-zero shard width and at least one shard, "
+                            "got shard_width_tiles={} num_shards={}",
+                            shard_width_tiles,
+                            num_banks);
+                        TT_FATAL(
+                            num_banks * shard_width_tiles >= N_tiles,
+                            "WIDTH_SHARDED input B: total sharded width (num_shards={} * shard_width_tiles={} "
+                            "= {} tiles) must be >= N ({} tiles).",
+                            num_banks,
+                            shard_width_tiles,
+                            num_banks * shard_width_tiles,
+                            N_tiles);
+                        TT_FATAL(
+                            (num_banks - 1) * shard_width_tiles < N_tiles,
+                            "WIDTH_SHARDED input B: shard layout has fully-padded shards past N. "
+                            "(num_shards - 1) * shard_width_tiles = ({} - 1) * {} = {} must be < N ({} tiles); "
+                            "only the last shard may be partially padded. Reduce num_shards or shard_width "
+                            "so the shard layout matches N.",
+                            num_banks,
+                            shard_width_tiles,
+                            (num_banks - 1) * shard_width_tiles,
+                            N_tiles);
+
+                        // The compute grid must produce exactly N tiles of output when in1 is
+                        // width-sharded. If grid_x * per_core_N > N_tiles, the kernel iterates past
+                        // the last valid shard tile (reading padded/garbage data and writing past N
+                        // in the output); if < N_tiles, some output tiles are never written.
+                        const uint32_t grid_x = program_config.compute_with_storage_grid_size.x;
+                        TT_FATAL(
+                            grid_x * program_config.per_core_N == N_tiles,
+                            "WIDTH_SHARDED input B: grid_x ({}) * per_core_N ({}) = {} must equal N "
+                            "({} tiles). When in1 is width-sharded, the compute grid must produce "
+                            "exactly N tiles of output.",
+                            grid_x,
+                            program_config.per_core_N,
+                            grid_x * program_config.per_core_N,
+                            N_tiles);
                     }
                 }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -931,11 +931,12 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                             input_tensor_b.shard_spec()->grid.bounding_box().start_coord.y,
                             input_tensor_b.shard_spec()->grid.bounding_box().end_coord.y);
 
-                        // For WIDTH_SHARDED in1, the shard layout must align with N: shards must
-                        // cover N, and at most the last shard may be partially padded. Otherwise
-                        // the kernel reader fetches in1 tiles from fully-padded shards (garbage)
-                        // for any tile_id_n that the compute grid iterates past the last valid
-                        // shard, silently producing wrong results.
+                        // For WIDTH_SHARDED in1, the compute grid must produce exactly N tiles of
+                        // output. If grid_x * per_core_N > N_tiles, the kernel iterates past the
+                        // valid shard data (reading padded tiles from trailing shards and writing
+                        // past N in the output); if < N_tiles, some output tiles are never
+                        // written. Trailing fully-padded shards are fine on their own — the kernel
+                        // simply never reads them as long as this equality holds.
                         const auto N_tiles = operations::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
                         const auto& in1_shard_spec = input_tensor_b.shard_spec().value();
                         const uint32_t shard_width_tiles = in1_shard_spec.shape[1] / in1_tile.get_width();
@@ -954,21 +955,7 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                             shard_width_tiles,
                             num_banks * shard_width_tiles,
                             N_tiles);
-                        TT_FATAL(
-                            (num_banks - 1) * shard_width_tiles < N_tiles,
-                            "WIDTH_SHARDED input B: shard layout has fully-padded shards past N. "
-                            "(num_shards - 1) * shard_width_tiles = ({} - 1) * {} = {} must be < N ({} tiles); "
-                            "only the last shard may be partially padded. Reduce num_shards or shard_width "
-                            "so the shard layout matches N.",
-                            num_banks,
-                            shard_width_tiles,
-                            (num_banks - 1) * shard_width_tiles,
-                            N_tiles);
 
-                        // The compute grid must produce exactly N tiles of output when in1 is
-                        // width-sharded. If grid_x * per_core_N > N_tiles, the kernel iterates past
-                        // the last valid shard tile (reading padded/garbage data and writing past N
-                        // in the output); if < N_tiles, some output tiles are never written.
                         const uint32_t grid_x = program_config.compute_with_storage_grid_size.x;
                         TT_FATAL(
                             grid_x * program_config.per_core_N == N_tiles,

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -133,8 +133,8 @@ void py_module(nb::module_& mod) {
         Supported input_tensor_b memory layouts:
           * INTERLEAVED (DRAM or L1).
           * WIDTH_SHARDED in DRAM. The shard grid must be a single row, the shards must collectively
-            cover N (with at most the last shard partially padded — no fully-padded shards past N),
-            and ``compute_with_storage_grid_size.x * per_core_N`` must equal N (in tiles).
+            cover N, and ``compute_with_storage_grid_size.x * per_core_N`` must equal N (in tiles).
+            Trailing shards beyond N (fully padded) are allowed and simply unread.
           * HEIGHT_SHARDED in DRAM, for batched matmul (``fuse_batch=False``); each DRAM bank holds
             complete [K, N] matrices stacked along the height dimension.
           * WIDTH_SHARDED in L1, in which case ``per_core_N`` must equal the shard width (in tiles).
@@ -728,7 +728,7 @@ void py_module(nb::module_& mod) {
                   - Height Sharded (DRAM)
                 * - MatmulMultiCoreReuseMultiCastProgramConfig
                   - Interleaved (L1/DRAM), Block Sharded (L1)
-                  - Interleaved (L1/DRAM), Width Sharded (DRAM, single-row shard grid; shards must cover N with at most the last shard partially padded; ``grid_x * per_core_N`` must equal N in tiles)
+                  - Interleaved (L1/DRAM), Width Sharded (DRAM, single-row shard grid; shards must cover N; ``grid_x * per_core_N`` must equal N in tiles)
                 * - MatmulMultiCoreReuseMultiCastProgramConfig (only for row major orientation without transpose multicast)
                   - Interleaved (L1/DRAM), Height Sharded (L1)
                   - Interleaved (L1/DRAM), Width Sharded (L1: ``per_core_N`` must equal shard width in tiles; DRAM: same constraints as above), Height Sharded (DRAM batched matmuls where each bank holds B/num_banks complete [K,N] matrices)

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -127,7 +127,17 @@ void py_module(nb::module_& mod) {
     auto matmul_multi_core_reuse_multicast_program_config =
         tt_serializable_class<MatmulMultiCoreReuseMultiCastProgramConfig>(
             mod, "MatmulMultiCoreReuseMultiCastProgramConfig", R"doc(
-        The "2D" matmul program config is used for block sharded tensors, and general interleaved tensors.
+        The "2D" matmul program config, used for block-sharded or interleaved input_tensor_a paired
+        with interleaved or DRAM-sharded input_tensor_b.
+
+        Supported input_tensor_b memory layouts:
+          * INTERLEAVED (DRAM or L1).
+          * WIDTH_SHARDED in DRAM. The shard grid must be a single row, the shards must collectively
+            cover N (with at most the last shard partially padded — no fully-padded shards past N),
+            and ``compute_with_storage_grid_size.x * per_core_N`` must equal N (in tiles).
+          * HEIGHT_SHARDED in DRAM, for batched matmul (``fuse_batch=False``); each DRAM bank holds
+            complete [K, N] matrices stacked along the height dimension.
+          * WIDTH_SHARDED in L1, in which case ``per_core_N`` must equal the shard width (in tiles).
     )doc");
 
     matmul_multi_core_reuse_multicast_program_config.def(
@@ -718,10 +728,10 @@ void py_module(nb::module_& mod) {
                   - Height Sharded (DRAM)
                 * - MatmulMultiCoreReuseMultiCastProgramConfig
                   - Interleaved (L1/DRAM), Block Sharded (L1)
-                  - Interleaved (L1/DRAM), Width Sharded (DRAM)
+                  - Interleaved (L1/DRAM), Width Sharded (DRAM, single-row shard grid; shards must cover N with at most the last shard partially padded; ``grid_x * per_core_N`` must equal N in tiles)
                 * - MatmulMultiCoreReuseMultiCastProgramConfig (only for row major orientation without transpose multicast)
                   - Interleaved (L1/DRAM), Height Sharded (L1)
-                  - Interleaved (L1/DRAM), Width Sharded (L1/DRAM), Height Sharded (DRAM batched matmuls where each bank holds B/num_banks complete [K,N] matrices)
+                  - Interleaved (L1/DRAM), Width Sharded (L1: ``per_core_N`` must equal shard width in tiles; DRAM: same constraints as above), Height Sharded (DRAM batched matmuls where each bank holds B/num_banks complete [K,N] matrices)
                 * - MatmulMultiCoreReuseMultiCast1DProgramConfig (mcast_in0=False)
                   - Interleaved (L1/DRAM), Width Sharded (L1)
                   - Interleaved (L1/DRAM), Width Sharded (L1)


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Closes #29047

The issue was for a dram sharded weight matmul with the 2d mcast program config. That was indicted as not supported by documentation, however, it turns out that the reason it didn't work was because of the choice of parameters for inputs. Therefore added checks to make sure that the choice of parameters, updated the documentation, and added a passing test to nightly for this configuration.

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-29047_dram_shard_weight_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-29047_dram_shard_weight_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-29047_dram_shard_weight_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-29047_dram_shard_weight_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-29047_dram_shard_weight_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-29047_dram_shard_weight_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-29047_dram_shard_weight_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-29047_dram_shard_weight_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-29047_dram_shard_weight_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-29047_dram_shard_weight_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-29047_dram_shard_weight_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-29047_dram_shard_weight_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-29047_dram_shard_weight_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-29047_dram_shard_weight_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-29047_dram_shard_weight_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-29047_dram_shard_weight_mm)