### PR TITLE
[fuser] pack l1 accumulation

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/packer.py
@@ -11,9 +11,7 @@ from fuser.fused_loop import FusedLoop
 from fuser.fused_operation import FusedOperation
 from fuser.fused_packer import Packer as BasePacker
 from fuser.fuser_config import GlobalConfig
-from helpers.golden_generators import PackGolden
 from helpers.llk_params import L1Accumulation, PackerReluType
-from helpers.tilize_untilize import tilize_block, untilize_block
 
 
 class Packer(BasePacker):
@@ -33,38 +31,10 @@ class Packer(BasePacker):
         config: GlobalConfig,
     ) -> torch.Tensor:
         if operation.pack_relu != PackerReluType.NoRelu:
-            intermediate_format = config.sentinel.golden_format.pack_src
-            relu_config = PackGolden.generate_relu_config(
-                operation.pack_relu, operation.relu_threshold, intermediate_format
-            )
-            tensor = PackGolden.apply_relu(tensor, relu_config, intermediate_format)
+            tensor = self._relu_golden(tensor, operation, config)
 
         if operation.pack_l1_acc == L1Accumulation.Yes:
-            output_dims = operation.output.dimensions
-            output_format = operation.output.data_format
-            tile_size = operation.output.tile_shape.total_tile_size()
-            tile_count_x = operation.output.tile_count_x
-            tile_count_y = operation.output.tile_count_y
-            block_tiles_x = operation.block_tiles_x
-            block_tiles_y = operation.block_tiles_y
-
-            tensor = tilize_block(tensor, output_dims, output_format).flatten()
-            tile_grid = tensor.view(tile_count_y, tile_count_x, tile_size)
-
-            accumulated = torch.zeros(
-                block_tiles_y, block_tiles_x, tile_size, dtype=tensor.dtype
-            )
-            for by in range(0, tile_count_y, block_tiles_y):
-                for bx in range(0, tile_count_x, block_tiles_x):
-                    bty = min(block_tiles_y, tile_count_y - by)
-                    btx = min(block_tiles_x, tile_count_x - bx)
-                    accumulated[:bty, :btx] += tile_grid[by : by + bty, bx : bx + btx]
-
-            result_grid = torch.zeros(
-                tile_count_y, tile_count_x, tile_size, dtype=tensor.dtype
-            )
-            result_grid[:block_tiles_y, :block_tiles_x] = accumulated
-            tensor = untilize_block(result_grid.flatten(), output_format, output_dims)
+            tensor = self._l1_acc_golden(tensor, operation, config)
 
         return tensor
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/packer.py
@@ -33,7 +33,7 @@ class Packer(BasePacker):
         if operation.pack_relu != PackerReluType.NoRelu:
             tensor = self._relu_golden(tensor, operation, config)
 
-        if operation.pack_l1_acc == L1Accumulation.Yes:
+        if operation.pack_l1_accumulation == L1Accumulation.Yes:
             tensor = self._l1_acc_golden(tensor, operation, config)
 
         return tensor

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/packer.py
@@ -12,7 +12,8 @@ from fuser.fused_operation import FusedOperation
 from fuser.fused_packer import Packer as BasePacker
 from fuser.fuser_config import GlobalConfig
 from helpers.golden_generators import PackGolden
-from helpers.llk_params import PackerReluType
+from helpers.llk_params import L1Accumulation, PackerReluType
+from helpers.tilize_untilize import tilize_block, untilize_block
 
 
 class Packer(BasePacker):
@@ -37,6 +38,34 @@ class Packer(BasePacker):
                 operation.pack_relu, operation.relu_threshold, intermediate_format
             )
             tensor = PackGolden.apply_relu(tensor, relu_config, intermediate_format)
+
+        if operation.pack_l1_acc == L1Accumulation.Yes:
+            output_dims = operation.output.dimensions
+            output_format = operation.output.data_format
+            tile_size = operation.output.tile_shape.total_tile_size()
+            tile_count_x = operation.output.tile_count_x
+            tile_count_y = operation.output.tile_count_y
+            block_tiles_x = operation.block_tiles_x
+            block_tiles_y = operation.block_tiles_y
+
+            tensor = tilize_block(tensor, output_dims, output_format).flatten()
+            tile_grid = tensor.view(tile_count_y, tile_count_x, tile_size)
+
+            accumulated = torch.zeros(
+                block_tiles_y, block_tiles_x, tile_size, dtype=tensor.dtype
+            )
+            for by in range(0, tile_count_y, block_tiles_y):
+                for bx in range(0, tile_count_x, block_tiles_x):
+                    bty = min(block_tiles_y, tile_count_y - by)
+                    btx = min(block_tiles_x, tile_count_x - bx)
+                    accumulated[:bty, :btx] += tile_grid[by : by + bty, bx : bx + btx]
+
+            result_grid = torch.zeros(
+                tile_count_y, tile_count_x, tile_size, dtype=tensor.dtype
+            )
+            result_grid[:block_tiles_y, :block_tiles_x] = accumulated
+            tensor = untilize_block(result_grid.flatten(), output_format, output_dims)
+
         return tensor
 
     def init(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
@@ -439,7 +439,7 @@ class OperationSchema(BaseModel):
     block_size: Annotated[List[int], Field(min_length=2, max_length=2)] = [32, 32]
     pack_relu: PackerReluType = PackerReluType.NoRelu
     relu_threshold: float = 0.0
-    pack_l1_acc: L1Accumulation = L1Accumulation.No
+    pack_l1_accumulation: L1Accumulation = L1Accumulation.No
     bh_tilize: Optional[Tilize] = None
 
     @field_validator("packer", mode="before")
@@ -495,7 +495,7 @@ class OperationSchema(BaseModel):
             )
 
         if (
-            self.pack_l1_acc == L1Accumulation.Yes
+            self.pack_l1_accumulation == L1Accumulation.Yes
             and not output.data_format.supports_l1_acc()
         ):
             raise ValueError(f"{output.data_format} does not support L1 accumulation")
@@ -509,8 +509,8 @@ class OperationSchema(BaseModel):
             kwargs["pack_relu"] = self.pack_relu
         if self.relu_threshold:
             kwargs["relu_threshold"] = self.relu_threshold
-        if self.pack_l1_acc:
-            kwargs["pack_l1_acc"] = self.pack_l1_acc
+        if self.pack_l1_accumulation:
+            kwargs["pack_l1_accumulation"] = self.pack_l1_accumulation
         if self.bh_tilize:
             kwargs["bh_tilize"] = self.bh_tilize
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
@@ -16,6 +16,7 @@ from helpers.llk_params import (
     DestSync,
     EltwiseBinaryReuseDestType,
     EnforceFP32Accumulation,
+    L1Accumulation,
     MathFidelity,
     MathOperation,
     PackerReluType,
@@ -438,6 +439,7 @@ class OperationSchema(BaseModel):
     block_size: Annotated[List[int], Field(min_length=2, max_length=2)] = [32, 32]
     pack_relu: PackerReluType = PackerReluType.NoRelu
     relu_threshold: float = 0.0
+    pack_l1_acc: L1Accumulation = L1Accumulation.No
     bh_tilize: Optional[Tilize] = None
 
     @field_validator("packer", mode="before")
@@ -492,6 +494,12 @@ class OperationSchema(BaseModel):
                 f"Block size {self.block_size} exceeds output dimensions {output.dimensions}"
             )
 
+        if (
+            self.pack_l1_acc == L1Accumulation.Yes
+            and not output.data_format.supports_l1_acc()
+        ):
+            raise ValueError(f"{output.data_format} does not support L1 accumulation")
+
         kwargs = {}
         if self.dest_sync:
             kwargs["dest_sync"] = self.dest_sync
@@ -501,6 +509,8 @@ class OperationSchema(BaseModel):
             kwargs["pack_relu"] = self.pack_relu
         if self.relu_threshold:
             kwargs["relu_threshold"] = self.relu_threshold
+        if self.pack_l1_acc:
+            kwargs["pack_l1_acc"] = self.pack_l1_acc
         if self.bh_tilize:
             kwargs["bh_tilize"] = self.bh_tilize
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
@@ -496,7 +496,7 @@ class OperationSchema(BaseModel):
 
         if (
             self.pack_l1_accumulation == L1Accumulation.Yes
-            and not output.data_format.supports_l1_acc()
+            and not output.data_format.supports_l1_accumulation()
         ):
             raise ValueError(f"{output.data_format} does not support L1 accumulation")
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_loop.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_loop.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from .fuser_config import GlobalConfig
     from .block_data import BlockData
 
-from helpers.llk_params import PerfRunType
+from helpers.llk_params import L1Accumulation, PerfRunType
 
 
 class FusedLoop:
@@ -46,7 +46,12 @@ class FusedLoop:
             return code
         code += f"for (std::uint32_t tile_x = 0; tile_x < {block.block_tiles_x}; tile_x++) {{\n"
         code += f"for (std::uint32_t tile_y = 0; tile_y < {block.block_tiles_y}; tile_y++) {{\n"
-        code += f"std::uint32_t l1_tile_id = {block.tile_count_x} * ({block.block_y} + tile_y) + ({block.block_x} + tile_x);\n"
+        if operation.pack_l1_acc == L1Accumulation.Yes:
+            code += (
+                f"std::uint32_t l1_tile_id = tile_y * {block.tile_count_x} + tile_x;\n"
+            )
+        else:
+            code += f"std::uint32_t l1_tile_id = {block.tile_count_x} * ({block.block_y} + tile_y) + ({block.block_x} + tile_x);\n"
         code += (
             f"std::uint32_t dest_tile_id = tile_y * {block.block_tiles_x} + tile_x;\n"
         )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_loop.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_loop.py
@@ -46,7 +46,7 @@ class FusedLoop:
             return code
         code += f"for (std::uint32_t tile_x = 0; tile_x < {block.block_tiles_x}; tile_x++) {{\n"
         code += f"for (std::uint32_t tile_y = 0; tile_y < {block.block_tiles_y}; tile_y++) {{\n"
-        if operation.pack_l1_acc == L1Accumulation.Yes:
+        if operation.pack_l1_accumulation == L1Accumulation.Yes:
             code += (
                 f"std::uint32_t l1_tile_id = tile_y * {block.tile_count_x} + tile_x;\n"
             )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
@@ -307,7 +307,7 @@ class ComputePipeline:
         return code
 
     @staticmethod
-    def _pack_relu_config(config: "GlobalConfig", operation: "FusedOperation"):
+    def _pack_relu_config(config: "GlobalConfig", operation: "FusedOperation") -> str:
         from helpers.golden_generators import PackGolden
 
         pack_src_format = config.sentinel._pack_format.pack_src
@@ -316,6 +316,11 @@ class ComputePipeline:
             operation.pack_relu, operation.relu_threshold, pack_src_format
         )
         return f"_llk_pack_relu_config_({relu_config});\n"
+
+    @staticmethod
+    def _pack_l1_acc_config(config: "GlobalConfig", operation: "FusedOperation") -> str:
+        l1_acc = operation.pack_l1_acc.cpp_enum_value
+        return f"_llk_pack_reconfig_l1_acc_({l1_acc});\n"
 
     def pack_body(self, operation: "FusedOperation", config: "GlobalConfig") -> str:
         code = self._pack_constants(operation, config)
@@ -328,6 +333,7 @@ class ComputePipeline:
         code += self._pack_reduce_mask_config()
         code += self.packer().init(operation, config, None, None)
         code += self._pack_relu_config(config, operation)
+        code += self._pack_l1_acc_config(config, operation)
 
         if config.profiler_enabled:
             code += "PROFILER_SYNC();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
@@ -318,8 +318,10 @@ class ComputePipeline:
         return f"_llk_pack_relu_config_({relu_config});\n"
 
     @staticmethod
-    def _pack_l1_acc_config(config: "GlobalConfig", operation: "FusedOperation") -> str:
-        l1_acc = operation.pack_l1_acc.cpp_enum_value
+    def _pack_l1_accumulation_config(
+        config: "GlobalConfig", operation: "FusedOperation"
+    ) -> str:
+        l1_acc = operation.pack_l1_accumulation.cpp_enum_value
         return f"_llk_pack_reconfig_l1_acc_({l1_acc});\n"
 
     def pack_body(self, operation: "FusedOperation", config: "GlobalConfig") -> str:
@@ -333,7 +335,7 @@ class ComputePipeline:
         code += self._pack_reduce_mask_config()
         code += self.packer().init(operation, config, None, None)
         code += self._pack_relu_config(config, operation)
-        code += self._pack_l1_acc_config(config, operation)
+        code += self._pack_l1_accumulation_config(config, operation)
 
         if config.profiler_enabled:
             code += "PROFILER_SYNC();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
@@ -157,11 +157,15 @@ class Operand:
         tile_elements = self.tile_shape.total_tile_size()
         tile_size = self.data_format.num_bytes_per_tile(tile_elements)
 
-        buffer = tilize_block(
-            self.raw_data,
-            dimensions=self.dimensions,
-            stimuli_format=self.data_format,
-        ).flatten()
+        buffer = (
+            tilize_block(
+                self.raw_data,
+                dimensions=self.dimensions,
+                stimuli_format=self.data_format,
+            ).flatten()
+            if self.is_input()
+            else torch.zeros(self.dimensions).flatten()
+        )
 
         packed_tiles = []
 
@@ -295,6 +299,10 @@ class OperandRegistry:
         """Write all input operands to L1 memory."""
 
         for operand in self.get_all_inputs():
+            for addr, packed_data in operand.pack_for_l1():
+                write_to_device(location, addr, packed_data)
+
+        for operand in self.get_all_outputs():
             for addr, packed_data in operand.pack_for_l1():
                 write_to_device(location, addr, packed_data)
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operation.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operation.py
@@ -9,6 +9,7 @@ import torch
 from helpers.llk_params import (
     DestSync,
     GoldenType,
+    L1Accumulation,
     PackerReluType,
     StochasticRounding,
     Tilize,
@@ -32,6 +33,7 @@ class FusedOperation:
     block_size: Tuple[int, int] = (32, 32)
     pack_relu: PackerReluType = PackerReluType.NoRelu
     relu_threshold: float = 0.0
+    pack_l1_acc: L1Accumulation = L1Accumulation.No
     bh_tilize: Tilize = Tilize.No
 
     def __post_init__(self):
@@ -80,4 +82,5 @@ class FusedOperation:
             f"  Output: {self.output}\n"
             f"  Block Size: {self.block_size}\n"
             f"  Dest Sync: {self.dest_sync}\n"
+            f"  {self.pack_l1_acc}\n"
         )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operation.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operation.py
@@ -82,5 +82,5 @@ class FusedOperation:
             f"  Output: {self.output}\n"
             f"  Block Size: {self.block_size}\n"
             f"  Dest Sync: {self.dest_sync}\n"
-            f"  {self.pack_l1_acc}\n"
+            f"  Pack L1 Acc: {self.pack_l1_acc}\n"
         )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operation.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operation.py
@@ -82,5 +82,5 @@ class FusedOperation:
             f"  Output: {self.output}\n"
             f"  Block Size: {self.block_size}\n"
             f"  Dest Sync: {self.dest_sync}\n"
-            f"  Pack L1 Acc: {self.pack_l1_accumulation}\n"
+            f"  Pack L1 Accumulation: {self.pack_l1_accumulation}\n"
         )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operation.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operation.py
@@ -33,7 +33,7 @@ class FusedOperation:
     block_size: Tuple[int, int] = (32, 32)
     pack_relu: PackerReluType = PackerReluType.NoRelu
     relu_threshold: float = 0.0
-    pack_l1_acc: L1Accumulation = L1Accumulation.No
+    pack_l1_accumulation: L1Accumulation = L1Accumulation.No
     bh_tilize: Tilize = Tilize.No
 
     def __post_init__(self):
@@ -82,5 +82,5 @@ class FusedOperation:
             f"  Output: {self.output}\n"
             f"  Block Size: {self.block_size}\n"
             f"  Dest Sync: {self.dest_sync}\n"
-            f"  Pack L1 Acc: {self.pack_l1_acc}\n"
+            f"  Pack L1 Acc: {self.pack_l1_accumulation}\n"
         )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_packer.py
@@ -12,11 +12,58 @@ if TYPE_CHECKING:
     from .block_data import BlockData
     from .compute_node import ComputeNode
 
+from helpers.golden_generators import PackGolden
+from helpers.tilize_untilize import tilize_block, untilize_block
+
 from .fused_loop import FusedLoop
 
 
 class Packer:
     loop: FusedLoop = FusedLoop()
+
+    @staticmethod
+    def _l1_acc_golden(
+        tensor: torch.Tensor,
+        operation: "FusedOperation",
+        config: "GlobalConfig",
+    ) -> torch.Tensor:
+        output_dims = operation.output.dimensions
+        output_format = operation.output.data_format
+        tile_size = operation.output.tile_shape.total_tile_size()
+        tile_count_x = operation.output.tile_count_x
+        tile_count_y = operation.output.tile_count_y
+        block_tiles_x = operation.block_tiles_x
+        block_tiles_y = operation.block_tiles_y
+
+        tensor = tilize_block(tensor, output_dims, output_format).flatten()
+        tile_grid = tensor.view(tile_count_y, tile_count_x, tile_size)
+
+        accumulated = torch.zeros(
+            block_tiles_y, block_tiles_x, tile_size, dtype=tensor.dtype
+        )
+        for by in range(0, tile_count_y, block_tiles_y):
+            for bx in range(0, tile_count_x, block_tiles_x):
+                bty = min(block_tiles_y, tile_count_y - by)
+                btx = min(block_tiles_x, tile_count_x - bx)
+                accumulated[:bty, :btx] += tile_grid[by : by + bty, bx : bx + btx]
+
+        result_grid = torch.zeros(
+            tile_count_y, tile_count_x, tile_size, dtype=tensor.dtype
+        )
+        result_grid[:block_tiles_y, :block_tiles_x] = accumulated
+        return untilize_block(result_grid.flatten(), output_format, output_dims)
+
+    @staticmethod
+    def _relu_golden(
+        tensor: torch.Tensor,
+        operation: "FusedOperation",
+        config: "GlobalConfig",
+    ) -> torch.Tensor:
+        intermediate_format = config.sentinel.golden_format.pack_src
+        relu_config = PackGolden.generate_relu_config(
+            operation.pack_relu, operation.relu_threshold, intermediate_format
+        )
+        return PackGolden.apply_relu(tensor, relu_config, intermediate_format)
 
     def get_headers(self) -> List[str]:
         return []

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/packer.py
@@ -32,7 +32,7 @@ class Packer(BasePacker):
         if operation.pack_relu != PackerReluType.NoRelu:
             tensor = self._relu_golden(tensor, operation, config)
 
-        if operation.pack_l1_acc == L1Accumulation.Yes:
+        if operation.pack_l1_accumulation == L1Accumulation.Yes:
             tensor = self._l1_acc_golden(tensor, operation, config)
 
         return tensor

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/packer.py
@@ -11,9 +11,7 @@ from fuser.fused_math import ComputeNode
 from fuser.fused_operation import FusedOperation
 from fuser.fused_packer import Packer as BasePacker
 from fuser.fuser_config import GlobalConfig
-from helpers.golden_generators import PackGolden
 from helpers.llk_params import L1Accumulation, PackerReluType
-from helpers.tilize_untilize import tilize_block, untilize_block
 
 
 class Packer(BasePacker):
@@ -32,38 +30,10 @@ class Packer(BasePacker):
         config: GlobalConfig,
     ) -> torch.Tensor:
         if operation.pack_relu != PackerReluType.NoRelu:
-            intermediate_format = config.sentinel.golden_format.pack_src
-            relu_config = PackGolden.generate_relu_config(
-                operation.pack_relu, operation.relu_threshold, intermediate_format
-            )
-            tensor = PackGolden.apply_relu(tensor, relu_config, intermediate_format)
+            tensor = self._relu_golden(tensor, operation, config)
 
         if operation.pack_l1_acc == L1Accumulation.Yes:
-            output_dims = operation.output.dimensions
-            output_format = operation.output.data_format
-            tile_size = operation.output.tile_shape.total_tile_size()
-            tile_count_x = operation.output.tile_count_x
-            tile_count_y = operation.output.tile_count_y
-            block_tiles_x = operation.block_tiles_x
-            block_tiles_y = operation.block_tiles_y
-
-            tensor = tilize_block(tensor, output_dims, output_format).flatten()
-            tile_grid = tensor.view(tile_count_y, tile_count_x, tile_size)
-
-            accumulated = torch.zeros(
-                block_tiles_y, block_tiles_x, tile_size, dtype=tensor.dtype
-            )
-            for by in range(0, tile_count_y, block_tiles_y):
-                for bx in range(0, tile_count_x, block_tiles_x):
-                    bty = min(block_tiles_y, tile_count_y - by)
-                    btx = min(block_tiles_x, tile_count_x - bx)
-                    accumulated[:bty, :btx] += tile_grid[by : by + bty, bx : bx + btx]
-
-            result_grid = torch.zeros(
-                tile_count_y, tile_count_x, tile_size, dtype=tensor.dtype
-            )
-            result_grid[:block_tiles_y, :block_tiles_x] = accumulated
-            tensor = untilize_block(result_grid.flatten(), output_format, output_dims)
+            tensor = self._l1_acc_golden(tensor, operation, config)
 
         return tensor
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/packer.py
@@ -12,7 +12,8 @@ from fuser.fused_operation import FusedOperation
 from fuser.fused_packer import Packer as BasePacker
 from fuser.fuser_config import GlobalConfig
 from helpers.golden_generators import PackGolden
-from helpers.llk_params import PackerReluType
+from helpers.llk_params import L1Accumulation, PackerReluType
+from helpers.tilize_untilize import tilize_block, untilize_block
 
 
 class Packer(BasePacker):
@@ -36,6 +37,34 @@ class Packer(BasePacker):
                 operation.pack_relu, operation.relu_threshold, intermediate_format
             )
             tensor = PackGolden.apply_relu(tensor, relu_config, intermediate_format)
+
+        if operation.pack_l1_acc == L1Accumulation.Yes:
+            output_dims = operation.output.dimensions
+            output_format = operation.output.data_format
+            tile_size = operation.output.tile_shape.total_tile_size()
+            tile_count_x = operation.output.tile_count_x
+            tile_count_y = operation.output.tile_count_y
+            block_tiles_x = operation.block_tiles_x
+            block_tiles_y = operation.block_tiles_y
+
+            tensor = tilize_block(tensor, output_dims, output_format).flatten()
+            tile_grid = tensor.view(tile_count_y, tile_count_x, tile_size)
+
+            accumulated = torch.zeros(
+                block_tiles_y, block_tiles_x, tile_size, dtype=tensor.dtype
+            )
+            for by in range(0, tile_count_y, block_tiles_y):
+                for bx in range(0, tile_count_x, block_tiles_x):
+                    bty = min(block_tiles_y, tile_count_y - by)
+                    btx = min(block_tiles_x, tile_count_x - bx)
+                    accumulated[:bty, :btx] += tile_grid[by : by + bty, bx : bx + btx]
+
+            result_grid = torch.zeros(
+                tile_count_y, tile_count_x, tile_size, dtype=tensor.dtype
+            )
+            result_grid[:block_tiles_y, :block_tiles_x] = accumulated
+            tensor = untilize_block(result_grid.flatten(), output_format, output_dims)
+
         return tensor
 
     def init(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/parser.py
@@ -16,6 +16,7 @@ from helpers.llk_params import (
     DestSync,
     EltwiseBinaryReuseDestType,
     EnforceFP32Accumulation,
+    L1Accumulation,
     MathFidelity,
     MathOperation,
     PackerReluType,
@@ -437,6 +438,7 @@ class OperationSchema(BaseModel):
     block_size: Annotated[List[int], Field(min_length=2, max_length=2)] = [32, 32]
     pack_relu: PackerReluType = PackerReluType.NoRelu
     relu_threshold: float = 0.0
+    pack_l1_acc: L1Accumulation = L1Accumulation.No
 
     @field_validator("packer", mode="before")
     @classmethod
@@ -469,6 +471,12 @@ class OperationSchema(BaseModel):
                 f"Block size {self.block_size} exceeds output dimensions {output.dimensions}"
             )
 
+        if (
+            self.pack_l1_acc == L1Accumulation.Yes
+            and not output.data_format.supports_l1_acc()
+        ):
+            raise ValueError(f"{output.data_format} does not support L1 accumulation")
+
         kwargs = {}
         if self.dest_sync:
             kwargs["dest_sync"] = self.dest_sync
@@ -478,6 +486,8 @@ class OperationSchema(BaseModel):
             kwargs["pack_relu"] = self.pack_relu
         if self.relu_threshold:
             kwargs["relu_threshold"] = self.relu_threshold
+        if self.pack_l1_acc:
+            kwargs["pack_l1_acc"] = self.pack_l1_acc
 
         return FusedOperation(
             math=ComputePipeline(math_ops, self.packer.to_runtime()),

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/parser.py
@@ -473,7 +473,7 @@ class OperationSchema(BaseModel):
 
         if (
             self.pack_l1_accumulation == L1Accumulation.Yes
-            and not output.data_format.supports_l1_acc()
+            and not output.data_format.supports_l1_accumulation()
         ):
             raise ValueError(f"{output.data_format} does not support L1 accumulation")
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/parser.py
@@ -438,7 +438,7 @@ class OperationSchema(BaseModel):
     block_size: Annotated[List[int], Field(min_length=2, max_length=2)] = [32, 32]
     pack_relu: PackerReluType = PackerReluType.NoRelu
     relu_threshold: float = 0.0
-    pack_l1_acc: L1Accumulation = L1Accumulation.No
+    pack_l1_accumulation: L1Accumulation = L1Accumulation.No
 
     @field_validator("packer", mode="before")
     @classmethod
@@ -472,7 +472,7 @@ class OperationSchema(BaseModel):
             )
 
         if (
-            self.pack_l1_acc == L1Accumulation.Yes
+            self.pack_l1_accumulation == L1Accumulation.Yes
             and not output.data_format.supports_l1_acc()
         ):
             raise ValueError(f"{output.data_format} does not support L1 accumulation")
@@ -486,8 +486,8 @@ class OperationSchema(BaseModel):
             kwargs["pack_relu"] = self.pack_relu
         if self.relu_threshold:
             kwargs["relu_threshold"] = self.relu_threshold
-        if self.pack_l1_acc:
-            kwargs["pack_l1_acc"] = self.pack_l1_acc
+        if self.pack_l1_accumulation:
+            kwargs["pack_l1_accumulation"] = self.pack_l1_accumulation
 
         return FusedOperation(
             math=ComputePipeline(math_ops, self.packer.to_runtime()),

--- a/tt_metal/tt-llk/tests/python_tests/fuser_config/l1_accumulation.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_config/l1_accumulation.yaml
@@ -1,0 +1,23 @@
+operands:
+  - name: "input_A"
+    dims: [128, 128]
+    format: "Float16_b"
+  - name: "input_B"
+    dims: [128, 128]
+    format: "Float16_b"
+  - name: "l1_acc_out"
+    dims: [128, 128]
+    format: "Float16_b"
+
+operations:
+  - output: "l1_acc_out"
+    math:
+      - type: "Fpu"
+        src_a: "input_A"
+        src_b: "input_B"
+        operation: "Elwadd"
+        unpacker: "UnpackerAB"
+        math_fidelity: "LoFi"
+    packer: "Packer"
+    block_size: [64, 64]
+    pack_l1_acc: 1

--- a/tt_metal/tt-llk/tests/python_tests/fuser_config/l1_accumulation.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_config/l1_accumulation.yaml
@@ -20,4 +20,4 @@ operations:
         math_fidelity: "LoFi"
     packer: "Packer"
     block_size: [64, 64]
-    pack_l1_acc: 1
+    pack_l1_accumulation: 1

--- a/tt_metal/tt-llk/tests/python_tests/helpers/format_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/format_config.py
@@ -180,7 +180,7 @@ class DataFormat(Enum):
             DataFormat.MxFp8P,
         }
 
-    def supports_l1_acc(self) -> bool:
+    def supports_l1_accumulation(self) -> bool:
         """Checks if the data format supports L1 accumulation"""
         return self in {
             DataFormat.Float32,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/format_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/format_config.py
@@ -180,6 +180,15 @@ class DataFormat(Enum):
             DataFormat.MxFp8P,
         }
 
+    def supports_l1_acc(self) -> bool:
+        """Checks if the data format supports L1 accumulation"""
+        return self in {
+            DataFormat.Float32,
+            DataFormat.Int32,
+            DataFormat.Float16,
+            DataFormat.Float16_b,
+        }
+
 
 # ============================================================================
 # MX (Microscaling) Format Utilities

--- a/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
@@ -211,6 +211,10 @@ class L1Accumulation(Enum):
     Yes = 1
     No = 0
 
+    @property
+    def cpp_enum_value(self):
+        return str(self.value)
+
 
 class StochasticRounding(Enum):
     No = "StochRndType::None"


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Add pack L1 accumulation to the fuser, where the packer adds to L1 instead of overwriting, so partial results from multiple blocks accumulate at the same addresses. The pack loop addresses tiles using the grid stride so all blocks map to the same L1 region. A `supports_l1_acc()` check on `DataFormat` validates that the output format can use L! accumulation.


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=markoradosavljevic/fuser-l1-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:markoradosavljevic/fuser-l1-acc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=markoradosavljevic/fuser-l1-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:markoradosavljevic/fuser-l1-acc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=markoradosavljevic/fuser-l1-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:markoradosavljevic/fuser-l1-acc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=markoradosavljevic/fuser-l1-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:markoradosavljevic/fuser-l1-acc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=markoradosavljevic/fuser-l1-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:markoradosavljevic/fuser-l1-acc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=markoradosavljevic/fuser-l1-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:markoradosavljevic/fuser-l1-acc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=markoradosavljevic/fuser-l1-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:markoradosavljevic/fuser-l1-acc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=markoradosavljevic/fuser-l1-acc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:markoradosavljevic/fuser-l1-acc)