### PR TITLE
Saturate abs_int32 on INT32_MIN on Blackhole

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_int32.py
@@ -212,3 +212,34 @@ def test_abs_int32(device):
     output_tensor = ttnn.to_torch(result)
 
     assert torch.equal(torch_output_tensor, output_tensor)
+
+
+def test_abs_int32_edge_cases(device):
+    # Covers issue #20852: on Blackhole, SFPABS on INT32_MIN overflows. The kernel
+    # saturates the overflowing lane to INT32_MAX, which differs from torch.abs's
+    # wrap-around behavior — so the expected output is built explicitly here.
+    int32_min = -2147483648
+    int32_max = 2147483647
+    inputs = [int32_min, int32_min + 1, -1, 0, 1, int32_max - 1, int32_max]
+    expected = [int32_max, int32_max, 1, 0, 1, int32_max - 1, int32_max]
+
+    tile = 32 * 32
+    repeats = tile // len(inputs) + 1
+    flat_in = (inputs * repeats)[:tile]
+    flat_exp = (expected * repeats)[:tile]
+
+    torch_input_tensor_a = torch.tensor(flat_in, dtype=torch.int32).reshape(1, 1, 32, 32)
+    torch_expected_tensor = torch.tensor(flat_exp, dtype=torch.int32).reshape(1, 1, 32, 32)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.int32,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    result = ttnn.abs(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    output_tensor = ttnn.to_torch(result)
+
+    assert torch.equal(torch_expected_tensor, output_tensor)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
@@ -26,9 +26,10 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_abs_int32() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        TT_SFPLOAD(1, 12, ADDR_MOD_7, 0);
-        TTI_SFPABS(0, 1, 0, 0);
-        TTI_SFPSTORE(0, 12, ADDR_MOD_7, 0);
+        vInt result = sfpi::abs(vInt(dst_reg[0]));
+        v_if(result < 0) { result -= 1; }
+        v_endif;
+        dst_reg[0] = result;
         dst_reg++;
     }
 }


### PR DESCRIPTION
### PR Category
Fix

### Summary
Fixes #20852. On Blackhole, `SFPABS` on INT32_MIN (`0x80000000`) does not saturate — bit 31 stays set. `calculate_abs_int32` now detects those lanes post-`SFPABS` and subtracts 1 so they wrap to `INT32_MAX` (`0x7FFFFFFF`).

### Notes for reviewers
- The function is now written in sfpi (`vInt` + `sfpi::abs` + `v_if`/`v_endif`), matching the pattern already used in `tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_div_int32_floor.h`.
- Added `test_abs_int32_edge_cases`; the expected vector is built by hand because `torch.abs(INT32_MIN)` wraps, whereas the fixed kernel saturates.
- Verified on Blackhole p100a: both tests pass with the fix; the new edge-case test fails without it.
- Scoped to SFPABS only. The issue thread mentions sibling bugs (SFPCAST mode 2 sign-magn cast, SFPGT/SFPLE semantics, SFP_STOCH_RND); those are separate concerns and are not resolved in this PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/fix-20852-bh-abs-int32-min)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/fix-20852-bh-abs-int32-min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstamatovic/fix-20852-bh-abs-int32-min)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstamatovic/fix-20852-bh-abs-int32-min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nstamatovic/fix-20852-bh-abs-int32-min)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nstamatovic/fix-20852-bh-abs-int32-min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/fix-20852-bh-abs-int32-min)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/fix-20852-bh-abs-int32-min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstamatovic/fix-20852-bh-abs-int32-min)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstamatovic/fix-20852-bh-abs-int32-min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/fix-20852-bh-abs-int32-min)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/fix-20852-bh-abs-int32-min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/fix-20852-bh-abs-int32-min)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/fix-20852-bh-abs-int32-min)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/fix-20852-bh-abs-int32-min)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/fix-20852-bh-abs-int32-min)