### PR TITLE
[Feature] Widen prefetch queue entry type to 32 bits except for WH ETH dispatch

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
@@ -63,7 +63,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchQBuffer) {
 TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchQBufferWith2ByteEntries) {
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_entries = 0x1000;
-    const uint32_t expected_buffer_bytes = expected_buffer_entries * 2;  // 2-byte entry size for wormhole-eth
+    const uint32_t expected_buffer_bytes = expected_buffer_entries * 2;
     DispatchSettings settings(hw_cqs, CoreType::ETH, false, false, default_l1_alignment, 2);
     settings.prefetch_q_entries(expected_buffer_entries);
     EXPECT_EQ(settings.prefetch_q_entries_, expected_buffer_entries);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
@@ -22,12 +22,16 @@ static constexpr uint32_t default_l1_alignment = 16;
 
 TEST(DispatchSettingsTest, TestDispatchSettingsDefaultUnsupportedCoreType) {
     const auto unsupported_core = CoreType::ARC;
-    EXPECT_THROW(DispatchSettings(1, unsupported_core, false, false, default_l1_alignment), std::runtime_error);
+    EXPECT_THROW(DispatchSettings(1, unsupported_core, false, false, default_l1_alignment, 4), std::runtime_error);
+}
+
+TEST(DispatchSettingsTest, TestDispatchSettingsInvalidPrefetchQEntrySize) {
+    EXPECT_THROW(DispatchSettings(1, CoreType::WORKER, false, false, default_l1_alignment, 3), std::runtime_error);
 }
 
 TEST(DispatchSettingsTest, TestDispatchSettingsEq) {
     const uint32_t hw_cqs = 2;
-    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment);
+    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment, 4);
     DispatchSettings settings_2 = settings;  // Copy
     EXPECT_EQ(settings, settings_2);
     settings_2.dispatch_size_ += 1;
@@ -39,7 +43,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchDBuffer) {
     const uint32_t expected_buffer_bytes = 0xcafe;
     const uint32_t expected_page_count =
         expected_buffer_bytes / (1 << DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment);
+    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment, 4);
     settings.prefetch_d_buffer_size(expected_buffer_bytes);
     EXPECT_EQ(settings.prefetch_d_buffer_size_, expected_buffer_bytes);
     EXPECT_EQ(settings.prefetch_d_pages_, expected_page_count);
@@ -48,18 +52,30 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchDBuffer) {
 TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchQBuffer) {
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_entries = 0x1000;
-    const uint32_t expected_buffer_bytes = expected_buffer_entries * sizeof(DispatchSettings::prefetch_q_entry_type);
-    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment);
+    const uint32_t expected_buffer_bytes = expected_buffer_entries * 4;
+    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment, 4);
     settings.prefetch_q_entries(expected_buffer_entries);
     EXPECT_EQ(settings.prefetch_q_entries_, expected_buffer_entries);
     EXPECT_EQ(settings.prefetch_q_size_, expected_buffer_bytes);
+    EXPECT_EQ(settings.prefetch_q_entry_size_bytes_, 4);
+}
+
+TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchQBufferWith2ByteEntries) {
+    const uint32_t hw_cqs = 2;
+    const uint32_t expected_buffer_entries = 0x1000;
+    const uint32_t expected_buffer_bytes = expected_buffer_entries * 2;  // 2-byte entry size for wormhole-eth
+    DispatchSettings settings(hw_cqs, CoreType::ETH, false, false, default_l1_alignment, 2);
+    settings.prefetch_q_entries(expected_buffer_entries);
+    EXPECT_EQ(settings.prefetch_q_entries_, expected_buffer_entries);
+    EXPECT_EQ(settings.prefetch_q_size_, expected_buffer_bytes);
+    EXPECT_EQ(settings.prefetch_q_entry_size_bytes_, 2);
 }
 
 TEST(DispatchSettingsTest, TestDispatchSettingsSetDispatchBuffer) {
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_bytes = 0x2000;
     const uint32_t expected_page_count = expected_buffer_bytes / (1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment);
+    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment, 4);
     settings.dispatch_size(expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_size_, expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_pages_, expected_page_count);
@@ -70,7 +86,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetDispatchSBuffer) {
     const uint32_t expected_buffer_bytes = 0x2000;
     const uint32_t expected_page_count =
         expected_buffer_bytes / (1 << DispatchSettings::DISPATCH_S_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment);
+    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment, 4);
     settings.dispatch_s_buffer_size(expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_s_buffer_size_, expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_s_buffer_pages_, expected_page_count);

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -18,7 +18,12 @@ namespace tt::tt_metal {
 DispatchMemMap::DispatchMemMap(
     const CoreType& core_type, uint32_t num_hw_cqs, const Hal& hal, bool is_galaxy_cluster, bool are_cqs_dram_backed) :
     settings(DispatchSettings(
-        num_hw_cqs, core_type, is_galaxy_cluster, are_cqs_dram_backed, hal.get_alignment(HalMemType::L1))),
+        num_hw_cqs,
+        core_type,
+        is_galaxy_cluster,
+        are_cqs_dram_backed,
+        hal.get_alignment(HalMemType::L1),
+        (hal.get_arch() == tt::ARCH::WORMHOLE_B0 && core_type == CoreType::ETH) ? 2u : 4u)),
     host_alignment_(hal.get_alignment(HalMemType::HOST)),
     l1_alignment_(hal.get_alignment(HalMemType::L1)),
     noc_overlay_start_addr_(hal.get_noc_overlay_start_addr()),
@@ -117,6 +122,8 @@ DispatchMemMap::DispatchMemMap(
 }
 
 uint32_t DispatchMemMap::prefetch_q_entries() const { return settings.prefetch_q_entries_; }
+
+uint32_t DispatchMemMap::prefetch_q_entry_size_bytes() const { return settings.prefetch_q_entry_size_bytes_; }
 
 uint32_t DispatchMemMap::prefetch_q_size() const { return settings.prefetch_q_size_; }
 

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -23,6 +23,11 @@ DispatchMemMap::DispatchMemMap(
         is_galaxy_cluster,
         are_cqs_dram_backed,
         hal.get_alignment(HalMemType::L1),
+        // Prefetch queue entry width: each entry encodes the prefetch command size with the MSB reserved as a
+        // stall flag. Both 2-byte (15 size bits) and 4-byte (31 size bits) widths cover today's
+        // prefetch_max_cmd_size on every arch. We prefer 4 bytes because sub-32-bit reads/writes have been
+        // observed to fail on Quasar, and using one width everywhere keeps host/kernel code simple. WH ETH
+        // stays at 2 bytes because of tighter memory constraints.
         (hal.get_arch() == tt::ARCH::WORMHOLE_B0 && core_type == CoreType::ETH) ? 2u : 4u)),
     host_alignment_(hal.get_alignment(HalMemType::HOST)),
     l1_alignment_(hal.get_alignment(HalMemType::L1)),

--- a/tt_metal/impl/dispatch/dispatch_mem_map.hpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.hpp
@@ -40,6 +40,8 @@ public:
 
     uint32_t prefetch_q_entries() const;
 
+    uint32_t prefetch_q_entry_size_bytes() const;
+
     uint32_t prefetch_q_size() const;
 
     uint32_t max_prefetch_command_size() const;

--- a/tt_metal/impl/dispatch/dispatch_settings.hpp
+++ b/tt_metal/impl/dispatch/dispatch_settings.hpp
@@ -29,7 +29,8 @@ public:
         const CoreType& core_type,
         bool is_galaxy_cluster,
         bool are_cqs_dram_backed,
-        uint32_t l1_alignment);
+        uint32_t l1_alignment,
+        uint32_t prefetch_q_entry_size_bytes);
 
     bool operator==(const DispatchSettings& other) const;
 
@@ -76,10 +77,6 @@ public:
     //
     // Non Configurable Settings
     //
-
-    // Prefetch Queue entry type
-    // Same as the one in cq_prefetch.cpp
-    using prefetch_q_entry_type = uint16_t;
 
     // Prefetch Queue pointer type
     // Same as the one in cq_prefetch.cpp
@@ -143,6 +140,7 @@ public:
     uint32_t other_ptrs_size{};               // configured with alignment
 
     // cq_prefetch
+    uint32_t prefetch_q_entry_size_bytes_{};  // 2 for WH ETH, 4 otherwise
     uint32_t prefetch_q_entries_{0};
     uint32_t prefetch_q_size_{};
     uint32_t prefetch_max_cmd_size_{};

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -538,6 +538,9 @@ void PrefetchKernel::CreateKernel() {
         {"IS_H_VARIANT", std::to_string(static_config_.is_h_variant.value())},
     };
 
+    const auto& my_dispatch_constants = *dispatch_mem_map_[enchantum::to_underlying(GetCoreType())].get();
+    defines["PREFETCH_Q_ENTRY_BITS"] = std::to_string(my_dispatch_constants.prefetch_q_entry_size_bytes() * 8);
+
     if (!is_hd()) {
         defines["FABRIC_RELAY"] = "1";
         if (static_config_.is_2d_fabric.value_or(false)) {

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -576,7 +576,9 @@ void PrefetchKernel::ConfigureCore() {
         const auto& my_dispatch_constants = *dispatch_mem_map_[enchantum::to_underlying(GetCoreType())].get();
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();
-        std::vector<uint32_t> prefetch_q(my_dispatch_constants.prefetch_q_entries(), 0);
+        const uint32_t prefetch_q_bytes = my_dispatch_constants.prefetch_q_size();
+        TT_ASSERT(prefetch_q_bytes % sizeof(uint32_t) == 0);
+        std::vector<uint32_t> prefetch_q(prefetch_q_bytes / sizeof(uint32_t), 0);
         uint32_t prefetch_q_base =
             my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::UNRESERVED);
         std::vector<uint32_t> prefetch_q_rd_ptr_addr_data = {

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -41,7 +41,13 @@ union CQPrefetchHToPrefetchDHeader {
 };
 static_assert((sizeof(CQPrefetchHToPrefetchDHeader) & (CQ_PREFETCH_CMD_BARE_MIN_SIZE - 1)) == 0);
 
+#if PREFETCH_Q_ENTRY_BITS == 16
 using prefetch_q_entry_type = uint16_t;
+#elif PREFETCH_Q_ENTRY_BITS == 32
+using prefetch_q_entry_type = uint32_t;
+#else
+#error "Unsupported PREFETCH_Q_ENTRY_BITS"
+#endif
 
 // Use named defines instead of get_compile_time_arg_val indices
 constexpr uint32_t downstream_cb_base = DOWNSTREAM_CB_BASE;

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -796,14 +796,15 @@ void SystemMemoryManager::fetch_queue_write(uint32_t command_size_B, const uint8
         return;
     }
 
-    uint32_t max_command_size_B = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
+    const DispatchMemMap& dispatch_mem_map = MetalContext::instance(this->context_id).dispatch_mem_map();
+    const uint32_t max_command_size_B = dispatch_mem_map.max_prefetch_command_size();
     TT_ASSERT(
         command_size_B <= max_command_size_B,
         "Generated prefetcher command of size {} B exceeds max command size {} B",
         command_size_B,
         max_command_size_B);
 
-    const uint32_t entry_bytes = MetalContext::instance().dispatch_mem_map().prefetch_q_entry_size_bytes();
+    const uint32_t entry_bytes = dispatch_mem_map.prefetch_q_entry_size_bytes();
     const uint32_t shift_for_msb = entry_bytes * 8 - 1;
     const uint32_t max_encodable = 1u << shift_for_msb;
     TT_ASSERT(

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -256,7 +256,7 @@ void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint
         this->cq_to_last_completed_event.push_back(0);
         this->prefetch_q_dev_ptrs[cq_id] = prefetch_q_base;
         this->prefetch_q_dev_fences[cq_id] = prefetch_q_base + ctx.dispatch_mem_map().prefetch_q_entries() *
-                                                                   sizeof(DispatchSettings::prefetch_q_entry_type);
+                                                                   ctx.dispatch_mem_map().prefetch_q_entry_size_bytes();
     }
 }
 
@@ -694,7 +694,7 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
     uint32_t prefetch_q_base =
         ctx.dispatch_mem_map().get_device_command_queue_addr(CommandQueueDeviceAddrType::UNRESERVED);
     uint32_t prefetch_q_limit = prefetch_q_base + (ctx.dispatch_mem_map().prefetch_q_entries() *
-                                                   sizeof(DispatchSettings::prefetch_q_entry_type));
+                                                   ctx.dispatch_mem_map().prefetch_q_entry_size_bytes());
     if (this->prefetch_q_dev_ptrs[cq_id] == prefetch_q_limit) {
         this->prefetch_q_dev_ptrs[cq_id] = prefetch_q_base;
         wait_for_fetch_q_space();
@@ -802,25 +802,35 @@ void SystemMemoryManager::fetch_queue_write(uint32_t command_size_B, const uint8
         "Generated prefetcher command of size {} B exceeds max command size {} B",
         command_size_B,
         max_command_size_B);
+
+    const uint32_t entry_bytes = MetalContext::instance().dispatch_mem_map().prefetch_q_entry_size_bytes();
+    const uint32_t shift_for_msb = entry_bytes * 8 - 1;
+    const uint32_t max_encodable = 1u << shift_for_msb;
     TT_ASSERT(
-        (command_size_B >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "FetchQ command too large to represent");
+        (command_size_B >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE) < max_encodable,
+        "FetchQ command too large to represent");
     TT_ASSERT(command_size_B > 0, "Command size must be greater than 0");
     if (this->bypass_enable) {
         return;
     }
     tt_driver_atomics::sfence();
-    DispatchSettings::prefetch_q_entry_type command_size_16B =
-        command_size_B >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE;
+    uint32_t entry_val = command_size_B >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE;
 
     // stall_prefetcher is used for enqueuing traces, as replaying a trace will hijack the cmd_data_q
     // so prefetcher fetches multiple cmds that include the trace cmd, they will be corrupted by trace pulling data
     // from DRAM stall flag prevents pulling prefetch q entries that occur after the stall entry Stall flag for
     // prefetcher is MSB of FetchQ entry.
     if (stall_prefetcher) {
-        command_size_16B |= (1 << ((sizeof(DispatchSettings::prefetch_q_entry_type) * 8) - 1));
+        entry_val |= 1u << shift_for_msb;
     }
-    this->prefetch_q_windows[cq_id]->write16(this->prefetch_q_dev_ptrs[cq_id], command_size_16B);
-    this->prefetch_q_dev_ptrs[cq_id] += sizeof(DispatchSettings::prefetch_q_entry_type);
+
+    if (entry_bytes == 2) {
+        this->prefetch_q_windows[cq_id]->write16(this->prefetch_q_dev_ptrs[cq_id], static_cast<uint16_t>(entry_val));
+    } else {
+        TT_ASSERT(entry_bytes == 4);
+        this->prefetch_q_windows[cq_id]->write32(this->prefetch_q_dev_ptrs[cq_id], entry_val);
+    }
+    this->prefetch_q_dev_ptrs[cq_id] += entry_bytes;
 }
 
 bool SystemMemoryManager::is_dram_backed() const {

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -38,7 +38,13 @@ DispatchSettings::DispatchSettings(
     const CoreType& core_type,
     bool is_galaxy_cluster,
     bool are_cqs_dram_backed,
-    uint32_t l1_alignment) {
+    uint32_t l1_alignment,
+    uint32_t prefetch_q_entry_size_bytes) {
+    TT_FATAL(
+        prefetch_q_entry_size_bytes == 2 || prefetch_q_entry_size_bytes == 4,
+        "prefetch_q_entry_size_bytes must be 2 or 4, got {}",
+        prefetch_q_entry_size_bytes);
+    this->prefetch_q_entry_size_bytes_ = prefetch_q_entry_size_bytes;
     switch (core_type) {
         case CoreType::WORKER:
             init_worker_defaults(num_hw_cqs, is_galaxy_cluster, are_cqs_dram_backed, l1_alignment);
@@ -139,6 +145,7 @@ bool DispatchSettings::operator==(const DispatchSettings& other) const {
     return num_hw_cqs_ == other.num_hw_cqs_ && prefetch_q_rd_ptr_size_ == other.prefetch_q_rd_ptr_size_ &&
            prefetch_q_pcie_rd_ptr_size_ == other.prefetch_q_pcie_rd_ptr_size_ &&
            dispatch_s_sync_sem_ == other.dispatch_s_sync_sem_ && other_ptrs_size == other.other_ptrs_size &&
+           prefetch_q_entry_size_bytes_ == other.prefetch_q_entry_size_bytes_ &&
            prefetch_q_entries_ == other.prefetch_q_entries_ && prefetch_q_size_ == other.prefetch_q_size_ &&
            prefetch_max_cmd_size_ == other.prefetch_max_cmd_size_ &&
            prefetch_cmddat_q_size_ == other.prefetch_cmddat_q_size_ &&
@@ -189,7 +196,7 @@ DispatchSettings& DispatchSettings::prefetch_ringbuffer_size(uint32_t val) {
 // Setter for prefetch_q_entries and update prefetch_q_size
 DispatchSettings& DispatchSettings::prefetch_q_entries(uint32_t val) {
     this->prefetch_q_entries_ = val;
-    this->prefetch_q_size_ = val * sizeof(prefetch_q_entry_type);
+    this->prefetch_q_size_ = val * this->prefetch_q_entry_size_bytes_;
     return *this;
 }
 


### PR DESCRIPTION
### PR Category
Feature

### Summary
The prefetch queue entry type was hardcoded as `uint16_t`. This PR widens it to `uint32_t` for all architectures and core types except Wormhole ethernet dispatch, which remains as 16 bits due to the tighter memory constraints.

The entry type width is now a parameter passed through DispatchSettings (new `prefetch_q_entry_size_bytes_` field), propagated through `DispatchMemMap` (new `prefetch_q_entry_size_bytes()` accessor), and exposed to the `cq_prefetch` kernel via a new `PREFETCH_Q_ENTRY_BITS` compile-time define. The stall-flag MSB, the wrap-around pointer arithmetic, and the oversize-command assertion in `SystemMemoryManager::fetch_queue_write()` are all derived from the width of the prefetch queue entry type rather than `sizeof(prefetch_q_entry_type)`, so they remain correct for both widths.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/prefetch_q_entry_type_32_bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/prefetch_q_entry_type_32_bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/prefetch_q_entry_type_32_bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/prefetch_q_entry_type_32_bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/prefetch_q_entry_type_32_bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/prefetch_q_entry_type_32_bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/prefetch_q_entry_type_32_bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/prefetch_q_entry_type_32_bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/prefetch_q_entry_type_32_bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/prefetch_q_entry_type_32_bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/prefetch_q_entry_type_32_bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/prefetch_q_entry_type_32_bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/prefetch_q_entry_type_32_bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/prefetch_q_entry_type_32_bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/prefetch_q_entry_type_32_bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/prefetch_q_entry_type_32_bit)