### PR TITLE
Add Index-AniSoraV3.2 model  and LoRA pipeline for Wan2.2 I2V 

### DIFF
--- a/models/tt_dit/README.md
+++ b/models/tt_dit/README.md
@@ -12,6 +12,8 @@ For detailed information about each model including performance metrics, usage i
 - **[Qwen-Image](models/QwenImage.md)** - Text-to-image generation model
 - **[Mochi-1](models/Mochi_1.md)** - Video generation model
 - **[Wan2.2-T2V-A14B](models/Wan2_2.md)** - Text-to-video generation model
+- **[Index-AniSora V3.2](models/AniSora.md)** - Anime-domain image-to-video (Wan2.2-based)
+- **[Wan2.2 LoRA Adapter](models/Wan2_2_LoRA.md)** - LoRA adapter pipeline for Wan2.2 I2V (camera control, distill, style)
 
 ## Directory Structure
 
@@ -26,7 +28,9 @@ tt_dit/
 │   ├── Motif.md         # Motif model documentation
 │   ├── QwenImage.md     # Qwen-Image model documentation
 │   ├── Mochi_1.md       # Mochi-1 model documentation
-│   └── Wan2_2.md        # Wan2.2 model documentation
+│   ├── Wan2_2.md        # Wan2.2 model documentation
+│   ├── AniSora.md       # Index-AniSora V3.2 model documentation
+│   └── Wan2_2_LoRA.md   # Wan2.2 LoRA adapter documentation
 ├── encoders/            # Text encoder implementations
 │   ├── clip/           # CLIP encoder
 │   └── t5/             # T5 encoder

--- a/models/tt_dit/models/AniSora.md
+++ b/models/tt_dit/models/AniSora.md
@@ -1,0 +1,136 @@
+# Index-AniSora V3.2 (I2V)
+
+## Introduction
+
+[IndexTeam/Index-anisora](https://huggingface.co/IndexTeam/Index-anisora) V3.2
+is an anime-domain image-to-video model derived from
+[Wan2.2-I2V-A14B](https://huggingface.co/Wan-AI/Wan2.2-I2V-A14B-Diffusers).
+It preserves the two-expert (high-noise / low-noise) MoE structure of Wan2.2
+and ships a finetuned weight pair specialized for anime-style motion.
+
+This is a **full checkpoint replacement** (not a LoRA adapter or distilled model).
+The model graph is identical to base Wan2.2 I2V — see [Wan2_2.md](Wan2_2.md) for
+the underlying architecture.
+
+## Details
+
+The two-stage MoE schedule is preserved: the high-noise expert handles the
+first 90% of the denoising trajectory and the low-noise expert handles the
+final 10% (`boundary_ratio=0.9`, vs 0.5 for base Wan2.2).
+
+The AniSora safetensors use the original-Wan key naming
+(`blocks.X.self_attn.q.weight`, etc), identical to the lightx2v distill
+checkpoints. The same `wan_lightx2v_to_diffusers_key` rename function in
+`models/tt_dit/utils/lightx2v_loader.py` is reused.
+
+`NUM_STEPS` is configurable (default 40). Lower step counts (16, 8) can produce video at decent quality.
+
+## Weights
+
+### AniSora V3.2 experts (DiT only)
+
+- **Source:** [IndexTeam/Index-anisora](https://huggingface.co/IndexTeam/Index-anisora)
+- **Files:**
+  - `V3.2/high_noise_model/diffusion_pytorch_model.safetensors` (~28 GB, BF16)
+  - `V3.2/low_noise_model/diffusion_pytorch_model.safetensors` (~28 GB, BF16)
+- **Total download:** ~57 GB (auto-downloaded on first run with `TT_DIT_ALLOW_HF_DOWNLOAD=1`)
+
+### Base Wan2.2 components (shared, not re-downloaded if already cached)
+
+- **Source:** [Wan-AI/Wan2.2-I2V-A14B-Diffusers](https://huggingface.co/Wan-AI/Wan2.2-I2V-A14B-Diffusers)
+- **Components:** tokenizer, UMT5 text encoder, VAE, scheduler config
+- **Total download:** ~12 GB (shared with base Wan2.2)
+
+### Download weights manually (optional)
+
+Weights are auto-downloaded via HuggingFace Hub on first run. To pre-download or use a local copy:
+
+```bash
+# Option 1: Pre-download to HF cache
+python -c "
+from huggingface_hub import hf_hub_download
+for f in ['V3.2/high_noise_model/diffusion_pytorch_model.safetensors',
+          'V3.2/low_noise_model/diffusion_pytorch_model.safetensors']:
+    hf_hub_download('IndexTeam/Index-anisora', f)
+"
+
+# Option 2: Point to a local directory
+# Layout must be:
+#   $ANISORA_LOCAL_DIR/V3.2/high_noise_model/diffusion_pytorch_model.safetensors
+#   $ANISORA_LOCAL_DIR/V3.2/low_noise_model/diffusion_pytorch_model.safetensors
+export ANISORA_LOCAL_DIR=/path/to/index-anisora-weights
+```
+
+## Inference defaults
+
+Mirrors `anisoraV3.2/wan/configs/wan_i2v_A14B.py`:
+
+| Parameter | Value | Note |
+|---|---|---|
+| `num_inference_steps` | 40 | UniPC sampler (configurable via `NUM_STEPS` env var) |
+| `boundary_ratio` | 0.9 | High-noise covers first 90% of timesteps |
+| `guidance_scale` | 3.5 | High-noise stage CFG |
+| `guidance_scale_2` | 3.5 | Low-noise stage CFG |
+| `sample_shift` | 5.0 | Inherited from base Wan2.2 scheduler config |
+
+## Performance
+
+BH Galaxy 4x8 Ring (sp=8, tp=4), 81 frames @ 16fps (~5s video):
+
+| Stage | Base Wan2.2 I2V 480p | AniSora V3.2 I2V 480p | AniSora V3.2 I2V 720p |
+|---|---|---|---|
+| Text Encoding | 0.13s | 0.14s | 0.14s |
+| Image Encoding | 5.03s | 5.02s | 12.84s |
+| Denoising | 48.92s (40 steps, 1.22s/step) | 48.29s (40 steps, 1.21s/step) | 133.61s (40 steps, 3.34s/step) |
+| VAE Decoding | 0.43s | 0.43s | 0.70s |
+| **Total** | **54.52s** | **53.90s** | **147.32s** |
+
+### Reduced-steps perf (AniSora V3.2)
+
+| Steps | 480p (832x480) | 720p (1280x720) |
+|---|---|---|
+| 40 | 53.90s | 147.32s |
+| 16 | 25.0s | 67.2s |
+| 8 | 15.3s | 40.4s |
+
+## Supported configurations
+
+| System | Mesh | SP | TP | Topology | Test ID |
+|---|---|---|---|---|---|
+| BH Galaxy | 4x8 | 8 (axis 1) | 4 (axis 0) | Ring | `bh_4x8sp1tp0_ring` |
+
+## Prerequisites
+- Cloned [tt-metal repository](https://github.com/tenstorrent/tt-metal) for source code
+- Installed: [TT-Metalium / TT-NN](https://github.com/tenstorrent/tt-metal/blob/main/INSTALLING.md)
+
+## How to Run
+
+```bash
+# Environment setup
+export TT_DIT_CACHE_DIR=/your/cache/path
+export TT_METAL_HOME=$(pwd)
+export PYTHONPATH=$(pwd)
+export TT_DIT_ALLOW_HF_DOWNLOAD=1
+
+# Set input image and prompt
+export PROMPT_IMAGE=$TT_METAL_HOME/dog.jpg
+export PROMPT="An anime girl smiling, soft lighting, cinematic"
+export NUM_STEPS=40       # 40 default, or 16/8 for faster previews
+export NO_PROMPT=1
+
+# Run AniSora inference (480p)
+pytest models/tt_dit/tests/models/wan2_2/test_pipeline_anisora.py \
+  -v -k "bh_4x8sp1tp0_ring and resolution_480p and not random_weights" \
+  --timeout 1800 -s
+# Output: ./wan_anisora_i2v_832x480_0.mp4
+
+# Run AniSora inference (720p)
+pytest models/tt_dit/tests/models/wan2_2/test_pipeline_anisora.py \
+  -v -k "bh_4x8sp1tp0_ring and resolution_720p and not random_weights" \
+  --timeout 1800 -s
+# Output: ./wan_anisora_i2v_1280x720_0.mp4
+
+# Random-weights smoke test (no large download needed)
+pytest models/tt_dit/tests/models/wan2_2/test_pipeline_anisora.py::test_pipeline_inference_random_weights \
+  -v --timeout 1500 -s
+```

--- a/models/tt_dit/models/Wan2_2_LoRA.md
+++ b/models/tt_dit/models/Wan2_2_LoRA.md
@@ -1,0 +1,150 @@
+# Wan2.2 I2V — LoRA Adapter Pipeline
+
+## Introduction
+
+`WanLoraPipelineI2V` fuses [LoRA](https://arxiv.org/abs/2106.09685) adapters
+into the base [Wan2.2-I2V-A14B](https://huggingface.co/Wan-AI/Wan2.2-I2V-A14B-Diffusers)
+weights on CPU before pushing to device. This enables camera control, style
+transfer, distill acceleration, and other adapter-based effects without
+retraining or replacing the full checkpoint.
+
+See [Wan2_2.md](Wan2_2.md) for the base model architecture.
+
+## Details
+
+- **CPU-side LoRA fusion:** each LoRA weight pair (`lora_down` × `lora_up`) is
+  multiplied and added to the corresponding base weight (`W' = W + scale × up @ down`).
+  Optional per-module alpha scaling is applied when present.
+- **L2 norm verification:** after fusion, the pipeline checks that fused weights
+  differ from base weights (catches silent load failures from key mismatches).
+- **Key format auto-detection:** supports both diffusers-style keys
+  (`transformer.blocks.0.attn1.to_q.lora_A.weight`) and kohya/A1111-style keys
+  (`lora_unet_blocks_0_cross_attn_k.lora_down.weight`).
+- **Two LoRA modes:**
+  - **Split LoRA** — separate adapters for high-noise and low-noise experts
+    (set both `LORA_HIGH_PATH` and `LORA_LOW_PATH`)
+  - **Single-file LoRA** — one adapter for the high-noise expert only; the
+    low-noise expert uses unmodified base weights (set only `LORA_HIGH_PATH`)
+
+## Weights
+
+### Earth zoom-out LoRA
+
+- **Source:** [wangkanai/wan22-fp16-i2v-loras](https://huggingface.co/wangkanai/wan22-fp16-i2v-loras)
+- **File:** `loras/wan/wan22-camera-earthzoomout.safetensors` (293 MB)
+- **Format:** Single-file, kohya/A1111-style keys
+- **Effect:** Adds a dramatic earth zoom-out perspective transition to any I2V generation
+
+### Camera rotation LoRA
+
+- **Source:** [wangkanai/wan22-fp16-i2v-loras](https://huggingface.co/wangkanai/wan22-fp16-i2v-loras)
+- **File:** `loras/wan/wan22-camera-rotation-rank16-v2.safetensors` (293 MB)
+- **Format:** Single-file, kohya/A1111-style keys
+- **Effect:** Rotates the camera around the subject
+- [More camera LoRAs on HuggingFace](https://huggingface.co/wangkanai/wan22-fp16-i2v-loras/tree/main/loras/wan)
+
+### Base Wan2.2 components (shared, not re-downloaded if already cached)
+
+- **Source:** [Wan-AI/Wan2.2-I2V-A14B-Diffusers](https://huggingface.co/Wan-AI/Wan2.2-I2V-A14B-Diffusers)
+- **Components:** tokenizer, UMT5 text encoder, VAE, scheduler config, transformer base weights
+- **Total download:** ~70 GB (shared with base Wan2.2)
+
+### Download weights
+
+```bash
+pip install huggingface_hub   # if not already installed
+
+# Camera control LoRAs (~293 MB each)
+python -c "
+from huggingface_hub import hf_hub_download
+import os
+os.makedirs('/storage/sdawle/lora-camera', exist_ok=True)
+for f in ['loras/wan/wan22-camera-earthzoomout.safetensors',
+          'loras/wan/wan22-camera-rotation-rank16-v2.safetensors']:
+    hf_hub_download('wangkanai/wan22-fp16-i2v-loras', f,
+                    local_dir='/storage/sdawle/lora-camera')
+"
+```
+
+## Supported configurations
+
+| System | Mesh | SP | TP | Topology | Test ID |
+|---|---|---|---|---|---|
+| BH Galaxy | 4x8 | 8 (axis 1) | 4 (axis 0) | Ring | `bh_4x8sp1tp0_ring` |
+
+## Prerequisites
+- Cloned [tt-metal repository](https://github.com/tenstorrent/tt-metal) for source code
+- Installed: [TT-Metalium / TT-NN](https://github.com/tenstorrent/tt-metal/blob/main/INSTALLING.md)
+- LoRA weight files downloaded (see above)
+
+## How to Run
+
+### Earth zoom-out LoRA (40 steps)
+
+```bash
+# Environment setup
+export TT_DIT_CACHE_DIR=/your/cache/path
+export TT_METAL_HOME=$(pwd)
+export PYTHONPATH=$(pwd)
+export TT_DIT_ALLOW_HF_DOWNLOAD=1
+
+# LoRA config
+export LORA_HIGH_PATH=/storage/sdawle/lora-camera/wan22-camera-earthzoomout.safetensors
+unset LORA_LOW_PATH          # single-file: low-noise expert uses base weights
+export LORA_SCALE=1.0
+
+# Inference config
+export PROMPT_IMAGE=$TT_METAL_HOME/dog.jpg
+export PROMPT="A golden retriever running on a sandy beach, waves in the background"
+export NUM_STEPS=40
+export GUIDANCE_SCALE=3.5
+export BOUNDARY_RATIO=0.875
+export NO_PROMPT=1
+
+pytest models/tt_dit/tests/models/wan2_2/test_pipeline_lora.py \
+  -v -k "bh_4x8sp1tp0_ring and resolution_480p" \
+  --timeout 1800 -s
+# Output: ./wan_lora_i2v_832x480_0.mp4
+```
+
+### Camera rotation LoRA (40 steps)
+
+```bash
+export LORA_HIGH_PATH=/storage/sdawle/lora-camera/wan22-camera-rotation-rank16-v2.safetensors
+unset LORA_LOW_PATH
+export LORA_SCALE=1.0
+
+export PROMPT_IMAGE=$TT_METAL_HOME/dog.jpg
+export PROMPT="A golden retriever running on a sandy beach, waves in the background"
+export NUM_STEPS=40
+export GUIDANCE_SCALE=3.5
+export BOUNDARY_RATIO=0.875
+export NO_PROMPT=1
+
+pytest models/tt_dit/tests/models/wan2_2/test_pipeline_lora.py \
+  -v -k "bh_4x8sp1tp0_ring and resolution_480p" \
+  --timeout 1800 -s
+# Output: ./wan_lora_i2v_832x480_0.mp4
+```
+
+## Environment variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `LORA_HIGH_PATH` | Yes | — | Path to high-noise expert LoRA `.safetensors` |
+| `LORA_LOW_PATH` | No | None | Path to low-noise expert LoRA (omit for single-file LoRAs) |
+| `LORA_SCALE` | No | 1.0 | Blend strength (0.0 = no effect, 1.0 = full effect) |
+| `NUM_STEPS` | No | 4 | Inference steps (4 for distill LoRAs, 40 for camera/style) |
+| `GUIDANCE_SCALE` | No | 1.0 | CFG scale (1.0 for distill, 3.5 for camera/style) |
+| `BOUNDARY_RATIO` | No | 0.5 | High/low expert split ratio (0.875 for camera, 0.5 for distill) |
+| `PROMPT_IMAGE` | No | `./prompt_image.png` | Seed image path |
+| `PROMPT` | No | anime default | Text prompt |
+
+## Limitations / open items
+
+- LoRA fusion happens on CPU before device push — adds ~5–10 s to pipeline
+  initialization (one-time cost, not per-frame).
+- Only `bh_4x8sp1tp0_ring` is exercised so far.
+- Dedicated perf test function (`test_pipeline_performance_lora`) not yet added.
+- Any community LoRA trained for Wan2.2 I2V should work if its keys follow
+  diffusers or kohya/A1111 naming. Untested LoRAs may need key remap additions.

--- a/models/tt_dit/models/Wan2_2_LoRA.md
+++ b/models/tt_dit/models/Wan2_2_LoRA.md
@@ -17,9 +17,11 @@ See [Wan2_2.md](Wan2_2.md) for the base model architecture.
   Optional per-module alpha scaling is applied when present.
 - **L2 norm verification:** after fusion, the pipeline checks that fused weights
   differ from base weights (catches silent load failures from key mismatches).
-- **Key format auto-detection:** supports both diffusers-style keys
-  (`transformer.blocks.0.attn1.to_q.lora_A.weight`) and kohya/A1111-style keys
-  (`lora_unet_blocks_0_cross_attn_k.lora_down.weight`).
+- **Key format auto-detection:** supports Wan/lightx2v-style module keys under
+  `blocks.<i>...`, including checkpoints that prefix those keys with
+  `diffusion_model.`, `transformer.`, `unet.`, or `model.`, as well as
+  kohya/A1111-style keys such as
+  `lora_unet_blocks_0_cross_attn_k.lora_down.weight`.
 - **Two LoRA modes:**
   - **Split LoRA** — separate adapters for high-noise and low-noise experts
     (set both `LORA_HIGH_PATH` and `LORA_LOW_PATH`)
@@ -134,11 +136,11 @@ pytest models/tt_dit/tests/models/wan2_2/test_pipeline_lora.py \
 | `LORA_HIGH_PATH` | Yes | — | Path to high-noise expert LoRA `.safetensors` |
 | `LORA_LOW_PATH` | No | None | Path to low-noise expert LoRA (omit for single-file LoRAs) |
 | `LORA_SCALE` | No | 1.0 | Blend strength (0.0 = no effect, 1.0 = full effect) |
-| `NUM_STEPS` | No | 4 | Inference steps (4 for distill LoRAs, 40 for camera/style) |
-| `GUIDANCE_SCALE` | No | 1.0 | CFG scale (1.0 for distill, 3.5 for camera/style) |
-| `BOUNDARY_RATIO` | No | 0.5 | High/low expert split ratio (0.875 for camera, 0.5 for distill) |
+| `NUM_STEPS` | No | 40 | Inference steps (40 for camera/style LoRAs, 4 for distill) |
+| `GUIDANCE_SCALE` | No | 3.5 | CFG scale (3.5 for camera/style, 1.0 for distill) |
+| `BOUNDARY_RATIO` | No | 0.875 | High/low expert split ratio (0.875 for camera, 0.5 for distill) |
 | `PROMPT_IMAGE` | No | `./prompt_image.png` | Seed image path |
-| `PROMPT` | No | anime default | Text prompt |
+| `PROMPT` | No | golden retriever prompt | Text prompt |
 
 ## Limitations / open items
 

--- a/models/tt_dit/pipelines/wan/pipeline_anisora.py
+++ b/models/tt_dit/pipelines/wan/pipeline_anisora.py
@@ -29,6 +29,7 @@ from the base diffusers repo (~12 GB total).
 from __future__ import annotations
 
 import os
+from contextlib import nullcontext
 
 from ...utils import cache
 from ...utils.lightx2v_loader import load_lightx2v_state_dict
@@ -68,10 +69,8 @@ class AniSoraPipeline(WanPipelineI2V):
         self._allow_download = allow_download
         self._random_weights = random_weights
 
-        if random_weights:
-            with _patch_torch_transformer_random():
-                super().__init__(*args, **kwargs)
-        else:
+        ctx = _patch_torch_transformer_random() if random_weights else nullcontext()
+        with ctx:
             super().__init__(*args, **kwargs)
 
     def _prepare_transformer(self, idx: int):

--- a/models/tt_dit/pipelines/wan/pipeline_anisora.py
+++ b/models/tt_dit/pipelines/wan/pipeline_anisora.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""IndexTeam/Index-anisora V3.2 I2V pipeline.
+
+A thin subclass of :class:`WanPipelineI2V` that:
+
+1. Uses ``Wan-AI/Wan2.2-I2V-A14B-Diffusers`` for tokenizer, text encoder, VAE,
+   and scheduler — the AniSora HF repo only ships the DiT experts.
+2. Replaces both expert transformer state dicts with AniSora's ``V3.2``
+   ``diffusion_pytorch_model.safetensors`` files (high-noise + low-noise pair).
+3. Defaults to 40 sampling steps with ``boundary_ratio=0.9`` and
+   ``guidance_scale=3.5`` for both stages, matching the upstream config in
+   ``anisoraV3.2/wan/configs/wan_i2v_A14B.py``.
+
+AniSora's safetensors use the same original-Wan key naming as the lightx2v
+distill checkpoints (verified: 1095 keys, identical layout). The
+``wan_lightx2v_to_diffusers_key`` rename function in
+:mod:`models.tt_dit.utils.lightx2v_loader` is reused as-is.
+
+A ``random_weights`` mode is provided for smoke-testing without HuggingFace
+downloads. It (a) skips the two ~28 GB transformer subfolder downloads by
+constructing config-only random ``TorchWanTransformer3DModel`` instances and
+(b) feeds those random ``state_dict()``s into the TT model in place of the
+AniSora safetensors. Tokenizer, text encoder, VAE, and scheduler still come
+from the base diffusers repo (~12 GB total).
+"""
+from __future__ import annotations
+
+import os
+
+from ...utils import cache
+from ...utils.lightx2v_loader import load_lightx2v_state_dict
+from .pipeline_wan import WanPipeline
+from .pipeline_wan_distill import _patch_torch_transformer_random
+from .pipeline_wan_i2v import WanPipelineI2V
+
+
+class AniSoraPipeline(WanPipelineI2V):
+    HF_REPO = "IndexTeam/Index-anisora"
+    HIGH_NOISE_FILE = "V3.2/high_noise_model/diffusion_pytorch_model.safetensors"
+    LOW_NOISE_FILE = "V3.2/low_noise_model/diffusion_pytorch_model.safetensors"
+    BASE_DIFFUSERS_REPO = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
+    CACHE_NAMESPACE = "Index-anisora-V3.2"
+    RANDOM_CACHE_NAMESPACE = "Index-anisora-random"
+    ANISORA_BOUNDARY_RATIO = 0.9
+
+    def __init__(
+        self,
+        *args,
+        anisora_local_dir: str | None = None,
+        allow_download: bool | None = None,
+        random_weights: bool | None = None,
+        **kwargs,
+    ):
+        kwargs["checkpoint_name"] = kwargs.get("checkpoint_name") or self.BASE_DIFFUSERS_REPO
+        kwargs["boundary_ratio"] = self.ANISORA_BOUNDARY_RATIO
+
+        if allow_download is None:
+            allow_download = os.environ.get("TT_DIT_ALLOW_HF_DOWNLOAD") == "1"
+        if anisora_local_dir is None:
+            anisora_local_dir = os.environ.get("ANISORA_LOCAL_DIR")
+        if random_weights is None:
+            random_weights = os.environ.get("TT_DIT_RANDOM_WEIGHTS") == "1"
+
+        self._anisora_local_dir = anisora_local_dir
+        self._allow_download = allow_download
+        self._random_weights = random_weights
+
+        if random_weights:
+            with _patch_torch_transformer_random():
+                super().__init__(*args, **kwargs)
+        else:
+            super().__init__(*args, **kwargs)
+
+    def _prepare_transformer(self, idx: int):
+        if self._random_weights:
+            state = self.transformer_states[idx]
+            cache.load_model(
+                state.model,
+                model_name=self.RANDOM_CACHE_NAMESPACE,
+                subfolder=state.subfolder,
+                parallel_config=self.parallel_config,
+                mesh_shape=tuple(self.mesh_device.shape),
+                is_fsdp=self.is_fsdp,
+                get_torch_state_dict=lambda s=state: s.torch_model.state_dict(),
+            )
+            return
+
+        state = self.transformer_states[idx]
+        filename = self.HIGH_NOISE_FILE if idx == 0 else self.LOW_NOISE_FILE
+        cache.load_model(
+            state.model,
+            model_name=self.CACHE_NAMESPACE,
+            subfolder=state.subfolder,
+            parallel_config=self.parallel_config,
+            mesh_shape=tuple(self.mesh_device.shape),
+            is_fsdp=self.is_fsdp,
+            get_torch_state_dict=lambda f=filename: load_lightx2v_state_dict(
+                self.HF_REPO,
+                f,
+                allow_download=self._allow_download,
+                local_dir=self._anisora_local_dir,
+            ),
+        )
+
+    @staticmethod
+    def create_pipeline(*args, random_weights: bool | None = None, **kwargs):
+        # Base WanPipeline.create_pipeline doesn't forward arbitrary kwargs to
+        # the constructor, so we hand random_weights through the env var that
+        # __init__ already reads.
+        if random_weights:
+            os.environ["TT_DIT_RANDOM_WEIGHTS"] = "1"
+        kwargs["checkpoint_name"] = kwargs.get("checkpoint_name") or AniSoraPipeline.BASE_DIFFUSERS_REPO
+        return WanPipeline.create_pipeline(*args, pipeline_class=AniSoraPipeline, **kwargs)

--- a/models/tt_dit/pipelines/wan/pipeline_anisora.py
+++ b/models/tt_dit/pipelines/wan/pipeline_anisora.py
@@ -107,10 +107,10 @@ class AniSoraPipeline(WanPipelineI2V):
 
     @staticmethod
     def create_pipeline(*args, random_weights: bool | None = None, **kwargs):
-        # Base WanPipeline.create_pipeline doesn't forward arbitrary kwargs to
-        # the constructor, so we hand random_weights through the env var that
-        # __init__ already reads.
+        kwargs["checkpoint_name"] = kwargs.get("checkpoint_name") or AniSoraPipeline.BASE_DIFFUSERS_REPO
         if random_weights:
             os.environ["TT_DIT_RANDOM_WEIGHTS"] = "1"
-        kwargs["checkpoint_name"] = kwargs.get("checkpoint_name") or AniSoraPipeline.BASE_DIFFUSERS_REPO
-        return WanPipeline.create_pipeline(*args, pipeline_class=AniSoraPipeline, **kwargs)
+        try:
+            return WanPipeline.create_pipeline(*args, pipeline_class=AniSoraPipeline, **kwargs)
+        finally:
+            os.environ.pop("TT_DIT_RANDOM_WEIGHTS", None)

--- a/models/tt_dit/pipelines/wan/pipeline_wan_distill.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan_distill.py
@@ -168,11 +168,10 @@ class WanDistillPipelineI2V(WanPipelineI2V):
 
     @staticmethod
     def create_pipeline(*args, random_weights: bool | None = None, **kwargs):
-        # Base WanPipeline.create_pipeline doesn't forward arbitrary kwargs to
-        # the constructor, so we hand random_weights through the env var that
-        # __init__ already reads. Don't restore — pytest test boundaries
-        # provide adequate isolation.
+        kwargs["checkpoint_name"] = kwargs.get("checkpoint_name") or WanDistillPipelineI2V.BASE_DIFFUSERS_REPO
         if random_weights:
             os.environ["TT_DIT_RANDOM_WEIGHTS"] = "1"
-        kwargs["checkpoint_name"] = kwargs.get("checkpoint_name") or WanDistillPipelineI2V.BASE_DIFFUSERS_REPO
-        return WanPipeline.create_pipeline(*args, pipeline_class=WanDistillPipelineI2V, **kwargs)
+        try:
+            return WanPipeline.create_pipeline(*args, pipeline_class=WanDistillPipelineI2V, **kwargs)
+        finally:
+            os.environ.pop("TT_DIT_RANDOM_WEIGHTS", None)

--- a/models/tt_dit/pipelines/wan/pipeline_wan_distill.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan_distill.py
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Wan2.2 lightx2v distilled I2V pipeline.
+
+A thin subclass of :class:`WanPipelineI2V` that:
+
+1. Uses ``Wan-AI/Wan2.2-I2V-A14B-Diffusers`` for tokenizer, text encoder, VAE,
+   and scheduler — the lightx2v repo ships only the DiT.
+2. Replaces both expert transformer state dicts with lightx2v's flat
+   ``.safetensors`` files (4-step distill, high-noise + low-noise pair).
+3. Defaults ``boundary_ratio=0.5`` (2 high-noise + 2 low-noise steps).
+
+Test/caller passes ``num_inference_steps=4`` and ``guidance_scale=1.0`` for both
+stages since CFG is baked into the distill.
+
+A ``random_weights`` mode is provided for smoke-testing without HuggingFace
+downloads. It (a) skips the two ~28 GB transformer subfolder downloads by
+constructing config-only random ``TorchWanTransformer3DModel`` instances and
+(b) feeds those random ``state_dict()``s into the TT model in place of the
+lightx2v safetensors. Tokenizer, text encoder, VAE, and scheduler still come
+from the base diffusers repo (~12 GB total).
+"""
+from __future__ import annotations
+
+import contextlib
+import os
+
+import torch
+
+from ...utils import cache
+from ...utils.lightx2v_loader import load_lightx2v_state_dict
+from .pipeline_wan import TorchWanTransformer3DModel, WanPipeline
+from .pipeline_wan_i2v import WanPipelineI2V
+
+# Hard-coded config for Wan2.2-I2V-A14B-Diffusers transformer subfolders. Used
+# only in random_weights mode so we don't have to fetch transformer/config.json
+# from HF. Both transformer and transformer_2 share this architecture; only
+# weights differ between high-noise and low-noise experts.
+_RANDOM_I2V_TRANSFORMER_CONFIG = dict(
+    patch_size=(1, 2, 2),
+    num_attention_heads=40,
+    attention_head_dim=128,
+    in_channels=36,  # I2V: 4 mask + 16 image latent + 16 noise latent
+    out_channels=16,
+    text_dim=4096,
+    freq_dim=256,
+    ffn_dim=13824,
+    num_layers=40,
+    cross_attn_norm=True,
+    qk_norm="rms_norm_across_heads",
+    eps=1e-6,
+    rope_max_seq_len=1024,
+    image_dim=None,
+    added_kv_proj_dim=None,
+    pos_embed_seq_len=None,
+)
+
+
+@contextlib.contextmanager
+def _patch_torch_transformer_random(seed: int = 0):
+    """Replace ``TorchWanTransformer3DModel.from_pretrained`` with a stub that
+    instantiates from a hard-coded I2V config and never touches the network or
+    disk. Restored on exit."""
+    cls = TorchWanTransformer3DModel
+    sentinel = object()
+    saved = cls.__dict__.get("from_pretrained", sentinel)
+
+    def _stub(_cls, *args, **kwargs):
+        torch.manual_seed(seed)
+        return _cls(**_RANDOM_I2V_TRANSFORMER_CONFIG)
+
+    cls.from_pretrained = classmethod(_stub)
+    try:
+        yield
+    finally:
+        if saved is sentinel:
+            # `from_pretrained` was inherited; delete our override to restore inheritance.
+            try:
+                delattr(cls, "from_pretrained")
+            except AttributeError:
+                pass
+        else:
+            cls.from_pretrained = saved
+
+
+class WanDistillPipelineI2V(WanPipelineI2V):
+    LIGHTX2V_REPO = "lightx2v/Wan2.2-Distill-Models"
+    HIGH_NOISE_FILE = "wan2.2_i2v_A14b_high_noise_lightx2v_4step.safetensors"
+    LOW_NOISE_FILE = "wan2.2_i2v_A14b_low_noise_lightx2v_4step.safetensors"
+    BASE_DIFFUSERS_REPO = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
+    CACHE_NAMESPACE = "Wan2.2-Distill-lightx2v-4step"
+    RANDOM_CACHE_NAMESPACE = "Wan2.2-Distill-random"
+    DISTILL_BOUNDARY_RATIO = 0.5
+
+    def __init__(
+        self,
+        *args,
+        lightx2v_local_dir: str | None = None,
+        allow_download: bool | None = None,
+        random_weights: bool | None = None,
+        **kwargs,
+    ):
+        kwargs["checkpoint_name"] = kwargs.get("checkpoint_name") or self.BASE_DIFFUSERS_REPO
+        kwargs["boundary_ratio"] = self.DISTILL_BOUNDARY_RATIO
+
+        if allow_download is None:
+            allow_download = os.environ.get("TT_DIT_ALLOW_HF_DOWNLOAD") == "1"
+        if lightx2v_local_dir is None:
+            lightx2v_local_dir = os.environ.get("LIGHTX2V_LOCAL_DIR")
+        if random_weights is None:
+            random_weights = os.environ.get("TT_DIT_RANDOM_WEIGHTS") == "1"
+
+        self._lightx2v_local_dir = lightx2v_local_dir
+        self._allow_download = allow_download
+        self._random_weights = random_weights
+
+        if random_weights:
+            with _patch_torch_transformer_random():
+                super().__init__(*args, **kwargs)
+        else:
+            super().__init__(*args, **kwargs)
+
+    def prepare_text_conditioning(self, tt_model, prompt_embeds, buffer, traced=False):
+        # When CFG is baked in (guidance_scale=1.0), encode_prompt returns
+        # negative_prompt_embeds=None. The base loop still calls this for the
+        # negative buffer; forwarding None into the text embedder hits a
+        # NoneType.padded_shape in Linear. combined_step already short-circuits
+        # on do_classifier_free_guidance=False, so leaving the buffer as-is is
+        # safe.
+        if prompt_embeds is None:
+            return buffer
+        return super().prepare_text_conditioning(tt_model, prompt_embeds, buffer, traced)
+
+    def _prepare_transformer(self, idx: int):
+        if self._random_weights:
+            # Use the random-init torch model's state_dict directly. Cache under
+            # a separate namespace so a real-weights run doesn't reuse it.
+            state = self.transformer_states[idx]
+            cache.load_model(
+                state.model,
+                model_name=self.RANDOM_CACHE_NAMESPACE,
+                subfolder=state.subfolder,
+                parallel_config=self.parallel_config,
+                mesh_shape=tuple(self.mesh_device.shape),
+                is_fsdp=self.is_fsdp,
+                get_torch_state_dict=lambda s=state: s.torch_model.state_dict(),
+            )
+            return
+
+        state = self.transformer_states[idx]
+        filename = self.HIGH_NOISE_FILE if idx == 0 else self.LOW_NOISE_FILE
+        cache.load_model(
+            state.model,
+            model_name=self.CACHE_NAMESPACE,
+            subfolder=state.subfolder,
+            parallel_config=self.parallel_config,
+            mesh_shape=tuple(self.mesh_device.shape),
+            is_fsdp=self.is_fsdp,
+            get_torch_state_dict=lambda f=filename: load_lightx2v_state_dict(
+                self.LIGHTX2V_REPO,
+                f,
+                allow_download=self._allow_download,
+                local_dir=self._lightx2v_local_dir,
+            ),
+        )
+
+    @staticmethod
+    def create_pipeline(*args, random_weights: bool | None = None, **kwargs):
+        # Base WanPipeline.create_pipeline doesn't forward arbitrary kwargs to
+        # the constructor, so we hand random_weights through the env var that
+        # __init__ already reads. Don't restore — pytest test boundaries
+        # provide adequate isolation.
+        if random_weights:
+            os.environ["TT_DIT_RANDOM_WEIGHTS"] = "1"
+        kwargs["checkpoint_name"] = kwargs.get("checkpoint_name") or WanDistillPipelineI2V.BASE_DIFFUSERS_REPO
+        return WanPipeline.create_pipeline(*args, pipeline_class=WanDistillPipelineI2V, **kwargs)

--- a/models/tt_dit/pipelines/wan/pipeline_wan_distill.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan_distill.py
@@ -116,10 +116,8 @@ class WanDistillPipelineI2V(WanPipelineI2V):
         self._allow_download = allow_download
         self._random_weights = random_weights
 
-        if random_weights:
-            with _patch_torch_transformer_random():
-                super().__init__(*args, **kwargs)
-        else:
+        ctx = _patch_torch_transformer_random() if random_weights else contextlib.nullcontext()
+        with ctx:
             super().__init__(*args, **kwargs)
 
     def prepare_text_conditioning(self, tt_model, prompt_embeds, buffer, traced=False):

--- a/models/tt_dit/pipelines/wan/pipeline_wan_lora.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan_lora.py
@@ -1,0 +1,407 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Wan2.2 I2V pipeline with LoRA hot-swap.
+
+Subclass of :class:`WanPipelineI2V` that fuses a pair of LoRA adapters
+(high-noise + low-noise expert) into the base PyTorch transformer state dict
+before TT conversion. Output behaves like a vanilla Wan2.2 I2V model with the
+LoRA permanently applied -- no per-step LoRA evaluation on device.
+
+LoRA keys are detected and fused into the base PyTorch weights, then handed
+to ``cache.load_model``. The rank-r delta is computed manually
+(``W_fused = W + scale * B @ A``) producing a single fused weight matrix
+per linear with no LoRA-specific runtime cost.
+
+Cache keying: each (high_path, low_path, scale) combination produces a
+distinct namespace via :func:`_lora_cache_namespace`, so the TT cache for one
+LoRA never aliases another.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+import torch
+from loguru import logger
+from safetensors.torch import load_file
+
+from ...utils import cache
+from ...utils.lightx2v_loader import wan_lightx2v_to_diffusers_key
+from .pipeline_wan import WanPipeline
+from .pipeline_wan_i2v import WanPipelineI2V
+
+
+def _strip_diffusion_model_prefix(key: str) -> str:
+    return key[len("diffusion_model.") :] if key.startswith("diffusion_model.") else key
+
+
+def _kohya_to_lightx2v(key: str) -> str:
+    """Convert kohya/A1111-style keys to lightx2v-style keys.
+
+    ``lora_unet_blocks_0_cross_attn_k.lora_down.weight``
+    → ``blocks.0.cross_attn.k.lora_down.weight``
+
+    Also handles ``.alpha`` keys.
+    """
+    import re
+
+    if not key.startswith("lora_unet_"):
+        return key
+    parts = key.split(".", 1)
+    module_path = parts[0]  # e.g. "lora_unet_blocks_0_cross_attn_k"
+    suffix = f".{parts[1]}" if len(parts) > 1 else ""
+
+    module_path = module_path[len("lora_unet_") :]
+
+    # Wan2.2 kohya keys follow: blocks_{N}_{attn_type}_{param} or blocks_{N}_ffn_{idx}
+    # attn_type: cross_attn or self_attn, param: q/k/v/o
+    m = re.match(r"blocks_(\d+)_(cross_attn|self_attn)_([a-z]+)", module_path)
+    if m:
+        return f"blocks.{m.group(1)}.{m.group(2)}.{m.group(3)}{suffix}"
+
+    m = re.match(r"blocks_(\d+)_(ffn)_(\d+)", module_path)
+    if m:
+        return f"blocks.{m.group(1)}.{m.group(2)}.{m.group(3)}{suffix}"
+
+    logger.warning(f"Unrecognized kohya key structure: {key}")
+    return key
+
+
+def _lora_base_path_to_diffusers_weight_key(lightx2v_base_path: str) -> str:
+    """``blocks.0.self_attn.q`` -> ``blocks.0.attn1.to_q.weight``."""
+    return wan_lightx2v_to_diffusers_key(f"{lightx2v_base_path}.weight")
+
+
+def _diffusers_target(lightx2v_base_path: str, suffix: str) -> str:
+    """Map a lightx2v base path + suffix (.weight/.bias) to the diffusers key.
+
+    The lightx2v-to-diffusers map operates on full parameter names ending in
+    ``.weight``, so we feed it ``<base>.weight``, swap to the requested suffix
+    afterwards.
+    """
+    weight_key = wan_lightx2v_to_diffusers_key(f"{lightx2v_base_path}.weight")
+    if suffix == ".weight":
+        return weight_key
+    return weight_key[: -len(".weight")] + suffix
+
+
+def fuse_lora_state_dict(
+    base_state_dict: dict[str, torch.Tensor],
+    lora_state_dict: dict[str, torch.Tensor],
+    *,
+    scale: float = 1.0,
+) -> dict[str, torch.Tensor]:
+    """Return a new state dict with LoRA deltas fused into ``base_state_dict``.
+
+    Supports three lightx2v-style adapter conventions, all keyed under a
+    ``diffusion_model.`` prefix that is stripped before mapping:
+
+    1. **Low-rank pairs** at ``<base>.lora_A.weight``/``<base>.lora_B.weight``
+       OR ``<base>.lora_down.weight``/``<base>.lora_up.weight``. Adds
+       ``scale * B @ A`` to the base ``.weight``.
+    2. **Bias deltas** at ``<base>.diff_b``: adds the tensor to the base
+       ``.bias`` directly.
+    3. **Full param deltas** at ``<base>.diff``: adds to the base ``.weight``.
+       Used for params without a low-rank factorization (e.g. RMSNorm gammas).
+
+    Keys whose remapped target is absent from ``base_state_dict`` are skipped
+    with a warning -- this happens for adapter modules that don't exist in
+    the diffusers Wan2.2 I2V architecture (e.g. ``cross_attn.k_img`` from a
+    Wan2.1 I2V-trained adapter; Wan2.2 I2V uses channel-concat conditioning
+    instead). ``base_state_dict`` is not mutated.
+
+    Raises:
+        KeyError: a LoRA low-rank pair is missing one half (lora_A without
+            lora_B or vice versa).
+    """
+    LOW_RANK_SUFFIXES = {
+        ".lora_A.weight": "A",
+        ".lora_B.weight": "B",
+        ".lora_down.weight": "A",
+        ".lora_up.weight": "B",
+    }
+    pairs: dict[str, dict[str, torch.Tensor]] = {}
+    direct_deltas: list[tuple[str, str, torch.Tensor]] = []  # (base_path, suffix, tensor)
+    skipped_unknown: list[str] = []
+
+    alphas: dict[str, float] = {}
+
+    for raw_key, tensor in lora_state_dict.items():
+        key = _strip_diffusion_model_prefix(raw_key)
+        key = _kohya_to_lightx2v(key)
+        matched = False
+        for suffix, slot in LOW_RANK_SUFFIXES.items():
+            if key.endswith(suffix):
+                base_path = key[: -len(suffix)]
+                pairs.setdefault(base_path, {})[slot] = tensor
+                matched = True
+                break
+        if matched:
+            continue
+        if key.endswith(".diff_b"):
+            direct_deltas.append((key[: -len(".diff_b")], ".bias", tensor))
+        elif key.endswith(".diff"):
+            direct_deltas.append((key[: -len(".diff")], ".weight", tensor))
+        elif key.endswith(".alpha"):
+            base_path = key[: -len(".alpha")]
+            alphas[base_path] = tensor.item()
+        else:
+            skipped_unknown.append(raw_key)
+
+    if skipped_unknown:
+        logger.warning(
+            f"LoRA fusion: {len(skipped_unknown)} unrecognized key suffixes ignored (first: {skipped_unknown[0]})"
+        )
+
+    fused = dict(base_state_dict)
+    applied_pairs = 0
+    skipped_unmapped: list[str] = []
+
+    for base_path, ab in pairs.items():
+        if "A" not in ab or "B" not in ab:
+            raise KeyError(f"LoRA pair incomplete for '{base_path}': have {list(ab)}")
+        diffusers_key = _diffusers_target(base_path, ".weight")
+        if diffusers_key not in fused:
+            skipped_unmapped.append(diffusers_key)
+            continue
+        base_weight = fused[diffusers_key]
+        # Per-module alpha scaling: effective_scale = scale * (alpha / rank)
+        rank = ab["A"].shape[0]
+        alpha = alphas.get(base_path, float(rank))
+        effective_scale = scale * (alpha / rank)
+        delta = effective_scale * (ab["B"].to(torch.float32) @ ab["A"].to(torch.float32))
+        fused[diffusers_key] = (base_weight.to(torch.float32) + delta).to(base_weight.dtype)
+        applied_pairs += 1
+
+    applied_direct = 0
+    for base_path, suffix, tensor in direct_deltas:
+        diffusers_key = _diffusers_target(base_path, suffix)
+        if diffusers_key not in fused:
+            skipped_unmapped.append(diffusers_key)
+            continue
+        base = fused[diffusers_key]
+        if base.shape != tensor.shape:
+            logger.warning(
+                f"LoRA direct delta shape mismatch for '{diffusers_key}': base {tuple(base.shape)} vs delta {tuple(tensor.shape)}; skipping."
+            )
+            continue
+        fused[diffusers_key] = (base.to(torch.float32) + scale * tensor.to(torch.float32)).to(base.dtype)
+        applied_direct += 1
+
+    if skipped_unmapped:
+        sample = skipped_unmapped[:5]
+        logger.warning(
+            f"LoRA fusion: {len(skipped_unmapped)} adapter targets not present in base model; skipped. "
+            f"Examples: {sample}"
+        )
+
+    logger.info(f"Fused {applied_pairs} low-rank pairs and {applied_direct} direct deltas (scale={scale})")
+    return fused
+
+
+def _verify_fusion_changed_weights(
+    base_sd: dict[str, torch.Tensor],
+    fused_sd: dict[str, torch.Tensor],
+    *,
+    min_changed: int = 3,
+    label: str,
+) -> None:
+    """Sanity check: at least ``min_changed`` weights must differ post-fusion.
+
+    Logs the L2 norm of the diff for the first few changed tensors. Raises
+    ``RuntimeError`` if no weights changed at all -- the canonical "LoRA
+    silently failed to apply" failure mode.
+    """
+    changed: list[tuple[str, float]] = []
+    max_diff = 0.0
+    for k, base in base_sd.items():
+        fused = fused_sd.get(k)
+        if fused is None or fused.shape != base.shape:
+            continue
+        if fused.data_ptr() == base.data_ptr():
+            continue  # untouched (same tensor object)
+        diff = (fused.to(torch.float32) - base.to(torch.float32)).norm().item()
+        if diff > 0.0:
+            changed.append((k, diff))
+            max_diff = max(max_diff, diff)
+            if len(changed) >= min_changed:
+                # Keep scanning past min to surface the max accurately, but
+                # stop logging beyond a small sample.
+                pass
+
+    if max_diff == 0.0:
+        raise RuntimeError(
+            f"LoRA silently failed to apply -- weights are unchanged for '{label}'. "
+            f"Verified {len(base_sd)} keys against fused dict; max L2 diff is 0.0."
+        )
+
+    sample = changed[: max(min_changed, 5)]
+    logger.info(
+        f"LoRA fusion verified for '{label}': {len(changed)} tensors changed, "
+        f"max L2 diff={max_diff:.4f}. Sample diffs:"
+    )
+    for k, d in sample:
+        logger.info(f"  {k}: L2={d:.4f}")
+
+    if len(changed) < min_changed:
+        raise RuntimeError(
+            f"LoRA fusion changed only {len(changed)} weights for '{label}' (require >= {min_changed}). "
+            f"Likely indicates partial LoRA load."
+        )
+
+
+def _lora_cache_namespace(high_path: str, low_path: str | None, scale: float) -> str:
+    """Stable short hash so distinct (paths, scale) combos cache separately."""
+    h = hashlib.sha1()
+    h.update(str(Path(high_path).resolve()).encode())
+    h.update(b"\x00")
+    h.update(str(Path(low_path).resolve()).encode() if low_path else b"none")
+    h.update(b"\x00")
+    h.update(f"{scale:.6f}".encode())
+    return f"Wan2.2-I2V-LoRA-{h.hexdigest()[:12]}"
+
+
+class WanLoraPipelineI2V(WanPipelineI2V):
+    """Wan2.2 I2V with LoRA adapters fused into the base PyTorch weights.
+
+    Each expert transformer can get its own LoRA file, or a single LoRA
+    can be applied to the high-noise expert only. Inference parameters
+    (steps, CFG, boundary_ratio) are left to the caller.
+
+    Args:
+        lora_high_path: Path to ``.safetensors`` LoRA for the high-noise
+            expert (``transformer``). May also be passed via the
+            ``LORA_HIGH_PATH`` env var.
+        lora_low_path: Path to ``.safetensors`` LoRA for the low-noise
+            expert (``transformer_2``). May also be passed via
+            ``LORA_LOW_PATH``.
+        lora_scale: Scalar multiplier applied to the fused delta
+            ``W' = W + scale * B @ A``. Default 1.0.
+    """
+
+    def __init__(
+        self,
+        *args,
+        lora_high_path: str | None = None,
+        lora_low_path: str | None = None,
+        lora_scale: float = 1.0,
+        **kwargs,
+    ):
+        # Resolve LoRA paths/scale and (optional) boundary_ratio from env.
+        # NOTE: WanPipeline.create_pipeline drops unknown kwargs and hardcodes
+        # boundary_ratio=0.875, so the test funnels per-run overrides through
+        # env vars (LORA_HIGH_PATH/LORA_LOW_PATH/LORA_SCALE/BOUNDARY_RATIO).
+        lora_high_path = lora_high_path or os.environ.get("LORA_HIGH_PATH")
+        lora_low_path = lora_low_path or os.environ.get("LORA_LOW_PATH") or None
+        if "LORA_SCALE" in os.environ:
+            lora_scale = float(os.environ["LORA_SCALE"])
+        if "BOUNDARY_RATIO" in os.environ:
+            kwargs["boundary_ratio"] = float(os.environ["BOUNDARY_RATIO"])
+        if not lora_high_path:
+            raise ValueError(
+                "WanLoraPipelineI2V requires at least lora_high_path "
+                "(or LORA_HIGH_PATH env var). LORA_LOW_PATH is optional — "
+                "if omitted, the low-noise expert uses unmodified base weights."
+            )
+        for p, name in [(lora_high_path, "lora_high_path")] + (
+            [(lora_low_path, "lora_low_path")] if lora_low_path else []
+        ):
+            if not Path(p).is_file():
+                raise FileNotFoundError(f"{name}: file does not exist: {p}")
+
+        self._lora_paths = (lora_high_path, lora_low_path)
+        self._lora_scale = float(lora_scale)
+        self._cache_namespace = _lora_cache_namespace(lora_high_path, lora_low_path, self._lora_scale)
+        # Lazily-built fused state dicts keyed by transformer index. Cleared
+        # after handoff to TT cache to free CPU memory.
+        self._fused_state_dicts: dict[int, dict[str, torch.Tensor] | None] = {0: None, 1: None}
+
+        super().__init__(*args, **kwargs)
+
+    def prepare_text_conditioning(self, tt_model, prompt_embeds, buffer, traced=False):
+        # When guidance_scale=1.0, encode_prompt returns negative_prompt_embeds=None.
+        # The base loop still calls this for the negative buffer; forwarding None
+        # would hit NoneType in Linear. Safe to skip since combined_step
+        # short-circuits on do_classifier_free_guidance=False.
+        if prompt_embeds is None:
+            return buffer
+        return super().prepare_text_conditioning(tt_model, prompt_embeds, buffer, traced)
+
+    def _build_fused_state_dict(self, idx: int) -> dict[str, torch.Tensor] | None:
+        state = self.transformer_states[idx]
+        lora_path = self._lora_paths[idx]
+        if lora_path is None:
+            logger.info(f"No LoRA for expert idx={idx} ('{state.subfolder}') — using base weights")
+            return None
+        label = state.subfolder
+        logger.info(f"Loading LoRA for '{label}' from {lora_path}")
+        lora_sd = load_file(str(lora_path))
+        has_lora = any(
+            ("lora_A" in k)
+            or ("lora_B" in k)
+            or ("lora_down" in k)
+            or ("lora_up" in k)
+            or k.endswith(".diff")
+            or k.endswith(".diff_b")
+            or k.startswith("lora_unet_")
+            for k in lora_sd
+        )
+        if not has_lora:
+            raise RuntimeError(
+                f"No LoRA-style keys (lora_A/lora_B, lora_down/lora_up, diff/diff_b) found in {lora_path}"
+            )
+
+        base_sd = state.torch_model.state_dict()
+        fused_sd = fuse_lora_state_dict(base_sd, lora_sd, scale=self._lora_scale)
+        _verify_fusion_changed_weights(base_sd, fused_sd, label=label)
+        return fused_sd
+
+    def _prepare_transformer(self, idx: int):
+        state = self.transformer_states[idx]
+
+        if self._lora_paths[idx] is None:
+            # No LoRA for this expert — use the base class path (vanilla weights).
+            super()._prepare_transformer(idx)
+            return
+
+        def _get_state_dict(idx_=idx):
+            cached = self._fused_state_dicts.get(idx_)
+            if cached is not None:
+                return cached
+            sd = self._build_fused_state_dict(idx_)
+            self._fused_state_dicts[idx_] = sd
+            return sd
+
+        cache.load_model(
+            state.model,
+            model_name=self._cache_namespace,
+            subfolder=state.subfolder,
+            parallel_config=self.parallel_config,
+            mesh_shape=tuple(self.mesh_device.shape),
+            is_fsdp=self.is_fsdp,
+            get_torch_state_dict=_get_state_dict,
+        )
+        self._fused_state_dicts[idx] = None
+
+    @staticmethod
+    def create_pipeline(*args, **kwargs):
+        # Pass through the LoRA-specific kwargs to the constructor. Everything
+        # else (mesh, parallelism, height/width) flows through the base
+        # WanPipeline.create_pipeline which forwards to WanLoraPipelineI2V.
+        kwargs["checkpoint_name"] = kwargs.get("checkpoint_name") or "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
+        # WanPipeline.create_pipeline drops kwargs it doesn't recognize, so
+        # surface the LoRA settings via env vars that __init__ already reads.
+        if "lora_high_path" in kwargs:
+            os.environ["LORA_HIGH_PATH"] = kwargs.pop("lora_high_path")
+        if "lora_low_path" in kwargs:
+            val = kwargs.pop("lora_low_path")
+            if val is not None:
+                os.environ["LORA_LOW_PATH"] = val
+            else:
+                os.environ.pop("LORA_LOW_PATH", None)
+        if "lora_scale" in kwargs:
+            os.environ["LORA_SCALE"] = str(kwargs.pop("lora_scale"))
+        return WanPipeline.create_pipeline(*args, pipeline_class=WanLoraPipelineI2V, **kwargs)

--- a/models/tt_dit/pipelines/wan/pipeline_wan_lora.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan_lora.py
@@ -33,9 +33,14 @@ from ...utils.lightx2v_loader import wan_lightx2v_to_diffusers_key
 from .pipeline_wan import WanPipeline
 from .pipeline_wan_i2v import WanPipelineI2V
 
+_STRIP_PREFIXES = ("diffusion_model.", "transformer.", "unet.", "model.")
 
-def _strip_diffusion_model_prefix(key: str) -> str:
-    return key[len("diffusion_model.") :] if key.startswith("diffusion_model.") else key
+
+def _strip_known_prefixes(key: str) -> str:
+    for prefix in _STRIP_PREFIXES:
+        if key.startswith(prefix):
+            return key[len(prefix) :]
+    return key
 
 
 def _kohya_to_lightx2v(key: str) -> str:
@@ -68,11 +73,6 @@ def _kohya_to_lightx2v(key: str) -> str:
 
     logger.warning(f"Unrecognized kohya key structure: {key}")
     return key
-
-
-def _lora_base_path_to_diffusers_weight_key(lightx2v_base_path: str) -> str:
-    """``blocks.0.self_attn.q`` -> ``blocks.0.attn1.to_q.weight``."""
-    return wan_lightx2v_to_diffusers_key(f"{lightx2v_base_path}.weight")
 
 
 def _diffusers_target(lightx2v_base_path: str, suffix: str) -> str:
@@ -130,7 +130,7 @@ def fuse_lora_state_dict(
     alphas: dict[str, float] = {}
 
     for raw_key, tensor in lora_state_dict.items():
-        key = _strip_diffusion_model_prefix(raw_key)
+        key = _strip_known_prefixes(raw_key)
         key = _kohya_to_lightx2v(key)
         matched = False
         for suffix, slot in LOW_RANK_SUFFIXES.items():

--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_anisora.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_anisora.py
@@ -1,0 +1,235 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import itertools
+import os
+
+import numpy as np
+import PIL
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.tt_dit.pipelines.wan.pipeline_anisora import AniSoraPipeline
+from models.tt_dit.pipelines.wan.pipeline_wan_i2v import ImagePrompt
+
+from ....utils.test import ring_params
+
+
+@pytest.mark.parametrize(
+    "no_prompt",
+    [{"1": True, "0": False}.get(os.environ.get("NO_PROMPT"), False)],
+)
+@pytest.mark.parametrize(
+    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology, is_fsdp",
+    [
+        # BH Galaxy 4x8 Ring — sole supported config in the first AniSora PR.
+        [(4, 8), (4, 8), 1, 0, 2, False, ring_params, ttnn.Topology.Ring, False],
+    ],
+    ids=["bh_4x8sp1tp0_ring"],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize(
+    "width, height",
+    [
+        (832, 480),
+        (1280, 720),
+    ],
+    ids=[
+        "resolution_480p",
+        "resolution_720p",
+    ],
+)
+def test_pipeline_inference(
+    mesh_device,
+    mesh_shape,
+    sp_axis,
+    tp_axis,
+    num_links,
+    dynamic_load,
+    topology,
+    width,
+    height,
+    is_fsdp,
+    no_prompt,
+):
+    parent_mesh = mesh_device
+    mesh_device = parent_mesh.create_submesh(ttnn.MeshShape(*mesh_shape))
+
+    pil_image = PIL.Image.open(os.environ.get("PROMPT_IMAGE", "./prompt_image.png"))
+    image_prompt = [ImagePrompt(image=pil_image, frame_pos=0)]
+    negative_prompt = ""
+
+    # AniSora upstream defaults (anisoraV3.2/wan/configs/wan_i2v_A14B.py):
+    #   sample_steps=40, boundary=0.9, sample_guide_scale=(3.5, 3.5).
+    num_frames = 81
+    num_inference_steps = int(os.environ.get("NUM_STEPS", "40"))
+    guidance_scale = 3.5
+    guidance_scale_2 = 3.5
+
+    pipeline = AniSoraPipeline.create_pipeline(
+        mesh_device=mesh_device,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        num_links=num_links,
+        dynamic_load=dynamic_load,
+        topology=topology,
+        is_fsdp=is_fsdp,
+        height=height,
+        width=width,
+        num_frames=num_frames,
+    )
+
+    prompt = os.environ.get("PROMPT") or "An anime girl smiling, soft lighting, cinematic."
+
+    def run(*, prompt, number, seed):
+        logger.info(f"Running AniSora inference with prompt: '{prompt}'")
+        logger.info(f"Parameters: {height}x{width}, {num_frames} frames, {num_inference_steps} steps")
+
+        with torch.no_grad():
+            result = pipeline(
+                prompt=prompt,
+                image_prompt=image_prompt,
+                negative_prompt=negative_prompt,
+                height=height,
+                width=width,
+                num_frames=num_frames,
+                num_inference_steps=num_inference_steps,
+                seed=seed,
+                guidance_scale=guidance_scale,
+                guidance_scale_2=guidance_scale_2,
+                output_type="uint8",
+            )
+
+        if hasattr(result, "frames"):
+            frames = result.frames
+        else:
+            frames = result[0] if isinstance(result, tuple) else result
+
+        logger.info("AniSora inference completed successfully")
+        logger.info(f"  Output shape: {frames.shape if hasattr(frames, 'shape') else 'Unknown'}")
+        logger.info(f"  Output type: {type(frames)}")
+
+        if isinstance(frames, np.ndarray):
+            logger.info(f"  Video data range: [{frames.min():.3f}, {frames.max():.3f}]")
+        elif isinstance(frames, torch.Tensor):
+            logger.info(f"  Video data range: [{frames.min().item():.3f}, {frames.max().item():.3f}]")
+
+        frames = frames[0]
+        output_filename = f"wan_anisora_i2v_{width}x{height}_{number}.mp4"
+        try:
+            from models.tt_dit.utils.video import export_to_video
+
+            export_to_video(frames, output_filename, fps=16)
+            logger.info(f"Saved video to: {output_filename}")
+        except ImportError:
+            logger.info("Could not export video - imageio_ffmpeg not available")
+
+    if no_prompt:
+        run(prompt=prompt, number=0, seed=42)
+    else:
+        for i in itertools.count():
+            new_prompt = input("Enter the input prompt, or q to exit: ")
+            if new_prompt:
+                prompt = new_prompt
+            if prompt[0] == "q":
+                break
+            run(prompt=prompt, number=i, seed=i)
+
+
+# ---------------------------------------------------------------------------
+# Random-weight smoke test
+# ---------------------------------------------------------------------------
+# Runs the full pipeline end-to-end without downloading the AniSora safetensors
+# or the two ~28 GB transformer subfolders from Wan-AI. Tokenizer / UMT5 text
+# encoder / VAE / scheduler still come from Wan-AI/Wan2.2-I2V-A14B-Diffusers
+# (~12 GB total) and require TT_DIT_ALLOW_HF_DOWNLOAD=1 the first time.
+# Output frames are garbage by design — this only validates compile / mesh /
+# shape / CCL plumbing, not numeric quality. Uses 4 sampling steps to keep the
+# smoke test short; the 40-step real-weights config is exercised above.
+
+
+@pytest.mark.parametrize(
+    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology, is_fsdp",
+    [
+        [(4, 8), (4, 8), 1, 0, 2, False, ring_params, ttnn.Topology.Ring, False],
+    ],
+    ids=["bh_4x8sp1tp0_ring"],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize(
+    "width, height",
+    [
+        (832, 480),
+    ],
+    ids=["resolution_480p"],
+)
+def test_pipeline_inference_random_weights(
+    mesh_device,
+    mesh_shape,
+    sp_axis,
+    tp_axis,
+    num_links,
+    dynamic_load,
+    topology,
+    width,
+    height,
+    is_fsdp,
+):
+    parent_mesh = mesh_device
+    mesh_device = parent_mesh.create_submesh(ttnn.MeshShape(*mesh_shape))
+
+    pil_image = PIL.Image.open(os.environ.get("PROMPT_IMAGE", "./prompt_image.png"))
+    image_prompt = [ImagePrompt(image=pil_image, frame_pos=0)]
+
+    num_frames = 81
+    num_inference_steps = 4
+
+    pipeline = AniSoraPipeline.create_pipeline(
+        mesh_device=mesh_device,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        num_links=num_links,
+        dynamic_load=dynamic_load,
+        topology=topology,
+        is_fsdp=is_fsdp,
+        height=height,
+        width=width,
+        num_frames=num_frames,
+        random_weights=True,
+    )
+
+    prompt = "smoke test — random weights, output is meaningless"
+    logger.info(f"Random-weight smoke test: {height}x{width}, {num_frames} frames, {num_inference_steps} steps")
+
+    with torch.no_grad():
+        result = pipeline(
+            prompt=prompt,
+            image_prompt=image_prompt,
+            negative_prompt="",
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            num_inference_steps=num_inference_steps,
+            seed=42,
+            guidance_scale=3.5,
+            guidance_scale_2=3.5,
+            output_type="uint8",
+        )
+
+    if hasattr(result, "frames"):
+        frames = result.frames
+    else:
+        frames = result[0] if isinstance(result, tuple) else result
+
+    if isinstance(frames, np.ndarray):
+        rng_str = f"[{frames.min():.3f}, {frames.max():.3f}]"
+    elif isinstance(frames, torch.Tensor):
+        rng_str = f"[{frames.min().item():.3f}, {frames.max().item():.3f}]"
+    else:
+        rng_str = "n/a"
+
+    shape = frames.shape if hasattr(frames, "shape") else "Unknown"
+    logger.info(f"Random-weight smoke test PASSED. Output shape={shape}, range={rng_str}")

--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_lora.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_lora.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end test for Wan2.2 I2V with a LoRA adapter fused into the base.
+
+Reads ``LORA_HIGH_PATH`` (required) and ``LORA_LOW_PATH`` (optional) from the
+environment. All inference parameters (steps, guidance scale, boundary ratio)
+are configurable via env vars to support different LoRA types.
+"""
+from __future__ import annotations
+
+import itertools
+import os
+
+import numpy as np
+import PIL
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.tt_dit.pipelines.wan.pipeline_wan_i2v import ImagePrompt
+from models.tt_dit.pipelines.wan.pipeline_wan_lora import WanLoraPipelineI2V
+
+from ....utils.test import ring_params
+
+
+@pytest.mark.parametrize(
+    "no_prompt",
+    [{"1": True, "0": False}.get(os.environ.get("NO_PROMPT"), False)],
+)
+@pytest.mark.parametrize(
+    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology, is_fsdp",
+    [
+        # BH Galaxy 4x8 Ring -- canonical config for the LoRA bringup.
+        [(4, 8), (4, 8), 1, 0, 2, False, ring_params, ttnn.Topology.Ring, False],
+    ],
+    ids=["bh_4x8sp1tp0_ring"],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize(
+    "width, height",
+    [
+        (832, 480),
+        (1280, 720),
+    ],
+    ids=[
+        "resolution_480p",
+        "resolution_720p",
+    ],
+)
+def test_pipeline_inference(
+    mesh_device,
+    mesh_shape,
+    sp_axis,
+    tp_axis,
+    num_links,
+    dynamic_load,
+    topology,
+    width,
+    height,
+    is_fsdp,
+    no_prompt,
+):
+    if not os.environ.get("LORA_HIGH_PATH"):
+        pytest.skip("LORA_HIGH_PATH env var is required for this test (LORA_LOW_PATH is optional).")
+
+    parent_mesh = mesh_device
+    mesh_device = parent_mesh.create_submesh(ttnn.MeshShape(*mesh_shape))
+
+    pil_image = PIL.Image.open(os.environ.get("PROMPT_IMAGE", "./prompt_image.png"))
+    image_prompt = [ImagePrompt(image=pil_image, frame_pos=0)]
+    negative_prompt = ""
+
+    num_frames = 81
+    num_inference_steps = int(os.environ.get("NUM_STEPS", "40"))
+    guidance_scale = float(os.environ.get("GUIDANCE_SCALE", "3.5"))
+    guidance_scale_2 = float(os.environ.get("GUIDANCE_SCALE_2", str(guidance_scale)))
+    lora_scale = float(os.environ.get("LORA_SCALE", "1.0"))
+    os.environ.setdefault("BOUNDARY_RATIO", "0.875")
+
+    pipeline = WanLoraPipelineI2V.create_pipeline(
+        mesh_device=mesh_device,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        num_links=num_links,
+        dynamic_load=dynamic_load,
+        topology=topology,
+        is_fsdp=is_fsdp,
+        height=height,
+        width=width,
+        num_frames=num_frames,
+        lora_high_path=os.environ["LORA_HIGH_PATH"],
+        lora_low_path=os.environ.get("LORA_LOW_PATH"),
+        lora_scale=lora_scale,
+    )
+
+    prompt = os.environ.get("PROMPT") or "A golden retriever running on a sandy beach, waves in the background"
+
+    def run(*, prompt, number, seed):
+        logger.info(f"Running LoRA inference with prompt: '{prompt}'")
+        logger.info(
+            f"Parameters: {height}x{width}, {num_frames} frames, {num_inference_steps} steps, "
+            f"lora_scale={lora_scale}"
+        )
+
+        with torch.no_grad():
+            result = pipeline(
+                prompt=prompt,
+                image_prompt=image_prompt,
+                negative_prompt=negative_prompt,
+                height=height,
+                width=width,
+                num_frames=num_frames,
+                num_inference_steps=num_inference_steps,
+                seed=seed,
+                guidance_scale=guidance_scale,
+                guidance_scale_2=guidance_scale_2,
+                output_type="uint8",
+            )
+
+        if hasattr(result, "frames"):
+            frames = result.frames
+        else:
+            frames = result[0] if isinstance(result, tuple) else result
+
+        logger.info("LoRA inference completed successfully")
+        logger.info(f"  Output shape: {frames.shape if hasattr(frames, 'shape') else 'Unknown'}")
+        logger.info(f"  Output type: {type(frames)}")
+
+        if isinstance(frames, np.ndarray):
+            logger.info(f"  Video data range: [{frames.min():.3f}, {frames.max():.3f}]")
+        elif isinstance(frames, torch.Tensor):
+            logger.info(f"  Video data range: [{frames.min().item():.3f}, {frames.max().item():.3f}]")
+
+        frames = frames[0]
+        output_filename = f"wan_lora_i2v_{width}x{height}_{number}.mp4"
+        try:
+            from models.tt_dit.utils.video import export_to_video
+
+            export_to_video(frames, output_filename, fps=16)
+            logger.info(f"Saved video to: {output_filename}")
+        except ImportError:
+            logger.info("Could not export video - imageio_ffmpeg not available")
+
+    if no_prompt:
+        run(prompt=prompt, number=0, seed=42)
+    else:
+        for i in itertools.count():
+            new_prompt = input("Enter the input prompt, or q to exit: ")
+            if new_prompt:
+                prompt = new_prompt
+            if prompt[0] == "q":
+                break
+            run(prompt=prompt, number=i, seed=i)

--- a/models/tt_dit/utils/lightx2v_loader.py
+++ b/models/tt_dit/utils/lightx2v_loader.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Loader for lightx2v Wan2.2 distilled weights.
+
+The ``lightx2v/Wan2.2-Distill-Models`` HF repo ships flat ``.safetensors`` files
+containing only the DiT weights (no ``transformer/``, ``vae/``, ``text_encoder/``
+subfolders). The keys use the *original Wan* naming
+(``blocks.X.self_attn.q.weight``, ``blocks.X.modulation``, ``head.head.weight``,
+``time_embedding.0.weight``, ...), but tt_dit's ``WanTransformer3DModel``
+consumes the *diffusers* layout (``blocks.X.attn1.to_q.weight``,
+``blocks.X.scale_shift_table``, ``proj_out.weight``,
+``condition_embedder.time_embedder.linear_1.weight``, ...).
+
+:func:`load_lightx2v_state_dict` applies :func:`wan_lightx2v_to_diffusers_key`
+to every key by default so the returned dict matches what
+``WanTransformer3DModel._prepare_torch_state`` expects.
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Callable, Mapping
+
+import torch
+from loguru import logger
+from safetensors.torch import load_file
+
+# Per-block suffix renames: applied to the part after ``blocks.<i>.``.
+# Verified 1:1 (matching shapes) against
+# Wan-AI/Wan2.2-I2V-A14B-Diffusers/transformer for all 40 blocks.
+_BLOCK_SUFFIX_REMAP: dict[str, str] = {
+    # self-attention
+    "self_attn.q.weight": "attn1.to_q.weight",
+    "self_attn.q.bias": "attn1.to_q.bias",
+    "self_attn.k.weight": "attn1.to_k.weight",
+    "self_attn.k.bias": "attn1.to_k.bias",
+    "self_attn.v.weight": "attn1.to_v.weight",
+    "self_attn.v.bias": "attn1.to_v.bias",
+    "self_attn.o.weight": "attn1.to_out.0.weight",
+    "self_attn.o.bias": "attn1.to_out.0.bias",
+    "self_attn.norm_q.weight": "attn1.norm_q.weight",
+    "self_attn.norm_k.weight": "attn1.norm_k.weight",
+    # cross-attention
+    "cross_attn.q.weight": "attn2.to_q.weight",
+    "cross_attn.q.bias": "attn2.to_q.bias",
+    "cross_attn.k.weight": "attn2.to_k.weight",
+    "cross_attn.k.bias": "attn2.to_k.bias",
+    "cross_attn.v.weight": "attn2.to_v.weight",
+    "cross_attn.v.bias": "attn2.to_v.bias",
+    "cross_attn.o.weight": "attn2.to_out.0.weight",
+    "cross_attn.o.bias": "attn2.to_out.0.bias",
+    "cross_attn.norm_q.weight": "attn2.norm_q.weight",
+    "cross_attn.norm_k.weight": "attn2.norm_k.weight",
+    # feedforward (linear-gelu_approx-linear)
+    "ffn.0.weight": "ffn.net.0.proj.weight",
+    "ffn.0.bias": "ffn.net.0.proj.bias",
+    "ffn.2.weight": "ffn.net.2.weight",
+    "ffn.2.bias": "ffn.net.2.bias",
+    # cross-attn input norm
+    "norm3.weight": "norm2.weight",
+    "norm3.bias": "norm2.bias",
+    # per-block 6-way modulation table
+    "modulation": "scale_shift_table",
+}
+
+# Top-level renames. ``patch_embedding.{weight,bias}`` matches verbatim and is
+# omitted here so it passes through unchanged.
+_TOP_LEVEL_REMAP: dict[str, str] = {
+    "text_embedding.0.weight": "condition_embedder.text_embedder.linear_1.weight",
+    "text_embedding.0.bias": "condition_embedder.text_embedder.linear_1.bias",
+    "text_embedding.2.weight": "condition_embedder.text_embedder.linear_2.weight",
+    "text_embedding.2.bias": "condition_embedder.text_embedder.linear_2.bias",
+    "time_embedding.0.weight": "condition_embedder.time_embedder.linear_1.weight",
+    "time_embedding.0.bias": "condition_embedder.time_embedder.linear_1.bias",
+    "time_embedding.2.weight": "condition_embedder.time_embedder.linear_2.weight",
+    "time_embedding.2.bias": "condition_embedder.time_embedder.linear_2.bias",
+    "time_projection.1.weight": "condition_embedder.time_proj.weight",
+    "time_projection.1.bias": "condition_embedder.time_proj.bias",
+    "head.head.weight": "proj_out.weight",
+    "head.head.bias": "proj_out.bias",
+    "head.modulation": "scale_shift_table",
+}
+
+_BLOCK_RE = re.compile(r"^blocks\.(\d+)\.(.+)$")
+
+
+def wan_lightx2v_to_diffusers_key(key: str) -> str:
+    """Rename one lightx2v key to its diffusers-canonical equivalent.
+
+    Returns the key unchanged when no rename applies (e.g. ``patch_embedding.*``).
+    """
+    if (m := _BLOCK_RE.match(key)) is not None:
+        idx, suffix = m.group(1), m.group(2)
+        new_suffix = _BLOCK_SUFFIX_REMAP.get(suffix, suffix)
+        return f"blocks.{idx}.{new_suffix}"
+    return _TOP_LEVEL_REMAP.get(key, key)
+
+
+# Optional flat-dict overrides applied AFTER wan_lightx2v_to_diffusers_key.
+# Empty by default — populate or pass ``key_remap=`` to handle future variants
+# without modifying the canonical Wan rename above.
+KEY_REMAP: dict[str, str] = {}
+
+
+class WeightsNotFoundError(FileNotFoundError):
+    """Raised when a lightx2v weight file is not on disk and downloads are disabled."""
+
+
+def _hf_cache_root() -> Path:
+    return Path(os.environ.get("HF_HOME") or Path.home() / ".cache" / "huggingface")
+
+
+def _resolve_path(
+    repo_id: str,
+    filename: str,
+    *,
+    allow_download: bool,
+    local_dir: str | None,
+) -> Path:
+    if local_dir is not None:
+        candidate = Path(local_dir) / filename
+        if candidate.is_file():
+            return candidate
+
+    repo_cache = _hf_cache_root() / "hub" / f"models--{repo_id.replace('/', '--')}" / "snapshots"
+    if repo_cache.is_dir():
+        for snap in sorted(repo_cache.iterdir()):
+            cand = snap / filename
+            if cand.is_file():
+                return cand
+
+    if not allow_download:
+        raise WeightsNotFoundError(
+            f"lightx2v weights '{filename}' not found for repo '{repo_id}'.\n"
+            f"To download from HuggingFace, re-run with TT_DIT_ALLOW_HF_DOWNLOAD=1 "
+            f"or pass allow_download=True to the pipeline.\n"
+            f"Alternatively, place the file at: "
+            f"{local_dir or _hf_cache_root() / 'hub'}/{filename}"
+        )
+
+    from huggingface_hub import hf_hub_download
+
+    logger.info(f"Downloading lightx2v weights from HuggingFace: {repo_id}/{filename}")
+    return Path(hf_hub_download(repo_id=repo_id, filename=filename))
+
+
+def load_lightx2v_state_dict(
+    repo_id: str,
+    filename: str,
+    *,
+    allow_download: bool = False,
+    local_dir: str | None = None,
+    key_remap: Mapping[str, str] | None = None,
+    rename_fn: Callable[[str], str] | None = wan_lightx2v_to_diffusers_key,
+) -> dict[str, torch.Tensor]:
+    """Load a lightx2v safetensors file and return a torch state dict.
+
+    Args:
+        repo_id: HuggingFace repo, e.g. ``"lightx2v/Wan2.2-Distill-Models"``.
+        filename: File within the repo, e.g.
+            ``"wan2.2_i2v_A14b_high_noise_lightx2v_4step.safetensors"``.
+        allow_download: When ``False`` (default), the file must already exist
+            in ``local_dir`` or the HF cache. When ``True``, missing files are
+            fetched via ``huggingface_hub.hf_hub_download``.
+        local_dir: Optional directory to check before the HF cache.
+        rename_fn: Per-key rename function applied first. Defaults to the
+            Wan2.2 lightx2v→diffusers map. Pass ``None`` to skip.
+        key_remap: Flat-dict overrides applied after ``rename_fn`` (and
+            after ``KEY_REMAP``). Useful for one-off renames in tests.
+
+    Returns:
+        State dict with diffusers-canonical keys ready for
+        ``WanTransformer3DModel.load_torch_state_dict``.
+    """
+    path = _resolve_path(repo_id, filename, allow_download=allow_download, local_dir=local_dir)
+    logger.info(f"Loading lightx2v state dict from '{path}'")
+    state = load_file(str(path))
+
+    if rename_fn is not None:
+        state = {rename_fn(k): v for k, v in state.items()}
+
+    remap = dict(KEY_REMAP)
+    if key_remap:
+        remap.update(key_remap)
+    if remap:
+        state = {remap.get(k, k): v for k, v in state.items()}
+    return state

--- a/models/tt_dit/utils/lightx2v_loader.py
+++ b/models/tt_dit/utils/lightx2v_loader.py
@@ -127,7 +127,7 @@ def _resolve_path(
 
     repo_cache = _hf_cache_root() / "hub" / f"models--{repo_id.replace('/', '--')}" / "snapshots"
     if repo_cache.is_dir():
-        for snap in sorted(repo_cache.iterdir()):
+        for snap in sorted(repo_cache.iterdir(), reverse=True):
             cand = snap / filename
             if cand.is_file():
                 return cand


### PR DESCRIPTION
## Summary

- **Index-AniSora V3.2 I2V ** (`pipeline_anisora.py`): Anime-domain fine-tune of Wan2.2 I2V.  Configurable inference steps via `NUM_STEPS` env var (default 40).
- **LoRA adapter pipeline** (`pipeline_wan_lora.py`): Fuses community LoRA adapters into base Wan2.2 I2V weights on CPU before device push. Supports split (high/low noise pair) and single-file LoRAs, auto-detects diffusers and kohya/A1111 key formats, includes L2 norm verification to catch silent load failures.
- **Tested LoRAs**: Camera earth zoom-out and camera rotation from wangkanai/wan22-fp16-i2v-loras
- **Model cards**: `AniSora.md` `Wan2_2_LoRA.md` with weight download scripts and run instructions, perf numbers. 

### Dependencies
- `lightx2v_loader.py` and `pipeline_wan_distill.py` are utilized from `sdawle/wan2.2_distil` branch. These will resolve cleanly when this branch merges to main first. 

### Performance (BH Galaxy 4x8 Ring, 81 frames, 480p)
| Model | Steps | Total |
|---|---|---|
| Base Wan2.2 I2V | 40 | 54.52s |
| AniSora V3.2 I2V | 40 | 53.90s |
| AniSora V3.2 I2V | 16 | 25.0s |
| AniSora V3.2 I2V | 8 | 15.3s |

### Earth Zoomout LoRA  results : same dog image, same prompt. 
Original NO LoRA: 


https://github.com/user-attachments/assets/50e6421e-7227-4c9a-83b6-ead16d0c6078


With LoRA : 


https://github.com/user-attachments/assets/aca7dbcd-3102-4dab-851e-93e8d0f88111



### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tvardhineni/Wan2.2_Anisora_LoRA)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tvardhineni/Wan2.2_Anisora_LoRA)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tvardhineni/Wan2.2_Anisora_LoRA)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tvardhineni/Wan2.2_Anisora_LoRA)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=tvardhineni/Wan2.2_Anisora_LoRA)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:tvardhineni/Wan2.2_Anisora_LoRA)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tvardhineni/Wan2.2_Anisora_LoRA)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tvardhineni/Wan2.2_Anisora_LoRA)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tvardhineni/Wan2.2_Anisora_LoRA)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tvardhineni/Wan2.2_Anisora_LoRA)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tvardhineni/Wan2.2_Anisora_LoRA)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tvardhineni/Wan2.2_Anisora_LoRA)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tvardhineni/Wan2.2_Anisora_LoRA)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tvardhineni/Wan2.2_Anisora_LoRA)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tvardhineni/Wan2.2_Anisora_LoRA)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tvardhineni/Wan2.2_Anisora_LoRA)