### PR TITLE
Enable to add custom build settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,10 @@ docs/doxygen_build
 # CMake build artifacts
 __cmake_systeminformation/
 
+# Build for custom platform
+/cmake/custom_platform.cmake
+install_depends_custom.sh
+
 **~
 **.swp
 **.swo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,9 @@ add_compile_options(
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-overloaded-virtual>"
 )
 
+# Optional settings for custom platform, include only when file exists.
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/custom_platform.cmake" OPTIONAL)
+
 # Planned to be temporary, remove later.
 if(TT_ENABLE_LIGHT_METAL_TRACE)
     add_compile_definitions(TT_ENABLE_LIGHT_METAL_TRACE=1)

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -247,6 +247,10 @@ init_packages() {
             fi
             ;;
     esac
+
+    if declare -F init_packages_custom >/dev/null; then
+        init_packages_custom
+    fi
 }
 
 prep_system() {
@@ -547,6 +551,12 @@ main() {
     cleanup
 
 }
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+CUSTOM_DEPENDS_SCRIPT="${SCRIPT_DIR}/install_depends_custom.sh"
+if [ -f "${CUSTOM_DEPENDS_SCRIPT}" ]; then
+    source "${CUSTOM_DEPENDS_SCRIPT}"
+fi
 
 if [ "${1}" != "--source-only" ]; then
     main "${@}"


### PR DESCRIPTION
### PR Category

Feature

### Summary

This will enable to add custom build settings for other platforms.
Changes are to check if custom override exist then include them.
With this change, others can maintain for their supported platforms in separate files.

### Notes for reviewers
N/A