### PR TITLE
[Quasar] L1 acc compute api and test, matmul short init 

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -21,6 +21,7 @@
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include "llk_device_fixture.hpp"
@@ -491,19 +492,17 @@ bool single_block_matmul(
     }
     return pass;
 }
-// blocked matmul has blocking on output, spill/reloads using intermediate
+// blocked matmul has blocking on output, spill/reloads or does l1 accumulation using intermediate
 bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const BlockedMatmulConfig& cfg) {
     const uint32_t M = cfg.M;
     const uint32_t K = cfg.K;
     const uint32_t N = cfg.N;
     const uint32_t num_blocks = cfg.num_blocks;
 
+    const bool is_quasar = MetalContext::instance().get_cluster().arch() == ARCH::QUASAR;
+
     bool pass = true;
     CoreCoord core(0, 0);
-    const uint32_t in0_cb_index = 0;
-    const uint32_t in1_cb_index = 1;
-    const uint32_t out_cb_index = 16;
-    const uint32_t partials_cb_index = 24;
     const size_t cb_page_size = 2 * 32 * 32;
     const size_t in0_block_byte_size = M * K * cb_page_size;
     const size_t in1_block_byte_size = K * N * cb_page_size;
@@ -548,56 +547,143 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     auto output_dram_buffer = CreateBuffer(dram_config_out);
     const uint32_t out_dram_addr = output_dram_buffer->address();
 
-    tt_metal::CircularBufferConfig l1_input0_cb_config =
-        tt_metal::CircularBufferConfig(in0_block_byte_size, {{in0_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(in0_cb_index, cb_page_size);
-    tt_metal::CreateCircularBuffer(program_, core, l1_input0_cb_config);
+    uint32_t in0_id = 0;
+    uint32_t in1_id = 0;
+    uint32_t out_id = 0;
+    uint32_t partials_id = 0;
 
-    tt_metal::CircularBufferConfig l1_input1_cb_config =
-        tt_metal::CircularBufferConfig(in1_block_byte_size, {{in1_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(in1_cb_index, cb_page_size);
-    tt_metal::CreateCircularBuffer(program_, core, l1_input1_cb_config);
+    if (is_quasar) {
+        auto make_dfb = [&](uint32_t entry_size, uint32_t num_entries, uint16_t producer_mask, uint16_t consumer_mask) {
+            return tt_metal::experimental::dfb::CreateDataflowBuffer(
+                program_,
+                core,
+                tt_metal::experimental::dfb::DataflowBufferConfig{
+                    .entry_size = entry_size,
+                    .num_entries = num_entries,
+                    .producer_risc_mask = producer_mask,
+                    .num_producers = 1,
+                    .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+                    .consumer_risc_mask = consumer_mask,
+                    .num_consumers = 1,
+                    .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+                    .enable_implicit_sync = false,
+                    .data_format = tt::DataFormat::Float16_b});
+        };
+        in0_id = make_dfb(cb_page_size, M * K, 0x1, 0x100);
+        in1_id = make_dfb(cb_page_size, K * N, 0x1, 0x100);
+        out_id = make_dfb(cb_page_size, M * N, 0x100, 0x2);
+        partials_id = tt_metal::experimental::dfb::CreateDataflowBuffer(
+            program_,
+            core,
+            tt_metal::experimental::dfb::DataflowBufferConfig{
+                .entry_size = cb_page_size,
+                .num_entries = M * N,
+                .num_producers = 1,
+                .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+                .num_consumers = 1,
+                .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+                .enable_implicit_sync = false,
+                .data_format = tt::DataFormat::Float16_b,
+                .tensix_scope = tt_metal::experimental::dfb::TensixScope::INTRA});
+    } else {
+        const uint32_t in0_cb_index = 0;
+        const uint32_t in1_cb_index = 1;
+        const uint32_t out_cb_index = 16;
+        const uint32_t partials_cb_index = 24;
 
-    tt_metal::CircularBufferConfig l1_output_cb_config =
-        tt_metal::CircularBufferConfig(out_byte_size, {{out_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(out_cb_index, cb_page_size);
-    tt_metal::CreateCircularBuffer(program_, core, l1_output_cb_config);
+        tt_metal::CircularBufferConfig l1_input0_cb_config =
+            tt_metal::CircularBufferConfig(in0_block_byte_size, {{in0_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(in0_cb_index, cb_page_size);
+        tt_metal::CreateCircularBuffer(program_, core, l1_input0_cb_config);
 
-    tt_metal::CircularBufferConfig l1_partials_cb_config =
-        tt_metal::CircularBufferConfig(out_byte_size, {{partials_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(partials_cb_index, cb_page_size);
-    tt_metal::CreateCircularBuffer(program_, core, l1_partials_cb_config);
+        tt_metal::CircularBufferConfig l1_input1_cb_config =
+            tt_metal::CircularBufferConfig(in1_block_byte_size, {{in1_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(in1_cb_index, cb_page_size);
+        tt_metal::CreateCircularBuffer(program_, core, l1_input1_cb_config);
 
-    auto reader_kernel = tt_metal::CreateKernel(
-        program_,
-        "tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/reader_binary_blocked.cpp",
-        core,
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = tt_metal::NOC::RISCV_1_default,
-            .compile_args = {in0_cb_index, in1_cb_index}});
+        tt_metal::CircularBufferConfig l1_output_cb_config =
+            tt_metal::CircularBufferConfig(out_byte_size, {{out_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(out_cb_index, cb_page_size);
+        tt_metal::CreateCircularBuffer(program_, core, l1_output_cb_config);
 
-    auto writer_kernel = tt_metal::CreateKernel(
-        program_,
-        "tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/writer_unary.cpp",
-        core,
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt_metal::NOC::RISCV_0_default,
-            .compile_args = {out_cb_index}});
+        tt_metal::CircularBufferConfig l1_partials_cb_config =
+            tt_metal::CircularBufferConfig(out_byte_size, {{partials_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(partials_cb_index, cb_page_size);
+        tt_metal::CreateCircularBuffer(program_, core, l1_partials_cb_config);
+
+        in0_id = in0_cb_index;
+        in1_id = in1_cb_index;
+        out_id = out_cb_index;
+        partials_id = partials_cb_index;
+    }
 
     std::map<std::string, std::string> compute_defines;
     if (cfg.packer_l1_acc) {
         compute_defines["PACKER_L1_ACC"] = "1";
     }
-    tt_metal::CreateKernel(
-        program_,
-        "tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp",
-        core,
-        tt_metal::ComputeConfig{
-            .compile_args =
-                {in0_cb_index, in1_cb_index, out_cb_index, partials_cb_index, M * K, K * N, M * N, M, N, K, num_blocks},
-            .defines = compute_defines});
+
+    std::vector<uint32_t> compute_compile_args = {
+        in0_id, in1_id, out_id, partials_id, M * K, K * N, M * N, M, N, K, num_blocks};
+
+    KernelHandle reader_kernel;
+    KernelHandle writer_kernel;
+    KernelHandle compute_kernel;
+
+    if (is_quasar) {
+        reader_kernel = tt_metal::experimental::quasar::CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/reader_binary_blocked.cpp",
+            core,
+            tt_metal::experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1, .compile_args = {in0_id, in1_id}});
+
+        writer_kernel = tt_metal::experimental::quasar::CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/writer_unary.cpp",
+            core,
+            tt_metal::experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1, .compile_args = {out_id}});
+
+        compute_kernel = tt_metal::experimental::quasar::CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp",
+            core,
+            tt_metal::experimental::quasar::QuasarComputeConfig{
+                .num_threads_per_cluster = 1, .compile_args = compute_compile_args, .defines = compute_defines});
+
+        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program_, in0_id, reader_kernel, compute_kernel);
+        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program_, in1_id, reader_kernel, compute_kernel);
+        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program_, out_id, compute_kernel, writer_kernel);
+        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program_, partials_id, compute_kernel, compute_kernel);
+    } else {
+        reader_kernel = tt_metal::CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/reader_binary_blocked.cpp",
+            core,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = tt_metal::NOC::RISCV_1_default,
+                .compile_args = {in0_id, in1_id}});
+
+        writer_kernel = tt_metal::CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/writer_unary.cpp",
+            core,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = {out_id}});
+
+        compute_kernel = tt_metal::CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp",
+            core,
+            tt_metal::ComputeConfig{.compile_args = compute_compile_args, .defines = compute_defines});
+    }
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Stimulus Generation
@@ -653,8 +739,11 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
             (uint32_t)(M * N),
         });
 
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    auto blocking = is_quasar;
+    distributed::EnqueueMeshWorkload(cq, workload, blocking);
+    if (not blocking) {
+        distributed::Finish(cq);
+    }
     ////////////////////////////////////////////////////////////////////////////
     //                      Comparison Checking
     ////////////////////////////////////////////////////////////////////////////
@@ -694,9 +783,15 @@ TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreSingleBlockSingleTileNoAccumula
         ASSERT_TRUE(unit_tests::compute::matmul::single_block_matmul(this->devices_.at(id), 2, 1, 2));
     }
 }
+TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreBlockedComputeMatmul) {
+    unit_tests::compute::matmul::BlockedMatmulConfig config{.M = 2, .K = 2, .N = 2, .num_blocks = 1};
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        ASSERT_TRUE(unit_tests::compute::matmul::blocked_matmul(this->devices_.at(id), config));
+    }
+}
 TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreMultiBlockSpillReloadComputeMatmul) {
     unit_tests::compute::matmul::BlockedMatmulConfig config{
-        .M = 2, .K = 2, .N = 2, .num_blocks = 2 .packer_l1_acc = false};
+        .M = 2, .K = 2, .N = 2, .num_blocks = 2, .packer_l1_acc = false};
     for (unsigned int id = 0; id < num_devices_; id++) {
         ASSERT_TRUE(unit_tests::compute::matmul::blocked_matmul(this->devices_.at(id), config));
     }

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -47,6 +47,18 @@ using namespace tt::test_utils::df;
 
 namespace unit_tests::compute::matmul {
 
+// Per-block matmul: out[M x N] = in0[M x K] * in1[K x N]
+// Repeated num_blocks times along K with partials accumulation.
+// If K > 1 -> dest accumulation within each block
+// If num_blocks > 1 -> partials accumulation (either l1 accumulation or spill and reload)
+struct BlockedMatmulConfig {
+    uint32_t M = 1;           // per-block rows (tiles)
+    uint32_t K = 1;           // per-block inner dim (tiles)
+    uint32_t N = 1;           // per-block cols (tiles)
+    uint32_t num_blocks = 1;  // number of K-blocks
+    bool packer_l1_acc = false;
+};
+
 void create_CBs_for_fused_matmul(
     distributed::MeshWorkload& workload,
     const std::shared_ptr<distributed::MeshDevice>& /*mesh_device*/,
@@ -480,19 +492,24 @@ bool single_block_matmul(
     return pass;
 }
 // blocked matmul has blocking on output, spill/reloads using intermediate
-bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t M, uint32_t K, uint32_t N) {
+bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const BlockedMatmulConfig& cfg) {
+    const uint32_t M = cfg.M;
+    const uint32_t K = cfg.K;
+    const uint32_t N = cfg.N;
+    const uint32_t num_blocks = cfg.num_blocks;
+
     bool pass = true;
-    // FIXME: Convert to config
     CoreCoord core(0, 0);
     const uint32_t in0_cb_index = 0;
     const uint32_t in1_cb_index = 1;
     const uint32_t out_cb_index = 16;
     const uint32_t partials_cb_index = 24;
     const size_t cb_page_size = 2 * 32 * 32;
-    const size_t in0_byte_size = M * K * cb_page_size;
-    const size_t in1_byte_size = K * N * cb_page_size;
+    const size_t in0_block_byte_size = M * K * cb_page_size;
+    const size_t in1_block_byte_size = K * N * cb_page_size;
+    const size_t in0_total_byte_size = num_blocks * in0_block_byte_size;
+    const size_t in1_total_byte_size = num_blocks * in1_block_byte_size;
     const size_t out_byte_size = M * N * cb_page_size;
-    const size_t num_blocks = 1;
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
@@ -504,14 +521,14 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
 
     tt::tt_metal::InterleavedBufferConfig dram_config_0{
         .device = device,
-        .size = in0_byte_size,
-        .page_size = in0_byte_size,
+        .size = in0_total_byte_size,
+        .page_size = in0_total_byte_size,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
 
     tt::tt_metal::InterleavedBufferConfig dram_config_1{
         .device = device,
-        .size = in1_byte_size,
-        .page_size = in1_byte_size,
+        .size = in1_total_byte_size,
+        .page_size = in1_total_byte_size,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
 
     tt::tt_metal::InterleavedBufferConfig dram_config_out{
@@ -531,12 +548,13 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     auto output_dram_buffer = CreateBuffer(dram_config_out);
     const uint32_t out_dram_addr = output_dram_buffer->address();
 
-    tt_metal::CircularBufferConfig l1_input0_cb_config = tt_metal::CircularBufferConfig(in0_byte_size, {{in0_cb_index, tt::DataFormat::Float16_b}})
-        .set_page_size(in0_cb_index, cb_page_size);
+    tt_metal::CircularBufferConfig l1_input0_cb_config =
+        tt_metal::CircularBufferConfig(in0_block_byte_size, {{in0_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(in0_cb_index, cb_page_size);
     tt_metal::CreateCircularBuffer(program_, core, l1_input0_cb_config);
 
     tt_metal::CircularBufferConfig l1_input1_cb_config =
-        tt_metal::CircularBufferConfig(in1_byte_size, {{in1_cb_index, tt::DataFormat::Float16_b}})
+        tt_metal::CircularBufferConfig(in1_block_byte_size, {{in1_cb_index, tt::DataFormat::Float16_b}})
             .set_page_size(in1_cb_index, cb_page_size);
     tt_metal::CreateCircularBuffer(program_, core, l1_input1_cb_config);
 
@@ -568,40 +586,38 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
             .noc = tt_metal::NOC::RISCV_0_default,
             .compile_args = {out_cb_index}});
 
+    std::map<std::string, std::string> compute_defines;
+    if (cfg.packer_l1_acc) {
+        compute_defines["PACKER_L1_ACC"] = "1";
+    }
     tt_metal::CreateKernel(
         program_,
         "tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp",
         core,
         tt_metal::ComputeConfig{
-            .compile_args = {
-                in0_cb_index,
-                in1_cb_index,
-                out_cb_index,
-                partials_cb_index,
-                M * K,
-                K * N,
-                M * N,
-                M,
-                N,
-                K,
-                num_blocks}});
+            .compile_args =
+                {in0_cb_index, in1_cb_index, out_cb_index, partials_cb_index, M * K, K * N, M * N, M, N, K, num_blocks},
+            .defines = compute_defines});
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Stimulus Generation
     ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> packed_input0 = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
-        1.0f, 1.0f, in0_byte_size / sizeof(bfloat16), std::chrono::system_clock::now().time_since_epoch().count());
+        1.0f,
+        1.0f,
+        in0_total_byte_size / sizeof(bfloat16),
+        std::chrono::system_clock::now().time_since_epoch().count());
     std::vector<uint32_t> packed_input1 = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
         0.03125f,
         0.03125f,
-        in1_byte_size / sizeof(bfloat16),
+        in1_total_byte_size / sizeof(bfloat16),
         std::chrono::system_clock::now().time_since_epoch().count());
     ////////////////////////////////////////////////////////////////////////////
     //                      Golden Generation
     ////////////////////////////////////////////////////////////////////////////
     auto packed_golden = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
-        1.0f * K,
-        1.0f * K,
+        1.0f * K * num_blocks,
+        1.0f * K * num_blocks,
         (out_byte_size) / sizeof(bfloat16),
         std::chrono::system_clock::now().time_since_epoch().count());
 
@@ -621,11 +637,11 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
             (uint32_t)0,
             (uint32_t)in1_dram_addr,
             (uint32_t)0,
-            (uint32_t)1,              // num_blocks
-            (uint32_t)M * K,          // in0_block_tile_cnt
-            (uint32_t)K * N,          // in1_block_tile_cnt
-            (uint32_t)in0_byte_size,  // in0_block_size_bytes
-            (uint32_t)in1_byte_size,  // in1_block_size_bytes
+            (uint32_t)num_blocks,
+            (uint32_t)(M * K),
+            (uint32_t)(K * N),
+            (uint32_t)in0_block_byte_size,
+            (uint32_t)in1_block_byte_size,
         });
     tt_metal::SetRuntimeArgs(
         program_,
@@ -634,7 +650,7 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
         {
             (uint32_t)out_dram_addr,
             (uint32_t)0,
-            (uint32_t)M * N,
+            (uint32_t)(M * N),
         });
 
     distributed::EnqueueMeshWorkload(cq, workload, false);
@@ -676,6 +692,20 @@ TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreSingleBlockSingleTileAccumulati
 TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreSingleBlockSingleTileNoAccumulationComputeMatmul) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         ASSERT_TRUE(unit_tests::compute::matmul::single_block_matmul(this->devices_.at(id), 2, 1, 2));
+    }
+}
+TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreMultiBlockSpillReloadComputeMatmul) {
+    unit_tests::compute::matmul::BlockedMatmulConfig config{
+        .M = 2, .K = 2, .N = 2, .num_blocks = 2 .packer_l1_acc = false};
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        ASSERT_TRUE(unit_tests::compute::matmul::blocked_matmul(this->devices_.at(id), config));
+    }
+}
+TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreMultiBlockL1AccComputeMatmul) {
+    unit_tests::compute::matmul::BlockedMatmulConfig config{
+        .M = 2, .K = 2, .N = 2, .num_blocks = 2, .packer_l1_acc = true};
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        ASSERT_TRUE(unit_tests::compute::matmul::blocked_matmul(this->devices_.at(id), config));
     }
 }
 

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -22,6 +22,7 @@
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include "llk_device_fixture.hpp"
@@ -785,14 +786,14 @@ TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreSingleBlockSingleTileNoAccumula
 }
 TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreMultiBlockSpillReloadComputeMatmul) {
     unit_tests::compute::matmul::BlockedMatmulConfig config{
-        .M = 2, .K = 2, .N = 2, .num_blocks = 2, .packer_l1_acc = false};
+        .M = 2, .K = 2, .N = 2, .num_blocks = 7, .packer_l1_acc = false};
     for (unsigned int id = 0; id < num_devices_; id++) {
         ASSERT_TRUE(unit_tests::compute::matmul::blocked_matmul(this->devices_.at(id), config));
     }
 }
 TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreMultiBlockL1AccComputeMatmul) {
     unit_tests::compute::matmul::BlockedMatmulConfig config{
-        .M = 2, .K = 2, .N = 2, .num_blocks = 2, .packer_l1_acc = true};
+        .M = 2, .K = 2, .N = 2, .num_blocks = 7, .packer_l1_acc = true};
     for (unsigned int id = 0; id < num_devices_; id++) {
         ASSERT_TRUE(unit_tests::compute::matmul::blocked_matmul(this->devices_.at(id), config));
     }

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -693,8 +693,10 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     ////////////////////////////////////////////////////////////////////////////
     //                      Stimulus Generation
     ////////////////////////////////////////////////////////////////////////////
-    auto packed_input0 = create_random_vector_of_bfloat16(in0_total_size_bytes, 1.0f, 0x1234);
-    auto packed_input1 = create_random_vector_of_bfloat16(in1_total_size_bytes, 1.0f, 0x5678, -0.5f);
+    std::vector<uint32_t> packed_input0 = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
+        0.0f, 1.0f, in0_total_size_bytes / sizeof(bfloat16), 0x1234);
+    std::vector<uint32_t> packed_input1 = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
+        -0.45f, 1.0f, in1_total_size_bytes / sizeof(bfloat16), 0x5678);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Golden Generation
@@ -791,19 +793,15 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     std::vector<uint32_t> dest_buffer_data;
     tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
 
-    auto comparison_function = [](float a, float b) {
-        const float rtol = 0.05f;
-        const float atol = 0.05f;
-        float maxabs = fmaxf(fabsf(a), fabsf(b));
-        float absdiff = fabsf(a - b);
-        return (absdiff <= atol) || absdiff < rtol * maxabs;
-    };
-    int argfail = -1;
-    pass &= packed_uint32_t_vector_comparison(dest_buffer_data, packed_golden, comparison_function, &argfail);
+    int failed_index;
+    pass &= is_close_packed_vectors<bfloat16, uint32_t>(
+        dest_buffer_data,
+        packed_golden,
+        [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b, 0.05f, 0.05f); },
+        &failed_index);
     if (not pass) {
-        log_info(tt::LogTest, "Failed at index={}", argfail);
-        print_vec_of_uint32_as_packed_bfloat16(dest_buffer_data, M * N, "Result");
-        print_vec_of_uint32_as_packed_bfloat16(packed_golden, M * N, "Golden");
+        log_info(tt::LogTest, "Failed Index={}", failed_index);
+        print_vector_fixed_numel_per_row(unpack_vector<bfloat16, uint32_t>(dest_buffer_data), 32);
     }
     return pass;
 }
@@ -831,14 +829,14 @@ TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreSingleBlockSingleTileNoAccumula
 }
 TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreMultiBlockSpillReloadComputeMatmul) {
     unit_tests::compute::matmul::BlockedMatmulConfig config{
-        .M = 2, .K = 2, .N = 2, .num_blocks = 7, .packer_l1_acc = false};
+        .M = 2, .K = 2, .N = 2, .num_blocks = 4, .packer_l1_acc = false};
     for (unsigned int id = 0; id < num_devices_; id++) {
         ASSERT_TRUE(unit_tests::compute::matmul::blocked_matmul(this->devices_.at(id), config));
     }
 }
 TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreMultiBlockL1AccComputeMatmul) {
     unit_tests::compute::matmul::BlockedMatmulConfig config{
-        .M = 2, .K = 2, .N = 2, .num_blocks = 7, .packer_l1_acc = true};
+        .M = 2, .K = 2, .N = 2, .num_blocks = 4, .packer_l1_acc = true};
     for (unsigned int id = 0; id < num_devices_; id++) {
         ASSERT_TRUE(unit_tests::compute::matmul::blocked_matmul(this->devices_.at(id), config));
     }

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -49,7 +49,7 @@ using namespace tt::test_utils::df;
 namespace unit_tests::compute::matmul {
 
 // Per-block matmul: out[M x N] = in0[M x K] * in1[K x N]
-// Repeated num_blocks times along K with partials accumulation.
+// Repeated num_blocks times
 // If K > 1 -> dest accumulation within each block
 // If num_blocks > 1 -> partials accumulation (either l1 accumulation or spill and reload)
 struct BlockedMatmulConfig {
@@ -504,10 +504,10 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     bool pass = true;
     CoreCoord core(0, 0);
     const size_t cb_page_size = 2 * 32 * 32;
-    const size_t in0_block_byte_size = M * K * cb_page_size;
-    const size_t in1_block_byte_size = K * N * cb_page_size;
-    const size_t in0_total_byte_size = num_blocks * in0_block_byte_size;
-    const size_t in1_total_byte_size = num_blocks * in1_block_byte_size;
+    const size_t in0_block_size_bytes = M * K * cb_page_size;
+    const size_t in1_block_size_bytes = K * N * cb_page_size;
+    const size_t in0_total_size_bytes = num_blocks * in0_block_size_bytes;
+    const size_t in1_total_size_bytes = num_blocks * in1_block_size_bytes;
     const size_t out_byte_size = M * N * cb_page_size;
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
@@ -520,14 +520,14 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
 
     tt::tt_metal::InterleavedBufferConfig dram_config_0{
         .device = device,
-        .size = in0_total_byte_size,
-        .page_size = in0_total_byte_size,
+        .size = in0_total_size_bytes,
+        .page_size = in0_total_size_bytes,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
 
     tt::tt_metal::InterleavedBufferConfig dram_config_1{
         .device = device,
-        .size = in1_total_byte_size,
-        .page_size = in1_total_byte_size,
+        .size = in1_total_size_bytes,
+        .page_size = in1_total_size_bytes,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
 
     tt::tt_metal::InterleavedBufferConfig dram_config_out{
@@ -592,12 +592,12 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
         const uint32_t partials_cb_index = 24;
 
         tt_metal::CircularBufferConfig l1_input0_cb_config =
-            tt_metal::CircularBufferConfig(in0_block_byte_size, {{in0_cb_index, tt::DataFormat::Float16_b}})
+            tt_metal::CircularBufferConfig(in0_block_size_bytes, {{in0_cb_index, tt::DataFormat::Float16_b}})
                 .set_page_size(in0_cb_index, cb_page_size);
         tt_metal::CreateCircularBuffer(program_, core, l1_input0_cb_config);
 
         tt_metal::CircularBufferConfig l1_input1_cb_config =
-            tt_metal::CircularBufferConfig(in1_block_byte_size, {{in1_cb_index, tt::DataFormat::Float16_b}})
+            tt_metal::CircularBufferConfig(in1_block_size_bytes, {{in1_cb_index, tt::DataFormat::Float16_b}})
                 .set_page_size(in1_cb_index, cb_page_size);
         tt_metal::CreateCircularBuffer(program_, core, l1_input1_cb_config);
 
@@ -691,12 +691,12 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     std::vector<uint32_t> packed_input0 = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
         1.0f,
         1.0f,
-        in0_total_byte_size / sizeof(bfloat16),
+        in0_total_size_bytes / sizeof(bfloat16),
         std::chrono::system_clock::now().time_since_epoch().count());
     std::vector<uint32_t> packed_input1 = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
         0.03125f,
         0.03125f,
-        in1_total_byte_size / sizeof(bfloat16),
+        in1_total_size_bytes / sizeof(bfloat16),
         std::chrono::system_clock::now().time_since_epoch().count());
     ////////////////////////////////////////////////////////////////////////////
     //                      Golden Generation
@@ -724,10 +724,10 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
             (uint32_t)in1_dram_addr,
             (uint32_t)0,
             (uint32_t)num_blocks,
-            (uint32_t)(M * K),
-            (uint32_t)(K * N),
-            (uint32_t)in0_block_byte_size,
-            (uint32_t)in1_block_byte_size,
+            (uint32_t)(M * K),  // in0_block_tile_cnt
+            (uint32_t)(K * N),  // in1_block_tile_cnt
+            (uint32_t)in0_block_size_bytes,
+            (uint32_t)in1_block_size_bytes,
         });
     tt_metal::SetRuntimeArgs(
         program_,
@@ -781,12 +781,6 @@ TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreSingleBlockSingleTileAccumulati
 TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreSingleBlockSingleTileNoAccumulationComputeMatmul) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         ASSERT_TRUE(unit_tests::compute::matmul::single_block_matmul(this->devices_.at(id), 2, 1, 2));
-    }
-}
-TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreBlockedComputeMatmul) {
-    unit_tests::compute::matmul::BlockedMatmulConfig config{.M = 2, .K = 2, .N = 2, .num_blocks = 1};
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        ASSERT_TRUE(unit_tests::compute::matmul::blocked_matmul(this->devices_.at(id), config));
     }
 }
 TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreMultiBlockSpillReloadComputeMatmul) {

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <bit>
 #include <chrono>
+#include <cmath>
 #include <fmt/base.h>
 #include <gtest/gtest.h>
 #include <cstdint>
@@ -31,6 +33,8 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+#include "impl/data_format/bfloat16_utils.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/df/float32.hpp"
 #include "tt_metal/test_utils/packing.hpp"
@@ -689,24 +693,60 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     ////////////////////////////////////////////////////////////////////////////
     //                      Stimulus Generation
     ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> packed_input0 = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
-        1.0f,
-        1.0f,
-        in0_total_size_bytes / sizeof(bfloat16),
-        std::chrono::system_clock::now().time_since_epoch().count());
-    std::vector<uint32_t> packed_input1 = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
-        0.03125f,
-        0.03125f,
-        in1_total_size_bytes / sizeof(bfloat16),
-        std::chrono::system_clock::now().time_since_epoch().count());
+    auto packed_input0 = create_random_vector_of_bfloat16(in0_total_size_bytes, 1.0f, 0x1234);
+    auto packed_input1 = create_random_vector_of_bfloat16(in1_total_size_bytes, 1.0f, 0x5678, -0.5f);
+
     ////////////////////////////////////////////////////////////////////////////
     //                      Golden Generation
     ////////////////////////////////////////////////////////////////////////////
-    auto packed_golden = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
-        1.0f * K * num_blocks,
-        1.0f * K * num_blocks,
-        (out_byte_size) / sizeof(bfloat16),
-        std::chrono::system_clock::now().time_since_epoch().count());
+    // Data in DRAM is in TILED_NFACES layout, stored as num_blocks consecutive
+    // blocks of [M*32, K*32] and [K*32, N*32] respectively.
+    const uint32_t M_elem = M * 32;
+    const uint32_t K_elem = K * 32;
+    const uint32_t N_elem = N * 32;
+    const uint32_t block_in0_elems = M_elem * K_elem;
+    const uint32_t block_in1_elems = K_elem * N_elem;
+    const uint32_t out_elems = M_elem * N_elem;
+
+    auto u16_in0 = u16_from_u32_vector(packed_input0);
+    auto u16_in1 = u16_from_u32_vector(packed_input1);
+
+    std::vector<float> golden_float(out_elems, 0.0f);
+    std::vector<uint32_t> block_shape_in0 = {1, 1, M_elem, K_elem};
+    std::vector<uint32_t> block_shape_in1 = {1, 1, K_elem, N_elem};
+
+    for (uint32_t b = 0; b < num_blocks; b++) {
+        // Extract this block's tile data and untilize to row-major
+        std::vector<uint16_t> block_in0(
+            u16_in0.begin() + b * block_in0_elems, u16_in0.begin() + (b + 1) * block_in0_elems);
+        std::vector<uint16_t> block_in1(
+            u16_in1.begin() + b * block_in1_elems, u16_in1.begin() + (b + 1) * block_in1_elems);
+
+        auto in0_rm = convert_layout<uint16_t>(
+            block_in0, block_shape_in0, TensorLayoutType::TILED_NFACES, TensorLayoutType::LIN_ROW_MAJOR);
+        auto in1_rm = convert_layout<uint16_t>(
+            block_in1, block_shape_in1, TensorLayoutType::TILED_NFACES, TensorLayoutType::LIN_ROW_MAJOR);
+
+        for (uint32_t i = 0; i < M_elem; i++) {
+            for (uint32_t j = 0; j < N_elem; j++) {
+                for (uint32_t k = 0; k < K_elem; k++) {
+                    float a = static_cast<float>(std::bit_cast<bfloat16>(in0_rm[i * K_elem + k]));
+                    float bb = static_cast<float>(std::bit_cast<bfloat16>(in1_rm[k * N_elem + j]));
+                    golden_float[i * N_elem + j] += a * bb;
+                }
+            }
+        }
+    }
+
+    // Convert golden from float to bfloat16, tilize, and pack
+    std::vector<uint16_t> golden_u16(out_elems);
+    for (uint32_t i = 0; i < out_elems; i++) {
+        golden_u16[i] = std::bit_cast<uint16_t>(bfloat16(golden_float[i]));
+    }
+    std::vector<uint32_t> out_shape = {1, 1, M_elem, N_elem};
+    auto golden_tiled = convert_layout<uint16_t>(
+        golden_u16, out_shape, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_NFACES);
+    auto packed_golden = u32_from_u16_vector(golden_tiled);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Compile and Execute Application
@@ -750,15 +790,20 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> dest_buffer_data;
     tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
-    int failed_index;
-    pass &= is_close_packed_vectors<bfloat16, uint32_t>(
-        dest_buffer_data,
-        packed_golden,
-        [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b, 0.015f); },
-        &failed_index);
+
+    auto comparison_function = [](float a, float b) {
+        const float rtol = 0.05f;
+        const float atol = 0.05f;
+        float maxabs = fmaxf(fabsf(a), fabsf(b));
+        float absdiff = fabsf(a - b);
+        return (absdiff <= atol) || absdiff < rtol * maxabs;
+    };
+    int argfail = -1;
+    pass &= packed_uint32_t_vector_comparison(dest_buffer_data, packed_golden, comparison_function, &argfail);
     if (not pass) {
-        log_info(tt::LogTest, "Failed Index={}", failed_index);
-        print_vector_fixed_numel_per_row(unpack_vector<bfloat16, uint32_t>(dest_buffer_data), 32);
+        log_info(tt::LogTest, "Failed at index={}", argfail);
+        print_vec_of_uint32_as_packed_bfloat16(dest_buffer_data, M * N, "Result");
+        print_vec_of_uint32_as_packed_bfloat16(packed_golden, M * N, "Golden");
     }
     return pass;
 }

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -694,9 +694,15 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     //                      Stimulus Generation
     ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> packed_input0 = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
-        0.0f, 1.0f, in0_total_size_bytes / sizeof(bfloat16), 0x1234);
+        0.0f,
+        1.0f,
+        in0_total_size_bytes / sizeof(bfloat16),
+        std::chrono::system_clock::now().time_since_epoch().count());
     std::vector<uint32_t> packed_input1 = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
-        -0.45f, 1.0f, in1_total_size_bytes / sizeof(bfloat16), 0x5678);
+        -0.45f,
+        1.0f,
+        in1_total_size_bytes / sizeof(bfloat16),
+        std::chrono::system_clock::now().time_since_epoch().count());
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Golden Generation

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
@@ -103,7 +103,7 @@ void kernel_main() {
         auto& cb_dst = is_last ? cb_out : cb_partials;
         const uint32_t cb_dst_id = is_last ? out_id : partials_id;
         if (is_last) {
-            PACK((llk_pack_init(out_id)));
+            pack_init(out_id);
         }
         cb_dst.reserve_back(out_block_num_tiles);
         for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
@@ -125,7 +125,7 @@ void kernel_main() {
     }
     cb_partials.pop_front(out_block_num_tiles);
 
-    PACK((llk_pack_init(out_id)));
+    pack_init(out_id);
     cb_out.reserve_back(out_block_num_tiles);
     for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
         pack_tile(tile_index, out_id);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
@@ -90,7 +90,7 @@ void kernel_main() {
 
 #ifdef PACKER_L1_ACC
         for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
-            pack_tile<true>(tile_index, partials_id, tile_index);
+            pack_tile<true /* out_of_order_output */>(tile_index, partials_id, tile_index);
         }
         if (block_id == 0) {
             pack_reconfig_l1_acc(1);
@@ -98,16 +98,16 @@ void kernel_main() {
         release_dst();
 #else
         const bool is_last = (block_id == last_block_id);
-        auto& cb_acc = is_last ? cb_out : cb_partials;
-        const uint32_t acc_id = is_last ? out_id : partials_id;
+        auto& cb_dst = is_last ? cb_out : cb_partials;
+        const uint32_t cb_dst_id = is_last ? out_id : partials_id;
         if (is_last) {
             PACK((llk_pack_init(out_id)));
         }
-        cb_acc.reserve_back(out_block_num_tiles);
+        cb_dst.reserve_back(out_block_num_tiles);
         for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
-            pack_tile(tile_index, acc_id);
+            pack_tile(tile_index, cb_dst_id);
         }
-        cb_acc.push_back(out_block_num_tiles);
+        cb_dst.push_back(out_block_num_tiles);
         release_dst();
 #endif
     }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
@@ -48,16 +48,15 @@ void kernel_main() {
 #endif
 
     // out = in0[r x k]*in1[k x c]
-    mm_init(in0_id, in1_id, out_id);
+    mm_init(in0_id, in1_id, partials_id);
+
+#ifdef PACKER_L1_ACC
+    cb_partials.reserve_back(out_block_num_tiles);
+#endif
 
     for (uint32_t block_id = 0; block_id < num_blocks; block_id++) {
         acquire_dst();
-#ifdef PACKER_L1_ACC
-        if (block_id > 0) {
-            cb_partials.wait_front(out_block_num_tiles);
-            cb_partials.pop_front(out_block_num_tiles);
-        }
-#else
+#ifndef PACKER_L1_ACC
         if (block_id > 0) {
             copy_tile_to_dst_init_short(partials_id);
             cb_partials.wait_front(out_block_num_tiles);
@@ -90,17 +89,20 @@ void kernel_main() {
         cb_in1.pop_front(in1_block_num_tiles);
 
 #ifdef PACKER_L1_ACC
-        pack_reconfig_l1_acc(block_id == 0 ? 0 : 1);
-        cb_partials.reserve_back(out_block_num_tiles);
         for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
-            pack_tile(tile_index, partials_id);
+            pack_tile<true>(tile_index, partials_id, tile_index);
         }
-        cb_partials.push_back(out_block_num_tiles);
+        if (block_id == 0) {
+            pack_reconfig_l1_acc(1);
+        }
         release_dst();
 #else
         const bool is_last = (block_id == last_block_id);
         auto& cb_acc = is_last ? cb_out : cb_partials;
         const uint32_t acc_id = is_last ? out_id : partials_id;
+        if (is_last) {
+            PACK((llk_pack_init(out_id)));
+        }
         cb_acc.reserve_back(out_block_num_tiles);
         for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
             pack_tile(tile_index, acc_id);
@@ -111,6 +113,7 @@ void kernel_main() {
     }
 
 #ifdef PACKER_L1_ACC
+    cb_partials.push_back(out_block_num_tiles);
     pack_reconfig_l1_acc(0);
 
     copy_tile_to_dst_init_short(partials_id);
@@ -121,6 +124,7 @@ void kernel_main() {
     }
     cb_partials.pop_front(out_block_num_tiles);
 
+    PACK((llk_pack_init(out_id)));
     cb_out.reserve_back(out_block_num_tiles);
     for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
         pack_tile(tile_index, out_id);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
@@ -5,7 +5,10 @@
 #include <cstdint>
 
 #include "api/compute/matmul.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/pack.h"
 #include "api/compute/compute_kernel_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     const uint32_t in0_cb = get_compile_time_arg_val(0);
@@ -31,6 +34,7 @@ void kernel_main() {
     mm_init(in0_cb, in1_cb, out_cb);
     for (uint32_t block_id = 0; block_id < num_blocks; block_id++) {
         acquire_dst();
+#ifndef PACKER_L1_ACC
         if (block_id > 0) {
             copy_tile_to_dst_init_short(partials_cb);
             cb_partials.wait_front(out_block_num_tiles);
@@ -40,6 +44,8 @@ void kernel_main() {
             cb_partials.pop_front(out_block_num_tiles);
             mm_init_short(in0_cb, in1_cb);
         }
+#endif
+
         uint32_t out_tile_index = 0;
         uint32_t in0_index_r_offset = 0;
         cb0.wait_front(in0_block_num_tiles);
@@ -51,7 +57,7 @@ void kernel_main() {
                     int in0_tile_index = in0_index_r_offset + k;
                     int in1_tile_index = in1_index_c_offset + c;
                     matmul_tiles(in0_cb, in1_cb, in0_tile_index, in1_tile_index, out_tile_index);
-                    in1_index_c_offset += k;
+                    in1_index_c_offset += out_c;
                 }
                 out_tile_index++;
             }
@@ -60,17 +66,51 @@ void kernel_main() {
         cb0.pop_front(in0_block_num_tiles);
         cb1.pop_front(in1_block_num_tiles);
 
+#ifdef PACKER_L1_ACC
+        pack_reconfig_l1_acc(block_id == 0 ? 0 : 1);
+        cb_partials.reserve_back(out_block_num_tiles);
         for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
-            if (block_id == last_block_id) {
-                cb_out.reserve_back(out_block_num_tiles);
-                pack_tile(tile_index, out_cb);
-                cb_out.push_back(out_block_num_tiles);
-            } else {
-                cb_partials.reserve_back(out_block_num_tiles);
-                pack_tile(tile_index, partials_cb);
-                cb_partials.push_back(out_block_num_tiles);
+            pack_tile(tile_index, partials_cb);
+        }
+        cb_partials.push_back(out_block_num_tiles);
+        release_dst();
+
+        if (block_id < last_block_id) {
+            cb_partials.wait_front(out_block_num_tiles);
+            cb_partials.pop_front(out_block_num_tiles);
+        }
+
+        if (block_id == last_block_id) {
+            pack_reconfig_l1_acc(0);
+            copy_tile_to_dst_init_short(partials_cb);
+            cb_partials.wait_front(out_block_num_tiles);
+            acquire_dst();
+            for (uint32_t i = 0; i < out_block_num_tiles; i++) {
+                copy_tile(partials_cb, i, i);
             }
+            cb_partials.pop_front(out_block_num_tiles);
+            cb_out.reserve_back(out_block_num_tiles);
+            for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
+                pack_tile(tile_index, out_cb);
+            }
+            cb_out.push_back(out_block_num_tiles);
+            release_dst();
+        }
+#else
+        if (block_id == last_block_id) {
+            cb_out.reserve_back(out_block_num_tiles);
+            for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
+                pack_tile(tile_index, out_cb);
+            }
+            cb_out.push_back(out_block_num_tiles);
+        } else {
+            cb_partials.reserve_back(out_block_num_tiles);
+            for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
+                pack_tile(tile_index, partials_cb);
+            }
+            cb_partials.push_back(out_block_num_tiles);
         }
         release_dst();
+#endif
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
@@ -50,10 +50,6 @@ void kernel_main() {
     // out = in0[r x k]*in1[k x c]
     mm_init(in0_id, in1_id, partials_id);
 
-#ifdef PACKER_L1_ACC
-    cb_partials.reserve_back(out_block_num_tiles);
-#endif
-
     for (uint32_t block_id = 0; block_id < num_blocks; block_id++) {
         acquire_dst();
 #ifndef PACKER_L1_ACC
@@ -89,13 +85,19 @@ void kernel_main() {
         cb_in1.pop_front(in1_block_num_tiles);
 
 #ifdef PACKER_L1_ACC
+        cb_partials.reserve_back(out_block_num_tiles);
         for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
-            pack_tile<true /* out_of_order_output */>(tile_index, partials_id, tile_index);
+            pack_tile(tile_index, partials_id);
         }
+        cb_partials.push_back(out_block_num_tiles);
         if (block_id == 0) {
             pack_reconfig_l1_acc(1);
         }
         release_dst();
+        if (block_id < last_block_id) {
+            cb_partials.wait_front(out_block_num_tiles);
+            cb_partials.pop_front(out_block_num_tiles);
+        }
 #else
         const bool is_last = (block_id == last_block_id);
         auto& cb_dst = is_last ? cb_out : cb_partials;
@@ -113,7 +115,6 @@ void kernel_main() {
     }
 
 #ifdef PACKER_L1_ACC
-    cb_partials.push_back(out_block_num_tiles);
     pack_reconfig_l1_acc(0);
 
     copy_tile_to_dst_init_short(partials_id);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
@@ -7,8 +7,11 @@
 #include "api/compute/matmul.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/pack.h"
-#include "api/compute/compute_kernel_api.h"
-#include "experimental/circular_buffer.h"
+#ifdef ARCH_QUASAR
+#include "api/dataflow/dataflow_buffer.h"
+#else
+#include "api/dataflow/circular_buffer.h"
+#endif
 
 void kernel_main() {
     const uint32_t in0_cb = get_compile_time_arg_val(0);
@@ -24,93 +27,105 @@ void kernel_main() {
     const uint32_t num_blocks = get_compile_time_arg_val(10);
     const uint32_t last_block_id = num_blocks - 1;
 
-    CircularBuffer cb0(in0_cb);
-    CircularBuffer cb1(in1_cb);
+#ifdef ARCH_QUASAR
+    DataflowBuffer cb_in0(in0_cb);
+    DataflowBuffer cb_in1(in1_cb);
+    DataflowBuffer cb_partials(partials_cb);
+    DataflowBuffer cb_out(out_cb);
+    const uint32_t in0_id = cb_in0.get_id();
+    const uint32_t in1_id = cb_in1.get_id();
+    const uint32_t out_id = cb_out.get_id();
+    const uint32_t partials_id = cb_partials.get_id();
+#else
+    CircularBuffer cb_in0(in0_cb);
+    CircularBuffer cb_in1(in1_cb);
     CircularBuffer cb_partials(partials_cb);
     CircularBuffer cb_out(out_cb);
+    const uint32_t in0_id = in0_cb;
+    const uint32_t in1_id = in1_cb;
+    const uint32_t out_id = out_cb;
+    const uint32_t partials_id = partials_cb;
+#endif
 
-    // we are looking at block
     // out = in0[r x k]*in1[k x c]
-    mm_init(in0_cb, in1_cb, out_cb);
+    mm_init(in0_id, in1_id, out_id);
+
     for (uint32_t block_id = 0; block_id < num_blocks; block_id++) {
         acquire_dst();
-#ifndef PACKER_L1_ACC
+#ifdef PACKER_L1_ACC
         if (block_id > 0) {
-            copy_tile_to_dst_init_short(partials_cb);
+            cb_partials.wait_front(out_block_num_tiles);
+            cb_partials.pop_front(out_block_num_tiles);
+        }
+#else
+        if (block_id > 0) {
+            copy_tile_to_dst_init_short(partials_id);
             cb_partials.wait_front(out_block_num_tiles);
             for (uint32_t i = 0; i < out_block_num_tiles; i++) {
-                copy_tile(partials_cb, i, i);
+                copy_tile(partials_id, i, i);
             }
             cb_partials.pop_front(out_block_num_tiles);
-            mm_init_short(in0_cb, in1_cb);
+            mm_init_short(in0_id, in1_id);
         }
 #endif
 
         uint32_t out_tile_index = 0;
         uint32_t in0_index_r_offset = 0;
-        cb0.wait_front(in0_block_num_tiles);
-        cb1.wait_front(in1_block_num_tiles);
+        cb_in0.wait_front(in0_block_num_tiles);
+        cb_in1.wait_front(in1_block_num_tiles);
         for (uint32_t r = 0; r < out_r; r++) {
             for (uint32_t c = 0; c < out_c; c++) {
                 uint32_t in1_index_c_offset = 0;
                 for (uint32_t k = 0; k < in0_k; k++) {
                     int in0_tile_index = in0_index_r_offset + k;
                     int in1_tile_index = in1_index_c_offset + c;
-                    matmul_tiles(in0_cb, in1_cb, in0_tile_index, in1_tile_index, out_tile_index);
+                    matmul_tiles(in0_id, in1_id, in0_tile_index, in1_tile_index, out_tile_index);
                     in1_index_c_offset += out_c;
                 }
                 out_tile_index++;
             }
             in0_index_r_offset += in0_k;
         }
-        cb0.pop_front(in0_block_num_tiles);
-        cb1.pop_front(in1_block_num_tiles);
+        cb_in0.pop_front(in0_block_num_tiles);
+        cb_in1.pop_front(in1_block_num_tiles);
 
 #ifdef PACKER_L1_ACC
         pack_reconfig_l1_acc(block_id == 0 ? 0 : 1);
         cb_partials.reserve_back(out_block_num_tiles);
         for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
-            pack_tile(tile_index, partials_cb);
+            pack_tile(tile_index, partials_id);
         }
         cb_partials.push_back(out_block_num_tiles);
         release_dst();
-
-        if (block_id < last_block_id) {
-            cb_partials.wait_front(out_block_num_tiles);
-            cb_partials.pop_front(out_block_num_tiles);
-        }
-
-        if (block_id == last_block_id) {
-            pack_reconfig_l1_acc(0);
-            copy_tile_to_dst_init_short(partials_cb);
-            cb_partials.wait_front(out_block_num_tiles);
-            acquire_dst();
-            for (uint32_t i = 0; i < out_block_num_tiles; i++) {
-                copy_tile(partials_cb, i, i);
-            }
-            cb_partials.pop_front(out_block_num_tiles);
-            cb_out.reserve_back(out_block_num_tiles);
-            for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
-                pack_tile(tile_index, out_cb);
-            }
-            cb_out.push_back(out_block_num_tiles);
-            release_dst();
-        }
 #else
-        if (block_id == last_block_id) {
-            cb_out.reserve_back(out_block_num_tiles);
-            for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
-                pack_tile(tile_index, out_cb);
-            }
-            cb_out.push_back(out_block_num_tiles);
-        } else {
-            cb_partials.reserve_back(out_block_num_tiles);
-            for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
-                pack_tile(tile_index, partials_cb);
-            }
-            cb_partials.push_back(out_block_num_tiles);
+        const bool is_last = (block_id == last_block_id);
+        auto& cb_acc = is_last ? cb_out : cb_partials;
+        const uint32_t acc_id = is_last ? out_id : partials_id;
+        cb_acc.reserve_back(out_block_num_tiles);
+        for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
+            pack_tile(tile_index, acc_id);
         }
+        cb_acc.push_back(out_block_num_tiles);
         release_dst();
 #endif
     }
+
+#ifdef PACKER_L1_ACC
+    pack_reconfig_l1_acc(0);
+
+    copy_tile_to_dst_init_short(partials_id);
+    cb_partials.wait_front(out_block_num_tiles);
+    acquire_dst();
+    for (uint32_t i = 0; i < out_block_num_tiles; i++) {
+        copy_tile(partials_id, i, i);
+    }
+    cb_partials.pop_front(out_block_num_tiles);
+
+    cb_out.reserve_back(out_block_num_tiles);
+    for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
+        pack_tile(tile_index, out_id);
+    }
+    cb_out.push_back(out_block_num_tiles);
+    release_dst();
+#endif
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
@@ -86,6 +86,9 @@ void kernel_main() {
 
 #ifdef PACKER_L1_ACC
         cb_partials.reserve_back(out_block_num_tiles);
+        if (block_id == 0) {
+            pack_reconfig_l1_acc(0);
+        }
         for (uint32_t tile_index = 0; tile_index < out_block_num_tiles; tile_index++) {
             pack_tile(tile_index, partials_id);
         }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
@@ -1,3 +1,5 @@
+
+
 // SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -11,6 +13,14 @@
 #include "api/dataflow/dataflow_buffer.h"
 #else
 #include "api/dataflow/circular_buffer.h"
+#endif
+
+#ifdef ARCH_QUASAR
+using Buffer = DataflowBuffer;
+inline uint32_t get_buffer_id(const Buffer& b) { return b.get_id(); }
+#else
+using Buffer = CircularBuffer;
+inline uint32_t get_buffer_id(const Buffer& b) { return b.get_cb_id(); }
 #endif
 
 void kernel_main() {
@@ -27,25 +37,14 @@ void kernel_main() {
     const uint32_t num_blocks = get_compile_time_arg_val(10);
     const uint32_t last_block_id = num_blocks - 1;
 
-#ifdef ARCH_QUASAR
-    DataflowBuffer cb_in0(in0_cb);
-    DataflowBuffer cb_in1(in1_cb);
-    DataflowBuffer cb_partials(partials_cb);
-    DataflowBuffer cb_out(out_cb);
-    const uint32_t in0_id = cb_in0.get_id();
-    const uint32_t in1_id = cb_in1.get_id();
-    const uint32_t out_id = cb_out.get_id();
-    const uint32_t partials_id = cb_partials.get_id();
-#else
-    CircularBuffer cb_in0(in0_cb);
-    CircularBuffer cb_in1(in1_cb);
-    CircularBuffer cb_partials(partials_cb);
-    CircularBuffer cb_out(out_cb);
-    const uint32_t in0_id = in0_cb;
-    const uint32_t in1_id = in1_cb;
-    const uint32_t out_id = out_cb;
-    const uint32_t partials_id = partials_cb;
-#endif
+    Buffer cb_in0(in0_cb);
+    Buffer cb_in1(in1_cb);
+    Buffer cb_partials(partials_cb);
+    Buffer cb_out(out_cb);
+    const uint32_t in0_id = get_buffer_id(cb_in0);
+    const uint32_t in1_id = get_buffer_id(cb_in1);
+    const uint32_t out_id = get_buffer_id(cb_out);
+    const uint32_t partials_id = get_buffer_id(cb_partials);
 
     // out = in0[r x k]*in1[k x c]
     mm_init(in0_id, in1_id, partials_id);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/reader_binary_blocked.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/reader_binary_blocked.cpp
@@ -43,9 +43,6 @@ void kernel_main() {
     uint32_t l1_write_addr_in1;
 
     for (uint32_t i = 0; i < num_blocks; i++) {
-        uint64_t src0_noc_addr = get_noc_addr_from_bank_id<true>(src0_dram_bank_id, src0_addr);
-        uint64_t src1_noc_addr = get_noc_addr_from_bank_id<true>(src1_dram_bank_id, src1_addr);
-
         cb_in0.reserve_back(in0_block_tile_cnt);
         cb_in1.reserve_back(in1_block_tile_cnt);
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/reader_binary_blocked.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/reader_binary_blocked.cpp
@@ -8,6 +8,11 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/endpoints.h"
 #include "api/dataflow/noc.h"
+#ifdef ARCH_QUASAR
+#include "api/dataflow/dataflow_buffer.h"
+#else
+#include "api/dataflow/circular_buffer.h"
+#endif
 
 void kernel_main() {
     const uint32_t in0_cb = get_compile_time_arg_val(0);
@@ -23,8 +28,13 @@ void kernel_main() {
     uint32_t in0_block_size_bytes = get_arg_val<uint32_t>(7);
     uint32_t in1_block_size_bytes = get_arg_val<uint32_t>(8);
 
-    CircularBuffer cb0(in0_cb);
-    CircularBuffer cb1(in1_cb);
+#ifdef ARCH_QUASAR
+    DataflowBuffer cb_in0(in0_cb);
+    DataflowBuffer cb_in1(in1_cb);
+#else
+    CircularBuffer cb_in0(in0_cb);
+    CircularBuffer cb_in1(in1_cb);
+#endif
     Noc noc;
     AllocatorBank<AllocatorBankType::DRAM> dram_src0;
     AllocatorBank<AllocatorBankType::DRAM> dram_src1;
@@ -36,16 +46,16 @@ void kernel_main() {
         uint64_t src0_noc_addr = get_noc_addr_from_bank_id<true>(src0_dram_bank_id, src0_addr);
         uint64_t src1_noc_addr = get_noc_addr_from_bank_id<true>(src1_dram_bank_id, src1_addr);
 
-        cb0.reserve_back(in0_block_tile_cnt);
-        cb1.reserve_back(in1_block_tile_cnt);
+        cb_in0.reserve_back(in0_block_tile_cnt);
+        cb_in1.reserve_back(in1_block_tile_cnt);
 
-        noc.async_read(dram_src0, cb0, in0_block_size_bytes, {.bank_id = src0_dram_bank_id, .addr = src0_addr}, {});
-        noc.async_read(dram_src1, cb1, in1_block_size_bytes, {.bank_id = src1_dram_bank_id, .addr = src1_addr}, {});
+        noc.async_read(dram_src0, cb_in0, in0_block_size_bytes, {.bank_id = src0_dram_bank_id, .addr = src0_addr}, {});
+        noc.async_read(dram_src1, cb_in1, in1_block_size_bytes, {.bank_id = src1_dram_bank_id, .addr = src1_addr}, {});
 
         noc.async_read_barrier();
 
-        cb0.push_back(in0_block_tile_cnt);
-        cb1.push_back(in1_block_tile_cnt);
+        cb_in0.push_back(in0_block_tile_cnt);
+        cb_in1.push_back(in1_block_tile_cnt);
 
         src0_addr += in0_block_size_bytes;
         src1_addr += in1_block_size_bytes;

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/writer_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/writer_unary.cpp
@@ -3,9 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
-#include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/endpoints.h"
 #include "api/dataflow/noc.h"
+#ifdef ARCH_QUASAR
+#include "api/dataflow/dataflow_buffer.h"
+#else
+#include "api/dataflow/circular_buffer.h"
+#endif
 
 void kernel_main() {
     const uint32_t out_cb = get_compile_time_arg_val(0);
@@ -13,23 +17,26 @@ void kernel_main() {
     uint32_t dst_dram_bank_id_addr = get_arg_val<uint32_t>(1);
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
 
+#ifdef ARCH_QUASAR
+    DataflowBuffer cb_out(out_cb);
+    uint32_t ublock_size_bytes = cb_out.get_entry_size();
+#else
+    CircularBuffer cb_out(out_cb);
+    uint32_t ublock_size_bytes = cb_out.get_tile_size();
+#endif
     // single-tile ublocks
-
-    CircularBuffer cb(out_cb);
+    uint32_t ublock_size_tiles = 1;
     Noc noc;
     AllocatorBank<AllocatorBankType::DRAM> dram_dst;
 
-    uint32_t ublock_size_bytes = cb.get_tile_size();
-    uint32_t ublock_size_tiles = 1;
-
     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
-        cb.wait_front(ublock_size_tiles);
+        cb_out.wait_front(ublock_size_tiles);
 
-        noc.async_write(cb, dram_dst, ublock_size_bytes, {}, {.bank_id = dst_dram_bank_id_addr, .addr = dst_addr});
+        noc.async_write(cb_out, dram_dst, ublock_size_bytes, {}, {.bank_id = dst_dram_bank_id_addr, .addr = dst_addr});
 
         noc.async_write_barrier();
 
-        cb.pop_front(ublock_size_tiles);
+        cb_out.pop_front(ublock_size_tiles);
         dst_addr += ublock_size_bytes;
     }
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
@@ -93,3 +93,10 @@ TT_ALWAYS_INLINE void llk_pack_relu_config(const std::uint32_t config) {
 TT_ALWAYS_INLINE void llk_pack_relu_config(const ckernel::ReluConfig& relu_config) {
     _llk_pack_relu_config_<p_pacr::PACK0, false /* EN_32B_DEST */>(relu_config);
 }
+
+/**
+ * @brief: Configure packer0 to enable or disable l1 accumulation
+ * @param l1_acc_en: if false -> l1 acc is disabled, true -> l1 acc enabled
+ **/
+ inline void llk_pack_reconfig_l1_acc(const std::uint32_t l1_acc_en) { _llk_pack_set_l1_acc_<p_pacr::PACK0>(l1_acc_en); }
+ 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
@@ -98,5 +98,4 @@ TT_ALWAYS_INLINE void llk_pack_relu_config(const ckernel::ReluConfig& relu_confi
  * @brief: Configure packer0 to enable or disable l1 accumulation
  * @param l1_acc_en: if false -> l1 acc is disabled, true -> l1 acc enabled
  **/
- inline void llk_pack_reconfig_l1_acc(const std::uint32_t l1_acc_en) { _llk_pack_set_l1_acc_<p_pacr::PACK0>(l1_acc_en); }
- 
+inline void llk_pack_reconfig_l1_acc(const std::uint32_t l1_acc_en) { _llk_pack_set_l1_acc_<p_pacr::PACK0>(l1_acc_en); }

--- a/tt_metal/hw/inc/api/compute/cb_api.h
+++ b/tt_metal/hw/inc/api/compute/cb_api.h
@@ -172,7 +172,7 @@ ALWI uint32_t get_tile_address(uint32_t cb_id, uint32_t tile_index) {
 #else
     ASSERT(false && "get_tile_address is not implemented for ARCH_QUASAR");
     return 0;
-#endif  // TODO: AM; add Quasar implementation
+#endif
 }
 
 // clang-format off
@@ -212,7 +212,7 @@ ALWI uint32_t read_tile_value(uint32_t cb_id, uint32_t tile_index, uint32_t elem
 #else
     ASSERT(false && "read_tile_value is not implemented for ARCH_QUASAR");
     return 0;
-#endif  // TODO: AM; add Quasar implementation
+#endif
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/matmul.h
+++ b/tt_metal/hw/inc/api/compute/matmul.h
@@ -186,7 +186,11 @@ ALWI void mm_init_short(
     state_configure(in1_cb_id, in0_cb_id, call_line);
     MATH((llk_math_matmul_init<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, transpose)));
     UNPACK((llk_unpack_AB_matmul_init(in0_cb_id, in1_cb_id, transpose)));
-#endif  // TODO: AM; add Quasar implementation
+#else
+    ASSERT(transpose == 0);  // matmul transpose not yet implemented for Quasar
+    UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(in0_cb_id, in1_cb_id)));
+    MATH((llk_math_matmul_init<MATH_FIDELITY>()));
+#endif
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/matmul.h
+++ b/tt_metal/hw/inc/api/compute/matmul.h
@@ -68,7 +68,7 @@ ALWI void matmul_block_math_dynamic_throttle(
         }
         MATH((llk_math_matmul<MATH_FIDELITY, MM_THROTTLE>(idst, ct_dim, rt_dim)));
     }
-#endif  // TODO: AM; add Quasar implementation
+#endif
 }
 #endif
 
@@ -164,7 +164,7 @@ template <uint32_t num_faces = 4>
 ALWI void matmul_tiles_math(uint32_t idst) {
 #ifndef ARCH_QUASAR
     MATH((llk_math_matmul<MATH_FIDELITY, MM_THROTTLE, num_faces>(idst)));
-#endif  // TODO: AM; add Quasar implementation
+#endif
 }
 
 // clang-format off
@@ -216,7 +216,7 @@ ALWI void mm_init_short_with_dt(
         (llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(c_in_old_srca, in1_cb_id)));
     MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(c_in_old_srca, in1_cb_id)));
     mm_init_short(in0_cb_id, in1_cb_id, transpose);
-#endif  // TODO: AM; add Quasar implementation
+#endif
 }
 
 // clang-format off
@@ -395,7 +395,7 @@ ALWI void mm_block_init_short_with_dt(
         (llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(old_in1_cb_id, in1_cb_id)));
     MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(old_in1_cb_id, in1_cb_id)));
     mm_block_init_short(in0_cb_id, in1_cb_id, transpose, ct_dim, rt_dim, kt_dim);
-#endif  // TODO: AM; add Quasar implementation
+#endif
 }
 
 // clang-format off
@@ -430,7 +430,7 @@ ALWI void mm_block_init_short_with_both_dt(
         old_in1_cb_id, in1_cb_id, old_in0_cb_id, in0_cb_id)));
     MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE>(old_in1_cb_id, in1_cb_id, old_in0_cb_id, in0_cb_id)));
     mm_block_init_short(in0_cb_id, in1_cb_id, transpose, ct_dim, rt_dim, kt_dim);
-#endif  // TODO: AM; add Quasar implementation
+#endif
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/matmul.h
+++ b/tt_metal/hw/inc/api/compute/matmul.h
@@ -6,6 +6,7 @@
 
 #include "api/compute/common.h"
 #include "api/compute/sentinel/compute_kernel_sentinel.h"
+#include "llk_assert.h"
 #ifdef TRISC_MATH
 #include "llk_math_matmul_api.h"
 #endif
@@ -104,7 +105,7 @@ ALWI void mm_init(
     PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>()));
     PACK((llk_pack_init(out_cb_id)));
 #else
-    ASSERT(transpose == 0);  // matmul transpose not yet implemented for Quasar
+    LLK_ASSERT(transpose == 0, "Matmul transpose not yet implemented for Quasar");
     UNPACK((llk_unpack_hw_configure(in1_cb_id, in0_cb_id)));
     UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(in0_cb_id, in1_cb_id)));
 
@@ -187,7 +188,7 @@ ALWI void mm_init_short(
     MATH((llk_math_matmul_init<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, transpose)));
     UNPACK((llk_unpack_AB_matmul_init(in0_cb_id, in1_cb_id, transpose)));
 #else
-    ASSERT(transpose == 0);  // matmul transpose not yet implemented for Quasar
+    LLK_ASSERT(transpose == 0, "Matmul transpose not yet implemented for Quasar");
     UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(in0_cb_id, in1_cb_id)));
     MATH((llk_math_matmul_init<MATH_FIDELITY>()));
 #endif
@@ -261,7 +262,7 @@ ALWI void mm_block_init(
     PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>()));
     PACK((llk_pack_init<PackMode::Default, false /* zero_output */>(out_cb_id)));
 #else
-    ASSERT(transpose == 0);  // matmul transpose not yet implemented for Quasar
+    LLK_ASSERT(transpose == 0, "Matmul transpose not yet implemented for Quasar");
     UNPACK((llk_unpack_hw_configure(in1_cb_id, in0_cb_id)));
     UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(in0_cb_id, in1_cb_id, ct_dim, rt_dim, kt_dim)));
 
@@ -356,7 +357,7 @@ ALWI void mm_block_init_short(
     MATH((throttled_mop_status = 0));
 #endif
 #else
-    ASSERT(transpose == 0);  // matmul transpose not yet implemented for Quasar
+    LLK_ASSERT(transpose == 0, "Matmul transpose not yet implemented for Quasar");
     UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(in0_cb_id, in1_cb_id, ct_dim, rt_dim, kt_dim)));
     MATH((llk_math_matmul_init<MATH_FIDELITY>(ct_dim, rt_dim)));
 #endif

--- a/tt_metal/hw/inc/api/compute/pack.h
+++ b/tt_metal/hw/inc/api/compute/pack.h
@@ -132,65 +132,6 @@ ALWI void pack_tile_block(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
 
 // clang-format off
 /**
- * Reconfigures the packer output data format by specifying the CB ID of the new operand. This function
- * call will always perform the reconfiguration, regardless of the data format of the old operand.
- * If the new CB ID is the same as the current one, reconfiguration will still occur.
- *
- * NOTE: Packer reconfiguration functions are used similarly to the initialization function, in a sense
- * that they are called before the call to the packer function that uses the new configuration. It is
- * recommended to call this function right after other op-specific initialization functions.
- *
- * Return value: None
- *
- * | Param Type | Name                    | Description                   | Type     | Valid Range | Required |
- * |------------|-------------------------|-------------------------------|----------|-------------|----------|
- * | Template   | is_tile_dim_reconfig_en | Toggle tile reconfiguration   | bool     | true/false  | False    |
- * | Function   | new_cb_id               | New data format operand value | uint32_t | Any         | True     |
- */
-// clang-format on
-template <bool is_tile_dim_reconfig_en = false>
-ALWI void pack_reconfig_data_format(const uint32_t new_cb_id) {
-#ifndef ARCH_QUASAR
-    PACK((llk_pack_reconfig_data_format<DST_ACCUM_MODE>(new_cb_id)));
-    if constexpr (is_tile_dim_reconfig_en) {
-        PACK((llk_pack_init<PackMode::Default, false /* zero_output */, true /* skip_addrmod_config */>(new_cb_id)));
-    }
-#endif  // TODO: AM; add Quasar implementation
-}
-
-// clang-format off
-/**
- * Reconfigures the packer output data format by specifying the CB IDs of the old and new operands.
- * This function internally calls the reconfiguration function with the new CB ID, but before it does so,
- * it checks if the old and new data formats are different. If they are the same, it does not perform
- * the reconfiguration. This function is useful when you want to ensure that the packer only reconfigures
- * when different data format is wanted, avoiding unnecessary reconfiguration overhead.
- *
- * NOTE: Packer reconfiguration functions are used similarly to the initialization function, in a sense
- * that they are called before the call to the packer function that uses the new configuration. It is
- * recommended to call this function right after other op-specific initialization functions.
- *
- * Return value: None
- *
- * | Param Type | Name                    | Description                        | Type     | Valid Range | Required |
- * |------------|-------------------------|------------------------------------|----------|-------------|----------|
- * | Template   | is_tile_dim_reconfig_en | Toggle tile reconfiguration        | bool     | true/false  | False    |
- * | Function   | old_cb_id               | Previous data format operand value | uint32_t | Any         | True     |
- * | Function   | new_cb_id               | New data format operand value      | uint32_t | Any         | True     |
- */
-// clang-format on
-template <bool is_tile_dim_reconfig_en = false>
-ALWI void pack_reconfig_data_format(const uint32_t old_cb_id, const uint32_t new_cb_id) {
-#ifndef ARCH_QUASAR
-    PACK((llk_pack_reconfig_data_format<DST_ACCUM_MODE>(old_cb_id, new_cb_id)));
-    if constexpr (is_tile_dim_reconfig_en) {
-        PACK((llk_pack_init<PackMode::Default, false /* zero_output */, true /* skip_addrmod_config */>(new_cb_id)));
-    }
-#endif  // TODO: AM; add Quasar implementation
-}
-
-// clang-format off
-/**
  * Helper function to reconfigure the packer L1 accumulation flag. This function would ideally be called
  * after other initialization functions that initialize the packer for a specific operation.
  * This function configures the packer to accumulate the values it takes from DEST with the ones that

--- a/tt_metal/hw/inc/api/compute/pack.h
+++ b/tt_metal/hw/inc/api/compute/pack.h
@@ -5,14 +5,32 @@
 #pragma once
 
 #include "common_globals.h"
+#include "sentinel/compute_kernel_sentinel.h"
 #ifdef TRISC_PACK
 #include "llk_pack_tile_api.h"
 #ifndef ARCH_QUASAR
 #include "llk_pack_rows_api.h"
 #endif
-#endif
 
 namespace ckernel {
+
+// clang-format off
+/**
+ * Initializes the packer to pack tiles into the specified output circular buffer.
+ *
+ * Call this function before using `pack_tile` or `pack_tile_block`.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name | Description                                       | Type     | Valid Range | Required |
+ * |------------|------|---------------------------------------------------|----------|-------------|----------|
+ * | Function   | ocb  | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31     | True     |
+ */
+// clang-format on
+ALWI void pack_init(uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
+    state_configure<Operand::PACK>(ocb, call_line);
+    PACK((llk_pack_init(ocb)));
+}
 
 // clang-format off
 /**

--- a/tt_metal/hw/inc/api/compute/pack.h
+++ b/tt_metal/hw/inc/api/compute/pack.h
@@ -11,6 +11,7 @@
 #ifndef ARCH_QUASAR
 #include "llk_pack_rows_api.h"
 #endif
+#endif
 
 namespace ckernel {
 

--- a/tt_metal/hw/inc/api/compute/pack.h
+++ b/tt_metal/hw/inc/api/compute/pack.h
@@ -192,11 +192,7 @@ ALWI void pack_reconfig_data_format(const uint32_t old_cb_id, const uint32_t new
  * | Function   | l1_acc_en | L1 accumulation enable flag        | uint32_t | 0 or 1      | True     |
  */
 // clang-format on
-ALWI void pack_reconfig_l1_acc(const uint32_t l1_acc_en) {
-#ifndef ARCH_QUASAR
-    PACK((llk_pack_reconfig_l1_acc(l1_acc_en)));
-#endif  // TODO: AM; add Quasar implementation
-}
+ALWI void pack_reconfig_l1_acc(const uint32_t l1_acc_en) { PACK((llk_pack_reconfig_l1_acc(l1_acc_en))); }
 
 // clang-format off
 /**

--- a/tt_metal/hw/inc/api/compute/reconfig_data_format.h
+++ b/tt_metal/hw/inc/api/compute/reconfig_data_format.h
@@ -6,6 +6,11 @@
 
 #include "common_globals.h"
 
+#ifdef TRISC_PACK
+#include "llk_pack_common_api.h"
+#include "llk_pack_tile_api.h"
+#endif
+
 namespace ckernel {
 
 /**

--- a/tt_metal/hw/inc/api/compute/reconfig_data_format.h
+++ b/tt_metal/hw/inc/api/compute/reconfig_data_format.h
@@ -25,7 +25,7 @@ ALWI void reconfig_data_format(const uint32_t srca_new_operand, const uint32_t s
             is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE,
             to_from_int8>(srca_new_operand, srcb_new_operand)));
     MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE, to_from_int8>(srca_new_operand, srcb_new_operand)));
-#endif  // TODO: AM; add Quasar implementation
+#endif
 }
 
 /**
@@ -45,7 +45,7 @@ ALWI void reconfig_data_format(
             to_from_int8>(srca_old_operand, srca_new_operand, srcb_old_operand, srcb_new_operand)));
     MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE, to_from_int8>(
         srca_old_operand, srca_new_operand, srcb_old_operand, srcb_new_operand)));
-#endif  // TODO: AM; add Quasar implementation
+#endif
 }
 
 /**
@@ -60,7 +60,7 @@ ALWI void reconfig_data_format_srca(const uint32_t srca_new_operand) {
             is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE,
             to_from_int8>(srca_new_operand)));
     MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE, to_from_int8>(srca_new_operand)));
-#endif  // TODO: AM; add Quasar implementation
+#endif
 }
 
 /**
@@ -75,7 +75,7 @@ ALWI void reconfig_data_format_srca(const uint32_t srca_old_operand, const uint3
             is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE,
             to_from_int8>(srca_old_operand, srca_new_operand)));
     MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE, to_from_int8>(srca_old_operand, srca_new_operand)));
-#endif  // TODO: AM; add Quasar implementation
+#endif
 }
 
 /**
@@ -90,7 +90,7 @@ ALWI void reconfig_data_format_srcb(const uint32_t srcb_new_operand) {
             is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE,
             to_from_int8>(srcb_new_operand)));
     MATH((llk_math_reconfig_data_format_srcb<DST_ACCUM_MODE, to_from_int8>(srcb_new_operand)));
-#endif  // TODO: AM; add Quasar implementation
+#endif
 }
 
 /**
@@ -105,7 +105,7 @@ ALWI void reconfig_data_format_srcb(const uint32_t srcb_old_operand, const uint3
             is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE,
             to_from_int8>(srcb_old_operand, srcb_new_operand)));
     MATH((llk_math_reconfig_data_format_srcb<DST_ACCUM_MODE, to_from_int8>(srcb_old_operand, srcb_new_operand)));
-#endif  // TODO: AM; add Quasar implementation
+#endif
 }
 
 // clang-format off
@@ -133,7 +133,7 @@ ALWI void pack_reconfig_data_format(const uint32_t new_cb_id) {
     if constexpr (is_tile_dim_reconfig_en) {
         PACK((llk_pack_init<PackMode::Default, false /* zero_output */, true /* skip_addrmod_config */>(new_cb_id)));
     }
-#endif  // TODO: AM; add Quasar implementation
+#endif
 }
 
 // clang-format off
@@ -164,7 +164,7 @@ ALWI void pack_reconfig_data_format(const uint32_t old_cb_id, const uint32_t new
     if constexpr (is_tile_dim_reconfig_en) {
         PACK((llk_pack_init<PackMode::Default, false /* zero_output */, true /* skip_addrmod_config */>(new_cb_id)));
     }
-#endif  // TODO: AM; add Quasar implementation
+#endif
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/reconfig_data_format.h
+++ b/tt_metal/hw/inc/api/compute/reconfig_data_format.h
@@ -103,4 +103,63 @@ ALWI void reconfig_data_format_srcb(const uint32_t srcb_old_operand, const uint3
 #endif  // TODO: AM; add Quasar implementation
 }
 
+// clang-format off
+/**
+ * Reconfigures the packer output data format by specifying the CB ID of the new operand. This function
+ * call will always perform the reconfiguration, regardless of the data format of the old operand.
+ * If the new CB ID is the same as the current one, reconfiguration will still occur.
+ *
+ * NOTE: Packer reconfiguration functions are used similarly to the initialization function, in a sense
+ * that they are called before the call to the packer function that uses the new configuration. It is
+ * recommended to call this function right after other op-specific initialization functions.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name                    | Description                   | Type     | Valid Range | Required |
+ * |------------|-------------------------|-------------------------------|----------|-------------|----------|
+ * | Template   | is_tile_dim_reconfig_en | Toggle tile reconfiguration   | bool     | true/false  | False    |
+ * | Function   | new_cb_id               | New data format operand value | uint32_t | Any         | True     |
+ */
+// clang-format on
+template <bool is_tile_dim_reconfig_en = false>
+ALWI void pack_reconfig_data_format(const uint32_t new_cb_id) {
+#ifndef ARCH_QUASAR
+    PACK((llk_pack_reconfig_data_format<DST_ACCUM_MODE>(new_cb_id)));
+    if constexpr (is_tile_dim_reconfig_en) {
+        PACK((llk_pack_init<PackMode::Default, false /* zero_output */, true /* skip_addrmod_config */>(new_cb_id)));
+    }
+#endif  // TODO: AM; add Quasar implementation
+}
+
+// clang-format off
+/**
+ * Reconfigures the packer output data format by specifying the CB IDs of the old and new operands.
+ * This function internally calls the reconfiguration function with the new CB ID, but before it does so,
+ * it checks if the old and new data formats are different. If they are the same, it does not perform
+ * the reconfiguration. This function is useful when you want to ensure that the packer only reconfigures
+ * when different data format is wanted, avoiding unnecessary reconfiguration overhead.
+ *
+ * NOTE: Packer reconfiguration functions are used similarly to the initialization function, in a sense
+ * that they are called before the call to the packer function that uses the new configuration. It is
+ * recommended to call this function right after other op-specific initialization functions.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name                    | Description                        | Type     | Valid Range | Required |
+ * |------------|-------------------------|------------------------------------|----------|-------------|----------|
+ * | Template   | is_tile_dim_reconfig_en | Toggle tile reconfiguration        | bool     | true/false  | False    |
+ * | Function   | old_cb_id               | Previous data format operand value | uint32_t | Any         | True     |
+ * | Function   | new_cb_id               | New data format operand value      | uint32_t | Any         | True     |
+ */
+// clang-format on
+template <bool is_tile_dim_reconfig_en = false>
+ALWI void pack_reconfig_data_format(const uint32_t old_cb_id, const uint32_t new_cb_id) {
+#ifndef ARCH_QUASAR
+    PACK((llk_pack_reconfig_data_format<DST_ACCUM_MODE>(old_cb_id, new_cb_id)));
+    if constexpr (is_tile_dim_reconfig_en) {
+        PACK((llk_pack_init<PackMode::Default, false /* zero_output */, true /* skip_addrmod_config */>(new_cb_id)));
+    }
+#endif  // TODO: AM; add Quasar implementation
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/sentinel/compute_kernel_sentinel.h
+++ b/tt_metal/hw/inc/api/compute/sentinel/compute_kernel_sentinel.h
@@ -313,14 +313,20 @@ ALWI bool ComputeKernelSentinelImpl<false>::verify_calls(uint8_t expected_calls)
 
 template <Operand operand = Operand::SRCA>
 ALWI void state_configure(uint32_t cb, uint32_t call_line) {
+#ifndef ARCH_QUASAR
     ComputeKernelSentinel::instance().reconfigure_single_operand<operand>(cb, call_line);
+#endif
 }
 
 template <Operand operand_a = Operand::SRCA, Operand operand_b = Operand::SRCB>
 ALWI void state_configure(uint32_t cb_a, uint32_t cb_b, uint32_t call_line) {
+#ifndef ARCH_QUASAR
     ComputeKernelSentinel::instance().reconfigure_dual_operand<operand_a, operand_b>(cb_a, cb_b, call_line);
+#endif
 }
 
 ALWI void state_configure(uint32_t cb_a, uint32_t cb_b, uint32_t cb_out, uint32_t call_line) {
+#ifndef ARCH_QUASAR
     ComputeKernelSentinel::instance().reconfig_all_operands(cb_a, cb_b, cb_out, call_line);
+#endif
 }

--- a/tt_metal/hw/inc/api/compute/sentinel/sentinel_core.h
+++ b/tt_metal/hw/inc/api/compute/sentinel/sentinel_core.h
@@ -6,7 +6,6 @@
 
 #include "api/compute/common_globals.h"
 #include "api/compute/reconfig_data_format.h"
-#include "api/compute/pack.h"
 
 // Constants and types needed by both SentinelCore and testing components
 #define RECONFIG_NOTHING_CHANGED 0x00
@@ -19,6 +18,15 @@
 #endif
 
 namespace ckernel {
+
+// Forward declaration of pack.h's `pack_reconfig_data_format` to break the
+// circular dependency: pack.h includes compute_kernel_sentinel.h (which
+// includes this file) so we cannot include pack.h here. The full definition
+// is provided in pack.h and is required to be visible at the point where
+// `inject_single_operand<Operand::PACK>` is instantiated (i.e. in user code,
+// after pack.h has been fully processed).
+template <bool is_tile_dim_reconfig_en>
+ALWI void pack_reconfig_data_format(uint32_t old_cb_id, uint32_t new_cb_id);
 
 enum class Operand : uint8_t {
     SRCA = 0x1,
@@ -207,7 +215,10 @@ ALWI void SentinelCore::inject_single_operand(uint32_t cb) {
             return;
         }
         if (m_enabled) {
-            pack_reconfig_data_format(m_pack_cb, cb);
+            // Use explicit template argument because the default value for
+            // `is_tile_dim_reconfig_en` is declared in pack.h's definition,
+            // not in the forward declaration above.
+            pack_reconfig_data_format<false>(m_pack_cb, cb);
         }
 
         DPRINT << "pack_reconfig_data_format - ";

--- a/tt_metal/hw/inc/api/compute/sentinel/sentinel_core.h
+++ b/tt_metal/hw/inc/api/compute/sentinel/sentinel_core.h
@@ -184,7 +184,7 @@ ALWI void SentinelCore::inject_single_operand(uint32_t cb) {
             return;
         }
         if (m_enabled) {
-            reconfig_data_format_srca<false, true>(m_srca_cb, cb);
+            reconfig_data_format_srca<false /* to_from_int8 */, true /* is_tile_dim_reconfig_en */>(m_srca_cb, cb);
         }
 
         DPRINT << "reconfig_data_format_srca - ";
@@ -195,7 +195,7 @@ ALWI void SentinelCore::inject_single_operand(uint32_t cb) {
             return;
         }
         if (m_enabled) {
-            reconfig_data_format_srcb<false, true>(m_srcb_cb, cb);
+            reconfig_data_format_srcb<false /* to_from_int8 */, true /* is_tile_dim_reconfig_en */>(m_srcb_cb, cb);
         }
 
         DPRINT << "reconfig_data_format_srcb - ";
@@ -206,7 +206,7 @@ ALWI void SentinelCore::inject_single_operand(uint32_t cb) {
             return;
         }
         if (m_enabled) {
-            pack_reconfig_data_format<false>(m_pack_cb, cb);
+            pack_reconfig_data_format<false /* is_tile_dim_reconfig_en */>(m_pack_cb, cb);
         }
 
         DPRINT << "pack_reconfig_data_format - ";

--- a/tt_metal/hw/inc/api/compute/sentinel/sentinel_core.h
+++ b/tt_metal/hw/inc/api/compute/sentinel/sentinel_core.h
@@ -19,15 +19,6 @@
 
 namespace ckernel {
 
-// Forward declaration of pack.h's `pack_reconfig_data_format` to break the
-// circular dependency: pack.h includes compute_kernel_sentinel.h (which
-// includes this file) so we cannot include pack.h here. The full definition
-// is provided in pack.h and is required to be visible at the point where
-// `inject_single_operand<Operand::PACK>` is instantiated (i.e. in user code,
-// after pack.h has been fully processed).
-template <bool is_tile_dim_reconfig_en>
-ALWI void pack_reconfig_data_format(uint32_t old_cb_id, uint32_t new_cb_id);
-
 enum class Operand : uint8_t {
     SRCA = 0x1,
     SRCB = 0x2,
@@ -215,9 +206,6 @@ ALWI void SentinelCore::inject_single_operand(uint32_t cb) {
             return;
         }
         if (m_enabled) {
-            // Use explicit template argument because the default value for
-            // `is_tile_dim_reconfig_en` is declared in pack.h's definition,
-            // not in the forward declaration above.
             pack_reconfig_data_format<false>(m_pack_cb, cb);
         }
 

--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -72,7 +72,7 @@ ALWI void copy_tile_to_dst_init_short_with_dt(uint32_t old_cbid, uint32_t new_cb
     UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(old_cbid, new_cbid)));
     MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(old_cbid, new_cbid)));
     copy_tile_to_dst_init_short(new_cbid, transpose);
-#endif  // TODO: AM; add Quasar implementation
+#endif
 }
 
 // clang-format off


### PR DESCRIPTION
### Issue 
https://github.com/tenstorrent/tt-llk/issues/1580

### PR Category
Quasar Bringup
Quasar, WH and BH tests

### Summary
The main aim of this PR is to bring up packer L1 accumulation compute API for Quasar.
I added L1 acc tests to `tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp`. This test suite has some matmul tests but it also had an unused function called `blocked_matmul`. It seems like this function was meant to be used to test spill and reload but was never called.

As it provided a solid foundation, I used it to expand the test suite and added L1 acc and spill and reload tests for all architectures. 

`mm_short_init` is called in this test so as a byproduct this compute api function was brought up for Quasar.

Adds `pack_init` compute API for all architectures.

### Notes for reviewers
Should the input dimensions be defined in some other way, and split into blocks differently? I just used some dimension repeated num_block times, over which the accumulation happens.
Is adding this as a WH/BH test okay or should I set it as only Quasar?

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/l1_acc_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/l1_acc_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/l1_acc_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/l1_acc_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amokan/l1_acc_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amokan/l1_acc_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/l1_acc_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/l1_acc_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/l1_acc_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/l1_acc_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/l1_acc_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/l1_acc_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/l1_acc_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/l1_acc_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/l1_acc_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/l1_acc_compute)