### PR TITLE
SFPU-based INT32 support for ttnn.min / ttnn.max

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max_sfpu.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max_sfpu.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""ttnn.max / ttnn.min vs torch.amax / torch.amin for int32 and float32 (SFPU reduce path)."""
+
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_equal, assert_with_pcc
+
+pytestmark = pytest.mark.use_module_device
+
+
+@pytest.mark.parametrize("in_dtype", [ttnn.int32, ttnn.float32])
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        (1, 1, 32, 32),
+        (1, 1, 30, 96),
+        (1, 1, 90, 32),
+        (1, 3, 17, 19),
+        (2, 4, 64, 60),
+        (2, 1, 256, 2048),
+        (2, 1, 2048, 256),
+    ],
+)
+@pytest.mark.parametrize("dim", [0, 1, -1, -2, (-1, -2), None])
+@pytest.mark.parametrize("op", ["max", "min"])
+def test_max_min(device, in_dtype, input_shape, dim, op):
+    torch.manual_seed(0)
+    if in_dtype == ttnn.int32:
+        torch_input_tensor = torch.randint(-50_000, 50_000, input_shape, dtype=torch.int32)
+    else:
+        torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+
+    torch_op = torch.amax if op == "max" else torch.amin
+    ttnn_op = ttnn.max if op == "max" else ttnn.min
+
+    torch_output_tensor = torch_op(torch_input_tensor, dim=dim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=in_dtype)
+    output_tensor = ttnn.to_torch(ttnn_op(input_tensor, dim=dim))
+
+    assert output_tensor.dtype == torch_input_tensor.dtype
+
+    if in_dtype == ttnn.int32:
+        assert_equal(output_tensor, torch_output_tensor)
+    else:
+        assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.999999)
+
+
+@pytest.mark.parametrize("in_dtype", [ttnn.int32, ttnn.float32])
+@pytest.mark.parametrize("scale", [2.0, 0.5, -3.0])
+@pytest.mark.parametrize(
+    "input_shape, dim",
+    [
+        ((1, 2, 64, 64), -1),
+        ((1, 1, 96, 64), -2),
+        ((1, 1, 64, 64), (-1, -2)),
+    ],
+)
+@pytest.mark.parametrize("op", ["max", "min"])
+def test_max_min_with_scaling(device, in_dtype, input_shape, dim, op, scale):
+    torch.manual_seed(0)
+    if in_dtype == ttnn.int32:
+        torch_input_tensor = torch.randint(-50_000, 50_000, input_shape, dtype=torch.int32)
+    else:
+        torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+
+    torch_op = torch.amax if op == "max" else torch.amin
+    ttnn_op = ttnn.max if op == "max" else ttnn.min
+
+    if in_dtype == ttnn.int32:
+        torch_expected = torch_op(torch_input_tensor.float() * scale, dim=dim).to(torch.int32)
+    else:
+        torch_expected = torch_op(torch_input_tensor * scale, dim=dim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=in_dtype)
+    output_tensor = ttnn.to_torch(ttnn_op(input_tensor, dim=dim, scalar=scale))
+
+    assert output_tensor.dtype == torch_input_tensor.dtype
+
+    if in_dtype == ttnn.int32:
+        assert_equal(output_tensor, torch_expected)
+    else:
+        assert_with_pcc(torch_expected, output_tensor, pcc=0.999999)
+
+
+# ---------------------------------------------------------------------------
+# FP32 precision retention: inputs all collapse to the same bf16 value but are
+# distinct in fp32 — verifies the SFPU path preserves fp32 mantissa bits.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "input_shape, dim",
+    [
+        ((1, 1, 32, 32), -1),  # W reduce, single tile
+        ((1, 1, 32, 32), -2),  # H reduce, single tile
+        ((1, 1, 64, 32), -1),  # W reduce, Ht=2
+        ((1, 1, 32, 64), -2),  # H reduce, Wt=2
+        ((1, 1, 32, 128), -1),
+        ((1, 1, 128, 32), -2),
+    ],
+)
+@pytest.mark.parametrize("op", ["max", "min"])
+def test_fp32_precision_beyond_bf16_resolution(device, input_shape, dim, op):
+    h, w = input_shape[-2], input_shape[-1]
+    fp32_ulp_at_one = 2.0**-23
+
+    n = h * w
+    values = torch.tensor([1.0 + (k + 1) * fp32_ulp_at_one for k in range(n)], dtype=torch.float32)
+    torch_input = values.reshape(input_shape)
+
+    collapsed = torch_input.to(torch.bfloat16).to(torch.float32)
+    assert torch.all(collapsed == 1.0).item(), "probe invariant broken: values are distinguishable in bf16"
+
+    torch_op = torch.amax if op == "max" else torch.amin
+    ttnn_op = ttnn.max if op == "max" else ttnn.min
+
+    torch_expected = torch_op(torch_input, dim=dim)
+
+    input_tensor = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.float32)
+    output_tensor = ttnn.to_torch(ttnn_op(input_tensor, dim=dim))
+
+    assert_equal(output_tensor, torch_expected)
+
+
+# ---------------------------------------------------------------------------
+# Boundary tests for INT32 input data containing INT32_MIN / INT32_MAX.
+# ---------------------------------------------------------------------------
+def _int32_input_with_injected_value(input_shape, base_low, base_high, injected_value, seed=0):
+    """Build a deterministic int32 tensor of given shape with `injected_value`
+    placed at the corners and the center so it lands in different tile rows/cols
+    regardless of reduce dim."""
+    torch.manual_seed(seed)
+    t = torch.randint(base_low, base_high, input_shape, dtype=torch.int32)
+    # Corners
+    t[..., 0, 0] = injected_value
+    t[..., -1, -1] = injected_value
+    # Around the center
+    h, w = input_shape[-2], input_shape[-1]
+    if h >= 2 and w >= 2:
+        t[..., h // 2, w // 2] = injected_value
+    return t
+
+
+@pytest.mark.parametrize(
+    "input_shape, dim",
+    [
+        ((1, 1, 60, 30), -1),
+        ((1, 1, 60, 30), -2),
+    ],
+)
+@pytest.mark.parametrize(
+    "injected_value",
+    [torch.iinfo(torch.int32).min, torch.iinfo(torch.int32).max],
+    ids=["INT32_MIN", "INT32_MAX"],
+)
+@pytest.mark.parametrize("op", ["max", "min"])
+@pytest.mark.parametrize(
+    "base_range",
+    [(10, 1000), (-1000, -10), (-1000, 1000)],
+    ids=["all_positive", "all_negative", "mixed"],
+)
+def test_int32_reduce_with_extreme_value_in_input(device, input_shape, dim, injected_value, op, base_range):
+    base_low, base_high = base_range
+    _INT32_MIN = torch.iinfo(torch.int32).min
+    _INT32_MAX = torch.iinfo(torch.int32).max
+
+    # A: MIN negates input before max-finding; -INT32_MIN overflows back to INT32_MIN, losing the extreme value
+    is_min_int32_edge = op == "min" and injected_value == _INT32_MIN
+
+    # B: INT32_MIN (0x80000000) is compared as 0 via INT32_2S_COMP; 0 beats all negatives so MAX returns wrong value
+    is_max_int32_min_edge = (
+        op == "max"
+        and injected_value == _INT32_MIN
+        and (base_high < 0 or (base_low < 0 and dim == -2 and input_shape[-2] % 32 != 0))
+    )
+
+    # C: row reduce uses sign-magnitude mode; SFPSWAP picks larger magnitude, inverting negative ordering
+    is_row_reduce_sign_magnitude_issue = (
+        dim == -1
+        and injected_value == _INT32_MAX
+        and ((op == "max" and base_high < 0) or (op == "min" and base_low > 0))
+    )
+
+    if is_min_int32_edge or is_max_int32_min_edge or is_row_reduce_sign_magnitude_issue:
+        pytest.xfail("Int32 SFPU reduce(min/max) returns wrong result with INT32_MIN/MAX in input (issue #44750).")
+
+    torch_input = _int32_input_with_injected_value(input_shape, base_low, base_high, injected_value)
+
+    torch_op = torch.amax if op == "max" else torch.amin
+    ttnn_op = ttnn.max if op == "max" else ttnn.min
+
+    torch_output = torch_op(torch_input, dim=dim)
+
+    input_tensor = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.int32)
+    output_tensor = ttnn.to_torch(ttnn_op(input_tensor, dim=dim))
+
+    assert_equal(output_tensor, torch_output)

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max_sfpu.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max_sfpu.py
@@ -2,18 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""ttnn.max / ttnn.min vs torch.amax / torch.amin for int32 and float32 (SFPU reduce path)."""
+"""ttnn.max / ttnn.min vs torch.amax / torch.amin for int32 (SFPU reduce path)."""
 
 import pytest
 import torch
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_equal, assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_equal
 
 pytestmark = pytest.mark.use_module_device
 
 
-@pytest.mark.parametrize("in_dtype", [ttnn.int32, ttnn.float32])
 @pytest.mark.parametrize(
     "input_shape",
     [
@@ -28,30 +27,22 @@ pytestmark = pytest.mark.use_module_device
 )
 @pytest.mark.parametrize("dim", [0, 1, -1, -2, (-1, -2), None])
 @pytest.mark.parametrize("op", ["max", "min"])
-def test_max_min(device, in_dtype, input_shape, dim, op):
+def test_max_min(device, input_shape, dim, op):
     torch.manual_seed(0)
-    if in_dtype == ttnn.int32:
-        torch_input_tensor = torch.randint(-50_000, 50_000, input_shape, dtype=torch.int32)
-    else:
-        torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    torch_input_tensor = torch.randint(-50_000, 50_000, input_shape, dtype=torch.int32)
 
     torch_op = torch.amax if op == "max" else torch.amin
     ttnn_op = ttnn.max if op == "max" else ttnn.min
 
     torch_output_tensor = torch_op(torch_input_tensor, dim=dim)
 
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=in_dtype)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.int32)
     output_tensor = ttnn.to_torch(ttnn_op(input_tensor, dim=dim))
 
     assert output_tensor.dtype == torch_input_tensor.dtype
-
-    if in_dtype == ttnn.int32:
-        assert_equal(output_tensor, torch_output_tensor)
-    else:
-        assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.999999)
+    assert_equal(output_tensor, torch_output_tensor)
 
 
-@pytest.mark.parametrize("in_dtype", [ttnn.int32, ttnn.float32])
 @pytest.mark.parametrize("scale", [2.0, 0.5, -3.0])
 @pytest.mark.parametrize(
     "input_shape, dim",
@@ -62,67 +53,19 @@ def test_max_min(device, in_dtype, input_shape, dim, op):
     ],
 )
 @pytest.mark.parametrize("op", ["max", "min"])
-def test_max_min_with_scaling(device, in_dtype, input_shape, dim, op, scale):
+def test_max_min_with_scaling(device, input_shape, dim, op, scale):
     torch.manual_seed(0)
-    if in_dtype == ttnn.int32:
-        torch_input_tensor = torch.randint(-50_000, 50_000, input_shape, dtype=torch.int32)
-    else:
-        torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    torch_input_tensor = torch.randint(-50_000, 50_000, input_shape, dtype=torch.int32)
 
     torch_op = torch.amax if op == "max" else torch.amin
     ttnn_op = ttnn.max if op == "max" else ttnn.min
 
-    if in_dtype == ttnn.int32:
-        torch_expected = torch_op(torch_input_tensor.float() * scale, dim=dim).to(torch.int32)
-    else:
-        torch_expected = torch_op(torch_input_tensor * scale, dim=dim)
+    torch_expected = torch_op(torch_input_tensor.float() * scale, dim=dim).to(torch.int32)
 
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=in_dtype)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.int32)
     output_tensor = ttnn.to_torch(ttnn_op(input_tensor, dim=dim, scalar=scale))
 
     assert output_tensor.dtype == torch_input_tensor.dtype
-
-    if in_dtype == ttnn.int32:
-        assert_equal(output_tensor, torch_expected)
-    else:
-        assert_with_pcc(torch_expected, output_tensor, pcc=0.999999)
-
-
-# ---------------------------------------------------------------------------
-# FP32 precision retention: inputs all collapse to the same bf16 value but are
-# distinct in fp32 — verifies the SFPU path preserves fp32 mantissa bits.
-# ---------------------------------------------------------------------------
-@pytest.mark.parametrize(
-    "input_shape, dim",
-    [
-        ((1, 1, 32, 32), -1),  # W reduce, single tile
-        ((1, 1, 32, 32), -2),  # H reduce, single tile
-        ((1, 1, 64, 32), -1),  # W reduce, Ht=2
-        ((1, 1, 32, 64), -2),  # H reduce, Wt=2
-        ((1, 1, 32, 128), -1),
-        ((1, 1, 128, 32), -2),
-    ],
-)
-@pytest.mark.parametrize("op", ["max", "min"])
-def test_fp32_precision_beyond_bf16_resolution(device, input_shape, dim, op):
-    h, w = input_shape[-2], input_shape[-1]
-    fp32_ulp_at_one = 2.0**-23
-
-    n = h * w
-    values = torch.tensor([1.0 + (k + 1) * fp32_ulp_at_one for k in range(n)], dtype=torch.float32)
-    torch_input = values.reshape(input_shape)
-
-    collapsed = torch_input.to(torch.bfloat16).to(torch.float32)
-    assert torch.all(collapsed == 1.0).item(), "probe invariant broken: values are distinguishable in bf16"
-
-    torch_op = torch.amax if op == "max" else torch.amin
-    ttnn_op = ttnn.max if op == "max" else ttnn.min
-
-    torch_expected = torch_op(torch_input, dim=dim)
-
-    input_tensor = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.float32)
-    output_tensor = ttnn.to_torch(ttnn_op(input_tensor, dim=dim))
-
     assert_equal(output_tensor, torch_expected)
 
 

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
@@ -17,3 +17,23 @@ constexpr bool reduce_uses_matmul() {
     return (pool_type == ckernel::PoolType::SUM || pool_type == ckernel::PoolType::AVG) &&
            reduce_dim == ckernel::ReduceDim::REDUCE_ROW;
 }
+
+/**
+ * @brief Determines whether a reduce operation should use the SFPU max path.
+ *
+ * Int32/Float32 MAX on REDUCE_ROW/COL uses SFPU. Float32 MAX REDUCE_SCALAR uses FPU.
+ * Int32 MAX REDUCE_SCALAR is unsupported.
+ */
+template <ckernel::PoolType pool_type, ckernel::ReduceDim reduce_dim, DataFormat data_format>
+constexpr bool is_sfpu_reduce_path() {
+    if constexpr (pool_type != ckernel::PoolType::MAX) {
+        return false;
+    }
+    if constexpr (data_format != DataFormat::Int32 && data_format != DataFormat::Float32) {
+        return false;
+    }
+    if constexpr (reduce_dim == ckernel::ReduceDim::REDUCE_SCALAR) {
+        return false;
+    }
+    return reduce_dim == ckernel::ReduceDim::REDUCE_ROW || reduce_dim == ckernel::ReduceDim::REDUCE_COL;
+}

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
@@ -21,15 +21,14 @@ constexpr bool reduce_uses_matmul() {
 /**
  * @brief Determines whether a reduce operation should use the SFPU max path.
  *
- * Int32/Float32 MAX on REDUCE_ROW/COL uses SFPU. Float32 MAX REDUCE_SCALAR uses FPU.
- * Int32 MAX REDUCE_SCALAR is unsupported.
+ * Int32 MAX on REDUCE_ROW/COL uses SFPU. Int32 MAX REDUCE_SCALAR is unsupported.
  */
 template <ckernel::PoolType pool_type, ckernel::ReduceDim reduce_dim, DataFormat data_format>
 constexpr bool is_sfpu_reduce_path() {
     if constexpr (pool_type != ckernel::PoolType::MAX) {
         return false;
     }
-    if constexpr (data_format != DataFormat::Int32 && data_format != DataFormat::Float32) {
+    if constexpr (data_format != DataFormat::Int32) {
         return false;
     }
     if constexpr (reduce_dim == ckernel::ReduceDim::REDUCE_SCALAR) {

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
@@ -36,18 +36,15 @@
  *   compute_kernel_hw_startup(dfb_in, dfb_scaler, dfb_out);
  *
  *   // Reduce each row (W dimension) - output has Ht tiles per batch
- *   compute_kernel_lib::reduce<SUM, REDUCE_ROW>(
- *       dfb_in, dfb_scaler, dfb_out,
+ *   compute_kernel_lib::reduce<SUM, REDUCE_ROW, dfb_in, dfb_scaler, dfb_out>(
  *       compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt, NC));
  *
  *   // Reduce each column (H dimension) - output has Wt tiles per batch
- *   compute_kernel_lib::reduce<SUM, REDUCE_COL>(
- *       dfb_in, dfb_scaler, dfb_out,
+ *   compute_kernel_lib::reduce<SUM, REDUCE_COL, dfb_in, dfb_scaler, dfb_out>(
  *       compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt, NC));
  *
  *   // Reduce entire HxW grid to single tile (REDUCE_SCALAR)
- *   compute_kernel_lib::reduce<SUM, REDUCE_SCALAR>(
- *       dfb_in, dfb_scaler, dfb_out,
+ *   compute_kernel_lib::reduce<SUM, REDUCE_SCALAR, dfb_in, dfb_scaler, dfb_out>(
  *       compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt, NC));
  *
  * See reduce() function documentation for advanced usage examples including:

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
@@ -291,16 +291,17 @@ struct NoOp {
  *
  * @tparam reduce_type The type of reduce operation (SUM, AVG, MAX) - required explicit parameter
  * @tparam reduce_dim The dimension to reduce (REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR) - required explicit parameter
- * @tparam reduce_format Routes Int32/Float32 MAX to the SFPU path (Float32 for precision; Int32 has
- *                       no FPU support). Pass via REDUCE_FORMAT define from host (same as REDUCE_OP
- *                       / REDUCE_DIM). Other formats use FPU/GMPOOL. Only REDUCE_ROW/REDUCE_COL MAX
- *                       on SFPU; MIN dispatched via reduce_{h,w}_neg.cpp (SFPU vs FPU branch).
+ * @tparam input_dfb_id Input DataflowBuffer ID containing tiles to reduce (compile-time CB id)
+ * @tparam scaler_dfb_id DataflowBuffer ID containing scaler tile (compile-time CB id)
+ * @tparam output_dfb_id Output DataflowBuffer ID for reduced tiles (compile-time CB id)
+ *                       The input/output formats are deduced from these CB ids
+ *                       (unpack_src_format / pack_dst_format), so Int32/Float32 MAX is routed to the
+ *                       SFPU path automatically (Int32 has no FPU support; Float32 for precision).
+ *                       Other formats use FPU/GMPOOL. Only REDUCE_ROW/REDUCE_COL MAX on SFPU; MIN
+ *                       dispatched via reduce_{h,w}_neg.cpp (SFPU vs FPU branch).
  * @tparam input_policy Input handling policy (default: WaitAndPopPerTile - streaming mode)
  * @tparam reconfig_mode Data format reconfiguration mode (default: INPUT_AND_OUTPUT)
  *
- * @param input_dfb_id Input DataflowBuffer ID containing tiles to reduce
- * @param scaler_dfb_id DataflowBuffer ID containing scaler tile
- * @param output_dfb_id Output DataflowBuffer ID for reduced tiles
  * @param input_block_shape Tile grid dimensions (rows x cols x batches)
  *              Use ReduceInputBlockShape::of(r, c, b), ::row(c), ::col(r), or ::single()
  * @param input_memory_layout Tile memory layout specification for NoWaitNoPop/WaitUpfrontNoPop policies (default:
@@ -311,48 +312,53 @@ struct NoOp {
  *
  * @example
  *   // Reduce entire HxW grid to single tile (REDUCE_SCALAR)
- *   compute_kernel_lib::reduce<SUM, REDUCE_SCALAR>(dfb_in, dfb_scaler, dfb_out,
+ *   compute_kernel_lib::reduce<SUM, REDUCE_SCALAR, dfb_in, dfb_scaler, dfb_out>(
  *       compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt, NC));
  *
  * @example
  *   // Reduce each row (W dimension) - output has Ht tiles per batch
- *   compute_kernel_lib::reduce<SUM, REDUCE_ROW>(dfb_in, dfb_scaler, dfb_out,
+ *   compute_kernel_lib::reduce<SUM, REDUCE_ROW, dfb_in, dfb_scaler, dfb_out>(
  *       compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt, NC));
  *
  * @example
  *   // Reduce each column (H dimension) - output has Wt tiles per batch
- *   compute_kernel_lib::reduce<SUM, REDUCE_COL>(dfb_in, dfb_scaler, dfb_out,
+ *   compute_kernel_lib::reduce<SUM, REDUCE_COL, dfb_in, dfb_scaler, dfb_out>(
  *       compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt, NC));
  *
  * @example
  *   // Reduce type and dimension specified with explicit namespace
- *   compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_SCALAR>(dfb_in, dfb_scaler, dfb_out,
+ *   compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_SCALAR, dfb_in, dfb_scaler, dfb_out>(
  *       compute_kernel_lib::ReduceInputBlockShape::single());
  *
  * @example
  *   // NoWaitNoPop policy: caller manages wait/pop externally
  *   // Use cases: (1) custom stride between rows, (2) sharded DFB mapped to tensor with data reuse
- *   compute_kernel_lib::reduce<SUM, REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop>(
- *       dfb_in, dfb_scaler, dfb_out, compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt, NC),
+ *   compute_kernel_lib::reduce<
+ *       SUM, REDUCE_ROW, dfb_in, dfb_scaler, dfb_out, compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop>(
+ *       compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt, NC),
  *       compute_kernel_lib::ReduceInputMemoryLayout::with_row_stride(input_stride));
  *
  * @example
  *   // WaitUpfrontNoPop policy: tiles persist for reuse (ideal for softmax pattern)
  *   // Library waits for tiles internally, but does NOT pop - tiles remain for subsequent ops
- *   compute_kernel_lib::reduce<MAX, REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
- *       dfb_values, dfb_scaler, dfb_max, compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt));
+ *   compute_kernel_lib::reduce<
+ *       MAX, REDUCE_ROW, dfb_values, dfb_scaler, dfb_max,
+ *       compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
+ *       compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt));
  *   // dfb_values tiles still available for sub_exp_block_bcast_cols_inplace()
  *
  * @example
  *   // BulkWaitBulkPop policy (bulk wait/pop - optimal for performance)
  *   // Library waits for all Wt tiles per row, processes them with indexed access, then pops all Wt tiles
- *   compute_kernel_lib::reduce<SUM, REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
- *       dfb_in, dfb_scaler, dfb_out, compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt, NC));
+ *   compute_kernel_lib::reduce<
+ *       SUM, REDUCE_ROW, dfb_in, dfb_scaler, dfb_out, compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
+ *       compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt, NC));
  *
  * @example
  *   // Post-reduce operation: softmax pattern with recip_tile after SUM reduce
- *   compute_kernel_lib::reduce<SUM, REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop>(
- *       dfb_exps, dfb_scaler, dfb_out, compute_kernel_lib::ReduceInputBlockShape::row(Wt),
+ *   compute_kernel_lib::reduce<
+ *       SUM, REDUCE_ROW, dfb_exps, dfb_scaler, dfb_out, compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop>(
+ *       compute_kernel_lib::ReduceInputBlockShape::row(Wt),
  *       compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
  *       NoAccumulation{},
  *       [](uint32_t dst_idx) {
@@ -363,10 +369,9 @@ struct NoOp {
  * @example
  *   // REDUCE_COL with post_reduce_op: apply recip_tile to each column result
  *   // dst_idx indicates which DEST register contains the column result (0 to current_chunk-1)
- *   compute_kernel_lib::reduce<SUM, REDUCE_COL>(
- *       dfb_in, dfb_scaler, dfb_out,
+ *   compute_kernel_lib::reduce<SUM, REDUCE_COL, dfb_in, dfb_scaler, dfb_out>(
  *       compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt),
- *       {},
+ *       compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
  *       NoAccumulation{},
  *       [](uint32_t dst_idx) {
  *           recip_tile_init();
@@ -376,15 +381,14 @@ struct NoOp {
 template <
     PoolType reduce_type,
     ReduceDim reduce_dim,
-    ReduceInputPolicy input_policy = ReduceInputPolicy::WaitAndPopPerTile,
-    ReduceDataFormatReconfigMode reconfig_mode = ReduceDataFormatReconfigMode::INPUT_AND_OUTPUT,
-    DataFormat reduce_format = DataFormat::Invalid,
-    typename AccumulateT = NoAccumulation,
-    typename PostReduceOp = NoOp>
-ALWI void reduce(
     uint32_t input_dfb_id,
     uint32_t scaler_dfb_id,
     uint32_t output_dfb_id,
+    ReduceInputPolicy input_policy = ReduceInputPolicy::WaitAndPopPerTile,
+    ReduceDataFormatReconfigMode reconfig_mode = ReduceDataFormatReconfigMode::INPUT_AND_OUTPUT,
+    typename AccumulateT = NoAccumulation,
+    typename PostReduceOp = NoOp>
+ALWI void reduce(
     ReduceInputBlockShape input_block_shape,
     ReduceInputMemoryLayout input_memory_layout = ReduceInputMemoryLayout::contiguous(),
     AccumulateT accumulate = AccumulateT{},

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
@@ -292,8 +292,8 @@ struct NoOp {
  * @tparam scaler_dfb_id DataflowBuffer ID containing scaler tile (compile-time CB id)
  * @tparam output_dfb_id Output DataflowBuffer ID for reduced tiles (compile-time CB id)
  *                       The input/output formats are deduced from these CB ids
- *                       (unpack_src_format / pack_dst_format), so Int32/Float32 MAX is routed to the
- *                       SFPU path automatically (Int32 has no FPU support; Float32 for precision).
+ *                       (unpack_src_format / pack_dst_format), so Int32 MAX is routed to the
+ *                       SFPU path automatically (Int32 has no FPU support).
  *                       Other formats use FPU/GMPOOL. Only REDUCE_ROW/REDUCE_COL MAX on SFPU; MIN
  *                       dispatched via reduce_{h,w}_neg.cpp (SFPU vs FPU branch).
  * @tparam input_policy Input handling policy (default: WaitAndPopPerTile - streaming mode)

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
@@ -291,6 +291,10 @@ struct NoOp {
  *
  * @tparam reduce_type The type of reduce operation (SUM, AVG, MAX) - required explicit parameter
  * @tparam reduce_dim The dimension to reduce (REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR) - required explicit parameter
+ * @tparam reduce_format Routes Int32/Float32 MAX to the SFPU path (Float32 for precision; Int32 has
+ *                       no FPU support). Pass via REDUCE_FORMAT define from host (same as REDUCE_OP
+ *                       / REDUCE_DIM). Other formats use FPU/GMPOOL. Only REDUCE_ROW/REDUCE_COL MAX
+ *                       on SFPU; MIN dispatched via reduce_{h,w}_neg.cpp (SFPU vs FPU branch).
  * @tparam input_policy Input handling policy (default: WaitAndPopPerTile - streaming mode)
  * @tparam reconfig_mode Data format reconfiguration mode (default: INPUT_AND_OUTPUT)
  *
@@ -374,6 +378,7 @@ template <
     ReduceDim reduce_dim,
     ReduceInputPolicy input_policy = ReduceInputPolicy::WaitAndPopPerTile,
     ReduceDataFormatReconfigMode reconfig_mode = ReduceDataFormatReconfigMode::INPUT_AND_OUTPUT,
+    DataFormat reduce_format = DataFormat::Invalid,
     typename AccumulateT = NoAccumulation,
     typename PostReduceOp = NoOp>
 ALWI void reduce(

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -262,19 +262,22 @@ ALWI void assert_output_dfb_size(uint32_t output_dfb_id, uint32_t total_outputs)
 template <
     PoolType reduce_type,
     ReduceDim reduce_dim,
-    ReduceInputPolicy input_policy,
-    ReduceDataFormatReconfigMode reconfig_mode,
-    DataFormat reduce_format,
-    typename AccumulateT,
-    typename PostReduceOp>
-ALWI void reduce(
     uint32_t input_dfb_id,
     uint32_t scaler_dfb_id,
     uint32_t output_dfb_id,
+    ReduceInputPolicy input_policy,
+    ReduceDataFormatReconfigMode reconfig_mode,
+    typename AccumulateT,
+    typename PostReduceOp>
+ALWI void reduce(
     ReduceInputBlockShape input_block_shape,
     ReduceInputMemoryLayout input_memory_layout,
     AccumulateT accumulate,
     PostReduceOp post_reduce_op) {
+    // Input data format is deduced from the input CB id (now a compile-time template parameter).
+    // Int32/Float32 MAX is routed to the SFPU path via is_sfpu_reduce_path<>(); all other formats
+    // use the FPU/GMPOOL path. This replaces the former explicit reduce_format template parameter.
+    constexpr DataFormat reduce_format = static_cast<DataFormat>(unpack_src_format[input_dfb_id]);
     // =============================================================================
     // Static Assertions (compile-time validation)
     // =============================================================================

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -68,24 +68,6 @@ ALWI bool sfpu_is_first_tile(uint32_t axis_index, const AccumulateT& accumulate)
     return axis_index == 0;
 }
 
-// Int32/Float32 MAX on REDUCE_ROW/COL uses SFPU. Float32 MAX REDUCE_SCALAR uses FPU. Int32 MAX REDUCE_SCALAR is unsupported.
-template <PoolType reduce_type, ReduceDim reduce_dim, DataFormat reduce_format>
-constexpr bool is_sfpu_reduce_path() {
-    if constexpr (reduce_type != PoolType::MAX) {
-        return false;
-    }
-    if constexpr (reduce_format != DataFormat::Int32 && reduce_format != DataFormat::Float32) {
-        return false;
-    }
-    if constexpr (reduce_dim == ReduceDim::REDUCE_SCALAR) {
-        static_assert(
-            reduce_format != DataFormat::Int32,
-            "Int32 MAX REDUCE_SCALAR is not supported");
-        return false;
-    }
-    return reduce_dim == ReduceDim::REDUCE_ROW || reduce_dim == ReduceDim::REDUCE_COL;
-}
-
 // Post-reduce scalar multiply. mul_unary_tile is fp32-only, so Int32 is bracketed with typecasts
 // (truncates toward zero on the way back); all other formats use plain mul_unary_tile.
 template <DataFormat reduce_format>
@@ -274,13 +256,14 @@ ALWI void reduce(
     ReduceInputMemoryLayout input_memory_layout,
     AccumulateT accumulate,
     PostReduceOp post_reduce_op) {
-    // Input data format is deduced from the input CB id (now a compile-time template parameter).
-    // Int32/Float32 MAX is routed to the SFPU path via is_sfpu_reduce_path<>(); all other formats
-    // use the FPU/GMPOOL path. This replaces the former explicit reduce_format template parameter.
+    // Int32/Float32 MAX is routed to the SFPU path via is_sfpu_reduce_path<>(); all other formats use FPU/GMPOOL.
     constexpr DataFormat reduce_format = static_cast<DataFormat>(unpack_src_format[input_dfb_id]);
     // =============================================================================
     // Static Assertions (compile-time validation)
     // =============================================================================
+    static_assert(
+        reduce_type != PoolType::MAX || reduce_dim != ReduceDim::REDUCE_SCALAR || reduce_format != DataFormat::Int32,
+        "Int32 MAX REDUCE_SCALAR is not supported");
     static_assert(
         is_accumulation_type_v<AccumulateT>,
         "AccumulateT must be a valid accumulation type (NoAccumulation or Accumulate)");
@@ -330,7 +313,7 @@ ALWI void reduce(
     const uint32_t num_batches = input_block_shape.batches;
 
     constexpr bool use_matmul = reduce_uses_matmul<reduce_type, reduce_dim>();
-    constexpr bool is_sfpu = detail::is_sfpu_reduce_path<reduce_type, reduce_dim, reduce_format>();
+    constexpr bool is_sfpu = is_sfpu_reduce_path<reduce_type, reduce_dim, reduce_format>();
 
     DataflowBuffer input_dfb(input_dfb_id);
     DataflowBuffer scaler_dfb(scaler_dfb_id);

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -345,7 +345,7 @@ ALWI void reduce(
     }
     scaler_dfb.wait_front(1);  // Wait for scaler tile
     if constexpr (is_sfpu) {
-        PACK((llk_pack_reduce_mask_config<reduce_dim>()));
+        PACK((llk_pack_reduce_mask_config<reduce_dim, PackMode::Default>(output_dfb_id)));
     }
 
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -5,6 +5,11 @@
 // Implementation file for reduce_helpers_compute.hpp
 // Do not include directly - include reduce_helpers_compute.hpp instead
 
+#include "api/compute/binary_max_min.h"
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/typecast.h"
 #include "api/compute/matmul.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/pack.h"
@@ -16,6 +21,89 @@
 
 
 namespace compute_kernel_lib {
+
+namespace detail {
+
+// SFPU MAX fold (also used by reduce_{h,w}_neg for -MAX(-x) MIN).
+template <DataFormat format>
+ALWI void sfpu_reduce_max_fold_init() {
+    static_assert(
+        format == DataFormat::Int32 || format == DataFormat::Float32, "SFPU reduce MAX fold: Int32 or Float32 only");
+    if constexpr (format == DataFormat::Int32) {
+        binary_max_int32_tile_init();
+    } else {
+        binary_max_tile_init();
+    }
+}
+
+template <DataFormat format>
+ALWI void sfpu_reduce_max_fold_tile(uint32_t a, uint32_t b, uint32_t out) {
+    static_assert(
+        format == DataFormat::Int32 || format == DataFormat::Float32, "SFPU reduce MAX fold: Int32 or Float32 only");
+    if constexpr (format == DataFormat::Int32) {
+        binary_max_int32_tile(a, b, out);
+    } else {
+        binary_max_tile(a, b, out);
+    }
+}
+
+// Copy one input tile into DST and fold into running MAX (first tile seeds dst_idx directly).
+template <DataFormat format>
+ALWI void sfpu_copy_and_fold_max(
+    uint32_t input_cb_id, uint32_t tile_idx, uint32_t dst_idx, uint32_t work_dst, bool is_first_tile) {
+    if (is_first_tile) {
+        copy_tile(input_cb_id, tile_idx, dst_idx);
+    } else {
+        copy_tile(input_cb_id, tile_idx, work_dst);
+        sfpu_reduce_max_fold_tile<format>(dst_idx, work_dst, dst_idx);
+    }
+}
+
+// Matches sfpu_copy_and_fold_max is_first_tile: copy on axis 0 unless Accumulate already reloaded DST.
+template <typename AccumulateT>
+ALWI bool sfpu_is_first_tile(uint32_t axis_index, const AccumulateT& accumulate) {
+    if constexpr (is_accumulate_v<AccumulateT>) {
+        return axis_index == 0 && accumulate.is_first();
+    }
+    return axis_index == 0;
+}
+
+// Int32/Float32 MAX on REDUCE_ROW/COL uses SFPU. Float32 MAX REDUCE_SCALAR uses FPU. Int32 MAX REDUCE_SCALAR is unsupported.
+template <PoolType reduce_type, ReduceDim reduce_dim, DataFormat reduce_format>
+constexpr bool is_sfpu_reduce_path() {
+    if constexpr (reduce_type != PoolType::MAX) {
+        return false;
+    }
+    if constexpr (reduce_format != DataFormat::Int32 && reduce_format != DataFormat::Float32) {
+        return false;
+    }
+    if constexpr (reduce_dim == ReduceDim::REDUCE_SCALAR) {
+        static_assert(
+            reduce_format != DataFormat::Int32,
+            "Int32 MAX REDUCE_SCALAR is not supported");
+        return false;
+    }
+    return reduce_dim == ReduceDim::REDUCE_ROW || reduce_dim == ReduceDim::REDUCE_COL;
+}
+
+// Post-reduce scalar multiply. mul_unary_tile is fp32-only, so Int32 is bracketed with typecasts
+// (truncates toward zero on the way back); all other formats use plain mul_unary_tile.
+template <DataFormat reduce_format>
+ALWI void reduce_post_mul_tile(uint32_t dst, uint32_t scaler_bits) {
+    if constexpr (reduce_format == DataFormat::Int32) {
+        typecast_tile_init<(uint32_t)DataFormat::Int32, (uint32_t)DataFormat::Float32>();
+        typecast_tile<(uint32_t)DataFormat::Int32, (uint32_t)DataFormat::Float32>(dst);
+        binop_with_scalar_tile_init();
+        mul_unary_tile(dst, scaler_bits);
+        typecast_tile_init<(uint32_t)DataFormat::Float32, (uint32_t)DataFormat::Int32>();
+        typecast_tile<(uint32_t)DataFormat::Float32, (uint32_t)DataFormat::Int32>(dst);
+    } else {
+        binop_with_scalar_tile_init();
+        mul_unary_tile(dst, scaler_bits);
+    }
+}
+
+}  // namespace detail
 
 // HiFi4 fidelity for matmul-based reduce (higher precision than kernel default)
 constexpr ckernel::MathFidelity REDUCE_MATMUL_FIDELITY = ckernel::MathFidelity::HiFi4;
@@ -98,8 +186,10 @@ ALWI constexpr uint32_t get_dst_index(const AccumulateT& accumulate) {
 template <
     PoolType reduce_type,
     ReduceDim reduce_dim,
+    DataFormat reduce_format,
     typename AccumulateT,
-    bool use_matmul = false>
+    bool use_matmul = false,
+    bool is_sfpu = false>
 ALWI void reload_accumulator_if_needed(
     DataflowBuffer& accum_dfb, uint32_t input_dfb_id, uint32_t scaler_dfb_id, const AccumulateT& accumulate) {
     if constexpr (is_accumulate_v<AccumulateT>) {
@@ -130,7 +220,9 @@ ALWI void reload_accumulator_if_needed(
             // CRITICAL: Re-init after copy_tile corrupts SRCA config
             // Use short version since packer config is still valid from initial init
             // Pass accumulator DFB as old_dfb_id to reconfigure data format from accumulator to input DFB
-            if constexpr (use_matmul) {
+            if constexpr (is_sfpu) {
+                detail::sfpu_reduce_max_fold_init<reduce_format>();
+            } else if constexpr (use_matmul) {
                 reduce_with_matmul_init_with_dt(input_dfb_id, scaler_dfb_id, accumulate.config.cb_accumulator);
             } else {
                 reduce_init_short_with_dt<reduce_type, reduce_dim>(
@@ -172,6 +264,7 @@ template <
     ReduceDim reduce_dim,
     ReduceInputPolicy input_policy,
     ReduceDataFormatReconfigMode reconfig_mode,
+    DataFormat reduce_format,
     typename AccumulateT,
     typename PostReduceOp>
 ALWI void reduce(
@@ -234,6 +327,7 @@ ALWI void reduce(
     const uint32_t num_batches = input_block_shape.batches;
 
     constexpr bool use_matmul = reduce_uses_matmul<reduce_type, reduce_dim>();
+    constexpr bool is_sfpu = detail::is_sfpu_reduce_path<reduce_type, reduce_dim, reduce_format>();
 
     DataflowBuffer input_dfb(input_dfb_id);
     DataflowBuffer scaler_dfb(scaler_dfb_id);
@@ -255,12 +349,18 @@ ALWI void reduce(
         pack_reconfig_data_format(output_dfb_id);
     }
     // Initialization
-    if constexpr (use_matmul) {
+    if constexpr (is_sfpu) {
+        init_sfpu(input_dfb_id, output_dfb_id);
+        copy_tile_to_dst_init_short(input_dfb_id);
+    } else if constexpr (use_matmul) {
         reduce_with_matmul_init(input_dfb_id, scaler_dfb_id);
     } else {
         reduce_init<reduce_type, reduce_dim>(input_dfb_id, scaler_dfb_id, output_dfb_id);
     }
     scaler_dfb.wait_front(1);  // Wait for scaler tile
+    if constexpr (is_sfpu) {
+        PACK((llk_pack_reduce_mask_config<reduce_dim>()));
+    }
 
     constexpr uint32_t onetile = 1;
 
@@ -296,7 +396,7 @@ ALWI void reduce(
             tile_regs_acquire();
 
             // Reload accumulator if needed (zero overhead when AccumulateT is NoAccumulation)
-            reload_accumulator_if_needed<reduce_type, reduce_dim, AccumulateT>(
+            reload_accumulator_if_needed<reduce_type, reduce_dim, reduce_format, AccumulateT, false, is_sfpu>(
                 accum_dfb, input_dfb_id, scaler_dfb_id, accumulate);
 
             const uint32_t dst_idx = get_dst_index(accumulate);
@@ -382,12 +482,33 @@ ALWI void reduce(
                 tile_regs_acquire();
 
                 // Reload accumulator if needed (zero overhead when AccumulateT is NoAccumulation)
-                reload_accumulator_if_needed<reduce_type, reduce_dim, AccumulateT, use_matmul>(
+                reload_accumulator_if_needed<reduce_type, reduce_dim, reduce_format, AccumulateT, use_matmul, is_sfpu>(
                     accum_dfb, input_dfb_id, scaler_dfb_id, accumulate);
+                if constexpr (is_sfpu) {
+                    if (Wt > 1) {
+                        detail::sfpu_reduce_max_fold_init<reduce_format>();
+                    }
+
+                }
 
                 const uint32_t dst_idx = get_dst_index(accumulate);
                 for (uint32_t wt = 0; wt < Wt; ++wt) {
-                    if constexpr (waits_per_tile(input_policy)) {
+                    if constexpr (is_sfpu) {
+                        constexpr uint32_t sfpu_work_dst = 1;
+                        const bool is_first_tile = detail::sfpu_is_first_tile(wt, accumulate);
+                        if constexpr (waits_per_tile(input_policy)) {
+                            input_dfb.wait_front(onetile);
+                            detail::sfpu_copy_and_fold_max<reduce_format>(
+                                input_dfb_id, 0, dst_idx, sfpu_work_dst, is_first_tile);
+                            input_dfb.pop_front(onetile);
+                        } else if constexpr (waits_bulk(input_policy)) {
+                            detail::sfpu_copy_and_fold_max<reduce_format>(
+                                input_dfb_id, wt, dst_idx, sfpu_work_dst, is_first_tile);
+                        } else {
+                            detail::sfpu_copy_and_fold_max<reduce_format>(
+                                input_dfb_id, wt + index_offset, dst_idx, sfpu_work_dst, is_first_tile);
+                        }
+                    } else if constexpr (waits_per_tile(input_policy)) {
                         // One-at-a-time: wait/pop per tile
                         input_dfb.wait_front(onetile);
                         if constexpr (use_matmul) {
@@ -412,6 +533,12 @@ ALWI void reduce(
                                 input_dfb_id, scaler_dfb_id, wt + index_offset, 0, dst_idx);
                         }
                     }
+                }
+
+                // SFPU intra-tile finalize
+                if constexpr (is_sfpu) {
+                    sfpu_reduce_init<reduce_type, reduce_format>();
+                    sfpu_reduce<reduce_type, reduce_format, reduce_dim>(dst_idx, /*ct_dim=*/1, /*rt_dim=*/1);
                 }
 
                 // Call post-reduce operation (e.g., recip_tile for softmax)
@@ -456,7 +583,7 @@ ALWI void reduce(
 
         // Auto-detect chunk size from DEST register capacity
         // Both reader (dataflow) and compute kernels compute this identically via DEST_AUTO_LIMIT
-        constexpr uint32_t chunk_size = DEST_AUTO_LIMIT;
+        constexpr uint32_t chunk_size = is_sfpu ? (DEST_AUTO_LIMIT - 1) : DEST_AUTO_LIMIT;
         const uint32_t stride = (input_memory_layout.row_stride > 0) ? input_memory_layout.row_stride : Wt;
         const uint32_t tiles_per_bulk = Ht * stride;
         const uint32_t total_output_tiles = Wt * num_batches;
@@ -489,14 +616,37 @@ ALWI void reduce(
                 tile_regs_acquire();
 
                 // Reload accumulator if needed (zero overhead when AccumulateT is NoAccumulation)
-                reload_accumulator_if_needed<reduce_type, reduce_dim, AccumulateT>(
+                reload_accumulator_if_needed<reduce_type, reduce_dim, reduce_format, AccumulateT, false, is_sfpu>(
                     accum_dfb, input_dfb_id, scaler_dfb_id, accumulate);
+                if constexpr (is_sfpu) {
+                    if (Ht > 1) {
+                        detail::sfpu_reduce_max_fold_init<reduce_format>();
+                    }
+
+                }
 
                 for (uint32_t ht = 0; ht < Ht; ++ht) {
                     // Base dst_index: from accumulation config or 0 for multi-column output
                     uint32_t dst_idx = get_dst_index(accumulate);
                     for (uint32_t i = wt; i < chunk_end; ++i) {
-                        if constexpr (waits_per_tile(input_policy)) {
+                        if constexpr (is_sfpu) {
+                            const bool is_first_tile = detail::sfpu_is_first_tile(ht, accumulate);
+                            constexpr uint32_t sfpu_work_dst = chunk_size;
+                            if constexpr (waits_per_tile(input_policy)) {
+                                input_dfb.wait_front(onetile);
+                                detail::sfpu_copy_and_fold_max<reduce_format>(
+                                    input_dfb_id, 0, dst_idx, sfpu_work_dst, is_first_tile);
+                                input_dfb.pop_front(onetile);
+                            } else if constexpr (waits_bulk(input_policy)) {
+                                const uint32_t tile_idx = ht * current_chunk + (i - wt);
+                                detail::sfpu_copy_and_fold_max<reduce_format>(
+                                    input_dfb_id, tile_idx, dst_idx, sfpu_work_dst, is_first_tile);
+                            } else {
+                                const uint32_t tile_idx = batch_offset + ht * stride + i;
+                                detail::sfpu_copy_and_fold_max<reduce_format>(
+                                    input_dfb_id, tile_idx, dst_idx, sfpu_work_dst, is_first_tile);
+                            }
+                        } else if constexpr (waits_per_tile(input_policy)) {
                             // One-at-a-time: wait/pop per tile
                             input_dfb.wait_front(onetile);
                             reduce_tile<reduce_type, reduce_dim>(
@@ -513,6 +663,16 @@ ALWI void reduce(
                                 input_dfb_id, scaler_dfb_id, tile_idx, 0, dst_idx);
                         }
                         ++dst_idx;
+                    }
+                }
+
+                // SFPU intra-tile finalize per output slot
+                if constexpr (is_sfpu) {
+                    const uint32_t sfpu_base_dst = get_dst_index(accumulate);
+                    sfpu_reduce_init<reduce_type, reduce_format>();
+                    for (uint32_t k = 0; k < current_chunk; ++k) {
+                        sfpu_reduce<reduce_type, reduce_format, reduce_dim>(
+                            sfpu_base_dst + k, /*ct_dim=*/1, /*rt_dim=*/1);
                     }
                 }
 
@@ -554,7 +714,9 @@ ALWI void reduce(
     }
 
     // Cleanup
-    if constexpr (!use_matmul) {
+    if constexpr (is_sfpu) {
+        PACK((llk_pack_reduce_mask_clear()));
+    } else if constexpr (!use_matmul) {
         reduce_uninit<>();
     }
 }

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -27,24 +27,14 @@ namespace detail {
 // SFPU MAX fold (also used by reduce_{h,w}_neg for -MAX(-x) MIN).
 template <DataFormat format>
 ALWI void sfpu_reduce_max_fold_init() {
-    static_assert(
-        format == DataFormat::Int32 || format == DataFormat::Float32, "SFPU reduce MAX fold: Int32 or Float32 only");
-    if constexpr (format == DataFormat::Int32) {
-        binary_max_int32_tile_init();
-    } else {
-        binary_max_tile_init();
-    }
+    static_assert(format == DataFormat::Int32, "SFPU reduce MAX fold: Int32 only");
+    binary_max_int32_tile_init();
 }
 
 template <DataFormat format>
 ALWI void sfpu_reduce_max_fold_tile(uint32_t a, uint32_t b, uint32_t out) {
-    static_assert(
-        format == DataFormat::Int32 || format == DataFormat::Float32, "SFPU reduce MAX fold: Int32 or Float32 only");
-    if constexpr (format == DataFormat::Int32) {
-        binary_max_int32_tile(a, b, out);
-    } else {
-        binary_max_tile(a, b, out);
-    }
+    static_assert(format == DataFormat::Int32, "SFPU reduce MAX fold: Int32 only");
+    binary_max_int32_tile(a, b, out);
 }
 
 // Copy one input tile into DST and fold into running MAX (first tile seeds dst_idx directly).
@@ -256,7 +246,7 @@ ALWI void reduce(
     ReduceInputMemoryLayout input_memory_layout,
     AccumulateT accumulate,
     PostReduceOp post_reduce_op) {
-    // Int32/Float32 MAX is routed to the SFPU path via is_sfpu_reduce_path<>(); all other formats use FPU/GMPOOL.
+    // Int32 MAX is routed to the SFPU path via is_sfpu_reduce_path<>(); all other formats use FPU/GMPOOL.
     constexpr DataFormat reduce_format = static_cast<DataFormat>(unpack_src_format[input_dfb_id]);
     // =============================================================================
     // Static Assertions (compile-time validation)

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -488,7 +488,6 @@ ALWI void reduce(
                     if (Wt > 1) {
                         detail::sfpu_reduce_max_fold_init<reduce_format>();
                     }
-
                 }
 
                 const uint32_t dst_idx = get_dst_index(accumulate);
@@ -622,7 +621,6 @@ ALWI void reduce(
                     if (Ht > 1) {
                         detail::sfpu_reduce_max_fold_init<reduce_format>();
                     }
-
                 }
 
                 for (uint32_t ht = 0; ht < Ht; ++ht) {

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.cpp
@@ -43,13 +43,12 @@ Tensor FillPadDeviceOperation::create_output_tensors(
 }
 
 ttnn::Tensor fill_pad(
-    const Tensor& input, float fill_value, const MemoryConfig& output_memory_config, bool fill_value_is_packed_bits) {
+    const Tensor& input, tt::tt_metal::PadValue fill_value, const MemoryConfig& output_memory_config) {
     using OperationType = ttnn::prim::FillPadDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .fill_value = fill_value,
             .output_mem_config = output_memory_config,
-            .fill_value_is_packed_bits = fill_value_is_packed_bits,
         },
         OperationType::tensor_args_t{.input = input});
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.cpp
@@ -42,12 +42,14 @@ Tensor FillPadDeviceOperation::create_output_tensors(
     return input_tensor;
 }
 
-ttnn::Tensor fill_pad(const Tensor& input, float fill_value, const MemoryConfig& output_memory_config) {
+ttnn::Tensor fill_pad(
+    const Tensor& input, float fill_value, const MemoryConfig& output_memory_config, bool fill_value_is_packed_bits) {
     using OperationType = ttnn::prim::FillPadDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .fill_value = fill_value,
             .output_mem_config = output_memory_config,
+            .fill_value_is_packed_bits = fill_value_is_packed_bits,
         },
         OperationType::tensor_args_t{.input = input});
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.hpp
@@ -27,10 +27,6 @@ struct FillPadDeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
 };
 
-ttnn::Tensor fill_pad(
-    const Tensor& input,
-    float fill_value,
-    const MemoryConfig& output_memory_config,
-    bool fill_value_is_packed_bits = false);
+ttnn::Tensor fill_pad(const Tensor& input, tt::tt_metal::PadValue fill_value, const MemoryConfig& output_memory_config);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.hpp
@@ -27,6 +27,10 @@ struct FillPadDeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
 };
 
-ttnn::Tensor fill_pad(const Tensor& input, float fill_value, const MemoryConfig& output_memory_config);
+ttnn::Tensor fill_pad(
+    const Tensor& input,
+    float fill_value,
+    const MemoryConfig& output_memory_config,
+    bool fill_value_is_packed_bits = false);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation_types.hpp
@@ -11,6 +11,10 @@ namespace ttnn::prim {
 struct FillPadParams {
     float fill_value;
     tt::tt_metal::MemoryConfig output_mem_config;
+    // When true, fill_value carries the raw bit pattern of an int32 fill value (used for int32 pad
+    // sentinels that are not float-representable). When false (default), int32 fill_value is decoded
+    // numerically via static_cast<int32_t>.
+    bool fill_value_is_packed_bits = false;
 };
 
 struct FillPadInputs {

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation_types.hpp
@@ -9,12 +9,8 @@
 namespace ttnn::prim {
 
 struct FillPadParams {
-    float fill_value;
+    tt::tt_metal::PadValue fill_value;
     tt::tt_metal::MemoryConfig output_mem_config;
-    // When true, fill_value carries the raw bit pattern of an int32 fill value (used for int32 pad
-    // sentinels that are not float-representable). When false (default), int32 fill_value is decoded
-    // numerically via static_cast<int32_t>.
-    bool fill_value_is_packed_bits = false;
 };
 
 struct FillPadInputs {

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -28,7 +28,7 @@ tt::tt_metal::ProgramDescriptor FillPadProgramFactory::create_descriptor(
         "FillPadProgramFactory: unsupported dtype {}",
         input_tensor.dtype());
 
-    const float fill_value = operation_attributes.fill_value;
+    const tt::tt_metal::PadValue& fill_value = operation_attributes.fill_value;
     tt::tt_metal::IDevice* device = input_tensor.device();
     ProgramDescriptor desc;
 
@@ -63,8 +63,7 @@ tt::tt_metal::ProgramDescriptor FillPadProgramFactory::create_descriptor(
     const bool need_fp32_dest_acc = is_fp32 || is_uint32 || is_int32;
     // Float types: raw bit pattern of fill_value for fill_tile_bitcast.
     // Integer types: packed native bit pattern for fill_tile_int.
-    const uint32_t fill_bits = detail::pack_fill_value_for_dtype(
-        input_tensor.dtype(), fill_value, operation_attributes.fill_value_is_packed_bits);
+    const uint32_t fill_bits = detail::pack_fill_value_for_dtype(input_tensor.dtype(), fill_value);
 
     const auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     const uint32_t num_cores_x = compute_with_storage_grid_size.x;
@@ -319,7 +318,7 @@ tt::tt_metal::ProgramDescriptor FillPadL1ShardedProgramFactory::create_descripto
         "FillPadL1ShardedProgramFactory: unsupported dtype {}",
         input_tensor.dtype());
 
-    const float fill_value = operation_attributes.fill_value;
+    const tt::tt_metal::PadValue& fill_value = operation_attributes.fill_value;
 
     ProgramDescriptor desc;
 
@@ -463,8 +462,7 @@ tt::tt_metal::ProgramDescriptor FillPadL1ShardedProgramFactory::create_descripto
     const bool is_uint32 = (input_tensor.dtype() == DataType::UINT32);
     const bool is_int32 = (input_tensor.dtype() == DataType::INT32);
     const bool need_fp32_dest_acc = is_fp32 || is_uint32 || is_int32;
-    const uint32_t fill_bits = detail::pack_fill_value_for_dtype(
-        input_tensor.dtype(), fill_value, operation_attributes.fill_value_is_packed_bits);
+    const uint32_t fill_bits = detail::pack_fill_value_for_dtype(input_tensor.dtype(), fill_value);
 
     // ---- CB indices ----
     constexpr uint32_t cb_data_in_idx = tt::CBIndex::c_0;

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -63,7 +63,8 @@ tt::tt_metal::ProgramDescriptor FillPadProgramFactory::create_descriptor(
     const bool need_fp32_dest_acc = is_fp32 || is_uint32 || is_int32;
     // Float types: raw bit pattern of fill_value for fill_tile_bitcast.
     // Integer types: packed native bit pattern for fill_tile_int.
-    const uint32_t fill_bits = detail::pack_fill_value_for_dtype(input_tensor.dtype(), fill_value);
+    const uint32_t fill_bits = detail::pack_fill_value_for_dtype(
+        input_tensor.dtype(), fill_value, operation_attributes.fill_value_is_packed_bits);
 
     const auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     const uint32_t num_cores_x = compute_with_storage_grid_size.x;
@@ -462,7 +463,8 @@ tt::tt_metal::ProgramDescriptor FillPadL1ShardedProgramFactory::create_descripto
     const bool is_uint32 = (input_tensor.dtype() == DataType::UINT32);
     const bool is_int32 = (input_tensor.dtype() == DataType::INT32);
     const bool need_fp32_dest_acc = is_fp32 || is_uint32 || is_int32;
-    const uint32_t fill_bits = detail::pack_fill_value_for_dtype(input_tensor.dtype(), fill_value);
+    const uint32_t fill_bits = detail::pack_fill_value_for_dtype(
+        input_tensor.dtype(), fill_value, operation_attributes.fill_value_is_packed_bits);
 
     // ---- CB indices ----
     constexpr uint32_t cb_data_in_idx = tt::CBIndex::c_0;

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
@@ -47,7 +47,9 @@ inline uint32_t pack_fill_value_for_dtype(ttnn::DataType dtype, float fill_value
         case ttnn::DataType::BFLOAT16: return pack_fill_value(fill_value);
         case ttnn::DataType::UINT16: return pack_fill_value(static_cast<uint16_t>(fill_value));
         case ttnn::DataType::UINT32: return pack_fill_value(static_cast<uint32_t>(fill_value));
-        case ttnn::DataType::INT32: return pack_fill_value(static_cast<int32_t>(fill_value));
+        // INT32: recover the raw int32 bits from fill_value via std::bit_cast<uint32_t>. Host passes
+        // bit-encoded sentinels as float (generic_reductions::get_pad_value); should not decode numerically.
+        case ttnn::DataType::INT32: return std::bit_cast<uint32_t>(fill_value);
         default: TT_THROW("fill_pad: unsupported dtype"); return 0u;
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
@@ -41,20 +41,29 @@ inline uint32_t pack_fill_value(T fill_value) {
 // Float DataTypes (FLOAT32, BFLOAT16) keep the full float32 bit pattern — the
 // compute kernel reconstructs it via fill_tile_bitcast and the downstream
 // packer handles the bf16 narrowing.
-inline uint32_t pack_fill_value_for_dtype(
-    ttnn::DataType dtype, float fill_value, bool fill_value_is_packed_bits = false) {
+inline uint32_t pack_fill_value_for_dtype(ttnn::DataType dtype, const tt::tt_metal::PadValue& pad_value) {
+    // PadValue's uint32_t arm carries an integer value / raw 32-bit pattern (e.g. reduce's int32 pad
+    // sentinels, which are not float-representable); the float arm carries a numeric float value (the
+    // default for prod, reshape, slice, ...). Mirrors tilize_with_val_padding's get_packed_value.
+    if (std::holds_alternative<uint32_t>(pad_value)) {
+        const uint32_t fill_value = std::get<uint32_t>(pad_value);
+        switch (dtype) {
+            // 32-bit integers: the value is already the native bit pattern.
+            case ttnn::DataType::INT32:
+            case ttnn::DataType::UINT32: return fill_value;
+            case ttnn::DataType::UINT16: return pack_fill_value(static_cast<uint16_t>(fill_value));
+            case ttnn::DataType::BFLOAT16:
+            case ttnn::DataType::FLOAT32: return pack_fill_value(static_cast<float>(fill_value));
+            default: TT_THROW("fill_pad: unsupported dtype"); return 0u;
+        }
+    }
+    const float fill_value = std::get<float>(pad_value);
     switch (dtype) {
         case ttnn::DataType::FLOAT32:
         case ttnn::DataType::BFLOAT16: return pack_fill_value(fill_value);
         case ttnn::DataType::UINT16: return pack_fill_value(static_cast<uint16_t>(fill_value));
         case ttnn::DataType::UINT32: return pack_fill_value(static_cast<uint32_t>(fill_value));
-        // INT32: numeric by default - fill_value carries the integer value (e.g. fill_implicit_tile_padding
-        // callers like prod, reshape, slice). Callers that must carry an exact int32 bit pattern that is not
-        // float-representable (reduce's min/max pad sentinels, see generic_reductions::get_pad_value) set
-        // fill_value_is_packed_bits=true to recover the raw bits via std::bit_cast<uint32_t> instead.
-        case ttnn::DataType::INT32:
-            return fill_value_is_packed_bits ? std::bit_cast<uint32_t>(fill_value)
-                                             : pack_fill_value(static_cast<int32_t>(fill_value));
+        case ttnn::DataType::INT32: return pack_fill_value(static_cast<int32_t>(fill_value));
         default: TT_THROW("fill_pad: unsupported dtype"); return 0u;
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
@@ -41,15 +41,20 @@ inline uint32_t pack_fill_value(T fill_value) {
 // Float DataTypes (FLOAT32, BFLOAT16) keep the full float32 bit pattern — the
 // compute kernel reconstructs it via fill_tile_bitcast and the downstream
 // packer handles the bf16 narrowing.
-inline uint32_t pack_fill_value_for_dtype(ttnn::DataType dtype, float fill_value) {
+inline uint32_t pack_fill_value_for_dtype(
+    ttnn::DataType dtype, float fill_value, bool fill_value_is_packed_bits = false) {
     switch (dtype) {
         case ttnn::DataType::FLOAT32:
         case ttnn::DataType::BFLOAT16: return pack_fill_value(fill_value);
         case ttnn::DataType::UINT16: return pack_fill_value(static_cast<uint16_t>(fill_value));
         case ttnn::DataType::UINT32: return pack_fill_value(static_cast<uint32_t>(fill_value));
-        // INT32: recover the raw int32 bits from fill_value via std::bit_cast<uint32_t>. Host passes
-        // bit-encoded sentinels as float (generic_reductions::get_pad_value); should not decode numerically.
-        case ttnn::DataType::INT32: return std::bit_cast<uint32_t>(fill_value);
+        // INT32: numeric by default - fill_value carries the integer value (e.g. fill_implicit_tile_padding
+        // callers like prod, reshape, slice). Callers that must carry an exact int32 bit pattern that is not
+        // float-representable (reduce's min/max pad sentinels, see generic_reductions::get_pad_value) set
+        // fill_value_is_packed_bits=true to recover the raw bits via std::bit_cast<uint32_t> instead.
+        case ttnn::DataType::INT32:
+            return fill_value_is_packed_bits ? std::bit_cast<uint32_t>(fill_value)
+                                             : pack_fill_value(static_cast<int32_t>(fill_value));
         default: TT_THROW("fill_pad: unsupported dtype"); return 0u;
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad.cpp
@@ -13,7 +13,10 @@
 namespace ttnn {
 
 Tensor fill_implicit_tile_padding(
-    const Tensor& input_tensor, float fill_value, const std::optional<MemoryConfig>& memory_config) {
+    const Tensor& input_tensor,
+    float fill_value,
+    const std::optional<MemoryConfig>& memory_config,
+    bool fill_value_is_packed_bits) {
     // if padded shape == logical shape for last 2 dims no padding should be present, and no fill pad is necessary
     uint32_t padded_height =
         tt::div_up(input_tensor.logical_shape()[-2], tt::constants::TILE_HEIGHT) * tt::constants::TILE_HEIGHT;
@@ -50,7 +53,8 @@ Tensor fill_implicit_tile_padding(
             /*sub_core_grid=*/std::nullopt,
             /*skip_padding_fill=*/true);
 
-        reshaped_tensor = ttnn::prim::fill_pad(reshaped_tensor, fill_value, output_memory_config);
+        reshaped_tensor =
+            ttnn::prim::fill_pad(reshaped_tensor, fill_value, output_memory_config, fill_value_is_packed_bits);
         output_tensor = ttnn::reshape(
             reshaped_tensor,
             original_shape,
@@ -60,7 +64,8 @@ Tensor fill_implicit_tile_padding(
             /*sub_core_grid=*/std::nullopt,
             /*skip_padding_fill=*/true);
     } else {
-        output_tensor = ttnn::prim::fill_pad(mutable_input_tensor, fill_value, output_memory_config);
+        output_tensor =
+            ttnn::prim::fill_pad(mutable_input_tensor, fill_value, output_memory_config, fill_value_is_packed_bits);
     }
     // BFLOAT8_B was typecast to BFLOAT16 above for fill_pad; restore the original dtype on every return path,
     // including the rank>3 branch (previously the cast-back only fired on the rank<=3 path, leaking BFLOAT16

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad.cpp
@@ -13,10 +13,7 @@
 namespace ttnn {
 
 Tensor fill_implicit_tile_padding(
-    const Tensor& input_tensor,
-    float fill_value,
-    const std::optional<MemoryConfig>& memory_config,
-    bool fill_value_is_packed_bits) {
+    const Tensor& input_tensor, tt::tt_metal::PadValue fill_value, const std::optional<MemoryConfig>& memory_config) {
     // if padded shape == logical shape for last 2 dims no padding should be present, and no fill pad is necessary
     uint32_t padded_height =
         tt::div_up(input_tensor.logical_shape()[-2], tt::constants::TILE_HEIGHT) * tt::constants::TILE_HEIGHT;
@@ -53,8 +50,7 @@ Tensor fill_implicit_tile_padding(
             /*sub_core_grid=*/std::nullopt,
             /*skip_padding_fill=*/true);
 
-        reshaped_tensor =
-            ttnn::prim::fill_pad(reshaped_tensor, fill_value, output_memory_config, fill_value_is_packed_bits);
+        reshaped_tensor = ttnn::prim::fill_pad(reshaped_tensor, fill_value, output_memory_config);
         output_tensor = ttnn::reshape(
             reshaped_tensor,
             original_shape,
@@ -64,8 +60,7 @@ Tensor fill_implicit_tile_padding(
             /*sub_core_grid=*/std::nullopt,
             /*skip_padding_fill=*/true);
     } else {
-        output_tensor =
-            ttnn::prim::fill_pad(mutable_input_tensor, fill_value, output_memory_config, fill_value_is_packed_bits);
+        output_tensor = ttnn::prim::fill_pad(mutable_input_tensor, fill_value, output_memory_config);
     }
     // BFLOAT8_B was typecast to BFLOAT16 above for fill_pad; restore the original dtype on every return path,
     // including the rank>3 branch (previously the cast-back only fired on the rank<=3 path, leaking BFLOAT16

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad.hpp
@@ -6,6 +6,12 @@
 #include "ttnn/types.hpp"
 
 namespace ttnn {
+// fill_value_is_packed_bits: when true, fill_value carries the raw int32 bit pattern (for int32 fill
+// values that are not float-representable, e.g. reduce min/max pad sentinels). Default false decodes
+// int32 fill_value numerically.
 Tensor fill_implicit_tile_padding(
-    const Tensor& input_tensor, float fill_value, const std::optional<MemoryConfig>& memory_config = std::nullopt);
+    const Tensor& input_tensor,
+    float fill_value,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    bool fill_value_is_packed_bits = false);
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad.hpp
@@ -6,12 +6,11 @@
 #include "ttnn/types.hpp"
 
 namespace ttnn {
-// fill_value_is_packed_bits: when true, fill_value carries the raw int32 bit pattern (for int32 fill
-// values that are not float-representable, e.g. reduce min/max pad sentinels). Default false decodes
-// int32 fill_value numerically.
+// fill_value: PadValue whose uint32_t arm carries a raw int32 bit pattern (for int32 fill values that
+// are not float-representable, e.g. reduce min/max pad sentinels) and whose float arm carries a numeric
+// value (the default).
 Tensor fill_implicit_tile_padding(
     const Tensor& input_tensor,
-    float fill_value,
-    const std::optional<MemoryConfig>& memory_config = std::nullopt,
-    bool fill_value_is_packed_bits = false);
+    tt::tt_metal::PadValue fill_value,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt);
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad_nanobind.cpp
@@ -26,6 +26,9 @@ void bind_fill_pad_op(nb::module_& mod) {
 
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+            fill_value_is_packed_bits (bool, optional): For INT32 tensors only, interpret fill_value as the raw
+                int32 bit pattern (via reinterpret) instead of decoding it numerically. Used to carry int32 fill
+                values that are not exactly float-representable. Defaults to `False` (numeric decode).
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -38,7 +41,8 @@ void bind_fill_pad_op(nb::module_& mod) {
         nb::arg("input_tensor"),
         nb::arg("fill_value"),
         nb::kw_only(),
-        nb::arg("memory_config") = nb::none());
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("fill_value_is_packed_bits") = false);
 }
 
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad_nanobind.cpp
@@ -8,6 +8,7 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/variant.h>
 
 #include "fill_pad.hpp"
 #include "ttnn-nanobind/bind_function.hpp"
@@ -22,13 +23,12 @@ void bind_fill_pad_op(nb::module_& mod) {
 
         Args:
             input_tensor (ttnn.Tensor): Any input tensor with desired device and data types for output tensor.
-            fill_value (float): Value to fill the tensor padding with.
+            fill_value (int or float): Value to fill the tensor padding with. An int is interpreted as the raw
+                integer bit pattern (e.g. for int32 values that are not exactly float-representable); a float is
+                decoded numerically.
 
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-            fill_value_is_packed_bits (bool, optional): For INT32 tensors only, interpret fill_value as the raw
-                int32 bit pattern (via reinterpret) instead of decoding it numerically. Used to carry int32 fill
-                values that are not exactly float-representable. Defaults to `False` (numeric decode).
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -41,8 +41,7 @@ void bind_fill_pad_op(nb::module_& mod) {
         nb::arg("input_tensor"),
         nb::arg("fill_value"),
         nb::kw_only(),
-        nb::arg("memory_config") = nb::none(),
-        nb::arg("fill_value_is_packed_bits") = false);
+        nb::arg("memory_config") = nb::none());
 }
 
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/gather.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/gather.cpp
@@ -59,7 +59,7 @@ Tensor pre_gather_transform_tensor(
 
     if (padding_index_tensor) {
         // Index tensor padding
-        return ttnn::fill_implicit_tile_padding(transformed_tensor, 0);
+        return ttnn::fill_implicit_tile_padding(transformed_tensor, 0.0f);
     }
 
     // Input tensor processing

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -371,7 +371,7 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTileRowInvarian
         uint32_t num_packed_values = sizeof(uint32_t) / element_size;
         num_writes = face_shape[1] / num_packed_values;
         switch (input_tensor.dtype()) {
-            case DataType::INT32:
+            case DataType::INT32: padding_val_packed = std::bit_cast<uint32_t>(pad_value); break;
             case DataType::UINT32: padding_val_packed = pad_value; break;
             case DataType::BFLOAT16:
                 padding_val_packed = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});
@@ -655,7 +655,7 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTiledGeneric::c
         num_writes = face_shape[1] / num_packed_values;
 
         switch (input_tensor.dtype()) {
-            case DataType::INT32:
+            case DataType::INT32: padding_val_packed = std::bit_cast<uint32_t>(pad_value); break;
             case DataType::UINT32: padding_val_packed = pad_value; break;
             case DataType::BFLOAT16:
                 padding_val_packed = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.cpp
@@ -27,12 +27,11 @@ uint32_t get_packed_value(const Tensor& tensor, const PadValue& pad_value) {
                     return ttnn::operations::data_movement::pack_two_uint16_into_uint32(
                         {uint16_pad_value, uint16_pad_value});
                 }
-                if (tensor.dtype() == DataType::FLOAT32) {
+                if (tensor.dtype() == DataType::FLOAT32 || tensor.dtype() == DataType::INT32) {
                     return std::bit_cast<uint32_t>(static_cast<float>(pad_value));
                 }
                 TT_FATAL(
-                    tensor.dtype() == DataType::UINT32 or tensor.dtype() == DataType::INT32,
-                    "only supporting bfloat16, float32, and uint32/int32/uint16");
+                    tensor.dtype() == DataType::UINT32, "only supporting bfloat16, float32, and uint32/int32/uint16");
                 return static_cast<uint32_t>(pad_value);
             }
             if constexpr (std::is_same_v<T, uint32_t>) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -157,7 +157,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
         uint32_t num_packed_values = sizeof(uint32_t) / element_size;
         num_writes = max_padding_write / num_packed_values;
         switch (input_tensor.dtype()) {
-            case DataType::INT32:
+            case DataType::INT32: padding_val_packed = std::bit_cast<uint32_t>(pad_value); break;
             case DataType::UINT32: padding_val_packed = pad_value; break;
             case DataType::BFLOAT16:
                 padding_val_packed = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/compute/rms_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/compute/rms_compute.cpp
@@ -160,18 +160,28 @@ void kernel_main() {
         const bool is_second_stage_reader = get_arg_val<uint32_t>(3) == 1;
         uint32_t num_blocks_reduce;
         num_blocks_reduce = (is_second_stage_reader) ? num_blocks_second_stage_reduction : num_blocks_first_stage;
-        const uint32_t cb_reduction_out =
-            (!use_two_stage_reduce or is_second_stage_reader) ? cb_to_allgather_writer : cb_ex2;
+        const auto reduce_block =
+            compute_kernel_lib::ReduceInputBlockShape::of(num_tiles_per_allgather_worker, num_blocks_reduce);
 
-        compute_kernel_lib::reduce<
-            PoolType::AVG,
-            ReduceDim::REDUCE_ROW,
-            compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
-            compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
-            cb_ex_external2,
-            cb_scaler_global,
-            cb_reduction_out,
-            compute_kernel_lib::ReduceInputBlockShape::of(num_tiles_per_allgather_worker, num_blocks_reduce));
+        if (!use_two_stage_reduce || is_second_stage_reader) {
+            compute_kernel_lib::reduce<
+                PoolType::AVG,
+                ReduceDim::REDUCE_ROW,
+                cb_ex_external2,
+                cb_scaler_global,
+                cb_to_allgather_writer,
+                compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
+                compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(reduce_block);
+        } else {
+            compute_kernel_lib::reduce<
+                PoolType::AVG,
+                ReduceDim::REDUCE_ROW,
+                cb_ex_external2,
+                cb_scaler_global,
+                cb_ex2,
+                compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
+                compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(reduce_block);
+        }
     }
 
     // Waits for stats tensor to have valid data
@@ -193,11 +203,11 @@ void kernel_main() {
             compute_kernel_lib::reduce<
                 PoolType::AVG,
                 ReduceDim::REDUCE_ROW,
-                compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop,
-                compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
                 cb_stats,
                 post_cb_scaler_global,
                 cb_var,
+                compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop,
+                compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
                 compute_kernel_lib::ReduceInputBlockShape::row(num_distributed_blocks));
             cb_pop_front(cb_stats, num_distributed_blocks);
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_grouped_gate/device/kernels/compute/deepseek_grouped_gate.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_grouped_gate/device/kernels/compute/deepseek_grouped_gate.cpp
@@ -264,20 +264,22 @@ void topk(
     cb_pop_front(cb_winning_group_indices, tiles);
 }
 
-void normalize_scores(
-    const uint32_t cb_gathered_sigmoid,
-    const uint32_t cb_reduce_ones_scalar,
-    const uint32_t cb_reduce_intermediate,
-    const uint32_t cb_reciprocal_sums,
-    const uint32_t cb_epsilon_scalar,
-    const uint32_t cb_normalized_scores) {
+template <
+    uint32_t cb_gathered_sigmoid,
+    uint32_t cb_reduce_ones_scalar,
+    uint32_t cb_reduce_intermediate,
+    uint32_t cb_reciprocal_sums,
+    uint32_t cb_epsilon_scalar,
+    uint32_t cb_normalized_scores>
+void normalize_scores() {
     // 1. Sum row (experts) to get row vector of sums [1, 32]
-    compute_kernel_lib::
-        reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
-            cb_gathered_sigmoid,
-            cb_reduce_ones_scalar,
-            cb_reduce_intermediate,
-            compute_kernel_lib::ReduceInputBlockShape::single());
+    compute_kernel_lib::reduce<
+        PoolType::SUM,
+        ReduceDim::REDUCE_ROW,
+        cb_gathered_sigmoid,
+        cb_reduce_ones_scalar,
+        cb_reduce_intermediate,
+        compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(compute_kernel_lib::ReduceInputBlockShape::single());
 
     // 2. Add epsilon to intermediate results
     tile_regs_acquire();
@@ -418,13 +420,13 @@ void kernel_main() {
             log_topk_groups,
             n_activated_experts,
             log_n_activated_experts);
-        blocks::normalize_scores(
+        blocks::normalize_scores<
             cb_gathered_sigmoid,
             cb_reduce_ones_scalar,
             cb_reduce_intermediate,
             cb_reciprocal_sums,
             cb_epsilon_scalar,
-            cb_normalized_scores);
+            cb_normalized_scores>();
         blocks::scale(cb_normalized_scores, cb_route_scale_scalar, cb_out_weights);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/ssm_1d_sum_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/ssm_1d_sum_reduce.cpp
@@ -54,11 +54,11 @@ void kernel_main() {
                 compute_kernel_lib::reduce<
                     PoolType::SUM,
                     ReduceDim::REDUCE_COL,
-                    compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
-                    compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
                     intermed_cb_id0,
                     scalar_cb_id,
                     intermed_cb_id1,
+                    compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
+                    compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
                     compute_kernel_lib::ReduceInputBlockShape::single());  // 1 x B
             }
             // Get full tile back from writer and transpose it

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/compute/rmsnorm_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/compute/rmsnorm_post_allgather.cpp
@@ -71,10 +71,7 @@ void kernel_main() {
          * cb_stats = [sum(x0**2), sum(x1**2), ...]
          * Uses auto-batched STREAMING mode - library handles CB lifecycle
          */
-        compute_kernel_lib::reduce<PoolType::AVG, ReduceDim::REDUCE_ROW>(
-            stats_cb,
-            reduce_scalar_cb,
-            reduce_result_cb,
+        compute_kernel_lib::reduce<PoolType::AVG, ReduceDim::REDUCE_ROW, stats_cb, reduce_scalar_cb, reduce_result_cb>(
             compute_kernel_lib::ReduceInputBlockShape::row(stats_tiles_cols));
 
         /*

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/compute/rmsnorm_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/compute/rmsnorm_pre_allgather.cpp
@@ -73,8 +73,8 @@ void kernel_main() {
         /*
          * sum(x**2)
          */
-        compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW>(
-            intermediate_cb, reduce_scalar_cb, output_cb, compute_kernel_lib::ReduceInputBlockShape::single());
+        compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, intermediate_cb, reduce_scalar_cb, output_cb>(
+            compute_kernel_lib::ReduceInputBlockShape::single());
     }
     cb_pop_front(reduce_scalar_cb, onetile);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/moreh_clip_grad_norm_step1_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/moreh_clip_grad_norm_step1_kernel.cpp
@@ -40,6 +40,10 @@ void kernel_main() {
     const auto cb_correct_xpow = intermed_id++;
     CircularBuffer cb_correct_xpow_obj(cb_correct_xpow);  // |x|^p * exp(log(|x|) * decimal)
 
+    constexpr auto cb_xpowadd_id = tt::CBIndex::c_26;
+    constexpr auto cb_one_id = tt::CBIndex::c_1;
+    constexpr auto cb_y_id = tt::CBIndex::c_16;
+
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
@@ -138,8 +142,8 @@ void kernel_main() {
     }
 
     // Compute cb_y - reduce single pre-accumulated tile to scalar
-    compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-        cb_xpowadd, cb_one, cb_y, compute_kernel_lib::ReduceInputBlockShape::single());
+    compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_xpowadd_id, cb_one_id, cb_y_id>(
+        compute_kernel_lib::ReduceInputBlockShape::single());
 
     cb_decimal_obj.pop_front(onetile);
     cb_one_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/moreh_clip_grad_norm_step1_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/moreh_clip_grad_norm_step1_kernel.cpp
@@ -16,33 +16,29 @@ void kernel_main() {
     const auto origin_h = get_arg_val<uint32_t>(i++);
     const auto origin_w = get_arg_val<uint32_t>(i++);
 
-    std::uint8_t input_id{0};
-    const auto cb_x = input_id++;
+    constexpr std::uint8_t input_id = 0;
+    constexpr auto cb_x = input_id + 0;
     CircularBuffer cb_x_obj(cb_x);  // input(==x)
-    const auto cb_one = input_id++;
+    constexpr auto cb_one = input_id + 1;
     CircularBuffer cb_one_obj(cb_one);  // one
-    const auto cb_decimal = input_id++;
+    constexpr auto cb_decimal = input_id + 2;
     CircularBuffer cb_decimal_obj(cb_decimal);  // decimal
-    const auto cb_mask_h_w = input_id++;
+    constexpr auto cb_mask_h_w = input_id + 3;
     CircularBuffer cb_mask_h_w_obj(cb_mask_h_w);  // mask_h_w
 
-    std::uint8_t output_id{16};
-    const auto cb_y = output_id++;  // output(==y)
+    constexpr std::uint8_t output_id = 16;
+    constexpr auto cb_y = output_id;  // output(==y)
 
-    std::uint8_t intermed_id{24};
-    const auto cb_xabs = intermed_id++;
+    constexpr std::uint8_t intermed_id = 24;
+    constexpr auto cb_xabs = intermed_id + 0;
     CircularBuffer cb_xabs_obj(cb_xabs);         // |x|
-    const auto cb_xpow = intermed_id++;          // |x|^p
-    const auto cb_xpowadd = intermed_id++;
+    constexpr auto cb_xpow = intermed_id + 1;    // |x|^p
+    constexpr auto cb_xpowadd = intermed_id + 2;
     CircularBuffer cb_xpowadd_obj(cb_xpowadd);   // Add[|x|^p * exp(log(|x|) * decimal)]
-    const auto cb_logx = intermed_id++;          // log(|x|)
-    const auto cb_exp_lxmd = intermed_id++;      // exp(log(|x|) * decimal)
-    const auto cb_correct_xpow = intermed_id++;
+    constexpr auto cb_logx = intermed_id + 3;    // log(|x|)
+    constexpr auto cb_exp_lxmd = intermed_id + 4;  // exp(log(|x|) * decimal)
+    constexpr auto cb_correct_xpow = intermed_id + 5;
     CircularBuffer cb_correct_xpow_obj(cb_correct_xpow);  // |x|^p * exp(log(|x|) * decimal)
-
-    constexpr auto cb_xpowadd_id = tt::CBIndex::c_26;
-    constexpr auto cb_one_id = tt::CBIndex::c_1;
-    constexpr auto cb_y_id = tt::CBIndex::c_16;
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
@@ -142,7 +138,7 @@ void kernel_main() {
     }
 
     // Compute cb_y - reduce single pre-accumulated tile to scalar
-    compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_xpowadd_id, cb_one_id, cb_y_id>(
+    compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_xpowadd, cb_one, cb_y>(
         compute_kernel_lib::ReduceInputBlockShape::single());
 
     cb_decimal_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
@@ -44,8 +44,6 @@ void kernel_main() {
         REL();
 
         // reduce-w
-        // Output CB depends on whether this is the last block; CB ids are now template params, so
-        // the runtime branch is hoisted into two compile-time instantiations.
         if (last_out) {
             compute_kernel_lib::reduce<
                 REDUCE_OP,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
@@ -44,16 +44,32 @@ void kernel_main() {
         REL();
 
         // reduce-w
-        compute_kernel_lib::reduce<
-            REDUCE_OP,
-            REDUCE_DIM,
-            compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
-            compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
-            tt::CBIndex::c_24,
-            tt::CBIndex::c_2,
-            last_out ? tt::CBIndex::c_16 : tt::CBIndex::c_25,
-            compute_kernel_lib::ReduceInputBlockShape::single(),
-            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-            compute_kernel_lib::Accumulate::at(tt::CBIndex::c_25, block));
+        // Output CB depends on whether this is the last block; CB ids are now template params, so
+        // the runtime branch is hoisted into two compile-time instantiations.
+        if (last_out) {
+            compute_kernel_lib::reduce<
+                REDUCE_OP,
+                REDUCE_DIM,
+                tt::CBIndex::c_24,
+                tt::CBIndex::c_2,
+                tt::CBIndex::c_16,
+                compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
+                compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
+                compute_kernel_lib::ReduceInputBlockShape::single(),
+                compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+                compute_kernel_lib::Accumulate::at(tt::CBIndex::c_25, block));
+        } else {
+            compute_kernel_lib::reduce<
+                REDUCE_OP,
+                REDUCE_DIM,
+                tt::CBIndex::c_24,
+                tt::CBIndex::c_2,
+                tt::CBIndex::c_25,
+                compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
+                compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
+                compute_kernel_lib::ReduceInputBlockShape::single(),
+                compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+                compute_kernel_lib::Accumulate::at(tt::CBIndex::c_25, block));
+        }
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_large_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_large_kernel.cpp
@@ -178,8 +178,8 @@ void kernel_main() {
          * E[x]
          * cb_ex
          */
-        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-            cb_xsum, cb_scaler, cb_ex, compute_kernel_lib::ReduceInputBlockShape::single());
+        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_xsum, cb_scaler, cb_ex>(
+            compute_kernel_lib::ReduceInputBlockShape::single());
 
         cb_ex_obj.wait_front(onetile);
         if (mean_has_value) {
@@ -327,8 +327,8 @@ void kernel_main() {
          * E[(x-E[x])^2 = Var[x]
          * cb_var
          */
-        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-            cb_xmm2sum, cb_scaler, cb_var, compute_kernel_lib::ReduceInputBlockShape::single());
+        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_xmm2sum, cb_scaler, cb_var>(
+            compute_kernel_lib::ReduceInputBlockShape::single());
 
         /*
          * 1.0/(sqrt(E[(x-E[x])^2] + eps))

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_small_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_small_kernel.cpp
@@ -185,8 +185,8 @@ void kernel_main() {
          * E[x] - reduce single pre-accumulated tile
          * cb_ex
          */
-        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-            cb_xsum, cb_scaler, cb_ex, compute_kernel_lib::ReduceInputBlockShape::single());
+        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_xsum, cb_scaler, cb_ex>(
+            compute_kernel_lib::ReduceInputBlockShape::single());
 
         cb_ex_obj.wait_front(onetile);
         if (mean_has_value) {
@@ -309,8 +309,8 @@ void kernel_main() {
          * E[(x-E[x])^2 = Var[x] - reduce single pre-accumulated tile
          * cb_var
          */
-        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-            cb_xmm2sum, cb_scaler, cb_var, compute_kernel_lib::ReduceInputBlockShape::single());
+        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_xmm2sum, cb_scaler, cb_var>(
+            compute_kernel_lib::ReduceInputBlockShape::single());
 
         /*
          * 1.0/(sqrt(E[(x-E[x])^2] + eps))

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_gamma_beta_grad_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_gamma_beta_grad_kernel.cpp
@@ -286,8 +286,8 @@ void kernel_main() {
             // Compute cb_dgamma
             if (is_lastdim_layernorm || is_groupnorm) {
                 // Sum[y * dy]
-                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-                    cb_ydyadd, cb_scaler, cb_dgamma, compute_kernel_lib::ReduceInputBlockShape::single());
+                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_ydyadd, cb_scaler, cb_dgamma>(
+                    compute_kernel_lib::ReduceInputBlockShape::single());
             } else {
                 // Just copy
                 tile_regs_acquire();
@@ -311,8 +311,8 @@ void kernel_main() {
             // Compute cb_dbeta
             if (is_lastdim_layernorm || is_groupnorm) {
                 // Sum[dy]
-                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-                    cb_dyadd, cb_scaler, cb_dbeta, compute_kernel_lib::ReduceInputBlockShape::single());
+                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_dyadd, cb_scaler, cb_dbeta>(
+                    compute_kernel_lib::ReduceInputBlockShape::single());
             } else {
                 // Just copy
                 tile_regs_acquire();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_large_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_large_kernel.cpp
@@ -322,13 +322,13 @@ void kernel_main() {
 
         // Compute cb_dysum
         // Sum[dy]
-        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-            cb_dyadd, cb_scaler, cb_dysum, compute_kernel_lib::ReduceInputBlockShape::single());
+        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_dyadd, cb_scaler, cb_dysum>(
+            compute_kernel_lib::ReduceInputBlockShape::single());
 
         // Compute cb_ydysum
         // Sum[y * dy]
-        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-            cb_ydyadd, cb_scaler, cb_ydysum, compute_kernel_lib::ReduceInputBlockShape::single());
+        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_ydyadd, cb_scaler, cb_ydysum>(
+            compute_kernel_lib::ReduceInputBlockShape::single());
 
         // Compute cb_recip_nrstd
         // rstd / n -> cb_tmp3

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_small_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_small_kernel.cpp
@@ -291,8 +291,8 @@ void kernel_main() {
 
         // Compute cb_dysum
         // Sum[dy]
-        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-            cb_dyadd, cb_scaler, cb_dysum, compute_kernel_lib::ReduceInputBlockShape::single());
+        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_dyadd, cb_scaler, cb_dysum>(
+            compute_kernel_lib::ReduceInputBlockShape::single());
 
         // Compute cb_ydy and cb_ydyadd
         constexpr auto cb_ydy = cb_tmp2;
@@ -354,8 +354,8 @@ void kernel_main() {
 
         // Compute cb_ydysum
         // Sum[y * dy]
-        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-            cb_ydyadd, cb_scaler, cb_ydysum, compute_kernel_lib::ReduceInputBlockShape::single());
+        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_ydyadd, cb_scaler, cb_ydysum>(
+            compute_kernel_lib::ReduceInputBlockShape::single());
 
         // Compute cb_dx
         // ((n * dy - Sum[dy]) - (y * Sum[y * dy])) * (rstd / n)

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_multi_core_h.cpp
@@ -45,7 +45,6 @@ void kernel_main() {
                 bool last_out = (num_tile_done == num_tiles - 1);
                 bool do_mask = (do_mask_h && last_row) || (do_mask_w && last_col);
 
-                auto cb_reduce = cb_in0;
                 if (do_mask) {
                     // get tile from reader and apply mask
                     cb_in0_obj.wait_front(onetile);
@@ -87,17 +86,32 @@ void kernel_main() {
                     tile_regs_release();
 
                     cb_in0_obj.pop_front(onetile);
-                    cb_reduce = cb_intermed0;
                 }
 
-                auto output_cb = last_out ? cb_out0 : cb_intermed1;
-                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-                    cb_reduce,
-                    cb_scaler,
-                    output_cb,
-                    compute_kernel_lib::ReduceInputBlockShape::single(),
-                    compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                    compute_kernel_lib::Accumulate::at(cb_intermed1, num_tile_done));
+                // CB ids are now reduce<> template params, but both the input CB (cb_in0 vs
+                // cb_intermed0, set by do_mask) and the output CB (cb_out0 vs cb_intermed1, set by
+                // last_out) are chosen at runtime, so the selection is hoisted into compile-time
+                // instantiations. The runtime args are identical across branches.
+                const auto reduce_block = compute_kernel_lib::ReduceInputBlockShape::single();
+                const auto reduce_layout = compute_kernel_lib::ReduceInputMemoryLayout::contiguous();
+                const auto reduce_accum = compute_kernel_lib::Accumulate::at(cb_intermed1, num_tile_done);
+                if (do_mask) {
+                    if (last_out) {
+                        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_intermed0, cb_scaler, cb_out0>(
+                            reduce_block, reduce_layout, reduce_accum);
+                    } else {
+                        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_intermed0, cb_scaler, cb_intermed1>(
+                            reduce_block, reduce_layout, reduce_accum);
+                    }
+                } else {
+                    if (last_out) {
+                        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_in0, cb_scaler, cb_out0>(
+                            reduce_block, reduce_layout, reduce_accum);
+                    } else {
+                        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_in0, cb_scaler, cb_intermed1>(
+                            reduce_block, reduce_layout, reduce_accum);
+                    }
+                }
 
                 num_tile_done++;
             }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_multi_core_h.cpp
@@ -88,10 +88,6 @@ void kernel_main() {
                     cb_in0_obj.pop_front(onetile);
                 }
 
-                // CB ids are now reduce<> template params, but both the input CB (cb_in0 vs
-                // cb_intermed0, set by do_mask) and the output CB (cb_out0 vs cb_intermed1, set by
-                // last_out) are chosen at runtime, so the selection is hoisted into compile-time
-                // instantiations. The runtime args are identical across branches.
                 const auto reduce_block = compute_kernel_lib::ReduceInputBlockShape::single();
                 const auto reduce_layout = compute_kernel_lib::ReduceInputMemoryLayout::contiguous();
                 const auto reduce_accum = compute_kernel_lib::Accumulate::at(cb_intermed1, num_tile_done);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_single_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_single_core_hw.cpp
@@ -44,7 +44,6 @@ void kernel_main() {
                 bool last_out = (num_tile_done == num_tiles - 1);
                 bool do_mask = (do_mask_h && last_row) || (do_mask_w && last_col);
 
-                auto cb_reduce = cb_in0;
                 if (do_mask) {
                     // get tile from reader and apply mask
                     cb_in0_obj.wait_front(onetile);
@@ -86,17 +85,32 @@ void kernel_main() {
                     tile_regs_release();
 
                     cb_in0_obj.pop_front(onetile);
-                    cb_reduce = cb_intermed0;
                 }
 
-                auto output_cb = last_out ? cb_out0 : cb_intermed1;
-                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-                    cb_reduce,
-                    cb_scaler,
-                    output_cb,
-                    compute_kernel_lib::ReduceInputBlockShape::single(),
-                    compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                    compute_kernel_lib::Accumulate::at(cb_intermed1, num_tile_done));
+                // CB ids are now reduce<> template params, but both the input CB (cb_in0 vs
+                // cb_intermed0, set by do_mask) and the output CB (cb_out0 vs cb_intermed1, set by
+                // last_out) are chosen at runtime, so the selection is hoisted into compile-time
+                // instantiations. The runtime args are identical across branches.
+                const auto reduce_block = compute_kernel_lib::ReduceInputBlockShape::single();
+                const auto reduce_layout = compute_kernel_lib::ReduceInputMemoryLayout::contiguous();
+                const auto reduce_accum = compute_kernel_lib::Accumulate::at(cb_intermed1, num_tile_done);
+                if (do_mask) {
+                    if (last_out) {
+                        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_intermed0, cb_scaler, cb_out0>(
+                            reduce_block, reduce_layout, reduce_accum);
+                    } else {
+                        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_intermed0, cb_scaler, cb_intermed1>(
+                            reduce_block, reduce_layout, reduce_accum);
+                    }
+                } else {
+                    if (last_out) {
+                        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_in0, cb_scaler, cb_out0>(
+                            reduce_block, reduce_layout, reduce_accum);
+                    } else {
+                        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_in0, cb_scaler, cb_intermed1>(
+                            reduce_block, reduce_layout, reduce_accum);
+                    }
+                }
 
                 num_tile_done++;
             }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_single_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_single_core_hw.cpp
@@ -87,10 +87,6 @@ void kernel_main() {
                     cb_in0_obj.pop_front(onetile);
                 }
 
-                // CB ids are now reduce<> template params, but both the input CB (cb_in0 vs
-                // cb_intermed0, set by do_mask) and the output CB (cb_out0 vs cb_intermed1, set by
-                // last_out) are chosen at runtime, so the selection is hoisted into compile-time
-                // instantiations. The runtime args are identical across branches.
                 const auto reduce_block = compute_kernel_lib::ReduceInputBlockShape::single();
                 const auto reduce_layout = compute_kernel_lib::ReduceInputMemoryLayout::contiguous();
                 const auto reduce_accum = compute_kernel_lib::Accumulate::at(cb_intermed1, num_tile_done);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_h.cpp
@@ -51,8 +51,8 @@ void kernel_main() {
 
             // Phase 1: Reduce Ht-1 tiles into accumulator (if Ht > 1)
             if (!is_h_single_tile) {
-                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-                    cb_input, cb_scaler, cb_accum_dst, compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
+                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_input, cb_scaler, cb_accum_dst>(
+                    compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
             }
 
             // Optional masking of last H tile
@@ -78,10 +78,7 @@ void kernel_main() {
                 cb_input_obj.pop_front(onetile);
 
                 // Phase 2 with masked input: Reduce final masked tile with accumulation
-                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-                    cb_masked_input,
-                    cb_scaler,
-                    cb_out,
+                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_masked_input, cb_scaler, cb_out>(
                     compute_kernel_lib::ReduceInputBlockShape::single(),
                     compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
                     compute_kernel_lib::Accumulate::at(cb_accum_dst, is_h_single_tile ? 0 : 1));
@@ -89,10 +86,7 @@ void kernel_main() {
                 // Phase 2 without masking: Reduce final tile with accumulation
                 // - If Ht == 1 (single tile): iteration=0, no accumulator reload
                 // - If Ht > 1 (multi-tile): iteration=1, reload accumulator from cb_accum_dst
-                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-                    cb_input,
-                    cb_scaler,
-                    cb_out,
+                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_input, cb_scaler, cb_out>(
                     compute_kernel_lib::ReduceInputBlockShape::single(),
                     compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
                     compute_kernel_lib::Accumulate::at(cb_accum_dst, is_h_single_tile ? 0 : 1));

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
@@ -136,8 +136,8 @@ void kernel_main() {
             }
         }
         // Sum(|x|^p) - reduce single pre-accumulated tile
-        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-            cb_xpowadd, cb_one, cb_xpowsum, compute_kernel_lib::ReduceInputBlockShape::single());
+        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_xpowadd, cb_one, cb_xpowsum>(
+            compute_kernel_lib::ReduceInputBlockShape::single());
 
         power_tile_to_cb(cb_xpowsum, cb_tmp0, cb_tmp1, cb_recip_p_decimal, cb_tmp2, cb_y, recip_p, recip_p_is_negative);
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
@@ -136,8 +136,8 @@ void kernel_main() {
             }
         }
         // Sum(|x|^p)
-        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-            cb_xpowadd, cb_one, cb_xpowsum, compute_kernel_lib::ReduceInputBlockShape::single());
+        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_xpowadd, cb_one, cb_xpowsum>(
+            compute_kernel_lib::ReduceInputBlockShape::single());
 
         power_tile_to_cb(cb_xpowsum, cb_tmp0, cb_tmp1, cb_recip_p_decimal, cb_tmp2, cb_y, recip_p, recip_p_is_negative);
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
@@ -35,6 +35,10 @@ void kernel_main() {
     const auto cb_reduce = cb_tmp2;
     CircularBuffer cb_reduce_obj(cb_reduce);  // reduce f(x)
 
+    constexpr auto cb_cal_id = tt::CBIndex::c_25;
+    constexpr auto cb_one_id = tt::CBIndex::c_1;
+    constexpr auto cb_reduce_id = tt::CBIndex::c_26;
+
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
@@ -139,8 +143,8 @@ void kernel_main() {
             }
         }
         // reduce f(x)
-        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-            cb_cal, cb_one, cb_reduce, compute_kernel_lib::ReduceInputBlockShape::single());
+        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_cal_id, cb_one_id, cb_reduce_id>(
+            compute_kernel_lib::ReduceInputBlockShape::single());
 
         tile_regs_acquire();
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
@@ -11,33 +11,28 @@ void kernel_main() {
     const auto Ht = get_arg_val<uint32_t>(i++);
     const auto origin_h = get_arg_val<uint32_t>(i++);
 
-    std::uint8_t input_id{tt::CB::c_in0};
-    const auto cb_x = input_id++;
+    constexpr std::uint8_t input_id = tt::CB::c_in0;
+    constexpr auto cb_x = input_id + 0;
     CircularBuffer cb_x_obj(cb_x);  // input
-    const auto cb_one = input_id++;
+    constexpr auto cb_one = input_id + 1;
     CircularBuffer cb_one_obj(cb_one);  // one
-    const auto cb_mask_h = input_id++;
+    constexpr auto cb_mask_h = input_id + 2;
     CircularBuffer cb_mask_h_obj(cb_mask_h);  // mask_h
 
-    std::uint8_t output_id{tt::CB::c_out0};
-    const auto cb_y = output_id++;
+    constexpr auto cb_y = tt::CB::c_out0;
     CircularBuffer cb_y_obj(cb_y);  // output
 
-    std::uint8_t intermed_id{tt::CB::c_intermed0};
-    const auto cb_tmp0 = intermed_id++;
-    const auto cb_tmp1 = intermed_id++;
-    const auto cb_tmp2 = intermed_id++;
+    constexpr std::uint8_t intermed_id = tt::CB::c_intermed0;
+    constexpr auto cb_tmp0 = intermed_id + 0;
+    constexpr auto cb_tmp1 = intermed_id + 1;
+    constexpr auto cb_tmp2 = intermed_id + 2;
 
-    const auto cb_val = cb_tmp0;
+    constexpr auto cb_val = cb_tmp0;
     CircularBuffer cb_val_obj(cb_val);  // f(x)
-    const auto cb_cal = cb_tmp1;
+    constexpr auto cb_cal = cb_tmp1;
     CircularBuffer cb_cal_obj(cb_cal);  // calculate f(x) over dimension
-    const auto cb_reduce = cb_tmp2;
+    constexpr auto cb_reduce = cb_tmp2;
     CircularBuffer cb_reduce_obj(cb_reduce);  // reduce f(x)
-
-    constexpr auto cb_cal_id = tt::CBIndex::c_25;
-    constexpr auto cb_one_id = tt::CBIndex::c_1;
-    constexpr auto cb_reduce_id = tt::CBIndex::c_26;
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
@@ -143,7 +138,7 @@ void kernel_main() {
             }
         }
         // reduce f(x)
-        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_cal_id, cb_one_id, cb_reduce_id>(
+        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_cal, cb_one, cb_reduce>(
             compute_kernel_lib::ReduceInputBlockShape::single());
 
         tile_regs_acquire();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
@@ -35,6 +35,10 @@ void kernel_main() {
     const auto cb_reduce = cb_tmp2;
     CircularBuffer cb_reduce_obj(cb_reduce);  // reduce f(x)
 
+    constexpr auto cb_cal_id = tt::CBIndex::c_25;
+    constexpr auto cb_one_id = tt::CBIndex::c_1;
+    constexpr auto cb_reduce_id = tt::CBIndex::c_26;
+
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
@@ -138,8 +142,8 @@ void kernel_main() {
             }
         }
         // reduce f(x)
-        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-            cb_cal, cb_one, cb_reduce, compute_kernel_lib::ReduceInputBlockShape::single());
+        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_cal_id, cb_one_id, cb_reduce_id>(
+            compute_kernel_lib::ReduceInputBlockShape::single());
 
         tile_regs_acquire();
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
@@ -11,33 +11,28 @@ void kernel_main() {
     const auto Wt = get_arg_val<uint32_t>(i++);
     const auto origin_w = get_arg_val<uint32_t>(i++);
 
-    std::uint8_t input_id{tt::CB::c_in0};
-    const auto cb_x = input_id++;
+    constexpr std::uint8_t input_id = tt::CB::c_in0;
+    constexpr auto cb_x = input_id + 0;
     CircularBuffer cb_x_obj(cb_x);  // input
-    const auto cb_one = input_id++;
+    constexpr auto cb_one = input_id + 1;
     CircularBuffer cb_one_obj(cb_one);  // one
-    const auto cb_mask_w = input_id++;
+    constexpr auto cb_mask_w = input_id + 2;
     CircularBuffer cb_mask_w_obj(cb_mask_w);  // mask_w
 
-    std::uint8_t output_id{tt::CB::c_out0};
-    const auto cb_y = output_id++;
+    constexpr auto cb_y = tt::CB::c_out0;
     CircularBuffer cb_y_obj(cb_y);  // output
 
-    std::uint8_t intermed_id{tt::CB::c_intermed0};
-    const auto cb_tmp0 = intermed_id++;
-    const auto cb_tmp1 = intermed_id++;
-    const auto cb_tmp2 = intermed_id++;
+    constexpr std::uint8_t intermed_id = tt::CB::c_intermed0;
+    constexpr auto cb_tmp0 = intermed_id + 0;
+    constexpr auto cb_tmp1 = intermed_id + 1;
+    constexpr auto cb_tmp2 = intermed_id + 2;
 
-    const auto cb_val = cb_tmp0;
+    constexpr auto cb_val = cb_tmp0;
     CircularBuffer cb_val_obj(cb_val);  // f(x)
-    const auto cb_cal = cb_tmp1;
+    constexpr auto cb_cal = cb_tmp1;
     CircularBuffer cb_cal_obj(cb_cal);  // calculate f(x) over dimension
-    const auto cb_reduce = cb_tmp2;
+    constexpr auto cb_reduce = cb_tmp2;
     CircularBuffer cb_reduce_obj(cb_reduce);  // reduce f(x)
-
-    constexpr auto cb_cal_id = tt::CBIndex::c_25;
-    constexpr auto cb_one_id = tt::CBIndex::c_1;
-    constexpr auto cb_reduce_id = tt::CBIndex::c_26;
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
@@ -142,7 +137,7 @@ void kernel_main() {
             }
         }
         // reduce f(x)
-        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_cal_id, cb_one_id, cb_reduce_id>(
+        compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_cal, cb_one, cb_reduce>(
             compute_kernel_lib::ReduceInputBlockShape::single());
 
         tile_regs_acquire();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h.cpp
@@ -47,18 +47,20 @@ void kernel_main() {
         if (Ht == 1) {
             mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, 0, 0, /*pop0=*/0, /*popm=*/0);
 
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL>(
-                cb_tmp, cb_max_scaler, cb_max, compute_kernel_lib::ReduceInputBlockShape::single());
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, cb_tmp, cb_max_scaler, cb_max>(
+                compute_kernel_lib::ReduceInputBlockShape::single());
         } else {
-            compute_kernel_lib::
-                reduce<PoolType::MAX, ReduceDim::REDUCE_COL, compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
-                    cb_in0, cb_max_scaler, cb_max, compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
-
-            mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, Ht - 1, 0, /*pop0=*/0, /*popm=*/0);
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL>(
-                cb_tmp,
+            compute_kernel_lib::reduce<
+                PoolType::MAX,
+                ReduceDim::REDUCE_COL,
+                cb_in0,
                 cb_max_scaler,
                 cb_max,
+                compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
+                compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
+
+            mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, Ht - 1, 0, /*pop0=*/0, /*popm=*/0);
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, cb_tmp, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::single(),
                 compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
                 compute_kernel_lib::Accumulate::at(cb_max, 1));  // iteration=1, reload from cb_max
@@ -116,32 +118,36 @@ void kernel_main() {
 
 #ifdef LOG
         // log(sum) - pop tiles after reduce
-        compute_kernel_lib::
-            reduce<PoolType::SUM, ReduceDim::REDUCE_COL, compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-                cb_exps,
-                cb_sum_scaler,
-                cb_recipsumexps,
-                compute_kernel_lib::ReduceInputBlockShape::col(Ht),
-                compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                compute_kernel_lib::NoAccumulation{},
-                [](uint32_t dst_idx) {
-                    log_tile_init();
-                    log_tile(dst_idx);
-                });
+        compute_kernel_lib::reduce<
+            PoolType::SUM,
+            ReduceDim::REDUCE_COL,
+            cb_exps,
+            cb_sum_scaler,
+            cb_recipsumexps,
+            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
+            compute_kernel_lib::ReduceInputBlockShape::col(Ht),
+            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+            compute_kernel_lib::NoAccumulation{},
+            [](uint32_t dst_idx) {
+                log_tile_init();
+                log_tile(dst_idx);
+            });
 #else
         // 1/sum - keep tiles for subsequent multiplication
-        compute_kernel_lib::
-            reduce<PoolType::SUM, ReduceDim::REDUCE_COL, compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
-                cb_exps,
-                cb_sum_scaler,
-                cb_recipsumexps,
-                compute_kernel_lib::ReduceInputBlockShape::col(Ht),
-                compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                compute_kernel_lib::NoAccumulation{},
-                [](uint32_t dst_idx) {
-                    recip_tile_init();
-                    recip_tile(dst_idx);
-                });
+        compute_kernel_lib::reduce<
+            PoolType::SUM,
+            ReduceDim::REDUCE_COL,
+            cb_exps,
+            cb_sum_scaler,
+            cb_recipsumexps,
+            compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
+            compute_kernel_lib::ReduceInputBlockShape::col(Ht),
+            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+            compute_kernel_lib::NoAccumulation{},
+            [](uint32_t dst_idx) {
+                recip_tile_init();
+                recip_tile(dst_idx);
+            });
 #endif
 
         // compute final result

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h_large.cpp
@@ -35,20 +35,17 @@ void kernel_main() {
         if (Ht == 1) {
             mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, 0, 0, /*pop0=*/1, /*popm=*/0);
 
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL>(
-                cb_tmp, cb_max_scaler, cb_max, compute_kernel_lib::ReduceInputBlockShape::single());
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, cb_tmp, cb_max_scaler, cb_max>(
+                compute_kernel_lib::ReduceInputBlockShape::single());
         } else {
             // Phase 1: Reduce Ht-1 tiles
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL>(
-                cb_in0, cb_max_scaler, cb_max, compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, cb_in0, cb_max_scaler, cb_max>(
+                compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
 
             mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, 0, 0, /*pop0=*/1, /*popm=*/0);
 
             // Phase 2: Reduce final masked tile with accumulation
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL>(
-                cb_tmp,
-                cb_max_scaler,
-                cb_max,
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_COL, cb_tmp, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::single(),
                 compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
                 compute_kernel_lib::Accumulate::at(cb_max, 1));  // iteration=1, reload from cb_max
@@ -99,32 +96,36 @@ void kernel_main() {
 
 #ifdef LOG
         // compute log(sum) - pop tile after reduce
-        compute_kernel_lib::
-            reduce<PoolType::SUM, ReduceDim::REDUCE_COL, compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-                cb_add,
-                cb_sum_scaler,
-                cb_recipsumexps,
-                compute_kernel_lib::ReduceInputBlockShape::single(),
-                compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                compute_kernel_lib::NoAccumulation{},
-                [](uint32_t dst_idx) {
-                    log_tile_init();
-                    log_tile(dst_idx);
-                });
+        compute_kernel_lib::reduce<
+            PoolType::SUM,
+            ReduceDim::REDUCE_COL,
+            cb_add,
+            cb_sum_scaler,
+            cb_recipsumexps,
+            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
+            compute_kernel_lib::ReduceInputBlockShape::single(),
+            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+            compute_kernel_lib::NoAccumulation{},
+            [](uint32_t dst_idx) {
+                log_tile_init();
+                log_tile(dst_idx);
+            });
 #else
         // compute 1/sum(exp(x)) - pop tile after reduce
-        compute_kernel_lib::
-            reduce<PoolType::SUM, ReduceDim::REDUCE_COL, compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-                cb_add,
-                cb_sum_scaler,
-                cb_recipsumexps,
-                compute_kernel_lib::ReduceInputBlockShape::single(),
-                compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                compute_kernel_lib::NoAccumulation{},
-                [](uint32_t dst_idx) {
-                    recip_tile_init();
-                    recip_tile(dst_idx);
-                });
+        compute_kernel_lib::reduce<
+            PoolType::SUM,
+            ReduceDim::REDUCE_COL,
+            cb_add,
+            cb_sum_scaler,
+            cb_recipsumexps,
+            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
+            compute_kernel_lib::ReduceInputBlockShape::single(),
+            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+            compute_kernel_lib::NoAccumulation{},
+            [](uint32_t dst_idx) {
+                recip_tile_init();
+                recip_tile(dst_idx);
+            });
 #endif
 
         // step 3, compute final result

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp
@@ -54,18 +54,20 @@ void kernel_main() {
             // Phase 1: reduce Wt-1 full tiles into cb_max via the helper.
             // cb_in0 holds all Wt tiles persistently for later steps, so use
             // WaitUpfrontNoPop — the helper waits for the slice it needs and never pops.
-            compute_kernel_lib::
-                reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
-                    cb_in0, cb_max_scaler, cb_max, compute_kernel_lib::ReduceInputBlockShape::row(Wt - 1));
+            compute_kernel_lib::reduce<
+                PoolType::MAX,
+                ReduceDim::REDUCE_ROW,
+                cb_in0,
+                cb_max_scaler,
+                cb_max,
+                compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
+                compute_kernel_lib::ReduceInputBlockShape::row(Wt - 1));
 
             // Phase 2: mask the last tile (index Wt-1, no pop) and continue reducing
             // into cb_max via Accumulate. The accumulator and output are both cb_max:
             // the helper waits+pops the previous tile, then packs+pushes the new one.
             mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, Wt - 1, 0, /*pop0=*/0, /*popm=*/0);
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW>(
-                cb_tmp,
-                cb_max_scaler,
-                cb_max,
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_tmp, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::row(1),
                 compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
                 compute_kernel_lib::Accumulate::at(cb_max, /*iter=*/1));

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp
@@ -48,8 +48,8 @@ void kernel_main() {
         if (Wt == 1) {
             mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, 0, 0, /*pop0=*/0, /*popm=*/0);
 
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW>(
-                cb_tmp, cb_max_scaler, cb_max, compute_kernel_lib::ReduceInputBlockShape::single());
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_tmp, cb_max_scaler, cb_max>(
+                compute_kernel_lib::ReduceInputBlockShape::single());
         } else {
             // Phase 1: reduce Wt-1 full tiles into cb_max via the helper.
             // cb_in0 holds all Wt tiles persistently for later steps, so use
@@ -123,32 +123,36 @@ void kernel_main() {
 
 #ifdef LOG
         // log(sum) - pop tiles after reduce
-        compute_kernel_lib::
-            reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-                cb_exps,
-                cb_sum_scaler,
-                cb_recipsumexps,
-                compute_kernel_lib::ReduceInputBlockShape::row(Wt),
-                compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                compute_kernel_lib::NoAccumulation{},
-                [](uint32_t dst_idx) {
-                    log_tile_init();
-                    log_tile(dst_idx);
-                });
+        compute_kernel_lib::reduce<
+            PoolType::SUM,
+            ReduceDim::REDUCE_ROW,
+            cb_exps,
+            cb_sum_scaler,
+            cb_recipsumexps,
+            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
+            compute_kernel_lib::ReduceInputBlockShape::row(Wt),
+            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+            compute_kernel_lib::NoAccumulation{},
+            [](uint32_t dst_idx) {
+                log_tile_init();
+                log_tile(dst_idx);
+            });
 #else
         // 1/sum - keep tiles for subsequent multiplication
-        compute_kernel_lib::
-            reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
-                cb_exps,
-                cb_sum_scaler,
-                cb_recipsumexps,
-                compute_kernel_lib::ReduceInputBlockShape::row(Wt),
-                compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                compute_kernel_lib::NoAccumulation{},
-                [](uint32_t dst_idx) {
-                    recip_tile_init();
-                    recip_tile(dst_idx);
-                });
+        compute_kernel_lib::reduce<
+            PoolType::SUM,
+            ReduceDim::REDUCE_ROW,
+            cb_exps,
+            cb_sum_scaler,
+            cb_recipsumexps,
+            compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
+            compute_kernel_lib::ReduceInputBlockShape::row(Wt),
+            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+            compute_kernel_lib::NoAccumulation{},
+            [](uint32_t dst_idx) {
+                recip_tile_init();
+                recip_tile(dst_idx);
+            });
 #endif
 
         // compute final result

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp
@@ -38,15 +38,12 @@ void kernel_main() {
                 compute_kernel_lib::ReduceInputBlockShape::single());
         } else {
             // Phase 1: reduce Wt-1 full tiles into cb_max (no accumulation, first call).
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW>(
-                cb_in0, cb_max_scaler, cb_max, compute_kernel_lib::ReduceInputBlockShape::row(Wt - 1));
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_in0, cb_max_scaler, cb_max>(
+                compute_kernel_lib::ReduceInputBlockShape::row(Wt - 1));
 
             // Phase 2: mask the last tile and continue reducing into cb_max via Accumulate.
             mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, 0, 0, /*pop0=*/1, /*popm=*/0);
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW>(
-                cb_tmp,
-                cb_max_scaler,
-                cb_max,
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_tmp, cb_max_scaler, cb_max>(
                 compute_kernel_lib::ReduceInputBlockShape::row(1),
                 compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
                 compute_kernel_lib::Accumulate::at(cb_max, /*iter=*/1));

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp
@@ -34,8 +34,8 @@ void kernel_main() {
         if (Wt == 1) {
             mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, 0, 0, /*pop0=*/1, /*popm=*/0);
 
-            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW>(
-                cb_tmp, cb_max_scaler, cb_max, compute_kernel_lib::ReduceInputBlockShape::single());
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_tmp, cb_max_scaler, cb_max>(
+                compute_kernel_lib::ReduceInputBlockShape::single());
         } else {
             // Phase 1: reduce Wt-1 full tiles into cb_max (no accumulation, first call).
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW>(
@@ -98,32 +98,36 @@ void kernel_main() {
 
 #ifdef LOG
         // compute log(sum) - pop tile after reduce
-        compute_kernel_lib::
-            reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-                cb_add,
-                cb_sum_scaler,
-                cb_recipsumexps,
-                compute_kernel_lib::ReduceInputBlockShape::single(),
-                compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                compute_kernel_lib::NoAccumulation{},
-                [](uint32_t dst_idx) {
-                    log_tile_init();
-                    log_tile(dst_idx);
-                });
+        compute_kernel_lib::reduce<
+            PoolType::SUM,
+            ReduceDim::REDUCE_ROW,
+            cb_add,
+            cb_sum_scaler,
+            cb_recipsumexps,
+            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
+            compute_kernel_lib::ReduceInputBlockShape::single(),
+            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+            compute_kernel_lib::NoAccumulation{},
+            [](uint32_t dst_idx) {
+                log_tile_init();
+                log_tile(dst_idx);
+            });
 #else
         // compute 1/sum(exp(x)) - pop tile after reduce
-        compute_kernel_lib::
-            reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-                cb_add,
-                cb_sum_scaler,
-                cb_recipsumexps,
-                compute_kernel_lib::ReduceInputBlockShape::single(),
-                compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                compute_kernel_lib::NoAccumulation{},
-                [](uint32_t dst_idx) {
-                    recip_tile_init();
-                    recip_tile(dst_idx);
-                });
+        compute_kernel_lib::reduce<
+            PoolType::SUM,
+            ReduceDim::REDUCE_ROW,
+            cb_add,
+            cb_sum_scaler,
+            cb_recipsumexps,
+            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
+            compute_kernel_lib::ReduceInputBlockShape::single(),
+            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+            compute_kernel_lib::NoAccumulation{},
+            [](uint32_t dst_idx) {
+                recip_tile_init();
+                recip_tile(dst_idx);
+            });
 #endif
 
         // step 3, compute final result

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h.cpp
@@ -36,20 +36,25 @@ void kernel_main() {
             // apply mask
             mask_tile_to_cb(cb_dy, cb_mask, cb_inter2, /*itile=*/0, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
-            compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_COL>(
-                cb_inter2, cb_bcast_scaler, cb_sum, compute_kernel_lib::ReduceInputBlockShape::single());
+            compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_COL, cb_inter2, cb_bcast_scaler, cb_sum>(
+                compute_kernel_lib::ReduceInputBlockShape::single());
         } else {
             constexpr auto cb_inter0 = tt::CBIndex::c_24;
-            compute_kernel_lib::
-                reduce<PoolType::SUM, ReduceDim::REDUCE_COL, compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
-                    cb_dy, cb_bcast_scaler, cb_inter0, compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
+            compute_kernel_lib::reduce<
+                PoolType::SUM,
+                ReduceDim::REDUCE_COL,
+                cb_dy,
+                cb_bcast_scaler,
+                cb_inter0,
+                compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
+                compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
 
             constexpr auto cb_inter1 = tt::CBIndex::c_25;
             mask_tile_to_cb(cb_dy, cb_mask, cb_inter1, /*itile=*/Ht - 1, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
             constexpr auto cb_inter2 = tt::CBIndex::c_26;
-            compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_COL>(
-                cb_inter1, cb_bcast_scaler, cb_inter2, compute_kernel_lib::ReduceInputBlockShape::single());
+            compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_COL, cb_inter1, cb_bcast_scaler, cb_inter2>(
+                compute_kernel_lib::ReduceInputBlockShape::single());
 
             add_tiles_to_cb(cb_inter0, cb_inter2, cb_sum);
         }
@@ -83,9 +88,13 @@ void kernel_main() {
         }
 
         // step 2, compute sum(y * dy)
-        compute_kernel_lib::
-            reduce<PoolType::SUM, ReduceDim::REDUCE_COL, compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-                cb_ydy, cb_bcast_scaler, cb_sum, compute_kernel_lib::ReduceInputBlockShape::col(Ht));
+        compute_kernel_lib::reduce<
+            PoolType::SUM,
+            ReduceDim::REDUCE_COL,
+            cb_ydy,
+            cb_bcast_scaler,
+            cb_sum,
+            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(compute_kernel_lib::ReduceInputBlockShape::col(Ht));
 
         // step 3, compute final result
         for (uint32_t h = 0; h < Ht; ++h) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h_large.cpp
@@ -50,8 +50,8 @@ void kernel_main() {
             }
         }
 
-        compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_COL>(
-            cb_add, cb_bcast_scaler, cb_sum, compute_kernel_lib::ReduceInputBlockShape::single());
+        compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_COL, cb_add, cb_bcast_scaler, cb_sum>(
+            compute_kernel_lib::ReduceInputBlockShape::single());
 
         for (uint32_t h = 0; h < Ht; ++h) {
             // exp(y)
@@ -85,8 +85,8 @@ void kernel_main() {
         }
 
         // step 2, compute sum(y * dy)
-        compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_COL>(
-            cb_add, cb_bcast_scaler, cb_sum, compute_kernel_lib::ReduceInputBlockShape::single());
+        compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_COL, cb_add, cb_bcast_scaler, cb_sum>(
+            compute_kernel_lib::ReduceInputBlockShape::single());
 
         // step 3, compute final result
         for (uint32_t h = 0; h < Ht; ++h) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w.cpp
@@ -36,20 +36,25 @@ void kernel_main() {
             // apply mask
             mask_tile_to_cb(cb_dy, cb_mask, cb_inter2, /*itile=*/0, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
-            compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW>(
-                cb_inter2, cb_bcast_scaler, cb_sum, compute_kernel_lib::ReduceInputBlockShape::single());
+            compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, cb_inter2, cb_bcast_scaler, cb_sum>(
+                compute_kernel_lib::ReduceInputBlockShape::single());
         } else {
             constexpr auto cb_inter0 = tt::CBIndex::c_24;
-            compute_kernel_lib::
-                reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
-                    cb_dy, cb_bcast_scaler, cb_inter0, compute_kernel_lib::ReduceInputBlockShape::row(Wt - 1));
+            compute_kernel_lib::reduce<
+                PoolType::SUM,
+                ReduceDim::REDUCE_ROW,
+                cb_dy,
+                cb_bcast_scaler,
+                cb_inter0,
+                compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
+                compute_kernel_lib::ReduceInputBlockShape::row(Wt - 1));
 
             constexpr auto cb_inter1 = tt::CBIndex::c_25;
             mask_tile_to_cb(cb_dy, cb_mask, cb_inter1, /*itile=*/Wt - 1, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
             constexpr auto cb_inter2 = tt::CBIndex::c_26;
-            compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW>(
-                cb_inter1, cb_bcast_scaler, cb_inter2, compute_kernel_lib::ReduceInputBlockShape::single());
+            compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, cb_inter1, cb_bcast_scaler, cb_inter2>(
+                compute_kernel_lib::ReduceInputBlockShape::single());
 
             add_tiles_to_cb(cb_inter0, cb_inter2, cb_sum);
         }
@@ -83,9 +88,13 @@ void kernel_main() {
         }
 
         // step 2, compute sum(y * dy)
-        compute_kernel_lib::
-            reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-                cb_ydy, cb_bcast_scaler, cb_sum, compute_kernel_lib::ReduceInputBlockShape::row(Wt));
+        compute_kernel_lib::reduce<
+            PoolType::SUM,
+            ReduceDim::REDUCE_ROW,
+            cb_ydy,
+            cb_bcast_scaler,
+            cb_sum,
+            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(compute_kernel_lib::ReduceInputBlockShape::row(Wt));
 
         // step 3, compute final result
         for (uint32_t w = 0; w < Wt; w += onetile) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w_large.cpp
@@ -50,8 +50,8 @@ void kernel_main() {
             }
         }
 
-        compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW>(
-            cb_add, cb_bcast_scaler, cb_sum, compute_kernel_lib::ReduceInputBlockShape::single());
+        compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, cb_add, cb_bcast_scaler, cb_sum>(
+            compute_kernel_lib::ReduceInputBlockShape::single());
 
         for (uint32_t w = 0; w < Wt; w += onetile) {
             // exp(y)
@@ -83,8 +83,8 @@ void kernel_main() {
         }
 
         // step 2, compute sum(y * dy)
-        compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW>(
-            cb_add, cb_bcast_scaler, cb_sum, compute_kernel_lib::ReduceInputBlockShape::single());
+        compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, cb_add, cb_bcast_scaler, cb_sum>(
+            compute_kernel_lib::ReduceInputBlockShape::single());
 
         // step 3, compute final result
         for (uint32_t w = 0; w < Wt; w += onetile) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_sum_h.cpp
@@ -46,8 +46,8 @@ void kernel_main() {
 
             // Phase 1: Reduce Ht-1 tiles into accumulator (if Ht > 1)
             if (!is_h_single_tile) {
-                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-                    cb_input, cb_scaler, cb_accum_dst, compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
+                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_input, cb_scaler, cb_accum_dst>(
+                    compute_kernel_lib::ReduceInputBlockShape::col(Ht - 1));
             }
 
             // Optional masking of last H tile
@@ -76,10 +76,7 @@ void kernel_main() {
                 cb_input_obj.pop_front(onetile);
 
                 // Phase 2 with masked input: Reduce final masked tile with accumulation
-                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-                    cb_masked_input,
-                    cb_scaler,
-                    cb_out,
+                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_masked_input, cb_scaler, cb_out>(
                     compute_kernel_lib::ReduceInputBlockShape::single(),
                     compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
                     compute_kernel_lib::Accumulate::at(cb_accum_dst, is_h_single_tile ? 0 : 1));
@@ -87,10 +84,7 @@ void kernel_main() {
                 // Phase 2 without masking: Reduce final tile with accumulation
                 // - If Ht == 1 (single tile): iteration=0, no accumulator reload
                 // - If Ht > 1 (multi-tile): iteration=1, reload accumulator from cb_accum_dst
-                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM>(
-                    cb_input,
-                    cb_scaler,
-                    cb_out,
+                compute_kernel_lib::reduce<REDUCE_OP, REDUCE_DIM, cb_input, cb_scaler, cb_out>(
                     compute_kernel_lib::ReduceInputBlockShape::single(),
                     compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
                     compute_kernel_lib::Accumulate::at(cb_accum_dst, is_h_single_tile ? 0 : 1));

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -348,11 +348,11 @@ void kernel_main() {
                 compute_kernel_lib::reduce<
                     PoolType::SUM,
                     ReduceDim::REDUCE_SCALAR,
-                    compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop,
-                    compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
                     cb_x_id,
                     cb_scaler_id,
                     cb_ex_partial_id,
+                    compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop,
+                    compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
                     compute_kernel_lib::ReduceInputBlockShape::of(out_block_h_actual, block_w));
                 cb_x.pop_front(out_block_hw_normal);
 
@@ -364,11 +364,11 @@ void kernel_main() {
                 compute_kernel_lib::reduce<
                     PoolType::SUM,
                     ReduceDim::REDUCE_SCALAR,
-                    compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
-                    compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
                     cb_ex_external_id,
                     cb_scaler_global_id,
                     cb_ex_global_id,
+                    compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
+                    compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
                     compute_kernel_lib::ReduceInputBlockShape::col(cb_ex_external_tiles_required));
                 if (num_cores_per_mcast_group > 1) {
                     cb_ex.reserve_back(1);
@@ -480,11 +480,11 @@ void kernel_main() {
                 compute_kernel_lib::reduce<
                     PoolType::SUM,
                     ReduceDim::REDUCE_SCALAR,
-                    compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop,
-                    compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
                     cb_xmm_id,
                     cb_scaler_id,
                     cb_ex2_partial_id,
+                    compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop,
+                    compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
                     compute_kernel_lib::ReduceInputBlockShape::of(out_block_h_actual, block_w));
                 cb_xmm.pop_front(out_block_hw_normal);
             }
@@ -494,11 +494,11 @@ void kernel_main() {
                 compute_kernel_lib::reduce<
                     PoolType::SUM,
                     ReduceDim::REDUCE_SCALAR,
-                    compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
-                    compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
                     cb_ex_external_id,
                     cb_scaler_global_id,
                     cb_ex2_global_id,
+                    compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
+                    compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
                     compute_kernel_lib::ReduceInputBlockShape::col(cb_ex_external_tiles_required));
                 if (num_cores_per_mcast_group > 1) {
                     cb_ex2.reserve_back(1);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -278,18 +278,19 @@ void kernel_main() {
             // (e.g. use `zero_whole_cb` from groupnorm_zero_fill.hpp, mirroring the
             // mcast reader). Same applies to the second REDUCE_SCALAR pack into
             // cb_ex_partial later in this kernel (variance).
-            compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_SCALAR>(
-                cb_ex2pe_id, cb_scaler_id, cb_ex_partial_id, compute_kernel_lib::ReduceInputBlockShape::single());
+            compute_kernel_lib::
+                reduce<PoolType::SUM, ReduceDim::REDUCE_SCALAR, cb_ex2pe_id, cb_scaler_id, cb_ex_partial_id>(
+                    compute_kernel_lib::ReduceInputBlockShape::single());
 
             if constexpr (is_mcast_sender and num_cores_per_mcast_group > 1) {
                 compute_kernel_lib::reduce<
                     PoolType::SUM,
                     ReduceDim::REDUCE_SCALAR,
-                    compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
-                    compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
                     cb_ex_external_id,
                     cb_scaler_global_id,
                     cb_ex_global_id,
+                    compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
+                    compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
                     compute_kernel_lib::ReduceInputBlockShape::single());
                 cb_ex.reserve_back(1);
                 cb_ex.push_back(1);
@@ -380,19 +381,20 @@ void kernel_main() {
             // The sharded reader's "single-tile-overwrite trick" depends on
             // this pack also clearing every non-result datum of cb_ex_partial
             // to exact zero (documented packer behavior for REDUCE_SCALAR).
-            compute_kernel_lib::reduce<PoolType::SUM, ReduceDim::REDUCE_SCALAR>(
-                cb_ex2pe_id, cb_scaler_id, cb_ex_partial_id, compute_kernel_lib::ReduceInputBlockShape::single());
+            compute_kernel_lib::
+                reduce<PoolType::SUM, ReduceDim::REDUCE_SCALAR, cb_ex2pe_id, cb_scaler_id, cb_ex_partial_id>(
+                    compute_kernel_lib::ReduceInputBlockShape::single());
 
             cb_ex_partial.wait_front(1);
             if constexpr (is_mcast_sender and num_cores_per_mcast_group > 1) {
                 compute_kernel_lib::reduce<
                     PoolType::SUM,
                     ReduceDim::REDUCE_SCALAR,
-                    compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
-                    compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
                     cb_ex_external_id,
                     cb_scaler_global_id,
                     cb_ex_global_id,
+                    compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
+                    compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
                     compute_kernel_lib::ReduceInputBlockShape::single());
                 cb_ex.reserve_back(1);
                 cb_ex.push_back(1);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
@@ -167,11 +167,11 @@ void kernel_main() {
     compute_kernel_lib::reduce<
         PoolType::AVG,
         ReduceDim::REDUCE_ROW,
-        compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop,
-        compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
         cb_in,
         cb_scaler,
         cb_ex_partial,
+        compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop,
+        compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
         compute_kernel_lib::ReduceInputBlockShape::of(block_h, num_reduce_tiles_per_block_h, 1),
         compute_kernel_lib::ReduceInputMemoryLayout::with_row_stride(block_w));
     reconfig_data_format(cb_ex_external, cb_scaler);
@@ -277,11 +277,11 @@ void kernel_main() {
     compute_kernel_lib::reduce<
         PoolType::AVG,
         ReduceDim::REDUCE_ROW,
-        compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop,
-        compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
         cb_xmm2,
         cb_scaler,
         cb_ex_partial2,
+        compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop,
+        compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
         compute_kernel_lib::ReduceInputBlockShape::of(block_h, num_reduce_tiles_per_block_h, 1),
         compute_kernel_lib::ReduceInputMemoryLayout::with_row_stride(block_w));
     reconfig_data_format(cb_xmm2, cb_scaler);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -128,11 +128,11 @@ void kernel_main() {
     compute_kernel_lib::reduce<
         PoolType::AVG,
         ReduceDim::REDUCE_ROW,
-        compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop,
-        compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
         cb_in,
         cb_scaler,
         cb_ex_partial2,
+        compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop,
+        compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
         compute_kernel_lib::ReduceInputBlockShape::of(block_h, num_reduce_tiles_per_block_h),
         compute_kernel_lib::ReduceInputMemoryLayout::with_row_stride(block_w));
     reconfig_data_format(cb_in, cb_in);
@@ -173,13 +173,15 @@ void kernel_main() {
 #endif  // RMSNORM
 
     // RMS E(x2) #Layernorm //E(x) and E(x^2)
-    compute_kernel_lib::
-        reduce<PoolType::AVG, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop>(
-            cb_x2,
-            cb_scaler,
-            cb_ex_partial2,
-            compute_kernel_lib::ReduceInputBlockShape::of(block_h, num_reduce_tiles_per_block_h),
-            compute_kernel_lib::ReduceInputMemoryLayout::with_row_stride(block_w));
+    compute_kernel_lib::reduce<
+        PoolType::AVG,
+        ReduceDim::REDUCE_ROW,
+        cb_x2,
+        cb_scaler,
+        cb_ex_partial2,
+        compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop>(
+        compute_kernel_lib::ReduceInputBlockShape::of(block_h, num_reduce_tiles_per_block_h),
+        compute_kernel_lib::ReduceInputMemoryLayout::with_row_stride(block_w));
     reconfig_data_format(cb_x2, cb_scaler);
     cb_pop_front(cb_x2, num_tiles_per_block);
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather.cpp
@@ -78,18 +78,26 @@ void kernel_main() {
 
         // BulkWaitBulkPop: All Wt tiles already in CB (see cumulative wait above)
         // Bulk mode for optimal performance
-        compute_kernel_lib::
-            reduce<PoolType::AVG, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-                cb_x2, cb_reduce, cb_out, compute_kernel_lib::ReduceInputBlockShape::row(Wt));
+        compute_kernel_lib::reduce<
+            PoolType::AVG,
+            ReduceDim::REDUCE_ROW,
+            cb_x2,
+            cb_reduce,
+            cb_out,
+            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(compute_kernel_lib::ReduceInputBlockShape::row(Wt));
 
         /*
          * sum(x)
          */
         // BulkWaitBulkPop: All Wt tiles already in CB (see cumulative wait above)
         // Bulk mode for optimal performance
-        compute_kernel_lib::
-            reduce<PoolType::AVG, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-                cb_inp, cb_reduce, cb_out, compute_kernel_lib::ReduceInputBlockShape::row(Wt));
+        compute_kernel_lib::reduce<
+            PoolType::AVG,
+            ReduceDim::REDUCE_ROW,
+            cb_inp,
+            cb_reduce,
+            cb_out,
+            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(compute_kernel_lib::ReduceInputBlockShape::row(Wt));
     }
     cb_pop_front(cb_reduce, 1);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather_2d.cpp
@@ -82,9 +82,13 @@ void kernel_main() {
          * sum(x**2)
          */
         // BulkWaitBulkPop: All Wt tiles already in CB (see cumulative wait above)
-        compute_kernel_lib::
-            reduce<PoolType::AVG, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-                cb_x2, cb_reduce, cb_out, compute_kernel_lib::ReduceInputBlockShape::row(Wt));
+        compute_kernel_lib::reduce<
+            PoolType::AVG,
+            ReduceDim::REDUCE_ROW,
+            cb_x2,
+            cb_reduce,
+            cb_out,
+            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(compute_kernel_lib::ReduceInputBlockShape::row(Wt));
         cb_pop_front(cb_inp, Wt);
         cb_pop_front(cb_reduce, 1);
     }

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_post_allgather.cpp
@@ -77,8 +77,8 @@ void kernel_main() {
          * RMSNorm reduces sum(x**2) directly into cb_var for rsqrt computation.
          * Uses auto-batched STREAMING mode - library handles CB lifecycle.
          */
-        compute_kernel_lib::reduce<PoolType::AVG, ReduceDim::REDUCE_ROW>(
-            cb_stats, cb_reduce, cb_var, compute_kernel_lib::ReduceInputBlockShape::row(stats_tiles_cols));
+        compute_kernel_lib::reduce<PoolType::AVG, ReduceDim::REDUCE_ROW, cb_stats, cb_reduce, cb_var>(
+            compute_kernel_lib::ReduceInputBlockShape::row(stats_tiles_cols));
 
         /*
          * 1/sqrt(var + eps)

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_pre_allgather.cpp
@@ -76,9 +76,13 @@ void kernel_main() {
          * sum(x**2)
          */
         // BulkWaitBulkPop: All Wt tiles already in CB (see cumulative wait above)
-        compute_kernel_lib::
-            reduce<PoolType::AVG, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-                cb_x2, cb_reduce, cb_out, compute_kernel_lib::ReduceInputBlockShape::row(Wt));
+        compute_kernel_lib::reduce<
+            PoolType::AVG,
+            ReduceDim::REDUCE_ROW,
+            cb_x2,
+            cb_reduce,
+            cb_out,
+            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(compute_kernel_lib::ReduceInputBlockShape::row(Wt));
         cb_pop_front(cb_inp, Wt);
     }
     cb_pop_front(cb_reduce, 1);

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_pre_allgather_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_pre_allgather_2d.cpp
@@ -73,9 +73,13 @@ void kernel_main() {
          * sum(x**2)
          */
         // BulkWaitBulkPop: All Wt tiles already in CB (see cumulative wait above)
-        compute_kernel_lib::
-            reduce<PoolType::AVG, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(
-                cb_x2, cb_reduce, cb_out, compute_kernel_lib::ReduceInputBlockShape::row(Wt));
+        compute_kernel_lib::reduce<
+            PoolType::AVG,
+            ReduceDim::REDUCE_ROW,
+            cb_x2,
+            cb_reduce,
+            cb_out,
+            compute_kernel_lib::ReduceInputPolicy::BulkWaitBulkPop>(compute_kernel_lib::ReduceInputBlockShape::row(Wt));
         cb_pop_front(cb_inp, Wt);
         cb_pop_front(cb_reduce, 1);
     }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax.cpp
@@ -19,8 +19,9 @@
 // The buffer for the att mask is currently sized as (1t,Wt) so we only reuse it for one HtWt-sized batch of x
 // then read another Wt tiles of mask for the next batch
 
-void calc_numeric_stable(
-    uint32_t Wt, uint32_t ndst, uint32_t cb_in, uint32_t cb_max_scaler, uint32_t cb_max, uint32_t cb_out) {
+// CB ids are template params because compute_kernel_lib::reduce<> now takes them as template args.
+template <uint32_t cb_in, uint32_t cb_max_scaler, uint32_t cb_max, uint32_t cb_out>
+void calc_numeric_stable(uint32_t Wt, uint32_t ndst) {
     auto cb_in_obj = CircularBuffer(cb_in);
     auto cb_max_obj = CircularBuffer(cb_max);
     auto cb_out_obj = CircularBuffer(cb_out);
@@ -29,9 +30,11 @@ void calc_numeric_stable(
     compute_kernel_lib::reduce<
         PoolType::MAX,
         ReduceDim::REDUCE_ROW,
+        cb_in,
+        cb_max_scaler,
+        cb_max,
         compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop,
-        compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
-        cb_in, cb_max_scaler, cb_max, compute_kernel_lib::ReduceInputBlockShape::row(Wt));
+        compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(compute_kernel_lib::ReduceInputBlockShape::row(Wt));
 
     // calculate x-max(x)
     exp_tile_init<EXP_APPROX>();
@@ -182,7 +185,7 @@ void kernel_main() {
 // add numeric_stable
 // fuse exp with sub tiles
 #ifdef NUMERIC_STABLE
-        calc_numeric_stable(Wt, ndst, cb_x, cb_max_scaler, cb_max, cb_exps);
+        calc_numeric_stable<cb_x, cb_max_scaler, cb_max, cb_exps>(Wt, ndst);
 #endif
 
 #ifdef CAUSAL_MASK
@@ -241,14 +244,14 @@ void kernel_main() {
 // add numeric_stable
 // fuse exp with sub tiles
 #ifdef NUMERIC_STABLE
-            calc_numeric_stable(Wt, ndst, cb_x, cb_max_scaler, cb_max, cb_exps);
+            calc_numeric_stable<cb_x, cb_max_scaler, cb_max, cb_exps>(Wt, ndst);
 #endif
 
         } else {
 // add numeric_stable
 // fuse exp with sub tiles
 #ifdef NUMERIC_STABLE
-            calc_numeric_stable(Wt, ndst, cb_in0, cb_max_scaler, cb_max, cb_exps);
+            calc_numeric_stable<cb_in0, cb_max_scaler, cb_max, cb_exps>(Wt, ndst);
 #else
             for (uint32_t wt = 0; wt < Wt; wt += ndst) {
                 tile_regs_acquire();
@@ -275,18 +278,20 @@ void kernel_main() {
 #endif
 
         // SUM reduce with reciprocal post-processing (1/sum)
-        compute_kernel_lib::
-            reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
-                cb_exps,
-                cb_sum_scaler,
-                cb_recipsumexps,
-                compute_kernel_lib::ReduceInputBlockShape::row(Wt),
-                compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                compute_kernel_lib::NoAccumulation{},
-                [](uint32_t) {
-                    recip_tile_init();
-                    recip_tile(0);
-                });
+        compute_kernel_lib::reduce<
+            PoolType::SUM,
+            ReduceDim::REDUCE_ROW,
+            cb_exps,
+            cb_sum_scaler,
+            cb_recipsumexps,
+            compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
+            compute_kernel_lib::ReduceInputBlockShape::row(Wt),
+            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+            compute_kernel_lib::NoAccumulation{},
+            [](uint32_t) {
+                recip_tile_init();
+                recip_tile(0);
+            });
 
         cb_recipsumexps_obj.wait_front(1);  // will reuse Wt times for bcast
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax.cpp
@@ -19,7 +19,6 @@
 // The buffer for the att mask is currently sized as (1t,Wt) so we only reuse it for one HtWt-sized batch of x
 // then read another Wt tiles of mask for the next batch
 
-// CB ids are template params because compute_kernel_lib::reduce<> now takes them as template args.
 template <uint32_t cb_in, uint32_t cb_max_scaler, uint32_t cb_max, uint32_t cb_out>
 void calc_numeric_stable(uint32_t Wt, uint32_t ndst) {
     auto cb_in_obj = CircularBuffer(cb_in);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
@@ -60,14 +60,8 @@ void apply_fused_attn_mask(
 void pad_input(uint32_t cb_in, uint32_t cb_out, uint32_t cb_length_t, uint32_t blk);
 void exp_cb(uint32_t cb_in, uint32_t cb_out, uint32_t cb_max, uint32_t cb_length_t, uint32_t blk);
 
-template <PoolType reduce_type>
-void reduce_cb(
-    uint32_t cb_in,
-    uint32_t cb_scaler,
-    uint32_t cb_prev_out,
-    uint32_t cb_out,
-    bool use_prev_reduce,
-    uint32_t cb_length_t);
+template <PoolType reduce_type, uint32_t cb_in_id, uint32_t cb_scaler_id, uint32_t cb_prev_out_id, uint32_t cb_out_id>
+void reduce_cb(bool use_prev_reduce, uint32_t cb_length_t);
 void apply_recip(uint32_t cb_in, uint32_t cb_recip, uint32_t cb_out, uint32_t cb_length_t, uint32_t blk);
 
 // for scale+mask+softmax:
@@ -249,31 +243,22 @@ void exp_cb(uint32_t cb_in, uint32_t cb_out, uint32_t cb_max, const uint32_t cb_
     }
 }
 
-template <PoolType reduce_type>
-void reduce_cb(
-    uint32_t cb_in,
-    uint32_t cb_scaler,
-    uint32_t cb_prev_out,
-    uint32_t cb_out,
-    bool use_prev_reduce,
-    uint32_t cb_length_t) {
+template <PoolType reduce_type, uint32_t cb_in_id, uint32_t cb_scaler_id, uint32_t cb_prev_out_id, uint32_t cb_out_id>
+void reduce_cb(bool use_prev_reduce, uint32_t cb_length_t) {
     // Single reduce call with lambda that conditionally accumulates
-    compute_kernel_lib::reduce<reduce_type, ReduceDim::REDUCE_ROW>(
-        cb_in,
-        cb_scaler,
-        cb_out,
+    compute_kernel_lib::reduce<reduce_type, ReduceDim::REDUCE_ROW, cb_in_id, cb_scaler_id, cb_out_id>(
         compute_kernel_lib::ReduceInputBlockShape::row(cb_length_t),
         compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
         compute_kernel_lib::NoAccumulation{},
         // PostReduceOp: conditionally accumulate with previous result
-        [cb_prev_out, use_prev_reduce](uint32_t) {
+        [use_prev_reduce](uint32_t) {
             if (use_prev_reduce) {
                 // At this point, DST[0] contains the current reduce result
                 // Load previous result into DST[1] and accumulate
-                cb_wait_front(cb_prev_out, 1);
-                reconfig_data_format_srca(cb_prev_out);
-                copy_tile_init(cb_prev_out);
-                copy_tile(cb_prev_out, 0, 1);
+                cb_wait_front(cb_prev_out_id, 1);
+                reconfig_data_format_srca(cb_prev_out_id);
+                copy_tile_init(cb_prev_out_id);
+                copy_tile(cb_prev_out_id, 0, 1);
 
                 // Accumulate based on reduce type
                 if constexpr (reduce_type == PoolType::MAX) {
@@ -285,11 +270,24 @@ void reduce_cb(
                     add_binary_tile(0, 1, 0);  // add(DST[0], DST[1]) -> DST[0]
                 }
 
-                cb_pop_front(cb_prev_out, 1);
+                cb_pop_front(cb_prev_out_id, 1);
             }
             // If !use_prev_reduce, lambda is no-op (compiles away)
         });
 }
+
+// Compile-time replacement for the old runtime std::swap(cb_ping_a, cb_ping_b) ping-pong: on even
+// passes write cb_ping_a (read prev from cb_ping_b), on odd passes swap the roles. CB ids must be
+// compile-time for reduce<>, so the swap is resolved here by pass parity instead of at runtime.
+template <PoolType reduce_type, uint32_t cb_in_id, uint32_t cb_scaler_id, uint32_t cb_ping_a, uint32_t cb_ping_b>
+ALWI void reduce_cb_pass(uint32_t cur_pass, bool use_prev_reduce, uint32_t cb_length_t) {
+    if ((cur_pass & 1) == 0) {
+        reduce_cb<reduce_type, cb_in_id, cb_scaler_id, cb_ping_b, cb_ping_a>(use_prev_reduce, cb_length_t);
+    } else {
+        reduce_cb<reduce_type, cb_in_id, cb_scaler_id, cb_ping_a, cb_ping_b>(use_prev_reduce, cb_length_t);
+    }
+}
+
 void apply_recip(uint32_t cb_in, uint32_t cb_recip, uint32_t cb_out, uint32_t cb_length_t, uint32_t blk) {
     CircularBuffer cb_in_obj(cb_in);
     CircularBuffer cb_recip_obj(cb_recip);
@@ -332,21 +330,20 @@ void kernel_main() {
     // We only do the reserve for the intermediates once and use pack_tile
     // So effectively these are used as pre-allocated arrays
     // Note that the entire W dimension must fit in the intermed0 CB for this kernel to be correct
-    auto cb_max_scaler = tt::CBIndex::c_2;
-    auto cb_sum_scaler = tt::CBIndex::c_13;
-    auto cb_fused_scale = tt::CBIndex::c_3;
-    auto cb_fused_attn = tt::CBIndex::c_4;
-    auto cb_exps = tt::CBIndex::c_6;
-    auto cb_scale_mask = tt::CBIndex::c_9;
-    auto cb_sumexps = tt::CBIndex::c_7;
-    auto cb_prev_reduce = tt::CBIndex::c_12;
-    auto cb_in0 = tt::CBIndex::c_0;
-    auto cb_out0 = tt::CBIndex::c_11;
-    auto cb_max = tt::CBIndex::c_8;
-    auto cb_x = tt::CBIndex::c_10;
-    // TODO: need to add this cb
-    auto cb_recip = tt::CBIndex::c_16;
-    auto cb_prev_max = tt::CBIndex::c_15;
+    constexpr auto cb_max_scaler = tt::CBIndex::c_2;
+    constexpr auto cb_sum_scaler = tt::CBIndex::c_13;
+    constexpr auto cb_fused_scale = tt::CBIndex::c_3;
+    constexpr auto cb_fused_attn = tt::CBIndex::c_4;
+    constexpr auto cb_exps = tt::CBIndex::c_6;
+    constexpr auto cb_scale_mask = tt::CBIndex::c_9;
+    constexpr auto cb_sumexps = tt::CBIndex::c_7;
+    constexpr auto cb_prev_reduce = tt::CBIndex::c_12;
+    constexpr auto cb_in0 = tt::CBIndex::c_0;
+    constexpr auto cb_out0 = tt::CBIndex::c_11;
+    constexpr auto cb_max = tt::CBIndex::c_8;
+    constexpr auto cb_x = tt::CBIndex::c_10;
+    constexpr auto cb_recip = tt::CBIndex::c_16;
+    constexpr auto cb_prev_max = tt::CBIndex::c_15;
     constexpr auto cb_mask_padded = tt::CBIndex::c_5;
     CircularBuffer cb_max_scaler_obj(cb_max_scaler);
     CircularBuffer cb_sum_scaler_obj(cb_sum_scaler);
@@ -364,10 +361,12 @@ void kernel_main() {
 #endif
 
     uint32_t num_cb_passes = 1 + ((Wt - 1) / cb_length_t);  // ceiling divide
+    // Ping-pong reduce outputs: odd num_cb_passes -> cb_max/cb_sumexps, even -> cb_prev_max/cb_prev_reduce
+    const uint32_t cb_max_final = (num_cb_passes & 1) ? cb_max : cb_prev_max;
+    const uint32_t cb_sum_final = (num_cb_passes & 1) ? cb_sumexps : cb_prev_reduce;
 
     // First loop is to parse and find the sum
     uint32_t dst0 = 0;
-    uint32_t cb_processed_input;
 
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         // This and all inner loops are for parsing the length of Wt in terms of chunks of the width that can fit in the
@@ -389,31 +388,28 @@ void kernel_main() {
 #if FUSED_SCALE_MASK
             apply_fused_scale_mask(cb_in0, cb_fused_scale, cb_scale_mask, cb_length_t, blk);
             apply_fused_attn_mask(cb_scale_mask, cb_fused_attn, cb_x, cb_length_t, blk, do_mask);
-            cb_processed_input = cb_x;
+            reduce_cb_pass<PoolType::MAX, cb_x, cb_max_scaler, cb_max, cb_prev_max>(
+                cur_pass, use_prev_reduce, cur_cb_length_t);
 #else
             if (do_mask && cur_pass == num_cb_passes - 1) {
-                // pad
                 pad_input(cb_in0, cb_x, cur_cb_length_t, blk);
-                cb_processed_input = cb_x;
+                reduce_cb_pass<PoolType::MAX, cb_x, cb_max_scaler, cb_max, cb_prev_max>(
+                    cur_pass, use_prev_reduce, cur_cb_length_t);
             } else {
-                // no Pad
-                cb_processed_input = cb_in0;
+                reduce_cb_pass<PoolType::MAX, cb_in0, cb_max_scaler, cb_max, cb_prev_max>(
+                    cur_pass, use_prev_reduce, cur_cb_length_t);
             }
 #endif
-            reduce_cb<PoolType::MAX>(cb_processed_input, cb_max_scaler, cb_prev_max, cb_max, use_prev_reduce, cur_cb_length_t);
             use_prev_reduce = true;
             length_left_t -= cur_cb_length_t;
             cur_cb_length_t = std::min(cur_cb_length_t, length_left_t);
-            if (cur_pass != num_cb_passes - 1) {
-                std::swap(cb_max, cb_prev_max);
-            }
         }
         use_prev_reduce = false;
         length_left_t = Wt;
         cur_cb_length_t = cb_length_t;
 #endif
 #ifdef NUMERIC_STABLE
-        CircularBuffer(cb_max).wait_front(1);
+        CircularBuffer(cb_max_final).wait_front(1);
 #endif
 
         /*
@@ -428,30 +424,24 @@ void kernel_main() {
 #if FUSED_SCALE_MASK
             apply_fused_scale_mask(cb_in0, cb_fused_scale, cb_scale_mask, cb_length_t, blk);
             apply_fused_attn_mask(cb_scale_mask, cb_fused_attn, cb_x, cb_length_t, blk, do_mask);
-            cb_processed_input = cb_x;
+            exp_cb(cb_x, cb_exps, cb_max_final, cur_cb_length_t, blk);
+            reduce_cb_pass<PoolType::SUM, cb_exps, cb_sum_scaler, cb_sumexps, cb_prev_reduce>(
+                cur_pass, use_prev_reduce, cur_cb_length_t);
 #else
-            // Following code is focuesed on padding the last tile that need -inf for sections of the tile that are not
-            // a part of the tensor
             if (do_mask && cur_pass == num_cb_passes - 1) {
-                // pad
                 pad_input(cb_in0, cb_x, cur_cb_length_t, blk);
-                cb_processed_input = cb_x;
+                exp_cb(cb_x, cb_exps, cb_max_final, cur_cb_length_t, blk);
+                reduce_cb_pass<PoolType::SUM, cb_exps, cb_sum_scaler, cb_sumexps, cb_prev_reduce>(
+                    cur_pass, use_prev_reduce, cur_cb_length_t);
             } else {
-                // no Pad
-                cb_processed_input = cb_in0;
+                exp_cb(cb_in0, cb_exps, cb_max_final, cur_cb_length_t, blk);
+                reduce_cb_pass<PoolType::SUM, cb_exps, cb_sum_scaler, cb_sumexps, cb_prev_reduce>(
+                    cur_pass, use_prev_reduce, cur_cb_length_t);
             }
-
 #endif
-            exp_cb(cb_processed_input, cb_exps, cb_max, cur_cb_length_t, blk);
-
-            reduce_cb<PoolType::SUM>(
-                cb_exps, cb_sum_scaler, cb_prev_reduce, cb_sumexps, use_prev_reduce, cur_cb_length_t);
             use_prev_reduce = true;  // We want to accumulate the previous cb reductions
             length_left_t -= cur_cb_length_t;
             cur_cb_length_t = std::min(cur_cb_length_t, length_left_t);
-            if (cur_pass != num_cb_passes - 1) {
-                std::swap(cb_sumexps, cb_prev_reduce);
-            }
         }
         /*
          * --------------------------------------------------------
@@ -460,15 +450,15 @@ void kernel_main() {
          * --------------------------------------------------------
          * --------------------------------------------------------
          */
-        CircularBuffer(cb_sumexps).wait_front(1);
+        CircularBuffer(cb_sum_final).wait_front(1);
 
-        reconfig_data_format_srca(cb_sumexps);
-        pack_reconfig_data_format(cb_sumexps, cb_recip);
+        reconfig_data_format_srca(cb_sum_final);
+        pack_reconfig_data_format(cb_sum_final, cb_recip);
         tile_regs_acquire();
-        copy_tile_init(cb_sumexps);
-        copy_tile(cb_sumexps, 0, dst0);
+        copy_tile_init(cb_sum_final);
+        copy_tile(cb_sum_final, 0, dst0);
 
-        CircularBuffer(cb_sumexps).pop_front(1);
+        CircularBuffer(cb_sum_final).pop_front(1);
 
         recip_tile_init();
         recip_tile(dst0);
@@ -497,26 +487,22 @@ void kernel_main() {
 #if FUSED_SCALE_MASK
             apply_fused_scale_mask(cb_in0, cb_fused_scale, cb_scale_mask, cb_length_t, blk);
             apply_fused_attn_mask(cb_scale_mask, cb_fused_attn, cb_x, cb_length_t, blk, do_mask);
-            cb_processed_input = cb_x;
+            exp_cb(cb_x, cb_exps, cb_max_final, cur_cb_length_t, blk);
 #else
             if (do_mask && cur_pass == num_cb_passes - 1) {
-                // pad
                 pad_input(cb_in0, cb_x, cur_cb_length_t, blk);
-                cb_processed_input = cb_x;
+                exp_cb(cb_x, cb_exps, cb_max_final, cur_cb_length_t, blk);
             } else {
-                // no Pad
-                cb_processed_input = cb_in0;
+                exp_cb(cb_in0, cb_exps, cb_max_final, cur_cb_length_t, blk);
             }
 #endif
-            exp_cb(cb_processed_input, cb_exps, cb_max, cur_cb_length_t, blk);
-
             apply_recip(cb_exps, cb_recip, cb_out0, cur_cb_length_t, blk);
             length_left_t -= cur_cb_length_t;
             cur_cb_length_t = std::min(cur_cb_length_t, length_left_t);
         }
         cb_recip_obj.pop_front(1);
 #ifdef NUMERIC_STABLE
-        CircularBuffer(cb_max).pop_front(1);
+        CircularBuffer(cb_max_final).pop_front(1);
 #endif
     }
     cb_mask_padded_obj.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
@@ -276,9 +276,6 @@ void reduce_cb(bool use_prev_reduce, uint32_t cb_length_t) {
         });
 }
 
-// Compile-time replacement for the old runtime std::swap(cb_ping_a, cb_ping_b) ping-pong: on even
-// passes write cb_ping_a (read prev from cb_ping_b), on odd passes swap the roles. CB ids must be
-// compile-time for reduce<>, so the swap is resolved here by pass parity instead of at runtime.
 template <PoolType reduce_type, uint32_t cb_in_id, uint32_t cb_scaler_id, uint32_t cb_ping_a, uint32_t cb_ping_b>
 ALWI void reduce_cb_pass(uint32_t cur_pass, bool use_prev_reduce, uint32_t cb_length_t) {
     if ((cur_pass & 1) == 0) {

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_sharded.cpp
@@ -12,30 +12,41 @@
 #include "api/dataflow/circular_buffer.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 
-template <uint32_t block_w, uint32_t num_subblocks_w, uint32_t subblock_w>
-ALWI void calc_numeric_stable(uint32_t cb_in, uint32_t cb_max_scaler, uint32_t cb_max, uint32_t cb_out) {
-    auto cb_in_obj = CircularBuffer(cb_in);
-    auto cb_max_obj = CircularBuffer(cb_max);
-    auto cb_out_obj = CircularBuffer(cb_out);
+template <
+    uint32_t block_w,
+    uint32_t num_subblocks_w,
+    uint32_t subblock_w,
+    uint32_t cb_in_id,
+    uint32_t cb_max_scaler_id,
+    uint32_t cb_max_id,
+    uint32_t cb_out_id>
+ALWI void calc_numeric_stable() {
+    auto cb_in_obj = CircularBuffer(cb_in_id);
+    auto cb_max_obj = CircularBuffer(cb_max_id);
+    auto cb_out_obj = CircularBuffer(cb_out_id);
 
     // Use reduce_helpers for MAX reduce (REDUCE_ROW, PRELOADED mode)
     // Note: The library handles waiting for scaler tile internally
-    compute_kernel_lib::
-        reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop>(
-            cb_in, cb_max_scaler, cb_max, compute_kernel_lib::ReduceInputBlockShape::row(block_w));
+    compute_kernel_lib::reduce<
+        PoolType::MAX,
+        ReduceDim::REDUCE_ROW,
+        cb_in_id,
+        cb_max_scaler_id,
+        cb_max_id,
+        compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop>(compute_kernel_lib::ReduceInputBlockShape::row(block_w));
 
     // calculate x-max(x)
     exp_tile_init<EXP_APPROX>();
-    reconfig_data_format_srcb(cb_max);
+    reconfig_data_format_srcb(cb_max_id);
     cb_max_obj.wait_front(1);
-    sub_bcast_cols_init_short(cb_in, cb_max);
+    sub_bcast_cols_init_short(cb_in_id, cb_max_id);
     uint32_t index_subblock_w_offset = 0;
     for (uint32_t j = 0; j < num_subblocks_w; j++) {
         tile_regs_acquire();
         cb_out_obj.reserve_back(subblock_w);
         for (uint32_t w = 0; w < subblock_w; w++) {
             uint32_t index = w + index_subblock_w_offset;
-            sub_tiles_bcast_cols(cb_in, cb_max, index, 0, w);
+            sub_tiles_bcast_cols(cb_in_id, cb_max_id, index, 0, w);
         }
         cb_out_obj.reserve_back(subblock_w);
         for (uint32_t w = 0; w < subblock_w; w++) {
@@ -44,7 +55,7 @@ ALWI void calc_numeric_stable(uint32_t cb_in, uint32_t cb_max_scaler, uint32_t c
         tile_regs_commit();
         tile_regs_wait();
         for (uint32_t w = 0; w < subblock_w; w++) {
-            pack_tile(w, cb_out);
+            pack_tile(w, cb_out_id);
         }
         tile_regs_release();
         cb_out_obj.push_back(subblock_w);
@@ -175,7 +186,7 @@ void kernel_main() {
 // fuse exp with sub tiles
 #ifdef NUMERIC_STABLE
         cb_x_obj.wait_front(block_w);
-        calc_numeric_stable<block_w, num_subblocks_w, subblock_w>(cb_x, cb_max_scaler, cb_max, cb_exps);
+        calc_numeric_stable<block_w, num_subblocks_w, subblock_w, cb_x, cb_max_scaler, cb_max, cb_exps>();
 #endif
 
 #ifdef CAUSAL_MASK
@@ -186,7 +197,7 @@ void kernel_main() {
 #else
 
 #ifdef NUMERIC_STABLE
-        calc_numeric_stable<block_w, num_subblocks_w, subblock_w>(cb_in0, cb_max_scaler, cb_max, cb_exps);
+        calc_numeric_stable<block_w, num_subblocks_w, subblock_w, cb_in0, cb_max_scaler, cb_max, cb_exps>();
 #else
         reconfig_data_format(cb_in0, cb_in0);
         pack_reconfig_data_format(cb_exps);
@@ -221,18 +232,20 @@ void kernel_main() {
         // PRELOADED is correct for sharded - all tiles loaded at once
         // Auto-detects FP32 mode from ENABLE_FP32_DEST_ACC define
         cb_wait_front(cb_exps, block_w);
-        compute_kernel_lib::
-            reduce<PoolType::SUM, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop>(
-                cb_exps,
-                cb_sum_scaler,
-                cb_recipsumexps,
-                compute_kernel_lib::ReduceInputBlockShape::row(block_w),
-                compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
-                compute_kernel_lib::NoAccumulation{},
-                [](uint32_t) {
-                    recip_tile_init();
-                    recip_tile(0);
-                });
+        compute_kernel_lib::reduce<
+            PoolType::SUM,
+            ReduceDim::REDUCE_ROW,
+            cb_exps,
+            cb_sum_scaler,
+            cb_recipsumexps,
+            compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop>(
+            compute_kernel_lib::ReduceInputBlockShape::row(block_w),
+            compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+            compute_kernel_lib::NoAccumulation{},
+            [](uint32_t) {
+                recip_tile_init();
+                recip_tile(0);
+            });
 
         // exp(x) / (sum(exp(x)))
         reconfig_data_format(cb_exps, cb_recipsumexps);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
@@ -2,16 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Thin wrapper around compute_kernel_lib::reduce<>. When the host defines REDUCE_FORMAT
-// (Int32 or Float32), routes to the SFPU MAX path; otherwise FPU/GMPOOL.
-// MIN on Int32/Float32 is dispatched separately via reduce_{h,w}_neg.
+// Thin wrapper around compute_kernel_lib::reduce<>. The input data format is deduced from the input
+// CB id inside the helper, so Int32/Float32 MAX is routed to the SFPU path automatically; otherwise
+// FPU/GMPOOL. MIN on Int32/Float32 is dispatched separately via reduce_{h,w}_neg.
 
 #include <cstdint>
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
-
-#if defined(REDUCE_POST_MUL) && !defined(REDUCE_FORMAT)
-#include "api/compute/eltwise_unary/binop_with_scalar.h"
-#endif
 
 void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
@@ -23,30 +19,22 @@ void kernel_main() {
     compute_kernel_lib::reduce<
         REDUCE_OP,
         REDUCE_DIM,
-        compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
-        compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT
-#ifdef REDUCE_FORMAT
-        ,
-        REDUCE_FORMAT
-#endif
-        >(
         tt::CBIndex::c_0,
         tt::CBIndex::c_2,
         tt::CBIndex::c_3,
+        compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
+        compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
         compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt, NC),
         compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
         compute_kernel_lib::NoAccumulation{},
 #ifdef REDUCE_POST_MUL
         // GMPOOL only respects the scaler's exponent for MAX/MIN and SFPU reduce ignores the
         // scaler CB entirely, so both paths apply the user scalar here per output tile.
+        // reduce_post_mul_tile handles Int32 (typecast-bracketed) and float formats uniformly.
         [](uint32_t dst_idx) {
             constexpr uint32_t post_mul_scaler_bits = get_compile_time_arg_val(3);
-#ifdef REDUCE_FORMAT
-            compute_kernel_lib::detail::reduce_post_mul_tile<REDUCE_FORMAT>(dst_idx, post_mul_scaler_bits);
-#else
-            binop_with_scalar_tile_init();
-            mul_unary_tile(dst_idx, post_mul_scaler_bits);
-#endif
+            constexpr DataFormat reduce_format = static_cast<DataFormat>(unpack_src_format[tt::CBIndex::c_0]);
+            compute_kernel_lib::detail::reduce_post_mul_tile<reduce_format>(dst_idx, post_mul_scaler_bits);
         }
 #else
         compute_kernel_lib::NoOp{}

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Thin wrapper around compute_kernel_lib::reduce<>. The input data format is deduced from the input
-// CB id inside the helper, so Int32/Float32 MAX is routed to the SFPU path automatically; otherwise
-// FPU/GMPOOL. MIN on Int32/Float32 is dispatched separately via reduce_{h,w}_neg.
+// CB id inside the helper, so Int32 MAX is routed to the SFPU path automatically; otherwise
+// FPU/GMPOOL. MIN on Int32 is dispatched separately via reduce_{h,w}_neg.
 
 #include <cstdint>
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
@@ -2,10 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Thin wrapper around compute_kernel_lib::reduce<>. When the host defines REDUCE_FORMAT
+// (Int32 or Float32), routes to the SFPU MAX path; otherwise FPU/GMPOOL.
+// MIN on Int32/Float32 is dispatched separately via reduce_{h,w}_neg.
+
 #include <cstdint>
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 
-#ifdef REDUCE_POST_MUL
+#if defined(REDUCE_POST_MUL) && !defined(REDUCE_FORMAT)
 #include "api/compute/eltwise_unary/binop_with_scalar.h"
 #endif
 
@@ -20,7 +24,12 @@ void kernel_main() {
         REDUCE_OP,
         REDUCE_DIM,
         compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
-        compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
+        compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT
+#ifdef REDUCE_FORMAT
+        ,
+        REDUCE_FORMAT
+#endif
+        >(
         tt::CBIndex::c_0,
         tt::CBIndex::c_2,
         tt::CBIndex::c_3,
@@ -28,13 +37,16 @@ void kernel_main() {
         compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
         compute_kernel_lib::NoAccumulation{},
 #ifdef REDUCE_POST_MUL
-        // GMPOOL only respects the scaler's exponent for MAX/MIN, so the host requests reduction
-        // with scaler=1.0 and then applies the user scalar via mul_unary_tile (SFPU) on each
-        // output DEST register.
+        // GMPOOL only respects the scaler's exponent for MAX/MIN and SFPU reduce ignores the
+        // scaler CB entirely, so both paths apply the user scalar here per output tile.
         [](uint32_t dst_idx) {
             constexpr uint32_t post_mul_scaler_bits = get_compile_time_arg_val(3);
+#ifdef REDUCE_FORMAT
+            compute_kernel_lib::detail::reduce_post_mul_tile<REDUCE_FORMAT>(dst_idx, post_mul_scaler_bits);
+#else
             binop_with_scalar_tile_init();
             mul_unary_tile(dst_idx, post_mul_scaler_bits);
+#endif
         }
 #else
         compute_kernel_lib::NoOp{}

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
@@ -4,6 +4,9 @@
 
 #include <cstdint>
 
+#include "api/compute/cb_api.h"
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/pack.h"
 #include "api/compute/reduce.h"
 
 #include "api/compute/eltwise_unary/eltwise_unary.h"
@@ -11,6 +14,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/dataflow/circular_buffer.h"
 #include "ttnn/cpp/ttnn/kernel_lib/dest_helpers.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 
 #ifdef REDUCE_POST_MUL
 #include "api/compute/eltwise_unary/binop_with_scalar.h"
@@ -24,12 +28,86 @@ void kernel_main() {
     // Packed fp32 user scalar applied via mul_unary_tile after the reduce+negate finishes.
     constexpr uint32_t post_mul_scaler_bits = get_compile_time_arg_val(3);
 #endif
-    constexpr uint32_t row_chunk = compute_kernel_lib::DEST_AUTO_LIMIT;
 
     // Circular buffers:
     constexpr uint32_t cb_input = tt::CBIndex::c_0;
     constexpr uint32_t cb_scaler = tt::CBIndex::c_2;
     constexpr uint32_t cb_output = tt::CBIndex::c_3;
+    constexpr uint32_t onetile = 1;
+    constexpr DataFormat reduce_format = static_cast<DataFormat>(unpack_src_format[cb_input]);
+
+    if constexpr (compute_kernel_lib::detail::is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format>()) {
+        constexpr uint32_t row_chunk = compute_kernel_lib::DEST_AUTO_LIMIT - 1;
+        constexpr uint32_t work_dst = row_chunk;
+
+        init_sfpu(cb_input, cb_output);
+        copy_tile_to_dst_init_short(cb_input);
+        cb_wait_front(cb_scaler, onetile);
+        PACK((llk_pack_reduce_mask_config<REDUCE_DIM>()));
+
+        for (uint32_t nc = 0; nc < NC; ++nc) {
+            for (uint32_t wt_base = 0; wt_base < Wt; wt_base += row_chunk) {
+                const uint32_t current_chunk = std::min(wt_base + row_chunk, Wt) - wt_base;
+
+                tile_regs_acquire();
+                negative_tile_init();
+                if (Ht > 1) {
+                    compute_kernel_lib::detail::sfpu_reduce_max_fold_init<reduce_format>();
+                }
+
+                for (uint32_t ht = 0; ht < Ht; ++ht) {
+                    for (uint32_t k = 0; k < current_chunk; ++k) {
+                        cb_wait_front(cb_input, onetile);
+                        if (ht == 0) {
+                            copy_tile(cb_input, 0, k);
+                            if constexpr (reduce_format == DataFormat::Int32) {
+                                negative_tile_int32(k);
+                            } else {
+                                negative_tile(k);
+                            }
+                        } else {
+                            copy_tile(cb_input, 0, work_dst);
+                            if constexpr (reduce_format == DataFormat::Int32) {
+                                negative_tile_int32(work_dst);
+                            } else {
+                                negative_tile(work_dst);
+                            }
+                            compute_kernel_lib::detail::sfpu_reduce_max_fold_tile<reduce_format>(k, work_dst, k);
+                        }
+                        cb_pop_front(cb_input, onetile);
+                    }
+                }
+
+                sfpu_reduce_init<REDUCE_OP, reduce_format>();
+                for (uint32_t k = 0; k < current_chunk; ++k) {
+                    sfpu_reduce<REDUCE_OP, reduce_format, REDUCE_DIM>(k, /*ct_dim=*/1, /*rt_dim=*/1);
+                    if constexpr (reduce_format == DataFormat::Int32) {
+                        negative_tile_int32(k);
+                    } else {
+                        negative_tile(k);
+                    }
+                }
+#ifdef REDUCE_POST_MUL
+                for (uint32_t k = 0; k < current_chunk; ++k) {
+                    compute_kernel_lib::detail::reduce_post_mul_tile<reduce_format>(k, post_mul_scaler_bits);
+                }
+#endif
+
+                tile_regs_commit();
+                tile_regs_wait();
+                for (uint32_t k = 0; k < current_chunk; ++k) {
+                    cb_reserve_back(cb_output, onetile);
+                    pack_tile(k, cb_output);
+                    cb_push_back(cb_output, onetile);
+                }
+                tile_regs_release();
+            }
+        }
+
+        PACK((llk_pack_reduce_mask_clear()));
+        return;
+    }
+
     constexpr uint32_t cb_acc = tt::CBIndex::c_4;
     constexpr uint32_t cb_ineg = tt::CBIndex::c_5;
 
@@ -39,10 +117,10 @@ void kernel_main() {
     CircularBuffer cb_acc_obj(cb_acc);
     CircularBuffer cb_ineg_obj(cb_ineg);
 
+    constexpr uint32_t row_chunk = compute_kernel_lib::DEST_AUTO_LIMIT;
+
     compute_kernel_hw_startup(cb_input, cb_scaler, cb_output);
     cb_scaler_obj.wait_front(1);  // scaler tile from the reader
-
-    constexpr int onetile = 1;
 
     // tiles are expected to come in the N C W_skip H W_chunk order
     // W_skip(chunk size) represents the number of tile columns whose reduction will be intertwined

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
@@ -14,6 +14,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/dataflow/circular_buffer.h"
 #include "ttnn/cpp/ttnn/kernel_lib/dest_helpers.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 
 #ifdef REDUCE_POST_MUL
@@ -36,7 +37,7 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     constexpr DataFormat reduce_format = static_cast<DataFormat>(unpack_src_format[cb_input]);
 
-    if constexpr (compute_kernel_lib::detail::is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format>()) {
+    if constexpr (is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format>()) {
         constexpr uint32_t row_chunk = compute_kernel_lib::DEST_AUTO_LIMIT - 1;
         constexpr uint32_t work_dst = row_chunk;
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
@@ -44,7 +44,7 @@ void kernel_main() {
         init_sfpu(cb_input, cb_output);
         copy_tile_to_dst_init_short(cb_input);
         cb_wait_front(cb_scaler, onetile);
-        PACK((llk_pack_reduce_mask_config<REDUCE_DIM>()));
+        PACK((llk_pack_reduce_mask_config<REDUCE_DIM, PackMode::Default>(cb_output)));
 
         for (uint32_t nc = 0; nc < NC; ++nc) {
             for (uint32_t wt_base = 0; wt_base < Wt; wt_base += row_chunk) {

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_rm.cpp
@@ -47,11 +47,11 @@ FORCE_INLINE void reduce_block(
         compute_kernel_lib::reduce<
             REDUCE_OP,
             REDUCE_DIM,
-            compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
-            compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
             cb_tile_in,
             cb_scaler,
             cb_out,
+            compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
+            compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
             compute_kernel_lib::ReduceInputBlockShape::of(ht_in_chunk, wt_in_chunk, NC),
             compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
             compute_kernel_lib::Accumulate::at(cb_acc, chunk_idx),
@@ -69,11 +69,11 @@ FORCE_INLINE void reduce_block(
         compute_kernel_lib::reduce<
             REDUCE_OP,
             REDUCE_DIM,
-            compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
-            compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
             cb_tile_in,
             cb_scaler,
             cb_acc,
+            compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
+            compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
             compute_kernel_lib::ReduceInputBlockShape::of(ht_in_chunk, wt_in_chunk, NC),
             compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
             compute_kernel_lib::Accumulate::at(cb_acc, chunk_idx),

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
@@ -46,7 +46,7 @@ void kernel_main() {
         init_sfpu(cb_input, cb_output);
         copy_tile_to_dst_init_short(cb_input);
         cb_wait_front(cb_scaler, onetile);
-        PACK((llk_pack_reduce_mask_config<REDUCE_DIM>()));
+        PACK((llk_pack_reduce_mask_config<REDUCE_DIM, PackMode::Default>(cb_output)));
 
         for (uint32_t nc = 0; nc < NC; ++nc) {
             for (uint32_t ht = 0; ht < Ht; ++ht) {

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
@@ -14,6 +14,7 @@
 #include "api/compute/eltwise_unary/negative.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/dataflow/circular_buffer.h"
+#include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 
 #include "llk_math_eltwise_binary.h"
@@ -38,7 +39,7 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     constexpr DataFormat reduce_format = static_cast<DataFormat>(unpack_src_format[cb_input]);
 
-    if constexpr (compute_kernel_lib::detail::is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format>()) {
+    if constexpr (is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format>()) {
         constexpr uint32_t acc_dst = 0;
         constexpr uint32_t work_dst = 1;
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
@@ -4,6 +4,9 @@
 
 #include <cstdint>
 
+#include "api/compute/cb_api.h"
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/pack.h"
 #include "api/compute/reduce.h"
 
 #include "api/compute/eltwise_binary.h"
@@ -11,6 +14,7 @@
 #include "api/compute/eltwise_unary/negative.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/dataflow/circular_buffer.h"
+#include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 
 #include "llk_math_eltwise_binary.h"
 
@@ -31,6 +35,72 @@ void kernel_main() {
     constexpr uint32_t cb_input = tt::CBIndex::c_0;
     constexpr uint32_t cb_scaler = tt::CBIndex::c_2;
     constexpr uint32_t cb_output = tt::CBIndex::c_3;
+    constexpr uint32_t onetile = 1;
+    constexpr DataFormat reduce_format = static_cast<DataFormat>(unpack_src_format[cb_input]);
+
+    if constexpr (compute_kernel_lib::detail::is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format>()) {
+        constexpr uint32_t acc_dst = 0;
+        constexpr uint32_t work_dst = 1;
+
+        init_sfpu(cb_input, cb_output);
+        copy_tile_to_dst_init_short(cb_input);
+        cb_wait_front(cb_scaler, onetile);
+        PACK((llk_pack_reduce_mask_config<REDUCE_DIM>()));
+
+        for (uint32_t nc = 0; nc < NC; ++nc) {
+            for (uint32_t ht = 0; ht < Ht; ++ht) {
+                tile_regs_acquire();
+                negative_tile_init();
+                if (Wt > 1) {
+                    compute_kernel_lib::detail::sfpu_reduce_max_fold_init<reduce_format>();
+                }
+
+                for (uint32_t wt = 0; wt < Wt; ++wt) {
+                    cb_wait_front(cb_input, onetile);
+                    if (wt == 0) {
+                        copy_tile(cb_input, 0, acc_dst);
+                        if constexpr (reduce_format == DataFormat::Int32) {
+                            negative_tile_int32(acc_dst);
+                        } else {
+                            negative_tile(acc_dst);
+                        }
+                    } else {
+                        copy_tile(cb_input, 0, work_dst);
+                        if constexpr (reduce_format == DataFormat::Int32) {
+                            negative_tile_int32(work_dst);
+                        } else {
+                            negative_tile(work_dst);
+                        }
+                        compute_kernel_lib::detail::sfpu_reduce_max_fold_tile<reduce_format>(
+                            acc_dst, work_dst, acc_dst);
+                    }
+                    cb_pop_front(cb_input, onetile);
+                }
+
+                sfpu_reduce_init<REDUCE_OP, reduce_format>();
+                sfpu_reduce<REDUCE_OP, reduce_format, REDUCE_DIM>(acc_dst, /*ct_dim=*/1, /*rt_dim=*/1);
+                if constexpr (reduce_format == DataFormat::Int32) {
+                    negative_tile_int32(acc_dst);
+                } else {
+                    negative_tile(acc_dst);
+                }
+#ifdef REDUCE_POST_MUL
+                compute_kernel_lib::detail::reduce_post_mul_tile<reduce_format>(acc_dst, post_mul_scaler_bits);
+#endif
+
+                tile_regs_commit();
+                cb_reserve_back(cb_output, onetile);
+                tile_regs_wait();
+                pack_tile(acc_dst, cb_output);
+                tile_regs_release();
+                cb_push_back(cb_output, onetile);
+            }
+        }
+
+        PACK((llk_pack_reduce_mask_clear()));
+        return;
+    }
+
     constexpr uint32_t cb_acc = tt::CBIndex::c_4;
     constexpr uint32_t cb_ineg = tt::CBIndex::c_5;
 
@@ -44,7 +114,6 @@ void kernel_main() {
 
     cb_scaler_obj.wait_front(1);  // scaler tile from the reader
     for (uint32_t nc = 0; nc < NC; nc++) {
-        constexpr int onetile = 1;
         int dst_idx = 0;
         for (uint32_t ht = 0; ht < Ht; ++ht) {
             // tiles are expected to be coming in in NCHW order (W-contiguous)

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
@@ -7,6 +7,7 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/endpoints.h"
+#include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/dest_helpers.hpp"
 
@@ -31,13 +32,11 @@ void kernel_main() {
     // Emit tiles in N, W_skip, H, W_chunk order to match the chunked iteration of the
     // unified reduce compute kernel (row_chunk = DEST_AUTO_LIMIT). For shard_Wt=1 this
     // degenerates to one column per chunk; for shard_Wt>1 it interleaves columns.
-    // SFPU min/max (signalled by REDUCE_SFPU_PATH) reserves one DST for the binary fold work
-    // tile, so it uses DEST_AUTO_LIMIT - 1.
-#ifdef REDUCE_SFPU_PATH
-    constexpr uint32_t row_chunk = compute_kernel_lib::DEST_AUTO_LIMIT - 1;
-#else
-    constexpr uint32_t row_chunk = compute_kernel_lib::DEST_AUTO_LIMIT;
-#endif
+    // Int32/Float32 SFPU max reserves one DST for the binary-fold work tile (DEST_AUTO_LIMIT - 1).
+    constexpr DataFormat reduce_format = get_dataformat(cb_id_in0);
+    constexpr bool use_sfpu_reduce_path = is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format>();
+    constexpr uint32_t row_chunk =
+        use_sfpu_reduce_path ? (compute_kernel_lib::DEST_AUTO_LIMIT - 1) : compute_kernel_lib::DEST_AUTO_LIMIT;
 
     constexpr uint32_t onetile = 1;
     uint32_t tile_bytes = get_tile_size(cb_id_in0);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
@@ -31,7 +31,13 @@ void kernel_main() {
     // Emit tiles in N, W_skip, H, W_chunk order to match the chunked iteration of the
     // unified reduce compute kernel (row_chunk = DEST_AUTO_LIMIT). For shard_Wt=1 this
     // degenerates to one column per chunk; for shard_Wt>1 it interleaves columns.
+    // SFPU min/max (signalled by REDUCE_SFPU_PATH) reserves one DST for the binary fold work
+    // tile, so it uses DEST_AUTO_LIMIT - 1.
+#ifdef REDUCE_SFPU_PATH
+    constexpr uint32_t row_chunk = compute_kernel_lib::DEST_AUTO_LIMIT - 1;
+#else
     constexpr uint32_t row_chunk = compute_kernel_lib::DEST_AUTO_LIMIT;
+#endif
 
     constexpr uint32_t onetile = 1;
     uint32_t tile_bytes = get_tile_size(cb_id_in0);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
@@ -32,7 +32,7 @@ void kernel_main() {
     // Emit tiles in N, W_skip, H, W_chunk order to match the chunked iteration of the
     // unified reduce compute kernel (row_chunk = DEST_AUTO_LIMIT). For shard_Wt=1 this
     // degenerates to one column per chunk; for shard_Wt>1 it interleaves columns.
-    // Int32/Float32 SFPU max reserves one DST for the binary-fold work tile (DEST_AUTO_LIMIT - 1).
+    // Int32 SFPU max reserves one DST for the binary-fold work tile (DEST_AUTO_LIMIT - 1).
     constexpr DataFormat reduce_format = get_dataformat(cb_id_in0);
     constexpr bool use_sfpu_reduce_path = is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format>();
     constexpr uint32_t row_chunk =

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
@@ -30,7 +30,7 @@ void kernel_main() {
     // Welford must process one column at a time because the SFPU can only maintain
     // a single running mean/M2 state. DEST_AUTO_LIMIT interleaves multiple columns
     // per chunk, which would feed the Welford kernel tiles from the wrong columns.
-    // Int32/Float32 SFPU max keeps one acc DST per column plus one shared work DST (DEST_AUTO_LIMIT - 1).
+    // Int32 SFPU max keeps one acc DST per column plus one shared work DST (DEST_AUTO_LIMIT - 1).
     constexpr DataFormat reduce_format = get_dataformat(cb_id_in0);
     constexpr bool use_sfpu_reduce_path = is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format>();
     constexpr uint32_t row_chunk = use_welford ? 1

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
@@ -7,6 +7,7 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/dest_helpers.hpp"
 
@@ -23,18 +24,18 @@ void kernel_main() {
 
     constexpr uint32_t scaler_bits = get_compile_time_arg_val(3);
     constexpr bool use_welford = get_compile_time_arg_val(4) != 0;
+
+    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
+
     // Welford must process one column at a time because the SFPU can only maintain
     // a single running mean/M2 state. DEST_AUTO_LIMIT interleaves multiple columns
     // per chunk, which would feed the Welford kernel tiles from the wrong columns.
-    // SFPU min/max (signalled by REDUCE_SFPU_PATH) keeps one acc DST per column in the
-    // chunk plus one shared work DST, so it reserves one DST and uses DEST_AUTO_LIMIT - 1.
-#ifdef REDUCE_SFPU_PATH
-    constexpr uint32_t row_chunk = use_welford ? 1 : (compute_kernel_lib::DEST_AUTO_LIMIT - 1);
-#else
-    constexpr uint32_t row_chunk = use_welford ? 1 : compute_kernel_lib::DEST_AUTO_LIMIT;
-#endif
-
-    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
+    // Int32/Float32 SFPU max keeps one acc DST per column plus one shared work DST (DEST_AUTO_LIMIT - 1).
+    constexpr DataFormat reduce_format = get_dataformat(cb_id_in0);
+    constexpr bool use_sfpu_reduce_path = is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format>();
+    constexpr uint32_t row_chunk = use_welford ? 1
+                                               : (use_sfpu_reduce_path ? (compute_kernel_lib::DEST_AUTO_LIMIT - 1)
+                                                                       : compute_kernel_lib::DEST_AUTO_LIMIT);
 
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
@@ -26,7 +26,13 @@ void kernel_main() {
     // Welford must process one column at a time because the SFPU can only maintain
     // a single running mean/M2 state. DEST_AUTO_LIMIT interleaves multiple columns
     // per chunk, which would feed the Welford kernel tiles from the wrong columns.
+    // SFPU min/max (signalled by REDUCE_SFPU_PATH) keeps one acc DST per column in the
+    // chunk plus one shared work DST, so it reserves one DST and uses DEST_AUTO_LIMIT - 1.
+#ifdef REDUCE_SFPU_PATH
+    constexpr uint32_t row_chunk = use_welford ? 1 : (compute_kernel_lib::DEST_AUTO_LIMIT - 1);
+#else
     constexpr uint32_t row_chunk = use_welford ? 1 : compute_kernel_lib::DEST_AUTO_LIMIT;
+#endif
 
     constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -192,7 +192,16 @@ Tensor reduce(
     // sqrt(scaler) in ReduceSingleCoreHwProgramFactory::create.
     // However, sqrt of a negative number is NaN, so negative scalers
     // must take the two-step W-then-H path where the scaler is applied once.
-    if (is_multicore_hw || (reduce_dim == tt::tt_metal::ReduceOpDim::HW && reduce_scaler < 0)) {
+    //
+    // INT32 SFPU max/min has no REDUCE_SCALAR primitive (ROW/COL only), so Int32 HW always uses
+    // W-then-H. Float32 max HW can use single-core REDUCE_SCALAR (FPU) when num_tiles == 1;
+    // multi-tile HW still uses W-then-H via is_multicore_hw. Applies to MAX and MIN (MIN via negate).
+    const bool use_two_step_hw_sfpu_reduce = (reduce_dim == tt::tt_metal::ReduceOpDim::HW) &&
+                                             (tilized_input.dtype() == tt::tt_metal::DataType::INT32) &&
+                                             (reduce_math == tt::tt_metal::ReduceOpMath::MAX);
+
+    if (is_multicore_hw || use_two_step_hw_sfpu_reduce ||
+        (reduce_dim == tt::tt_metal::ReduceOpDim::HW && reduce_scaler < 0)) {
         // Multi-core HW reduction: first reduce W, then reduce H on the result.
         // For the Sum chain's terminal fp32->bf16 stage, keep W in fp32 so only H packs to bf16.
         const auto out_final_dtype = output_dtype.value_or(input_tensor.dtype());

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -79,10 +79,17 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
             static_cast<int>(operation_attributes.output_mem_config.memory_layout()));
     } else {
         TT_FATAL((tensor_args.layout() == Layout::TILE), "Inputs to reduce must be tilized");
+        // INT32 MIN/MAX is supported via the SFPU reduce path (format deduced from input CB in
+        // compute_kernel_lib::reduce and reduce_{h,w}_neg; MIN uses the dedicated reduce_{h,w}_neg kernels).
+        // FLOAT32 MIN/MAX also takes the SFPU path because GMPOOL truncates SrcA/SrcB to bf16.
+        const bool is_int32_max_reduce =
+            tensor_args.dtype() == DataType::INT32 && operation_attributes.math_op == ReduceOpMath::MAX;
         TT_FATAL(
             tensor_args.dtype() == DataType::BFLOAT16 || tensor_args.dtype() == DataType::FLOAT32 ||
-                tensor_args.dtype() == DataType::BFLOAT8_B || tensor_args.dtype() == DataType::UINT32,
-            "Only FLOAT32, BFLOAT16, BFLOAT8_B, and UINT32 are supported for generic reduction - got {}",
+                tensor_args.dtype() == DataType::BFLOAT8_B || tensor_args.dtype() == DataType::UINT32 ||
+                is_int32_max_reduce,
+            "Only FLOAT32, BFLOAT16, BFLOAT8_B, and UINT32 are supported for generic reduction "
+            "(INT32 is supported for MAX/MIN) - got {}.",
             tensor_args.dtype());
     }
     validate_reduce_sharded_buffer_types(tensor_args.memory_config(), operation_attributes.output_mem_config, "reduce");

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -81,7 +81,6 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL((tensor_args.layout() == Layout::TILE), "Inputs to reduce must be tilized");
         // INT32 MIN/MAX is supported via the SFPU reduce path (format deduced from input CB in
         // compute_kernel_lib::reduce and reduce_{h,w}_neg; MIN uses the dedicated reduce_{h,w}_neg kernels).
-        // FLOAT32 MIN/MAX also takes the SFPU path because GMPOOL truncates SrcA/SrcB to bf16.
         const bool is_int32_max_reduce =
             tensor_args.dtype() == DataType::INT32 && operation_attributes.math_op == ReduceOpMath::MAX;
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -83,6 +83,15 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
     // reduction via SFPU mul_unary_tile inside the compute kernel.
     const bool use_post_mul = operation_attributes.post_mul_scaler != 1.0f;
 
+    // Int32 and Float32 max/min use the SFPU reduce path.
+    //  - Int32: GMPOOL has no Int32 support at all.
+    //  - Float32: GMPOOL feeds SrcA/SrcB which truncates to bf16, losing fp32 precision.
+    // The host already lowers reduce_min to math_op=MAX + negate=true (see reduce_op.cpp::reduce_min),
+    // so this single check covers both MAX and MIN.
+    const bool use_sfpu_reduce_path = (a.dtype() == DataType::INT32 || a.dtype() == DataType::FLOAT32) &&
+                                      operation_attributes.math_op == ReduceOpMath::MAX;
+    const bool use_fpu_negate = operation_attributes.negate && !use_sfpu_reduce_path;
+
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     auto num_cols = NC * Wt;
     uint32_t num_cores;
@@ -190,7 +199,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
             .tensor = &a,
         });
     } else {
-        uint32_t num_input_tiles = operation_attributes.negate ? chunk_size : 2;
+        uint32_t num_input_tiles = use_fpu_negate ? chunk_size : 2;
         desc.cbs.push_back(CBDescriptor{
             .total_size = num_input_tiles * src0_single_tile_size,
             .core_ranges = all_cores,
@@ -238,7 +247,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
             .tensor = &output,
         });
     } else {
-        uint32_t num_output_tiles = operation_attributes.negate ? chunk_size : 2;
+        uint32_t num_output_tiles = use_fpu_negate ? chunk_size : 2;
         desc.cbs.push_back(CBDescriptor{
             .total_size = num_output_tiles * dst_single_tile_size,
             .core_ranges = all_cores,
@@ -253,7 +262,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
     // Packed fp32 scalar passed to the compute kernel for mul_unary_tile post-reduction scaling.
     uint32_t post_mul_scaler_bits = std::bit_cast<uint32_t>(operation_attributes.post_mul_scaler);
 
-    if (operation_attributes.negate) {
+    if (use_fpu_negate) {
         // The reduce_h_neg kernel pushes ntiles tiles per inner-loop iteration
         // via push_back(ntiles).  The CB FIFO write pointer only wraps when
         // wr_ptr exactly reaches fifo_limit, so it is not enough for the CB
@@ -349,6 +358,19 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
         reduce_defines["REDUCE_POST_MUL"] = "1";
     }
 
+    if (use_sfpu_reduce_path) {
+        reduce_defines["REDUCE_FORMAT"] = a.dtype() == DataType::INT32 ? "DataFormat::Int32" : "DataFormat::Float32";
+        reduce_defines["REDUCE_SFPU_PATH"] = "1";
+    }
+
+    // Float32 SFPU reduce must unpack source tiles straight into the fp32 DST register.
+    // Without this, the unpacker rounds Float32 -> Tf32/bf16 before SFPU sees the data,
+    // silently destroying mantissa precision.
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (use_sfpu_reduce_path && a.dtype() == DataType::FLOAT32) {
+        unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    }
+
     KernelDescriptor reader_desc;
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = all_cores;
@@ -440,6 +462,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
         };
     }
 
+    // reduce.cpp is REDUCE_FORMAT-aware; MIN uses -MAX(-x) in reduce_h_neg.
     const std::string compute_kernel =
         rm_path ? std::string("ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_rm.cpp")
                 : std::string("ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce") +
@@ -455,6 +478,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
         .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,
         .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
     };
 
     std::optional<KernelDescriptor> compute_desc_g2;
@@ -485,6 +509,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
             .math_fidelity = math_fidelity,
             .fp32_dest_acc_en = fp32_dest_acc_en,
             .dst_full_sync_en = dst_full_sync_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
         };
         compute_desc_g2 = std::move(d);
     }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -358,11 +358,6 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
         reduce_defines["REDUCE_POST_MUL"] = "1";
     }
 
-    if (use_sfpu_reduce_path) {
-        reduce_defines["REDUCE_FORMAT"] = a.dtype() == DataType::INT32 ? "DataFormat::Int32" : "DataFormat::Float32";
-        reduce_defines["REDUCE_SFPU_PATH"] = "1";
-    }
-
     // Float32 SFPU reduce must unpack source tiles straight into the fp32 DST register.
     // Without this, the unpacker rounds Float32 -> Tf32/bf16 before SFPU sees the data,
     // silently destroying mantissa precision.
@@ -462,7 +457,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
         };
     }
 
-    // reduce.cpp is REDUCE_FORMAT-aware; MIN uses -MAX(-x) in reduce_h_neg.
+    // MIN on Int32/Float32 uses -MAX(-x) in reduce_h_neg.
     const std::string compute_kernel =
         rm_path ? std::string("ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_rm.cpp")
                 : std::string("ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce") +

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -83,13 +83,10 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
     // reduction via SFPU mul_unary_tile inside the compute kernel.
     const bool use_post_mul = operation_attributes.post_mul_scaler != 1.0f;
 
-    // Int32 and Float32 max/min use the SFPU reduce path.
-    //  - Int32: GMPOOL has no Int32 support at all.
-    //  - Float32: GMPOOL feeds SrcA/SrcB which truncates to bf16, losing fp32 precision.
+    // Int32 max/min use the SFPU reduce path (GMPOOL has no Int32 support).
     // The host already lowers reduce_min to math_op=MAX + negate=true (see reduce_op.cpp::reduce_min),
     // so this single check covers both MAX and MIN.
-    const bool use_sfpu_reduce_path = (a.dtype() == DataType::INT32 || a.dtype() == DataType::FLOAT32) &&
-                                      operation_attributes.math_op == ReduceOpMath::MAX;
+    const bool use_sfpu_reduce_path = a.dtype() == DataType::INT32 && operation_attributes.math_op == ReduceOpMath::MAX;
     const bool use_fpu_negate = operation_attributes.negate && !use_sfpu_reduce_path;
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
@@ -358,13 +355,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
         reduce_defines["REDUCE_POST_MUL"] = "1";
     }
 
-    // Float32 SFPU reduce must unpack source tiles straight into the fp32 DST register.
-    // Without this, the unpacker rounds Float32 -> Tf32/bf16 before SFPU sees the data,
-    // silently destroying mantissa precision.
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    if (use_sfpu_reduce_path && a.dtype() == DataType::FLOAT32) {
-        unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-    }
 
     KernelDescriptor reader_desc;
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
@@ -457,7 +448,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
         };
     }
 
-    // MIN on Int32/Float32 uses -MAX(-x) in reduce_h_neg.
+    // MIN on Int32 uses -MAX(-x) in reduce_h_neg.
     const std::string compute_kernel =
         rm_path ? std::string("ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_rm.cpp")
                 : std::string("ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce") +

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -176,13 +176,10 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     const bool use_post_mul = operation_attributes.post_mul_scaler != 1.0f;
     uint32_t post_mul_scaler_bits = std::bit_cast<uint32_t>(operation_attributes.post_mul_scaler);
 
-    // Int32 and Float32 max/min use the SFPU reduce path.
-    //  - Int32: GMPOOL has no Int32 support at all.
-    //  - Float32: GMPOOL feeds SrcA/SrcB which truncates to bf16, losing fp32 precision.
+    // Int32 max/min use the SFPU reduce path (GMPOOL has no Int32 support).
     // The host already lowers reduce_min to math_op=MAX + negate=true (see reduce_op.cpp::reduce_min),
     // so this single check covers both MAX and MIN.
-    const bool use_sfpu_reduce_path = (a.dtype() == DataType::INT32 || a.dtype() == DataType::FLOAT32) &&
-                                      operation_attributes.math_op == ReduceOpMath::MAX;
+    const bool use_sfpu_reduce_path = a.dtype() == DataType::INT32 && operation_attributes.math_op == ReduceOpMath::MAX;
     const bool use_fpu_negate = operation_attributes.negate && !use_sfpu_reduce_path;
 
     std::vector<uint32_t> reader_compile_time_args;
@@ -234,13 +231,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
         reduce_defines["REDUCE_POST_MUL"] = "1";
     }
 
-    // Float32 SFPU reduce must unpack source tiles straight into the fp32 DST register.
-    // Without this, the unpacker rounds Float32 -> Tf32/bf16 before SFPU sees the data,
-    // silently destroying mantissa precision.
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    if (use_sfpu_reduce_path && a.dtype() == DataType::FLOAT32) {
-        unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-    }
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source =
@@ -286,7 +277,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
         };
     }
 
-    // MIN on Int32/Float32 uses -MAX(-x) in reduce_w_neg.
+    // MIN on Int32 uses -MAX(-x) in reduce_w_neg.
     const std::string compute_kernel =
         rm_path ? std::string("ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_rm.cpp")
                 : std::string("ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce") +

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -176,6 +176,15 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     const bool use_post_mul = operation_attributes.post_mul_scaler != 1.0f;
     uint32_t post_mul_scaler_bits = std::bit_cast<uint32_t>(operation_attributes.post_mul_scaler);
 
+    // Int32 and Float32 max/min use the SFPU reduce path.
+    //  - Int32: GMPOOL has no Int32 support at all.
+    //  - Float32: GMPOOL feeds SrcA/SrcB which truncates to bf16, losing fp32 precision.
+    // The host already lowers reduce_min to math_op=MAX + negate=true (see reduce_op.cpp::reduce_min),
+    // so this single check covers both MAX and MIN.
+    const bool use_sfpu_reduce_path = (a.dtype() == DataType::INT32 || a.dtype() == DataType::FLOAT32) &&
+                                      operation_attributes.math_op == ReduceOpMath::MAX;
+    const bool use_fpu_negate = operation_attributes.negate && !use_sfpu_reduce_path;
+
     std::vector<uint32_t> reader_compile_time_args;
     if (rm_path) {
         reader_compile_time_args = build_rm_reader_ct_args(
@@ -193,7 +202,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
         TensorAccessorArgs(output).append_to(writer_compile_time_args);
     }
 
-    if (operation_attributes.negate) {
+    if (use_fpu_negate) {
         uint32_t acc_cb_index = tt::CBIndex::c_4;
         uint32_t num_acc_tiles = 1;
         desc.cbs.push_back(CBDescriptor{
@@ -223,6 +232,19 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
         reduce_op_utils::get_defines(operation_attributes.math_op, ReduceOpDim::W);
     if (use_post_mul) {
         reduce_defines["REDUCE_POST_MUL"] = "1";
+    }
+
+    if (use_sfpu_reduce_path) {
+        reduce_defines["REDUCE_FORMAT"] = a.dtype() == DataType::INT32 ? "DataFormat::Int32" : "DataFormat::Float32";
+        reduce_defines["REDUCE_SFPU_PATH"] = "1";
+    }
+
+    // Float32 SFPU reduce must unpack source tiles straight into the fp32 DST register.
+    // Without this, the unpacker rounds Float32 -> Tf32/bf16 before SFPU sees the data,
+    // silently destroying mantissa precision.
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (use_sfpu_reduce_path && a.dtype() == DataType::FLOAT32) {
+        unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
     }
 
     KernelDescriptor reader_desc;
@@ -269,6 +291,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
         };
     }
 
+    // reduce.cpp is REDUCE_FORMAT-aware; MIN uses -MAX(-x) in reduce_w_neg.
     const std::string compute_kernel =
         rm_path ? std::string("ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_rm.cpp")
                 : std::string("ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce") +
@@ -283,6 +306,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     compute_desc_g1.config = ComputeConfigDescriptor{
         .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = unpack_to_dest_mode,
     };
 
     std::optional<KernelDescriptor> compute_desc_g2;
@@ -308,6 +332,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
         d.config = ComputeConfigDescriptor{
             .math_fidelity = math_fidelity,
             .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
         };
         compute_desc_g2 = std::move(d);
     }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -234,11 +234,6 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
         reduce_defines["REDUCE_POST_MUL"] = "1";
     }
 
-    if (use_sfpu_reduce_path) {
-        reduce_defines["REDUCE_FORMAT"] = a.dtype() == DataType::INT32 ? "DataFormat::Int32" : "DataFormat::Float32";
-        reduce_defines["REDUCE_SFPU_PATH"] = "1";
-    }
-
     // Float32 SFPU reduce must unpack source tiles straight into the fp32 DST register.
     // Without this, the unpacker rounds Float32 -> Tf32/bf16 before SFPU sees the data,
     // silently destroying mantissa precision.
@@ -291,7 +286,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
         };
     }
 
-    // reduce.cpp is REDUCE_FORMAT-aware; MIN uses -MAX(-x) in reduce_w_neg.
+    // MIN on Int32/Float32 uses -MAX(-x) in reduce_w_neg.
     const std::string compute_kernel =
         rm_path ? std::string("ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_rm.cpp")
                 : std::string("ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce") +

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -21,6 +21,7 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 #include <algorithm>
+#include <bit>
 #include <cmath>
 #include <numeric>
 
@@ -72,9 +73,27 @@ std::pair<ttnn::SmallVector<int>, ttnn::SmallVector<int>> split_height_width_dim
     return {non_height_width_dims, height_width_dims};
 }
 
-float get_pad_value(reduction_common::ReduceType reduce_type) {
+float get_pad_value(
+    reduction_common::ReduceType reduce_type, tt::tt_metal::DataType dtype = tt::tt_metal::DataType::FLOAT32) {
     // Prod reduction is handled separately in prod.cpp.
     TT_FATAL(reduce_type != reduction_common::ReduceType::Prod, "Prod reduction is not supported");
+
+    // INT32 max/min: pad_value flows through float-typed pad APIs (transpose / permute /
+    // tilize_with_val_padding / fill_pad), and static_cast<uint32_t>(±inf) is UB.
+    // We therefore carry the int32 sentinel as the float's bit pattern; the data-movement
+    // ops use bit_cast<uint32_t> on the INT32 branch to recover the original int32 bits.
+    if (dtype == tt::tt_metal::DataType::INT32) {
+        if (reduce_type == reduction_common::ReduceType::Max) {
+            // SFPU int32 MAX reduce can return an incorrect maximum when the INT32_MIN bit pattern (0x80000000)
+            // appears in padded lanes; use INT32_MIN + 1 instead.
+            return std::bit_cast<float>(static_cast<uint32_t>(0x80000001u));  // INT32_MIN + 1
+        }
+        if (reduce_type == reduction_common::ReduceType::Min) {
+            return std::bit_cast<float>(static_cast<uint32_t>(0x7FFFFFFFu));  // INT32_MAX
+        }
+        return 0.0f;
+    }
+
     return reduce_type == reduction_common::ReduceType::Max
                ? -std::numeric_limits<float>::infinity()
                : (reduce_type == reduction_common::ReduceType::Min ? std::numeric_limits<float>::infinity() : 0);
@@ -136,7 +155,7 @@ static Tensor reduce_impl(
         return reduction_common::zero_volume_reduce<reduce_type>(input_tensor_arg, dim, keepdim, memory_config);
     }
 
-    float pad_value = get_pad_value(reduce_type);
+    float pad_value = get_pad_value(reduce_type, input_tensor_arg.dtype());
     bool single_reduce_op = (dim.empty()) || (dim.size() == 1 && (dim[0] == rank - 1 || dim[0] == rank - 2)) ||
                             (dim.size() == 2 && dim[1] == rank - 1 && dim[0] == rank - 2);
     if (!single_reduce_op) {
@@ -551,7 +570,7 @@ Tensor reduce(
     const std::optional<CoreRangeSet>& sub_core_grids,
     bool use_legacy) {
     ttnn::SmallVector<int> dim = reduction_common::generate_reduce_dim(input_tensor_arg, dim_arg);
-    float pad_value = get_pad_value(reduce_type);
+    float pad_value = get_pad_value(reduce_type, input_tensor_arg.dtype());
     // TODO: generalize to support all types, parameters, and formats. Issue #18566
     ttnn::SmallVector<int> non_height_width_dims{}, height_width_dims{};
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -590,7 +590,12 @@ Tensor reduce(
     }
 
     bool is_tiled = input_tensor_arg.layout() == TILE_LAYOUT;
-    auto input_tensor = is_tiled ? ttnn::fill_implicit_tile_padding(input_tensor_arg, pad_value) : input_tensor_arg;
+    // For INT32 the pad sentinel is carried as a raw bit pattern (see get_pad_value), so fill_pad must
+    // recover the bits rather than decode numerically.
+    const bool pad_value_is_packed_bits = input_tensor_arg.dtype() == tt::tt_metal::DataType::INT32;
+    auto input_tensor =
+        is_tiled ? ttnn::fill_implicit_tile_padding(input_tensor_arg, pad_value, std::nullopt, pad_value_is_packed_bits)
+                 : input_tensor_arg;
 
     // bf16 multi-axis Sum precision chain: carry FP32 between stages and pack bf16
     // only on the final stage. Skipped for full-tensor reductions (dim covers every

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -590,12 +590,13 @@ Tensor reduce(
     }
 
     bool is_tiled = input_tensor_arg.layout() == TILE_LAYOUT;
-    // For INT32 the pad sentinel is carried as a raw bit pattern (see get_pad_value), so fill_pad must
-    // recover the bits rather than decode numerically.
-    const bool pad_value_is_packed_bits = input_tensor_arg.dtype() == tt::tt_metal::DataType::INT32;
+    // For INT32 the pad sentinel is carried as a raw bit pattern (see get_pad_value); pass it through
+    // PadValue's integer arm so fill_pad reinterprets the bits rather than decoding numerically.
+    const tt::tt_metal::PadValue fill_pad_value = input_tensor_arg.dtype() == tt::tt_metal::DataType::INT32
+                                                      ? tt::tt_metal::PadValue{std::bit_cast<uint32_t>(pad_value)}
+                                                      : tt::tt_metal::PadValue{pad_value};
     auto input_tensor =
-        is_tiled ? ttnn::fill_implicit_tile_padding(input_tensor_arg, pad_value, std::nullopt, pad_value_is_packed_bits)
-                 : input_tensor_arg;
+        is_tiled ? ttnn::fill_implicit_tile_padding(input_tensor_arg, fill_pad_value) : input_tensor_arg;
 
     // bf16 multi-axis Sum precision chain: carry FP32 between stages and pack bf16
     // only on the final stage. Skipped for full-tensor reductions (dim covers every

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/compute/moe.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/compute/moe.cpp
@@ -200,8 +200,9 @@ void reduce_c(uint32_t rows, uint32_t cols) {
     // Postcondition: scale_cb has 1 produced
     // Postcondition: out_cb has rows produced
 
-    compute_kernel_lib::reduce<pool_type, reduce_dim, compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
-        in_cb, scale_cb, out_cb, compute_kernel_lib::ReduceInputBlockShape::of(rows, cols));
+    compute_kernel_lib::
+        reduce<pool_type, reduce_dim, in_cb, scale_cb, out_cb, compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
+            compute_kernel_lib::ReduceInputBlockShape::of(rows, cols));
 
     UNPACK(tensix_sync());  // Workaround for issue #9370
 }

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp
@@ -178,9 +178,12 @@ void reduce_c() {
     compute_kernel_lib::reduce<
         pool_type,
         reduce_dim,
+        in0_cb,
+        scale_cb,
+        out_cb,
         compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop,
         compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT>(
-        in0_cb, scale_cb, out_cb, compute_kernel_lib::ReduceInputBlockShape::of(rows, cols));
+        compute_kernel_lib::ReduceInputBlockShape::of(rows, cols));
     UNPACK(tensix_sync());  // Workaround for issue #9370
 }
 


### PR DESCRIPTION
### PR Category
**[Feature]**

### Summary
Closes:
- #26726
- #31295

Adds SFPU-based `ttnn.min` / `ttnn.max` for INT32. Previously INT32 was unsupported through the existing FPU/GMPOOL and it is now routed through a dedicated **SFPU** compute path: **correctness for INT32**. MIN reuses the MAX path via `-MAX(-x)` in `reduce_{h,w}_neg`.

### What's changed (24 files)

#### Reduction / SFPU path (12 files)

* `reduce_helpers_compute.{hpp,inl}` - SFPU MAX fold helpers (`sfpu_reduce_max_fold_*`), an optional `reduce_format` template param (default `Invalid`), `is_sfpu_reduce_path<>()` dispatch, and Int32 post-mul scaling (`typecast`-bracketed `mul_unary_tile`).
* Compute kernels `reduce.cpp`, `reduce_h_neg.cpp`, `reduce_w_neg.cpp` - `REDUCE_FORMAT`-aware MAX fold; MIN via negated MAX.
* Reader kernels `reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp`, `reader_unary_transpose_wh_universal_input_cols_partitioned.cpp` - reserve one DST for the binary-fold work tile (`DEST_AUTO_LIMIT - 1`) under `REDUCE_SFPU_PATH`.
* `reduce_op.cpp` - INT32 HW always decomposes to W-then-H (no INT32 `REDUCE_SCALAR` primitive); FP32 single-tile HW stays on the FPU path.
* `reduce_op_device_operation.cpp` - validation admits INT32 for MAX/MIN.
* `reduce_op_multi_core_{h,w}_program_factory.cpp` - `REDUCE_FORMAT` / `REDUCE_SFPU_PATH` defines, SFPU-vs-FPU negate selection, and `UnpackToDestFp32` for FP32 precision.
* `tests/.../reduction/test_min_max_sfpu.py` - new nightly coverage.

#### Padding (12 files)

INT32 reduce has to fill padding with sentinel values at the very edge of the int32 range (`INT32_MIN+1` for MAX, `INT32_MAX` for MIN). These values can't be stored exactly in a normal float, so reduce carries them as raw bit patterns instead. To avoid changing how int32 padding behaves for every other op, the shared padding ops keep their existing behavior - the fill value is treated as a plain number - and reduce explicitly requests the raw-bits interpretation only for its own sentinels:

* `generic_reductions.cpp` - `get_pad_value` produces the bit-encoded sentinel; reduce passes `fill_value_is_packed_bits=true` for INT32.
* `fill_pad/*` (8 files) - `fill_implicit_tile_padding` / `prim::fill_pad` / `FillPadParams` / `pack_fill_value_for_dtype` gain a defaulted `fill_value_is_packed_bits` flag (also exposed as a nanobind kwarg). Default keeps the existing numeric behavior for all current callers (prod, reshape, slice, sort, topk, pad, gather, layernorm).
* `permute_tiled_program_factory.cpp`, `tilize_with_val_padding_factory_helper.cpp`, `transpose_hc_tiled_interleaved_program_factory.cpp` - INT32 reuses the bit-pattern path that reduce relies on (via the transpose carried in the dim-0/1 reduce path).


### Perf Comparision:

The table below shows performance details (`Device FW Duration` in ns) from L1 Sharded and L1 Interleaved tests on Wormhole (N300). `bfloat16` and `float32` use the same execution path on both branches and show no significant performance change. For `int32`, **MAX** shows some regression because the new SFPU fold is slower per tile than the previous FPU `reduce_tile` implementation, while **MIN** improves because the old path incurred a per-tile SFPU↔FPU pipeline-switch overhead (negate + reduce) that is eliminated by the new all-SFPU implementation.

> Note : Diff % represent perf calculation with (`current branch - main branch`)

| S.No | Shape | Input DType | Dim | Op | L1 Sharded Diff % (+Ve = Degradation) | L1 Interleaved Diff % (+Ve = Degradation) |
|------|--------|------------|-----|-----|--------------------------------------|-------------------------------------------|
| 1 | (1,1,32,128) | bfloat16 | -1 | max | 0.06% | 0.11% |
| 2 | (1,1,32,128) | bfloat16 | -1 | min | -0.23% | 0.15% |
| 3 | (1,1,32,128) | bfloat16 | -2 | max | -0.66% | -0.55% |
| 4 | (1,1,32,128) | bfloat16 | -2 | min | 0.07% | 0.47% |
| 5 | (1,1,32,128) | int32 | -1 | max | 33.31% | 14.42% |
| 6 | (1,1,32,128) | int32 | -1 | min | -9.60% | -8.92% |
| 7 | (1,1,32,128) | int32 | -2 | max | 8.95% | 6.20% |
| 8 | (1,1,32,128) | int32 | -2 | min | -20.26% | -22.26% |
| 9 | (1,1,32,128) | float32 | -1 | max | 0.02% | 0.18% |
| 10 | (1,1,32,128) | float32 | -1 | min | 0.20% | -0.01% |
| 11 | (1,1,32,128) | float32 | -2 | max | 0.01% | 0.15% |
| 12 | (1,1,32,128) | float32 | -2 | min | -0.19% | -0.01% |
| 13 | (1,1,128,32) | bfloat16 | -1 | max | 0.13% | 0.15% |
| 14 | (1,1,128,32) | bfloat16 | -1 | min | 0.01% | 0.12% |
| 15 | (1,1,128,32) | bfloat16 | -2 | max | 0.14% | -0.04% |
| 16 | (1,1,128,32) | bfloat16 | -2 | min | -0.01% | 0.16% |
| 17 | (1,1,128,32) | int32 | -1 | max | 10.93% | 11.85% |
| 18 | (1,1,128,32) | int32 | -1 | min | -7.69% | -7.72% |
| 19 | (1,1,128,32) | int32 | -2 | max | 28.28% | 9.51% |
| 20 | (1,1,128,32) | int32 | -2 | min | -23.73% | -20.81% |
| 21 | (1,1,128,32) | float32 | -1 | max | -0.26% | -0.08% |
| 22 | (1,1,128,32) | float32 | -1 | min | -0.44% | -0.03% |
| 23 | (1,1,128,32) | float32 | -2 | max | -0.04% | 0.00% |
| 24 | (1,1,128,32) | float32 | -2 | min | -0.03% | 0.07% |
| 25 | (1,1,1024,1024) | bfloat16 | -1 | max | 0.02% | 0.93% |
| 26 | (1,1,1024,1024) | bfloat16 | -1 | min | 0.03% | -0.15% |
| 27 | (1,1,1024,1024) | bfloat16 | -2 | max | -0.04% | 1.05% |
| 28 | (1,1,1024,1024) | bfloat16 | -2 | min | 0.04% | 0.00% |
| 29 | (1,1,1024,1024) | int32 | -1 | max | 1.92% | 1.43% |
| 30 | (1,1,1024,1024) | int32 | -1 | min | -3.72% | -1.78% |
| 31 | (1,1,1024,1024) | int32 | -2 | max | 54.71% | 0.79% |
| 32 | (1,1,1024,1024) | int32 | -2 | min | -28.11% | -7.96% |
| 33 | (1,1,1024,1024) | float32 | -1 | max | -0.27% | -0.66% |
| 34 | (1,1,1024,1024) | float32 | -1 | min | 1.85% | -0.06% |
| 35 | (1,1,1024,1024) | float32 | -2 | max | -0.06% | -0.37% |
| 36 | (1,1,1024,1024) | float32 | -2 | min | 0.02% | -1.04% |
| 37 | (1,1,4096,256) | bfloat16 | -1 | max | 0.17% | 0.54% |
| 38 | (1,1,4096,256) | bfloat16 | -1 | min | -0.06% | -0.63% |
| 39 | (1,1,4096,256) | bfloat16 | -2 | max | -0.06% | 0.07% |
| 40 | (1,1,4096,256) | bfloat16 | -2 | min | 0.02% | 0.02% |
| 41 | (1,1,4096,256) | int32 | -1 | max | 2.84% | 2.70% |
| 42 | (1,1,4096,256) | int32 | -1 | min | 0.25% | -1.59% |
| 43 | (1,1,4096,256) | int32 | -2 | max | 63.32% | 0.31% |
| 44 | (1,1,4096,256) | int32 | -2 | min | 62.62% | -16.94% |
| 45 | (1,1,4096,256) | float32 | -1 | max | 0.85% | -0.27% |
| 46 | (1,1,4096,256) | float32 | -1 | min | -0.26% | -0.59% |
| 47 | (1,1,4096,256) | float32 | -2 | max | 0.07% | 0.18% |
| 48 | (1,1,4096,256) | float32 | -2 | min | 0.01% | 0.19% |
| 49 | (1,1,256,4096) | bfloat16 | -1 | max | -0.01% | 0.18% |
| 50 | (1,1,256,4096) | bfloat16 | -1 | min | 0.00% | 0.03% |
| 51 | (1,1,256,4096) | bfloat16 | -2 | max | -0.24% | -0.57% |
| 52 | (1,1,256,4096) | bfloat16 | -2 | min | 0.05% | 0.49% |
| 53 | (1,1,256,4096) | int32 | -1 | max | 0.84% | 1.30% |
| 54 | (1,1,256,4096) | int32 | -1 | min | -3.27% | -2.64% |
| 55 | (1,1,256,4096) | int32 | -2 | max | 45.22% | 3.17% |
| 56 | (1,1,256,4096) | int32 | -2 | min | -19.62% | -8.99% |
| 57 | (1,1,256,4096) | float32 | -1 | max | 1.58% | -0.14% |
| 58 | (1,1,256,4096) | float32 | -1 | min | -1.99% | -0.23% |
| 59 | (1,1,256,4096) | float32 | -2 | max | 0.00% | 1.49% |
| 60 | (1,1,256,4096) | float32 | -2 | min | -0.01% | -0.36% |


### Notes for reviewers

- Why the opt-in flag, not unconditional bit-cast: an earlier revision had `fill_pad` always reinterpret `int32` bits. That broke the numeric int32 behavior for its `non-reduce` callers (e.g. prod filling padding with 1 would instead store `bit_cast<uint32_t>(1.0f)`). The flag confines bit-carriage to reduce; the default stays numeric.
- Consolidation over new kernels: SFPU logic lives inside the existing reduction helpers rather than separate kernels, for maintainability.
- DST budget: the SFPU fold needs one scratch DST tile, so the chunk size drops to `DEST_AUTO_LIMIT − 1`; reader and compute kernels compute this identically.
- Performance: bf16 and fp32 unchanged (legacy FPU). INT32 MAX regress slightly (per-tile SFPU fold vs. FPU reduce). MIN improves substantially by removing the old `SFPU→FPU` pipeline-switch (negate+reduce).


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/sudha-int32-support-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/sudha-int32-support-min-max)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/sudha-int32-support-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/sudha-int32-support-min-max)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/sudha-int32-support-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/sudha-int32-support-min-max)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/sudha-int32-support-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/sudha-int32-support-min-max)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/sudha-int32-support-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/sudha-int32-support-min-max)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/sudha-int32-support-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-int32-support-min-max)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/sudha-int32-support-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-int32-support-min-max)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/sudha-int32-support-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-int32-support-min-max)


### Additional Pipelines
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=ign/sudha-int32-support-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml?query=branch%3Aign%2Fsudha-int32-support-min-max)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml/badge.svg?branch=ign/sudha-int32-support-min-max)](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml?query=branch%3Aign%2Fsudha-int32-support-min-max)