### PR TITLE
SDXL new expected encoder perf

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -145,7 +145,7 @@ DEVICE_PERF_EXPECTATIONS = {
     },
     "clip_encoder_2": {
         "wormhole": 125_300_000,
-        "blackhole": 60_903_932,
+        "blackhole": 59_431_573,
     },
 }
 


### PR DESCRIPTION
## Problem Description
After: **Fix unroll pragmas, warn on unknown pragma (https://github.com/tenstorrent/tt-metal/pull/43824)** CI device perf is failing: [example_link](https://github.com/tenstorrent/tt-metal/actions/runs/25590178093/job/75177532741) because improved perf on test encoder2 so I lowered the expected value

## Checklist
- [x] [device perf](https://github.com/tenstorrent/tt-metal/actions/runs/25683345404) passes

