### PR TITLE
[skip ci] e2e: bump Falcon-7B [wh_n150] job timeout 5 → 6 min

### DIFF
--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -405,7 +405,7 @@
   model: falcon-7b
   skus:
     wh_n150:
-      timeout: 5
+      timeout: 6
       tier: 3
   owner_id: U07RY6B5FLJ # Gongyu Wang
   team: models


### PR DESCRIPTION
## Summary
The Tier 3 Falcon-7B e2e test has tripped its 5-minute job-level timeout on the last 3 consecutive scheduled `main` runs (2026-05-09, 05-10, 05-11), all with the same `action timed out after 5 minutes` signal — the job-level timeout, not `pytest --timeout`.

This bumps the job-level allocation from 5 → 6 minutes. One minute of headroom should clear the intermittent timeout.

## Change
- `tests/pipeline_reorg/models_e2e_tests.yaml` — Falcon-7B `wh_n150` `timeout: 5 → 6`.
- `pytest --timeout 420` left unchanged (not what was firing here).

## Budget impact
`wh_n150` e2e budget is 100 min. Sum was 56 min before this PR; goes to 57 min after. Plenty of headroom (43%).

## Failing runs that motivated this
- [2026-05-11 06:17](https://github.com/tenstorrent/tt-metal/actions/runs/25653697645)
- [2026-05-10 06:02](https://github.com/tenstorrent/tt-metal/actions/runs/25621382253)
- [2026-05-09 05:56](https://github.com/tenstorrent/tt-metal/actions/runs/25593473141)

## Confirmation run
Dispatched via `all-model-tests` (Tier 3 e2e, `wh_n150`, model=`falcon-7b`):
- https://github.com/tenstorrent/tt-metal/actions/runs/25667618846

## Test plan
- [ ] Confirmation run above completes within the new 6-minute budget.
- [ ] Next scheduled Tier 3 e2e cycle includes Falcon-7B in the green column.
- [ ] If 6 min still trips, investigate the underlying slowdown rather than bumping further blindly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/falcon7b-timeout-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/falcon7b-timeout-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/falcon7b-timeout-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/falcon7b-timeout-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/falcon7b-timeout-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/falcon7b-timeout-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/falcon7b-timeout-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/falcon7b-timeout-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/falcon7b-timeout-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/falcon7b-timeout-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/falcon7b-timeout-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/falcon7b-timeout-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/falcon7b-timeout-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/falcon7b-timeout-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/falcon7b-timeout-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/falcon7b-timeout-bump)
