### PR TITLE
ds_prefill(l1_ptr) - add missing tt_l1_ptr on L1 pointers

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
@@ -202,7 +202,7 @@ void kernel_main() {
         noc_async_read_page(i, offsets_addr_gen, offsets_base_addr + i * aligned_offsets_page_size);
     }
     noc_async_read_barrier();
-    uint32_t* offsets = (uint32_t*)offsets_base_addr;
+    tt_l1_ptr uint32_t* offsets = reinterpret_cast<tt_l1_ptr uint32_t*>(offsets_base_addr);
 
     // Read dispatch table into local scratch
     const auto dispatch_table_addr_gen = TensorAccessor(dispatch_table_args, dispatch_table_tensor_address);
@@ -213,7 +213,7 @@ void kernel_main() {
             i, dispatch_table_addr_gen, dispatch_table_base_addr + i * aligned_dispatch_table_page_size);
     }
     noc_async_read_barrier();
-    int32_t* expert_dispatch_table = (int32_t*)dispatch_table_base_addr;
+    tt_l1_ptr int32_t* expert_dispatch_table = reinterpret_cast<tt_l1_ptr int32_t*>(dispatch_table_base_addr);
 
     // Reserve scratch space once — these CBs are not used as FIFOs. Each batch
     // overwrites the same region at offsets [0, batch_count) without push/pop.
@@ -335,8 +335,10 @@ void kernel_main() {
             bool has_non_local = false;
 
             for (uint32_t t = 0; t < batch_count; t++) {
-                int32_t* indices_t = (int32_t*)(indices_base + t * aligned_indices_page_size);
-                uint16_t* weights_t = (uint16_t*)(weights_base + t * aligned_weights_page_size);
+                tt_l1_ptr int32_t* indices_t =
+                    reinterpret_cast<tt_l1_ptr int32_t*>(indices_base + t * aligned_indices_page_size);
+                tt_l1_ptr uint16_t* weights_t =
+                    reinterpret_cast<tt_l1_ptr uint16_t*>(weights_base + t * aligned_weights_page_size);
                 for (uint32_t k = 0; k < num_experts_per_tok; k++) {
                     auto routed_expert = indices_t[k];
                     if (((uint32_t)routed_expert & core_mask) != dispatch_core_idx) {
@@ -437,8 +439,10 @@ void kernel_main() {
 #else
             uint32_t token_input_addr = input_base + t * aligned_input_page_size;
 #endif
-            int32_t* indices = (int32_t*)(indices_base + t * aligned_indices_page_size);
-            uint16_t* weights = (uint16_t*)(weights_base + t * aligned_weights_page_size);
+            tt_l1_ptr int32_t* indices =
+                reinterpret_cast<tt_l1_ptr int32_t*>(indices_base + t * aligned_indices_page_size);
+            tt_l1_ptr uint16_t* weights =
+                reinterpret_cast<tt_l1_ptr uint16_t*>(weights_base + t * aligned_weights_page_size);
 
             for (uint32_t k = 0; k < num_experts_per_tok; ++k) {
                 auto routed_expert = indices[k];

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_writer.cpp
@@ -105,8 +105,9 @@ void kernel_main() {
 
             bool has_local = true;
             if constexpr (use_dispatch_table_skip) {
-                int32_t* dispatch_table = (int32_t*)dispatch_table_write_addr;
-                int32_t* token_indices = (int32_t*)(indices_write_addr + token_idx * indices_aligned_page_size);
+                tt_l1_ptr int32_t* dispatch_table = reinterpret_cast<tt_l1_ptr int32_t*>(dispatch_table_write_addr);
+                tt_l1_ptr int32_t* token_indices =
+                    reinterpret_cast<tt_l1_ptr int32_t*>(indices_write_addr + token_idx * indices_aligned_page_size);
                 has_local = false;
                 for (uint32_t k = 0; k < num_experts; ++k) {
                     if (dispatch_table[token_indices[k]] != -1) {
@@ -125,7 +126,8 @@ void kernel_main() {
                     if (!has_local && is_last) {
                         // No local experts for this token — zero the weight tile so compute's
                         // must_zero_init multiply produces zeros regardless of combine_output.
-                        volatile uint32_t* ptr = (volatile uint32_t*)cb_write_addr;
+                        volatile tt_l1_ptr uint32_t* ptr =
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_write_addr);
                         for (uint32_t w = 0; w < weight_tile_size / sizeof(uint32_t); w++) {
                             ptr[w] = 0;
                         }


### PR DESCRIPTION
## Summary
- Add the `tt_l1_ptr` attribute to 11 pointer declarations across 4 DeepSeek prefill kernels that were casting raw L1 addresses (from `get_read_ptr` / `get_write_ptr`) to typed pointers without it. Without the attribute the RISC-V backend treats the address as generic memory — potentially wrong load/store semantics, bad scheduling against L1 latency, silent timing-dependent bugs.
- Fixed sites: `writer_dispatch.cpp:168` and `writer_combine.cpp:191` (`route_info`, volatile); `post_combine_reduce_writer.cpp:108,109,128` (`dispatch_table`, `token_indices`, zero-init `ptr`); `reader_dispatch.cpp:205,216,338-339,440-441` (`offsets`, `expert_dispatch_table`, per-token `indices`/`weights`).
- Preserved each site's existing `volatile` qualifier — sync-flavored buffers (`route_info`, signal_ptrs) stay `volatile`; read-once scratch buffers filled under `noc_async_read_barrier` stay non-volatile. C-style casts replaced with `reinterpret_cast`.

## Test plan
- `/deepseek-pipelines` (all 4 CI workflows)

### DeepSeek Prefill CI
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mbezulj/2605-l1-ptr-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:mbezulj/2605-l1-ptr-fixes) Galaxy
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/2605-l1-ptr-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mbezulj/2605-l1-ptr-fixes) T3K
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=mbezulj/2605-l1-ptr-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:mbezulj/2605-l1-ptr-fixes) Single Card
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/2605-l1-ptr-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/2605-l1-ptr-fixes) Blackhole

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2605-l1-ptr-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2605-l1-ptr-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/2605-l1-ptr-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/2605-l1-ptr-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2605-l1-ptr-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2605-l1-ptr-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2605-l1-ptr-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2605-l1-ptr-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/2605-l1-ptr-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/2605-l1-ptr-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2605-l1-ptr-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2605-l1-ptr-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2605-l1-ptr-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2605-l1-ptr-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2605-l1-ptr-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2605-l1-ptr-fixes)