### PR TITLE
Matmul Bug Fix - Correct Sub Core Grid Usage

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -3453,21 +3453,43 @@ def test_matmul_on_subdevice_1d_mcast(device, m_size, k_size, n_size):
 
 
 @skip_for_slow_dispatch()
+@pytest.mark.parametrize(
+    "sd_start, sd_end",
+    [
+        ((2, 3), (5, 7)),  # 4x5 offset in both x and y: trips old helper's available-cores undercount (20 vs 6)
+        ((1, 4), (6, 5)),  # 6x2 wide-short rect: y-offset 4 >= rect height 2 trips old start.y bounds assertion
+        ((6, 1), (7, 4)),  # 2x4 right-edge rect: x-offset 6 >= rect width 2 trips old start.x bounds assertion
+        ((3, 3), (6, 6)),  # 4x4 square rect mid-device: another available-cores undercount case (16 vs 1)
+        ((3, 2), (3, 6)),  # 1x5 single-column rect: exercises the grid.x==1 branch of receiver_start_core
+        (None, None),  # device-sized full-width y-offset rect (0,1)->(cols-1,rows-1): the original #43900 repro
+    ],
+    ids=["2,3-5,7", "1,4-6,5", "6,1-7,4", "3,3-6,6", "3,2-3,6", "full_width_offset"],
+)
 @pytest.mark.parametrize("mcast_in0", [True, False], ids=["mcast_in0", "mcast_in1"])
-def test_matmul_on_subdevice_1d_mcast_full_grid(device, mcast_in0):
-    """Regression for issue #43900: 1-D multicast matmul over the full offset
-    worker rectangle. Requesting `cols * (rows - 1)` cores from a sub-device
-    anchored at (0, 1) exceeds the old (0, 0)-anchored helper's underestimate
-    by exactly one row's worth, which used to trip a spurious
-    'target > available' TT_FATAL.
+def test_matmul_on_subdevice_1d_mcast_full_grid(device, sd_start, sd_end, mcast_in0):
+    """Regression for issue #43900: 1-D multicast matmul over an offset
+    worker rectangle.  Each parametrized shape would trip a TT_FATAL inside
+    the old (0, 0)-anchored core-range helper (either an undercount of
+    available cores or a start-core-out-of-grid assertion); the fix
+    switches the factory to the sub-core-grid-aware helper so any
+    rectangular sub-device whose bounding box fits the device is accepted.
     """
     grid = device.compute_with_storage_grid_size()
-    if grid.y < 3:
-        pytest.skip("Need at least 3 rows for the offset full-grid sub-device test")
+    if sd_start is None:
+        if grid.y < 3:
+            pytest.skip("Need at least 3 rows for the full-width offset sub-device case")
+        sd_start, sd_end = (0, 1), (grid.x - 1, grid.y - 1)
+    if sd_end[0] >= grid.x or sd_end[1] >= grid.y:
+        pytest.skip(f"Device grid {grid.x}x{grid.y} too small for sub-device ending at {sd_end}")
 
-    sub_device_manager, worker_sub_device_id, _, _ = _setup_subdevice(device)
+    worker_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(*sd_start), ttnn.CoreCoord(*sd_end))})
+    worker_sub_device = ttnn.SubDevice([worker_crs])
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_manager = device.create_sub_device_manager([worker_sub_device], 0)
+    device.load_sub_device_manager(sub_device_manager)
+    device.set_sub_device_stall_group([worker_sub_device_id])
     try:
-        sub_grid = ttnn.CoreCoord(grid.x, grid.y - 1)
+        sub_grid = ttnn.CoreCoord(sd_end[0] - sd_start[0] + 1, sd_end[1] - sd_start[1] + 1)
         num_cores = sub_grid.x * sub_grid.y
         tile = 32
         m_size, n_size = (tile, tile * num_cores) if mcast_in0 else (tile * num_cores, tile)

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -3452,6 +3452,64 @@ def test_matmul_on_subdevice_1d_mcast(device, m_size, k_size, n_size):
         _teardown_subdevice(device, sub_device_manager)
 
 
+@skip_for_slow_dispatch()
+@pytest.mark.parametrize("mcast_in0", [True, False], ids=["mcast_in0", "mcast_in1"])
+def test_matmul_on_subdevice_1d_mcast_full_grid(device, mcast_in0):
+    """Regression for issue #43900: 1-D multicast matmul over the full offset
+    worker rectangle. Requesting `cols * (rows - 1)` cores from a sub-device
+    anchored at (0, 1) exceeds the old (0, 0)-anchored helper's underestimate
+    by exactly one row's worth, which used to trip a spurious
+    'target > available' TT_FATAL.
+    """
+    grid = device.compute_with_storage_grid_size()
+    if grid.y < 3:
+        pytest.skip("Need at least 3 rows for the offset full-grid sub-device test")
+
+    sub_device_manager, worker_sub_device_id, _, _ = _setup_subdevice(device)
+    try:
+        sub_grid = ttnn.CoreCoord(grid.x, grid.y - 1)
+        num_cores = sub_grid.x * sub_grid.y
+        tile = 32
+        m_size, n_size = (tile, tile * num_cores) if mcast_in0 else (tile * num_cores, tile)
+        k_size = 1024
+
+        program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=sub_grid,
+            in0_block_w=1,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            per_core_M=1,
+            per_core_N=1,
+            fuse_batch=False,
+            mcast_in0=mcast_in0,
+            fused_activation=None,
+        )
+
+        torch.manual_seed(0)
+        torch_input_a = torch.randn((1, 1, m_size, k_size), dtype=torch.bfloat16)
+        torch_input_b = torch.randn((1, 1, k_size, n_size), dtype=torch.bfloat16)
+        torch_output = torch_input_a @ torch_input_b
+
+        kwargs = dict(
+            dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+        input_a = ttnn.from_torch(torch_input_a, **kwargs)
+        input_b = ttnn.from_torch(torch_input_b, **kwargs)
+
+        output = ttnn.matmul(input_a, input_b, program_config=program_config, sub_device_id=worker_sub_device_id)
+        output = ttnn.to_torch(output)
+        assert_numeric_metrics(
+            torch_output,
+            output,
+            atol=0.004 * k_size,
+            rtol=0.79 * k_size,
+            frobenius_threshold=0.001 * k_size,
+            pcc_threshold=0.999,
+        )
+    finally:
+        _teardown_subdevice(device, sub_device_manager)
+
+
 @pytest.mark.parametrize(
     "weight_dtype, pcc_threshold",
     [

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config_types.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config_types.hpp
@@ -37,13 +37,16 @@ struct MatmulMultiCoreReuseMultiCastProgramConfig {
 
 // 1D mcast matmul program config.
 //
-// `compute_with_storage_grid_size` describes the size of the rectangular grid of worker cores
-// that matmul will use, anchored at (0, 0) on the device, or at the bounding-box start of the
-// active sub-device when `sub_device_id` is set on the op. The 1D mcast factory targets a
-// single bounding-box rectangle for multicast and the per-core index math assumes a single
-// contiguous row-major rectangle, so when `sub_device_id` is provided the sub-device's worker
-// cores must themselves form a single rectangle. Non-rectangular sub-device grids are rejected
-// at validate time.
+// When `gather_in0 == false`, `compute_with_storage_grid_size` describes the size of the
+// rectangular grid of worker cores that the multicast paths will use, anchored at (0, 0) on
+// the device, or at the bounding-box start of the active sub-device when `sub_device_id` is
+// set on the op. The 1D mcast factory targets a single bounding-box rectangle for multicast
+// and the per-core index math assumes a single contiguous row-major rectangle, so when
+// `sub_device_id` is provided the sub-device's worker cores must themselves form a single
+// rectangle. Non-rectangular sub-device grids are rejected at validate time.
+//
+// When `gather_in0 == true`, `compute_with_storage_grid_size` is ignored and the gather path
+// can run on any sub-device worker layout, including non-rectangular ones.
 struct MatmulMultiCoreReuseMultiCast1DProgramConfig {
     CoreCoord compute_with_storage_grid_size;
     std::size_t in0_block_w{};

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config_types.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config_types.hpp
@@ -35,6 +35,15 @@ struct MatmulMultiCoreReuseMultiCastProgramConfig {
     bool fuse_batch = true;
 };
 
+// 1D mcast matmul program config.
+//
+// `compute_with_storage_grid_size` describes the size of the rectangular grid of worker cores
+// that matmul will use, anchored at (0, 0) on the device, or at the bounding-box start of the
+// active sub-device when `sub_device_id` is set on the op. The 1D mcast factory targets a
+// single bounding-box rectangle for multicast and the per-core index math assumes a single
+// contiguous row-major rectangle, so when `sub_device_id` is provided the sub-device's worker
+// cores must themselves form a single rectangle. Non-rectangular sub-device grids are rejected
+// at validate time.
 struct MatmulMultiCoreReuseMultiCast1DProgramConfig {
     CoreCoord compute_with_storage_grid_size;
     std::size_t in0_block_w{};

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -201,9 +201,9 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     // The matmul region is the rectangle of size `compute_with_storage_grid_size`
     // anchored at `start_core`. Callers must ensure this rectangle lies entirely
     // within the active sub-device's worker cores (validated upstream). Using a
-    // CoreRangeSet here lets num_cores_to_corerangeset_in_subcoregrids honor the
+    // CoreRangeSet here lets num_cores_to_corerangeset_in_subcoregrids honour the
     // start offset when the sub-device is not anchored at (0, 0).
-    CoreRangeSet sub_device_cores(CoreRange(
+    CoreRangeSet matmul_core_rect(CoreRange(
         start_core,
         CoreCoord(
             start_core_x + compute_with_storage_grid_size.x - 1, start_core_y + compute_with_storage_grid_size.y - 1)));
@@ -228,14 +228,14 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
 
     constexpr bool row_major = true;
     CoreRangeSet all_cores =
-        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, sub_device_cores, row_major);
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, matmul_core_rect, row_major);
 
     CoreRangeSet in0_mcast_sender_cores =
-        num_cores_to_corerangeset_in_subcoregrids(start_core, in0_sender_num_cores, sub_device_cores, row_major);
+        num_cores_to_corerangeset_in_subcoregrids(start_core, in0_sender_num_cores, matmul_core_rect, row_major);
     CoreCoord in0_mcast_sender_cores_grid = in0_mcast_sender_cores.bounding_box().grid_size();
 
     CoreRangeSet all_cores_with_work =
-        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores_with_work, sub_device_cores, row_major);
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores_with_work, matmul_core_rect, row_major);
     CoreRange in0_mcast_receiver_cores_bounding_box = all_cores_with_work.bounding_box();
     uint32_t in0_mcast_receiver_num_cores = in0_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
     uint32_t in0_mcast_receiver_num_dests = std::min(
@@ -258,7 +258,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
             uint32_t core_idx_y = num_cores_with_work / num_cores_c;
             CoreCoord start_core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
             in0_mcast_cores_without_work_and_in_receiver_grid = num_cores_to_corerangeset_in_subcoregrids(
-                start_core, in0_mcast_cores_without_work_and_in_receiver_grid_num_cores, sub_device_cores, row_major);
+                start_core, in0_mcast_cores_without_work_and_in_receiver_grid_num_cores, matmul_core_rect, row_major);
         }
 
         if (in0_sender_num_cores > in0_mcast_receiver_num_dests) {
@@ -270,7 +270,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
             in0_mcast_cores_without_work_and_not_in_receiver_grid = num_cores_to_corerangeset_in_subcoregrids(
                 start_core,
                 in0_mcast_cores_without_work_and_not_in_receiver_grid_num_cores,
-                sub_device_cores,
+                matmul_core_rect,
                 row_major);
         }
 
@@ -292,7 +292,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
             auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
                                                                             : CoreCoord{start_core.x, start_core.y + 1};
             in0_mcast_receivers = num_cores_to_corerangeset_in_subcoregrids(
-                receiver_start_core, num_cores - 1, sub_device_cores, row_major);
+                receiver_start_core, num_cores - 1, matmul_core_rect, row_major);
         }
     }
 
@@ -1254,7 +1254,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     // The matmul region is the rectangle of size `compute_with_storage_grid_size`
     // anchored at `start_core`. Callers must ensure this rectangle lies entirely
     // within the active sub-device's worker cores (validated upstream).
-    CoreRangeSet sub_device_cores(CoreRange(
+    CoreRangeSet matmul_core_rect(CoreRange(
         start_core,
         CoreCoord(
             start_core.x + compute_with_storage_grid_size.x - 1, start_core.y + compute_with_storage_grid_size.y - 1)));
@@ -1266,7 +1266,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
 
     constexpr bool row_major = true;
     CoreRangeSet all_cores =
-        tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, sub_device_cores, row_major);
+        tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, matmul_core_rect, row_major);
     CoreRange in1_mcast_receiver_cores_bounding_box = all_cores.bounding_box();
     uint32_t in1_mcast_receiver_num_cores = in1_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
 
@@ -1278,7 +1278,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
                                                                         : CoreCoord{start_core.x, start_core.y + 1};
         in1_mcast_receivers = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
-            receiver_start_core, num_cores - 1, sub_device_cores, row_major);
+            receiver_start_core, num_cores - 1, matmul_core_rect, row_major);
     }
 
     // Mcast args
@@ -3046,7 +3046,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
     // The matmul region is the rectangle of size `compute_with_storage_grid_size`
     // anchored at `start_core`. Callers must ensure this rectangle lies entirely
     // within the active sub-device's worker cores (validated upstream).
-    CoreRangeSet sub_device_cores(CoreRange(
+    CoreRangeSet matmul_core_rect(CoreRange(
         start_core,
         CoreCoord(
             start_core_x + compute_with_storage_grid_size.x - 1, start_core_y + compute_with_storage_grid_size.y - 1)));
@@ -3071,14 +3071,14 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
 
     constexpr bool row_major = true;
     CoreRangeSet all_cores =
-        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, sub_device_cores, row_major);
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, matmul_core_rect, row_major);
 
     CoreRangeSet in0_mcast_sender_cores =
-        num_cores_to_corerangeset_in_subcoregrids(start_core, in0_sender_num_cores, sub_device_cores, row_major);
+        num_cores_to_corerangeset_in_subcoregrids(start_core, in0_sender_num_cores, matmul_core_rect, row_major);
     CoreCoord in0_mcast_sender_cores_grid = in0_mcast_sender_cores.bounding_box().grid_size();
 
     CoreRangeSet all_cores_with_work =
-        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores_with_work, sub_device_cores, row_major);
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores_with_work, matmul_core_rect, row_major);
     CoreRange in0_mcast_receiver_cores_bounding_box = all_cores_with_work.bounding_box();
     uint32_t in0_mcast_receiver_num_cores = in0_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
     uint32_t in0_mcast_receiver_num_dests = std::min(
@@ -3101,7 +3101,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
             uint32_t core_idx_y = num_cores_with_work / num_cores_c;
             CoreCoord start_core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
             in0_mcast_cores_without_work_and_in_receiver_grid = num_cores_to_corerangeset_in_subcoregrids(
-                start_core, in0_mcast_cores_without_work_and_in_receiver_grid_num_cores, sub_device_cores, row_major);
+                start_core, in0_mcast_cores_without_work_and_in_receiver_grid_num_cores, matmul_core_rect, row_major);
         }
 
         if (in0_sender_num_cores > in0_mcast_receiver_num_dests) {
@@ -3113,7 +3113,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
             in0_mcast_cores_without_work_and_not_in_receiver_grid = num_cores_to_corerangeset_in_subcoregrids(
                 start_core,
                 in0_mcast_cores_without_work_and_not_in_receiver_grid_num_cores,
-                sub_device_cores,
+                matmul_core_rect,
                 row_major);
         }
 
@@ -3135,7 +3135,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
             auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
                                                                             : CoreCoord{start_core.x, start_core.y + 1};
             in0_mcast_receivers = num_cores_to_corerangeset_in_subcoregrids(
-                receiver_start_core, num_cores - 1, sub_device_cores, row_major);
+                receiver_start_core, num_cores - 1, matmul_core_rect, row_major);
         }
     }
 
@@ -4094,7 +4094,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
     // The matmul region is the rectangle of size `compute_with_storage_grid_size`
     // anchored at `start_core`. Callers must ensure this rectangle lies entirely
     // within the active sub-device's worker cores (validated upstream).
-    CoreRangeSet sub_device_cores(CoreRange(
+    CoreRangeSet matmul_core_rect(CoreRange(
         start_core,
         CoreCoord(
             start_core.x + compute_with_storage_grid_size.x - 1, start_core.y + compute_with_storage_grid_size.y - 1)));
@@ -4106,7 +4106,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
 
     constexpr bool row_major = true;
     CoreRangeSet all_cores =
-        tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, sub_device_cores, row_major);
+        tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, matmul_core_rect, row_major);
     CoreRange in1_mcast_receiver_cores_bounding_box = all_cores.bounding_box();
     uint32_t in1_mcast_receiver_num_cores = in1_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
 
@@ -4118,7 +4118,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
         auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
                                                                         : CoreCoord{start_core.x, start_core.y + 1};
         in1_mcast_receivers = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
-            receiver_start_core, num_cores - 1, sub_device_cores, row_major);
+            receiver_start_core, num_cores - 1, matmul_core_rect, row_major);
     }
 
     // Mcast args — semaphore IDs assigned sequentially (0, 1)
@@ -5044,14 +5044,14 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
     // contiguous row-major rectangle of width `compute_with_storage_grid_size.x`.
     CoreCoord sub_device_start_core = {0, 0};
     if (sub_device_id.has_value()) {
-        auto sub_device_cores =
+        auto sd_worker_cores =
             device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sub_device_id.value());
-        auto bbox = sub_device_cores.bounding_box();
+        auto bbox = sd_worker_cores.bounding_box();
         TT_FATAL(
-            sub_device_cores.num_cores() == bbox.size(),
+            sd_worker_cores.num_cores() == bbox.size(),
             "matmul_multicore_reuse_mcast_1d only supports rectangular sub-device worker grids. "
             "Got sub-device worker cores: {} (bounding box: {})",
-            sub_device_cores,
+            sd_worker_cores,
             bbox);
         TT_FATAL(
             bbox.start_coord.x + compute_with_storage_grid_size.x - 1 <= bbox.end_coord.x &&
@@ -5249,14 +5249,14 @@ ProgramDescriptor MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
     // contiguous row-major rectangle of width `compute_with_storage_grid_size.x`.
     CoreCoord sub_device_start_core = {0, 0};
     if (operation_attributes.sub_device_id.has_value()) {
-        auto sub_device_cores = device->worker_cores(
+        auto sd_worker_cores = device->worker_cores(
             tt::tt_metal::HalProgrammableCoreType::TENSIX, operation_attributes.sub_device_id.value());
-        auto bbox = sub_device_cores.bounding_box();
+        auto bbox = sd_worker_cores.bounding_box();
         TT_FATAL(
-            sub_device_cores.num_cores() == bbox.size(),
+            sd_worker_cores.num_cores() == bbox.size(),
             "matmul_multicore_reuse_mcast_1d only supports rectangular sub-device worker grids. "
             "Got sub-device worker cores: {} (bounding box: {})",
-            sub_device_cores,
+            sd_worker_cores,
             bbox);
         TT_FATAL(
             bbox.start_coord.x + program_config.compute_with_storage_grid_size.x - 1 <= bbox.end_coord.x &&

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -116,7 +116,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
     bool row_broadcast_bias = true,
     CoreCoord sub_device_start_core = {0, 0}) {
-    using tt::tt_metal::num_cores_to_corerangeset;
+    using tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids;
 
     // currently only support transpose of the full tile
     bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
@@ -198,6 +198,16 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     uint32_t start_core_y = start_core.y;
     uint32_t num_cores_c = compute_with_storage_grid_size.x;
 
+    // The matmul region is the rectangle of size `compute_with_storage_grid_size`
+    // anchored at `start_core`. Callers must ensure this rectangle lies entirely
+    // within the active sub-device's worker cores (validated upstream). Using a
+    // CoreRangeSet here lets num_cores_to_corerangeset_in_subcoregrids honor the
+    // start offset when the sub-device is not anchored at (0, 0).
+    CoreRangeSet sub_device_cores(CoreRange(
+        start_core,
+        CoreCoord(
+            start_core_x + compute_with_storage_grid_size.x - 1, start_core_y + compute_with_storage_grid_size.y - 1)));
+
     uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
     uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
     uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
@@ -218,14 +228,14 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
 
     constexpr bool row_major = true;
     CoreRangeSet all_cores =
-        num_cores_to_corerangeset(start_core, num_cores, compute_with_storage_grid_size, row_major);
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, sub_device_cores, row_major);
 
     CoreRangeSet in0_mcast_sender_cores =
-        num_cores_to_corerangeset(start_core, in0_sender_num_cores, compute_with_storage_grid_size, row_major);
+        num_cores_to_corerangeset_in_subcoregrids(start_core, in0_sender_num_cores, sub_device_cores, row_major);
     CoreCoord in0_mcast_sender_cores_grid = in0_mcast_sender_cores.bounding_box().grid_size();
 
     CoreRangeSet all_cores_with_work =
-        num_cores_to_corerangeset(start_core, num_cores_with_work, compute_with_storage_grid_size, row_major);
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores_with_work, sub_device_cores, row_major);
     CoreRange in0_mcast_receiver_cores_bounding_box = all_cores_with_work.bounding_box();
     uint32_t in0_mcast_receiver_num_cores = in0_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
     uint32_t in0_mcast_receiver_num_dests = std::min(
@@ -247,11 +257,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
             uint32_t core_idx_x = num_cores_with_work % num_cores_c;
             uint32_t core_idx_y = num_cores_with_work / num_cores_c;
             CoreCoord start_core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
-            in0_mcast_cores_without_work_and_in_receiver_grid = num_cores_to_corerangeset(
-                start_core,
-                in0_mcast_cores_without_work_and_in_receiver_grid_num_cores,
-                compute_with_storage_grid_size,
-                row_major);
+            in0_mcast_cores_without_work_and_in_receiver_grid = num_cores_to_corerangeset_in_subcoregrids(
+                start_core, in0_mcast_cores_without_work_and_in_receiver_grid_num_cores, sub_device_cores, row_major);
         }
 
         if (in0_sender_num_cores > in0_mcast_receiver_num_dests) {
@@ -260,10 +267,10 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
             uint32_t core_idx_x = in0_mcast_receiver_num_dests % num_cores_c;
             uint32_t core_idx_y = in0_mcast_receiver_num_dests / num_cores_c;
             CoreCoord start_core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
-            in0_mcast_cores_without_work_and_not_in_receiver_grid = num_cores_to_corerangeset(
+            in0_mcast_cores_without_work_and_not_in_receiver_grid = num_cores_to_corerangeset_in_subcoregrids(
                 start_core,
                 in0_mcast_cores_without_work_and_not_in_receiver_grid_num_cores,
-                compute_with_storage_grid_size,
+                sub_device_cores,
                 row_major);
         }
 
@@ -280,11 +287,12 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     } else {
         in0_mcast_cores_with_work_and_in_receiver_grid = CoreRangeSet({CoreRange(start_core, start_core)});
         if (in0_mcast_receiver_num_cores > 1) {
-            auto receiver_start_core = start_core.x != (compute_with_storage_grid_size.x - 1)
-                                           ? CoreCoord{start_core.x + 1, start_core.y}
-                                           : CoreCoord{start_core.x, start_core.y + 1};
-            in0_mcast_receivers = num_cores_to_corerangeset(
-                receiver_start_core, num_cores - 1, compute_with_storage_grid_size, row_major);
+            // Check against the actual rectangle width (instead of bare grid_size.x-1) so that
+            // sub-devices anchored away from (0, 0) wrap correctly.
+            auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
+                                                                            : CoreCoord{start_core.x, start_core.y + 1};
+            in0_mcast_receivers = num_cores_to_corerangeset_in_subcoregrids(
+                receiver_start_core, num_cores - 1, sub_device_cores, row_major);
         }
     }
 
@@ -1243,6 +1251,14 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
 
     CoreCoord start_core = sub_device_start_core;
 
+    // The matmul region is the rectangle of size `compute_with_storage_grid_size`
+    // anchored at `start_core`. Callers must ensure this rectangle lies entirely
+    // within the active sub-device's worker cores (validated upstream).
+    CoreRangeSet sub_device_cores(CoreRange(
+        start_core,
+        CoreCoord(
+            start_core.x + compute_with_storage_grid_size.x - 1, start_core.y + compute_with_storage_grid_size.y - 1)));
+
     uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
     uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
     uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
@@ -1250,18 +1266,19 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
 
     constexpr bool row_major = true;
     CoreRangeSet all_cores =
-        tt::tt_metal::num_cores_to_corerangeset(start_core, num_cores, compute_with_storage_grid_size, row_major);
+        tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, sub_device_cores, row_major);
     CoreRange in1_mcast_receiver_cores_bounding_box = all_cores.bounding_box();
     uint32_t in1_mcast_receiver_num_cores = in1_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
 
     CoreRange in1_mcast_sender(start_core, start_core);
     CoreRangeSet in1_mcast_receivers;
     if (in1_mcast_receiver_num_cores > 1) {
-        auto receiver_start_core = start_core.x != (compute_with_storage_grid_size.x - 1)
-                                       ? CoreCoord{start_core.x + 1, start_core.y}
-                                       : CoreCoord{start_core.x, start_core.y + 1};
-        in1_mcast_receivers = tt::tt_metal::num_cores_to_corerangeset(
-            receiver_start_core, num_cores - 1, compute_with_storage_grid_size, row_major);
+        // Check against the actual rectangle width (instead of bare grid_size.x-1) so that
+        // sub-devices anchored away from (0, 0) wrap correctly.
+        auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
+                                                                        : CoreCoord{start_core.x, start_core.y + 1};
+        in1_mcast_receivers = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
+            receiver_start_core, num_cores - 1, sub_device_cores, row_major);
     }
 
     // Mcast args
@@ -2944,7 +2961,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
     std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
     bool row_broadcast_bias = true,
     CoreCoord sub_device_start_core = {0, 0}) {
-    using tt::tt_metal::num_cores_to_corerangeset;
+    using tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids;
 
     // currently only support transpose of the full tile
     bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
@@ -3026,6 +3043,14 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
     uint32_t start_core_y = start_core.y;
     uint32_t num_cores_c = compute_with_storage_grid_size.x;
 
+    // The matmul region is the rectangle of size `compute_with_storage_grid_size`
+    // anchored at `start_core`. Callers must ensure this rectangle lies entirely
+    // within the active sub-device's worker cores (validated upstream).
+    CoreRangeSet sub_device_cores(CoreRange(
+        start_core,
+        CoreCoord(
+            start_core_x + compute_with_storage_grid_size.x - 1, start_core_y + compute_with_storage_grid_size.y - 1)));
+
     uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
     uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
     uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
@@ -3046,14 +3071,14 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
 
     constexpr bool row_major = true;
     CoreRangeSet all_cores =
-        num_cores_to_corerangeset(start_core, num_cores, compute_with_storage_grid_size, row_major);
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, sub_device_cores, row_major);
 
     CoreRangeSet in0_mcast_sender_cores =
-        num_cores_to_corerangeset(start_core, in0_sender_num_cores, compute_with_storage_grid_size, row_major);
+        num_cores_to_corerangeset_in_subcoregrids(start_core, in0_sender_num_cores, sub_device_cores, row_major);
     CoreCoord in0_mcast_sender_cores_grid = in0_mcast_sender_cores.bounding_box().grid_size();
 
     CoreRangeSet all_cores_with_work =
-        num_cores_to_corerangeset(start_core, num_cores_with_work, compute_with_storage_grid_size, row_major);
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores_with_work, sub_device_cores, row_major);
     CoreRange in0_mcast_receiver_cores_bounding_box = all_cores_with_work.bounding_box();
     uint32_t in0_mcast_receiver_num_cores = in0_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
     uint32_t in0_mcast_receiver_num_dests = std::min(
@@ -3075,11 +3100,8 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
             uint32_t core_idx_x = num_cores_with_work % num_cores_c;
             uint32_t core_idx_y = num_cores_with_work / num_cores_c;
             CoreCoord start_core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
-            in0_mcast_cores_without_work_and_in_receiver_grid = num_cores_to_corerangeset(
-                start_core,
-                in0_mcast_cores_without_work_and_in_receiver_grid_num_cores,
-                compute_with_storage_grid_size,
-                row_major);
+            in0_mcast_cores_without_work_and_in_receiver_grid = num_cores_to_corerangeset_in_subcoregrids(
+                start_core, in0_mcast_cores_without_work_and_in_receiver_grid_num_cores, sub_device_cores, row_major);
         }
 
         if (in0_sender_num_cores > in0_mcast_receiver_num_dests) {
@@ -3088,10 +3110,10 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
             uint32_t core_idx_x = in0_mcast_receiver_num_dests % num_cores_c;
             uint32_t core_idx_y = in0_mcast_receiver_num_dests / num_cores_c;
             CoreCoord start_core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
-            in0_mcast_cores_without_work_and_not_in_receiver_grid = num_cores_to_corerangeset(
+            in0_mcast_cores_without_work_and_not_in_receiver_grid = num_cores_to_corerangeset_in_subcoregrids(
                 start_core,
                 in0_mcast_cores_without_work_and_not_in_receiver_grid_num_cores,
-                compute_with_storage_grid_size,
+                sub_device_cores,
                 row_major);
         }
 
@@ -3108,11 +3130,12 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
     } else {
         in0_mcast_cores_with_work_and_in_receiver_grid = CoreRangeSet({CoreRange(start_core, start_core)});
         if (in0_mcast_receiver_num_cores > 1) {
-            auto receiver_start_core = start_core.x != (compute_with_storage_grid_size.x - 1)
-                                           ? CoreCoord{start_core.x + 1, start_core.y}
-                                           : CoreCoord{start_core.x, start_core.y + 1};
-            in0_mcast_receivers = num_cores_to_corerangeset(
-                receiver_start_core, num_cores - 1, compute_with_storage_grid_size, row_major);
+            // Check against the actual rectangle width (instead of bare grid_size.x-1) so that
+            // sub-devices anchored away from (0, 0) wrap correctly.
+            auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
+                                                                            : CoreCoord{start_core.x, start_core.y + 1};
+            in0_mcast_receivers = num_cores_to_corerangeset_in_subcoregrids(
+                receiver_start_core, num_cores - 1, sub_device_cores, row_major);
         }
     }
 
@@ -4068,6 +4091,14 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
 
     CoreCoord start_core = sub_device_start_core;
 
+    // The matmul region is the rectangle of size `compute_with_storage_grid_size`
+    // anchored at `start_core`. Callers must ensure this rectangle lies entirely
+    // within the active sub-device's worker cores (validated upstream).
+    CoreRangeSet sub_device_cores(CoreRange(
+        start_core,
+        CoreCoord(
+            start_core.x + compute_with_storage_grid_size.x - 1, start_core.y + compute_with_storage_grid_size.y - 1)));
+
     uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
     uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
     uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
@@ -4075,18 +4106,19 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
 
     constexpr bool row_major = true;
     CoreRangeSet all_cores =
-        tt::tt_metal::num_cores_to_corerangeset(start_core, num_cores, compute_with_storage_grid_size, row_major);
+        tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, sub_device_cores, row_major);
     CoreRange in1_mcast_receiver_cores_bounding_box = all_cores.bounding_box();
     uint32_t in1_mcast_receiver_num_cores = in1_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
 
     CoreRange in1_mcast_sender(start_core, start_core);
     CoreRangeSet in1_mcast_receivers;
     if (in1_mcast_receiver_num_cores > 1) {
-        auto receiver_start_core = start_core.x != (compute_with_storage_grid_size.x - 1)
-                                       ? CoreCoord{start_core.x + 1, start_core.y}
-                                       : CoreCoord{start_core.x, start_core.y + 1};
-        in1_mcast_receivers = tt::tt_metal::num_cores_to_corerangeset(
-            receiver_start_core, num_cores - 1, compute_with_storage_grid_size, row_major);
+        // Check against the actual rectangle width (instead of bare grid_size.x-1) so that
+        // sub-devices anchored away from (0, 0) wrap correctly.
+        auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
+                                                                        : CoreCoord{start_core.x, start_core.y + 1};
+        in1_mcast_receivers = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
+            receiver_start_core, num_cores - 1, sub_device_cores, row_major);
     }
 
     // Mcast args — semaphore IDs assigned sequentially (0, 1)
@@ -5007,11 +5039,28 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
     ////////////////////////////////////////////////////////////////////////////
     //                      Sub-device start core
     ////////////////////////////////////////////////////////////////////////////
+    // The 1D mcast matmul only supports rectangular sub-device worker grids, because the in0/in1
+    // multicast targets a single bounding-box rectangle and the per-core index math assumes a
+    // contiguous row-major rectangle of width `compute_with_storage_grid_size.x`.
     CoreCoord sub_device_start_core = {0, 0};
     if (sub_device_id.has_value()) {
         auto sub_device_cores =
             device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sub_device_id.value());
         auto bbox = sub_device_cores.bounding_box();
+        TT_FATAL(
+            sub_device_cores.num_cores() == bbox.size(),
+            "matmul_multicore_reuse_mcast_1d only supports rectangular sub-device worker grids. "
+            "Got sub-device worker cores: {} (bounding box: {})",
+            sub_device_cores,
+            bbox);
+        TT_FATAL(
+            bbox.start_coord.x + compute_with_storage_grid_size.x - 1 <= bbox.end_coord.x &&
+                bbox.start_coord.y + compute_with_storage_grid_size.y - 1 <= bbox.end_coord.y,
+            "matmul_multicore_reuse_mcast_1d compute_with_storage_grid_size {} anchored at sub-device start {} "
+            "extends past the sub-device's worker bounding box {}",
+            compute_with_storage_grid_size,
+            bbox.start_coord,
+            bbox);
         sub_device_start_core = bbox.start_coord;
     }
 
@@ -5195,11 +5244,28 @@ ProgramDescriptor MatmulMultiCoreReuseMcast1DProgramFactory::create_descriptor(
 
     tt_metal::Buffer* out_buffer = output.buffer();
 
+    // The 1D mcast matmul only supports rectangular sub-device worker grids, because the in0/in1
+    // multicast targets a single bounding-box rectangle and the per-core index math assumes a
+    // contiguous row-major rectangle of width `compute_with_storage_grid_size.x`.
     CoreCoord sub_device_start_core = {0, 0};
     if (operation_attributes.sub_device_id.has_value()) {
         auto sub_device_cores = device->worker_cores(
             tt::tt_metal::HalProgrammableCoreType::TENSIX, operation_attributes.sub_device_id.value());
         auto bbox = sub_device_cores.bounding_box();
+        TT_FATAL(
+            sub_device_cores.num_cores() == bbox.size(),
+            "matmul_multicore_reuse_mcast_1d only supports rectangular sub-device worker grids. "
+            "Got sub-device worker cores: {} (bounding box: {})",
+            sub_device_cores,
+            bbox);
+        TT_FATAL(
+            bbox.start_coord.x + program_config.compute_with_storage_grid_size.x - 1 <= bbox.end_coord.x &&
+                bbox.start_coord.y + program_config.compute_with_storage_grid_size.y - 1 <= bbox.end_coord.y,
+            "matmul_multicore_reuse_mcast_1d compute_with_storage_grid_size {} anchored at sub-device start {} "
+            "extends past the sub-device's worker bounding box {}",
+            program_config.compute_with_storage_grid_size,
+            bbox.start_coord,
+            bbox);
         sub_device_start_core = bbox.start_coord;
     }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -287,6 +287,37 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
         }
     }
 
+    // matmul_multicore_reuse_mcast_1d (both program- and descriptor-based) targets a single
+    // bounding-box rectangle for the in0/in1 multicast and expects the sub-device's worker
+    // cores to form one contiguous row-major rectangle. Reject non-rectangular sub-device
+    // grids early with a clear message.
+    if (std::holds_alternative<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
+            chosen_program_config) &&
+        attributes.sub_device_id.has_value()) {
+        const auto& program_config_1d =
+            std::get<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(chosen_program_config);
+        if (!program_config_1d.gather_in0) {
+            auto* device = input_tensor_a.device();
+            auto sub_device_cores =
+                device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, attributes.sub_device_id.value());
+            auto bbox = sub_device_cores.bounding_box();
+            TT_FATAL(
+                sub_device_cores.num_cores() == bbox.size(),
+                "matmul_multicore_reuse_mcast_1d only supports rectangular sub-device worker grids. "
+                "Got sub-device worker cores: {} (bounding box: {})",
+                sub_device_cores,
+                bbox);
+            TT_FATAL(
+                bbox.start_coord.x + program_config_1d.compute_with_storage_grid_size.x - 1 <= bbox.end_coord.x &&
+                    bbox.start_coord.y + program_config_1d.compute_with_storage_grid_size.y - 1 <= bbox.end_coord.y,
+                "matmul_multicore_reuse_mcast_1d compute_with_storage_grid_size {} anchored at sub-device start {} "
+                "extends past the sub-device's worker bounding box {}",
+                program_config_1d.compute_with_storage_grid_size,
+                bbox.start_coord,
+                bbox);
+        }
+    }
+
     if (std::holds_alternative<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
             chosen_program_config) &&
         attributes.global_cb.has_value() && input_tensor_b.is_sharded() && input_tensor_b.buffer()->is_dram()) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
@@ -141,7 +141,7 @@ SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(
     // Only support mcast_in0 for now
     TT_FATAL(mcast_in0, "Only mcast_in0 is supported for sparse matmul");
 
-    using tt::tt_metal::num_cores_to_corerangeset;
+    using tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids;
 
     uint32_t num_blocks = Kt / in0_block_w;
     // Only enable packer l1 accumulation when there are spills, otherwise
@@ -184,6 +184,15 @@ SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(
 
     CoreCoord start_core = {0, 0};
 
+    // The matmul region is the rectangle of size `compute_with_storage_grid_size`
+    // anchored at `start_core`. The sparse 1D matmul path does not yet anchor at a sub-device
+    // start, but keeping the rectangle expression here keeps the API uniform with the dense 1D
+    // path and is safe (sub_device_cores == full compute grid when start_core == (0, 0)).
+    CoreRangeSet sub_device_cores(CoreRange(
+        start_core,
+        CoreCoord(
+            start_core.x + compute_with_storage_grid_size.x - 1, start_core.y + compute_with_storage_grid_size.y - 1)));
+
     uint32_t num_cores_with_work = num_blocks_total;
 
     uint32_t in0_sender_num_cores = 1;
@@ -191,13 +200,13 @@ SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(
 
     constexpr bool row_major = true;
     CoreRangeSet all_cores =
-        num_cores_to_corerangeset(start_core, num_cores, compute_with_storage_grid_size, row_major);
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, sub_device_cores, row_major);
 
     CoreRangeSet in0_mcast_sender_cores =
-        num_cores_to_corerangeset(in0_sender_num_cores, compute_with_storage_grid_size, row_major);
+        num_cores_to_corerangeset_in_subcoregrids(start_core, in0_sender_num_cores, sub_device_cores, row_major);
 
     CoreRangeSet all_cores_with_work =
-        num_cores_to_corerangeset(num_cores_with_work, compute_with_storage_grid_size, row_major);
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores_with_work, sub_device_cores, row_major);
     CoreRange in0_mcast_receiver_cores_bounding_box = all_cores_with_work.bounding_box();
     uint32_t in0_mcast_receiver_num_cores = in0_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
 
@@ -223,11 +232,12 @@ SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(
 
     in0_mcast_cores_with_work_and_in_receiver_grid = CoreRangeSet({CoreRange(start_core, start_core)});
     if (in0_mcast_receiver_num_cores > 1) {
-        auto receiver_start_core = start_core.x != (compute_with_storage_grid_size.x - 1)
-                                       ? CoreCoord{start_core.x + 1, start_core.y}
-                                       : CoreCoord{start_core.x, start_core.y + 1};
+        // Check against the actual rectangle width (instead of bare grid_size.x-1) so that
+        // sub-devices anchored away from (0, 0) would wrap correctly.
+        auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
+                                                                        : CoreCoord{start_core.x, start_core.y + 1};
         in0_mcast_receivers =
-            num_cores_to_corerangeset(receiver_start_core, num_cores - 1, compute_with_storage_grid_size, row_major);
+            num_cores_to_corerangeset_in_subcoregrids(receiver_start_core, num_cores - 1, sub_device_cores, row_major);
     }
 
     // Mcast args

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
@@ -187,8 +187,8 @@ SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(
     // The matmul region is the rectangle of size `compute_with_storage_grid_size`
     // anchored at `start_core`. The sparse 1D matmul path does not yet anchor at a sub-device
     // start, but keeping the rectangle expression here keeps the API uniform with the dense 1D
-    // path and is safe (sub_device_cores == full compute grid when start_core == (0, 0)).
-    CoreRangeSet sub_device_cores(CoreRange(
+    // path and is safe (matmul_core_rect == full compute grid when start_core == (0, 0)).
+    CoreRangeSet matmul_core_rect(CoreRange(
         start_core,
         CoreCoord(
             start_core.x + compute_with_storage_grid_size.x - 1, start_core.y + compute_with_storage_grid_size.y - 1)));
@@ -200,13 +200,13 @@ SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(
 
     constexpr bool row_major = true;
     CoreRangeSet all_cores =
-        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, sub_device_cores, row_major);
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, matmul_core_rect, row_major);
 
     CoreRangeSet in0_mcast_sender_cores =
-        num_cores_to_corerangeset_in_subcoregrids(start_core, in0_sender_num_cores, sub_device_cores, row_major);
+        num_cores_to_corerangeset_in_subcoregrids(start_core, in0_sender_num_cores, matmul_core_rect, row_major);
 
     CoreRangeSet all_cores_with_work =
-        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores_with_work, sub_device_cores, row_major);
+        num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores_with_work, matmul_core_rect, row_major);
     CoreRange in0_mcast_receiver_cores_bounding_box = all_cores_with_work.bounding_box();
     uint32_t in0_mcast_receiver_num_cores = in0_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
 
@@ -237,7 +237,7 @@ SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(
         auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
                                                                         : CoreCoord{start_core.x, start_core.y + 1};
         in0_mcast_receivers =
-            num_cores_to_corerangeset_in_subcoregrids(receiver_start_core, num_cores - 1, sub_device_cores, row_major);
+            num_cores_to_corerangeset_in_subcoregrids(receiver_start_core, num_cores - 1, matmul_core_rect, row_major);
     }
 
     // Mcast args

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -301,11 +301,13 @@ void py_module(nb::module_& mod) {
 
         This program config is for use with width and height sharded tensors, or very narrow interleaved tensors.
 
-        When the matmul op is invoked with a ``sub_device_id``, ``compute_with_storage_grid_size`` is
-        anchored at the sub-device's worker bounding-box start instead of ``(0, 0)``. The 1D multicast
-        targets a single bounding-box rectangle and the per-core index math assumes a contiguous
-        row-major rectangle, so the sub-device's worker cores must themselves form a single rectangle.
-        Non-rectangular sub-device worker grids are rejected at validate time.
+        When ``gather_in0`` is False and the matmul op is invoked with a ``sub_device_id``,
+        ``compute_with_storage_grid_size`` is anchored at the sub-device's worker bounding-box start
+        instead of ``(0, 0)``. The 1D multicast targets a single bounding-box rectangle and the
+        per-core index math assumes a contiguous row-major rectangle, so the sub-device's worker
+        cores must themselves form a single rectangle. Non-rectangular sub-device worker grids are
+        rejected at validate time. When ``gather_in0`` is True, ``compute_with_storage_grid_size``
+        is ignored and the gather path can run on any sub-device worker layout.
     )doc");
 
     matmul_multi_core_reuse_multicast_1d_program_config
@@ -374,9 +376,9 @@ void py_module(nb::module_& mod) {
             this grid is used to determine the communication pattern for broadcasting data
             along one dimension while distributing computation.
 
-            When the matmul op is invoked with a ``sub_device_id``, this rectangle is anchored at
-            the sub-device's worker bounding-box start (instead of ``(0, 0)``) and must fit
-            inside that bounding box.
+            When the matmul op is invoked with a ``sub_device_id`` (and ``gather_in0`` is False),
+            this rectangle is anchored at the sub-device's worker bounding-box start (instead of
+            ``(0, 0)``) and must fit inside that bounding box. Ignored when ``gather_in0`` is True.
         )doc")
         .def_rw("in0_block_w", &MatmulMultiCoreReuseMultiCast1DProgramConfig::in0_block_w, R"doc(
             Block width for both input tensors along the K dimension (shared inner dimension).

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -300,6 +300,12 @@ void py_module(nb::module_& mod) {
         Configuration class for 1D multicast matmul operations with advanced features.
 
         This program config is for use with width and height sharded tensors, or very narrow interleaved tensors.
+
+        When the matmul op is invoked with a ``sub_device_id``, ``compute_with_storage_grid_size`` is
+        anchored at the sub-device's worker bounding-box start instead of ``(0, 0)``. The 1D multicast
+        targets a single bounding-box rectangle and the per-core index math assumes a contiguous
+        row-major rectangle, so the sub-device's worker cores must themselves form a single rectangle.
+        Non-rectangular sub-device worker grids are rejected at validate time.
     )doc");
 
     matmul_multi_core_reuse_multicast_1d_program_config
@@ -367,6 +373,10 @@ void py_module(nb::module_& mod) {
             Defines the 2D grid of cores that will be used for computation. In 1D multicast,
             this grid is used to determine the communication pattern for broadcasting data
             along one dimension while distributing computation.
+
+            When the matmul op is invoked with a ``sub_device_id``, this rectangle is anchored at
+            the sub-device's worker bounding-box start (instead of ``(0, 0)``) and must fit
+            inside that bounding box.
         )doc")
         .def_rw("in0_block_w", &MatmulMultiCoreReuseMultiCast1DProgramConfig::in0_block_w, R"doc(
             Block width for both input tensors along the K dimension (shared inner dimension).


### PR DESCRIPTION
### Summary
#43900 

Running a 1D matmul with a sub device could result in an incorrect TT_FATAL whenever the sub-device's worker rectangle was offset from (0, 0). This was because the 1D mcast factory used `num_cores_to_corerangeset`, which assumes a (0, 0)-anchored grid and could undercount available cores by one partial row/column. 

This PR swaps those calls for `num_cores_to_corerangeset_in_subcoregrids` (which respects the anchor) in the dense and sparse 1D mcast factories. It also adds validation that the sub-device's worker cores form a rectangle, as the existing code assumes this. Finally it adds a regression test covering this case.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=edwinlee/43900/matmul_sub_core_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/43900/matmul_sub_core_grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=edwinlee/43900/matmul_sub_core_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:edwinlee/43900/matmul_sub_core_grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=edwinlee/43900/matmul_sub_core_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:edwinlee/43900/matmul_sub_core_grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/43900/matmul_sub_core_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/43900/matmul_sub_core_grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=edwinlee/43900/matmul_sub_core_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:edwinlee/43900/matmul_sub_core_grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/43900/matmul_sub_core_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/43900/matmul_sub_core_grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/43900/matmul_sub_core_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/43900/matmul_sub_core_grid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/43900/matmul_sub_core_grid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/43900/matmul_sub_core_grid)