### PR TITLE
#41555: Fix transpose common-runtime-args refresh on interleaved buffers (watcher-deterministic VAE attention crash)

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
@@ -171,11 +171,15 @@ ShardSpec generate_transpose_shard_spec(
     return ShardSpec(all_cores, shard_shape, ShardOrientation::ROW_MAJOR);
 }
 
-// Refresh runtime-tensor-shape common args on cache hits. Strict size equality detects any drift
-// in the TensorAccessorArgs footprint between program creation and reuse.
+// Skip refresh when the buffer carries no common runtime args (interleaved case).
+// Only sharded buffers populate RuntimeTensorShape; the strict size check below
+// applies to them.
 void copy_transpose_common_runtime_args(const Buffer& buffer, std::span<std::uint32_t> dst) {
     const auto src =
         TensorAccessorArgs(buffer, tensor_accessor::ArgConfig::RuntimeTensorShape).get_common_runtime_args();
+    if (src.empty()) {
+        return;
+    }
     TT_FATAL(
         dst.size() == src.size(),
         "copy_transpose_common_runtime_args: destination span ({} elems) must match common args ({} elems).",


### PR DESCRIPTION
### Ticket
Follow-up to [#41555](https://github.com/tenstorrent/tt-metal/issues/41555) / [#42155](https://github.com/tenstorrent/tt-metal/pull/42155).

### Problem
The nightly debug pipeline ([Sanity tests nightly debug run with watcher](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests-debug.yaml)) deterministically fails on `models-unit-tests (P150)` after PR #42155 landed:

```
RuntimeError: TT_FATAL @ ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp:183: dst.size() == src.size()
copy_transpose_common_runtime_args: destination span (4294967295 elems) must match common args (0 elems).
```

Reproduced locally on Wormhole + watcher with a 5-line repro: `[1, 4096, 1, 512]` TILE bfloat8_b interleaved DRAM tensor → `ttnn.transpose(x, 1, 2)` invoked twice with program cache enabled. The second call (cache hit) hits the fatal.

### Root cause
`copy_transpose_common_runtime_args` (added in PR #42155) refreshes `RuntimeTensorShape` common args on cache hits and asserts strict size equality. For **interleaved** input/output buffers:

- `TensorAccessorArgs::update_args_config()` resets `args_config_` to `None` (interleaved branch wipes the user-passed `RuntimeTensorShape` flag).
- `append_to(...)` therefore writes **0** common runtime args at create time → `SetCommonRuntimeArgs(program, kid, {})` is called with an empty vector.
- `get_common_runtime_args()` at refresh time also returns **0** elements.
- `GetCommonRuntimeArgs(program, kid)` then returns a `RuntimeArgsData` whose `rt_args_count` is left uninitialised (observed as `UINT32_MAX = 4294967295` under watcher mode); the strict size check fires.

The bug is masked outside of watcher mode because the uninitialised field happens to read as zero in the regular memory init pattern, which is why the PR-gate Sanity tests never caught it.

### Fix
Treat an empty source as a no-op in `copy_transpose_common_runtime_args` and only enforce the strict size check when the buffer actually carries common runtime args (i.e. sharded buffers). Sharded path is unchanged; interleaved path now correctly skips a no-op refresh.

```cpp
void copy_transpose_common_runtime_args(const Buffer& buffer, std::span<std::uint32_t> dst) {
    const auto src =
        TensorAccessorArgs(buffer, tensor_accessor::ArgConfig::RuntimeTensorShape).get_common_runtime_args();
    if (src.empty()) {
        return;
    }
    TT_FATAL(dst.size() == src.size(), ...);
    std::copy(src.begin(), src.end(), dst.begin());
}
```

### Verification
- Local reproducer with `TT_METAL_WATCHER=1`:
  - Pre-fix: `RuntimeError: TT_FATAL ... destination span (4294967295 elems) must match common args (0 elems).` (matches CI exactly).
  - Post-fix: `PASS: cache-miss == cache-hit`.
- Sharded path (assertion is preserved) unaffected.

### Notes for reviewers
The strategic fix for this class of issue is to migrate transpose's program factories to the modern `ProgramDescriptor::create_descriptor` API (as `unary_ng`, `binary_ng`, `ternary` already use). Those ops do not have `override_runtime_arguments` or `GetCommonRuntimeArgs` callsites at all, which is why they cannot hit this bug. Transpose's seven legacy factories will move incrementally; tracked separately.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/transpose_vae_attention_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/transpose_vae_attention_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/transpose_vae_attention_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/transpose_vae_attention_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/transpose_vae_attention_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/transpose_vae_attention_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/transpose_vae_attention_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/transpose_vae_attention_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/transpose_vae_attention_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/transpose_vae_attention_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/transpose_vae_attention_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/transpose_vae_attention_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/transpose_vae_attention_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/transpose_vae_attention_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/transpose_vae_attention_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/transpose_vae_attention_fix)
