### PR TITLE
ci: Mark ai-run-summary jobs continue-on-error

### DIFF
--- a/.github/workflows/all-model-tests.yaml
+++ b/.github/workflows/all-model-tests.yaml
@@ -401,6 +401,7 @@ jobs:
       - t3-unit-tests
       - t3-e2e-tests
     if: always()
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -295,6 +295,7 @@ jobs:
     name: "AI Run Summary"
     needs: [generate-matrix, multi-card-unit-tests]
     if: always()
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/galaxy-deepseek-prefill-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-prefill-tests-impl.yaml
@@ -154,6 +154,7 @@ jobs:
     name: "AI Run Summary"
     needs: [load-test-matrix, galaxy-deepseek-tests]
     if: always()
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/models-device-perf-tests-impl.yaml
+++ b/.github/workflows/models-device-perf-tests-impl.yaml
@@ -221,6 +221,7 @@ jobs:
     name: "AI Run Summary"
     needs: [load-test-matrix, models-device-perf-tests]
     if: always()
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/t3000-e2e-tests-impl.yaml
+++ b/.github/workflows/t3000-e2e-tests-impl.yaml
@@ -143,6 +143,7 @@ jobs:
     name: "AI Run Summary"
     needs: [load-test-matrix, t3000-e2e-tests]
     if: always()
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -727,6 +727,7 @@ jobs:
     name: "AI Run Summary"
     needs: [generate-matrix, vllm-tests]
     if: always()
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Set `continue-on-error: true` at the **job** level on every `ai-run-summary` job, in addition to the existing step-level setting on the action call.
- Why: the summary is best-effort, but step-level `continue-on-error` only covers the action step itself. A `checkout` failure or a `Show report` step failure would still mark the job (and therefore the workflow) failed. The job-level flag closes that gap.
- Affects 6 workflows: `vllm-nightly-tests-impl.yaml`, `all-model-tests.yaml`, `models-device-perf-tests-impl.yaml`, `galaxy-deepseek-prefill-tests-impl.yaml`, `t3000-e2e-tests-impl.yaml`, `blackhole-multi-card-unit-tests-impl.yaml`.
- Follow-up to Copilot review on #43624 (same fix is being added to that branch directly so demo-sp-release is consistent on merge).

## Test plan
- [ ] CI passes (YAML lint + workflow parse)
- [ ] Confirm rendered workflow run shows `ai-run-summary` job result not affecting the overall conclusion when the job step fails (best verified once an upstream summary call actually fails — no easy synthetic trigger, change is conservative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ppetrovic/ai-run-summary-continue-on-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ppetrovic/ai-run-summary-continue-on-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ppetrovic/ai-run-summary-continue-on-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ppetrovic/ai-run-summary-continue-on-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ppetrovic/ai-run-summary-continue-on-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ppetrovic/ai-run-summary-continue-on-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ppetrovic/ai-run-summary-continue-on-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ppetrovic/ai-run-summary-continue-on-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ppetrovic/ai-run-summary-continue-on-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ppetrovic/ai-run-summary-continue-on-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ppetrovic/ai-run-summary-continue-on-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ppetrovic/ai-run-summary-continue-on-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ppetrovic/ai-run-summary-continue-on-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ppetrovic/ai-run-summary-continue-on-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ppetrovic/ai-run-summary-continue-on-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ppetrovic/ai-run-summary-continue-on-error)