### PR TITLE
[Bug fix] Disable realtime profiling for mock devices

### DIFF
--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -98,19 +98,27 @@ struct RealtimeProfilerEligibility {
 
 // Consolidated eligibility check; logs the reason for disabling and returns
 // {enabled=false} on failure. Checks (in order):
-//   1. Device is MMIO-capable (D2H sockets need a PCIe-connected sender core).
-//   2. D2H socket memory-allocation path is supported (64-bit PCIe addressing requires IOMMU).
-//   3. Fabric tensix datamover (MUX / UDM) is disabled (it competes for the same dispatch pool).
-//   4. A tensix core was reserved for the RT profiler at dispatch_core_manager construction.
-//   5. Reserved coordinate lives inside the logical TENSIX grid.
-//   6. Kernels are not nullified (DEBUG_NULL_KERNELS / TT_METAL_NULL_KERNELS).
-//   7. Reserved profiler core's L1 bank fits the ring + socket-config layout.
+//   1. Device is not a mock.
+//   2. Device is MMIO-capable (D2H sockets need a PCIe-connected sender core).
+//   3. D2H socket memory-allocation path is supported (64-bit PCIe addressing requires IOMMU).
+//   4. Fabric tensix datamover (MUX / UDM) is disabled (it competes for the same dispatch pool).
+//   5. A tensix core was reserved for the RT profiler at dispatch_core_manager construction.
+//   6. Reserved coordinate lives inside the logical TENSIX grid.
+//   7. Kernels are not nullified (DEBUG_NULL_KERNELS / TT_METAL_NULL_KERNELS).
+//   8. Reserved profiler core's L1 bank fits the ring + socket-config layout.
 RealtimeProfilerEligibility evaluate_realtime_profiler_eligibility(IDevice* device) {
     auto device_id = device->id();
     auto& metal = MetalContext::instance();
     const auto& hal = metal.hal();
     const auto& cluster = metal.get_cluster();
     auto& dispatch_core_manager = metal.get_dispatch_core_manager();
+
+    if (cluster.get_target_device_type() == tt::TargetDevice::Mock) {
+        log_debug(tt::LogMetal,
+                  "Real-time profiler disabled on device {}: target is mock.",
+                  device_id);
+        return {};
+    }
 
     if (!device->is_mmio_capable()) {
         log_debug(


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Fixes https://github.com/tenstorrent/tt-metal/issues/43964

https://github.com/tenstorrent/tt-metal/commit/ea72d20d0c65baf2c14ffc6ea5deac8a007e2829 added a new real time profiling API, but [evaluate_realtime_profile_eligibility](https://github.com/tenstorrent/tt-metal/blob/3f39ff3267cd48366885084aa9027f3cf556b2d4/tt_metal/distributed/realtime_profiler_manager.cpp#L108) didn't exclude runs on mock devices.

This causes certain tests within tt-mlir to fail. Failing CI run: https://github.com/tenstorrent/tt-mlir/actions/runs/25637487335.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
This is currently blocking the tt-metal to tt-mlir uplift, so please treat it as a P0.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=hshah/fix-profiler-mock-latest)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:hshah/fix-profiler-mock-latest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=hshah/fix-profiler-mock-latest)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:hshah/fix-profiler-mock-latest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=hshah/fix-profiler-mock-latest)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:hshah/fix-profiler-mock-latest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=hshah/fix-profiler-mock-latest)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:hshah/fix-profiler-mock-latest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=hshah/fix-profiler-mock-latest)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:hshah/fix-profiler-mock-latest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=hshah/fix-profiler-mock-latest)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:hshah/fix-profiler-mock-latest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=hshah/fix-profiler-mock-latest)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:hshah/fix-profiler-mock-latest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=hshah/fix-profiler-mock-latest)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:hshah/fix-profiler-mock-latest)