### PR TITLE
Integrate MeshTensor infra to host APIs

### DIFF
--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -25,6 +25,12 @@
 #include <tt-metalium/device.hpp>
 #include "device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+#include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
+#include <tt-metalium/experimental/tensor/topology/tensor_topology.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 #include "gtest/gtest.h"
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/program.hpp>
@@ -380,6 +386,72 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferAddress) {
         UpdateDynamicCircularBufferAddress(program_, cb_ids[0], *l1_buffer);
         golden_addresses_per_core[core0][0] = l1_buffer->address();
         validate_cb_address(workload, this->devices_.at(id), cr_set, golden_addresses_per_core);
+    }
+}
+
+// Verifies that the MeshTensor overloads of CircularBufferConfig::set_globally_allocated_address[_and_total_size]
+// produce a CircularBufferConfig with identical state to the underlying Buffer overload. CircularBufferConfig's
+// operator== compares total_size, globally_allocated_address, data_formats, page_sizes, tiles, and
+// shadow_global_buffer.
+TEST_F(MeshDeviceFixture, TensixTestSetGloballyAllocatedAddressFromMeshTensorMatchesBuffer) {
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        auto& mesh_device = devices_.at(id);
+        CBConfig cb_config;
+
+        // Single-tile BFLOAT16 tensor → exactly one L1 page of cb_config.page_size (2048 B) bytes in one bank,
+        // matching the CB's total_size and satisfying the dynamic-CB bank-size validation.
+        auto tensor_layout = TensorLayout(
+            DataType::BFLOAT16,
+            PageConfig(Layout::TILE),
+            MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
+        auto spec = TensorSpec(Shape{32, 32}, tensor_layout);
+        auto tensor = MeshTensor::allocate_on_device(*mesh_device, spec, TensorTopology());
+
+        Buffer* underlying_buffer = tensor.mesh_buffer().get_reference_buffer();
+        ASSERT_NE(underlying_buffer, nullptr);
+
+        CircularBufferConfig config_via_buffer = CircularBufferConfig(cb_config.page_size, {{0, cb_config.data_format}})
+                                                     .set_page_size(0, cb_config.page_size)
+                                                     .set_globally_allocated_address(*underlying_buffer);
+        CircularBufferConfig config_via_tensor = CircularBufferConfig(cb_config.page_size, {{0, cb_config.data_format}})
+                                                     .set_page_size(0, cb_config.page_size)
+                                                     .set_globally_allocated_address(tensor);
+
+        EXPECT_EQ(config_via_buffer, config_via_tensor);
+    }
+}
+
+TEST_F(MeshDeviceFixture, TensixTestSetGloballyAllocatedAddressAndTotalSizeFromMeshTensorMatchesBuffer) {
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        auto& mesh_device = devices_.at(id);
+        CBConfig cb_config;
+
+        auto tensor_layout = TensorLayout(
+            DataType::BFLOAT16,
+            PageConfig(Layout::TILE),
+            MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
+        auto spec = TensorSpec(Shape{32, 32}, tensor_layout);
+        auto tensor = MeshTensor::allocate_on_device(*mesh_device, spec, TensorTopology());
+
+        Buffer* underlying_buffer = tensor.mesh_buffer().get_reference_buffer();
+        ASSERT_NE(underlying_buffer, nullptr);
+
+        const uint32_t new_total_size = cb_config.page_size / 2;
+
+        CircularBufferConfig config_via_buffer =
+            CircularBufferConfig(cb_config.page_size, {{0, cb_config.data_format}})
+                .set_page_size(0, cb_config.page_size)
+                .set_globally_allocated_address_and_total_size(*underlying_buffer, new_total_size);
+        CircularBufferConfig config_via_tensor =
+            CircularBufferConfig(cb_config.page_size, {{0, cb_config.data_format}})
+                .set_page_size(0, cb_config.page_size)
+                .set_globally_allocated_address_and_total_size(tensor, new_total_size);
+
+        EXPECT_EQ(config_via_buffer, config_via_tensor);
+        EXPECT_EQ(config_via_buffer.total_size(), new_total_size);
+        EXPECT_EQ(config_via_tensor.total_size(), new_total_size);
+        EXPECT_EQ(config_via_buffer.globally_allocated_address(), underlying_buffer->address());
+        EXPECT_EQ(config_via_tensor.globally_allocated_address(), underlying_buffer->address());
     }
 }
 

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
@@ -19,6 +19,7 @@
 #include <tt-metalium/device.hpp>
 #include "device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/tensor/tensor_types.hpp>
 #include "gtest/gtest.h"
 #include <tt-metalium/hal_types.hpp>
 #include "hostdevcommon/kernel_structs.h"
@@ -137,6 +138,33 @@ TEST_F(MeshDeviceFixture, TestCreateCircularBufferWithMismatchingConfig) {
 
     EXPECT_ANY_THROW(
         CircularBufferConfig(cb_config.page_size, {{0, cb_config.data_format}}).set_page_size(1, cb_config.page_size));
+}
+
+// Verifies that the DataType-based CircularBufferConfig constructor produces a config with identical state to the
+// tt::DataFormat-based constructor when the spec entries map to each other via datatype_to_dataformat_converter.
+// CircularBufferConfig::operator== covers total_size, globally_allocated_address, data_formats, page_sizes, tiles,
+// and shadow_global_buffer.
+TEST_F(MeshDeviceFixture, TestCircularBufferConfigConstructorWithDataTypeMatchesDataFormat) {
+    CBConfig cb_config;
+
+    const std::map<uint8_t, DataType> data_type_spec = {
+        {0, DataType::BFLOAT16},
+        {2, DataType::FLOAT32},
+        {16, DataType::UINT32},
+    };
+
+    std::map<uint8_t, tt::DataFormat> data_format_spec;
+    for (const auto& [idx, dtype] : data_type_spec) {
+        data_format_spec[idx] = datatype_to_dataformat_converter(dtype);
+    }
+
+    CircularBufferConfig config_via_data_format(cb_config.page_size, data_format_spec);
+    CircularBufferConfig config_via_data_type(cb_config.page_size, data_type_spec);
+
+    EXPECT_EQ(config_via_data_format, config_via_data_type);
+    EXPECT_EQ(config_via_data_format.total_size(), cb_config.page_size);
+    EXPECT_EQ(config_via_data_type.total_size(), cb_config.page_size);
+    EXPECT_EQ(config_via_data_format.data_formats(), config_via_data_type.data_formats());
 }
 
 TEST_F(MeshDeviceFixture, TensixTestCreateCircularBufferAtOverlappingIndex) {

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -29,6 +29,7 @@ set(UNIT_TESTS_API_SOURCES
     tensor/test_tensor_sharding.cpp
     tensor/test_host_tensor.cpp
     tensor/test_mesh_tensor.cpp
+    tensor/test_tensor_types.cpp
     test_banked.cpp
     test_bit_utils.cpp
     test_filesystem_utils.cpp

--- a/tests/tt_metal/tt_metal/api/tensor/test_tensor_types.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_tensor_types.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Sanity tests for DataType-related free functions declared in tensor_types.hpp.
+
+#include <gtest/gtest.h>
+
+#include <tt-metalium/experimental/tensor/tensor_types.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+
+namespace tt::tt_metal {
+namespace {
+
+// tt::tt_metal::tile_size(DataType) must return the same value as tt::tile_size(DataFormat) once the DataType is
+// converted via datatype_to_dataformat_converter — it is implemented exactly that way, but this test pins down the
+// contract so future changes don't silently drift.
+TEST(TensorTypesTileSizeTest, MatchesDataFormatTileSize) {
+    constexpr DataType kDataTypes[] = {
+        DataType::BFLOAT16,
+        DataType::FLOAT32,
+        DataType::UINT32,
+        DataType::BFLOAT8_B,
+        DataType::BFLOAT4_B,
+        DataType::UINT8,
+        DataType::UINT16,
+        DataType::INT32,
+    };
+
+    for (DataType dtype : kDataTypes) {
+        const tt::DataFormat format = datatype_to_dataformat_converter(dtype);
+        EXPECT_EQ(tt::tt_metal::tile_size(dtype), tt::tile_size(format))
+            << "tile_size mismatch for DataType=" << static_cast<int>(dtype)
+            << ", DataFormat=" << static_cast<int>(format);
+    }
+}
+
+TEST(TensorTypesTileSizeTest, InvalidDataTypeThrows) {
+    EXPECT_ANY_THROW((void)tt::tt_metal::tile_size(DataType::INVALID));
+}
+
+}  // namespace
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/circular_buffer_config.hpp
+++ b/tt_metal/api/tt-metalium/circular_buffer_config.hpp
@@ -21,6 +21,8 @@ namespace tt {
 enum class DataFormat : uint8_t;
 namespace tt_metal {
 class Buffer;
+class MeshTensor;
+enum class DataType;
 }  // namespace tt_metal
 }  // namespace tt
 
@@ -32,6 +34,7 @@ class CircularBufferConfig {
 public:
     // Static circular buffer spec
     CircularBufferConfig(uint32_t total_size, const std::map<uint8_t, tt::DataFormat>& data_format_spec);
+    CircularBufferConfig(uint32_t total_size, const std::map<uint8_t, DataType>& data_type_spec);
 
     // User is expected to use the builder here.
     CircularBufferConfig(uint32_t total_size);
@@ -61,6 +64,8 @@ public:
     CircularBufferConfig& set_total_size(uint32_t total_size);
 
     CircularBufferConfig& set_globally_allocated_address(const Buffer& buffer);
+
+    CircularBufferConfig& set_globally_allocated_address(const MeshTensor& tensor);
 
     CircularBufferConfig& set_globally_allocated_address_and_total_size(const Buffer& buffer, uint32_t total_size);
 

--- a/tt_metal/api/tt-metalium/circular_buffer_config.hpp
+++ b/tt_metal/api/tt-metalium/circular_buffer_config.hpp
@@ -69,6 +69,8 @@ public:
 
     CircularBufferConfig& set_globally_allocated_address_and_total_size(const Buffer& buffer, uint32_t total_size);
 
+    CircularBufferConfig& set_globally_allocated_address_and_total_size(const MeshTensor& tensor, uint32_t total_size);
+
     CircularBufferConfig& set_tile_dims(uint8_t buffer_index, const Tile& tile);
 
     const std::array<std::optional<Tile>, NUM_CIRCULAR_BUFFERS>& tiles() const;

--- a/tt_metal/api/tt-metalium/experimental/tensor/tensor_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/tensor_types.hpp
@@ -65,7 +65,12 @@ bool is_block_float(DataType dtype);
 tt::DataFormat datatype_to_dataformat_converter(DataType datatype);
 tt::tt_metal::DataType dataformat_to_datatype_converter(tt::DataFormat dataformat);
 
-uint32_t tile_size(const DataType& dtype);
+/**
+ * Returns tile size of given data type in bytes.
+ *
+ * Equivalent to tt::tile_size(datatype_to_dataformat_converter(dtype)).
+ */
+uint32_t tile_size(DataType dtype);
 
 struct NdShardSpec {
     Shape shard_shape;

--- a/tt_metal/api/tt-metalium/experimental/tensor/tensor_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/tensor_types.hpp
@@ -65,6 +65,8 @@ bool is_block_float(DataType dtype);
 tt::DataFormat datatype_to_dataformat_converter(DataType datatype);
 tt::tt_metal::DataType dataformat_to_datatype_converter(tt::DataFormat dataformat);
 
+uint32_t tile_size(const DataType& dtype);
+
 struct NdShardSpec {
     Shape shard_shape;
     CoreRangeSet grid;

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -45,6 +45,7 @@ class Buffer;
 class GlobalSemaphore;
 class CoreRange;
 class CoreRangeSet;
+class MeshTensor;
 
 // ==================================================
 //                  HOST API: Device management
@@ -292,6 +293,9 @@ void UpdateDynamicCircularBufferAddress(
 // clang-format on
 void UpdateDynamicCircularBufferAddressAndTotalSize(
     Program& program, CBHandle cb_handle, const Buffer& buffer, uint32_t total_size);
+
+void UpdateDynamicCircularBufferAddressAndTotalSize(
+    Program& program, CBHandle cb_handle, const MeshTensor& tensor, uint32_t total_size);
 
 // clang-format off
 /**

--- a/tt_metal/impl/buffers/circular_buffer_config.cpp
+++ b/tt_metal/impl/buffers/circular_buffer_config.cpp
@@ -10,6 +10,7 @@
 #include "buffer.hpp"
 #include "hal.hpp"
 #include "impl/context/metal_context.hpp"
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 
 namespace tt {
 enum class DataFormat : uint8_t;
@@ -21,6 +22,15 @@ namespace tt::tt_metal {
 CircularBufferConfig::CircularBufferConfig(
     uint32_t total_size, const std::map<uint8_t, tt::DataFormat>& data_format_spec) :
     total_size_(total_size), globally_allocated_address_(std::nullopt) {
+    this->set_config(data_format_spec);
+}
+
+CircularBufferConfig::CircularBufferConfig(uint32_t total_size, const std::map<uint8_t, DataType>& data_type_spec) :
+    total_size_(total_size), globally_allocated_address_(std::nullopt) {
+    std::map<uint8_t, tt::DataFormat> data_format_spec;
+    for (const auto& [idx, dtype] : data_type_spec) {
+        data_format_spec[idx] = datatype_to_dataformat_converter(dtype);
+    }
     this->set_config(data_format_spec);
 }
 
@@ -158,6 +168,10 @@ CircularBufferConfig& CircularBufferConfig::set_total_size(uint32_t total_size) 
 
 CircularBufferConfig& CircularBufferConfig::set_globally_allocated_address(const Buffer& buffer) {
     return this->set_globally_allocated_address_and_total_size(buffer, this->total_size_);
+}
+
+CircularBufferConfig& CircularBufferConfig::set_globally_allocated_address(const MeshTensor& tensor) {
+    return set_globally_allocated_address(*tensor.mesh_buffer().get_reference_buffer());
 }
 
 CircularBufferConfig& CircularBufferConfig::set_globally_allocated_address_and_total_size(

--- a/tt_metal/impl/buffers/circular_buffer_config.cpp
+++ b/tt_metal/impl/buffers/circular_buffer_config.cpp
@@ -175,6 +175,11 @@ CircularBufferConfig& CircularBufferConfig::set_globally_allocated_address(const
 }
 
 CircularBufferConfig& CircularBufferConfig::set_globally_allocated_address_and_total_size(
+    const MeshTensor& tensor, uint32_t total_size) {
+    return set_globally_allocated_address_and_total_size(*tensor.mesh_buffer().get_reference_buffer(), total_size);
+}
+
+CircularBufferConfig& CircularBufferConfig::set_globally_allocated_address_and_total_size(
     const Buffer& buffer, uint32_t total_size) {
     if (not buffer.is_l1()) {
         TT_THROW("Only L1 buffers can have an associated circular buffer!");

--- a/tt_metal/impl/buffers/circular_buffer_config.cpp
+++ b/tt_metal/impl/buffers/circular_buffer_config.cpp
@@ -11,6 +11,7 @@
 #include "hal.hpp"
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+#include <tt-metalium/experimental/tensor/tensor_types.hpp>
 
 namespace tt {
 enum class DataFormat : uint8_t;

--- a/tt_metal/impl/tensor/tensor_types.cpp
+++ b/tt_metal/impl/tensor/tensor_types.cpp
@@ -112,7 +112,7 @@ tt::tt_metal::DataType dataformat_to_datatype_converter(tt::DataFormat dataforma
     }
 }
 
-uint32_t tile_size(const DataType& dtype) {
+uint32_t tile_size(DataType dtype) {
     auto output_data_format = tt::tt_metal::datatype_to_dataformat_converter(dtype);
     return tt::tile_size(output_data_format);
 }

--- a/tt_metal/impl/tensor/tensor_types.cpp
+++ b/tt_metal/impl/tensor/tensor_types.cpp
@@ -112,6 +112,11 @@ tt::tt_metal::DataType dataformat_to_datatype_converter(tt::DataFormat dataforma
     }
 }
 
+uint32_t tile_size(const DataType& dtype) {
+    auto output_data_format = tt::tt_metal::datatype_to_dataformat_converter(dtype);
+    return tt::tile_size(output_data_format);
+}
+
 }  // namespace tt::tt_metal
 
 auto fmt::formatter<tt::tt_metal::DataType>::format(tt::tt_metal::DataType dt, format_context& ctx) const

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1543,8 +1543,9 @@ void UpdateDynamicCircularBufferAddressAndTotalSize(
 
 void UpdateDynamicCircularBufferAddressAndTotalSize(
     Program& program, CBHandle cb_handle, const MeshTensor& tensor, uint32_t total_size) {
-    UpdateDynamicCircularBufferAddressAndTotalSize(
-        program, cb_handle, *tensor.mesh_buffer().get_reference_buffer(), total_size);
+    auto circular_buffer = program.impl().get_circular_buffer(cb_handle);
+    circular_buffer->config().set_globally_allocated_address_and_total_size(tensor, total_size);
+    circular_buffer->assign_global_address();
 }
 
 uint32_t CreateSemaphore(

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -66,6 +66,7 @@
 #include "common/tt_backend_api_types.hpp"
 #include <experimental/fabric/control_plane.hpp>
 #include "impl/buffers/circular_buffer.hpp"
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 
 #ifdef TT_METAL_USE_EMULE
 #include "impl/emulation/emulated_program_runner.hpp"
@@ -1538,6 +1539,12 @@ void UpdateDynamicCircularBufferAddressAndTotalSize(
     auto circular_buffer = program.impl().get_circular_buffer(cb_handle);
     circular_buffer->config().set_globally_allocated_address_and_total_size(buffer, total_size);
     circular_buffer->assign_global_address();
+}
+
+void UpdateDynamicCircularBufferAddressAndTotalSize(
+    Program& program, CBHandle cb_handle, const MeshTensor& tensor, uint32_t total_size) {
+    UpdateDynamicCircularBufferAddressAndTotalSize(
+        program, cb_handle, *tensor.mesh_buffer().get_reference_buffer(), total_size);
 }
 
 uint32_t CreateSemaphore(


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

This PR adds ergonomic improvements now that the Metal Tensor infrastructure is within `tt_metal`. This is in preparation of Metal Tensor integration to program factory as these optimizes common patterns seen.

Specifically:

1. Adds `tile_size` overload for `DataType`.
    A common pattern in ops codebase is to convert `DatatType` from `Tensor` to `DataFormat` in metal land, and use it to compute the `tile_size`. Here in the PR we provide a convince function to avoid this conversion.
2. Adds various MeshTensor based overload in place of original Buffer orientated CB functions

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Tests are added to ensure parity

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/tensor-impr0)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/tensor-impr0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/tensor-impr0)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/tensor-impr0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/tensor-impr0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/tensor-impr0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/tensor-impr0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/tensor-impr0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/tensor-impr0)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/tensor-impr0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/tensor-impr0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/tensor-impr0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/tensor-impr0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/tensor-impr0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/tensor-impr0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/tensor-impr0)