### PR TITLE
Fix nic filter

### DIFF
--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -32,7 +32,7 @@ default_mpi_tcp_interface() {
     for n in /sys/class/net/*; do
         n="${n##*/}"
         case "${n}" in
-            lo | docker* | br-* | veth* | tailscale*) continue ;;
+            lo | docker* | br-* | veth* | tailscale* | cali*) continue ;;
         esac
         state="$(cat "/sys/class/net/${n}/operstate" 2>/dev/null || true)"
         if [[ "${state}" == "up" ]]; then


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The previous script didn't exclude the `cali*` nic, and chose the wrong nic occasionally.
