### PR TITLE
[Cleanup] Move LLK debug helpers out of common APIs

### DIFF
--- a/tech_reports/Handling_Special_Value/special_values.md
+++ b/tech_reports/Handling_Special_Value/special_values.md
@@ -70,7 +70,6 @@ ALWI uint32_t get_compute_special_value_flags()
 ALWI uint32_t get_compute_special_value_flags_fpu(uint32_t special_value_flags_reg)
 ALWI uint32_t get_compute_special_value_flags_sfpu(uint32_t special_value_flags_reg)
 ALWI void clear_compute_special_value_flags()
-ALWI void store_compute_special_value_flags_to_l1(uint32_t l1_addr)
 ```
 All APIs execute on MATH thread only (trisc1).
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_api.h
@@ -49,7 +49,14 @@ template <
     MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_acc = true) {
-    LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
+    // DEVICE_PRINT("llk_math_eltwise_binary: dst_index = {}, max dest tiles = {}\n",
+    //     dst_index,
+    //     get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>());
+
+    LLK_ASSERT(
+        (dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()),
+        "llk_math_eltwise_binary: dst index exceeds available dest register capacity. Uncomment the DEVICE_PRINT "
+        "block above and enable DEVICE_PRINT support to inspect the dst index and max dest tile values.");
 
     _llk_math_eltwise_binary_<
         eltwise_binary_type,
@@ -68,7 +75,14 @@ template <
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary(
     const std::uint32_t operand_A, const std::uint32_t operand_B, uint dst_index, const bool clear_fp32_dst_acc) {
-    LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
+    // DEVICE_PRINT("llk_math_eltwise_binary: dst_index = {}, max dest tiles = {}\n",
+    //     dst_index,
+    //     get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>());
+
+    LLK_ASSERT(
+        (dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()),
+        "llk_math_eltwise_binary: dst index exceeds available dest register capacity. Uncomment the DEVICE_PRINT "
+        "block above and enable DEVICE_PRINT support to inspect the dst index and max dest tile values.");
 
     const std::uint32_t operand_id = get_operand_id(operand_A);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
@@ -10,10 +10,8 @@
 #include "cmath_common.h"
 #include "api/debug/waypoint.h"
 #include "llk_defs.h"
-#include "llk_io.h"
 #include "llk_math_common.h"
 #include "llk_operands.h"
-#include "llk_param_structs.h"
 
 // Need to revisit why we even need this
 #define EPS 1.19209e-07  // std::numeric_limits::epsilon() for FP32
@@ -48,10 +46,6 @@ template <bool is_fp32_dest_acc_en>
 inline void llk_math_pack_sync_init() {
     _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
-
-inline void llk_math_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _llk_math_debug_dump_(data, byte_size); }
-
-inline void llk_math_debug_dump_seek(std::uint8_t offset) { _llk_math_debug_dump_seek_(offset); }
 
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
@@ -115,25 +109,4 @@ inline void llk_math_reconfig_data_format_srcb(
     if ((unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
         llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8>(srcb_new_operand);
     }
-}
-
-inline std::uint32_t llk_math_get_compute_special_value_flags() { return _llk_math_get_compute_special_value_flags_(); }
-
-inline std::uint32_t llk_math_get_compute_special_value_flags_fpu(std::uint32_t special_value_flags_reg) {
-    constexpr std::uint32_t special_value_flags_fpu_mask = 0xf;
-    constexpr std::uint32_t special_value_flags_fpu_shift = 4;
-    return (special_value_flags_reg & special_value_flags_fpu_mask) >> special_value_flags_fpu_shift;
-}
-
-inline std::uint32_t llk_math_get_compute_special_value_flags_sfpu(std::uint32_t special_value_flags_reg) {
-    constexpr std::uint32_t special_value_flags_sfpu_mask = 0xf;
-    constexpr std::uint32_t special_value_flags_sfpu_shift = 0;
-    return (special_value_flags_reg & special_value_flags_sfpu_mask) >> special_value_flags_sfpu_shift;
-}
-
-inline void llk_math_clear_compute_special_value_flags() { _llk_math_clear_compute_special_value_flags_(); }
-
-inline void llk_math_store_compute_special_value_flags_to_l1(std::uint32_t l1_addr) {
-    volatile tt_l1_ptr std::uint32_t* l1_addr_ptr = reinterpret_cast<volatile tt_l1_ptr std::uint32_t*>(l1_addr);
-    l1_addr_ptr[0] = _llk_math_get_compute_special_value_flags_();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_debug.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_debug.h
@@ -17,8 +17,3 @@ inline std::uint32_t llk_math_extract_compute_special_value_flags(std::uint32_t 
 }
 
 inline void llk_math_clear_compute_special_value_flags() { _llk_math_clear_compute_special_value_flags_(); }
-
-inline void llk_math_store_compute_special_value_flags_to_l1(std::uint32_t l1_addr) {
-    volatile tt_l1_ptr std::uint32_t* l1_addr_ptr = reinterpret_cast<volatile tt_l1_ptr std::uint32_t*>(l1_addr);
-    l1_addr_ptr[0] = _llk_math_get_compute_special_value_flags_();
-}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_debug.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_debug.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "llk_math_common.h"
+
+inline std::uint32_t llk_math_get_compute_special_value_flags() { return _llk_math_get_compute_special_value_flags_(); }
+
+template <bool isFpu>
+inline std::uint32_t llk_math_extract_compute_special_value_flags(std::uint32_t special_value_flags_reg) {
+    constexpr std::uint32_t special_value_flags_mask = isFpu ? 0x7 : 0xf;
+    constexpr std::uint32_t special_value_flags_shift = isFpu ? 4 : 0;
+    return (special_value_flags_reg >> special_value_flags_shift) & special_value_flags_mask;
+}
+
+inline void llk_math_clear_compute_special_value_flags() { _llk_math_clear_compute_special_value_flags_(); }
+
+inline void llk_math_store_compute_special_value_flags_to_l1(std::uint32_t l1_addr) {
+    volatile tt_l1_ptr std::uint32_t* l1_addr_ptr = reinterpret_cast<volatile tt_l1_ptr std::uint32_t*>(l1_addr);
+    l1_addr_ptr[0] = _llk_math_get_compute_special_value_flags_();
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
@@ -34,12 +34,6 @@ inline void llk_math_matmul_init(
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0, uint32_t num_faces = 4 /*not used*/>
 inline void llk_math_matmul(const uint dst_index, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1) {
     static_assert(num_faces == 4, "num_faces other than 4 is not supported in llk_math_matmul");
-    LLK_ASSERT(
-        (ckernel::math::get_dest_max_matmul_tiles(dst_index, ct_dim, rt_dim) <
-         get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()),
-        "llk_math_matmul: computed matmul dest tile range exceeds available dest register "
-        "capacity. Uncomment the DEVICE_PRINT block below and enable DEVICE_PRINT support to inspect "
-        "the calculated and max dest tile values.");
 
     // DEVICE_PRINT("llk_math_matmul: calculated dest tiles = {}, max dest tiles = {} (dst_index={}, ct_dim={},
     // rt_dim={})\n",
@@ -48,6 +42,13 @@ inline void llk_math_matmul(const uint dst_index, const std::uint32_t ct_dim = 1
     //     dst_index,
     //     ct_dim,
     //     rt_dim);
+
+    LLK_ASSERT(
+        (ckernel::math::get_dest_max_matmul_tiles(dst_index, ct_dim, rt_dim) <
+         get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()),
+        "llk_math_matmul: computed matmul dest tile range exceeds available dest register "
+        "capacity. Uncomment the DEVICE_PRINT block above and enable DEVICE_PRINT support to inspect "
+        "the calculated and max dest tile values.");
 
     _llk_math_matmul_<math_fidelity, THROTTLE_LEVEL>(dst_index, ct_dim, rt_dim);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -24,17 +24,6 @@
  * LLK PACK
  *************************************************************************/
 
-// TODO NC: Remove as the part of tt-metal#34499
-template <bool untilize = false, bool zero_output = false, bool tilize = false>
-inline void llk_pack_mop_config(const uint32_t output, std::uint32_t num_tiles = 1) {
-    const std::uint32_t output_id = get_output_id(output);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
-
-    _llk_pack_mop_config_<untilize, zero_output, tilize>(face_r_dim, tile_c_dim, num_faces, num_tiles);
-}
-
 inline void llk_pack_set_fp32_dest_acc(bool enable) { _llk_pack_set_fp32_dest_acc_(enable); }
 
 template <bool is_fp32_dest_acc_en>
@@ -308,7 +297,7 @@ inline void llk_pack_dest_init([[maybe_unused]] const std::uint32_t pack_output 
     _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
-template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const std::uint32_t output_id = get_output_id(new_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -24,6 +24,17 @@
  * LLK PACK
  *************************************************************************/
 
+// TODO NC: Remove as the part of tt-metal#34499
+template <bool untilize = false, bool zero_output = false, bool tilize = false>
+inline void llk_pack_mop_config(const uint32_t output, std::uint32_t num_tiles = 1) {
+    const std::uint32_t output_id = get_output_id(output);
+    const std::uint32_t num_faces = get_output_num_faces(output_id);
+    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
+    const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
+
+    _llk_pack_mop_config_<untilize, zero_output, tilize>(face_r_dim, tile_c_dim, num_faces, num_tiles);
+}
+
 inline void llk_pack_set_fp32_dest_acc(bool enable) { _llk_pack_set_fp32_dest_acc_(enable); }
 
 template <bool is_fp32_dest_acc_en>
@@ -282,11 +293,6 @@ inline void llk_matmul_pack(
 
 inline void llk_packer_wait_for_math_done() { _llk_packer_wait_for_math_done_(); }
 
-template <uint WaitRes = p_stall::NONE>
-inline void llk_packer_set_math_semaphore() {
-    _llk_packer_set_math_semaphore_<WaitRes>();
-}
-
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_dest_section_done() {
     _llk_pack_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
@@ -302,11 +308,7 @@ inline void llk_pack_dest_init([[maybe_unused]] const std::uint32_t pack_output 
     _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
-inline void llk_pack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _llk_pack_debug_dump_(data, byte_size); }
-
-inline void llk_pack_debug_dump_seek(std::uint8_t offset) { _llk_pack_debug_dump_seek_(offset); }
-
-template <bool is_fp32_dest_acc_en>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const std::uint32_t output_id = get_output_id(new_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -337,38 +337,3 @@ inline void llk_pack_reduce_mask_config() {
 }
 
 inline void llk_pack_reduce_mask_clear() { _llk_pack_reduce_mask_clear_(); }
-
-// FIXME-WH-UPLIFT
-template <ReduceDim dim, bool is_fp32_dest_acc_en, bool at_kernel_start = false, bool revert = false>
-inline void llk_pack_reduce_config_v2(uint32_t icb_out) {
-    const bool untilize = false;
-    if constexpr (at_kernel_start) {
-        const std::uint32_t output_id = get_output_id(icb_out);
-        const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-        const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
-        const std::uint32_t num_faces = get_output_num_faces(output_id);
-        const bool partial_face = get_output_partial_face(output_id);
-        const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
-        const llk_relu_config_u relu_config = {
-            .f = {
-                .ApplyRelu = (std::uint32_t)ReluType::NO_RELU,
-                .Threshold = 0,
-            }};
-
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize>(
-            pack_src_format[output_id],
-            pack_dst_format[output_id],
-            tile_size,
-            face_r_dim,
-            tile_c_dim,
-            num_faces,
-            partial_face,
-            relu_config.val);
-    }
-
-    if constexpr (revert) {
-        _llk_pack_reduce_mask_clear_();
-    } else {
-        _llk_pack_reduce_mask_config_<untilize, dim>();
-    }
-}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_binary_api.h
@@ -49,7 +49,14 @@ template <
     MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_acc = true) {
-    LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
+    // DEVICE_PRINT("llk_math_eltwise_binary: dst_index = {}, max dest tiles = {}\n",
+    //     dst_index,
+    //     get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>());
+
+    LLK_ASSERT(
+        (dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()),
+        "llk_math_eltwise_binary: dst index exceeds available dest register capacity. Uncomment the DEVICE_PRINT "
+        "block above and enable DEVICE_PRINT support to inspect the dst index and max dest tile values.");
 
     _llk_math_eltwise_binary_<
         eltwise_binary_type,
@@ -71,7 +78,14 @@ inline void llk_math_eltwise_binary(
     const std::uint32_t operand_B,
     uint dst_index,
     const bool clear_fp32_dst_acc = true) {
-    LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
+    // DEVICE_PRINT("llk_math_eltwise_binary: dst_index = {}, max dest tiles = {}\n",
+    //     dst_index,
+    //     get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>());
+
+    LLK_ASSERT(
+        (dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()),
+        "llk_math_eltwise_binary: dst index exceeds available dest register capacity. Uncomment the DEVICE_PRINT "
+        "block above and enable DEVICE_PRINT support to inspect the dst index and max dest tile values.");
 
     const std::uint32_t operand_id = get_operand_id(operand_A);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
@@ -9,10 +9,8 @@
 #include "ckernel_template.h"
 #include "cmath_common.h"
 #include "llk_defs.h"
-#include "llk_io.h"
 #include "llk_math_common.h"
 #include "llk_operands.h"
-#include "llk_param_structs.h"
 #include "api/debug/waypoint.h"
 
 // Need to revisit why we even need this
@@ -46,10 +44,6 @@ template <bool is_fp32_dest_acc_en>
 inline void llk_math_pack_sync_init() {
     _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
-
-inline void llk_math_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _llk_math_debug_dump_(data, byte_size); }
-
-inline void llk_math_debug_dump_seek(std::uint8_t offset) { _llk_math_debug_dump_seek_(offset); }
 
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
@@ -113,25 +107,4 @@ inline void llk_math_reconfig_data_format_srcb(
     if ((unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
         llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8>(srcb_new_operand);
     }
-}
-
-inline std::uint32_t llk_math_get_compute_special_value_flags() { return _llk_math_get_compute_special_value_flags_(); }
-
-inline std::uint32_t llk_math_get_compute_special_value_flags_fpu(std::uint32_t special_value_flags_reg) {
-    constexpr std::uint32_t special_value_flags_fpu_mask = 0x7;
-    constexpr std::uint32_t special_value_flags_fpu_shift = 4;
-    return (special_value_flags_reg & special_value_flags_fpu_mask) >> special_value_flags_fpu_shift;
-}
-
-inline std::uint32_t llk_math_get_compute_special_value_flags_sfpu(std::uint32_t special_value_flags_reg) {
-    constexpr std::uint32_t special_value_flags_sfpu_mask = 0xf;
-    constexpr std::uint32_t special_value_flags_sfpu_shift = 0;
-    return (special_value_flags_reg & special_value_flags_sfpu_mask) >> special_value_flags_sfpu_shift;
-}
-
-inline void llk_math_clear_compute_special_value_flags() { _llk_math_clear_compute_special_value_flags_(); }
-
-inline void llk_math_store_compute_special_value_flags_to_l1(std::uint32_t l1_addr) {
-    volatile tt_l1_ptr std::uint32_t* l1_addr_ptr = reinterpret_cast<volatile tt_l1_ptr std::uint32_t*>(l1_addr);
-    l1_addr_ptr[0] = _llk_math_get_compute_special_value_flags_();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_debug.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_debug.h
@@ -17,8 +17,3 @@ inline std::uint32_t llk_math_extract_compute_special_value_flags(std::uint32_t 
 }
 
 inline void llk_math_clear_compute_special_value_flags() { _llk_math_clear_compute_special_value_flags_(); }
-
-inline void llk_math_store_compute_special_value_flags_to_l1(std::uint32_t l1_addr) {
-    volatile tt_l1_ptr std::uint32_t* l1_addr_ptr = reinterpret_cast<volatile tt_l1_ptr std::uint32_t*>(l1_addr);
-    l1_addr_ptr[0] = _llk_math_get_compute_special_value_flags_();
-}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_debug.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_debug.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "llk_math_common.h"
+
+inline std::uint32_t llk_math_get_compute_special_value_flags() { return _llk_math_get_compute_special_value_flags_(); }
+
+template <bool isFpu>
+inline std::uint32_t llk_math_extract_compute_special_value_flags(std::uint32_t special_value_flags_reg) {
+    constexpr std::uint32_t special_value_flags_mask = isFpu ? 0x7 : 0xf;
+    constexpr std::uint32_t special_value_flags_shift = isFpu ? 4 : 0;
+    return (special_value_flags_reg >> special_value_flags_shift) & special_value_flags_mask;
+}
+
+inline void llk_math_clear_compute_special_value_flags() { _llk_math_clear_compute_special_value_flags_(); }
+
+inline void llk_math_store_compute_special_value_flags_to_l1(std::uint32_t l1_addr) {
+    volatile tt_l1_ptr std::uint32_t* l1_addr_ptr = reinterpret_cast<volatile tt_l1_ptr std::uint32_t*>(l1_addr);
+    l1_addr_ptr[0] = _llk_math_get_compute_special_value_flags_();
+}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -25,19 +25,6 @@
  * LLK PACK
  *************************************************************************/
 
-// TODO NC: Remove as the part of tt-metal#34499
-template <bool untilize = false, bool zero_output = false, bool tilize = false /*unused*/>
-inline void llk_pack_mop_config(const uint32_t output, std::uint32_t num_tiles = 1) {
-    const std::uint32_t output_id = get_output_id(output);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const bool partial_face = get_output_partial_face(output_id) && IS_BFP_FORMAT((uint)pack_dst_format[output_id]);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
-
-    _llk_pack_mop_config_<untilize, zero_output>(
-        pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
-}
-
 inline void llk_pack_set_fp32_dest_acc(bool enable) { _llk_pack_set_fp32_dest_acc_(enable); }
 
 template <bool is_fp32_dest_acc_en>
@@ -384,7 +371,7 @@ inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
     _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en, untilize>(face_r_dim, narrow_tile);
 }
 
-template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const std::uint32_t output_id = get_output_id(new_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -25,6 +25,19 @@
  * LLK PACK
  *************************************************************************/
 
+// TODO NC: Remove as the part of tt-metal#34499
+template <bool untilize = false, bool zero_output = false, bool tilize = false /*unused*/>
+inline void llk_pack_mop_config(const uint32_t output, std::uint32_t num_tiles = 1) {
+    const std::uint32_t output_id = get_output_id(output);
+    const std::uint32_t num_faces = get_output_num_faces(output_id);
+    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
+    const bool partial_face = get_output_partial_face(output_id) && IS_BFP_FORMAT((uint)pack_dst_format[output_id]);
+    const bool narrow_tile = get_output_narrow_tile(output_id);
+
+    _llk_pack_mop_config_<untilize, zero_output>(
+        pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
+}
+
 inline void llk_pack_set_fp32_dest_acc(bool enable) { _llk_pack_set_fp32_dest_acc_(enable); }
 
 template <bool is_fp32_dest_acc_en>
@@ -348,11 +361,6 @@ inline void llk_pack_fast_tilize_block(
 
 inline void llk_packer_wait_for_math_done() { _llk_packer_wait_for_math_done_(); }
 
-template <uint WaitRes = p_stall::NONE>
-inline void llk_packer_set_math_semaphore() {
-    _llk_packer_set_math_semaphore_<WaitRes>();
-}
-
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_dest_section_done() {
     _llk_pack_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
@@ -376,11 +384,7 @@ inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
     _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en, untilize>(face_r_dim, narrow_tile);
 }
 
-inline void llk_pack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _llk_pack_debug_dump_(data, byte_size); }
-
-inline void llk_pack_debug_dump_seek(std::uint8_t offset) { _llk_pack_debug_dump_seek_(offset); }
-
-template <bool is_fp32_dest_acc_en>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const std::uint32_t output_id = get_output_id(new_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -412,38 +412,3 @@ inline void llk_pack_reduce_mask_config() {
 }
 
 inline void llk_pack_reduce_mask_clear() { _llk_pack_reduce_mask_clear_(); }
-
-// FIXME-WH-UPLIFT
-template <ReduceDim dim, bool is_fp32_dest_acc_en, bool at_kernel_start = false, bool revert = false>
-inline void llk_pack_reduce_config_v2(uint32_t icb_out) {
-    const bool untilize = false;
-    if constexpr (at_kernel_start) {
-        const std::uint32_t output_id = get_output_id(icb_out);
-        const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-        const std::uint32_t num_faces = get_output_num_faces(output_id);
-        const bool partial_face = get_output_partial_face(output_id);
-        const bool narrow_tile = get_output_narrow_tile(output_id);
-        const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
-        const llk_relu_config_u relu_config = {
-            .f = {
-                .ApplyRelu = (std::uint32_t)ReluType::NO_RELU,
-                .Threshold = 0,
-            }};
-
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize>(
-            pack_src_format[output_id],
-            pack_dst_format[output_id],
-            tile_size,
-            face_r_dim,
-            num_faces,
-            partial_face,
-            narrow_tile,
-            relu_config.val);
-    }
-
-    if constexpr (revert) {
-        _llk_pack_reduce_mask_clear_();
-    } else {
-        _llk_pack_reduce_mask_config_<untilize, dim>();
-    }
-}

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -18,6 +18,9 @@
 
 #ifdef TRISC_MATH
 #include "llk_math_common_api.h"
+#if defined(ARCH_BLACKHOLE) || defined(ARCH_WORMHOLE)
+#include "llk_math_debug.h"
+#endif
 #include "llk_math_matmul_api.h"
 #include "llk_math_unary_datacopy_api.h"
 #include "llk_math_unary_sfpu_api.h"
@@ -978,6 +981,7 @@ ALWI void unary_min_tile(uint32_t idst, uint32_t param0) {
  */
 ALWI void unary_min_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_min_init())); }
 
+#if defined(ARCH_BLACKHOLE) || defined(ARCH_WORMHOLE)
 ALWI uint32_t get_compute_special_value_flags() {
     uint32_t ret_val = 0;
     MATH((ret_val = llk_math_get_compute_special_value_flags()));
@@ -986,21 +990,18 @@ ALWI uint32_t get_compute_special_value_flags() {
 
 ALWI uint32_t get_compute_special_value_flags_fpu(uint32_t special_value_flags_reg) {
     uint32_t ret_val = 0;
-    MATH((ret_val = llk_math_get_compute_special_value_flags_fpu(special_value_flags_reg)));
+    MATH((ret_val = llk_math_extract_compute_special_value_flags<true /* isFpu */>(special_value_flags_reg)));
     return ret_val;
 }
 
 ALWI uint32_t get_compute_special_value_flags_sfpu(uint32_t special_value_flags_reg) {
     uint32_t ret_val = 0;
-    MATH((ret_val = llk_math_get_compute_special_value_flags_sfpu(special_value_flags_reg)));
+    MATH((ret_val = llk_math_extract_compute_special_value_flags<false /* isFpu */>(special_value_flags_reg)));
     return ret_val;
 }
 
 ALWI void clear_compute_special_value_flags() { MATH((llk_math_clear_compute_special_value_flags())); }
-
-ALWI void store_compute_special_value_flags_to_l1(uint32_t l1_addr) {
-    MATH((llk_math_store_compute_special_value_flags_to_l1(l1_addr)));
-}
+#endif
 
 #endif
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel.h
@@ -586,9 +586,6 @@ inline void record_kernel_runtime(std::uint64_t kernel_runtime)
     debug_mailbox_base[mailbox_end - 1] = (kernel_runtime >> 48) & 0xffff;
 }
 
-void debug_dump(const std::uint8_t *data, std::uint32_t byte_size);
-void debug_dump_seek(std::uint8_t offset);
-
 // If the TRACK_x bit is set, then the Tensix hardware will automatically
 // stall TRISC memory accesses and/or Tensix instructions to x in order
 // to guarantee correct ordering. This should eliminate most cases where

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -116,16 +116,6 @@ inline void _llk_math_pack_sync_init_()
     }
 }
 
-inline void _llk_math_debug_dump_(std::uint8_t* data, std::uint32_t byte_size)
-{
-    debug_dump(data, byte_size);
-}
-
-inline void _llk_math_debug_dump_seek_(std::uint8_t offset)
-{
-    debug_dump_seek(offset);
-}
-
 // Following functions do not need to program ALU_FORMAT_SPEC_REG0_SrcA/ALU_FORMAT_SPEC_REG1_SrcB
 // for blackhole since ALU format is inferred
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
@@ -86,16 +86,6 @@ inline void set_dst_write_addr(const std::uint32_t tile_index)
     TT_SETADC(p_setadc::PAC, p_setadc::CH_0, p_setadc::SET_W, tile_index);
 }
 
-inline void _llk_pack_debug_dump_(std::uint8_t *data, std::uint32_t byte_size)
-{
-    debug_dump(data, byte_size);
-}
-
-inline void _llk_pack_debug_dump_seek_(std::uint8_t offset)
-{
-    debug_dump_seek(offset);
-}
-
 TT_ALWAYS_INLINE void _llk_pack_relu_config_(const std::uint32_t config)
 {
     ReluType mode     = (config & 0xf) == 0 ? ReluType::NO_RELU : ((config & 0xf) == 3 ? ReluType::MAX_THRESHOLD_RELU : ReluType::MIN_THRESHOLD_RELU);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel.h
@@ -594,9 +594,6 @@ inline void record_kernel_runtime(std::uint64_t kernel_runtime)
     debug_mailbox_base[mailbox_end - 1] = (kernel_runtime >> 48) & 0xffff;
 }
 
-void debug_dump(const std::uint8_t *data, std::uint32_t byte_size);
-void debug_dump_seek(std::uint8_t offset);
-
 inline void init_prng_seed(const std::uint32_t seed)
 {
     // The seed for PRNG should at least be initialized during chip boot-up time.

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -101,16 +101,6 @@ inline void _llk_math_pack_sync_init_()
     }
 }
 
-inline void _llk_math_debug_dump_(std::uint8_t* data, std::uint32_t byte_size)
-{
-    debug_dump(data, byte_size);
-}
-
-inline void _llk_math_debug_dump_seek_(std::uint8_t offset)
-{
-    debug_dump_seek(offset);
-}
-
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
 inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_format)
 {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
@@ -130,16 +130,6 @@ inline void set_dst_write_addr(const std::uint32_t tile_index)
     TT_SETADC(p_setadc::PAC, p_setadc::CH_0, p_setadc::SET_W, tile_index);
 }
 
-inline void _llk_pack_debug_dump_(std::uint8_t *data, std::uint32_t byte_size)
-{
-    debug_dump(data, byte_size);
-}
-
-inline void _llk_pack_debug_dump_seek_(std::uint8_t offset)
-{
-    debug_dump_seek(offset);
-}
-
 TT_ALWAYS_INLINE void _llk_pack_relu_config_(const std::uint32_t config)
 {
     ReluType mode     = (config & 0xf) == 0 ? ReluType::NO_RELU : ((config & 0xf) == 3 ? ReluType::MAX_THRESHOLD_RELU : ReluType::MIN_THRESHOLD_RELU);


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Moves debug-only and widget LLK API helpers out of common Blackhole, Wormhole, and Quasar headers into targeted debug/widget headers. This keeps the common LLK API surfaces focused on active runtime paths while preserving access to debug helpers through explicit includes.

### Notes for reviewers
Review the new per-architecture debug/widget headers and the compute API include updates that keep documented debug helpers available for Blackhole and Wormhole. Also note the LLK assert message improvements in the binary and matmul wrappers.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/move_llk_api_special_functions)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/move_llk_api_special_functions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/move_llk_api_special_functions)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/move_llk_api_special_functions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/move_llk_api_special_functions)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/move_llk_api_special_functions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/move_llk_api_special_functions)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/move_llk_api_special_functions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/move_llk_api_special_functions)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/move_llk_api_special_functions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/move_llk_api_special_functions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/move_llk_api_special_functions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/move_llk_api_special_functions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/move_llk_api_special_functions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/move_llk_api_special_functions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/move_llk_api_special_functions)