### PR TITLE
[Bug fix] ttnn/device: fix DispatchCoreConfig silently ignoring WORKER/ROW enum values due to Python truthiness bug

### DIFF
--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -109,14 +109,16 @@ def get_default_dispatch_core_axis(fabric_tensix_config=None):
 
 class DispatchCoreConfig(ttnn._ttnn.device.DispatchCoreConfig):
     def __init__(self, type: DispatchCoreType = None, axis: DispatchCoreAxis = None, fabric_tensix_config=None):
-        # Validate user provided args
-        if type:
+        # Validate user provided args.
+        # NOTE: Use `is not None` (not truthiness) because DispatchCoreType.WORKER == 0
+        # and DispatchCoreAxis.ROW == 0, both of which are falsy in Python.
+        if type is not None:
             if not isinstance(type, DispatchCoreType):
                 valid_values = [e for e in DispatchCoreType.__members__.values()]
                 raise ValueError(f"Invalid dispatch core type: {type}. Valid values are: {valid_values}")
             if type == DispatchCoreType.ETH and axis == DispatchCoreAxis.COL:
                 raise ValueError("COL axis is not supported for ETH dispatch core type")
-        if axis:
+        if axis is not None:
             if not isinstance(axis, DispatchCoreAxis):
                 valid_values = [e for e in DispatchCoreAxis.__members__.values()]
                 raise ValueError(f"Invalid dispatch core axis: {axis}. Valid values are: {valid_values}")
@@ -124,16 +126,16 @@ class DispatchCoreConfig(ttnn._ttnn.device.DispatchCoreConfig):
                 raise ValueError(
                     "ROW dispatch core axis is not supported for blackhole arch unless fabric tensix MUX is enabled"
                 )
-        if type and axis:
+        if type is not None and axis is not None:
             # User provided both valid type and axis, check if they are compatible
             self.type = type
             self.axis = axis
-        elif type:
+        elif type is not None:
             # User provided only valid type
             self.type = type
             self.axis = get_default_dispatch_core_axis(fabric_tensix_config)
             logger.debug(f"Using default dispatch core axis for this system: {self.axis}")
-        elif axis:
+        elif axis is not None:
             self.axis = axis
             # User provided only valid axis
             if self.axis == DispatchCoreAxis.COL:


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`DispatchCoreConfig.__init__` in `ttnn/ttnn/device.py` uses Python truthiness
checks (`if type:`, `if axis:`) to detect whether callers supplied those
arguments. However, in C++ both zero-indexed enums evaluate to **0** for
their first member:

```cpp
// tt_metal/api/tt-metalium/dispatch_core_common.hpp
enum class DispatchCoreType : uint32_t { WORKER, ETH, COUNT };  // WORKER == 0
enum class DispatchCoreAxis               { ROW,   COL, COUNT }; // ROW    == 0
```

When nanobind/pybind11 exposes these to Python, `DispatchCoreType.WORKER`
and `DispatchCoreAxis.ROW` are **falsy** (`bool(x) == False`). Every
truthiness gate in `__init__` therefore silently treats them as "not
provided," falling through to the system-default detection path instead of
honouring the caller's explicit choice.

**Concrete impact:**
- `DispatchCoreConfig(type=DispatchCoreType.WORKER)` on an N300/T3K cluster
  silently resolves to `ETH` dispatch (the cluster default), ignoring the
  explicit `WORKER` request.
- `DispatchCoreConfig(axis=DispatchCoreAxis.ROW)` silently resolves to the
  system default axis.
- `conftest.py:618` passes `dispatch_core_type=ttnn.device.DispatchCoreType.WORKER`
  explicitly — that value is silently dropped on clusters whose default is ETH.

**Fix:** replace all five truthiness guards with `is not None` checks,
which is the correct Python sentinel idiom and correctly distinguishes
"caller passed `WORKER` (value=0)" from "caller passed nothing (value=None)".
No change in behaviour for `ETH` (value=1) or `COL` (value=1), which were
already handled correctly.

### Notes for reviewers
- The change is confined to exactly five predicate expressions in a single
  `__init__` method; no logic reordering, no new imports, no API surface change.
- `ETH`/`COL` paths are unaffected (both have integer value 1, always truthy).
- A trivial unit test that constructs
  `DispatchCoreConfig(type=DispatchCoreType.WORKER)` and asserts
  `config.type == DispatchCoreType.WORKER` would permanently guard this class
  against regression — worth adding in a follow-up if the team has a home for
  Python-level device config tests.