### PR TITLE
Feature: Persist H2D/D2H Socket Connector state in SHM across Processes

### DIFF
--- a/tests/tt_metal/distributed/test_multiproc_loopback.cpp
+++ b/tests/tt_metal/distributed/test_multiproc_loopback.cpp
@@ -10,12 +10,19 @@
 // Run with: mpirun -np 2 ./multiproc_loopback_test
 //
 
+#include <algorithm>
+#include <cerrno>
 #include <cstdint>
+#include <cstring>
 #include <iostream>
 #include <numeric>
 #include <string>
 #include <thread>
 #include <vector>
+
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include "gtest/gtest.h"
 #include <tt-metalium/distributed.hpp>
@@ -51,10 +58,15 @@ constexpr LoopbackConfig loopback_configs[] = {
 
 const MeshCoreCoord SOCKET_CORE = {MeshCoordinate(0, 0), CoreCoord(0, 0)};
 
-void run_launcher(const std::shared_ptr<MeshDevice>& mesh_device, H2DMode h2d_mode, const LoopbackConfig& cfg) {
+void run_launcher(
+    const std::shared_ptr<MeshDevice>& mesh_device,
+    H2DMode h2d_mode,
+    const LoopbackConfig& cfg,
+    uint32_t num_iterations,
+    const std::string& socket_id_suffix) {
     const auto& socket_core = SOCKET_CORE;
-    std::string h2d_socket_id = fmt::format("test_h2d_xproc_{}", test_counter);
-    std::string d2h_socket_id = fmt::format("test_d2h_xproc_{}", test_counter);
+    std::string h2d_socket_id = fmt::format("test_h2d_xproc_{}", socket_id_suffix);
+    std::string d2h_socket_id = fmt::format("test_d2h_xproc_{}", socket_id_suffix);
 
     auto h2d_socket = H2DSocket(mesh_device, socket_core, BufferType::L1, cfg.fifo_size, h2d_mode);
     h2d_socket.export_descriptor(h2d_socket_id);
@@ -75,7 +87,7 @@ void run_launcher(const std::shared_ptr<MeshDevice>& mesh_device, H2DMode h2d_mo
                 static_cast<uint32_t>(d2h_socket.get_config_buffer_address()),
                 static_cast<uint32_t>(cfg.page_size),
                 static_cast<uint32_t>(cfg.data_size),
-                static_cast<uint32_t>(NUM_ITERATIONS),
+                num_iterations,
                 static_cast<uint32_t>(h2d_mode == H2DMode::DEVICE_PULL),
             }});
 
@@ -83,6 +95,47 @@ void run_launcher(const std::shared_ptr<MeshDevice>& mesh_device, H2DMode h2d_mo
     mesh_workload.add_program(MeshCoordinateRange(socket_core.device_coord), std::move(program));
     EnqueueMeshWorkload(mesh_device->mesh_command_queue(), mesh_workload, false);
     Finish(mesh_device->mesh_command_queue());
+}
+
+void run_launcher(const std::shared_ptr<MeshDevice>& mesh_device, H2DMode h2d_mode, const LoopbackConfig& cfg) {
+    run_launcher(mesh_device, h2d_mode, cfg, NUM_ITERATIONS, fmt::to_string(test_counter));
+}
+
+// Drive a contiguous range of iterations [start_iter, end_iter) against an
+// already-attached pair of sockets. Takes raw pointers so it can be used both
+// with std::vector buffers (pass .data()) and with mmap-shared buffers in the
+// crash-safe test. Does NOT call barrier() — the caller decides whether to
+// synchronize (e.g. the crash-safe child intentionally skips the barriers).
+void drive_iter_range(
+    H2DSocket& h2d_socket,
+    D2HSocket& d2h_socket,
+    const uint32_t* src,
+    uint32_t* dst,
+    const LoopbackConfig& cfg,
+    uint32_t start_iter,
+    uint32_t end_iter) {
+    uint32_t page_size_words = cfg.page_size / sizeof(uint32_t);
+    uint32_t data_size_words = cfg.data_size / sizeof(uint32_t);
+    uint32_t num_txns = cfg.data_size / cfg.page_size;
+
+    std::thread write_thread([&]() {
+        for (uint32_t i = start_iter; i < end_iter; i++) {
+            for (uint32_t j = 0; j < num_txns; j++) {
+                h2d_socket.write(const_cast<uint32_t*>(src) + (i * data_size_words) + (j * page_size_words), 1);
+            }
+        }
+    });
+
+    std::thread read_thread([&]() {
+        for (uint32_t i = start_iter; i < end_iter; i++) {
+            for (uint32_t j = 0; j < num_txns; j++) {
+                d2h_socket.read(dst + (i * data_size_words) + (j * page_size_words), 1);
+            }
+        }
+    });
+
+    write_thread.join();
+    read_thread.join();
 }
 
 void run_connector(const LoopbackConfig& cfg) {
@@ -95,38 +148,139 @@ void run_connector(const LoopbackConfig& cfg) {
     h2d_socket->set_page_size(cfg.page_size);
     d2h_socket->set_page_size(cfg.page_size);
 
-    uint32_t page_size_words = cfg.page_size / sizeof(uint32_t);
     uint32_t data_size_words = cfg.data_size / sizeof(uint32_t);
-    uint32_t num_txns = cfg.data_size / cfg.page_size;
-
     std::vector<uint32_t> src_vec(data_size_words * NUM_ITERATIONS);
     std::vector<uint32_t> dst_vec(data_size_words * NUM_ITERATIONS, 0);
     std::iota(src_vec.begin(), src_vec.end(), 0);
 
-    std::thread write_thread([&]() {
-        for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
-            for (uint32_t j = 0; j < num_txns; j++) {
-                h2d_socket->write(src_vec.data() + (i * data_size_words) + (j * page_size_words), 1);
-            }
-        }
-    });
-
-    std::thread read_thread([&]() {
-        for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
-            for (uint32_t j = 0; j < num_txns; j++) {
-                d2h_socket->read(dst_vec.data() + (i * data_size_words) + (j * page_size_words), 1);
-            }
-        }
-    });
-
-    write_thread.join();
-    read_thread.join();
-
+    drive_iter_range(*h2d_socket, *d2h_socket, src_vec.data(), dst_vec.data(), cfg, 0, NUM_ITERATIONS);
     h2d_socket->barrier();
     d2h_socket->barrier();
 
     EXPECT_EQ(src_vec, dst_vec) << "Loopback verification FAILED (fifo=" << cfg.fifo_size << " page=" << cfg.page_size
                                 << " data=" << cfg.data_size << ")";
+}
+
+// Drive consecutive H2D/D2H socket attach/detach cycles against a single
+// launcher kernel. Connector k handles iters_per_connector[k] iterations and
+// then destructs (close SHM, no unlink). The next connector calls
+// H2DSocket::connect / D2HSocket::connect anew and must pick up the prior
+// connector's state (bytes_sent / bytes_acked / write_ptr / read_ptr /
+// page_size) from SHM. Verifies the connector-state persistence path.
+void run_sequential_connectors(
+    const LoopbackConfig& cfg, const std::vector<uint32_t>& iters_per_connector, const std::string& socket_id_suffix) {
+    std::string h2d_socket_id = fmt::format("test_h2d_xproc_{}", socket_id_suffix);
+    std::string d2h_socket_id = fmt::format("test_d2h_xproc_{}", socket_id_suffix);
+
+    const uint32_t total_iters = std::accumulate(iters_per_connector.begin(), iters_per_connector.end(), 0u);
+    const uint32_t data_size_words = cfg.data_size / sizeof(uint32_t);
+
+    std::vector<uint32_t> src_vec(data_size_words * total_iters);
+    std::vector<uint32_t> dst_vec(data_size_words * total_iters, 0);
+    std::iota(src_vec.begin(), src_vec.end(), 0);
+
+    uint32_t start = 0;
+    for (uint32_t iters : iters_per_connector) {
+        auto h2d_socket = H2DSocket::connect(h2d_socket_id, 30000);
+        auto d2h_socket = D2HSocket::connect(d2h_socket_id, 30000);
+
+        // set_page_size is idempotent and exercises the page_size_/fifo_curr_size_
+        // flush path on every attach.
+        h2d_socket->set_page_size(cfg.page_size);
+        d2h_socket->set_page_size(cfg.page_size);
+
+        uint32_t end = start + iters;
+        drive_iter_range(*h2d_socket, *d2h_socket, src_vec.data(), dst_vec.data(), cfg, start, end);
+        h2d_socket->barrier();
+        d2h_socket->barrier();
+        // h2d_socket / d2h_socket destroyed here: SHM is unmapped (not unlinked).
+        // Persistent state is left behind in the SHM region for the next connector
+        // iteration.
+        start = end;
+    }
+
+    EXPECT_EQ(src_vec, dst_vec) << "Sequential connector loopback FAILED (fifo=" << cfg.fifo_size
+                                << " page=" << cfg.page_size << " data=" << cfg.data_size
+                                << " num_connectors=" << iters_per_connector.size() << ")";
+}
+
+void run_sequential_connectors(
+    const LoopbackConfig& cfg,
+    uint32_t num_connectors,
+    uint32_t iters_per_connector,
+    const std::string& socket_id_suffix) {
+    run_sequential_connectors(cfg, std::vector<uint32_t>(num_connectors, iters_per_connector), socket_id_suffix);
+}
+
+// Verify that the per-op flush in push_bytes / pop_bytes / set_page_size leaves
+// SHM connector-state in a consistent shape even when the driving process is
+// killed without running destructors or barriers. A fork()'d child drives
+// `child_iters` iterations and then _exit(0)s — no h2d.barrier(), no D2H
+// barrier, no socket destruction. The parent then attaches a fresh connector
+// and drives the remaining iterations to completion. Without per-op flushing,
+// the parent would see all-zero connector state and desync from the device.
+void run_crash_safe_connector(
+    const LoopbackConfig& cfg, uint32_t total_iters, uint32_t child_iters, const std::string& socket_id_suffix) {
+    ASSERT_LT(child_iters, total_iters);
+
+    std::string h2d_socket_id = fmt::format("test_h2d_xproc_{}", socket_id_suffix);
+    std::string d2h_socket_id = fmt::format("test_d2h_xproc_{}", socket_id_suffix);
+
+    const uint32_t data_size_words = cfg.data_size / sizeof(uint32_t);
+    const size_t total_words = static_cast<size_t>(data_size_words) * total_iters;
+    const size_t total_bytes = total_words * sizeof(uint32_t);
+
+    // mmap with MAP_SHARED | MAP_ANONYMOUS so child writes to dst_vec are
+    // visible to the parent post-_exit. Layout: [src_vec][dst_vec].
+    void* shared = mmap(nullptr, 2 * total_bytes, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(shared, MAP_FAILED) << "mmap failed: " << std::strerror(errno);
+    auto* src_vec = static_cast<uint32_t*>(shared);
+    auto* dst_vec = src_vec + total_words;
+    std::iota(src_vec, src_vec + total_words, 0u);
+    std::memset(dst_vec, 0, total_bytes);
+
+    pid_t pid = fork();
+    ASSERT_NE(pid, -1) << "fork failed: " << std::strerror(errno);
+
+    if (pid == 0) {
+        // Child: attach, drive child_iters of loopback, then _exit(0) WITHOUT
+        // running destructors or barriers. Per-op SHM flushes are the only
+        // mechanism leaving consistent state behind.
+        auto h2d_socket = H2DSocket::connect(h2d_socket_id, 30000);
+        auto d2h_socket = D2HSocket::connect(d2h_socket_id, 30000);
+        h2d_socket->set_page_size(cfg.page_size);
+        d2h_socket->set_page_size(cfg.page_size);
+        drive_iter_range(*h2d_socket, *d2h_socket, src_vec, dst_vec, cfg, 0, child_iters);
+        _exit(0);
+    }
+
+    int status = 0;
+    ASSERT_EQ(waitpid(pid, &status, 0), pid);
+    ASSERT_TRUE(WIFEXITED(status)) << "Child did not exit cleanly (signal "
+                                   << (WIFSIGNALED(status) ? WTERMSIG(status) : -1) << ")";
+    ASSERT_EQ(WEXITSTATUS(status), 0);
+
+    {
+        auto h2d_socket = H2DSocket::connect(h2d_socket_id, 30000);
+        auto d2h_socket = D2HSocket::connect(d2h_socket_id, 30000);
+
+        // The parent intentionally does NOT call set_page_size — it must be
+        // inherited from the child's flushed SHM state, alongside the byte and
+        // pointer counters.
+        EXPECT_EQ(h2d_socket->get_page_size(), cfg.page_size) << "page_size not inherited from crashed child connector";
+        EXPECT_EQ(d2h_socket->get_page_size(), cfg.page_size) << "page_size not inherited from crashed child connector";
+
+        drive_iter_range(*h2d_socket, *d2h_socket, src_vec, dst_vec, cfg, child_iters, total_iters);
+        h2d_socket->barrier();
+        d2h_socket->barrier();
+    }
+
+    bool ok = std::equal(src_vec, src_vec + total_words, dst_vec);
+    EXPECT_TRUE(ok) << "Crash-safe loopback verification FAILED (fifo=" << cfg.fifo_size << " page=" << cfg.page_size
+                    << " data=" << cfg.data_size << " child_iters=" << child_iters << " total_iters=" << total_iters
+                    << ")";
+
+    ASSERT_EQ(munmap(shared, 2 * total_bytes), 0);
 }
 
 class MultiProcLoopbackFixture : public MeshDeviceFixtureBase {
@@ -166,6 +320,222 @@ TEST_F(MultiProcLoopbackFixture, CrossProcessLoopback) {
             }
             test_counter++;
         }
+    }
+}
+
+// Verify connector-state persistence across sequential connector attach/detach
+// cycles. The launcher kernel runs once for total_iters; rank 1 drives that
+// kernel from `num_connectors` consecutive H2DSocket/D2HSocket instances.
+// Without state persistence, the second connector's counters would reset to
+// zero, desyncing it from the device-resident pointers and hanging.
+TEST_F(MultiProcLoopbackFixture, BackToBackConnectorPersistence) {
+    if (rank_ == 0) {
+        if (!experimental::GetMemoryPinningParameters(*mesh_device_).can_map_to_noc) {
+            GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        }
+    }
+
+    // Uneven-wrap config is the most stressing for connector handoff: the FIFO
+    // pointer is at an arbitrary offset when the prior connector destructs.
+    const LoopbackConfig cfg = {4096, 1088, 78336};
+    constexpr uint32_t NUM_CONNECTORS = 8;
+    constexpr uint32_t ITERS_PER_CONNECTOR = 200;
+    constexpr uint32_t TOTAL_ITERS = NUM_CONNECTORS * ITERS_PER_CONNECTOR;
+
+    for (auto h2d_mode : {H2DMode::HOST_PUSH, H2DMode::DEVICE_PULL}) {
+        std::string suffix = fmt::format("seq_{}", test_counter);
+        if (rank_ == 0) {
+            run_launcher(mesh_device_, h2d_mode, cfg, TOTAL_ITERS, suffix);
+        } else {
+            run_sequential_connectors(cfg, NUM_CONNECTORS, ITERS_PER_CONNECTOR, suffix);
+        }
+        test_counter++;
+    }
+}
+
+// Verify that the per-op SHM flushes in push_bytes / pop_bytes / set_page_size
+// are sufficient to recover when a driver process dies without running
+// destructors. rank 1 fork()s a child that drives part of the kernel's
+// iterations and _exit(0)s; the parent then attaches a fresh connector and
+// completes the remaining iterations using only the state the child flushed
+// per-op.
+TEST_F(MultiProcLoopbackFixture, CrashSafeConnectorPersistence) {
+    if (rank_ == 0) {
+        if (!experimental::GetMemoryPinningParameters(*mesh_device_).can_map_to_noc) {
+            GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        }
+    }
+
+    const LoopbackConfig cfg = {4096, 1088, 78336};
+    constexpr uint32_t CHILD_ITERS = 100;
+    constexpr uint32_t TOTAL_ITERS = 200;
+
+    for (auto h2d_mode : {H2DMode::HOST_PUSH, H2DMode::DEVICE_PULL}) {
+        std::string suffix = fmt::format("crash_{}", test_counter);
+        if (rank_ == 0) {
+            run_launcher(mesh_device_, h2d_mode, cfg, TOTAL_ITERS, suffix);
+        } else {
+            run_crash_safe_connector(cfg, TOTAL_ITERS, CHILD_ITERS, suffix);
+        }
+        test_counter++;
+    }
+}
+
+// Connector handoff at non-uniform iteration boundaries. The connector handoff
+// happens at arbitrary FIFO offsets (not iter-aligned multiples), confirming
+// the persisted write_ptr / read_ptr / bytes_sent / bytes_acked are sufficient
+// regardless of where the previous connector stopped.
+TEST_F(MultiProcLoopbackFixture, UnevenIterDistribution) {
+    if (rank_ == 0) {
+        if (!experimental::GetMemoryPinningParameters(*mesh_device_).can_map_to_noc) {
+            GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        }
+    }
+
+    const LoopbackConfig cfg = {4096, 1088, 78336};
+    const std::vector<uint32_t> iters_per_connector = {1, 47, 391, 161};  // 600 total
+    const uint32_t total_iters = std::accumulate(iters_per_connector.begin(), iters_per_connector.end(), 0u);
+
+    for (auto h2d_mode : {H2DMode::HOST_PUSH, H2DMode::DEVICE_PULL}) {
+        std::string suffix = fmt::format("uneven_{}", test_counter);
+        if (rank_ == 0) {
+            run_launcher(mesh_device_, h2d_mode, cfg, total_iters, suffix);
+        } else {
+            run_sequential_connectors(cfg, iters_per_connector, suffix);
+        }
+        test_counter++;
+    }
+}
+
+// True multi-process connector reuse: rank 1 fork()s `num_connectors` children
+// sequentially, each one a complete attach → drive → clean-destruct → exit
+// cycle in its OWN OS process. Each child has its own PID, address space, fd
+// table, and PCIeCoreWriter cluster cache — matching the production scenario
+// the persistent state was added to support ("process 1 drives the socket and
+// exits, process 2 launches and connects").
+//
+// Only the first child calls set_page_size, exercising the cross-process
+// page_size_/fifo_curr_size_ inheritance in addition to the counter/pointer
+// inheritance.
+void run_multi_process_connectors(
+    const LoopbackConfig& cfg,
+    uint32_t num_connectors,
+    uint32_t iters_per_connector,
+    const std::string& socket_id_suffix) {
+    std::string h2d_socket_id = fmt::format("test_h2d_xproc_{}", socket_id_suffix);
+    std::string d2h_socket_id = fmt::format("test_d2h_xproc_{}", socket_id_suffix);
+
+    const uint32_t total_iters = num_connectors * iters_per_connector;
+    const uint32_t data_size_words = cfg.data_size / sizeof(uint32_t);
+    const size_t total_words = static_cast<size_t>(data_size_words) * total_iters;
+    const size_t total_bytes = total_words * sizeof(uint32_t);
+
+    // mmap with MAP_SHARED | MAP_ANONYMOUS so each child's writes to dst_vec
+    // are visible to the parent for verification. Layout: [src_vec][dst_vec].
+    void* shared = mmap(nullptr, 2 * total_bytes, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(shared, MAP_FAILED) << "mmap failed: " << std::strerror(errno);
+    auto* src_vec = static_cast<uint32_t*>(shared);
+    auto* dst_vec = src_vec + total_words;
+    std::iota(src_vec, src_vec + total_words, 0u);
+    std::memset(dst_vec, 0, total_bytes);
+
+    for (uint32_t k = 0; k < num_connectors; ++k) {
+        pid_t pid = fork();
+        ASSERT_NE(pid, -1) << "fork failed: " << std::strerror(errno);
+
+        if (pid == 0) {
+            // Child scope: socket destructors run on scope exit, then _exit(0)
+            // skips global teardown (atexit handlers, MPI dtors) that belongs
+            // to the parent.
+            {
+                auto h2d_socket = H2DSocket::connect(h2d_socket_id, 30000);
+                auto d2h_socket = D2HSocket::connect(d2h_socket_id, 30000);
+
+                if (k == 0) {
+                    h2d_socket->set_page_size(cfg.page_size);
+                    d2h_socket->set_page_size(cfg.page_size);
+                } else {
+                    // Subsequent children inherit page_size from prior child via SHM.
+                    if (h2d_socket->get_page_size() != cfg.page_size || d2h_socket->get_page_size() != cfg.page_size) {
+                        _exit(2);  // signal inheritance failure to the parent
+                    }
+                }
+
+                uint32_t start = k * iters_per_connector;
+                uint32_t end = start + iters_per_connector;
+                drive_iter_range(*h2d_socket, *d2h_socket, src_vec, dst_vec, cfg, start, end);
+                h2d_socket->barrier();
+                d2h_socket->barrier();
+            }
+            _exit(0);
+        }
+
+        int status = 0;
+        ASSERT_EQ(waitpid(pid, &status, 0), pid);
+        ASSERT_TRUE(WIFEXITED(status)) << "Connector child " << k << " did not exit cleanly (signal "
+                                       << (WIFSIGNALED(status) ? WTERMSIG(status) : -1) << ")";
+        ASSERT_EQ(WEXITSTATUS(status), 0) << "Connector child " << k << " exited with status " << WEXITSTATUS(status)
+                                          << (WEXITSTATUS(status) == 2 ? " (page_size inheritance failed)" : "");
+    }
+
+    bool ok = std::equal(src_vec, src_vec + total_words, dst_vec);
+    EXPECT_TRUE(ok) << "Multi-process connector reuse FAILED (fifo=" << cfg.fifo_size << " page=" << cfg.page_size
+                    << " data=" << cfg.data_size << " num_connectors=" << num_connectors << ")";
+
+    ASSERT_EQ(munmap(shared, 2 * total_bytes), 0);
+}
+
+// Stress repeated attach/detach to catch accumulated drift or per-attach
+// leakage. Uses many short-lived connectors over the same launcher kernel.
+TEST_F(MultiProcLoopbackFixture, ManyShortConnectors) {
+    if (rank_ == 0) {
+        if (!experimental::GetMemoryPinningParameters(*mesh_device_).can_map_to_noc) {
+            GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        }
+    }
+
+    const LoopbackConfig cfg = {4096, 1088, 78336};
+    constexpr uint32_t NUM_CONNECTORS = 30;
+    constexpr uint32_t ITERS_PER_CONNECTOR = 10;
+    constexpr uint32_t TOTAL_ITERS = NUM_CONNECTORS * ITERS_PER_CONNECTOR;
+
+    for (auto h2d_mode : {H2DMode::HOST_PUSH, H2DMode::DEVICE_PULL}) {
+        std::string suffix = fmt::format("many_{}", test_counter);
+        if (rank_ == 0) {
+            run_launcher(mesh_device_, h2d_mode, cfg, TOTAL_ITERS, suffix);
+        } else {
+            run_sequential_connectors(cfg, NUM_CONNECTORS, ITERS_PER_CONNECTOR, suffix);
+        }
+        test_counter++;
+    }
+}
+
+// End-to-end test that connectors are truly cross-process reusable: rank 1
+// fork()s NUM_CONNECTORS distinct children sequentially against a single
+// launcher kernel. Each child is a fresh OS process with its own PID, fd
+// table, and PCIeCoreWriter cluster cache. This mirrors the production
+// scenario the persistent state mechanism was added for ("process 1 drives
+// the socket, exits, process 2 launches and connects, etc.").
+TEST_F(MultiProcLoopbackFixture, MultiProcessConnectorReuse) {
+    if (rank_ == 0) {
+        if (!experimental::GetMemoryPinningParameters(*mesh_device_).can_map_to_noc) {
+            GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        }
+    }
+
+    const LoopbackConfig cfg = {4096, 1088, 78336};
+    constexpr uint32_t NUM_CONNECTORS = 4;
+    constexpr uint32_t ITERS_PER_CONNECTOR = 50;
+    constexpr uint32_t TOTAL_ITERS = NUM_CONNECTORS * ITERS_PER_CONNECTOR;
+
+    for (auto h2d_mode : {H2DMode::HOST_PUSH, H2DMode::DEVICE_PULL}) {
+        std::string suffix = fmt::format("mpr_{}", test_counter);
+        if (rank_ == 0) {
+            run_launcher(mesh_device_, h2d_mode, cfg, TOTAL_ITERS, suffix);
+        } else {
+            run_multi_process_connectors(cfg, NUM_CONNECTORS, ITERS_PER_CONNECTOR, suffix);
+        }
+        test_counter++;
     }
 }
 

--- a/tests/tt_metal/distributed/test_multiproc_loopback.cpp
+++ b/tests/tt_metal/distributed/test_multiproc_loopback.cpp
@@ -184,6 +184,14 @@ void run_sequential_connectors(
         auto h2d_socket = H2DSocket::connect(h2d_socket_id, 30000);
         auto d2h_socket = D2HSocket::connect(d2h_socket_id, 30000);
 
+        // Every prior connector destructed cleanly (owner stamps clean_shutdown=1
+        // on construct; each iteration's destructor reasserts it), so each
+        // attach here must observe clean_shutdown == 1.
+        EXPECT_TRUE(h2d_socket->had_clean_prior_shutdown())
+            << "H2D connector saw unclean prior shutdown after clean destructor";
+        EXPECT_TRUE(d2h_socket->had_clean_prior_shutdown())
+            << "D2H connector saw unclean prior shutdown after clean destructor";
+
         // set_page_size is idempotent and exercises the page_size_/fifo_curr_size_
         // flush path on every attach.
         h2d_socket->set_page_size(cfg.page_size);
@@ -263,6 +271,14 @@ void run_crash_safe_connector(
     {
         auto h2d_socket = H2DSocket::connect(h2d_socket_id, 30000);
         auto d2h_socket = D2HSocket::connect(d2h_socket_id, 30000);
+
+        // Child _exit()'d without running destructors, so the SHM clean_shutdown
+        // flag must still be 0 here — the resumed connectors should report the
+        // prior shutdown as unclean.
+        EXPECT_FALSE(h2d_socket->had_clean_prior_shutdown())
+            << "H2D connector failed to detect crashed child's unclean shutdown";
+        EXPECT_FALSE(d2h_socket->had_clean_prior_shutdown())
+            << "D2H connector failed to detect crashed child's unclean shutdown";
 
         // The parent intentionally does NOT call set_page_size — it must be
         // inherited from the child's flushed SHM state, alongside the byte and

--- a/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
@@ -260,6 +260,17 @@ public:
 
     MeshDevice* get_mesh_device() const;
 
+    /**
+     * @brief Returns whether the prior connector process shut down cleanly.
+     *
+     * On the owner side this is always true (no prior connector existed). On a
+     * connector created via connect(), this reflects the clean_shutdown flag
+     * left in SHM by the previous process: true if it ran its destructor, false
+     * if it exited via crash, _exit, or kill. Useful for warning the operator
+     * or deciding whether to call discard_pending_pages() to drop stale data.
+     */
+    bool had_clean_prior_shutdown() const { return prior_clean_shutdown_; }
+
     D2HSocket(const D2HSocket&) = delete;
     D2HSocket& operator=(const D2HSocket&) = delete;
 
@@ -321,6 +332,7 @@ private:
     bool exported_ = false;
     HDSocketConnectorState* connector_state_ = nullptr;
     uint32_t connector_state_offset_ = 0;
+    bool prior_clean_shutdown_ = true;
 
     bool using_hugepage_ = false;
     uint32_t* hugepage_data_host_ptr_ = nullptr;

--- a/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
@@ -17,6 +17,7 @@ namespace tt::tt_metal::distributed {
 
 class NamedShm;
 class PCIeCoreWriter;
+struct HDSocketConnectorState;
 
 /**
  * @brief A socket for streaming data from a device core to the host.
@@ -318,6 +319,8 @@ private:
     bool is_owner_ = true;
     std::string descriptor_path_;
     bool exported_ = false;
+    HDSocketConnectorState* connector_state_ = nullptr;
+    uint32_t connector_state_offset_ = 0;
 
     bool using_hugepage_ = false;
     uint32_t* hugepage_data_host_ptr_ = nullptr;

--- a/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
@@ -134,6 +134,17 @@ public:
 
     H2DMode get_h2d_mode() const;
 
+    /**
+     * @brief Returns whether the prior connector process shut down cleanly.
+     *
+     * On the owner side this is always true (no prior connector existed). On a
+     * connector created via connect(), this reflects the clean_shutdown flag
+     * left in SHM by the previous process: true if it ran its destructor, false
+     * if it exited via crash, _exit, or kill. Useful for warning the operator
+     * or running cleanup (e.g. discard_pending_pages on the paired D2H socket).
+     */
+    bool had_clean_prior_shutdown() const { return prior_clean_shutdown_; }
+
     H2DSocket(const H2DSocket&) = delete;
     H2DSocket& operator=(const H2DSocket&) = delete;
 
@@ -198,6 +209,7 @@ private:
     bool exported_ = false;
     HDSocketConnectorState* connector_state_ = nullptr;
     uint32_t connector_state_offset_ = 0;
+    bool prior_clean_shutdown_ = true;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
@@ -17,6 +17,7 @@ namespace tt::tt_metal::distributed {
 
 class NamedShm;
 class PCIeCoreWriter;
+struct HDSocketConnectorState;
 
 /**
  * @brief Specifies the data transfer mode for Host-to-Device communication.
@@ -195,6 +196,8 @@ private:
     bool is_owner_ = true;
     std::string descriptor_path_;
     bool exported_ = false;
+    HDSocketConnectorState* connector_state_ = nullptr;
+    uint32_t connector_state_offset_ = 0;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -226,12 +226,15 @@ void D2HSocket::init_common(const std::shared_ptr<MeshDevice>& mesh_device) {
         bytes_sent_info.addr_hi = static_cast<uint32_t>(bytes_sent_addr >> 32);
 
         // Map the persistent connector-state struct living past the pinned region.
-        // NamedShm::create zero-initialized the page; we only stamp the version.
-        // Hugepage fallback does not create an SHM region and cannot be exported,
-        // so connector_state_ stays null in that path.
+        // NamedShm::create zero-initialized the page; we stamp the version and set
+        // clean_shutdown=1 so the first connect() sees "no prior crash" (the owner
+        // side has nothing to recover from). Hugepage fallback does not create an
+        // SHM region and cannot be exported, so connector_state_ stays null in
+        // that path.
         connector_state_ =
             reinterpret_cast<HDSocketConnectorState*>(static_cast<uint8_t*>(shm_->ptr()) + connector_state_offset_);
         connector_state_->version = kHDSocketConnectorStateVersion;
+        connector_state_->clean_shutdown = 1;
     } else {
         data_info = init_host_buffer_hugepage(mesh_device);
 
@@ -297,6 +300,13 @@ D2HSocket::~D2HSocket() noexcept {
         log_warning(LogMetal, "D2HSocket destructor: barrier failed with exception: {}", e.what());
     } catch (...) {
         log_warning(LogMetal, "D2HSocket destructor: barrier failed with unknown exception");
+    }
+    // Mark a clean shutdown so the next connector sees clean_shutdown=1. A process
+    // that exits without running this destructor (crash, _exit, kill) leaves the
+    // 0 written by connect()/owner-construct in place, signalling unclean exit.
+    // connector_state_ is null in hugepage fallback mode (no SHM region).
+    if (connector_state_) {
+        connector_state_->clean_shutdown = 1;
     }
     if (is_owner_ && !using_hugepage_) {
         pinned_memory_.reset();
@@ -556,6 +566,18 @@ std::unique_ptr<D2HSocket> D2HSocket::connect(const std::string& socket_id, std:
         "HDSocketConnectorState version mismatch: got {}, expected {}.",
         socket->connector_state_->version,
         kHDSocketConnectorStateVersion);
+    // Capture the prior process's clean_shutdown before overwriting it. A 0 here
+    // means the previous connector exited without running its destructor (crash,
+    // _exit, kill); callers can query had_clean_prior_shutdown() to react (e.g.
+    // call discard_pending_pages() to drop stale data).
+    socket->prior_clean_shutdown_ = (socket->connector_state_->clean_shutdown != 0);
+    if (!socket->prior_clean_shutdown_) {
+        log_warning(
+            LogMetal,
+            "D2HSocket::connect: prior connector process exited without running its destructor. State has been "
+            "recovered from SHM, but stale pages may be pending in the FIFO; consider discard_pending_pages().");
+    }
+    socket->connector_state_->clean_shutdown = 0;
     socket->page_size_ = socket->connector_state_->page_size;
     socket->fifo_curr_size_ = socket->connector_state_->fifo_curr_size;
     socket->bytes_acked_ = socket->connector_state_->bytes_acked;

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -5,6 +5,7 @@
 #include <tt-metalium/experimental/sockets/d2h_socket.hpp>
 #include "tt_metal/distributed/mesh_socket_utils.hpp"
 #include "tt_metal/distributed/named_shm.hpp"
+#include "tt_metal/distributed/hd_socket_connector_state.hpp"
 #include "tt_metal/distributed/hd_socket_descriptor.hpp"
 #include "tt_metal/distributed/pcie_core_writer.hpp"
 #include "tt_metal/distributed/shm_resource_tracker.hpp"
@@ -36,11 +37,16 @@ D2HSocket::PinnedBufferInfo D2HSocket::init_host_buffer(
     const MeshCoordinateRangeSet& device_range,
     uint32_t pcie_alignment,
     const std::string& shm_name) {
-    // Buffer layout: [data_region (fifo_size bytes)][bytes_sent (4 bytes)]
+    // Buffer layout: [data_region (fifo_size bytes)][bytes_sent (4 bytes)][HDSocketConnectorState]
     uint32_t total_buffer_size_bytes = fifo_size_ + sizeof(uint32_t);
     uint32_t total_buffer_size_words = total_buffer_size_bytes / sizeof(uint32_t);
     size_t page_size = sysconf(_SC_PAGESIZE);
-    size_t alloc_size = align(total_buffer_size_bytes, page_size);
+    // Reserve room for HDSocketConnectorState past the pinned region, aligned up
+    // to its own alignment requirement so the reinterpret_cast<> in connect() is
+    // well-defined. The pinned HostBuffer view below still spans only
+    // [data | bytes_sent], so the device never touches the state struct.
+    connector_state_offset_ = align(total_buffer_size_bytes, alignof(HDSocketConnectorState));
+    size_t alloc_size = align(connector_state_offset_ + sizeof(HDSocketConnectorState), page_size);
 
     shm_ = std::make_unique<NamedShm>(NamedShm::create(shm_name, alloc_size));
     void* aligned_ptr = shm_->ptr();
@@ -218,6 +224,14 @@ void D2HSocket::init_common(const std::shared_ptr<MeshDevice>& mesh_device) {
         bytes_sent_info = data_info;
         bytes_sent_info.addr_lo = static_cast<uint32_t>(bytes_sent_addr & 0xFFFFFFFFull);
         bytes_sent_info.addr_hi = static_cast<uint32_t>(bytes_sent_addr >> 32);
+
+        // Map the persistent connector-state struct living past the pinned region.
+        // NamedShm::create zero-initialized the page; we only stamp the version.
+        // Hugepage fallback does not create an SHM region and cannot be exported,
+        // so connector_state_ stays null in that path.
+        connector_state_ =
+            reinterpret_cast<HDSocketConnectorState*>(static_cast<uint8_t*>(shm_->ptr()) + connector_state_offset_);
+        connector_state_->version = kHDSocketConnectorStateVersion;
     } else {
         data_info = init_host_buffer_hugepage(mesh_device);
 
@@ -320,6 +334,12 @@ void D2HSocket::set_page_size(uint32_t page_size) {
     read_ptr_ = next_fifo_rd_ptr;
     page_size_ = page_size;
     fifo_curr_size_ = fifo_page_aligned_size;
+    if (connector_state_) {
+        connector_state_->page_size = page_size_;
+        connector_state_->fifo_curr_size = fifo_curr_size_;
+        connector_state_->bytes_acked = bytes_acked_;
+        connector_state_->read_ptr = read_ptr_;
+    }
 }
 
 bool D2HSocket::has_data() {
@@ -364,6 +384,12 @@ void D2HSocket::pop_bytes(uint32_t num_bytes) {
         read_ptr_ += num_bytes;
         bytes_acked_ += num_bytes;
     }
+    // Crash-safe persistence for the next driver process. Null in hugepage
+    // fallback mode, which doesn't support cross-process attach.
+    if (connector_state_) {
+        connector_state_->bytes_acked = bytes_acked_;
+        connector_state_->read_ptr = read_ptr_;
+    }
 }
 
 uint32_t D2HSocket::discard_pending_pages() {
@@ -392,6 +418,10 @@ uint32_t D2HSocket::discard_pending_pages() {
     }
     read_ptr_ = cursor;
     bytes_acked_ += bytes_to_discard;
+    if (connector_state_) {
+        connector_state_->bytes_acked = bytes_acked_;
+        connector_state_->read_ptr = read_ptr_;
+    }
     notify_sender();
     return pages;
 }
@@ -482,6 +512,7 @@ std::string D2HSocket::export_descriptor(const std::string& socket_id) {
     desc.populate_from_owner("d2h", *shm_, fifo_size_, config_buffer_address_, mesh_device_, sender_core_);
     desc.bytes_sent_offset = fifo_size_;
     desc.bytes_acked_device_offset = bytes_acked_device_offset_;
+    desc.connector_state_offset = connector_state_offset_;
 
     descriptor_path_ = descriptor_path_for_socket("d2h", socket_id);
     desc.write_to_file(descriptor_path_);
@@ -509,6 +540,37 @@ std::unique_ptr<D2HSocket> D2HSocket::connect(const std::string& socket_id, std:
     socket->pcie_writer_instance_ =
         std::make_unique<PCIeCoreWriter>(desc.device_id, desc.virtual_core_x, desc.virtual_core_y);
     socket->pcie_writer_ = socket->pcie_writer_instance_->get_pcie_writer();
+
+    // Restore connector-mutable state left behind by any prior driver process.
+    // First connector after owner-init sees an all-zero struct (version stamped
+    // by the owner), which matches a fresh socket.
+    TT_FATAL(
+        desc.connector_state_offset + sizeof(HDSocketConnectorState) <= desc.shm_size,
+        "Descriptor connector_state_offset out of range for SHM size {}.",
+        desc.shm_size);
+    socket->connector_state_offset_ = desc.connector_state_offset;
+    socket->connector_state_ = reinterpret_cast<HDSocketConnectorState*>(
+        static_cast<uint8_t*>(socket->shm_->ptr()) + desc.connector_state_offset);
+    TT_FATAL(
+        socket->connector_state_->version == kHDSocketConnectorStateVersion,
+        "HDSocketConnectorState version mismatch: got {}, expected {}.",
+        socket->connector_state_->version,
+        kHDSocketConnectorStateVersion);
+    socket->page_size_ = socket->connector_state_->page_size;
+    socket->fifo_curr_size_ = socket->connector_state_->fifo_curr_size;
+    socket->bytes_acked_ = socket->connector_state_->bytes_acked;
+    socket->read_ptr_ = socket->connector_state_->read_ptr;
+    // bytes_sent_ is the cached copy of the device-written counter that already
+    // lives in SHM. Read it live so wait_for_bytes() sees fresh data immediately.
+    socket->bytes_sent_ = socket->bytes_sent_ptr_[0];
+
+    // Reconcile the device-side bytes_acked with the restored SHM value. The
+    // previous driver process may have died between pop_bytes (SHM flushed)
+    // and notify_sender (PCIe write to the device's config buffer), leaving
+    // the device's bytes_acked behind. Without this, the device kernel may
+    // stall thinking the FIFO is full while the new connector waits for fresh
+    // data. For a fresh socket this writes 0 over 0 — a no-op.
+    socket->notify_sender();
 
     return socket;
 }

--- a/tt_metal/distributed/flatbuffer/hd_socket_descriptor.fbs
+++ b/tt_metal/distributed/flatbuffer/hd_socket_descriptor.fbs
@@ -31,6 +31,11 @@ table HDSocketDescriptor {
     virtual_core_y: uint32;
     pcie_alignment: uint32;
     bytes_acked_device_offset: uint32;
+
+    // Offset within the SHM region of the HDSocketConnectorState struct.
+    // Used by connectors to restore page_size / fifo_curr_size / bytes_sent /
+    // bytes_acked / write_ptr / read_ptr from the previous driver process.
+    connector_state_offset: uint32;
 }
 
 root_type HDSocketDescriptor;

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -5,6 +5,7 @@
 #include <tt-metalium/experimental/sockets/h2d_socket.hpp>
 #include "tt_metal/distributed/mesh_socket_utils.hpp"
 #include "tt_metal/distributed/named_shm.hpp"
+#include "tt_metal/distributed/hd_socket_connector_state.hpp"
 #include "tt_metal/distributed/hd_socket_descriptor.hpp"
 #include "tt_metal/distributed/pcie_core_writer.hpp"
 #include "tt_metal/distributed/shm_resource_tracker.hpp"
@@ -27,6 +28,16 @@ H2DSocket::PinnedBufferInfo H2DSocket::init_bytes_acked_buffer(
     uint32_t pcie_alignment,
     const std::string& shm_name) {
     size_t page_size = sysconf(_SC_PAGESIZE);
+    // The pinned region is just a 4-byte bytes_acked counter; the rest of the
+    // page hosts the connector-state struct so consecutive driver processes
+    // can resume from the previous driver's bytes_sent / write_ptr / page_size.
+    // Place the struct immediately after the pinned region, aligned up to its
+    // own alignment requirement so the reinterpret_cast<> in connect() is
+    // well-defined.
+    connector_state_offset_ = static_cast<uint32_t>(align(sizeof(uint32_t), alignof(HDSocketConnectorState)));
+    TT_FATAL(
+        page_size >= connector_state_offset_ + sizeof(HDSocketConnectorState),
+        "System page size too small to host HDSocketConnectorState.");
     shm_ = std::make_unique<NamedShm>(NamedShm::create(shm_name, page_size));
     void* aligned_ptr = shm_->ptr();
     TT_FATAL(
@@ -59,7 +70,12 @@ H2DSocket::PinnedBufferInfo H2DSocket::init_host_data_buffer(
     uint32_t host_buffer_size_bytes = fifo_size_ + sizeof(uint32_t);
     uint32_t host_buffer_size_words = host_buffer_size_bytes / sizeof(uint32_t);
     size_t page_size = sysconf(_SC_PAGESIZE);
-    size_t alloc_size = align(host_buffer_size_bytes, page_size);
+    // Reserve room for HDSocketConnectorState immediately after the pinned region,
+    // aligned up to its own alignment requirement so the reinterpret_cast<> in
+    // connect() is well-defined. The pinned HostBuffer view below still spans
+    // only [data | bytes_acked], so the device never touches the state struct.
+    connector_state_offset_ = align(host_buffer_size_bytes, alignof(HDSocketConnectorState));
+    size_t alloc_size = align(connector_state_offset_ + sizeof(HDSocketConnectorState), page_size);
     shm_ = std::make_unique<NamedShm>(NamedShm::create(shm_name, alloc_size));
     void* aligned_ptr = shm_->ptr();
     TT_FATAL(
@@ -239,6 +255,12 @@ H2DSocket::H2DSocket(
     init_receiver_tlb(mesh_device);
 
     config_buffer_address_ = config_buffer_->address();
+
+    // Initialize the persistent connector-state struct living in SHM.
+    // NamedShm::create zero-initialized the region; we only stamp the version.
+    connector_state_ =
+        reinterpret_cast<HDSocketConnectorState*>(static_cast<uint8_t*>(shm_->ptr()) + connector_state_offset_);
+    connector_state_->version = kHDSocketConnectorStateVersion;
 }
 
 H2DSocket::~H2DSocket() noexcept {
@@ -282,6 +304,9 @@ void H2DSocket::push_bytes(uint32_t num_bytes) {
         write_ptr_ += num_bytes;
         bytes_sent_ += num_bytes;
     }
+    // Crash-safe persistence for the next driver process.
+    connector_state_->bytes_sent = bytes_sent_;
+    connector_state_->write_ptr = write_ptr_;
 }
 
 void H2DSocket::notify_receiver() {
@@ -305,6 +330,10 @@ void H2DSocket::set_page_size(uint32_t page_size) {
     write_ptr_ = next_fifo_wr_ptr;
     page_size_ = page_size;
     fifo_curr_size_ = fifo_page_aligned_size;
+    connector_state_->page_size = page_size_;
+    connector_state_->fifo_curr_size = fifo_curr_size_;
+    connector_state_->bytes_sent = bytes_sent_;
+    connector_state_->write_ptr = write_ptr_;
 }
 
 void H2DSocket::barrier(std::optional<uint32_t> timeout_ms) {
@@ -361,6 +390,7 @@ std::string H2DSocket::export_descriptor(const std::string& socket_id) {
     desc.bytes_acked_offset = (h2d_mode_ == H2DMode::DEVICE_PULL) ? fifo_size_ : 0;
     desc.h2d_mode = static_cast<uint32_t>(h2d_mode_);
     desc.aligned_data_buf_start = aligned_data_buf_start_;
+    desc.connector_state_offset = connector_state_offset_;
 
     descriptor_path_ = descriptor_path_for_socket("h2d", socket_id);
     desc.write_to_file(descriptor_path_);
@@ -395,6 +425,38 @@ std::unique_ptr<H2DSocket> H2DSocket::connect(const std::string& socket_id, std:
     socket->pcie_writer_instance_ =
         std::make_unique<PCIeCoreWriter>(desc.device_id, desc.virtual_core_x, desc.virtual_core_y);
     socket->pcie_writer = socket->pcie_writer_instance_->get_pcie_writer();
+
+    // Restore connector-mutable state left behind by any prior driver process.
+    // First connector after owner-init sees an all-zero struct (version stamped
+    // by the owner), which matches a fresh socket.
+    TT_FATAL(
+        desc.connector_state_offset + sizeof(HDSocketConnectorState) <= desc.shm_size,
+        "Descriptor connector_state_offset out of range for SHM size {}.",
+        desc.shm_size);
+    socket->connector_state_offset_ = desc.connector_state_offset;
+    socket->connector_state_ = reinterpret_cast<HDSocketConnectorState*>(
+        static_cast<uint8_t*>(socket->shm_->ptr()) + desc.connector_state_offset);
+    TT_FATAL(
+        socket->connector_state_->version == kHDSocketConnectorStateVersion,
+        "HDSocketConnectorState version mismatch: got {}, expected {}.",
+        socket->connector_state_->version,
+        kHDSocketConnectorStateVersion);
+    socket->page_size_ = socket->connector_state_->page_size;
+    socket->fifo_curr_size_ = socket->connector_state_->fifo_curr_size;
+    socket->bytes_sent_ = socket->connector_state_->bytes_sent;
+    socket->write_ptr_ = socket->connector_state_->write_ptr;
+    // bytes_acked_ is the cached copy of the device-written counter that
+    // already lives in SHM. Read it live so we don't underestimate the
+    // available FIFO space on the first reserve_bytes().
+    socket->bytes_acked_ = socket->bytes_acked_ptr_[0];
+
+    // Reconcile the device-side bytes_sent with the restored SHM value. The
+    // previous driver process may have died between push_bytes (SHM flushed)
+    // and notify_receiver (PCIe write to the device's config buffer), leaving
+    // the device's bytes_sent behind. Without this, a barrier() on the new
+    // connector would wait forever for the device to ack bytes it never knew
+    // were sent. For a fresh socket this writes 0 over 0 — a no-op.
+    socket->notify_receiver();
 
     return socket;
 }

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -257,10 +257,13 @@ H2DSocket::H2DSocket(
     config_buffer_address_ = config_buffer_->address();
 
     // Initialize the persistent connector-state struct living in SHM.
-    // NamedShm::create zero-initialized the region; we only stamp the version.
+    // NamedShm::create zero-initialized the region; we stamp the version and
+    // mark clean_shutdown=1 so the first connect() sees "no prior crash" (the
+    // owner side has nothing to recover from).
     connector_state_ =
         reinterpret_cast<HDSocketConnectorState*>(static_cast<uint8_t*>(shm_->ptr()) + connector_state_offset_);
     connector_state_->version = kHDSocketConnectorStateVersion;
+    connector_state_->clean_shutdown = 1;
 }
 
 H2DSocket::~H2DSocket() noexcept {
@@ -272,6 +275,12 @@ H2DSocket::~H2DSocket() noexcept {
         log_warning(LogMetal, "H2DSocket destructor: barrier failed with exception: {}", e.what());
     } catch (...) {
         log_warning(LogMetal, "H2DSocket destructor: barrier failed with unknown exception");
+    }
+    // Mark a clean shutdown so the next connector sees clean_shutdown=1. A process
+    // that exits without running this destructor (crash, _exit, kill) leaves the
+    // 0 written by connect()/owner-construct in place, signalling unclean exit.
+    if (connector_state_) {
+        connector_state_->clean_shutdown = 1;
     }
     if (is_owner_) {
         pinned_memory_.reset();
@@ -441,6 +450,18 @@ std::unique_ptr<H2DSocket> H2DSocket::connect(const std::string& socket_id, std:
         "HDSocketConnectorState version mismatch: got {}, expected {}.",
         socket->connector_state_->version,
         kHDSocketConnectorStateVersion);
+    // Capture the prior process's clean_shutdown before overwriting it. A 0 here
+    // means the previous connector exited without running its destructor (crash,
+    // _exit, kill); callers can query had_clean_prior_shutdown() to react.
+    socket->prior_clean_shutdown_ = (socket->connector_state_->clean_shutdown != 0);
+    if (!socket->prior_clean_shutdown_) {
+        log_warning(
+            LogMetal,
+            "H2DSocket::connect: prior connector process exited without running its destructor. State has been "
+            "recovered from SHM, but downstream effects (in-flight writes, device-side counters) may need manual "
+            "inspection.");
+    }
+    socket->connector_state_->clean_shutdown = 0;
     socket->page_size_ = socket->connector_state_->page_size;
     socket->fifo_curr_size_ = socket->connector_state_->fifo_curr_size;
     socket->bytes_sent_ = socket->connector_state_->bytes_sent;

--- a/tt_metal/distributed/hd_socket_connector_state.hpp
+++ b/tt_metal/distributed/hd_socket_connector_state.hpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace tt::tt_metal::distributed {
+
+inline constexpr uint32_t kHDSocketConnectorStateVersion = 1;
+
+// Persistent connector-side state for H2D/D2H sockets. Lives in the socket's
+// named SHM region so that consecutive driver processes (which connect via
+// H2DSocket::connect / D2HSocket::connect) can pick up where the previous
+// process left off, rather than restarting counters at zero and desyncing
+// from the device-resident pointers.
+//
+// Layout is fixed at 64 bytes (one cache line) so the trailing _pad never
+// needs to grow when fields are added; future fields take from _pad and bump
+// the version when semantics change.
+struct alignas(64) HDSocketConnectorState {
+    uint32_t version;         // kHDSocketConnectorStateVersion
+    uint32_t page_size;       // 0 = unset
+    uint32_t fifo_curr_size;  // 0 = unset
+    uint32_t bytes_sent;      // H2D: live counter; D2H: unused
+    uint32_t bytes_acked;     // D2H: live counter; H2D: unused
+    uint32_t write_ptr;       // H2D only
+    uint32_t read_ptr;        // D2H only
+    uint32_t _pad[9];
+};
+static_assert(sizeof(HDSocketConnectorState) == 64, "HDSocketConnectorState must be 64 bytes");
+static_assert(alignof(HDSocketConnectorState) == 64, "HDSocketConnectorState must be cache-line aligned");
+
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/hd_socket_connector_state.hpp
+++ b/tt_metal/distributed/hd_socket_connector_state.hpp
@@ -27,7 +27,12 @@ struct alignas(64) HDSocketConnectorState {
     uint32_t bytes_acked;     // D2H: live counter; H2D: unused
     uint32_t write_ptr;       // H2D only
     uint32_t read_ptr;        // D2H only
-    uint32_t _pad[9];
+    // Set to 0 on open (owner construct stamps 1 since no connector is yet attached;
+    // connect() writes 0 after reading the prior value); set to 1 in the destructor.
+    // A connector that reads 0 here knows the previous process exited without running
+    // its destructor (crash, _exit, kill).
+    uint32_t clean_shutdown;
+    uint32_t _pad[8];
 };
 static_assert(sizeof(HDSocketConnectorState) == 64, "HDSocketConnectorState must be 64 bytes");
 static_assert(alignof(HDSocketConnectorState) == 64, "HDSocketConnectorState must be cache-line aligned");

--- a/tt_metal/distributed/hd_socket_descriptor.cpp
+++ b/tt_metal/distributed/hd_socket_descriptor.cpp
@@ -65,7 +65,8 @@ void HDSocketDescriptor::write_to_file(const std::string& path) const {
         virtual_core_x,
         virtual_core_y,
         pcie_alignment,
-        bytes_acked_device_offset);
+        bytes_acked_device_offset,
+        connector_state_offset);
     builder.Finish(fb_desc);
 
     std::string tmp_path = path + ".tmp";
@@ -115,6 +116,7 @@ HDSocketDescriptor HDSocketDescriptor::read_from_file(const std::string& path) {
     desc.virtual_core_y = fb->virtual_core_y();
     desc.pcie_alignment = fb->pcie_alignment();
     desc.bytes_acked_device_offset = fb->bytes_acked_device_offset();
+    desc.connector_state_offset = fb->connector_state_offset();
 
     return desc;
 }

--- a/tt_metal/distributed/hd_socket_descriptor.hpp
+++ b/tt_metal/distributed/hd_socket_descriptor.hpp
@@ -57,6 +57,7 @@ struct HDSocketDescriptor {
     uint32_t virtual_core_y = 0;             // Virtual (translated) core coordinate Y
     uint32_t pcie_alignment = 0;             // PCIe page alignment in bytes (e.g. 64 for Blackhole)
     uint32_t bytes_acked_device_offset = 0;  // D2H: L1 offset of bytes_acked within config buffer
+    uint32_t connector_state_offset = 0;     // Offset of HDSocketConnectorState within the SHM region
 
     /**
      * @brief Populate common fields from the owner socket's state.


### PR DESCRIPTION
### PR Category
Feature

### Summary
- The H2D/D2H socket descriptor was written once at owner-export time and never updated
- When a connector process exited mid-stream, the counters (`bytes_sent`, `bytes_acked`, `write_ptr`, `read_ptr`, `page_size`) were lost
- A subsequent connector restarted from zero, desyncing from the device-resident pointers and hanging on the first txn
- Add `HDSocketConnectorState`, a 64-byte struct living past the pinned region of each socket's SHM
- The owner stamps a version on construction; `push_bytes` / `pop_bytes` / `set_page_size` flush updates after every mutation
- `H2DSocket::connect` and `D2HSocket::connect` now restore from this struct
- The descriptor gains a `connector_state_offset` field, telling the connector where to find the struct. Hugepage fallback in D2H (no SHM region, no cross-process export) leaves the pointer null and skips the flush

Tests in `test_multiproc_loopback.cpp`:
- `MultiProcessConnectorReuse`: N forked children sequentially drive one launcher kernel, each a full clean attach/drive/destruct cycle — direct repro of the original bug.
- `CrashSafeConnectorPersistence`: child `_exit()`s without destructors; parent resumes — validates the per-op flush.
- `BackToBackConnectorPersistence` / `UnevenIterDistribution` / `ManyShortConnectors`: stress the SHM state machine.

### Notes for reviewers
- This feature unblocks production setups where a pipelined workload exposing sockets (ex: Deepseek V3 B1), can be launched once, with multiple connector processes (ex: Inference Server) sequentially driving the same instance of the workload

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=asaigal/persistent_sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:asaigal/persistent_sockets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=asaigal/persistent_sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:asaigal/persistent_sockets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/persistent_sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/persistent_sockets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/persistent_sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/persistent_sockets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=asaigal/persistent_sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:asaigal/persistent_sockets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/persistent_sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/persistent_sockets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/persistent_sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/persistent_sockets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/persistent_sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/persistent_sockets)