### PR TITLE
[Bug fix] Fix Deepseek 32k garbage output

### DIFF
--- a/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
+++ b/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
@@ -12,7 +12,11 @@ from loguru import logger
 import ttnn
 from models.demos.deepseek_v3.demo.demo import run_demo
 from models.demos.deepseek_v3.demo.token_accuracy import decompress_lzma_payload
-from models.demos.deepseek_v3.utils.config_helpers import DEFAULT_MAX_SEQ_LEN, K_CHUNK_SIZE
+from models.demos.deepseek_v3.utils.config_helpers import (
+    DEFAULT_MAX_SEQ_LEN,
+    K_CHUNK_SIZE,
+    align_prefill_padded_seq_len,
+)
 from models.demos.deepseek_v3.utils.hf_model_utils import load_tokenizer
 from models.demos.deepseek_v3.utils.test_utils import system_name_to_mesh_shape
 
@@ -36,7 +40,7 @@ ARTIFACT_DIR = Path("generated/artifacts")
 GENERATED_OUTPUTS_FILE = ARTIFACT_DIR / "teacher_forced_generated_outputs.json"
 
 
-def tile_align(length: int) -> int:
+def _get_tile_aligned_max_seq_len(length: int) -> int:
     k_chunk_size = K_CHUNK_SIZE
     aligned_size = max(int(ttnn.TILE_SIZE), k_chunk_size)
     return ((int(length) + aligned_size - 1) // aligned_size) * aligned_size
@@ -133,7 +137,8 @@ def test_demo_teacher_forcing_accuracy(
         )
 
     max_prompt_len = max(int(entry["tf_prompt_len"]) for entry in entries)
-    configured_max_seq_len = tile_align(max_prompt_len + max_new_tokens)
+    tf_prompt_len_padded = align_prefill_padded_seq_len(max_prompt_len, mesh_shape[0])
+    configured_max_seq_len = _get_tile_aligned_max_seq_len(tf_prompt_len_padded + max_new_tokens)
     if configured_max_seq_len > DEFAULT_MAX_SEQ_LEN:
         pytest.skip(
             f"Teacher-forced context needs max_seq_len={configured_max_seq_len}, "

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -36,6 +36,7 @@ from models.demos.deepseek_v3.utils.config_helpers import (
     PREFILL_WARMUP_MODE_LINEAR_ADDITIVE,
     PREFILL_WARMUP_MODE_LINEAR_MULTIPLES,
     USERS_PER_ROW,
+    align_prefill_padded_seq_len,
     align_up,
     even_int_div,
     get_min_alignment_value_for_prefill,
@@ -1348,9 +1349,7 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         max_len = max(len(t) for t in tokens_list)
         if self.prefill_max_tokens is not None:
             max_len = min(self.prefill_max_tokens, max_len)  # truncate all sequences to the prefill_max_tokens
-        # Round up to nearest multiple of TILE_SIZE.
-        alignment = ttnn.TILE_SIZE
-        max_len = ((max_len + alignment - 1) // alignment) * alignment
+        max_len = align_prefill_padded_seq_len(max_len, self.mesh_device.shape[0])
 
         pad_id = self._get_pad_id()
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Closes #43604
Applies seq_len alignment from https://github.com/tenstorrent/tt-metal/pull/42517

### Notes for reviewers
- [X] Now generation text looks valid and prefill token is `<think>` - `"text": "<think>\nOkaymm, this user has sent"`
- [X] [Deepseek demo](https://github.com/tenstorrent/tt-metal/actions/runs/25658297555) - passed
- [X] [Galaxy Deepseek](https://github.com/tenstorrent/tt-metal/actions/runs/25657740268) - passed

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtsishkouski/43604-deepseek-32k-garbage-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtsishkouski/43604-deepseek-32k-garbage-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtsishkouski/43604-deepseek-32k-garbage-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtsishkouski/43604-deepseek-32k-garbage-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtsishkouski/43604-deepseek-32k-garbage-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtsishkouski/43604-deepseek-32k-garbage-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtsishkouski/43604-deepseek-32k-garbage-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtsishkouski/43604-deepseek-32k-garbage-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtsishkouski/43604-deepseek-32k-garbage-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtsishkouski/43604-deepseek-32k-garbage-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtsishkouski/43604-deepseek-32k-garbage-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtsishkouski/43604-deepseek-32k-garbage-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtsishkouski/43604-deepseek-32k-garbage-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtsishkouski/43604-deepseek-32k-garbage-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtsishkouski/43604-deepseek-32k-garbage-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtsishkouski/43604-deepseek-32k-garbage-output)